### PR TITLE
Subscriptions: Fix the Subscribe block insertion toggle label

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -160,7 +160,7 @@ function SubscriptionsSettings( props ) {
 									onChange={ handleSubscribePostEndToggleChange }
 									label={
 										<>
-											{ __( 'Add the Subscribe Block at the of each post', 'jetpack' ) }
+											{ __( 'Add the Subscribe Block at the end of each post', 'jetpack' ) }
 											{ isBlockTheme && singlePostTemplateEditorUrl && (
 												<>
 													{ '. ' }

--- a/projects/plugins/jetpack/changelog/update-subscribe-block-label-fix
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-label-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Fix the Subscribe block insertion toggle label


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

It adds a missing word to the Subscribe block insertion toggle label in the Newsletter settings.

This feature is at the moment behind the FF. To see the toggle you need the following line in your `0-sandbox.php` file:
```php
add_filter( 'jetpack_subscription_site_enabled', '__return_true' );
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Just a code review should be enough.

