### PR TITLE
Fix/weirdness with post register redirection on purchase

### DIFF
--- a/projects/js-packages/connection/changelog/fix-weirdness-with-post-register-redirection-on-purchase
+++ b/projects/js-packages/connection/changelog/fix-weirdness-with-post-register-redirection-on-purchase
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix some redirect after purchase behavior when site is not connected

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -168,7 +168,9 @@ export default function useProductCheckoutWorkflow( {
 			return handleAfterRegistration( redirect );
 		}
 
-		registerSite( { registrationNonce, redirectUri: redirectUrl } ).then( handleAfterRegistration );
+		registerSite( { registrationNonce, redirectUri: redirectUrl } ).then( () =>
+			handleAfterRegistration( redirect )
+		);
 	};
 
 	// Initialize/Setup the REST API.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.33.3",
+	"version": "0.33.4-alpha",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This diff fixes a bug in the checkout flow when a site is not registered - post-checkout redirection was broken in some cases.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
peb6dq-2im-p2#comment-1555

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Without this patch, first:
* Boot up a JN site with only Jetpack Beta installed.
* Activate the beta release of Jetpack Protect.
* Visit the Protect admin page and choose to upgrade from the pricing table shown.
* Approve the user connection, complete the checkout process.
* You will be left on the WordPress.com “thank you” page, instead of being redirected back to your site.
* Now, with this patch applied, repeat the steps above and confirm that you are properly redirected back to the protect admin page