### PR TITLE
Boost: Make annotations clickable

### DIFF
--- a/projects/js-packages/components/changelog/update-make-annotations-clickable
+++ b/projects/js-packages/components/changelog/update-make-annotations-clickable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Annotations: Make it possible to interact with them

--- a/projects/js-packages/components/components/boost-score-graph/annotations-plugin.ts
+++ b/projects/js-packages/components/components/boost-score-graph/annotations-plugin.ts
@@ -35,12 +35,13 @@ export function annotationsPlugin( annotations: Annotation[] ) {
 				annotationEl.style.display = 'block';
 				annotationEl.style.left = u.valToPos( annotation.timestamp / 1000, 'x' ) + 'px';
 			} );
-			lineEl.addEventListener( 'mouseleave', () => {
-				annotationEl.style.display = 'none';
-			} );
 
 			annotation.line = lineEl;
 			annotationsContainer.appendChild( lineEl );
+		} );
+
+		annotationEl.addEventListener( 'mouseleave', () => {
+			annotationEl.style.display = 'none';
 		} );
 
 		containerEl.appendChild( annotationsContainer );

--- a/projects/js-packages/components/components/boost-score-graph/style-annotation.scss
+++ b/projects/js-packages/components/components/boost-score-graph/style-annotation.scss
@@ -58,13 +58,18 @@ $white: #ffffff;
 		background-color: $black;
 		color: $white;
 		width: fit-content;
+		width: 20em;
 		padding: 16px 24px;
 		border-radius: 4px;
 		font-size: 14px;
-		position: relative;
+		position: absolute;
 		box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.05);
 		text-align: center;
 		transform: translateX(-50%);
 		z-index: 2;
+
+		a {
+			color: $white !important;
+		}
 	}
 }

--- a/projects/js-packages/components/components/boost-score-graph/style-annotation.scss
+++ b/projects/js-packages/components/components/boost-score-graph/style-annotation.scss
@@ -46,15 +46,15 @@ $white: #ffffff;
 			height: 0;
 			border-left: 8px solid transparent;
 			border-right: 8px solid transparent;
-			border-bottom: 8px solid $black;
+			border-top: 8px solid $black;
 			position: absolute;
-			top: -7px;
+			bottom: -7px;
 			left: 50%;
 			transform: translateX(-50%);
 		}
 
 		display: none;
-		top: 100%;
+		bottom: 100%;
 		background-color: $black;
 		color: $white;
 		width: fit-content;

--- a/projects/js-packages/components/components/boost-score-graph/style-tooltip.scss
+++ b/projects/js-packages/components/components/boost-score-graph/style-tooltip.scss
@@ -2,6 +2,11 @@ $grey: #8e8e8e;
 $black: #101517;
 $white: #ffffff;
 
