### PR TITLE
Scheduled updates: Update scheduled updates cron event name to jetpack_scheduled_plugins_update

### DIFF
--- a/projects/packages/scheduled-updates/changelog/update-cron-event-name
+++ b/projects/packages/scheduled-updates/changelog/update-cron-event-name
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Update cron event name from jetpack_scheduled_update to jetpack_scheduled_plugins_update
+Scheduled Updates: Update cron event name from jetpack_scheduled_update to jetpack_scheduled_plugins_update

--- a/projects/packages/scheduled-updates/changelog/update-cron-event-name
+++ b/projects/packages/scheduled-updates/changelog/update-cron-event-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update cron event name from jetpack_scheduled_update to jetpack_scheduled_plugins_update

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -41,7 +41,7 @@ class Scheduled_Updates {
 			return;
 		}
 
-		add_action( 'jetpack_scheduled_update', array( __CLASS__, 'run_scheduled_update' ), 10, 10 );
+		add_action( 'jetpack_scheduled_plugins_update', array( __CLASS__, 'run_scheduled_update' ), 10, 10 );
 		add_action( 'rest_api_init', array( __CLASS__, 'add_is_managed_extension_field' ) );
 		add_filter( 'auto_update_plugin', array( __CLASS__, 'allowlist_scheduled_plugins' ), 10, 2 );
 		add_filter( 'plugin_auto_update_setting_html', array( __CLASS__, 'show_scheduled_updates' ), 10, 2 );
