### PR TITLE
Newsletters: Add Filter for Timing of Subscribe Modal Pop-up

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscription-modal-load-time
+++ b/projects/plugins/jetpack/changelog/update-subscription-modal-load-time
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletters: Add filter that enables user to control the timing at which the Subscribe Modal loads.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -62,6 +62,19 @@ class Jetpack_Subscribe_Modal {
 		if ( $this->should_user_see_modal() ) {
 			wp_enqueue_style( 'subscribe-modal-css', plugins_url( 'subscribe-modal.css', __FILE__ ), array(), JETPACK__VERSION );
 			wp_enqueue_script( 'subscribe-modal-js', plugins_url( 'subscribe-modal.js', __FILE__ ), array( 'wp-dom-ready' ), JETPACK__VERSION, true );
+
+			/**
+			 * Filter how many milliseconds a user must scroll for until the Subscribe Modal appears.
+			 *
+			 * @module subscriptions
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param int 300 Time in milliseconds for the Subscribe Modal to appear upon scrolling.
+			 */
+			$load_time = absint( apply_filters( 'jetpack_subscribe_modal_load_time', 300 ) );
+
+			wp_localize_script( 'subscribe-modal-js', 'Jetpack_Subscriptions', array( 'loadTime' => $load_time ) );
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -74,7 +74,7 @@ class Jetpack_Subscribe_Modal {
 			 */
 			$load_time = absint( apply_filters( 'jetpack_subscribe_modal_load_time', 300 ) );
 
-			wp_localize_script( 'subscribe-modal-js', 'Jetpack_Subscriptions', array( 'loadTime' => $load_time ) );
+			wp_localize_script( 'subscribe-modal-js', 'Jetpack_Subscriptions', array( 'modalLoadTime' => $load_time ) );
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -1,3 +1,4 @@
+/* global Jetpack_Subscriptions */
 const { domReady } = wp;
 
 domReady( function () {
@@ -21,7 +22,7 @@ domReady( function () {
 			if ( ! hasLoaded ) {
 				openModal();
 			}
-		}, 300 );
+		}, Jetpack_Subscriptions.loadTime );
 	};
 
 	// User can edit modal, and could remove close link.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -22,7 +22,7 @@ domReady( function () {
 			if ( ! hasLoaded ) {
 				openModal();
 			}
-		}, Jetpack_Subscriptions.loadTime );
+		}, Jetpack_Subscriptions.modalLoadTime );
 	};
 
 	// User can edit modal, and could remove close link.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35743

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Newsletters: add filter that enables user to control the timing at which the Subscribe Modal loads.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See #35743.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

* Ensure that the Subscribe Modal pop-up (`Enable subscription pop-up when scrolling a post`) is set to display: `/wp-admin/admin.php?page=jetpack#/newsletter`
* Confirm that it currently loads after three seconds when loading a post 
* Add the following snippet

```php
add_filter( 'jetpack_subscribe_modal_load_time', 'custom_jetpack_subscribe_modal_load_time' );
function custom_jetpack_subscribe_modal_load_time( $load_time ) {
    return 5000; // 5 seconds.
}

```

* Confirm that it loads after five seconds (you'll need to use incognito if you've already dismissed it) 

cc @simison 