### PR TITLE
Update Notes cache buster

### DIFF
--- a/projects/plugins/jetpack/changelog/update-notes-cache-buster
+++ b/projects/plugins/jetpack/changelog/update-notes-cache-buster
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Notifications: update cache buster

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -108,28 +108,6 @@ class Jetpack_Notifications {
 		if ( self::is_block_editor() ) {
 			return;
 		}
-		$is_rtl = is_rtl();
-
-		if ( Jetpack::is_module_active( 'masterbar' ) ) {
-			/**
-			 * Can be used to force Notifications to display in RTL style.
-			 *
-			 * @module notes
-			 *
-			 * @since 4.8.0
-			 *
-			 * @param bool true Should notifications be displayed in RTL style. Defaults to false.
-			 */
-			$is_rtl = apply_filters( 'a8c_wpcom_masterbar_enqueue_rtl_notification_styles', false );
-		}
-
-		if ( ! $is_rtl ) {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array( 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
-		} else {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array( 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
-		}
-
-		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array( 'wpcom-notes-admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
 
 		$this->print_js();
 
@@ -152,6 +130,29 @@ class Jetpack_Notifications {
 				2
 			);
 		}
+
+		$is_rtl = is_rtl();
+
+		if ( Jetpack::is_module_active( 'masterbar' ) ) {
+			/**
+			 * Can be used to force Notifications to display in RTL style.
+			 *
+			 * @module notes
+			 *
+			 * @since 4.8.0
+			 *
+			 * @param bool true Should notifications be displayed in RTL style. Defaults to false.
+			 */
+			$is_rtl = apply_filters( 'a8c_wpcom_masterbar_enqueue_rtl_notification_styles', false );
+		}
+
+		if ( ! $is_rtl ) {
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array( 'wpcom-notes-common', 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
+		} else {
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array( 'wpcom-notes-common', 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
+		}
+
+		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array( 'wpcom-notes-admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
 	}
 
 	/**
@@ -208,7 +209,7 @@ class Jetpack_Notifications {
 	 * @return string
 	 */
 	private static function get_notes_markup() {
-		return '<span id="wpnt-notes-unread-count" class="wpnt-loading wpn-read wpn-hide"></span>
+		return '<span id="wpnt-notes-unread-count" class="wpnt-loading wpn-read"></span>
 <span class="noticon noticon-bell"></span>
 <span class="screen-reader-text">' . esc_html__( 'Notifications', 'jetpack' ) . '</span>';
 	}

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -208,8 +208,7 @@ class Jetpack_Notifications {
 	 * @return string
 	 */
 	private static function get_notes_markup() {
-		return '<span id="wpnt-notes-unread-count" class="wpnt-loading wpn-read"></span>
-<span class="noticon noticon-bell"></span>
+		return '<span class="noticon noticon-bell"></span>
 <span class="screen-reader-text">' . esc_html__( 'Notifications', 'jetpack' ) . '</span>';
 	}
 

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -108,6 +108,28 @@ class Jetpack_Notifications {
 		if ( self::is_block_editor() ) {
 			return;
 		}
+		$is_rtl = is_rtl();
+
+		if ( Jetpack::is_module_active( 'masterbar' ) ) {
+			/**
+			 * Can be used to force Notifications to display in RTL style.
+			 *
+			 * @module notes
+			 *
+			 * @since 4.8.0
+			 *
+			 * @param bool true Should notifications be displayed in RTL style. Defaults to false.
+			 */
+			$is_rtl = apply_filters( 'a8c_wpcom_masterbar_enqueue_rtl_notification_styles', false );
+		}
+
+		if ( ! $is_rtl ) {
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array( 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
+		} else {
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array( 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
+		}
+
+		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array( 'wpcom-notes-admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
 
 		$this->print_js();
 
@@ -130,29 +152,6 @@ class Jetpack_Notifications {
 				2
 			);
 		}
-
-		$is_rtl = is_rtl();
-
-		if ( Jetpack::is_module_active( 'masterbar' ) ) {
-			/**
-			 * Can be used to force Notifications to display in RTL style.
-			 *
-			 * @module notes
-			 *
-			 * @since 4.8.0
-			 *
-			 * @param bool true Should notifications be displayed in RTL style. Defaults to false.
-			 */
-			$is_rtl = apply_filters( 'a8c_wpcom_masterbar_enqueue_rtl_notification_styles', false );
-		}
-
-		if ( ! $is_rtl ) {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array( 'wpcom-notes-common', 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
-		} else {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array( 'wpcom-notes-common', 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
-		}
-
-		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array( 'wpcom-notes-admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -208,7 +208,8 @@ class Jetpack_Notifications {
 	 * @return string
 	 */
 	private static function get_notes_markup() {
-		return '<span class="noticon noticon-bell"></span>
+		return '<span id="wpnt-notes-unread-count" class="wpnt-loading wpn-read wpn-hide"></span>
+<span class="noticon noticon-bell"></span>
 <span class="screen-reader-text">' . esc_html__( 'Notifications', 'jetpack' ) . '</span>';
 	}
 

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -17,7 +17,7 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
 if ( ! defined( 'JETPACK_NOTES__CACHE_BUSTER' ) ) {
-	define( 'JETPACK_NOTES__CACHE_BUSTER', JETPACK__VERSION . '-' . gmdate( 'oW' ) . '-lite' );
+	define( 'JETPACK_NOTES__CACHE_BUSTER', JETPACK__VERSION . '-' . gmdate( 'oW' ) );
 }
 
 /**


### PR DESCRIPTION
This PR is a follow up to https://github.com/Automattic/jetpack/pull/36297 and fixes an issue that will crop up if we don't update the Notes cache buster.

The JS and CSS files used on Jetpack notes module use the following define as a cache buster;

```
define( 'JETPACK_NOTES__CACHE_BUSTER', JETPACK__VERSION . '-' . gmdate( 'oW' ) . '-lite' );
```

This means that the cache won't get updated until the week number changes (since the Jetpack version will remain the same).

https://github.com/Automattic/jetpack/pull/36297 changes the markup and expects the JS and CSS files to update but they won't. 

There is also some weirdness when the icon loads, where a hamburger icon and a line next to bell icon briefly appear. This is fixed with the patch - D142671-code.

## Before

If you use the Jetpack Beta tester on Atomic site, with Bleeding Edge version activated;

https://github.com/Automattic/jetpack/assets/5560595/25f56798-efc4-4de0-97c2-571d80e877ce

## After

https://github.com/Automattic/jetpack/assets/5560595/9a78ce13-4dd6-4528-bcbf-9d4a5b7f43cb


## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Install Jetpack beta tester plugin on Atomic site
* Search for this branch and activate 
* Apply D142671-code and sandbox the s0.wp.com domain
* Confirm the notification icon appears in the after video above.