### PR TITLE
100 Year Plan: Remove cap filter if site doesn't support it

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-cap-management
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-cap-management
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a bug where locked mode was applied to all sites in /me/sites that followed a site with locked mode enabled.

--- a/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/locked-mode.php
@@ -17,6 +17,8 @@ function wpcom_lm_maybe_add_map_meta_cap_filter() {
 
 	if ( wpcom_site_has_feature( WPCOM_Features::LOCKED_MODE ) && get_option( 'wpcom_locked_mode' ) ) {
 		add_filter( 'map_meta_cap', 'wpcom_lm_remove_post_capabilities', 10, 2 );
+	} else {
+		remove_filter( 'map_meta_cap', 'wpcom_lm_remove_post_capabilities' );
 	}
 }
 add_action( 'plugins_loaded', 'wpcom_lm_maybe_add_map_meta_cap_filter', 11 );


### PR DESCRIPTION
Fixes p1710369803419599/1710369069.447759-slack-CKZHG0QCR

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove cap filter in all cases where a site doesn't have it enabled, in case it was added previously.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using store admin, apply a 100-year plan to a test site.
* In General Settings, enable Locked Mode on that site.
* Go to https://developer.wordpress.com/docs/api/console/ and query WPCOM API, v1.1, `/me/sites`
* Identify the site with 100 year plan in the response and check subsequent sites for their `capabilities` array. The caps should reflect your user role on the site.
