### PR TITLE
transport-helper: Fix upgrades from plugins embedding v0.2.0

### DIFF
--- a/projects/packages/transport-helper/changelog/fix-transport-helper-post-upgrade-fatal
+++ b/projects/packages/transport-helper/changelog/fix-transport-helper-post-upgrade-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Handle upgrades from plugins embedding version 0.2.0 of the package.

--- a/projects/packages/transport-helper/package.json
+++ b/projects/packages/transport-helper/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-transport-helper",
-	"version": "0.2.1",
+	"version": "0.2.2-alpha",
 	"description": "Package to help transport server communication",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/transport-helper/#readme",
 	"bugs": {

--- a/projects/packages/transport-helper/src/class-package-version.php
+++ b/projects/packages/transport-helper/src/class-package-version.php
@@ -36,4 +36,6 @@ class Package_Version {
 
 // For compatibility with plugins that had a broken version of the package, this file needs to define the "V0001"-namespaced class
 // because this filename is what the old plugins' autoloader will be loading. So load the file that defines that class now.
-require __DIR__ . '/class-package-version-compat.php';
+if ( ! class_exists( \Automattic\Jetpack\Transport_Helper\V0001\Package_Version::class, false ) ) {
+	require __DIR__ . '/class-package-version-compat.php';
+}

--- a/projects/packages/transport-helper/src/class-package-version.php
+++ b/projects/packages/transport-helper/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Transport_Helper;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '0.2.1';
+	const PACKAGE_VERSION = '0.2.2-alpha';
 
 	const PACKAGE_SLUG = 'transport-helper';
 
@@ -33,3 +33,7 @@ class Package_Version {
 		return $package_versions;
 	}
 }
+
+// For compatibility with plugins that had a broken version of the package, this file needs to define the "V0001"-namespaced class
+// because this filename is what the old plugins' autoloader will be loading. So load the file that defines that class now.
+require __DIR__ . '/class-package-version-compat.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In v0.2.0, namespaces were changed for classes in the package. This broke upgrades of plugins embedding the package due to a hook being registered for one of these classes on startup since the class no longer existed by the time the hook was called.

v0.2.1 renamed that class back, and added a stub with the versioned name to try to handle upgrades from v0.2.0. Unfortunately the stub isn't in the right place: plugins embedding v0.2.0 will have an autoloader that specifies the namespaced class is in `class-package-version.php` while the stub is actually in `class-package-version-compat.php`.

This fixes those upgrades by having `class-package-version.php` require `class-package-version-compat.php` so those autoloaders can still find the namespaced stub class.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1710781988599579-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* If CI (specifically the Plugin Upgrade check) is happy, this should be good.