### PR TITLE
Boost: Disable Activate License link on Atomic sites

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/activate-license/activate-license.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/activate-license/activate-license.tsx
@@ -3,6 +3,11 @@ import { __ } from '@wordpress/i18n';
 import styles from './activate-license.module.scss';
 
 const ActivateLicense = () => {
+	const { site } = Jetpack_Boost;
+	if ( site.isAtomic ) {
+		return null;
+	}
+
 	const activateLicenseUrl = 'admin.php?page=my-jetpack#/add-license';
 
 	return (

--- a/projects/plugins/boost/changelog/update-activate-license-to-hide-on-atomic
+++ b/projects/plugins/boost/changelog/update-activate-license-to-hide-on-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update Activate License to be hidden on Atomic sites.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #30576

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable activate license link on atomic. The check is done inside the component, that way when ever it's used, it will always be hidden on atomic.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/issues/30576

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup this version of Boost on Atomic;
* Make sure the Activate License link isn't visible anywhere (its normally visible on `#getting-started` and `#upgrade`).