### PR TITLE
Add/jetpack search custom results

### DIFF
--- a/projects/packages/search/changelog/add-jetpack-search-custom-results
+++ b/projects/packages/search/changelog/add-jetpack-search-custom-results
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: Add ability to customize results

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -229,6 +229,7 @@ class SearchApp extends Component {
 			postsPerPage: this.props.options.postsPerPage,
 			adminQueryFilter: this.props.options.adminQueryFilter,
 			highlightFields: this.props.options.highlightFields,
+			customResults: this.props.options.customResults,
 			isInCustomizer: this.props.isInCustomizer,
 		} );
 	};

--- a/projects/packages/search/src/instant-search/components/search-result.jsx
+++ b/projects/packages/search/src/instant-search/components/search-result.jsx
@@ -18,6 +18,17 @@ class SearchResult extends Component {
 	}
 
 	getCommonTrainTracksProps() {
+		let uiAlgo = 'jetpack-instant-search-ui/v1';
+		if ( this.props.resultFormat === RESULT_FORMAT_PRODUCT ) {
+			uiAlgo = uiAlgo + '-product';
+		} else if ( this.props.resultFormat === RESULT_FORMAT_EXPANDED ) {
+			uiAlgo = uiAlgo + '-expanded';
+		} else {
+			uiAlgo = uiAlgo + '-minimal';
+		}
+		if ( this.props.result.custom ) {
+			uiAlgo = uiAlgo + '-custom';
+		}
 		return {
 			fetch_algo: this.props.railcar.fetch_algo,
 			fetch_position: this.props.railcar.fetch_position,
@@ -26,8 +37,7 @@ class SearchResult extends Component {
 			rec_blog_id: this.props.railcar.rec_blog_id,
 			rec_post_id: this.props.railcar.rec_post_id,
 			session_id: this.props.railcar.session_id,
-			// TODO: Add a way to differentiate between different result formats
-			ui_algo: 'jetpack-instant-search-ui/v1',
+			ui_algo: uiAlgo,
 			ui_position: this.props.index,
 		};
 	}

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -335,8 +335,18 @@ function generateApiQueryString( {
 	}
 
 	// Support customized search results by promoting certain documents to the top for specific queries
-	for ( const [ customQuery, postIds ] of Object.entries( customResults ) ) {
-		if ( customQuery === query ) {
+	// By default we do exact matches, but also allow for regex, if the pattern
+	// starts with "regex:". For regex, we anchor the pattern to the start and
+	// end of the query. If the user really wants to match anywhere within the
+	// query, they can use for example ".*hello.*"
+	for ( const [ queryPattern, postIds ] of Object.entries( customResults ) ) {
+		if ( queryPattern.startsWith( 'regex:' ) ) {
+			const pattern = '^' + queryPattern.replace( 'regex:', '' ) + '$';
+			if ( query.match( pattern ) ) {
+				params.custom_results = postIds;
+				break;
+			}
+		} else if ( query === queryPattern ) {
 			params.custom_results = postIds;
 			break;
 		}

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -353,6 +353,7 @@ function generateApiQueryString( {
 			params.custom_results = postIds;
 			return false;
 		}
+		return true;
 	} );
 
 	if ( staticFilters && Object.keys( staticFilters ).length > 0 ) {

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -339,18 +339,21 @@ function generateApiQueryString( {
 	// starts with "regex:". For regex, we anchor the pattern to the start and
 	// end of the query. If the user really wants to match anywhere within the
 	// query, they can use for example ".*hello.*"
-	for ( const [ queryPattern, postIds ] of Object.entries( customResults ) ) {
-		if ( queryPattern.startsWith( 'regex:' ) ) {
-			const pattern = '^' + queryPattern.replace( 'regex:', '' ) + '$';
+	//
+	customResults.every( rule => {
+		let pattern = rule.pattern;
+		const postIds = rule.ids;
+		if ( pattern.startsWith( 'regex:' ) ) {
+			pattern = '^' + pattern.replace( 'regex:', '' ) + '$';
 			if ( query.match( pattern ) ) {
 				params.custom_results = postIds;
-				break;
+				return false;
 			}
-		} else if ( query === queryPattern ) {
+		} else if ( query === pattern ) {
 			params.custom_results = postIds;
-			break;
+			return false;
 		}
-	}
+	} );
 
 	if ( staticFilters && Object.keys( staticFilters ).length > 0 ) {
 		params = {

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -263,7 +263,7 @@ function generateApiQueryString( {
 	isInCustomizer = false,
 	additionalBlogIds = [],
 	highlightFields = [ 'title', 'content', 'comments' ],
-	customResults = [],
+	customResults = {},
 } ) {
 	if ( query === null ) {
 		query = '';
@@ -335,9 +335,11 @@ function generateApiQueryString( {
 	}
 
 	// Support customized search results by promoting certain documents to the top for specific queries
-	if ( customResults?.length > 0 ) {
-		// `blog_id` is required when additional_blog_ids is set.
-		params.custom_results = customResults;
+	for ( const [ customQuery, postIds ] of Object.entries( customResults ) ) {
+		if ( customQuery === query ) {
+			params.custom_results = postIds;
+			break;
+		}
 	}
 
 	if ( staticFilters && Object.keys( staticFilters ).length > 0 ) {

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -263,6 +263,7 @@ function generateApiQueryString( {
 	isInCustomizer = false,
 	additionalBlogIds = [],
 	highlightFields = [ 'title', 'content', 'comments' ],
+	customResults = [],
 } ) {
 	if ( query === null ) {
 		query = '';
@@ -331,6 +332,12 @@ function generateApiQueryString( {
 		// `blog_id` is required when additional_blog_ids is set.
 		params.fields = fields.concat( [ 'author', 'blog_name', 'blog_icon_url', 'blog_id' ] );
 		params.additional_blog_ids = additionalBlogIds;
+	}
+
+	// Support customized search results by promoting certain documents to the top for specific queries
+	if ( customResults?.length > 0 ) {
+		// `blog_id` is required when additional_blog_ids is set.
+		params.custom_results = customResults;
 	}
 
 	if ( staticFilters && Object.keys( staticFilters ).length > 0 ) {

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -263,7 +263,7 @@ function generateApiQueryString( {
 	isInCustomizer = false,
 	additionalBlogIds = [],
 	highlightFields = [ 'title', 'content', 'comments' ],
-	customResults = {},
+	customResults = [],
 } ) {
 	if ( query === null ) {
 		query = '';

--- a/projects/plugins/jetpack/changelog/add-jetpack-search-custom-results
+++ b/projects/plugins/jetpack/changelog/add-jetpack-search-custom-results
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Search: add ability to customize order of results

--- a/projects/plugins/search/changelog/add-jetpack-search-custom-results
+++ b/projects/plugins/search/changelog/add-jetpack-search-custom-results
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: Added ability to customize results

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -26,12 +26,7 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
-<<<<<<< HEAD
 define( 'JETPACK_SEARCH_PLUGIN__VERSION', '3.0.1' );
-=======
-define( 'JETPACK_SEARCH_PLUGIN__VERSION', '2.2.0-alpha' );
->>>>>>> 12e5b707eb (updated version numbers)
-
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 
 defined( 'JETPACK__API_BASE' ) || define( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -26,7 +26,11 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
+<<<<<<< HEAD
 define( 'JETPACK_SEARCH_PLUGIN__VERSION', '3.0.1' );
+=======
+define( 'JETPACK_SEARCH_PLUGIN__VERSION', '2.2.0-alpha' );
+>>>>>>> 12e5b707eb (updated version numbers)
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We frequently get requests from website owners who would like specific posts to be returned for specific queries. This can be thought of as "pinned posts" or "sponsored posts". This change adds the ability to specify which posts should be put at the top of search results for given queries. 

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

The queries and matching documents can be specified in PHP, e.g. in a theme's `functions.php` file like so
```
add_action( 'init', 'twentytwentyfour_pattern_categories' );

function jps_custom_results( $options ) {
  $custom_results = get_option( 'jetpack_search_custom_results' );
  if ( $custom _results ) {
    $options['customResults'] = $custom_results;
  } else {
    $options['customResults'] = array(
      array(
        'pattern' => 'best WordPress plugins',
        'ids' => array(
            "123-p-8",
            "456-9",
        ),
      ),
      array(
        'pattern' => 'regex:(how )?(to )develop WordPress',
        'ids' => array(
          "123-p-6",
        ),
      ),
    );
  }
    return $options;
}

add_filter( 'jetpack_instant_search_options', 'jps_custom_results' );
```
Note that the document ids are of the form `<blog_id>-p-<post_id>'. This format is relatively easy to understand, though it does require one to know the blog_id of their site. This can be found by inspecting the queries to the public API when performing a search in the developer tools of a browser. The format is also flexible enough such that if you are searching across multiple blogs simultaneously, it allows one to specify pinned posts from multiple blogs. Also note that the order in which the ids are coded is the order in which the results will be returned. It is possible to specify up to 100 documents IDs for a given query pattern. If you specify more, it will simply be truncated. 

There are two types of queries - by default, we will use exact matching. However, it is also possible to specify a query with a regular expression by preceding the query with "regex:". The regexes are evaluated anchored to the beginning and end of the query, such that "regex:hello.*world" will match the query string "hello beautiful world", but not "i say hello to the world" or "hello world i love you". If you would like to get rid of this anchoring, you can add ".*" at the beginning or end of your pattern (or both). This is similar to how regular expressions work in Java. The reasoning behind this is that regular expressions are complicated and it is easy for inexperience developers to get in trouble with them, so we are trying to avoid that as much as possible. Note that the order in which the rules are added is important. The first matching rule will be used.

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

For now, I think we should only implement this with advanced users in mind, thus requiring PHP code. In the future, we might want to create a UI/UX to allow users to add rules in wp-admin.

We may also want to add a way to mark that these posts are being artificially added to the top of the search results. 

<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
In order to test this you will need a Jetpack site with Jetpack Search installed and active. In order to activate Jetpack Search you must have a user connection and purchase it. You can purchase the free plan. You will need to make sure that the site is properly synced and that the site has been indexed. You can check this by looking at the Jetpack Debugger or by looking at the Jetpack Search settings page, which will tell you how many documents have been indexed. 

You also need to sandbox the public api, and apply this patch on your sandbox:  D165510-code
After applying that patch, edit `public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-search-site-v1-3-endpoint.php` adding a line like this around line 561: Use whatever blog_id you are testing with.
```
				$all_a8c_p2s[] = 211634998;
```
We are only allowing the custom results functionality on a limited number of sites right now. That is why you need to add it manually there. 

Add several posts of your choosing. I tested by adding a post with the title "hello universe". I then added a rule saying that searching for "hello world" should return the "hello universe" post on top, even though the default "hello world" post would be a better match. I added this in my themes functions.php file like so:
```
add_action( 'init', 'twentytwentyfour_pattern_categories' );
function jps_custom_results( $options ) {
    $options['customResults'] = array(
        array(
            'pattern' => 'regex:aff.*',
            'ids' => array( "211634998-p-6",)
        ),
        array(
            'pattern' => 'hello world',
            'ids' => array( "211634998-p-6",)
        ),
    );
    return $options;
}
add_filter( 'jetpack_instant_search_options', 'jps_custom_results' );
```
After adding this to the functions.php file, if you perform a search on your site, you should see the "hello universe" post come out as the top result

<img width="1114" alt="Bildschirmfoto 2024-03-13 um 19 42 30" src="https://github.com/Automattic/jetpack/assets/19924/54eede28-7b13-4761-aab0-4fa32f0a41de">
<img width="1128" alt="Bildschirmfoto 2024-03-13 um 19 42 51" src="https://github.com/Automattic/jetpack/assets/19924/45e45609-64d3-4ada-89e1-d757117efb61">