### PR TITLE
Fix/memberships/login code

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-memberships-login-code
+++ b/projects/plugins/jetpack/changelog/fix-memberships-login-code
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Filter intended for wpcom use now can accept arguments properly.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/include.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/include.php
@@ -81,4 +81,4 @@ function default_service( $service, $user_id = null ) {
 	// Return an Unconfigured Subscription Service if this is not a WPCOM or Jetpack site or if both of those services are not available.
 	return new Unconfigured_Subscription_Service();
 }
-add_filter( PAYWALL_FILTER, 'Automattic\Jetpack\Extensions\Premium_Content\default_service' );
+add_filter( PAYWALL_FILTER, 'Automattic\Jetpack\Extensions\Premium_Content\default_service', 10, 2 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # 107-gh-automattic/gold

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a missing change that was meant to be included with 35587
* This change allows the filter to accept multiple arguments, which is needed to use the wpcom provider over the jetpack one in this use case.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See https://github.com/Automattic/jetpack/pull/35587