### PR TITLE
Starter Plugin: Explicitly add the Connection package as dependency

### DIFF
--- a/projects/plugins/starter-plugin/changelog/add-jetpack-connection-as-explicit-dependency-of-starter-plugin
+++ b/projects/plugins/starter-plugin/changelog/add-jetpack-connection-as-explicit-dependency-of-starter-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Explicitly add the Connection package as dependency

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -9,11 +9,11 @@
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",
 		"automattic/jetpack-config": "@dev",
+		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-identity-crisis": "@dev",
 		"automattic/jetpack-my-jetpack": "@dev",
 		"automattic/jetpack-plugins-installer": "@dev",
-		"automattic/jetpack-sync": "@dev",
-		"automattic/jetpack-connection": "@dev"
+		"automattic/jetpack-sync": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.1.0",

--- a/projects/plugins/starter-plugin/composer.json
+++ b/projects/plugins/starter-plugin/composer.json
@@ -12,7 +12,8 @@
 		"automattic/jetpack-identity-crisis": "@dev",
 		"automattic/jetpack-my-jetpack": "@dev",
 		"automattic/jetpack-plugins-installer": "@dev",
-		"automattic/jetpack-sync": "@dev"
+		"automattic/jetpack-sync": "@dev",
+		"automattic/jetpack-connection": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.1.0",

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c034be5ed6d672c0cd502939f5f5a90",
+    "content-hash": "80a76eb6b9f23e24e6f406b2bff156a7",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -4594,6 +4594,7 @@
         "automattic/jetpack-my-jetpack": 20,
         "automattic/jetpack-plugins-installer": 20,
         "automattic/jetpack-sync": 20,
+        "automattic/jetpack-connection": 20,
         "automattic/jetpack-changelogger": 20
     },
     "prefer-stable": true,

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80a76eb6b9f23e24e6f406b2bff156a7",
+    "content-hash": "8db5f0e6ffdd851b2e330d38d9895a5d",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -4590,11 +4590,11 @@
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,
+        "automattic/jetpack-connection": 20,
         "automattic/jetpack-identity-crisis": 20,
         "automattic/jetpack-my-jetpack": 20,
         "automattic/jetpack-plugins-installer": 20,
         "automattic/jetpack-sync": 20,
-        "automattic/jetpack-connection": 20,
         "automattic/jetpack-changelogger": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
The connection was pulled in before, as it was dependency of other dependencies.

While taking a look at https://github.com/Automattic/jetpack/pull/35953 I saw [this commit ](https://github.com/Automattic/jetpack/pull/35953/commits/e8e6b071d7c3341b9a0d4e118f1d15e6813adfd5)and thought I could replicate here. 

I also saw this and chatted with @rcanepa  as it was confusing that when showcasing him how to kickstart a plugin, he couldn't see connection among the deps but the generated plugin was still able to connect


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `automattic/jetpack-connection` to composer.json

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Checkout this branch
* Jump into `projects/plugins/starter-plugin`
* Run `jetpack install plugins/starter-plugin`
* Run `jetpack build plugins/starter-plugin`
* Confirm there's no error

