### PR TITLE
phan: Fix PhanRedefinedXXX issues due to yoast/phpunit-polyfills

### DIFF
--- a/.phan/config.base.php
+++ b/.phan/config.base.php
@@ -106,6 +106,10 @@ function make_phan_config( $dir, $options = array() ) {
 					// Ignore any `wordpress`, `jetpack_vendor`, `vendor`, and `node_modules` inside `vendor` and `jetpack_vendor`.
 					// Most of these are probably from our intra-monorepo symlinks.
 					'(?:jetpack_)?vendor/.*/(?:wordpress|(?:jetpack_)?vendor|node_modules)/',
+					// Yoast/phpunit-polyfills triggers a lot of PhanRedefinedXXX errors.
+					// Avoid that by excluding certain files.
+					'vendor/yoast/phpunit-polyfills/src/Polyfills/.*_Empty\.php',
+					'vendor/yoast/phpunit-polyfills/src/TestCases/TestCasePHPUnitGte8\.php',
 					// Other stuff to ignore.
 					'node_modules/',
 					'tests/e2e/node_modules/',

--- a/projects/packages/assets/.phan/baseline.php
+++ b/projects/packages/assets/.phan/baseline.php
@@ -12,7 +12,6 @@ return [
     // PhanTypeMismatchArgument : 10+ occurrences
     // PhanDeprecatedFunction : 5 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
-    // PhanRedefinedUsedTrait : 3 occurrences
     // PhanParamTooFewUnpack : 2 occurrences
     // PhanImpossibleTypeComparison : 1 occurrence
     // PhanParamTooMany : 1 occurrence
@@ -24,8 +23,7 @@ return [
     'file_suppressions' => [
         'src/class-assets.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'src/class-semver.php' => ['PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeInvalidRightOperandOfNumericOp'],
-        'tests/php/test-assets.php' => ['PhanDeprecatedFunction', 'PhanImpossibleTypeComparison', 'PhanParamTooFewUnpack', 'PhanParamTooMany', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassReference'],
-        'tests/php/test-semver.php' => ['PhanRedefinedUsedTrait'],
+        'tests/php/test-assets.php' => ['PhanDeprecatedFunction', 'PhanImpossibleTypeComparison', 'PhanParamTooFewUnpack', 'PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassReference'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/assets/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/assets/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/autoloader/.phan/baseline.php
+++ b/projects/packages/autoloader/.phan/baseline.php
@@ -21,7 +21,6 @@ return [
     // PhanTypePossiblyInvalidDimOffset : 3 occurrences
     // PhanDeprecatedFunction : 2 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 2 occurrences
-    // PhanRedefinedUsedTrait : 2 occurrences
     // PhanTypeMismatchArgumentNullableInternal : 2 occurrences
     // PhanUndeclaredInterface : 2 occurrences
     // PhanPossiblyNullTypeMismatchProperty : 1 occurrence
@@ -59,8 +58,8 @@ return [
         'tests/php/tests/unit/ManifestReaderTest.php' => ['PhanTypeInvalidDimOffset', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredTypeProperty'],
         'tests/php/tests/unit/PHPAutoloaderTest.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
         'tests/php/tests/unit/PathProcessorTest.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty'],
-        'tests/php/tests/unit/PluginLocatorTest.php' => ['PhanRedefinedUsedTrait', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredTypeProperty'],
-        'tests/php/tests/unit/PluginsHandlerTest.php' => ['PhanRedefinedUsedTrait', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredTypeProperty'],
+        'tests/php/tests/unit/PluginLocatorTest.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredTypeProperty'],
+        'tests/php/tests/unit/PluginsHandlerTest.php' => ['PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredTypeProperty'],
         'tests/php/tests/unit/ShutdownHandlerTest.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredTypeProperty'],
         'tests/php/tests/unit/VersionLoaderTest.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
         'tests/php/tests/unit/VersionSelectorTest.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty'],

--- a/projects/packages/autoloader/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/autoloader/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/autoloader/src/AutoloadGenerator.php
+++ b/projects/packages/autoloader/src/AutoloadGenerator.php
@@ -21,7 +21,7 @@ use Composer\Util\PackageSorter;
  */
 class AutoloadGenerator {
 
-	const VERSION = '3.0.3';
+	const VERSION = '3.0.4-alpha';
 
 	/**
 	 * IO object.

--- a/projects/packages/blocks/.phan/baseline.php
+++ b/projects/packages/blocks/.phan/baseline.php
@@ -13,7 +13,6 @@ return [
     // PhanTypeMismatchArgument : 2 occurrences
     // PhanUndeclaredClassMethod : 2 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 1 occurrence
-    // PhanRedefinedUsedTrait : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanUndeclaredClassInCallable : 1 occurrence
     // PhanUndeclaredClassReference : 1 occurrence
@@ -23,7 +22,7 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-blocks.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeReturnType'],
-        'tests/php/test-blocks.php' => ['PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassProperty'],
+        'tests/php/test-blocks.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassProperty'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/blocks/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/blocks/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/boost-speed-score/.phan/baseline.php
+++ b/projects/packages/boost-speed-score/.phan/baseline.php
@@ -17,7 +17,6 @@ return [
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
     // PhanUndeclaredClassMethod : 2 occurrences
     // PhanRedefineFunction : 1 occurrence
-    // PhanRedefinedExtendedClass : 1 occurrence
     // PhanTypeMismatchPropertyDefault : 1 occurrence
     // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
@@ -31,7 +30,6 @@ return [
         'src/class-speed-score-request.php' => ['PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-speed-score.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
         'tests/bootstrap.php' => ['PhanRedefineFunction', 'PhanTypeMismatchReturnProbablyReal'],
-        'tests/php/class-base-test-case.php' => ['PhanRedefinedExtendedClass'],
         'tests/php/lib/test-class-speed-score-history.php' => ['PhanTypeExpectedObjectPropAccess'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/boost-speed-score/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/boost-speed-score/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -23,7 +23,7 @@ if ( ! defined( 'JETPACK_BOOST_REST_PREFIX' ) ) {
  */
 class Speed_Score {
 
-	const PACKAGE_VERSION = '0.3.6';
+	const PACKAGE_VERSION = '0.3.7-alpha';
 
 	/**
 	 * An instance of Automatic\Jetpack_Boost\Modules\Modules_Setup passed to the constructor

--- a/projects/packages/changelogger/.phan/baseline.php
+++ b/projects/packages/changelogger/.phan/baseline.php
@@ -12,7 +12,6 @@ return [
     // PhanTypeMismatchArgument : 30+ occurrences
     // PhanUndeclaredClassMethod : 25+ occurrences
     // PhanUndeclaredMethod : 25+ occurrences
-    // PhanRedefinedUsedTrait : 20+ occurrences
     // PhanMisspelledAnnotation : 10+ occurrences
     // PhanParamTooMany : 10+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 10+ occurrences
@@ -64,24 +63,20 @@ return [
         'src/ValidateCommand.php' => ['PhanImpossibleCondition', 'PhanTypeArraySuspiciousNullable', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredProperty'],
         'src/VersionCommand.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeThrowsType'],
         'src/WriteCommand.php' => ['PhanParamTooMany', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod'],
-        'tests/php/includes/lib/ParserTestCase.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedefinedUsedTrait', 'PhanTypePossiblyInvalidDimOffset'],
+        'tests/php/includes/lib/ParserTestCase.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypePossiblyInvalidDimOffset'],
         'tests/php/includes/src/CommandTestCase.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeReturnType'],
-        'tests/php/tests/lib/ChangeEntryTest.php' => ['PhanNoopNew', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument'],
-        'tests/php/tests/lib/ChangelogEntryTest.php' => ['PhanNoopNew', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument'],
-        'tests/php/tests/lib/ChangelogTest.php' => ['PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument'],
+        'tests/php/tests/lib/ChangeEntryTest.php' => ['PhanNoopNew', 'PhanTypeMismatchArgument'],
+        'tests/php/tests/lib/ChangelogEntryTest.php' => ['PhanNoopNew', 'PhanTypeMismatchArgument'],
+        'tests/php/tests/lib/ChangelogTest.php' => ['PhanTypeMismatchArgument'],
         'tests/php/tests/lib/ParserTest.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
-        'tests/php/tests/src/AddCommandTest.php' => ['PhanRedefinedUsedTrait'],
-        'tests/php/tests/src/ApplicationTest.php' => ['PhanRedefinedUsedTrait', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument'],
-        'tests/php/tests/src/CommandLoaderTest.php' => ['PhanRedefinedUsedTrait'],
-        'tests/php/tests/src/ConfigTest.php' => ['PhanPluginMixedKeyNoKey', 'PhanRedefinedUsedTrait', 'PhanUndeclaredClassReference'],
+        'tests/php/tests/src/ApplicationTest.php' => ['PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument'],
+        'tests/php/tests/src/ConfigTest.php' => ['PhanPluginMixedKeyNoKey', 'PhanUndeclaredClassReference'],
         'tests/php/tests/src/PluginTraitTest.php' => ['PhanUndeclaredMethod'],
-        'tests/php/tests/src/Plugins/SemverVersioningTest.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanPluginMixedKeyNoKey', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument', 'PhanUndeclaredMethod'],
-        'tests/php/tests/src/Plugins/WordpressVersioningTest.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanPluginMixedKeyNoKey', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument', 'PhanUndeclaredMethod'],
-        'tests/php/tests/src/SquashCommandTest.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod'],
-        'tests/php/tests/src/UtilsTest.php' => ['PhanDeprecatedFunction', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument', 'PhanUndeclaredProperty'],
-        'tests/php/tests/src/ValidateCommandTest.php' => ['PhanRedefinedUsedTrait'],
-        'tests/php/tests/src/VersionCommandTest.php' => ['PhanRedefinedUsedTrait'],
-        'tests/php/tests/src/WriteCommandTest.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginMixedKeyNoKey', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod'],
+        'tests/php/tests/src/Plugins/SemverVersioningTest.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument', 'PhanUndeclaredMethod'],
+        'tests/php/tests/src/Plugins/WordpressVersioningTest.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument', 'PhanUndeclaredMethod'],
+        'tests/php/tests/src/SquashCommandTest.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod'],
+        'tests/php/tests/src/UtilsTest.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanUndeclaredProperty'],
+        'tests/php/tests/src/WriteCommandTest.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/changelogger/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/changelogger/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/codesniffer/.phan/baseline.php
+++ b/projects/packages/codesniffer/.phan/baseline.php
@@ -11,7 +11,6 @@ return [
     // # Issue statistics:
     // PhanRedefinedClassReference : 4 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 2 occurrences
-    // PhanRedefinedUsedTrait : 2 occurrences
     // PhanUnextractableAnnotationSuffix : 2 occurrences
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanRedefineClass : 1 occurrence
@@ -24,8 +23,7 @@ return [
         'Jetpack/Sniffs/Functions/I18nSniff.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUnextractableAnnotationSuffix'],
         'Jetpack/Sniffs/Functions/SetCookieSniff.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool'],
         'hacks/PHPUnitTestTrait.php' => ['PhanRedefineClass', 'PhanRedefinedClassReference', 'UnusedPluginSuppression'],
-        'tests/php/tests/test-jetpack-compat.php' => ['PhanRedefinedUsedTrait', 'PhanTypeMismatchReturn'],
-        'tests/php/tests/test-jetpackstandard.php' => ['PhanRedefinedUsedTrait'],
+        'tests/php/tests/test-jetpack-compat.php' => ['PhanTypeMismatchReturn'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/codesniffer/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/codesniffer/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/connection/.phan/baseline.php
+++ b/projects/packages/connection/.phan/baseline.php
@@ -25,7 +25,6 @@ return [
     // PhanUndeclaredProperty : 8 occurrences
     // PhanUndeclaredTypeParameter : 8 occurrences
     // PhanNoopNew : 6 occurrences
-    // PhanRedefinedUsedTrait : 6 occurrences
     // PhanTypeArraySuspiciousNullable : 5 occurrences
     // PhanTypeMismatchDefault : 5 occurrences
     // PhanUndeclaredTypeThrowsType : 5 occurrences
@@ -85,21 +84,21 @@ return [
         'tests/php/test-class-nonce-handler.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchArgument'],
         'tests/php/test-class-plugin.php' => ['PhanUndeclaredTypeThrowsType'],
         'tests/php/test-class-webhooks.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeThrowsType'],
-        'tests/php/test-partner-coupon.php' => ['PhanDeprecatedFunction', 'PhanRedefinedUsedTrait', 'PhanUndeclaredMethodInCallable'],
+        'tests/php/test-partner-coupon.php' => ['PhanDeprecatedFunction', 'PhanUndeclaredMethodInCallable'],
         'tests/php/test-partner.php' => ['PhanUndeclaredTypeThrowsType'],
-        'tests/php/test-rest-endpoints.php' => ['PhanNoopNew', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethodInCallable', 'PhanUndeclaredTypeReturnType'],
+        'tests/php/test-rest-endpoints.php' => ['PhanNoopNew', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethodInCallable', 'PhanUndeclaredTypeReturnType'],
         'tests/php/test-terms-of-service.php' => ['PhanTypeMismatchProperty', 'PhanUndeclaredMethod'],
         'tests/php/test-tracking.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanUndeclaredMethod'],
-        'tests/php/test_Error_Handler.php' => ['PhanParamTooMany', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument', 'PhanUndeclaredConstant'],
+        'tests/php/test_Error_Handler.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanUndeclaredConstant'],
         'tests/php/test_Jetpack_IXR_ClientMulticall.php' => ['PhanUndeclaredConstant'],
         'tests/php/test_Manager_integration.php' => ['PhanParamTooMany'],
-        'tests/php/test_Manager_unit.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanRedefinedUsedTrait', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredMethod'],
+        'tests/php/test_Manager_unit.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredMethod'],
         'tests/php/test_Rest_Authentication.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanUndeclaredMethod'],
         'tests/php/test_Server_Sandbox.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument'],
         'tests/php/test_Signature.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/test_Tokens.php' => ['PhanDeprecatedFunction', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchProperty', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredConstant', 'PhanUndeclaredMethod'],
+        'tests/php/test_Tokens.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchProperty', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredConstant', 'PhanUndeclaredMethod'],
         'tests/php/test_XMLPC_Async_Call.php' => ['PhanUndeclaredConstant'],
-        'tests/php/test_jetpack_xmlrpc_server.php' => ['PhanDeprecatedFunction', 'PhanPluginSimplifyExpressionBool', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanUndeclaredMethodInCallable'],
+        'tests/php/test_jetpack_xmlrpc_server.php' => ['PhanDeprecatedFunction', 'PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanUndeclaredMethodInCallable'],
         'tests/php/test_package_version_tracker.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/connection/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/connection/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -62,7 +62,7 @@ return [
         'src/service/class-google-drive.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
         'src/service/class-post-to-url.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
         'tests/php/contact-form/test-class.contact-form-plugin.php' => ['PhanPluginMixedKeyNoKey'],
-        'tests/php/contact-form/test-class.contact-form.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
+        'tests/php/contact-form/test-class.contact-form.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/forms/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/forms/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Don't try to manually polyfill for `assertStringContainsString`, the WorDBless base class already includes a polyfill.
+
+

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -22,22 +22,6 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	private $plugin;
 
 	/**
-	 * Fallback for missing assertStringContainsString in lower PHPUnit versions.
-	 *
-	 * @param  string $expected_value
-	 * @param  string $value
-	 * @param  string $message
-	 * @return boolean
-	 */
-	public static function assertStringContains( $expected_value, $value, $message = '' ) {
-		if ( method_exists( get_parent_class( self::class ), 'assertStringContainsString' ) ) {
-			return parent::assertStringContainsString( $expected_value, $value, $message );
-		}
-
-		return parent::assertContains( $expected_value, $value, $message );
-	}
-
-	/**
 	 * Sets up the test environment before the class tests begin.
 	 *
 	 * @beforeClass
@@ -145,7 +129,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		// Default metadata should be saved.
 		$email = get_post_meta( $submission->ID, '_feedback_email', true );
 		$this->assertEquals( 'john <john@example.com>', $email['to'][0] );
-		$this->assertStringContains( 'IP Address: 127.0.0.1', $email['message'] );
+		$this->assertStringContainsString( 'IP Address: 127.0.0.1', $email['message'] );
 	}
 
 	/**
@@ -211,7 +195,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
 
 		// Default metadata should be saved.
-		$this->assertStringContains( 'SUBJECT: I\\\'m sorry, but the party\\\'s over', $submission->post_content, 'The stored subject didn\'t match the given' );
+		$this->assertStringContainsString( 'SUBJECT: I\\\'m sorry, but the party\\\'s over', $submission->post_content, 'The stored subject didn\'t match the given' );
 	}
 
 	/**
@@ -239,7 +223,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		$submission  = get_post( $feedback_id );
 		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
 
-		$this->assertStringContains( 'SUBJECT: Hello John Doe from Kansas!', $submission->post_content, 'The stored subject didn\'t match the given' );
+		$this->assertStringContainsString( 'SUBJECT: Hello John Doe from Kansas!', $submission->post_content, 'The stored subject didn\'t match the given' );
 	}
 
 	/**
@@ -266,7 +250,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		$submission  = get_post( $feedback_id );
 		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
 
-		$this->assertStringContains( 'SUBJECT: Hello John Doe from Kansas!', $submission->post_content, 'The stored subject didn\'t match the given' );
+		$this->assertStringContainsString( 'SUBJECT: Hello John Doe from Kansas!', $submission->post_content, 'The stored subject didn\'t match the given' );
 	}
 
 	/**
@@ -293,7 +277,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		$submission  = get_post( $feedback_id );
 		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
 
-		$this->assertStringContains( 'SUBJECT: Hello John Doe from Kansas!', $submission->post_content, 'The stored subject didn\'t match the given' );
+		$this->assertStringContainsString( 'SUBJECT: Hello John Doe from Kansas!', $submission->post_content, 'The stored subject didn\'t match the given' );
 	}
 
 	/**
@@ -324,10 +308,10 @@ class WP_Test_Contact_Form extends BaseTestCase {
 		$submission  = get_post( $feedback_id );
 		$this->assertEquals( 'feedback', $submission->post_type, 'Post type doesn\'t match' );
 
-		$this->assertStringContains( '\"1_Name\":\"John Doe\"', $submission->post_content, 'Post content did not contain the name label and/or value' );
-		$this->assertStringContains( '\"2_Dropdown\":\"First option\"', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
-		$this->assertStringContains( '\"3_Radio\":\"Second option\"', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
-		$this->assertStringContains( '\"4_Text\":\"Texty text\"', $submission->post_content, 'Post content did not contain the text field label and/or value' );
+		$this->assertStringContainsString( '\"1_Name\":\"John Doe\"', $submission->post_content, 'Post content did not contain the name label and/or value' );
+		$this->assertStringContainsString( '\"2_Dropdown\":\"First option\"', $submission->post_content, 'Post content did not contain the dropdown label and/or value' );
+		$this->assertStringContainsString( '\"3_Radio\":\"Second option\"', $submission->post_content, 'Post content did not contain the radio button label and/or value' );
+		$this->assertStringContainsString( '\"4_Text\":\"Texty text\"', $submission->post_content, 'Post content did not contain the text field label and/or value' );
 	}
 
 	/**
@@ -561,7 +545,7 @@ class WP_Test_Contact_Form extends BaseTestCase {
 	 *                    subject, message, headers, and attachments values.
 	 */
 	public function pre_test_process_submission_labels_message_as_spam_in_subject_if_marked_as_spam_with_true_and_sending_spam( $args ) {
-		$this->assertStringContains( '***SPAM***', $args['subject'] );
+		$this->assertStringContainsString( '***SPAM***', $args['subject'] );
 	}
 
 	/**

--- a/projects/packages/ignorefile/.phan/baseline.php
+++ b/projects/packages/ignorefile/.phan/baseline.php
@@ -9,14 +9,13 @@
  */
 return [
     // # Issue statistics:
-    // PhanRedefinedUsedTrait : 1 occurrence
     // PhanTypeMismatchArgumentInternal : 1 occurrence
     // PhanTypeMismatchDimFetch : 1 occurrence
     // PhanUndeclaredClassInstanceof : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'tests/php/IgnoreFileTest.php' => ['PhanRedefinedUsedTrait', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchDimFetch', 'PhanUndeclaredClassInstanceof'],
+        'tests/php/IgnoreFileTest.php' => ['PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchDimFetch', 'PhanUndeclaredClassInstanceof'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/ignorefile/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/ignorefile/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/lazy-images/.phan/baseline.php
+++ b/projects/packages/lazy-images/.phan/baseline.php
@@ -11,14 +11,13 @@ return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 2 occurrences
     // PhanParamTooMany : 1 occurrence
-    // PhanRedefinedUsedTrait : 1 occurrence
     // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
     // PhanUndeclaredFunction : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/lazy-images.php' => ['PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredFunction'],
-        'tests/php/test_class.lazy-images.php' => ['PhanParamTooMany', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument'],
+        'tests/php/test_class.lazy-images.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/lazy-images/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/lazy-images/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/logo/.phan/baseline.php
+++ b/projects/packages/logo/.phan/baseline.php
@@ -8,12 +8,9 @@
  * (can be combined with --load-baseline)
  */
 return [
-    // # Issue statistics:
-    // PhanRedefinedUsedTrait : 1 occurrence
-
+    // This baseline has no suppressions
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'tests/php/test-logo.php' => ['PhanRedefinedUsedTrait'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/logo/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/logo/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/phpcs-filter/.phan/baseline.php
+++ b/projects/packages/phpcs-filter/.phan/baseline.php
@@ -12,7 +12,6 @@ return [
     // PhanUndeclaredFunction : 10+ occurrences
     // PhanPossiblyUndeclaredVariable : 3 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 2 occurrences
-    // PhanRedefinedUsedTrait : 2 occurrences
     // PhanTypeMismatchReturnNullable : 2 occurrences
     // PhanUndeclaredMethod : 2 occurrences
     // PhanUndeclaredTypeParameter : 2 occurrences
@@ -36,8 +35,8 @@ return [
         'tests/fixtures/perdir/excludedfile.php' => ['PhanUndeclaredFunction'],
         'tests/fixtures/perdir/file.php' => ['PhanUndeclaredFunction'],
         'tests/fixtures/perdir/severity-to-0/file.php' => ['PhanUndeclaredFunction'],
-        'tests/php/PhpcsFilterTest.php' => ['PhanPluginLoopVariableReuse', 'PhanPossiblyUndeclaredVariable', 'PhanRedefinedUsedTrait'],
-        'tests/php/StdinBootstrapTest.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedefinedUsedTrait', 'PhanTypeArraySuspiciousNullable', 'PhanUndeclaredClassMethod'],
+        'tests/php/PhpcsFilterTest.php' => ['PhanPluginLoopVariableReuse', 'PhanPossiblyUndeclaredVariable'],
+        'tests/php/StdinBootstrapTest.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable', 'PhanUndeclaredClassMethod'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/phpcs-filter/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/phpcs-filter/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/search/.phan/baseline.php
+++ b/projects/packages/search/.phan/baseline.php
@@ -34,7 +34,6 @@ return [
     // PhanPluginRedundantAssignment : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanPossiblyUndeclaredVariable : 1 occurrence
-    // PhanRedefinedUsedTrait : 1 occurrence
     // PhanTypeComparisonToArray : 1 occurrence
     // PhanTypeInvalidDimOffset : 1 occurrence
     // PhanTypeMismatchDeclaredParamNullable : 1 occurrence
@@ -67,7 +66,7 @@ return [
         'src/wpes/class-query-builder.php' => ['PhanImpossibleCondition', 'PhanRedundantCondition', 'PhanTypeMismatchDimAssignment', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
         'src/wpes/class-query-parser.php' => ['PhanUndeclaredProperty'],
         'tests/php/test-get-ios-version.php' => ['PhanUndeclaredFunctionInCallable'],
-        'tests/php/test-helpers.php' => ['PhanPluginMixedKeyNoKey', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredTypeProperty', 'PhanUnextractableAnnotation'],
+        'tests/php/test-helpers.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredTypeProperty', 'PhanUnextractableAnnotation'],
         'tests/php/test-module-control.php' => ['PhanTypeMismatchArgument'],
         'tests/php/test-plan.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/test-rest-controller.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeReturnType'],

--- a/projects/packages/search/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/search/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/packages/waf/.phan/baseline.php
+++ b/projects/packages/waf/.phan/baseline.php
@@ -29,7 +29,6 @@ return [
     // PhanUndeclaredTypeReturnType : 3 occurrences
     // PhanUnextractableAnnotationElementName : 3 occurrences
     // PhanPluginRedundantAssignment : 2 occurrences
-    // PhanRedefinedUsedTrait : 2 occurrences
     // PhanStaticCallToNonStatic : 2 occurrences
     // PhanTypeArraySuspiciousNullable : 2 occurrences
     // PhanTypeMismatchArgumentNullable : 2 occurrences
@@ -71,8 +70,8 @@ return [
         'tests/php/integration/test-waf-unsupported-environment.php' => ['PhanTypeMismatchArgument'],
         'tests/php/unit/functions-wordpress.php' => ['PhanRedefineFunction'],
         'tests/php/unit/test-waf-operators.php' => ['PhanTypeMismatchArgumentInternal'],
-        'tests/php/unit/test-waf-request.php' => ['PhanRedefinedUsedTrait', 'PhanTypeMismatchReturn'],
-        'tests/php/unit/test-waf-runtime-targets.php' => ['PhanPluginRedundantAssignment', 'PhanRedefinedUsedTrait', 'PhanTypeMismatchReturn', 'PhanUnextractableAnnotationElementName', 'PhanUnextractableAnnotationSuffix'],
+        'tests/php/unit/test-waf-request.php' => ['PhanTypeMismatchReturn'],
+        'tests/php/unit/test-waf-runtime-targets.php' => ['PhanPluginRedundantAssignment', 'PhanTypeMismatchReturn', 'PhanUnextractableAnnotationElementName', 'PhanUnextractableAnnotationSuffix'],
         'tests/php/unit/test-waf-runtime.php' => ['PhanImpossibleTypeComparison', 'PhanTypeMismatchArgument'],
         'tests/php/unit/test-waf-standalone-bootstrap.php' => ['PhanDeprecatedFunction', 'PhanNoopNew', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
     ],

--- a/projects/packages/waf/changelog/fix-phan-yoast-polyfills
+++ b/projects/packages/waf/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/plugins/boost/.phan/baseline.php
+++ b/projects/plugins/boost/.phan/baseline.php
@@ -46,7 +46,6 @@ return [
     // PhanPluginNeverReturnFunction : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanRedefineFunction : 1 occurrence
-    // PhanRedefinedExtendedClass : 1 occurrence
     // PhanTypeComparisonToArray : 1 occurrence
     // PhanTypeInvalidUnaryOperandIncOrDec : 1 occurrence
     // PhanTypeMismatchArgumentNullable : 1 occurrence
@@ -126,7 +125,6 @@ return [
         'compatibility/wp-super-cache.php' => ['PhanUndeclaredFunction'],
         'jetpack-boost.php' => ['PhanNoopNew'],
         'tests/bootstrap.php' => ['PhanRedefineFunction', 'PhanTypeMismatchReturnProbablyReal'],
-        'tests/php/class-base-test-case.php' => ['PhanRedefinedExtendedClass'],
         'wp-js-data-sync.php' => ['PhanParamTooMany'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/plugins/boost/changelog/fix-phan-yoast-polyfills
+++ b/projects/plugins/boost/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update phan baseline for base config change. No change to functionality.
+
+

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -22,8 +22,8 @@ return [
     // PhanUndeclaredMethod : 130+ occurrences
     // PhanTypePossiblyInvalidDimOffset : 110+ occurrences
     // PhanDeprecatedProperty : 95+ occurrences
-    // PhanRedefinedClassReference : 95+ occurrences
     // PhanTypeArraySuspiciousNullable : 95+ occurrences
+    // PhanRedefinedClassReference : 90+ occurrences
     // PhanRedundantCondition : 75+ occurrences
     // PhanUndeclaredThis : 70+ occurrences
     // PhanPossiblyUndeclaredVariable : 65+ occurrences
@@ -80,7 +80,6 @@ return [
     // PhanUnextractableAnnotationElementName : 6 occurrences
     // PhanImpossibleCondition : 5 occurrences
     // PhanPluginUnreachableCode : 5 occurrences
-    // PhanRedefinedExtendedClass : 5 occurrences
     // PhanTypeConversionFromArray : 5 occurrences
     // PhanTypeMismatchDimAssignment : 5 occurrences
     // PhanTypeSuspiciousEcho : 5 occurrences
@@ -96,6 +95,7 @@ return [
     // PhanTypeInvalidRightOperandOfNumericOp : 4 occurrences
     // PhanDeprecatedFunctionInternal : 3 occurrences
     // PhanDeprecatedTrait : 3 occurrences
+    // PhanRedefinedExtendedClass : 3 occurrences
     // PhanTypeMismatchArgumentReal : 3 occurrences
     // PhanTypeObjectUnsetDeclaredProperty : 3 occurrences
     // PhanUndeclaredStaticMethod : 3 occurrences
@@ -739,8 +739,7 @@ return [
         'tests/php/sync/test_class.jetpack-sync-woocommerce.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
         'tests/php/sync/test_class.jetpack-sync-wp_super_cache.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspiciousNullable'],
         'tests/php/sync/test_class.jetpack_sync_backward_compatibility.php' => ['PhanParamTooMany'],
-        'tests/php/sync/test_interface.jetpack-sync-codec.php' => ['PhanRedefinedExtendedClass'],
-        'tests/php/sync/test_interface.jetpack-sync-replicastore.php' => ['PhanRedefinedClassReference', 'PhanRedefinedExtendedClass', 'PhanRedundantConditionInLoop', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant'],
+        'tests/php/sync/test_interface.jetpack-sync-replicastore.php' => ['PhanRedundantConditionInLoop', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant'],
         'tests/php/test_class.functions.opengraph.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/test_deprecation.php' => ['PhanDeprecatedFunction', 'PhanUndeclaredMethodInCallable'],
         'tests/php/trait-woo-tests.php' => ['PhanUndeclaredClassMethod'],

--- a/projects/plugins/jetpack/changelog/fix-phan-yoast-polyfills
+++ b/projects/plugins/jetpack/changelog/fix-phan-yoast-polyfills
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update phan baseline for base config change. No change to functionality.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When Phan processes vendor/yoast/phpunit-polyfills, it results in a bunch of `PhanRedefinedXXX` issues because the actual package only loads one file depending on the PHP version running while Phan just processes them all.
    
So let's add to the base config some `exclude_file_regex` rules to exclude some of the files so Phan sees only one copy of each class or trait.

Also, a test in packages/forms was manually polyfilling `assertStringContainsString`. Remove that to use the Yoast polyfill already being brought in by the WorDBless base class.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
