### PR TITLE
Scheduled Updates: Limit plugins number up to ten per schedule

### DIFF
--- a/projects/packages/scheduled-updates/changelog/update-limit-plugins-number
+++ b/projects/packages/scheduled-updates/changelog/update-limit-plugins-number
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Scheduled Updates: limit plugins up to ten per schedule

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -17,7 +17,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.4';
+	const PACKAGE_VERSION = '0.3.5-alpha';
 
 	/**
 	 * Initialize the class.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -328,12 +328,13 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function validate_plugins_param( $plugins ) {
-		if ( count( $plugins ) > 10 ) {
-			return new WP_Error(
-				'rest_invalid_param',
-				__( 'You can schedule a maximum of 10 plugins at one time.', 'jetpack-scheduled-updates' ),
-				array( 'status' => 400 )
-			);
+		$schema            = array(
+			'items'    => array( 'type' => 'string' ),
+			'maxItems' => 10,
+		);
+		$validated_plugins = rest_validate_array_value_from_schema( $plugins, $schema, 'plugins' );
+		if ( is_wp_error( $validated_plugins ) ) {
+			return $validated_plugins;
 		}
 
 		foreach ( $plugins as $plugin ) {
@@ -519,9 +520,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			'plugins'  => array(
 				'description'       => 'List of plugin slugs to update.',
 				'type'              => 'array',
-				'items'             => array(
-					'type' => 'string',
-				),
 				'validate_callback' => array( $this, 'validate_plugins_param' ),
 				'sanitize_callback' => array( $this, 'sanitize_plugins_param' ),
 			),

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -328,6 +328,14 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function validate_plugins_param( $plugins ) {
+		if ( count( $plugins ) > 10 ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				__( 'You can schedule a maximum of 10 plugins at one time.', 'jetpack-scheduled-updates' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		foreach ( $plugins as $plugin ) {
 			if ( ! $this->validate_plugin_param( $plugin ) ) {
 				return new WP_Error(

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -289,6 +289,43 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
+	 * Include over 10 plugins when creating a schedule.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_creating_schedule_with_more_than_ten_plugins() {
+		$plugins = array(
+			'plugin-1/plugin-1.php',
+			'plugin-2/plugin-2.php',
+			'plugin-3/plugin-3.php',
+			'plugin-4/plugin-4.php',
+			'plugin-5/plugin-5.php',
+			'plugin-6/plugin-6.php',
+			'plugin-7/plugin-7.php',
+			'plugin-8/plugin-8.php',
+			'plugin-9/plugin-9.php',
+			'plugin-10/plugin-10.php',
+			'plugin-11/plugin-11.php',
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params(
+			array(
+				'plugins'  => $plugins,
+				'schedule' => array(
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'interval'  => 'weekly',
+				),
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+		$this->assertSame( 400, $result->get_status() );
+		$this->assertSame( 'rest_invalid_param', $result->get_data()['code'] );
+	}
+
+	/**
 	 * Test get item.
 	 *
 	 * @covers ::get_item


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36369

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevent users from creating a schedule with more than 10 plugins. We've already limited this in the FE, and to unify both FE and BE, we are adding a check in this PR to handle this use case. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do a POST request to `/wpcom/v2/update-schedules` with more than 10 plugins, and you'll receive an error code with `rest_invalid_param` and an error message showing "You can schedule a maximum of 10 plugins at one time."
* Run unit test and make sure there's no fails.

