### PR TITLE
Verbum: Release Gutenberg to 100%

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-gutenberg-verbum-100
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-gutenberg-verbum-100
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Release gutenberg to all verbum comments

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -561,24 +561,7 @@ HTML;
 			return false;
 		}
 
-		$blog_id         = $this->blog_id;
-		$e2e_tests       = function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'a8c-e2e-test-blog', $blog_id );
-		$has_blocks_flag = function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'verbum-block-comments', $blog_id );
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$gutenberg_query_param = isset( $_GET['verbum_gutenberg'] ) ? intval( $_GET['verbum_gutenberg'] ) : null;
-		// This will release to 80% of sites.
-		$blog_in_80_percent = $blog_id % 100 >= 20;
-		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] )
-			? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) )
-			: defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
-
-		// Check if the parameter is set and its value is either 0 or 1, if any random value is passed, it is ignored.
-		if ( $gutenberg_query_param !== null ) {
-			return $gutenberg_query_param === 1;
-		}
-
-		return $has_blocks_flag || $e2e_tests || $blog_in_80_percent;
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

This PR releases Gutenberg to all Verbum comments.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Sandbox jetpack
- Check that Verbum uses Gutenberg.
