### PR TITLE
repo-gardening: Handle empty PR body in Check Description task

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-gardening-empty-description
+++ b/projects/github-actions/repo-gardening/changelog/fix-gardening-empty-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check description task: Handle empty PR body.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -263,10 +263,10 @@ async function getStatusChecks( payload, octokit ) {
 	const { name: repo, owner } = payload.repository;
 	const ownerLogin = owner.login;
 
-	const hasLongDescription = body.length > 200;
+	const hasLongDescription = body?.length > 200;
 	const isLabeled = await hasStatusLabels( octokit, ownerLogin, repo, number );
-	const hasTesting = body.includes( 'Testing instructions' );
-	const hasPrivacy = body.includes( 'data or activity we track or use' );
+	const hasTesting = !! body?.includes( 'Testing instructions' );
+	const hasPrivacy = !! body?.includes( 'data or activity we track or use' );
 	const projectsWithoutChangelog = await getChangelogEntries( octokit, ownerLogin, repo, number );
 	const isFromContributor = head.repo.full_name === base.repo.full_name;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If the body is empty GitHub is returning null, which makes the code fail with an error about "Cannot read properties of null (reading 'length')".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a PR based on this one with an empty description, and see if the task fails.
  * Or just look at #36445, particularly [this run based on trunk](https://github.com/Automattic/jetpack/actions/runs/8333258227/job/22804282837?pr=36445) versus [this run based on this branch](https://github.com/Automattic/jetpack/actions/runs/8333290116/job/22804384743?pr=36445).
