### PR TITLE
WPCOM_JSON_API_List_Comments_Endpoint: Do not prefetch comment meta for large hierarchical threads

### DIFF
--- a/projects/plugins/jetpack/changelog/update-WPCOM_JSON_API_List_Comments_Endpoint
+++ b/projects/plugins/jetpack/changelog/update-WPCOM_JSON_API_List_Comments_Endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WPCOM_JSON_API_List_Comments_Endpoint: Do not prefetch comment meta for large hierarchical threads

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-comments-endpoint.php
@@ -308,6 +308,10 @@ class WPCOM_JSON_API_List_Comments_Endpoint extends WPCOM_JSON_API_Comment_Endpo
 				}
 			}
 		}
+		if ( $args['hierarchical'] && $found > 5000 ) {
+			// Massive comment thread found; don't pre-load comment metadata to reduce memory used.
+			$query['update_comment_meta_cache'] = false;
+		}
 
 		if ( $post_id ) {
 			$post = get_post( $post_id );


### PR DESCRIPTION
## Proposed changes:

* When `WPCOM_JSON_API_List_Comments_Endpoint` is fetching the hierarchical view of a comment thread with over 5,000 comments, pass the `update_comment_meta_cache=>false` to reduce memory usage.

When hitting an endpoint to read threaded comments for a post with over 40,000 comments, we can OOM. Part of the reason is the hierarchical view runs `get_comments()` on the entire thread and uses that data to sort the comments into the correct order before returning only the single page of comments that was requested. To help with the memory pressure, let's look for this case of a threaded view on an extremely large comments section, and ask `get_comments()` to not prefetch the meta values for all 40,000 comments. It will have to fetch the meta values later after the hierarchical code has figured out which ~25 comments to return, which is okay.

See: https://developer.wordpress.org/reference/classes/wp_comment_query/__construct/ 
```
update_comment_meta_cache bool
Whether to prime the metadata cache for found comments.
Default true.
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Testing helper and instructions in D142309-code