@@ -97,7 +97,7 @@ class Scheduled_Updates {
 	 * @return false|array Updated statuses or false if not found.
 	 */
 	public static function set_scheduled_update_status( $schedule_id, $timestamp, $status ) {
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
 
 		if ( empty( $events[ $schedule_id ] ) ) {
 			// Scheduled update not found.
@@ -141,7 +141,7 @@ class Scheduled_Updates {
 				require_once __DIR__ . '/pluggable.php';
 			}
 
-			$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+			$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
 			foreach ( $events as $event ) {
 				if ( isset( $item->plugin ) && in_array( $item->plugin, $event->args, true ) ) {
 					return true;
@@ -165,7 +165,7 @@ class Scheduled_Updates {
 			require_once __DIR__ . '/pluggable.php';
 		}
 
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
 
 		$schedules = array();
 		foreach ( $events as $event ) {

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.4.1';
+	const PACKAGE_VERSION = '0.4.2-alpha';
 	/**
 	 * The cron event hook for the scheduled plugins update.
 	 *

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -21,6 +21,12 @@ class Scheduled_Updates {
 	 * @var string
 	 */
 	const PACKAGE_VERSION = '0.4.1';
+	/**
+	 * The cron event hook for the scheduled plugins update.
+	 *
+	 * @var string
+	 */
+	const PLUGIN_CRON_HOOK = 'jetpack_scheduled_plugins_update';
 
 	/**
 	 * Initialize the class.
@@ -41,7 +47,7 @@ class Scheduled_Updates {
 			return;
 		}
 
-		add_action( 'jetpack_scheduled_plugins_update', array( __CLASS__, 'run_scheduled_update' ), 10, 10 );
+		add_action( self::PLUGIN_CRON_HOOK, array( __CLASS__, 'run_scheduled_update' ), 10, 10 );
 		add_action( 'rest_api_init', array( __CLASS__, 'add_is_managed_extension_field' ) );
 		add_filter( 'auto_update_plugin', array( __CLASS__, 'allowlist_scheduled_plugins' ), 10, 2 );
 		add_filter( 'plugin_auto_update_setting_html', array( __CLASS__, 'show_scheduled_updates' ), 10, 2 );
@@ -97,7 +103,7 @@ class Scheduled_Updates {
 	 * @return false|array Updated statuses or false if not found.
 	 */
 	public static function set_scheduled_update_status( $schedule_id, $timestamp, $status ) {
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
+		$events = wp_get_scheduled_events( self::PLUGIN_CRON_HOOK );
 
 		if ( empty( $events[ $schedule_id ] ) ) {
 			// Scheduled update not found.
@@ -141,7 +147,7 @@ class Scheduled_Updates {
 				require_once __DIR__ . '/pluggable.php';
 			}
 
-			$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
+			$events = wp_get_scheduled_events( self::PLUGIN_CRON_HOOK );
 			foreach ( $events as $event ) {
 				if ( isset( $item->plugin ) && in_array( $item->plugin, $event->args, true ) ) {
 					return true;
@@ -165,7 +171,7 @@ class Scheduled_Updates {
 			require_once __DIR__ . '/pluggable.php';
 		}
 
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
+		$events = wp_get_scheduled_events( self::PLUGIN_CRON_HOOK );
 
 		$schedules = array();
 		foreach ( $events as $event ) {

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -198,7 +198,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$events   = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
+		$events   = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
 		$response = array();
 
 		foreach ( array_keys( $events ) as $schedule_id ) {
@@ -246,7 +246,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$plugins  = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );
 
-		$event = wp_schedule_event( $schedule['timestamp'], $schedule['interval'], 'jetpack_scheduled_plugins_update', $plugins, true );
+		$event = wp_schedule_event( $schedule['timestamp'], $schedule['interval'], Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins, true );
 		if ( is_wp_error( $event ) ) {
 			return $event;
 		}
@@ -289,7 +289,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error The scheduled event or a WP_Error if the schedule could not be found.
 	 */
 	public function get_item( $request ) {
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
 
 		if ( empty( $events[ $request['schedule_id'] ] ) ) {
 			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
@@ -356,7 +356,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error The updated event or a WP_Error if the schedule could not be found.
 	 */
 	public function update_status( $request ) {
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
 
 		if ( empty( $events[ $request['schedule_id'] ] ) ) {
 			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
@@ -411,7 +411,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
 
 		if ( ! isset( $events[ $request['schedule_id'] ] ) ) {
 			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
@@ -419,7 +419,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 
 		$event = $events[ $request['schedule_id'] ];
 
-		$result = wp_unschedule_event( $event->timestamp, 'jetpack_scheduled_plugins_update', $event->args, true );
+		$result = wp_unschedule_event( $event->timestamp, Scheduled_Updates::PLUGIN_CRON_HOOK, $event->args, true );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
@@ -554,7 +554,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function validate_schedule( $request ) {
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
 
 		$plugins = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -144,7 +144,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	}
 
 	/**
-	 * Add status fields to the jetpack_scheduled_update object.
+	 * Add status fields to the jetpack_scheduled_plugins_update object.
 	 */
 	public function add_status_fields() {
 		$object_type = $this->get_object_type();
@@ -198,7 +198,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$events   = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+		$events   = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
 		$response = array();
 
 		foreach ( array_keys( $events ) as $schedule_id ) {
@@ -246,7 +246,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$plugins  = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );
 
-		$event = wp_schedule_event( $schedule['timestamp'], $schedule['interval'], 'jetpack_scheduled_update', $plugins, true );
+		$event = wp_schedule_event( $schedule['timestamp'], $schedule['interval'], 'jetpack_scheduled_plugins_update', $plugins, true );
 		if ( is_wp_error( $event ) ) {
 			return $event;
 		}
@@ -289,7 +289,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error The scheduled event or a WP_Error if the schedule could not be found.
 	 */
 	public function get_item( $request ) {
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
 
 		if ( empty( $events[ $request['schedule_id'] ] ) ) {
 			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
@@ -356,7 +356,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error The updated event or a WP_Error if the schedule could not be found.
 	 */
 	public function update_status( $request ) {
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
 
 		if ( empty( $events[ $request['schedule_id'] ] ) ) {
 			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
@@ -411,7 +411,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
 
 		if ( ! isset( $events[ $request['schedule_id'] ] ) ) {
 			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
@@ -419,7 +419,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 
 		$event = $events[ $request['schedule_id'] ];
 
-		$result = wp_unschedule_event( $event->timestamp, 'jetpack_scheduled_update', $event->args, true );
+		$result = wp_unschedule_event( $event->timestamp, 'jetpack_scheduled_plugins_update', $event->args, true );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
@@ -554,7 +554,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function validate_schedule( $request ) {
-		$events = wp_get_scheduled_events( 'jetpack_scheduled_update' );
+		$events = wp_get_scheduled_events( 'jetpack_scheduled_plugins_update' );
 
 		$plugins = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -77,7 +77,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		// Clean up the plugins cache created by get_plugins()
 		wp_cache_delete( 'plugins', 'plugins' );
 
-		wp_clear_scheduled_hook( 'jetpack_scheduled_plugins_update' );
+		wp_clear_scheduled_hook( Scheduled_Updates::PLUGIN_CRON_HOOK );
 		delete_option( 'jetpack_scheduled_update_statuses' );
 
 		parent::tear_down_wordbless();

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -77,7 +77,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		// Clean up the plugins cache created by get_plugins()
 		wp_cache_delete( 'plugins', 'plugins' );
 
-		wp_clear_scheduled_hook( 'jetpack_scheduled_update' );
+		wp_clear_scheduled_hook( 'jetpack_scheduled_plugins_update' );
 		delete_option( 'jetpack_scheduled_update_statuses' );
 
 		parent::tear_down_wordbless();

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -70,7 +70,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		wp_delete_user( $this->admin_id );
 		wp_delete_user( $this->editor_id );
 
-		wp_clear_scheduled_hook( 'jetpack_scheduled_plugins_update' );
+		wp_clear_scheduled_hook( Scheduled_Updates::PLUGIN_CRON_HOOK );
 		delete_option( 'jetpack_scheduled_update_statuses' );
 	}
 
@@ -107,8 +107,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'gutenberg/gutenberg.php',
 			'custom-plugin/custom-plugin.php',
 		);
-		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_plugins_update', array( 'hello-dolly/hello-dolly.php' ) );
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins );
+		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', Scheduled_Updates::PLUGIN_CRON_HOOK, array( 'hello-dolly/hello-dolly.php' ) );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins );
 
 		// Successful request.
 		$result = rest_do_request( $request );
@@ -117,7 +117,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertEquals(
 			array(
 				Scheduled_Updates::generate_schedule_id( array( 'hello-dolly/hello-dolly.php' ) ) => array(
-					'hook'               => 'jetpack_scheduled_plugins_update',
+					'hook'               => Scheduled_Updates::PLUGIN_CRON_HOOK,
 					'args'               => array( 'hello-dolly/hello-dolly.php' ),
 					'timestamp'          => strtotime( 'next Tuesday 9:00' ),
 					'schedule'           => 'daily',
@@ -126,7 +126,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 					'last_run_status'    => null,
 				),
 				Scheduled_Updates::generate_schedule_id( $plugins ) => array(
-					'hook'               => 'jetpack_scheduled_plugins_update',
+					'hook'               => Scheduled_Updates::PLUGIN_CRON_HOOK,
 					'args'               => $plugins,
 					'timestamp'          => strtotime( 'next Monday 8:00' ),
 					'schedule'           => 'weekly',
@@ -211,7 +211,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'gutenberg/gutenberg.php',
 		);
 
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins );
 
 		// Can't create a schedule for the same time again.
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
@@ -239,8 +239,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	 */
 	public function test_creating_more_than_two_schedules() {
 		// Create two schedules.
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', array( 'gutenberg/gutenberg.php' ) );
-		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_plugins_update', array( 'custom-plugin/custom-plugin.php' ) );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', Scheduled_Updates::PLUGIN_CRON_HOOK, array( 'gutenberg/gutenberg.php' ) );
+		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', Scheduled_Updates::PLUGIN_CRON_HOOK, array( 'custom-plugin/custom-plugin.php' ) );
 
 		// Number 3.
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
@@ -325,7 +325,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertEquals(
 			array(
 				Scheduled_Updates::generate_schedule_id( $plugins ) => array(
-					'hook'               => 'jetpack_scheduled_plugins_update',
+					'hook'               => Scheduled_Updates::PLUGIN_CRON_HOOK,
 					'args'               => $plugins,
 					'timestamp'          => strtotime( 'next Wednesday 10:00' ),
 					'schedule'           => 'daily',
@@ -354,7 +354,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'last_run_status'    => 'success',
 		);
 
-		wp_schedule_event( strtotime( 'next Tuesday 0:00' ), 'daily', 'jetpack_scheduled_plugins_update', $plugins );
+		wp_schedule_event( strtotime( 'next Tuesday 0:00' ), 'daily', Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins );
 
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules/' . $id_1 . '/status' );
 		$request->set_body_params( $body );
@@ -396,7 +396,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'last_run_status'    => 'failure-and-rollback',
 		);
 
-		wp_schedule_event( strtotime( 'next Tuesday 09:00' ), 'daily', 'jetpack_scheduled_plugins_update', $plugins );
+		wp_schedule_event( strtotime( 'next Tuesday 09:00' ), 'daily', Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins );
 
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules/' . $id_2 . '/status' );
 		$request->set_body_params( $body );
@@ -468,7 +468,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		);
 		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
 
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins );
 
 		// Unauthenticated request.
 		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules/' . $schedule_id );
@@ -491,7 +491,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertEquals(
 			array(
-				'hook'               => 'jetpack_scheduled_plugins_update',
+				'hook'               => Scheduled_Updates::PLUGIN_CRON_HOOK,
 				'args'               => $plugins,
 				'timestamp'          => strtotime( 'next Monday 8:00' ),
 				'schedule'           => 'weekly',
@@ -530,7 +530,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		);
 		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
 
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins );
 
 		// Unauthenticated request.
 		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $schedule_id );
@@ -599,7 +599,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		);
 		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
 
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins );
 
 		// Unauthenticated request.
 		wp_set_current_user( 0 );
@@ -623,7 +623,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertTrue( $result->get_data() );
 
-		$this->assertFalse( wp_get_scheduled_event( 'jetpack_scheduled_plugins_update', $plugins ) );
+		$this->assertFalse( wp_get_scheduled_event( Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins ) );
 	}
 
 	/**
@@ -662,8 +662,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins_2 );
 
-		wp_schedule_event( strtotime( 'next Tuesday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins_1 );
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins_2 );
+		wp_schedule_event( strtotime( 'next Tuesday 8:00' ), 'weekly', Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins_1 );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins_2 );
 
 		update_option( 'auto_update_plugins', $auto_update );
 

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -70,7 +70,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		wp_delete_user( $this->admin_id );
 		wp_delete_user( $this->editor_id );
 
-		wp_clear_scheduled_hook( 'jetpack_scheduled_update' );
+		wp_clear_scheduled_hook( 'jetpack_scheduled_plugins_update' );
 		delete_option( 'jetpack_scheduled_update_statuses' );
 	}
 
@@ -107,8 +107,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'gutenberg/gutenberg.php',
 			'custom-plugin/custom-plugin.php',
 		);
-		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_update', array( 'hello-dolly/hello-dolly.php' ) );
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_plugins_update', array( 'hello-dolly/hello-dolly.php' ) );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins );
 
 		// Successful request.
 		$result = rest_do_request( $request );
@@ -117,7 +117,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertEquals(
 			array(
 				Scheduled_Updates::generate_schedule_id( array( 'hello-dolly/hello-dolly.php' ) ) => array(
-					'hook'               => 'jetpack_scheduled_update',
+					'hook'               => 'jetpack_scheduled_plugins_update',
 					'args'               => array( 'hello-dolly/hello-dolly.php' ),
 					'timestamp'          => strtotime( 'next Tuesday 9:00' ),
 					'schedule'           => 'daily',
@@ -126,7 +126,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 					'last_run_status'    => null,
 				),
 				Scheduled_Updates::generate_schedule_id( $plugins ) => array(
-					'hook'               => 'jetpack_scheduled_update',
+					'hook'               => 'jetpack_scheduled_plugins_update',
 					'args'               => $plugins,
 					'timestamp'          => strtotime( 'next Monday 8:00' ),
 					'schedule'           => 'weekly',
@@ -211,7 +211,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'gutenberg/gutenberg.php',
 		);
 
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins );
 
 		// Can't create a schedule for the same time again.
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
@@ -239,8 +239,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	 */
 	public function test_creating_more_than_two_schedules() {
 		// Create two schedules.
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', array( 'gutenberg/gutenberg.php' ) );
-		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_update', array( 'custom-plugin/custom-plugin.php' ) );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', array( 'gutenberg/gutenberg.php' ) );
+		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', 'jetpack_scheduled_plugins_update', array( 'custom-plugin/custom-plugin.php' ) );
 
 		// Number 3.
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
@@ -325,7 +325,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertEquals(
 			array(
 				Scheduled_Updates::generate_schedule_id( $plugins ) => array(
-					'hook'               => 'jetpack_scheduled_update',
+					'hook'               => 'jetpack_scheduled_plugins_update',
 					'args'               => $plugins,
 					'timestamp'          => strtotime( 'next Wednesday 10:00' ),
 					'schedule'           => 'daily',
@@ -354,7 +354,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'last_run_status'    => 'success',
 		);
 
-		wp_schedule_event( strtotime( 'next Tuesday 0:00' ), 'daily', 'jetpack_scheduled_update', $plugins );
+		wp_schedule_event( strtotime( 'next Tuesday 0:00' ), 'daily', 'jetpack_scheduled_plugins_update', $plugins );
 
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules/' . $id_1 . '/status' );
 		$request->set_body_params( $body );
@@ -396,7 +396,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			'last_run_status'    => 'failure-and-rollback',
 		);
 
-		wp_schedule_event( strtotime( 'next Tuesday 09:00' ), 'daily', 'jetpack_scheduled_update', $plugins );
+		wp_schedule_event( strtotime( 'next Tuesday 09:00' ), 'daily', 'jetpack_scheduled_plugins_update', $plugins );
 
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules/' . $id_2 . '/status' );
 		$request->set_body_params( $body );
@@ -468,7 +468,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		);
 		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
 
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins );
 
 		// Unauthenticated request.
 		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules/' . $schedule_id );
@@ -491,7 +491,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertEquals(
 			array(
-				'hook'               => 'jetpack_scheduled_update',
+				'hook'               => 'jetpack_scheduled_plugins_update',
 				'args'               => $plugins,
 				'timestamp'          => strtotime( 'next Monday 8:00' ),
 				'schedule'           => 'weekly',
@@ -530,7 +530,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		);
 		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
 
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins );
 
 		// Unauthenticated request.
 		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $schedule_id );
@@ -599,7 +599,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		);
 		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
 
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins );
 
 		// Unauthenticated request.
 		wp_set_current_user( 0 );
@@ -623,7 +623,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertTrue( $result->get_data() );
 
-		$this->assertFalse( wp_get_scheduled_event( 'jetpack_scheduled_update', $plugins ) );
+		$this->assertFalse( wp_get_scheduled_event( 'jetpack_scheduled_plugins_update', $plugins ) );
 	}
 
 	/**
@@ -662,8 +662,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins_2 );
 
-		wp_schedule_event( strtotime( 'next Tuesday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins_1 );
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_update', $plugins_2 );
+		wp_schedule_event( strtotime( 'next Tuesday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins_1 );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', 'jetpack_scheduled_plugins_update', $plugins_2 );
 
 		update_option( 'auto_update_plugins', $auto_update );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/dotcom-forge#6125

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update cron event name from `jetpack_scheduled_update` to `jetpack_scheduled_plugins_update`  so that it’ll be easier in the future to extend it to themes.

**Note:** By updating the hook name here, this means the existing schedules will not be picked up anymore. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow pcmemI-2Sx-p2 to setup a testing WoA site.
* You can either select this branch in your Jetpack Beta tester under WordPress.com features or use jetpack rsync to sync the changes to your testing site.
* Navigate to https://wordpress.com/plugins/scheduled-updates/<site-slug> and try to create, edit, and remove your schedules.
* Make sure everything works as expected as before.