### PR TITLE
WPCOM_JSON_API_List_Comments_Endpoint: Remove update_comment_cache() that is no longer needed

### DIFF
--- a/projects/plugins/jetpack/changelog/update-list-comments-endpoint
+++ b/projects/plugins/jetpack/changelog/update-list-comments-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WPCOM_JSON_API_List_Comments_Endpoint: Remove update_comment_cache() that is no longer needed

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -328,8 +328,6 @@ class WPCOM_JSON_API_List_Comments_Endpoint extends WPCOM_JSON_API_Comment_Endpo
 
 		$comments = get_comments( $query );
 
-		update_comment_cache( $comments );
-
 		if ( $args['hierarchical'] ) {
 			$walker      = new WPCOM_JSON_API_List_Comments_Walker();
 			$comment_ids = $walker->paged_walk( $comments, get_option( 'thread_comments_depth', -1 ), isset( $args['page'] ) ? $args['page'] : 1, $args['number'] );


### PR DESCRIPTION
## Proposed changes:

In 2014, the `update_comment_cache()` function call was [added](https://github.com/Automattic/jetpack/commit/5d2172cf1290fec496c42d8140cb5507551bfd90) to the `WPCOM_JSON_API_List_Comments_Endpoint` to ensure that comment caches were up to date.

 However, as of 2015, WordPress.org core has made changes to the `get_comments()` queries to automatically [find the IDs of uncached comments and update only those](https://github.com/WordPress/wordpress-develop/commit/2fd81992bc3e0b1f54dee#diff-d4e56abc478831ea79ffe4f6d4bcbae812a15de4b7c4eddc9c5e4d51e6c9b9aeR2392-R2401). This is accomplished by the `_prime_comment_caches()` function, which is called automatically by `get_comments()`.

This new approach is significantly more efficient than sending all comments every time to `update_comment_cache()`. By removing this unnecessary function call, we can improve the performance of the `WPCOM_JSON_API_List_Comments_Endpoint`. In a test case involving a page with 45,000 comments, removing this call resulted in a savings of 185MB of peak memory usage and prevented out-of-memory (OOM) errors.

This patch removes the `update_comment_cache()` function call from the `WPCOM_JSON_API_List_Comments_Endpoint`, as it is no longer needed due to the improvements made in WordPress.org core.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Testing helper and testing instructions in D141695-code.
