### PR TITLE
Boost: Update cloud css REST API endpoint to be present when module is off

### DIFF
--- a/projects/plugins/boost/app/modules/Modules_Setup.php
+++ b/projects/plugins/boost/app/modules/Modules_Setup.php
@@ -50,8 +50,6 @@ class Modules_Setup implements Has_Setup {
 	 * Used to register endpoints that will be available even
 	 * if the module is not enabled.
 	 *
-	 * @param Pluggable $feature
-	 *
 	 * @return bool|void
 	 */
 	public function register_always_available_endpoints( $feature ) {

--- a/projects/plugins/boost/app/modules/Modules_Setup.php
+++ b/projects/plugins/boost/app/modules/Modules_Setup.php
@@ -9,6 +9,7 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Regenerate;
 use Automattic\Jetpack_Boost\Lib\Setup;
 use Automattic\Jetpack_Boost\Lib\Status;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Cloud_CSS\Cloud_CSS;
+use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Always_Available_Endpoints;
 use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Endpoints;
 use Automattic\Jetpack_Boost\REST_API\REST_API;
 
@@ -45,6 +46,26 @@ class Modules_Setup implements Has_Setup {
 		return $status;
 	}
 
+	/**
+	 * Used to register endpoints that will be available even
+	 * if the module is not enabled.
+	 *
+	 * @param Has_Always_Available_Endpoints $feature
+	 *
+	 * @return bool|void
+	 */
+	public function register_always_available_endpoints( $feature ) {
+		if ( ! $feature instanceof Has_Always_Available_Endpoints ) {
+			return false;
+		}
+
+		if ( empty( $feature->get_always_available_endpoints() ) ) {
+			return false;
+		}
+
+		REST_API::register( $feature->get_always_available_endpoints() );
+	}
+
 	public function register_endpoints( $feature ) {
 		if ( ! $feature instanceof Has_Endpoints ) {
 			return false;
@@ -60,6 +81,8 @@ class Modules_Setup implements Has_Setup {
 	public function init_modules() {
 
 		foreach ( $this->available_modules as $slug => $module ) {
+
+			$this->register_always_available_endpoints( $module->feature );
 
 			if ( ! $module->is_enabled() ) {
 				continue;

--- a/projects/plugins/boost/app/modules/Modules_Setup.php
+++ b/projects/plugins/boost/app/modules/Modules_Setup.php
@@ -50,7 +50,7 @@ class Modules_Setup implements Has_Setup {
 	 * Used to register endpoints that will be available even
 	 * if the module is not enabled.
 	 *
-	 * @param Has_Always_Available_Endpoints $feature
+	 * @param Pluggable $feature
 	 *
 	 * @return bool|void
 	 */

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -13,10 +13,10 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Display_Critical_CSS;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Source_Providers\Source_Providers;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
-use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Endpoints;
+use Automattic\Jetpack_Boost\REST_API\Contracts\Has_Always_Available_Endpoints;
 use Automattic\Jetpack_Boost\REST_API\Endpoints\Update_Cloud_CSS;
 
-class Cloud_CSS implements Pluggable, Has_Endpoints, Changes_Page_Output {
+class Cloud_CSS implements Pluggable, Has_Always_Available_Endpoints, Changes_Page_Output {
 
 	/**
 	 * Critical CSS storage class instance.
@@ -59,7 +59,7 @@ class Cloud_CSS implements Pluggable, Has_Endpoints, Changes_Page_Output {
 		return 'cloud_css';
 	}
 
-	public function get_endpoints() {
+	public function get_always_available_endpoints() {
 		return array(
 			new Update_Cloud_CSS(),
 		);

--- a/projects/plugins/boost/app/rest-api/contracts/Has_Always_Available_Endpoints.php
+++ b/projects/plugins/boost/app/rest-api/contracts/Has_Always_Available_Endpoints.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\REST_API\Contracts;
+
+/**
+ * Interface for defining classes that provide endpoints which are always available.
+ */
+interface Has_Always_Available_Endpoints {
+
+	/**
+	 * Retrieves a list of endpoints that are always available.
+	 *
+	 * @return Endpoint[]
+	 */
+	public function get_always_available_endpoints();
+}

--- a/projects/plugins/boost/changelog/update-cloud-css-endpoint-to-always-be-available
+++ b/projects/plugins/boost/changelog/update-cloud-css-endpoint-to-always-be-available
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Cloud CSS: Update REST API endpoint to be available even if the module is turned off.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/boost-cloud/issues/383

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add an interface that allows features to have permanently available REST API endpoints;
* Update Cloud CSS `update` endpoint to be available even if the feature is turned off.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost premium;
* Generate critical CSS (not how long it takes, it could help later);
* Refresh the page and open the developer console to check the state of the critical css generation;
* Type `jetpack_boost_ds.critical_css_state.value` and note the values (it should look like the image below) 
  ![CleanShot 2024-03-18 at 17 24 32](https://github.com/Automattic/jetpack/assets/11799079/1327bff1-0d74-47e0-9537-826a72502358)
* Now quickly toggle the module off, then on and as soon as the description changes, turn it off again;
* Wait a bit (wait around the same time you waited during the first generation);
* Now open the console and check the state using `jetpack_boost_ds.critical_css_state.value` again - it should have updated
  ![CleanShot 2024-03-18 at 17 28 17](https://github.com/Automattic/jetpack/assets/11799079/2b672f87-2b66-4eb8-ab62-c728029e3437)


Another way to check if the endpoint is present, is to access your site's rest API (while the feature is turned off) by going to this URL - http://jetpack-boost.test/wp-json/jetpack-boost/v1 and see if `cloud-css/update` is present. If everything is working great, it should be there.