### PR TITLE
Improve WAF logging

### DIFF
--- a/projects/packages/waf/changelog/improve-waf-logs
+++ b/projects/packages/waf/changelog/improve-waf-logs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add data to WAF logs and add toggle for users to opt-in to share more data with us if needed.

--- a/projects/packages/waf/composer.json
+++ b/projects/packages/waf/composer.json
@@ -61,7 +61,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.15.x-dev"
+			"dev-trunk": "0.16.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/waf/src/class-rest-controller.php
+++ b/projects/packages/waf/src/class-rest-controller.php
@@ -121,7 +121,22 @@ class REST_Controller {
 
 		// Share Data
 		if ( isset( $request[ Waf_Runner::SHARE_DATA_OPTION_NAME ] ) ) {
+			// If a user disabled the regular share we should disable the debug share data option.
+			if ( false === $request[ Waf_Runner::SHARE_DATA_OPTION_NAME ] ) {
+				update_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, false );
+			}
+
 			update_option( Waf_Runner::SHARE_DATA_OPTION_NAME, (bool) $request[ Waf_Runner::SHARE_DATA_OPTION_NAME ] );
+		}
+
+		// Share Debug Data
+		if ( isset( $request[ Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME ] ) ) {
+			// If a user toggles the debug share we should enable the regular share data option.
+			if ( true === $request[ Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME ] ) {
+				update_option( Waf_Runner::SHARE_DATA_OPTION_NAME, true );
+			}
+
+			update_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, (bool) $request[ Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME ] );
 		}
 
 		// Brute Force Protection

--- a/projects/packages/waf/src/class-waf-constants.php
+++ b/projects/packages/waf/src/class-waf-constants.php
@@ -90,6 +90,10 @@ class Waf_Constants {
 			$share_data_option = get_option( Waf_Runner::SHARE_DATA_OPTION_NAME, false );
 			define( 'JETPACK_WAF_SHARE_DATA', $share_data_option );
 		}
+		if ( ! defined( 'JETPACK_WAF_SHARE_DEBUG_DATA' ) ) {
+			$share_debug_data_option = get_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, false );
+			define( 'JETPACK_WAF_SHARE_DEBUG_DATA', $share_debug_data_option );
+		}
 	}
 
 	/**

--- a/projects/packages/waf/src/class-waf-constants.php
+++ b/projects/packages/waf/src/class-waf-constants.php
@@ -87,11 +87,19 @@ class Waf_Constants {
 	 */
 	public static function define_share_data() {
 		if ( ! defined( 'JETPACK_WAF_SHARE_DATA' ) ) {
-			$share_data_option = get_option( Waf_Runner::SHARE_DATA_OPTION_NAME, false );
+			$share_data_option = false;
+			if ( function_exists( 'get_option' ) ) {
+				$share_data_option = get_option( Waf_Runner::SHARE_DATA_OPTION_NAME, false );
+			}
+
 			define( 'JETPACK_WAF_SHARE_DATA', $share_data_option );
 		}
 		if ( ! defined( 'JETPACK_WAF_SHARE_DEBUG_DATA' ) ) {
-			$share_debug_data_option = get_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, false );
+			$share_data_option = false;
+			if ( function_exists( 'get_option' ) ) {
+				$share_debug_data_option = get_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, false );
+			}
+
 			define( 'JETPACK_WAF_SHARE_DEBUG_DATA', $share_debug_data_option );
 		}
 	}

