### PR TITLE
WPCOM API: avoid PHP warnings when variables are not set

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-undefined-variable-api
+++ b/projects/plugins/jetpack/changelog/fix-undefined-variable-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WPCOM API: avoid PHP warnings when variables are not set.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -538,7 +538,6 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 		$media_files      = array();
 		$media_urls       = array();
 		$media_attrs      = array();
-		$media_results    = array();
 		$media_id_string  = '';
 
 		if ( $has_media || $has_media_by_url ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -535,8 +535,12 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 
 		$has_media        = ! empty( $input['media'] ) ? count( $input['media'] ) : false;
 		$has_media_by_url = ! empty( $input['media_urls'] ) ? count( $input['media_urls'] ) : false;
+		$media_files      = array();
+		$media_urls       = array();
+		$media_attrs      = array();
+		$media_results    = array();
+		$media_id_string  = '';
 
-		$media_id_string = '';
 		if ( $has_media || $has_media_by_url ) {
 			$media_files     = ! empty( $input['media'] ) ? $input['media'] : array();
 			$media_urls      = ! empty( $input['media_urls'] ) ? $input['media_urls'] : array();


### PR DESCRIPTION
Follow-up to #35977

## Proposed changes:

This should avoid issues like this one:

```
Warning: Undefined variable $media_files in /wp-content/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php on line 572
```


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This was most notable on WordPress.com Simple. It should not have an immediate impact on self-hosted sites.

See `b8fc2e62935fbfb5d9d446944183f1bc` in logstash for more info.
