### PR TITLE
Add notice priorities to my jetpack notices

### DIFF
--- a/projects/packages/my-jetpack/_inc/context/constants.ts
+++ b/projects/packages/my-jetpack/_inc/context/constants.ts
@@ -1,0 +1,3 @@
+export const NOTICE_PRIORITY_LOW = 100;
+export const NOTICE_PRIORITY_MEDIUM = 200;
+export const NOTICE_PRIORITY_HIGH = 300;

--- a/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
+++ b/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
@@ -20,6 +20,7 @@ const NoticeContextProvider = ( { children } ) => {
 	const [ currentNotice, setCurrentNotice ] = useState< Notice >( defaultNotice );
 
 	const setNotice = ( notice: Notice ) => {
+		// Only update notice if there is not already a notice or the new notice has a higher priority
 		if ( ! currentNotice.message || notice.priority > currentNotice.priority ) {
 			setCurrentNotice( notice );
 		}

--- a/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
+++ b/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
@@ -6,6 +6,7 @@ const defaultNotice: Notice = {
 	options: {
 		status: '',
 	},
+	priority: 0,
 };
 
 export const NoticeContext = createContext< NoticeContextType >( {
@@ -19,7 +20,7 @@ const NoticeContextProvider = ( { children } ) => {
 	const [ currentNotice, setCurrentNotice ] = useState< Notice >( defaultNotice );
 
 	const setNotice = ( notice: Notice ) => {
-		if ( ! currentNotice.message ) {
+		if ( ! currentNotice.message || notice.priority > currentNotice.priority ) {
 			setCurrentNotice( notice );
 		}
 	};

--- a/projects/packages/my-jetpack/_inc/context/notices/types.ts
+++ b/projects/packages/my-jetpack/_inc/context/notices/types.ts
@@ -10,6 +10,7 @@ export type Notice = {
 			noDefaultClasses?: boolean;
 		}[];
 	};
+	priority: number;
 };
 
 export type NoticeContextType< T = Notice > = {

--- a/projects/packages/my-jetpack/_inc/data/notices/use-fetching-error-notice.ts
+++ b/projects/packages/my-jetpack/_inc/data/notices/use-fetching-error-notice.ts
@@ -1,5 +1,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useContext, useEffect } from 'react';
+import { NOTICE_PRIORITY_LOW } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
 import {
 	QUERY_ACTIVATE_PRODUCT_KEY,
@@ -38,6 +39,7 @@ export const useFetchingErrorNotice = ( { infoName, isError, overrideMessage }: 
 			setNotice( {
 				message,
 				options: { status: 'error' },
+				priority: NOTICE_PRIORITY_LOW,
 			} );
 		}
 	}, [ message, setNotice, isError, infoName ] );

--- a/projects/packages/my-jetpack/_inc/hooks/use-connection-watcher/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-connection-watcher/index.ts
@@ -1,6 +1,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useContext } from 'react';
 import { MyJetpackRoutes } from '../../constants';
+import { NOTICE_PRIORITY_HIGH } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
 import { useAllProducts } from '../../data/products/use-product';
 import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
@@ -54,6 +55,7 @@ export default function useConnectionWatcher() {
 						},
 					],
 				},
+				priority: NOTICE_PRIORITY_HIGH,
 			} );
 		}
 	}, [

--- a/projects/packages/my-jetpack/changelog/add-priority-notices-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-priority-notices-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add notice priorities to My Jetpack


### PR DESCRIPTION
## Proposed changes:

* Add numerical priority to notices in My Jetpack

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-aby-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

I can't think of a way to test this with the Jetpack Beta plugin right now with so few notices. The only error notices are product activation and purchases, and those error doesn't show if the issue is site connectivity, which is the only other notice. Below are instructions on how to test it locally by editing the code a bit

1. Set up your local dev environment
2. Disconnect your site from Jetpack
![image](https://github.com/Automattic/jetpack/assets/65001528/b6cd4370-ce8e-4b27-9c01-a730eb659197)
3. Go to `projects/packages/my-jetpack/_inc/data/notices/use-fetching-error-notice.ts` and replace `NOTICE_PRIORITY_LOW` with 1000. This will give it a higher priority than the connection notice which is currently `PRIORITY_NOTICE_HIGH` with a value of 300.
4. Go to `projects/packages/my-jetpack/_inc/data/use-simple-query.ts` and on line 42, remove the `&& error.code !== 'not_connected'` part of the condition. This stops the notice from being shown if the reason for the error is the lack of a site connection
5. Lastly, go to `projects/packages/my-jetpack/src/class-rest-purchases.php` and add the following code to line 63 to return an error
```php
return new \WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
```
6. Go to `/wp-admin/admin.php?page=my-jetpack` and see the site connection issue notice
![image](https://github.com/Automattic/jetpack/assets/65001528/7398127c-e017-4db8-bed5-2f0dc1d67964)
7. Wait for the purchases query to fail 3 times and watch as the notice updates to the notice with a higher priority
![image](https://github.com/Automattic/jetpack/assets/65001528/30536bd1-3b73-4292-a531-97f9eab67ab2)