+.jb-score-tooltips-container {
+    width: 100%;
+    position: relative;
+}
+
 .jb-score-tooltip {
     background-color: $black;
     color: $white;

--- a/projects/js-packages/components/components/boost-score-graph/tooltips-plugin.ts
+++ b/projects/js-packages/components/components/boost-score-graph/tooltips-plugin.ts
@@ -11,6 +11,7 @@ import { Period } from '.';
  */
 export function tooltipsPlugin( periods ) {
 	const reactRoot = document.createElement( 'div' );
+	const container = document.createElement( 'div' );
 	let reactDom;
 
 	/**
@@ -19,8 +20,9 @@ export function tooltipsPlugin( periods ) {
 	 * @param {uPlot} u - The uPlot instance.
 	 * @param {object} _opts - Options for the uPlot instance.
 	 */
-	function init( u, _opts ) {
-		const container = u.over;
+	function init( u: uPlot, _opts: object ) {
+		container.classList.add( 'jb-score-tooltips-container' );
+
 		reactDom = ReactDOM.createRoot( reactRoot );
 		reactRoot.style.position = 'absolute';
 		reactRoot.style.bottom = -20 + 'px';
@@ -28,6 +30,8 @@ export function tooltipsPlugin( periods ) {
 		reactRoot.style.zIndex = '1000';
 
 		container.appendChild( reactRoot );
+
+		u.over.appendChild( container );
 
 		/**
 		 * Hides all tooltips.
@@ -52,6 +56,14 @@ export function tooltipsPlugin( periods ) {
 		container.addEventListener( 'mouseenter', () => {
 			showTips();
 		} );
+	}
+
+	/**
+	 * Called when the chart is resized.
+	 * @param {uPlot} u - The uPlot instance.
+	 */
+	function setSize( u: uPlot ) {
+		container.style.height = u.over.clientHeight + 'px';
 	}
 
 	/**
@@ -88,6 +100,7 @@ export function tooltipsPlugin( periods ) {
 		hooks: {
 			init,
 			setCursor,
+			setSize,
 		},
 	};
 }

--- a/projects/js-packages/components/components/boost-score-graph/tooltips-plugin.ts
+++ b/projects/js-packages/components/components/boost-score-graph/tooltips-plugin.ts
@@ -48,9 +48,7 @@ export function tooltipsPlugin( periods ) {
 		}
 
 		container.addEventListener( 'mouseleave', () => {
-			if ( ! u.cursor._lock ) {
-				hideTips();
-			}
+			hideTips();
 		} );
 
 		container.addEventListener( 'mouseenter', () => {

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.50.2",
+	"version": "0.50.3-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/plugins/boost/app/data-sync/Performance_History_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Performance_History_Entry.php
@@ -28,11 +28,19 @@ class Performance_History_Entry implements Lazy_Entry, Entry_Can_Get, Entry_Can_
 			);
 		}
 
+		$annotations = isset( $result['data']['annotations'] ) ? $result['data']['annotations'] : array();
+		// Sanitize the annotations
+		foreach ( $annotations as $key => $annotation ) {
+			$annotations[ $key ] = array(
+				'text' => wp_kses_post( $annotation['text'] ),
+			);
+		}
+
 		return array(
 			'startDate'   => $result['data']['_meta']['start'],
 			'endDate'     => $result['data']['_meta']['end'],
 			'periods'     => $result['data']['periods'],
-			'annotations' => isset( $result['data']['annotations'] ) ? $result['data']['annotations'] : array(),
+			'annotations' => $annotations,
 		);
 	}
 

--- a/projects/plugins/boost/app/data-sync/Performance_History_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Performance_History_Entry.php
@@ -32,7 +32,12 @@ class Performance_History_Entry implements Lazy_Entry, Entry_Can_Get, Entry_Can_
 			'startDate'   => $result['data']['_meta']['start'],
 			'endDate'     => $result['data']['_meta']['end'],
 			'periods'     => $result['data']['periods'],
-			'annotations' => isset( $result['data']['annotations'] ) ? $result['data']['annotations'] : array(),
+			'annotations' => array(
+				array(
+					'timestamp' => strtotime( 'yesterday' ) * 1000,
+					'text'      => 'Yesterday was a <a href="https://example.com">great day</a>!',
+				),
+			),
 		);
 	}
 

--- a/projects/plugins/boost/app/data-sync/Performance_History_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Performance_History_Entry.php
@@ -32,12 +32,7 @@ class Performance_History_Entry implements Lazy_Entry, Entry_Can_Get, Entry_Can_
 			'startDate'   => $result['data']['_meta']['start'],
 			'endDate'     => $result['data']['_meta']['end'],
 			'periods'     => $result['data']['periods'],
-			'annotations' => array(
-				array(
-					'timestamp' => strtotime( 'yesterday' ) * 1000,
-					'text'      => 'Yesterday was a <a href="https://example.com">great day</a>!',
-				),
-			),
+			'annotations' => isset( $result['data']['annotations'] ) ? $result['data']['annotations'] : array(),
 		);
 	}
 

--- a/projects/plugins/boost/app/data-sync/Performance_History_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Performance_History_Entry.php
@@ -32,7 +32,8 @@ class Performance_History_Entry implements Lazy_Entry, Entry_Can_Get, Entry_Can_
 		// Sanitize the annotations
 		foreach ( $annotations as $key => $annotation ) {
 			$annotations[ $key ] = array(
-				'text' => wp_kses_post( $annotation['text'] ),
+				'timestamp' => $annotation['timestamp'],
+				'text'      => wp_kses_post( $annotation['text'] ),
 			);
 		}
 

--- a/projects/plugins/boost/changelog/update-make-annotations-clickable
+++ b/projects/plugins/boost/changelog/update-make-annotations-clickable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Annotations: Make it possible to interact with them

--- a/projects/plugins/boost/changelog/update-make-annotations-clickable
+++ b/projects/plugins/boost/changelog/update-make-annotations-clickable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Annotations: Make it possible to interact with them

--- a/projects/plugins/boost/changelog/update-sanitize-annotation-text
+++ b/projects/plugins/boost/changelog/update-sanitize-annotation-text
@@ -1,4 +1,4 @@
 Significance: patch
-Type: updated
+Type: changed
 
 Performance History: Sanitize graph annotation text

--- a/projects/plugins/boost/changelog/update-sanitize-annotation-text
+++ b/projects/plugins/boost/changelog/update-sanitize-annotation-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: updated
+
+Performance History: Sanitize graph annotation text


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
* Update the annotations UI to make it possible to add clickable links

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
I tested this by injecting the following annotation:

```php
$annotations = array(
	array(
		'timestamp' => strtotime( 'yesterday' ) * 1000,
		'text'      => 'Yesterday was a <a href="https://example.com">great day</a>!',
	),
);
```
On: https://github.com/Automattic/jetpack/pull/36453/files#diff-60816f4a506b0e0e3b5d2c69d1f08f2fe3f5d2effb5a29891ef224ab32154ac2R31

https://github.com/Automattic/jetpack/assets/3737780/7a6eb537-c699-424f-8134-b2f2f9e6799d

