### PR TITLE
Social: Revert the change to hide the refresh url links. 

### DIFF
--- a/projects/js-packages/publicize-components/src/components/connection-verify/index.js
+++ b/projects/js-packages/publicize-components/src/components/connection-verify/index.js
@@ -8,9 +8,11 @@
  * not render anything.
  */
 
+import { Button, Notice } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { SOCIAL_STORE_ID } from '../../social-store';
 
 class PublicizeConnectionVerify extends Component {
@@ -18,8 +20,83 @@ class PublicizeConnectionVerify extends Component {
 		this.props.refreshConnections();
 	}
 
-	render() {
+	/**
+	 * Opens up popup so user can refresh connection
+	 *
+	 * Displays pop up with to specified URL where user
+	 * can refresh a specific connection.
+	 *
+	 * @param {object} event - Event instance for onClick.
+	 */
+	refreshConnectionClick = event => {
+		const { href, title } = event.target;
+		event.preventDefault();
+		// open a popup window
+		// when it is closed, kick off the tests again
+		const popupWin = window.open( href, title, '' );
+		const popupTimer = window.setInterval( () => {
+			if ( false !== popupWin.closed ) {
+				window.clearInterval( popupTimer );
+				this.props.refreshConnections();
+			}
+		}, 500 );
+	};
+
+	renderRefreshableConnections() {
+		const { failedConnections } = this.props;
+		const refreshableConnections = failedConnections.filter( connection => connection.can_refresh );
+
+		if ( refreshableConnections.length ) {
+			return (
+				<Notice className="jetpack-publicize-notice" isDismissible={ false } status="error">
+					<p>
+						{ __(
+							'Before you hit Publish, please refresh the following connection(s) to make sure we can share your post:',
+							'jetpack'
+						) }
+					</p>
+					{ refreshableConnections.map( connection => (
+						<Button
+							href={ connection.refresh_url }
+							isSmall
+							key={ connection.id }
+							onClick={ this.refreshConnectionClick }
+							title={ connection.refresh_text }
+						>
+							{ connection.refresh_text }
+						</Button>
+					) ) }
+				</Notice>
+			);
+		}
+
 		return null;
+	}
+
+	renderNonRefreshableConnections() {
+		const { failedConnections } = this.props;
+		const nonRefreshableConnections = failedConnections.filter(
+			connection => ! connection.can_refresh
+		);
+
+		if ( nonRefreshableConnections.length ) {
+			return nonRefreshableConnections.map( connection => (
+				<Notice className="jetpack-publicize-notice" isDismissible={ false } status="error">
+					<p>{ connection.test_message }</p>
+				</Notice>
+			) );
+		}
+
+		return null;
+	}
+
+	render() {
+		return (
+			<Fragment>
+				{ this.renderRefreshableConnections() }
+				{ this.renderNonRefreshableConnections() }
+			</Fragment>
+		);
 	}
 }
 


### PR DESCRIPTION
I want to test the refresh URL links on older versions of Jetpack, so temporarily opening a draft PR. This won't be merged. 