### PR TITLE
Blaze: Fix translations of "Blaze this %s" labels

### DIFF
--- a/projects/packages/blaze/changelog/fix-blaze-this-translations
+++ b/projects/packages/blaze/changelog/fix-blaze-this-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Blaze: Fix translations of "Blaze this %s" labels

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.21.1",
+	"version": "0.21.2-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.21.1';
+	const PACKAGE_VERSION = '0.21.2-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/blaze/src/js/editor.js
+++ b/projects/packages/blaze/src/js/editor.js
@@ -5,7 +5,7 @@ import { useSelect } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useEffect } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { external, Icon } from '@wordpress/icons';
 import { getPlugin, registerPlugin } from '@wordpress/plugins';
 import './editor.scss';
@@ -21,17 +21,15 @@ const BlazePostPublishPanel = () => {
 		[ tracks ]
 	);
 
-	const { isPostPublished, isPublishingPost, postId, postType, postTypeLabel, postVisibility } =
-		useSelect( selector => ( {
+	const { isPostPublished, isPublishingPost, postId, postType, postVisibility } = useSelect(
+		selector => ( {
 			isPostPublished: selector( editorStore ).isCurrentPostPublished(),
 			isPublishingPost: selector( editorStore ).isPublishingPost(),
 			postId: selector( editorStore ).getCurrentPostId(),
 			postType: selector( editorStore ).getCurrentPostType(),
-			postTypeLabel:
-				// Translators: default post type label.
-				selector( editorStore ).getPostTypeLabel() || _x( 'Post', 'noun', 'jetpack-blaze' ),
 			postVisibility: selector( editorStore ).getEditedPostVisibility(),
-		} ) );
+		} )
+	);
 	const wasPublishing = usePrevious( isPublishingPost );
 
 	const panelBodyProps = {
@@ -80,6 +78,13 @@ const BlazePostPublishPanel = () => {
 		return null;
 	}
 
+	const blazeThisLabel =
+		{
+			page: __( 'Blaze this page', 'jetpack-blaze' ),
+			post: __( 'Blaze this post', 'jetpack-blaze' ),
+			product: __( 'Blaze this product', 'jetpack-blaze' ),
+		}[ postType ] ?? __( 'Blaze this post', 'jetpack-blaze' );
+
 	return (
 		<PluginPostPublishPanel { ...panelBodyProps }>
 			<PanelRow>
@@ -98,11 +103,7 @@ const BlazePostPublishPanel = () => {
 				onKeyDown={ trackClick }
 			>
 				<Button variant="secondary" href={ blazeUrl } target="_top">
-					{ sprintf(
-						/* translators: %s is the post type (e.g. Post, Page, Product). */
-						__( 'Blaze this %s', 'jetpack-blaze' ),
-						postTypeLabel.toLowerCase()
-					) }
+					{ blazeThisLabel }
 					{ blazeUrlTemplate.external && (
 						<Icon icon={ external } className="blaze-panel-outbound-link__external_icon" />
 					) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Splits up `Blaze this %s` cases into separate strings to fix translations.

The `Blaze this %s` string has a placeholder that substitutes the translation of either `post`, `page`, or `product`. However, this isn't great for localization since the gender/case may change depending on the post type. For example, in Dutch, the current `Blaze dit pagina` is incorrect, it should be `Blaze deze pagina`.

This PR fixes this by specifying a string for each case. `shouldDisplayPanel` already checks if the `postType` is one of `post`, `page`, or `product`, so we can use these exact values as keys for a small object containing the different strings. Still, to be safe, I've added the `Blaze this post` translation as the default, corresponding to the default `postTypeLabel` used before this PR. 

The strings will be displayed in English until the translations are finished.

|Before|After (until translations are finished)|
|-|-|
|![image](https://github.com/Automattic/jetpack/assets/75777864/66c30857-ce61-4eee-9ef0-e762597c840d)|![image](https://github.com/Automattic/jetpack/assets/75777864/f61d6e21-f751-4c7d-ad97-f48d3afd8433)|

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
629-gh-Automattic/i18n-issues

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Choose a _public_ site (i.e. not Private or Coming Soon) to test with.
  * If it's a Simple site, download the branch to your sandbox with `bin/jetpack-downloader test jetpack fix/blaze-this-translations`, and sandbox the site and `s0.wp.com`. 
  * If it's a WoA site, switch to `fix/blaze-this-translations` in the Jetpack Beta plugin.
* On the site, create a new page draft or revert an existing test page to draft.
* Publish the page and verify that the English "Blaze this page" is shown at the bottom right of the page (in the sidebar) as per the screenshots in the description.

