### PR TITLE
GitHub Deployments: Remove feature flag call

### DIFF
--- a/projects/plugins/jetpack/changelog/github-deployments-remove-feature-flag-call
+++ b/projects/plugins/jetpack/changelog/github-deployments-remove-feature-flag-call
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+GitHub Deployments: remove feature flag

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -455,7 +455,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		/**
 		 * Adds the WordPress.com GitHub Deployments submenu under the main Tools menu.
 		 */
-		add_submenu_page( 'tools.php', esc_attr__( 'GitHub Deployments', 'jetpack' ), __( 'GitHub Deployments', 'jetpack' ), 'manage_options', 'https://wordpress.com/github-deployments/' . $this->domain, null, 7 );
+		add_submenu_page( 'tools.php', esc_attr__( 'GitHub Deployments', 'jetpack' ), __( 'GitHub Deployments', 'jetpack' ), 'manage_options', 'https://wordpress.com/github-deployments/' . $this->domain, null, 8 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -455,9 +455,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		/**
 		 * Adds the WordPress.com GitHub Deployments submenu under the main Tools menu.
 		 */
-		if ( apply_filters( 'jetpack_show_wpcom_github_deployments_menu', false ) ) {
-			add_submenu_page( 'tools.php', esc_attr__( 'GitHub Deployments', 'jetpack' ), __( 'GitHub Deployments', 'jetpack' ), 'manage_options', 'https://wordpress.com/github-deployments/' . $this->domain, null, 7 );
-		}
+		add_submenu_page( 'tools.php', esc_attr__( 'GitHub Deployments', 'jetpack' ), __( 'GitHub Deployments', 'jetpack' ), 'manage_options', 'https://wordpress.com/github-deployments/' . $this->domain, null, 7 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -375,18 +375,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	public function test_add_github_deployments_menu() {
 		global $submenu;
 
-		add_filter( 'jetpack_show_wpcom_github_deployments_menu', '__return_false', 99 );
 		static::$admin_menu->add_tools_menu();
-		remove_filter( 'jetpack_show_wpcom_github_deployments_menu', '__return_false', 99 );
-
-		$links = wp_list_pluck( array_values( $submenu['tools.php'] ), 2 );
-
-		$this->assertNotContains( 'https://wordpress.com/github-deployments/' . static::$domain, $links );
-
-		add_filter( 'jetpack_show_wpcom_github_deployments_menu', '__return_true', 99 );
-		static::$admin_menu->add_tools_menu();
-		remove_filter( 'jetpack_show_wpcom_github_deployments_menu', '__return_true', 99 );
-
 		$links = wp_list_pluck( array_values( $submenu['tools.php'] ), 2 );
 
 		$this->assertContains( 'https://wordpress.com/github-deployments/' . static::$domain, $links );


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/6017.

## Proposed changes:

This PR removes the conditional enabling of the feature.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

### Testing instructions:

Verify that the filter is not called anymore and the feature is always displayed. You can do that by commenting out the filter in WPCOMSH and testing the PR in WPCOM.