### PR TITLE
Newsletter Settings in JP: Reorder cards to improve hierarchy

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -16,7 +16,7 @@ const subscriptionsAndNewslettersSupportUrl =
 const FEATURED_IMAGE_IN_EMAIL_OPTION = 'wpcom_featured_image_in_email';
 const SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION = 'wpcom_subscription_emails_use_excerpt';
 
-const EmailSetting = props => {
+const EmailSettings = props => {
 	const {
 		isSavingAnyOption,
 		subscriptionsModule,
@@ -137,5 +137,5 @@ export default withModuleSettingsFormHelpers(
 				SUBSCRIPTIONS_MODULE_NAME
 			),
 		};
-	} )( EmailSetting )
+	} )( EmailSettings )
 );

--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -45,8 +45,8 @@ function Subscriptions( props ) {
 			{ foundSubscriptions && (
 				<>
 					<SubscriptionsSettings siteRawUrl={ siteRawUrl } blogID={ blogID } />
-					<EmailSettings />
 					<NewsletterCategories />
+					<EmailSettings />
 					<MessagesSetting { ...props } />
 				</>
 			) }

--- a/projects/plugins/jetpack/changelog/update-newsletter-settings-cards-reorder
+++ b/projects/plugins/jetpack/changelog/update-newsletter-settings-cards-reorder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Reorder newsletter settings cards to improve hierarchy


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack/issues/36346

## Proposed changes:

* Reorder cards to improve hierarchy
* Fix typo on EmailSettings component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Apply this PR to your JT testing site
* Go to `{your-site}/wp-admin/admin.php?page=jetpack#/newsletter`
* You should see the **Newsletter categories** as the second card and the **Email configuration** as the third one
* Check for regressions

<img width="1083" alt="Screenshot 2024-03-19 at 13 40 39" src="https://github.com/Automattic/jetpack/assets/3113712/dd96dbf9-d852-421f-86da-505976a14b0f">
