### PR TITLE
Update/bot list

### DIFF
--- a/projects/packages/device-detection/changelog/update-bot-list
+++ b/projects/packages/device-detection/changelog/update-bot-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add new bots

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -1579,6 +1579,8 @@ class User_Agent_Info {
 			'bne.es_bot', // https://www.bne.es/es/colecciones/archivo-web-espanola/aviso-webmasters
 			'google-safety;', // https://www.google.com/bot.html
 			'mojeekbot', // https://www.mojeek.com/bot.html
+			'x11; linux x86_64;', // Targeting - Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0
+			'linkwalker', // https://www.linkwalker.com/
 		);
 
 		foreach ( $bot_agents as $bot_agent ) {

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -1579,7 +1579,6 @@ class User_Agent_Info {
 			'bne.es_bot', // https://www.bne.es/es/colecciones/archivo-web-espanola/aviso-webmasters
 			'google-safety;', // https://www.google.com/bot.html
 			'mojeekbot', // https://www.mojeek.com/bot.html
-			'x11; linux x86_64;', // Targeting - Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0
 			'linkwalker', // https://www.linkwalker.com/
 		);
 


### PR DESCRIPTION
Similar to #35798

This PR add two new bot detection string so that we can ignore bots better based on the useragent. 

1. `Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0` I am seeing a spike in that useragent string that is unexpected. I can't really determine what device or the purpose of this user-agent is. But the spike seems to be coming from a hidden link that humans shouldn't be seeing. So I am assuming the clicking is done by a 
2. `linkwalker` should help us ignore the `linkwalker` crawler. 

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Do
