### PR TITLE
Stats: Add UTM stats endpoints

### DIFF
--- a/projects/packages/stats-admin/.phan/baseline.php
+++ b/projects/packages/stats-admin/.phan/baseline.php
@@ -9,7 +9,7 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassMethod : 55+ occurrences
+    // PhanUndeclaredClassMethod : 60+ occurrences
     // PhanUndeclaredTypeParameter : 20+ occurrences
     // PhanTypeMismatchReturn : 8 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 6 occurrences

--- a/projects/packages/stats-admin/changelog/update-add-stats-utm-endpoints
+++ b/projects/packages/stats-admin/changelog/update-add-stats-utm-endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add UTM stats endpoint

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -52,7 +52,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.16.x-dev"
+			"dev-trunk": "0.17.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.16.3-alpha",
+	"version": "0.17.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.16.3-alpha';
+	const VERSION = '0.17.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -367,6 +367,18 @@ class REST_Controller {
 				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
+
+		// Get UTM stats time series.
+		register_rest_route(
+			static::$namespace,
+			// /stats/utm/utm_campaign,utm_source,utm_medium
+			sprintf( '/sites/%d/stats/utm/(?P<utm_params>[_,\-\w]+)', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_utm_stats_time_series' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+			)
+		);
 	}
 
 	/**
@@ -824,6 +836,27 @@ class REST_Controller {
 			default:
 				return $this->get_forbidden_error();
 		}
+	}
+
+	/**
+	 * Get UTM stats time series.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array
+	 */
+	public function get_utm_stats_time_series( $req ) {
+		return WPCOM_Client::request_as_blog_cached(
+			sprintf(
+				'/sites/%d/stats/utm/%s?%s',
+				Jetpack_Options::get_option( 'id' ),
+				$req->get_param( 'utm_params' ),
+				$this->filter_and_build_query_string(
+					$req->get_params()
+				)
+			),
+			'v1.1',
+			array( 'timeout' => 10 )
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-add-stats-utm-endpoints
+++ b/projects/plugins/jetpack/changelog/update-add-stats-utm-endpoints
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2334,7 +2334,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/stats-admin",
-				"reference": "79533974543122e5051069845596cf08c15ad021"
+				"reference": "5f91aa7d5c4db7934073ce99143c52714777cea0"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2358,7 +2358,7 @@
 				"autotagger": true,
 				"mirror-repo": "Automattic/jetpack-stats-admin",
 				"branch-alias": {
-					"dev-trunk": "0.16.x-dev"
+					"dev-trunk": "0.17.x-dev"
 				},
 				"textdomain": "jetpack-stats-admin",
 				"version-constants": {


### PR DESCRIPTION
## Proposed changes:

* Add endpoint support for UTM stats

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Apply D141991-code to your sandbox
* Sandbox your Jetpack site `define( 'JETPACK__SANDBOX_DOMAIN', 'blabla.xxx.xxx.com' );`
* Build Stats `cd apps/odyssey-stats && STATS_PACKAGE_PATH=~/path/to/jetpack/projects/packages/stats-admin yarn dev`
* Open `/wp-admin/admin.php?page=stats#!/stats/day/:site?page=stats&flags=stats/utm-module`
* Ensure the UTM module works normally
* Click details in the UTM card
* Ensure the UTM summary page works okay

<img width="763" alt="image" src="https://github.com/Automattic/jetpack/assets/1425433/95714ab2-791a-40c7-b2f0-5436b480dfcc">
