### PR TITLE
AI Assistant: add quick actions per block

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-quick-actions-per-block
+++ b/projects/plugins/jetpack/changelog/add-ai-quick-actions-per-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Assistant: provide per block quick actions

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -8,7 +8,7 @@ import { MenuItem, MenuGroup, ToolbarButton, Dropdown, Notice } from '@wordpress
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { post, postContent, postExcerpt, termDescription } from '@wordpress/icons';
+import { post, postContent, postExcerpt, termDescription, blockTable } from '@wordpress/icons';
 import debugFactory from 'debug';
 import React from 'react';
 /**
@@ -22,6 +22,7 @@ import {
 	PROMPT_TYPE_SIMPLIFY,
 	PROMPT_TYPE_SUMMARIZE,
 	PROMPT_TYPE_CHANGE_LANGUAGE,
+	PROMPT_TYPE_USER_PROMPT,
 } from '../../lib/prompt';
 import { getRawTextFromHTML } from '../../lib/utils/block-content';
 import { transformToAIAssistantBlock } from '../../transforms';
@@ -52,32 +53,56 @@ const QUICK_EDIT_KEY_MAKE_LONGER = 'make-longer' as const;
 // Ask AI Assistant option
 export const KEY_ASK_AI_ASSISTANT = 'ask-ai-assistant' as const;
 
-const quickActionsList = [
-	{
-		name: __( 'Correct spelling and grammar', 'jetpack' ),
-		key: QUICK_EDIT_KEY_CORRECT_SPELLING,
-		aiSuggestion: PROMPT_TYPE_CORRECT_SPELLING,
-		icon: termDescription,
-	},
-	{
-		name: __( 'Simplify', 'jetpack' ),
-		key: QUICK_EDIT_KEY_SIMPLIFY,
-		aiSuggestion: PROMPT_TYPE_SIMPLIFY,
-		icon: post,
-	},
-	{
-		name: __( 'Summarize', 'jetpack' ),
-		key: QUICK_EDIT_KEY_SUMMARIZE,
-		aiSuggestion: PROMPT_TYPE_SUMMARIZE,
-		icon: postExcerpt,
-	},
-	{
-		name: __( 'Expand', 'jetpack' ),
-		key: QUICK_EDIT_KEY_MAKE_LONGER,
-		aiSuggestion: PROMPT_TYPE_MAKE_LONGER,
-		icon: postContent,
-	},
-];
+const quickActionsList = {
+	default: [
+		{
+			name: __( 'Correct spelling and grammar', 'jetpack' ),
+			key: QUICK_EDIT_KEY_CORRECT_SPELLING,
+			aiSuggestion: PROMPT_TYPE_CORRECT_SPELLING,
+			icon: termDescription,
+		},
+	],
+	'core/paragraph': [
+		{
+			name: __( 'Simplify', 'jetpack' ),
+			key: QUICK_EDIT_KEY_SIMPLIFY,
+			aiSuggestion: PROMPT_TYPE_SIMPLIFY,
+			icon: post,
+		},
+		{
+			name: __( 'Summarize', 'jetpack' ),
+			key: QUICK_EDIT_KEY_SUMMARIZE,
+			aiSuggestion: PROMPT_TYPE_SUMMARIZE,
+			icon: postExcerpt,
+		},
+		{
+			name: __( 'Expand', 'jetpack' ),
+			key: QUICK_EDIT_KEY_MAKE_LONGER,
+			aiSuggestion: PROMPT_TYPE_MAKE_LONGER,
+			icon: postContent,
+		},
+	],
+	'core/list': [
+		{
+			name: 'Turn list into a table',
+			key: 'turn-into-table',
+			aiSuggestion: PROMPT_TYPE_USER_PROMPT,
+			icon: blockTable,
+			options: {
+				userPrompt: 'make a table from this list, do not enclose the response in a code block',
+			},
+		},
+		{
+			name: 'Write a post from this list',
+			key: 'write-post-from-list',
+			aiSuggestion: PROMPT_TYPE_USER_PROMPT,
+			icon: post,
+			options: {
+				userPrompt: 'Write a post based on the list items. Try to use a heading for each entry',
+			},
+		},
+	],
+};
 
 export type AiAssistantDropdownOnChangeOptionsArgProps = {
 	tone?: ToneProp;
@@ -221,6 +246,8 @@ function AiAssistantDropdownContent( {
 		tracks.recordEvent( 'jetpack_ai_assistant_prompt_show', { block_type: blockType } );
 	};
 
+	const blockQuickActions = quickActionsList[ blockType ] ?? [];
+
 	return (
 		<>
 			{ noContent && (
@@ -242,7 +269,7 @@ function AiAssistantDropdownContent( {
 					</div>
 				</MenuItem>
 
-				{ quickActionsList.map( quickAction => (
+				{ [ ...quickActionsList.default, ...blockQuickActions ].map( quickAction => (
 					<MenuItem
 						icon={ quickAction?.icon }
 						iconPosition="left"

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -82,6 +82,7 @@ const quickActionsList = [
 export type AiAssistantDropdownOnChangeOptionsArgProps = {
 	tone?: ToneProp;
 	language?: string;
+	userPrompt?: string;
 };
 
 type AiAssistantControlComponentProps = {
@@ -247,7 +248,7 @@ function AiAssistantDropdownContent( {
 						iconPosition="left"
 						key={ `key-${ quickAction.key }` }
 						onClick={ () => {
-							requestSuggestion( quickAction.aiSuggestion, {} );
+							requestSuggestion( quickAction.aiSuggestion, { ...( quickAction.options ?? {} ) } );
 						} }
 						disabled={ noContent }
 					>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -84,7 +84,7 @@ const quickActionsList = {
 	],
 	'core/list': [
 		{
-			name: 'Turn list into a table',
+			name: __( 'Turn list into a table', 'jetpack' ),
 			key: 'turn-into-table',
 			aiSuggestion: PROMPT_TYPE_USER_PROMPT,
 			icon: blockTable,
@@ -93,7 +93,7 @@ const quickActionsList = {
 			},
 		},
 		{
-			name: 'Write a post from this list',
+			name: __( 'Write a post from this list', 'jetpack' ),
 			key: 'write-post-from-list',
 			aiSuggestion: PROMPT_TYPE_USER_PROMPT,
 			icon: post,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -189,7 +189,7 @@ const useSuggestionsFromOpenAI = ( {
 				postContentAbove: getPartialContentToBlock( clientId ),
 				currentPostTitle,
 				options,
-				userPrompt,
+				userPrompt: options?.userPrompt || userPrompt,
 				type,
 				isGeneratingTitle: attributes.promptType === 'generateTitle',
 				useGutenbergSyntax: !! attributes?.useGutenbergSyntax,


### PR DESCRIPTION
AI quick actions are the same for all supported block types, making for some futile actions on certain blocks while lacking in consistency/functionality in others

## Proposed changes:
This PR:
- separates quick actions into default and block-specific collections
- adds a way for the quick actions to provide an override to the userPrompt through options
- creates specific quick actions for core/list block

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-qrm-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the editor, create a list with some items. Click on the toolbar's AI icon. See that the list doesn't offer "Summarize", "Expand" or "Simplify". It should only offer "Turn into a table" and "Write a post from this list".
Test both quick actions. Verify expected output (be mindful that not all lists would make sense as a table, try using some shared data between items, like "Africa, 200 people" and "Europe, 100 people")

Test the paragraph's quick actions still work as expected.