### PR TITLE
Contact Info: add name and image fields for Schema markup

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-contact-info-block-meta
+++ b/projects/plugins/jetpack/changelog/fix-contact-info-block-meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Contact Info: add name and image fields for Schema markup

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/block.json
@@ -29,6 +29,12 @@
 		"attributes": {},
 		"innerBlocks": [
 			{
+				"name": "jetpack/name",
+				"attributes": {
+					"name": "Your Organization Name"
+				}
+			},
+			{
 				"name": "jetpack/email",
 				"attributes": {
 					"email": "hello@yourjetpack.blog"

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/block.json
@@ -35,6 +35,16 @@
 				}
 			},
 			{
+				"name": "jetpack/image",
+				"attributes": {
+					"image": {
+						"id": 123,
+						"url": "https://example.com/image.jpg",
+						"alt": "Your Organization Name"
+					}
+				}
+			},
+			{
 				"name": "jetpack/email",
 				"attributes": {
 					"email": "hello@yourjetpack.blog"

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
@@ -83,6 +83,21 @@ class Jetpack_Contact_Info_Block {
 	}
 
 	/**
+	 * Adds name schema attributes.
+	 *
+	 * @param array  $attr    Array containing the name block attributes.
+	 * @param string $content String containing the name block content.
+	 *
+	 * @return string
+	 */
+	public static function render_name( $attr, $content ) {
+		$content = self::has_attributes( $attr, array( 'className' ) ) ?
+			str_replace( 'class="wp-block-jetpack-name"', 'itemprop="name" class="wp-block-jetpack-name"', $content ) :
+			'';
+		return $content;
+	}
+
+	/**
 	 * Adds email schema attributes.
 	 *
 	 * @param array  $attr    Array containing the email block attributes.

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
@@ -98,6 +98,32 @@ class Jetpack_Contact_Info_Block {
 	}
 
 	/**
+	 * Adds name schema attributes.
+	 *
+	 * @param array  $attr    Array containing the image block attributes.
+	 * @param string $content String containing the image block content.
+	 *
+	 * @return string
+	 */
+	public static function render_image( $attr, $content ) {
+		$image = $attr['image'];
+
+		if ( isset( $image ) ) {
+			return str_replace(
+				'</div>',
+				sprintf(
+					'<img itemprop="image" src="%1$s" alt="%2$s"/></div>',
+					isset( $image['url'] ) ? esc_attr( $image['url'] ) : '',
+					isset( $image['alt'] ) ? esc_attr( $image['alt'] ) : ''
+				),
+				$content
+			);
+		}
+
+		return '';
+	}
+
+	/**
 	 * Adds email schema attributes.
 	 *
 	 * @param array  $attr    Array containing the email block attributes.

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
@@ -108,12 +108,12 @@ class Jetpack_Contact_Info_Block {
 	public static function render_image( $attr, $content ) {
 		$image = $attr['image'];
 
-		if ( isset( $image ) ) {
+		if ( isset( $image ) && isset( $image['url'] ) ) {
 			return str_replace(
-				'</div>',
+				'<div class="wp-block-jetpack-image"></div>',
 				sprintf(
-					'<img itemprop="image" src="%1$s" alt="%2$s"/></div>',
-					isset( $image['url'] ) ? esc_attr( $image['url'] ) : '',
+					'<div class="wp-block-jetpack-image"><img itemprop="image" src="%1$s" alt="%2$s"/></div>',
+					esc_attr( $image['url'] ),
 					isset( $image['alt'] ) ? esc_attr( $image['alt'] ) : ''
 				),
 				$content

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/contact-info.php
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/contact-info.php
@@ -17,6 +17,14 @@ Blocks::jetpack_register_block(
 );
 
 Blocks::jetpack_register_block(
+	'jetpack/name',
+	array(
+		'parent'          => array( 'jetpack/contact-info' ),
+		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_name' ),
+	)
+);
+
+Blocks::jetpack_register_block(
 	'jetpack/address',
 	array(
 		'parent'          => array( 'jetpack/contact-info' ),

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/contact-info.php
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/contact-info.php
@@ -25,6 +25,14 @@ Blocks::jetpack_register_block(
 );
 
 Blocks::jetpack_register_block(
+	'jetpack/image',
+	array(
+		'parent'          => array( 'jetpack/contact-info' ),
+		'render_callback' => array( 'Jetpack_Contact_Info_Block', 'render_image' ),
+	)
+);
+
+Blocks::jetpack_register_block(
 	'jetpack/address',
 	array(
 		'parent'          => array( 'jetpack/contact-info' ),

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/edit.js
@@ -7,6 +7,7 @@ const ALLOWED_BLOCKS = [
 	'jetpack/email',
 	'jetpack/phone',
 	'jetpack/map',
+	'jetpack/name',
 	'jetpack/business-hours',
 	'core/paragraph',
 	'core/image',
@@ -25,7 +26,12 @@ const ALLOWED_BLOCKS = [
 	'core/video',
 ];
 
-const TEMPLATE = [ [ 'jetpack/email' ], [ 'jetpack/phone' ], [ 'jetpack/address' ] ];
+const TEMPLATE = [
+	[ 'jetpack/name' ],
+	[ 'jetpack/email' ],
+	[ 'jetpack/phone' ],
+	[ 'jetpack/address' ],
+];
 
 const ContactInfoEdit = props => {
 	const { isSelected } = props;

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/edit.js
@@ -5,6 +5,7 @@ const ALLOWED_BLOCKS = [
 	'jetpack/markdown',
 	'jetpack/address',
 	'jetpack/email',
+	'jetpack/image',
 	'jetpack/phone',
 	'jetpack/map',
 	'jetpack/name',
@@ -27,6 +28,7 @@ const ALLOWED_BLOCKS = [
 ];
 
 const TEMPLATE = [
+	[ 'jetpack/image' ],
 	[ 'jetpack/name' ],
 	[ 'jetpack/email' ],
 	[ 'jetpack/phone' ],

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/edit.js
@@ -11,7 +11,6 @@ const ALLOWED_BLOCKS = [
 	'jetpack/name',
 	'jetpack/business-hours',
 	'core/paragraph',
-	'core/image',
 	'core/heading',
 	'core/gallery',
 	'core/list',

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/edit.native.js
@@ -5,6 +5,7 @@ import styles from './editor.scss';
 const ALLOWED_BLOCKS = [
 	'jetpack/address',
 	'jetpack/email',
+	'jetpack/image',
 	'jetpack/name',
 	'jetpack/phone',
 	'core/heading',
@@ -13,6 +14,7 @@ const ALLOWED_BLOCKS = [
 ];
 
 const TEMPLATE = [
+	[ 'jetpack/image' ],
 	[ 'jetpack/name' ],
 	[ 'jetpack/email' ],
 	[ 'jetpack/phone' ],

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/edit.native.js
@@ -5,13 +5,19 @@ import styles from './editor.scss';
 const ALLOWED_BLOCKS = [
 	'jetpack/address',
 	'jetpack/email',
+	'jetpack/name',
 	'jetpack/phone',
 	'core/heading',
 	'core/separator',
 	'core/spacer',
 ];
 
-const TEMPLATE = [ [ 'jetpack/email' ], [ 'jetpack/phone' ], [ 'jetpack/address' ] ];
+const TEMPLATE = [
+	[ 'jetpack/name' ],
+	[ 'jetpack/email' ],
+	[ 'jetpack/phone' ],
+	[ 'jetpack/address' ],
+];
 
 const ContactInfoEdit = () => {
 	return (

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/edit.native.js
@@ -5,7 +5,6 @@ import styles from './editor.scss';
 const ALLOWED_BLOCKS = [
 	'jetpack/address',
 	'jetpack/email',
-	'jetpack/image',
 	'jetpack/name',
 	'jetpack/phone',
 	'core/heading',
@@ -14,7 +13,6 @@ const ALLOWED_BLOCKS = [
 ];
 
 const TEMPLATE = [
-	[ 'jetpack/image' ],
 	[ 'jetpack/name' ],
 	[ 'jetpack/email' ],
 	[ 'jetpack/phone' ],

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/editor.js
@@ -4,6 +4,7 @@ import { name as addressName, settings as addressSettings } from './address/';
 import metadata from './block.json';
 import edit from './edit';
 import { name as emailName, settings as emailSettings } from './email/';
+import { name as imageName, settings as imageSettings } from './image';
 import { name, settings as nameSettings } from './name';
 import { name as phoneName, settings as phoneSettings } from './phone/';
 import save from './save';
@@ -70,6 +71,7 @@ registerJetpackBlockFromMetadata(
 		},
 	},
 	[
+		{ name: imageName, settings: imageSettings },
 		{ name, settings: nameSettings },
 		{ name: addressName, settings: addressSettings },
 		{ name: emailName, settings: emailSettings },

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/editor.js
@@ -4,6 +4,7 @@ import { name as addressName, settings as addressSettings } from './address/';
 import metadata from './block.json';
 import edit from './edit';
 import { name as emailName, settings as emailSettings } from './email/';
+import { name, settings as nameSettings } from './name';
 import { name as phoneName, settings as phoneSettings } from './phone/';
 import save from './save';
 
@@ -31,6 +32,9 @@ registerJetpackBlockFromMetadata(
 						let innerBlocks = [
 							createBlock( 'core/heading', {
 								content: instance.raw.title,
+							} ),
+							createBlock( 'jetpack/name', {
+								name: instance.raw.name,
 							} ),
 							createBlock( 'jetpack/email', {
 								email: instance.raw.email,
@@ -66,6 +70,7 @@ registerJetpackBlockFromMetadata(
 		},
 	},
 	[
+		{ name, settings: nameSettings },
 		{ name: addressName, settings: addressSettings },
 		{ name: emailName, settings: emailSettings },
 		{ name: phoneName, settings: phoneSettings },

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/editor.scss
@@ -19,6 +19,12 @@
 		border-radius: 4px;
 		resize: none;
 	}
+
+	.components-placeholder.block-editor-media-placeholder {
+		margin-bottom: 1.5rem;
+
+		box-shadow: none;
+	}
 }
 
 // Overrides to make the preview look good

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/image/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/image/edit.js
@@ -1,0 +1,33 @@
+import { MediaPlaceholder } from '@wordpress/block-editor';
+import { withNotices } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+
+const ImageEdit = props => {
+	const { attributes, noticeOperations, noticeUI, setAttributes } = props;
+	const { image } = attributes;
+
+	const onChange = ( { id, url, alt } ) => {
+		setAttributes( { image: { id, url, alt } } );
+	};
+
+	if ( image && image.url ) {
+		return <img id={ image.id } src={ image.url } alt={ image.alt } />;
+	}
+
+	return (
+		<MediaPlaceholder
+			labels={ {
+				title: __( 'Logo', 'jetpack' ),
+				instructions: __( 'Upload an image to represent your organization.', 'jetpack' ),
+			} }
+			accept="image/*"
+			allowedTypes={ [ 'image' ] }
+			onSelect={ onChange }
+			onError={ msg => noticeOperations.createErrorNotice( msg ) }
+			notices={ noticeUI }
+		/>
+	);
+};
+
+export default compose( [ withNotices ] )( ImageEdit );

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/image/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/image/editor.js
@@ -1,0 +1,4 @@
+import registerJetpackBlock from '../../../shared/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/image/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/image/index.js
@@ -1,0 +1,29 @@
+import { Path } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import renderMaterialIcon from '../../../shared/render-material-icon';
+import edit from './edit';
+import save from './save';
+
+const attributes = {
+	image: {
+		type: 'object',
+		default: null,
+	},
+};
+
+export const name = 'image';
+
+export const settings = {
+	title: __( 'Image', 'jetpack' ),
+	description: __( 'Lets you add an image with Schema markup.', 'jetpack' ),
+	keywords: [],
+	// Same icon as the contact-info block
+	icon: renderMaterialIcon(
+		<Path d="M2.25 1h15.5c0.69 0 1.25 0.56 1.25 1.25v15.5c0 0.69-0.56 1.25-1.25 1.25h-15.5c-0.69 0-1.25-0.56-1.25-1.25v-15.5c0-0.69 0.56-1.25 1.25-1.25zM17 17v-14h-14v14h14zM10 6c0-1.1-0.9-2-2-2s-2 0.9-2 2 0.9 2 2 2 2-0.9 2-2zM13 11c0 0 0-6 3-6v10c0 0.55-0.45 1-1 1h-10c-0.55 0-1-0.45-1-1v-7c2 0 3 4 3 4s1-3 3-3 3 2 3 2z" />
+	),
+	category: 'grow',
+	attributes,
+	parent: [ 'jetpack/contact-info' ],
+	edit,
+	save,
+};

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/image/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/image/index.js
@@ -17,7 +17,6 @@ export const settings = {
 	title: __( 'Image', 'jetpack' ),
 	description: __( 'Lets you add an image with Schema markup.', 'jetpack' ),
 	keywords: [],
-	// Same icon as the contact-info block
 	icon: renderMaterialIcon(
 		<Path d="M2.25 1h15.5c0.69 0 1.25 0.56 1.25 1.25v15.5c0 0.69-0.56 1.25-1.25 1.25h-15.5c-0.69 0-1.25-0.56-1.25-1.25v-15.5c0-0.69 0.56-1.25 1.25-1.25zM17 17v-14h-14v14h14zM10 6c0-1.1-0.9-2-2-2s-2 0.9-2 2 0.9 2 2 2 2-0.9 2-2zM13 11c0 0 0-6 3-6v10c0 0.55-0.45 1-1 1h-10c-0.55 0-1-0.45-1-1v-7c2 0 3 4 3 4s1-3 3-3 3 2 3 2z" />
 	),

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/image/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/image/save.js
@@ -1,0 +1,4 @@
+const save = ( { attributes: { image }, className } ) =>
+	image && <div className={ className }>{ image }</div>;
+
+export default save;

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/name/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/name/edit.js
@@ -1,0 +1,12 @@
+import { __ } from '@wordpress/i18n';
+import simpleInput from '../../../shared/simple-input';
+import save from './save';
+
+const NameEdit = props => {
+	const { setAttributes } = props;
+	return simpleInput( 'name', props, __( 'Name', 'jetpack' ), save, nextValue =>
+		setAttributes( { name: nextValue } )
+	);
+};
+
+export default NameEdit;

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/name/edit.native.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/name/edit.native.js
@@ -1,0 +1,15 @@
+import { __ } from '@wordpress/i18n';
+import CommonChildEdit from '../common';
+import save from './save';
+
+const NameEdit = props => (
+	<CommonChildEdit
+		{ ...props }
+		type={ 'name' }
+		save={ save }
+		label={ __( 'Name', 'jetpack' ) }
+		attributeKey={ 'name' }
+	/>
+);
+
+export default NameEdit;

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/name/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/name/editor.js
@@ -1,0 +1,4 @@
+import registerJetpackBlock from '../../../shared/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/name/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/name/index.js
@@ -1,0 +1,29 @@
+import { Path } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import renderMaterialIcon from '../../../shared/render-material-icon';
+import edit from './edit';
+import save from './save';
+
+const attributes = {
+	name: {
+		type: 'string',
+		default: '',
+	},
+};
+
+export const name = 'name';
+
+export const settings = {
+	title: __( 'Name', 'jetpack' ),
+	description: __( 'Lets you add a name with Schema markup.', 'jetpack' ),
+	keywords: [],
+	// Same icon as the contact-info block
+	icon: renderMaterialIcon(
+		<Path d="M19 5v14H5V5h14m0-2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 9c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3zm0-4c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1zm6 10H6v-1.53c0-2.5 3.97-3.58 6-3.58s6 1.08 6 3.58V18zm-9.69-2h7.38c-.69-.56-2.38-1.12-3.69-1.12s-3.01.56-3.69 1.12z" />
+	),
+	category: 'grow',
+	attributes,
+	parent: [ 'jetpack/contact-info' ],
+	edit,
+	save,
+};

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/name/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/name/save.js
@@ -1,0 +1,4 @@
+const save = ( { attributes: { name }, className } ) =>
+	name && <div className={ className }>{ name }</div>;
+
+export default save;

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/edit.js
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NameEdit from '../edit';
+
+const setAttributes = jest.fn();
+
+const defaultAttributes = {
+	name: '',
+};
+
+const defaultProps = {
+	attributes: defaultAttributes,
+	isSelected: false,
+	setAttributes,
+};
+
+describe( 'Name', () => {
+	beforeEach( () => {
+		setAttributes.mockClear();
+	} );
+
+	test( 'renders placeholder if not selected, and no content is entered', () => {
+		const propsNotSelected = { ...defaultProps, isSelected: false };
+		render( <NameEdit { ...propsNotSelected } /> );
+
+		expect( screen.getByPlaceholderText( 'Name' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders name, and no placeholders, when not selected', () => {
+		const propsNotSelected = {
+			...defaultProps,
+			attributes: { name: 'Acme Corporation' },
+			isSelected: false,
+		};
+		render( <NameEdit { ...propsNotSelected } /> );
+
+		expect( screen.getByText( 'Acme Corporation' ) ).toBeInTheDocument();
+		expect( screen.queryByPlaceholderText( 'Name' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'entering value into the name field updates the name attribute', async () => {
+		const user = userEvent.setup();
+		const propsSelected = { ...defaultProps, isSelected: true };
+		render( <NameEdit { ...propsSelected } /> );
+		await user.click( screen.getByPlaceholderText( 'Name' ) );
+		await user.paste( 'Acme Corporation' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { name: 'Acme Corporation' } );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/fixtures/jetpack__name.html
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/fixtures/jetpack__name.html
@@ -1,0 +1,7 @@
+<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info">
+	<!-- wp:jetpack/name {"name":"Acme Corporation"} -->
+	<div class="wp-block-jetpack-name">Acme Corporation</div>
+	<!-- /wp:jetpack/name -->
+</div>
+<!-- /wp:jetpack/contact-info -->

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/fixtures/jetpack__name.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/fixtures/jetpack__name.json
@@ -1,0 +1,21 @@
+[
+	{
+		"clientId": "_clientId_0",
+		"name": "jetpack/contact-info",
+		"isValid": true,
+		"attributes": {},
+		"innerBlocks": [
+			{
+				"clientId": "_clientId_0",
+				"name": "jetpack/name",
+				"isValid": true,
+				"attributes": {
+					"name": "Acme Corporation"
+				},
+				"innerBlocks": [],
+				"originalContent": "<div class=\"wp-block-jetpack-name\">Acme Corporation</div>"
+			}
+		],
+		"originalContent": "<div class=\"wp-block-jetpack-contact-info\">\n\t\n</div>"
+	}
+]

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/fixtures/jetpack__name.parsed.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/fixtures/jetpack__name.parsed.json
@@ -1,0 +1,19 @@
+[
+	{
+		"blockName": "jetpack/contact-info",
+		"attrs": {},
+		"innerBlocks": [
+			{
+				"blockName": "jetpack/name",
+				"attrs": {
+					"name": "Acme Corporation"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t<div class=\"wp-block-jetpack-name\">Acme Corporation</div>\n\t",
+				"innerContent": [ "\n\t<div class=\"wp-block-jetpack-name\">Acme Corporation</div>\n\t" ]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-jetpack-contact-info\">\n\t\n</div>\n",
+		"innerContent": [ "\n<div class=\"wp-block-jetpack-contact-info\">\n\t", null, "\n</div>\n" ]
+	}
+]

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/fixtures/jetpack__name.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/fixtures/jetpack__name.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:jetpack/contact-info -->
+<div class="wp-block-jetpack-contact-info"><!-- wp:jetpack/name {"name":"Acme Corporation"} -->
+<div class="wp-block-jetpack-name">Acme Corporation</div>
+<!-- /wp:jetpack/name --></div>
+<!-- /wp:jetpack/contact-info -->

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/validate.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/name/test/validate.js
@@ -1,0 +1,19 @@
+import { settings } from '../';
+import runBlockFixtureTests from '../../../../shared/test/block-fixtures';
+import parentBlockMetadata from '../../block.json';
+import parentSave from '../../save';
+
+// Need to include all the blocks involved in rendering this block.
+// The main block should be the first in the array.
+const blocks = [
+	{ name: 'jetpack/name', settings },
+	{
+		name: parentBlockMetadata.name,
+		settings: {
+			...parentBlockMetadata,
+			save: parentSave,
+		},
+	},
+];
+
+runBlockFixtureTests( 'jetpack/name', blocks, __dirname );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/25421

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds two optional fields to the Contact Info block: name and image, with the Schema markup on the frontend (see https://schema.org/Organization).

| Editor (empty) | Editor (filled) | Site |
| - | - | - |
|<img width="400" alt="Screenshot 2024-03-14 at 2 33 20 PM" src="https://github.com/Automattic/jetpack/assets/1620183/7b9443d1-209a-49f9-9d15-f1faae3c6d20">|<img width="400" alt="Screenshot 2024-03-14 at 2 34 44 PM" src="https://github.com/Automattic/jetpack/assets/1620183/7d2af8a3-5591-44f6-8a43-705cf6e93e81">|<img width="370" alt="Screenshot 2024-03-14 at 2 34 59 PM" src="https://github.com/Automattic/jetpack/assets/1620183/76f07c70-81e8-4be1-aca2-d572711ebc09">|


This is to allow end users to fix missing fields errors when validate a webpage with [Google's Rich Text tool.](https://search.google.com/test/rich-results).
<img width="400" alt="Screenshot 2024-03-13 at 3 48 18 PM" src="https://github.com/Automattic/jetpack/assets/1620183/7b558a64-ccad-40a8-91fb-2be86f8c8462">

_Note: I couldn't make tests pass for the `jetpack/image` child block and didn't include them in this PR._

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Build the plugin if you the branch locally
- Create a new post
- Add the Contact Info block
- Fill all fields
- Open the preview
- Notice you can see the organization name and logo
- Test the page with [Google's Rich Text test](https://search.google.com/test/rich-results)
- The results shouldn't contain any errors
<img width="400" alt="Screenshot 2024-03-14 at 2 35 45 PM" src="https://github.com/Automattic/jetpack/assets/1620183/b1d754f8-b813-4601-8cfa-f97d8fb0931a">

---

Feel free to comment about the added copy and design elements.
<img width="600" alt="Screenshot 2024-03-14 at 2 31 38 PM" src="https://github.com/Automattic/jetpack/assets/1620183/88fad2ab-b9a4-4cd2-aa8f-17c39fdd0fab">
<img width="600" alt="Screenshot 2024-03-14 at 2 31 48 PM" src="https://github.com/Automattic/jetpack/assets/1620183/7ba5a931-7e8b-4537-8452-d00e19f8faae">
<img width="600" alt="Screenshot 2024-03-14 at 2 33 13 PM" src="https://github.com/Automattic/jetpack/assets/1620183/15201da0-4126-49ca-970a-d4db2cc29f47">

