### PR TITLE
Jetpack_Portfolio: Prevent a division by 0 fatal when a user uses the shortcode with columns=0

### DIFF
--- a/projects/plugins/jetpack/changelog/update-portfolios
+++ b/projects/plugins/jetpack/changelog/update-portfolios
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack_Portfolio: Prevent a division by 0 fatal when a user uses the shortcode with columns=0

--- a/projects/plugins/jetpack/modules/custom-post-types/portfolios.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/portfolios.php
@@ -963,6 +963,7 @@ class Jetpack_Portfolio {
 	 * @return string
 	 */
 	private static function get_project_class( $portfolio_index_number, $columns ) {
+		$columns       = is_numeric( $columns ) ? max( 1, $columns ) : 1;
 		$project_types = wp_get_object_terms( get_the_ID(), self::CUSTOM_TAXONOMY_TYPE, array( 'fields' => 'slugs' ) );
 		$class         = array();
 


### PR DESCRIPTION
## Proposed changes:

* Fixes a fatal division by 0 error when `Jetpack_Portfolio::get_project_class(0, 0)` is called 
* The second parameter is `$columns`. It can be set to zero from an invalid or missing shortcode attribute.
* Change: Force the $column count to 1 if it's not a number, and if it is a number, make sure it is not zero or negative.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See D142241-code which has the changes and a url to sandbox and check

