### PR TITLE
 Map Block: Fix map width in Row and Stack layout

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-map-block-stack-row
+++ b/projects/plugins/jetpack/changelog/fix-map-block-stack-row
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Map Block: Fix styling in Row and Stack layout

--- a/projects/plugins/jetpack/extensions/blocks/map/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/map/editor.scss
@@ -5,6 +5,14 @@
 	}
 }
 .wp-block[data-type='jetpack/map'] {
+	.wp-block-group-is-layout-flex:not(.is-vertical) > & {
+		flex-basis: 100%;
+	}
+
+	.wp-block-group-is-layout-flex.is-vertical > & {
+		width: 100%;
+	}
+
 	.components-placeholder__label {
 		svg {
 			fill: currentColor;

--- a/projects/plugins/jetpack/extensions/blocks/map/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/map/style.scss
@@ -1,6 +1,14 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .wp-block-jetpack-map {
+	.wp-block-group-is-layout-flex:not(.is-vertical) > & {
+		flex-basis: 100%;
+	}
+
+	.wp-block-group-is-layout-flex.is-vertical > & {
+		width: 100%;
+	}
+	
 	.wp-block-jetpack-map__gm-container {
 		width: 100%;
 		overflow: hidden;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/35931

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR ensures the Map block has a correct width when grouped with another element.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Build the plugin if you run it locally
- Create a new post
- Add a Map block
- Add another block and group it with the Map block
<img width="400" alt="Screenshot 2024-03-19 at 9 39 15 AM" src="https://github.com/Automattic/jetpack/assets/1620183/7eac94c9-970a-4dfb-8002-a3c9a0e28b2d">

- In the sidebar, activate the Stack and Row views
<img width="278" alt="Screenshot 2024-03-19 at 9 38 48 AM" src="https://github.com/Automattic/jetpack/assets/1620183/ba5f2103-3d00-437d-80e7-6dfd9870fe96">

- Verify the Map is visible and the group elements are correctly aligned, in both the editor and preview

| Stack | Row |
| - | - |
|<img width="400" alt="" src="https://github.com/Automattic/jetpack/assets/1620183/44e73ede-1555-4cd3-8713-e4d2b72e5770">|<img width="400" alt="" src="https://github.com/Automattic/jetpack/assets/1620183/cab4acbd-ad16-439e-b8ca-df3b743077db">|


