### PR TITLE
Forms: avoid JS errors in dashboard.

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-connection-warnings
+++ b/projects/packages/forms/changelog/fix-forms-connection-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: add missing Connection state to the page.

--- a/projects/packages/forms/changelog/fix-forms-connection-warnings#2
+++ b/projects/packages/forms/changelog/fix-forms-connection-warnings#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: avoid JS errors when content disposition is not set.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Forms\Dashboard;
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Google_Drive;
@@ -19,6 +20,12 @@ use Automattic\Jetpack\Status\Host;
  * Handles the Jetpack Forms dashboard.
  */
 class Dashboard {
+	/**
+	 * Script handle for the JS file we enqueue in the Feedback admin page.
+	 *
+	 * @var string
+	 */
+	const SCRIPT_HANDLE = 'jp-forms-dashboard';
 
 	/**
 	 * Priority for the dashboard menu.
@@ -65,7 +72,7 @@ class Dashboard {
 		}
 
 		Assets::register_script(
-			'jp-forms-dashboard',
+			self::SCRIPT_HANDLE,
 			'../../dist/dashboard/jetpack-forms-dashboard.js',
 			__FILE__,
 			array(
@@ -76,12 +83,15 @@ class Dashboard {
 			)
 		);
 
+		// Adds Connection package initial state.
+		Connection_Initial_State::render_script( self::SCRIPT_HANDLE );
+
 		$api_root = defined( 'IS_WPCOM' ) && IS_WPCOM
 			? sprintf( '/wpcom/v2/sites/%s/', esc_url_raw( rest_url() ) )
 			: '/wp-json/wpcom/v2/';
 
 		wp_add_inline_script(
-			'jp-forms-dashboard',
+			self::SCRIPT_HANDLE,
 			'window.jetpackFormsData = ' . wp_json_encode( array( 'apiRoot' => $api_root ) ) . ';',
 			'before'
 		);
@@ -95,7 +105,7 @@ class Dashboard {
 					'in_footer'    => true,
 					'textdomain'   => 'jetpack-forms',
 					'enqueue'      => true,
-					'dependencies' => array( 'jp-forms-dashboard' ),
+					'dependencies' => array( self::SCRIPT_HANDLE ),
 				)
 			);
 		}

--- a/projects/packages/forms/src/dashboard/inbox/export-modal/csv.js
+++ b/projects/packages/forms/src/dashboard/inbox/export-modal/csv.js
@@ -17,7 +17,7 @@ const CSVExport = ( { onExport } ) => {
 			const a = document.createElement( 'a' );
 			a.href = window.URL.createObjectURL( blob );
 
-			const contentDispositionHeader = response.headers.get( 'Content-Disposition' );
+			const contentDispositionHeader = response.headers.get( 'Content-Disposition' ) ?? '';
 			a.download =
 				contentDispositionHeader.split( 'filename=' )[ 1 ] || 'Jetpack Form Responses.csv';
 


### PR DESCRIPTION
## Proposed changes:

This PR fixes 2 different JS errors that were reported for the Contact Form admin inbox dashboard.

```
Jetpack Connection Package: Initial state is missing. Check documentation to see how to use the Connection composer package to set up the initial state.
```

```
TypeError: Cannot read properties of null (reading split)
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1710468510258389/1707314258.579609-slack-C0393K4ADM3

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Connect your site to WordPress.com
* Go to the Feedback menu in wp-admin.
* Using the "View" tab in top right corner, switch to the "inbox" view.
    * You should not see any errors in your browser's JavaScript console.
