### PR TITLE
Verbum: Fix editor placeholder text

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-editor-text-verbum
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-editor-text-verbum
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Wrong text in the editor placeholder. It was not translated

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/editor-placeholder.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/editor-placeholder.tsx
@@ -1,4 +1,5 @@
 import { translate } from '../i18n';
+import { commentParent } from '../state';
 import { classNames } from '../utils';
 import { CustomLoadingSpinner } from './custom-loading-spinner';
 
@@ -26,7 +27,9 @@ export const EditorPlaceholder = ( { onClick, loading } ) => {
 							class="block-editor-block-list__layout__content"
 							style={ { margin: '18px 0', fontSize: '16px' } }
 						>
-							{ translate( 'Leave a comment' ) }
+							{ commentParent.value
+								? translate( 'Write a reply...' )
+								: translate( 'Write a comment...' ) }
 						</p>
 					) }
 				</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/82101

## Proposed changes:

The text for the editor placeholder was not translated, and it was the same for commenting and for replying

| Before | After |
|--------|--------|
| ![image](https://github.com/Automattic/jetpack/assets/52076348/005d83ea-8059-416b-9553-642e585bb0fa) | ![image](https://github.com/Automattic/jetpack/assets/52076348/10bf9a7b-fe98-4059-9e65-51964469fc58) |
| ![image](https://github.com/Automattic/jetpack/assets/52076348/c5e361da-6b54-408d-b23a-5722ba98493f) | ![image](https://github.com/Automattic/jetpack/assets/52076348/37980e68-f1f1-446f-afe2-c0e698c0adf2) | 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:


* `jetpack build packages/jetpack-mu-wpcom`
* Rsync to sandbox
* Sandbox the site

Or use `bin/jetpack-downloader test jetpack-mu-wpcom-plugin name-of-branch`

