### PR TITLE
Sharing Block: remove extra margin added to first button

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-button-first-button-alignment
+++ b/projects/plugins/jetpack/changelog/fix-sharing-button-first-button-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing Block: remove extra margin previously added to the first button.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/style.scss
@@ -95,6 +95,12 @@ a.jetpack-sharing-button__button {
 	flex-direction: row;
 	flex-wrap: wrap;
 	gap: 5px;
+
+	&:first-child {
+		.jetpack-sharing-button__button {
+			margin-inline-start: 0px;
+		}
+	}
 }
 
 .style-icon-text .jetpack-sharing-button__service-label {


### PR DESCRIPTION
See #36382

## Proposed changes:

We should not add any margin before the first button, to avoid alignment issues with other blocks.

| **Before** | **After** |
|--------|--------|
| <img width="403" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/7f228d7d-43ac-4f32-a6a5-e2b1171e30de"> | <img width="312" alt="Screenshot 2024-03-14 at 13 39 51" src="https://github.com/Automattic/jetpack/assets/426388/1e23bf6a-115d-4330-a673-fd565d79e12c"> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site using a block-based theme like Twenty Twenty Four
* Go to Appearance > Editor > Templates > Single Posts
* Somewhere below the post content, add a new Like block
* Turn that block into a group
* Change the group settings to a stack to align blocks within that group vertically
* Inside the group, add a sharing buttons block
* Add some buttons to that sharing buttons block
    * The first sharing button should be aligned with the Like block above.
