### PR TITLE
Backport mu-wpcom-plugin 2.1.4 Changes

### DIFF
--- a/projects/packages/a8c-mc-stats/CHANGELOG.md
+++ b/projects/packages/a8c-mc-stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [2.0.0] - 2023-11-20
 ### Changed
 - Updated required PHP version to >= 7.0. [#34192]
@@ -131,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Creates the MC Stats package
 
+[2.0.1]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v1.4.22...v2.0.0
 [1.4.22]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v1.4.21...v1.4.22
 [1.4.21]: https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v1.4.20...v1.4.21

--- a/projects/packages/a8c-mc-stats/changelog/add-phan
+++ b/projects/packages/a8c-mc-stats/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [0.4.0] - 2024-03-01
 ### Added
 - Register menus in network admin as well as regular admin. [#36058]
@@ -140,6 +144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
+[0.4.1]: https://github.com/Automattic/jetpack-admin-ui/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/Automattic/jetpack-admin-ui/compare/0.3.2...0.4.0
 [0.3.2]: https://github.com/Automattic/jetpack-admin-ui/compare/0.3.1...0.3.2
 [0.3.1]: https://github.com/Automattic/jetpack-admin-ui/compare/0.3.0...0.3.1

--- a/projects/packages/admin-ui/changelog/add-phan
+++ b/projects/packages/admin-ui/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.4.1-alpha",
+	"version": "0.4.1",
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Admin_UI;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.4.1-alpha';
+	const PACKAGE_VERSION = '0.4.1';
 
 	/**
 	 * Whether this class has been initialized

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [2.1.3] - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36325]
@@ -415,6 +419,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[2.1.4]: https://github.com/Automattic/jetpack-assets/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/Automattic/jetpack-assets/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/Automattic/jetpack-assets/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/Automattic/jetpack-assets/compare/v2.1.0...v2.1.1

--- a/projects/packages/assets/changelog/add-phan
+++ b/projects/packages/assets/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [4.1.0] - 2024-01-22
 ### Changed
 - Default for `--deduplicate` is now 0, as 1 caused unexpected behavior for some cases and so should be opted in to. [#35138]
@@ -208,6 +212,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Initial version.
 
+[4.1.1]: https://github.com/Automattic/jetpack-changelogger/compare/4.1.0...4.1.1
 [4.1.0]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.5...4.1.0
 [4.0.5]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.4...4.0.5
 [4.0.4]: https://github.com/Automattic/jetpack-changelogger/compare/4.0.3...4.0.4

--- a/projects/packages/changelogger/changelog/add-phan
+++ b/projects/packages/changelogger/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.1.1-alpha';
+	const VERSION = '4.1.1';
 
 	/**
 	 * Constructor.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [2.4.0] - 2024-03-12
 ### Added
 - Sync:Now Sync uses rest api endpoint for enabled sites [#36210]
@@ -983,6 +987,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.4.1]: https://github.com/Automattic/jetpack-connection/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/Automattic/jetpack-connection/compare/v2.3.4...v2.4.0
 [2.3.4]: https://github.com/Automattic/jetpack-connection/compare/v2.3.3...v2.3.4
 [2.3.3]: https://github.com/Automattic/jetpack-connection/compare/v2.3.2...v2.3.3

--- a/projects/packages/connection/changelog/add-phan
+++ b/projects/packages/connection/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.4.1-alpha';
+	const PACKAGE_VERSION = '2.4.1';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/constants/CHANGELOG.md
+++ b/projects/packages/constants/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [2.0.0] - 2023-11-20
 ### Changed
 - Updated required PHP version to >= 7.0. [#34192]
@@ -158,6 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Finish the constants package
 
+[2.0.1]: https://github.com/Automattic/jetpack-constants/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-constants/compare/v1.6.23...v2.0.0
 [1.6.23]: https://github.com/Automattic/jetpack-constants/compare/v1.6.22...v1.6.23
 [1.6.22]: https://github.com/Automattic/jetpack-constants/compare/v1.6.21...v1.6.22

--- a/projects/packages/constants/changelog/add-phan
+++ b/projects/packages/constants/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/ip/CHANGELOG.md
+++ b/projects/packages/ip/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [0.2.1] - 2023-11-21
 ### Changed
 - Added a note of non-usage of PHP8+ functions yet. [#34137]
@@ -43,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add jetpack-ip package functionality [#28846]
 - Initialized the package. [#28765]
 
+[0.2.2]: https://github.com/automattic/jetpack-ip/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/automattic/jetpack-ip/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/automattic/jetpack-ip/compare/v0.1.6...v0.2.0
 [0.1.6]: https://github.com/automattic/jetpack-ip/compare/v0.1.5...v0.1.6

--- a/projects/packages/ip/changelog/add-phan
+++ b/projects/packages/ip/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/ip/src/class-utils.php
+++ b/projects/packages/ip/src/class-utils.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\IP;
  */
 class Utils {
 
-	const PACKAGE_VERSION = '0.2.2-alpha';
+	const PACKAGE_VERSION = '0.2.2';
 
 	/**
 	 * Get the current user's IP address.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.16.1] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [5.16.0] - 2024-03-12
 ### Added
 - Added Connections to the Hosting menu [#36302]
@@ -647,6 +651,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.16.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.16.0...v5.16.1
 [5.16.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.15.2...v5.16.0
 [5.15.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.15.1...v5.15.2
 [5.15.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.15.0...v5.15.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-phan
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.16.1-alpha",
+	"version": "5.16.1",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.16.1-alpha';
+	const PACKAGE_VERSION = '5.16.1';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/logo/CHANGELOG.md
+++ b/projects/packages/logo/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [2.0.0] - 2023-11-20
 ### Changed
 - Updated required PHP version to >= 7.0. [#34192]
@@ -166,6 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Add a basic Jetpack Logo package
 
+[2.0.1]: https://github.com/Automattic/jetpack-logo/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-logo/compare/v1.6.3...v2.0.0
 [1.6.3]: https://github.com/Automattic/jetpack-logo/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/Automattic/jetpack-logo/compare/v1.6.1...v1.6.2

--- a/projects/packages/logo/changelog/add-phan
+++ b/projects/packages/logo/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/plans/CHANGELOG.md
+++ b/projects/packages/plans/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [0.4.2] - 2024-02-12
 ### Added
 - Plan features: add "sharing block" to the list of features supported in the free plan. [#35577]
@@ -118,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Moved the options class into Connection. [#24095]
 
+[0.4.3]: https://github.com/Automattic/jetpack-plans/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/Automattic/jetpack-plans/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/Automattic/jetpack-plans/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Automattic/jetpack-plans/compare/v0.3.5...v0.4.0

--- a/projects/packages/plans/changelog/add-phan
+++ b/projects/packages/plans/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.4.3-alpha",
+	"version": "0.4.3",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/redirect/CHANGELOG.md
+++ b/projects/packages/redirect/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [2.0.0] - 2023-11-20
 ### Changed
 - Replaced usage of strpos() with str_starts_with(). [#34135]
@@ -193,6 +197,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create Jetpack Redirect package
 
+[2.0.1]: https://github.com/Automattic/jetpack-redirect/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.27...v2.0.0
 [1.7.27]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.26...v1.7.27
 [1.7.26]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.25...v1.7.26

--- a/projects/packages/redirect/changelog/add-phan
+++ b/projects/packages/redirect/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/roles/CHANGELOG.md
+++ b/projects/packages/roles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [2.0.0] - 2023-11-20
 ### Changed
 - Updated required PHP version to >= 7.0. [#34192]
@@ -159,6 +163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Jetpack DNA: Introduce a Roles package
 
+[2.0.1]: https://github.com/Automattic/jetpack-roles/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-roles/compare/v1.4.25...v2.0.0
 [1.4.25]: https://github.com/Automattic/jetpack-roles/compare/v1.4.24...v1.4.25
 [1.4.24]: https://github.com/Automattic/jetpack-roles/compare/v1.4.23...v1.4.24

--- a/projects/packages/roles/changelog/add-phan
+++ b/projects/packages/roles/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2024-03-12
+### Fixed
+- Fixed a bug where only plugin slugs were send to the update handler instead of full update objects. [#36355]
+- Fixed a bug where the cron callback did not accept more than one plugin to update. [#36361]
+
 ## [0.3.3] - 2024-03-12
 ### Fixed
 - Fixed a bug where timezone difference where not taken into account when displaying schedule run times in wp-admin. [#36335]
@@ -58,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.3.4]: https://github.com/Automattic/scheduled-updates/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Automattic/scheduled-updates/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Automattic/scheduled-updates/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Automattic/scheduled-updates/compare/v0.3.0...v0.3.1

--- a/projects/packages/scheduled-updates/changelog/add-phan
+++ b/projects/packages/scheduled-updates/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/packages/scheduled-updates/changelog/fix-accepted-args
+++ b/projects/packages/scheduled-updates/changelog/fix-accepted-args
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a bug where the cron callback did not accept more than one plugin to update.

--- a/projects/packages/scheduled-updates/changelog/fix-plugins-update-payload
+++ b/projects/packages/scheduled-updates/changelog/fix-plugins-update-payload
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a bug where only plugin slugs were send to the update handler instead of full update objects.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.4-alpha';
+	const PACKAGE_VERSION = '0.3.4';
 
 	/**
 	 * Initialize the class.

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2024-03-12
+### Changed
+- Internal updates.
+
 ## [2.1.1] - 2024-03-01
 ### Fixed
 - Avoid issues when the dns_get_record function is not defined [#36019]
@@ -310,6 +314,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[2.1.2]: https://github.com/Automattic/jetpack-status/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/Automattic/jetpack-status/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/Automattic/jetpack-status/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/Automattic/jetpack-status/compare/v2.0.1...v2.0.2

--- a/projects/packages/status/changelog/add-phan
+++ b/projects/packages/status/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.4 - 2024-03-12
+### Changed
+- Internal updates.
+
 ## 2.1.3 - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36309]

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-phan
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-phan
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add Phan configuration. No change to the project itself.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_4_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_4"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.4-alpha
+ * Version: 2.1.4
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.4-alpha",
+	"version": "2.1.4",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.4

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.