### PR TITLE
[Boost] Do not setup a second uninstall hook

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -243,10 +243,6 @@ class Jetpack_Boost {
 		// When uninstalling, make sure all deactivation cleanups have run as well.
 		$this->deactivate();
 
-		// Tell Minify JS/CSS to clean up.
-		require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/functions-helpers.php';
-		jetpack_boost_page_optimize_uninstall();
-
 		// Delete all Jetpack Boost options.
 		//phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$option_names = $wpdb->get_col(

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -155,6 +155,11 @@ class Jetpack_Boost {
 	 */
 	public function deactivate() {
 		do_action( 'jetpack_boost_deactivate' );
+
+		// Tell Minify JS/CSS to clean up.
+		require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/functions-helpers.php';
+		jetpack_boost_page_optimize_deactivate();
+
 		Regenerate_Admin_Notice::dismiss();
 		Analytics::record_user_event( 'deactivate_plugin' );
 		Page_Cache_Setup::deactivate();
@@ -238,8 +243,9 @@ class Jetpack_Boost {
 		// When uninstalling, make sure all deactivation cleanups have run as well.
 		$this->deactivate();
 
-		// Give other parts of Jetpack Boost a chance to hook into uninstallation.
-		do_action( 'jetpack_boost_uninstall' );
+		// Tell Minify JS/CSS to clean up.
+		require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/functions-helpers.php';
+		jetpack_boost_page_optimize_uninstall();
 
 		// Delete all Jetpack Boost options.
 		//phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -238,6 +238,9 @@ class Jetpack_Boost {
 		// When uninstalling, make sure all deactivation cleanups have run as well.
 		$this->deactivate();
 
+		// Give other parts of Jetpack Boost a chance to hook into uninstallation.
+		do_action( 'jetpack_boost_uninstall' );
+
 		// Delete all Jetpack Boost options.
 		//phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$option_names = $wpdb->get_col(

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -62,22 +62,6 @@ function jetpack_boost_page_optimize_deactivate() {
 }
 
 /**
- * Plugin uninstall hook - cleanup options.
- */
-function jetpack_boost_page_optimize_uninstall() {
-	// Run cleanup on uninstall. You can uninstall an active plugin w/o deactivation.
-	jetpack_boost_page_optimize_deactivate();
-
-	// JS
-	delete_option( 'page_optimize-js' );
-	delete_option( 'page_optimize-load-mode' );
-	delete_option( 'page_optimize-js-exclude' );
-	// CSS
-	delete_option( 'page_optimize-css' );
-	delete_option( 'page_optimize-css-exclude' );
-}
-
-/**
  * Convert enqueued home-relative URLs to absolute ones.
  *
  * Enqueued script URLs which start with / are relative to WordPress' home URL.

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -316,8 +316,8 @@ function jetpack_boost_minify_setup() {
 	$setup_done = true;
 
 	// Hook up deactivation and uninstall cleanup paths.
-	register_deactivation_hook( JETPACK_BOOST_PATH, 'jetpack_boost_page_optimize_deactivate' );
-	register_uninstall_hook( JETPACK_BOOST_PATH, 'jetpack_boost_page_optimize_uninstall' );
+	add_action( 'jetpack_boost_deactivate', 'jetpack_boost_page_optimize_deactivate' );
+	add_action( 'jetpack_boost_uninstall', 'jetpack_boost_page_optimize_uninstall' );
 
 	// Schedule cache cleanup.
 	add_action( 'jetpack_boost_minify_cron_cache_cleanup', 'jetpack_boost_page_optimize_cache_cleanup' );

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -315,10 +315,6 @@ function jetpack_boost_minify_setup() {
 	}
 	$setup_done = true;
 
-	// Hook up deactivation and uninstall cleanup paths.
-	add_action( 'jetpack_boost_deactivate', 'jetpack_boost_page_optimize_deactivate' );
-	add_action( 'jetpack_boost_uninstall', 'jetpack_boost_page_optimize_uninstall' );
-
 	// Schedule cache cleanup.
 	add_action( 'jetpack_boost_minify_cron_cache_cleanup', 'jetpack_boost_page_optimize_cache_cleanup' );
 	jetpack_boost_page_optimize_schedule_cache_cleanup();

--- a/projects/plugins/boost/changelog/boost-fix-uninstall-hooks
+++ b/projects/plugins/boost/changelog/boost-fix-uninstall-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+General: Removed duplicate uninstall hook


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36389

Remove extra uninstall and deactivate hooks which were fighting with Boost's main hooks from the imported Page_Optimize code behind CSS/JS minify.

- The uninstall code was removed entirely - it was cleaning out Page_Optimize options we don't use any more,
- The deactivate code is now called directly from Jetpack Boost's deactivate code.

## Proposed changes:
* Remove uninstall code from page_optimize imported code-base.
* Call page_optimize deactivate code from main Boost hook instead of letting it use its own hook.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Activate Minify CSS or Minify JS in Boost UI
* Load the front page to allow it to cache some optimized css or js
* Deactivate the plugin
* Ensure that the `wp-content/cache/page_optimize` directory gets cleaned up.