### PR TITLE
Sharing: update the sharing button settings to clarify the available options (block or legacy sharing buttons).

### DIFF
--- a/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
@@ -5,6 +5,7 @@ import { __, _x } from '@wordpress/i18n';
 import Card from 'components/card';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
+import SimpleNotice from 'components/notice';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import analytics from 'lib/analytics';
@@ -94,7 +95,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 				const featureDescription = isActive
 					? createInterpolateElement(
 							__(
-								'You are using a block-based theme. You can continue using Jetpack’s legacy sharing buttons and configure them below. As an alternative, you could disable the legacy sharing feature above and add a sharing button block to your themes’s template instead. <a>Discover how</a>.',
+								'You are using a block-based theme. We recommend that you disable the legacy sharing feature above and add a sharing button block to your themes’s template instead. <a>Discover how</a>.',
 								'jetpack'
 							),
 							{
@@ -103,7 +104,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 					  )
 					: createInterpolateElement(
 							__(
-								'You are using a block-based theme. You can enable Jetpack’s legacy sharing buttons above, but you could also add a sharing button block to your themes’s template instead. <a>Discover how</a>.',
+								'You are using a block-based theme. Instead of enabling Jetpack’s legacy sharing buttons above, we would recommend that you add a sharing button block to your themes’s template in the site editor instead. <a>Discover how</a>.',
 								'jetpack'
 							),
 							{
@@ -116,7 +117,13 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 				return (
 					<>
 						{ toggle }
-						<p className="jp-settings-sharing__block-theme-description">{ featureDescription }</p>
+						<SimpleNotice
+							showDismiss={ false }
+							status={ 'is-info' }
+							className="jp-settings-sharing__block-theme-description"
+						>
+							{ featureDescription }
+						</SimpleNotice>
 					</>
 				);
 			};

--- a/projects/plugins/jetpack/_inc/client/sharing/style.scss
+++ b/projects/plugins/jetpack/_inc/client/sharing/style.scss
@@ -1,3 +1,5 @@
+@import '../scss/calypso-colors';
+
 .jp-settings-sharing__sig-toggle {
 	span  {
 		margin: 0 auto auto auto;
@@ -9,8 +11,8 @@
 }
 
 #jp-settings-sharing {
-	.jp-settings-sharing__block-theme-description {
-		font-style: italic;
+	.jp-settings-sharing__block-theme-description a {
+		color: $white;
 	}
 
 	.dops-card {

--- a/projects/plugins/jetpack/changelog/fix-sharing-block-settings-info
+++ b/projects/plugins/jetpack/changelog/fix-sharing-block-settings-info
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: update the sharing button settings to clarify the available options (block or legacy sharing buttons).


### PR DESCRIPTION
Follow-up to #34619

## Proposed changes:

There are currently 2 main options for sharing buttons:

- The legacy sharing buttons, the preferrable option when you use a legacy/classic theme.
- The sharing buttons block, when you use a block-based theme.

We've tried to highlight the 2 options in #34619, but the wording mentioning "below" for a link that in fact lead to the site editor was confusing. This commit updates the wording and introduces a notice instead of a basic paragraph text that may be missed.

| **before** | **after** |
|--------|--------|
| <img width="1095" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/66cfaa04-4f8f-481c-a93c-472f1740504b"> | <img width="1084" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/8085e6e8-fd97-499c-9fc5-81702ac18a54"> |
| <img width="1120" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/8520c205-1bcf-4fd6-9709-9f2cfb00d112"> | <img width="1104" alt="image" src="https://github.com/Automattic/jetpack/assets/426388/d1daf585-115c-41be-a37e-3732e36ba850"> | 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1710919627851779/1710908290.326479-slack-C06DN6QQVAQ

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

You will need to test the Jetpack > Settings > Sharing screen in different scenarios:

1. When using a classic theme like Twenty Fifteen and the sharing module off.
2. When using a classic theme like Twenty Fifteen and the sharing module **on**
3. When using a block-based theme like Twenty Twenty Four and the sharing module off.
4. When using a block-based theme like Twenty Twenty Four and the sharing
   module **on**. 