--- a/projects/packages/waf/src/class-waf-constants.php
+++ b/projects/packages/waf/src/class-waf-constants.php
@@ -95,7 +95,7 @@ class Waf_Constants {
 			define( 'JETPACK_WAF_SHARE_DATA', $share_data_option );
 		}
 		if ( ! defined( 'JETPACK_WAF_SHARE_DEBUG_DATA' ) ) {
-			$share_data_option = false;
+			$share_debug_data_option = false;
 			if ( function_exists( 'get_option' ) ) {
 				$share_debug_data_option = get_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, false );
 			}

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -16,9 +16,10 @@ use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
  */
 class Waf_Runner {
 
-	const WAF_MODULE_NAME        = 'waf';
-	const MODE_OPTION_NAME       = 'jetpack_waf_mode';
-	const SHARE_DATA_OPTION_NAME = 'jetpack_waf_share_data';
+	const WAF_MODULE_NAME              = 'waf';
+	const MODE_OPTION_NAME             = 'jetpack_waf_mode';
+	const SHARE_DATA_OPTION_NAME       = 'jetpack_waf_share_data';
+	const SHARE_DEBUG_DATA_OPTION_NAME = 'jetpack_waf_share_debug_data';
 
 	/**
 	 * Run the WAF
@@ -30,7 +31,11 @@ class Waf_Runner {
 			return;
 		}
 		Waf_Constants::define_mode();
-		Waf_Constants::define_share_data();
+
+		if ( ! self::get_standalone_mode_status() ) {
+			Waf_Constants::define_share_data();
+		}
+
 		if ( ! self::is_allowed_mode( JETPACK_WAF_MODE ) ) {
 			return;
 		}
@@ -163,6 +168,7 @@ class Waf_Runner {
 			Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME => get_option( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME ),
 			Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME => get_option( Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME ),
 			self::SHARE_DATA_OPTION_NAME                 => get_option( self::SHARE_DATA_OPTION_NAME ),
+			self::SHARE_DEBUG_DATA_OPTION_NAME           => get_option( self::SHARE_DEBUG_DATA_OPTION_NAME ),
 			'bootstrap_path'                             => self::get_bootstrap_file_path(),
 			'standalone_mode'                            => self::get_standalone_mode_status(),
 			'automatic_rules_available'                  => (bool) self::automatic_rules_available(),

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -31,10 +31,7 @@ class Waf_Runner {
 			return;
 		}
 		Waf_Constants::define_mode();
-
-		if ( ! self::get_standalone_mode_status() ) {
-			Waf_Constants::define_share_data();
-		}
+		Waf_Constants::define_share_data();
 
 		if ( ! self::is_allowed_mode( JETPACK_WAF_MODE ) ) {
 			return;

--- a/projects/packages/waf/src/class-waf-standalone-bootstrap.php
+++ b/projects/packages/waf/src/class-waf-standalone-bootstrap.php
@@ -140,9 +140,10 @@ class Waf_Standalone_Bootstrap {
 
 		$autoloader_file = $this->locate_autoloader_file();
 
-		$bootstrap_file    = $this->get_bootstrap_file_path();
-		$mode_option       = get_option( Waf_Runner::MODE_OPTION_NAME, false );
-		$share_data_option = get_option( Waf_Runner::SHARE_DATA_OPTION_NAME, false );
+		$bootstrap_file          = $this->get_bootstrap_file_path();
+		$mode_option             = get_option( Waf_Runner::MODE_OPTION_NAME, false );
+		$share_data_option       = get_option( Waf_Runner::SHARE_DATA_OPTION_NAME, false );
+		$share_debug_data_option = get_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, false );
 
 		// phpcs:disable WordPress.PHP.DevelopmentFunctions
 		$code = "<?php\n"
@@ -150,6 +151,7 @@ class Waf_Standalone_Bootstrap {
 			. "if ( defined( 'DISABLE_JETPACK_WAF' ) && DISABLE_JETPACK_WAF ) return;\n"
 			. sprintf( "define( 'JETPACK_WAF_MODE', %s );\n", var_export( $mode_option ? $mode_option : 'silent', true ) )
 			. sprintf( "define( 'JETPACK_WAF_SHARE_DATA', %s );\n", var_export( $share_data_option, true ) )
+			. sprintf( "define( 'JETPACK_WAF_SHARE_DEBUG_DATA', %s );\n", var_export( $share_debug_data_option, true ) )
 			. sprintf( "define( 'JETPACK_WAF_DIR', %s );\n", var_export( JETPACK_WAF_DIR, true ) )
 			. sprintf( "define( 'JETPACK_WAF_WPCONFIG', %s );\n", var_export( JETPACK_WAF_WPCONFIG, true ) )
 			. 'require_once ' . var_export( $autoloader_file, true ) . ";\n"

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -44,6 +44,7 @@ export const Waf = class extends Component {
 		ipBlockList: this.props.settings?.ipBlockList,
 		ipAllowList: this.props.settings?.ipAllowList,
 		shareData: this.props.settings?.shareData,
+		shareDebugData: this.props.settings?.shareDebugData,
 	};
 
 	/**
@@ -61,6 +62,7 @@ export const Waf = class extends Component {
 				ipBlockList: this.props.settings?.ipBlockList,
 				ipAllowList: this.props.settings?.ipAllowList,
 				shareData: this.props.settings?.shareData,
+				shareDebugData: this.props.settings?.shareDebugData,
 			} );
 		}
 
@@ -172,13 +174,32 @@ export const Waf = class extends Component {
 	 * Toggle share data.
 	 */
 	toggleShareData = () => {
-		this.setState(
-			{
-				...this.state,
-				shareData: ! this.state.shareData,
-			},
-			this.onSubmit
-		);
+		const state = {
+			...this.state,
+			shareData: ! this.state.shareData,
+		};
+
+		if ( ! state.shareData ) {
+			state.shareDebugData = state.shareData;
+		}
+
+		this.setState( state, this.onSubmit );
+	};
+
+	/**
+	 * Toggle share debug data.
+	 */
+	toggleShareDebugData = () => {
+		const state = {
+			...this.state,
+			shareDebugData: ! this.state.shareDebugData,
+		};
+
+		if ( state.shareDebugData ) {
+			state.shareData = state.shareDebugData;
+		}
+
+		this.setState( state, this.onSubmit );
 	};
 
 	render() {
@@ -332,7 +353,7 @@ export const Waf = class extends Component {
 					onChange={ this.toggleShareData }
 					label={
 						<div className="waf__settings__toggle-setting__label">
-							<span>{ __( 'Share data with Jetpack', 'jetpack' ) }</span>
+							<span>{ __( 'Share basic data with Jetpack', 'jetpack' ) }</span>
 							<InfoPopover
 								position="right"
 								screenReaderText={ __( 'Learn more', 'jetpack' ) }
@@ -340,7 +361,46 @@ export const Waf = class extends Component {
 							>
 								{ createInterpolateElement(
 									__(
-										'Allow Jetpack to collect data to improve Firewall protection and rules. <ExternalLink>Learn more</ExternalLink> <hr /> <ExternalLink>Privacy Information</ExternalLink>',
+										'Allow Jetpack to collect basic data from blocked requests to improve firewall protection and accuracy. <ExternalLink>Learn more</ExternalLink> <hr /> <ExternalLink>Privacy Information</ExternalLink>',
+										'jetpack'
+									),
+									{
+										ExternalLink: (
+											<ExternalLink
+												href={ getRedirectUrl( 'jetpack-waf-settings-privacy-info' ) }
+											/>
+										),
+										hr: <hr />,
+									}
+								) }
+							</InfoPopover>
+						</div>
+					}
+				/>
+			</div>
+		);
+
+		const shareDebugDataSettings = (
+			<div className="waf__settings__toggle-setting">
+				<ToggleControl
+					checked={ this.props.settings?.shareDebugData }
+					disabled={ baseInputDisabledCase }
+					toggling={
+						this.props.isUpdatingWafSettings &&
+						this.state.shareDebugData !== this.props.settings?.shareDebugData
+					}
+					onChange={ this.toggleShareDebugData }
+					label={
+						<div className="waf__settings__toggle-setting__label">
+							<span>{ __( 'Share detailed data with Jetpack', 'jetpack' ) }</span>
+							<InfoPopover
+								position="right"
+								screenReaderText={ __( 'Learn more', 'jetpack' ) }
+								className="waf__settings__share-data-popover"
+							>
+								{ createInterpolateElement(
+									__(
+										'Allow Jetpack to collect detailed data from blocked requests to enhance firewall protection and accuracy. <ExternalLink>Learn more</ExternalLink> <hr /> <ExternalLink>Privacy Information</ExternalLink>',
 										'jetpack'
 									),
 									{
@@ -471,6 +531,7 @@ export const Waf = class extends Component {
 							{ automaticRulesSettings }
 							{ ipListSettings }
 							{ shareDataSettings }
+							{ shareDebugDataSettings }
 						</FormFieldset>
 					) }
 				</SettingsGroup>

--- a/projects/plugins/jetpack/_inc/client/state/waf/actions.js
+++ b/projects/plugins/jetpack/_inc/client/state/waf/actions.js
@@ -55,6 +55,7 @@ export const updateWafIpAllowList = allowList => {
  * @param {string}  newSettings.ipAllowList        - The IP allow list.
  * @param {string}  newSettings.ipBlockList        - The IP block list.
  * @param {boolean} newSettings.shareData          - Whether to share data.
+ * @param {boolean} newSettings.shareDebugData     - Whether to share detailed data.
  * @returns {Function} - The action.
  */
 export const updateWafSettings = newSettings => {
@@ -69,6 +70,7 @@ export const updateWafSettings = newSettings => {
 				jetpack_waf_ip_allow_list: newSettings.ipAllowList,
 				jetpack_waf_ip_block_list: newSettings.ipBlockList,
 				jetpack_waf_share_data: newSettings.shareData,
+				jetpack_waf_share_debug_data: newSettings.shareDebugData,
 			} )
 			.then( settings => {
 				dispatch( {

--- a/projects/plugins/jetpack/_inc/client/state/waf/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/waf/reducer.js
@@ -27,6 +27,7 @@ export const data = ( state = {}, action ) => {
 				ipBlockList: action.settings?.jetpack_waf_ip_block_list || '',
 				shareData: Boolean( action.settings?.jetpack_waf_share_data ),
 				standaloneMode: Boolean( action.settings?.standalone_mode ),
+				shareDebugData: Boolean( action.settings?.jetpack_waf_share_debug_data ),
 			} );
 		case WAF_IP_ALLOW_LIST_UPDATED:
 			return assign( {}, state, {

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2394,7 +2394,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'settings',
 			),
 			'jetpack_waf_share_data'                => array(
-				'description'       => esc_html__( 'Share data with Jetpack.', 'jetpack' ),
+				'description'       => esc_html__( 'Share basic data with Jetpack.', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'waf',
+			),
+			'jetpack_waf_share_debug_data'          => array(
+				'description'       => esc_html__( 'Share detailed data with Jetpack.', 'jetpack' ),
 				'type'              => 'boolean',
 				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',

--- a/projects/plugins/jetpack/changelog/improve-waf-logs
+++ b/projects/plugins/jetpack/changelog/improve-waf-logs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add share debug data toggle on WAF settings

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2604,7 +2604,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/waf",
-				"reference": "12dc480f05fd60239d1aaa7d01d5c9c9ec1bb1bb"
+				"reference": "7c30728a366806da71f9eb62fb015980ae79ebb2"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2631,7 +2631,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.15.x-dev"
+					"dev-trunk": "0.16.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/protect/changelog/improve-waf-logs
+++ b/projects/plugins/protect/changelog/improve-waf-logs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add data to WAF logs and add toggle for users to opt-in to share more data with us if needed.

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -79,6 +79,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ2_1_1_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ2_2_0_alpha"
 	}
 }

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1597,7 +1597,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/waf",
-                "reference": "12dc480f05fd60239d1aaa7d01d5c9c9ec1bb1bb"
+                "reference": "7c30728a366806da71f9eb62fb015980ae79ebb2"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1624,7 +1624,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.15.x-dev"
+                    "dev-trunk": "0.16.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/jetpack-protect.php
+++ b/projects/plugins/protect/jetpack-protect.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Protect
  * Plugin URI: https://wordpress.org/plugins/jetpack-protect
  * Description: Security tools that keep your site safe and sound, from posts to plugins.
- * Version: 2.1.1-alpha
+ * Version: 2.2.0-alpha
  * Author: Automattic - Jetpack Security team
  * Author URI: https://jetpack.com/protect/
  * License: GPLv2 or later
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'JETPACK_PROTECT_VERSION', '2.1.1-alpha' );
+define( 'JETPACK_PROTECT_VERSION', '2.2.0-alpha' );
 define( 'JETPACK_PROTECT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_PROTECT_ROOT_FILE', __FILE__ );
 define( 'JETPACK_PROTECT_ROOT_FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );

--- a/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-footer/index.jsx
@@ -43,6 +43,72 @@ const StandaloneMode = () => {
 	);
 };
 
+const ShareDebugData = () => {
+	const { config, isUpdating, toggleShareDebugData } = useWafData();
+	const { jetpackWafShareDebugData } = config || {};
+	const { setNotice } = useDispatch( STORE_ID );
+
+	const [ settings, setSettings ] = useState( {
+		jetpack_waf_share_debug_data: jetpackWafShareDebugData,
+	} );
+
+	const handleShareDebugDataChange = useCallback( () => {
+		setSettings( {
+			...settings,
+			jetpack_waf_share_debug_data: ! settings.jetpack_waf_share_debug_data,
+		} );
+		toggleShareDebugData()
+			.then( () =>
+				setNotice( {
+					type: 'success',
+					duration: 5000,
+					dismissable: true,
+					message: __( 'Changes saved.', 'jetpack-protect' ),
+				} )
+			)
+			.catch( () => {
+				setNotice( {
+					type: 'error',
+					dismissable: true,
+					message: createInterpolateElement(
+						__(
+							'An error ocurred. Please try again or <supportLink>contact support</supportLink>.',
+							'jetpack-protect'
+						),
+						{
+							supportLink: <ExternalLink href={ PLUGIN_SUPPORT_URL } />,
+						}
+					),
+				} );
+			} );
+	}, [ settings, toggleShareDebugData, setNotice ] );
+
+	useEffect( () => {
+		setSettings( {
+			jetpack_waf_share_debug_data: jetpackWafShareDebugData,
+		} );
+	}, [ jetpackWafShareDebugData ] );
+
+	return (
+		<div className={ styles[ 'share-data-section' ] }>
+			<Title mb={ 2 }>{ __( ' Share detailed data with Jetpack', 'jetpack-protect' ) }</Title>
+			<div className={ styles[ 'footer-checkbox' ] }>
+				<CheckboxControl
+					checked={ Boolean( settings.jetpack_waf_share_debug_data ) }
+					onChange={ handleShareDebugDataChange }
+					disabled={ isUpdating }
+				/>
+				<Text>
+					{ __(
+						'Allow Jetpack to collect detailed data from blocked requests to enhance firewall protection and accuracy.',
+						'jetpack-protect'
+					) }
+				</Text>
+			</div>
+		</div>
+	);
+};
+
 const ShareData = () => {
 	const { config, isUpdating, toggleShareData } = useWafData();
 	const { jetpackWafShareData } = config || {};
@@ -88,7 +154,7 @@ const ShareData = () => {
 
 	return (
 		<div className={ styles[ 'share-data-section' ] }>
-			<Title mb={ 2 }>{ __( ' Share data with Jetpack', 'jetpack-protect' ) }</Title>
+			<Title mb={ 2 }>{ __( ' Share basic data with Jetpack', 'jetpack-protect' ) }</Title>
 			<div className={ styles[ 'footer-checkbox' ] }>
 				<CheckboxControl
 					checked={ Boolean( settings.jetpack_waf_share_data ) }
@@ -97,7 +163,7 @@ const ShareData = () => {
 				/>
 				<Text>
 					{ __(
-						'Allow Jetpack to collect data to improve firewall protection and rules. Collected data is also used to display advanced usage metrics.',
+						'Allow Jetpack to collect basic data from blocked requests to improve firewall protection and accuracy.',
 						'jetpack-protect'
 					) }
 				</Text>
@@ -113,7 +179,14 @@ const FirewallFooter = () => {
 		<AdminSectionHero>
 			<SeventyFiveLayout
 				main={ <StandaloneMode /> }
-				secondary={ isEnabled && <ShareData /> }
+				secondary={
+					isEnabled && (
+						<>
+							<ShareData />
+							<ShareDebugData />
+						</>
+					)
+				}
 				preserveSecondaryOnMobile={ true }
 			/>
 		</AdminSectionHero>

--- a/projects/plugins/protect/src/js/hooks/use-waf-data/index.jsx
+++ b/projects/plugins/protect/src/js/hooks/use-waf-data/index.jsx
@@ -111,6 +111,21 @@ const useWafData = () => {
 	}, [ ensureModuleIsEnabled, refreshWaf, setWafIsUpdating, waf.config.jetpackWafShareData ] );
 
 	/**
+	 * Toggle Share Debug Data
+	 *
+	 * Flips the switch on the share debug data option, and then refreshes the data.
+	 */
+	const toggleShareDebugData = useCallback( () => {
+		setWafIsUpdating( true );
+		return ensureModuleIsEnabled()
+			.then( () =>
+				API.updateWaf( { jetpack_waf_share_debug_data: ! waf.config.jetpackWafShareDebugData } )
+			)
+			.then( refreshWaf )
+			.finally( () => setWafIsUpdating( false ) );
+	}, [ ensureModuleIsEnabled, refreshWaf, setWafIsUpdating, waf.config.jetpackWafShareDebugData ] );
+
+	/**
 	 * Update WAF Config
 	 */
 	const updateConfig = useCallback(
@@ -140,6 +155,7 @@ const useWafData = () => {
 		toggleManualRules,
 		toggleBruteForceProtection,
 		toggleShareData,
+		toggleShareDebugData,
 		updateConfig,
 	};
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds more information to the WAF logs
* Adds a new toggle that allow users to opt-in to share more detailed debug data such as POST params and request headers for blocked requests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes. This PR increases the data that we collect for the WAF logs for blocked requests (GET params, user-agent, referer, content-type, request uri) and adds a opt-in toggle to share with us some more additional data (post params and request headers).

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a test site with a Scan subscription.
* Install Protect and toggle the share data and share debug data on.
* Make a few requests that are to be blocked.
* Verify that the information was properly logged in the log file.
* Turn off the debug data and verify that the post params and headers aren't being logged.

