### PR TITLE
My Jetpack: fix malformed property name productSlug

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -96,7 +96,7 @@ export default function ProductInterstitial( {
 		( isFreePlan = false, customSlug = null ) => {
 			recordEvent( 'jetpack_myjetpack_product_interstitial_add_link_click', {
 				product: customSlug ?? slug,
-				productSlug: getProductSlugForTrackEvent( isFreePlan ),
+				product_slug: getProductSlugForTrackEvent( isFreePlan ),
 			} );
 		},
 		[ recordEvent, slug, getProductSlugForTrackEvent ]
@@ -106,7 +106,7 @@ export default function ProductInterstitial( {
 		( isFreePlan = false ) => {
 			recordEvent( 'jetpack_myjetpack_product_interstitial_add_link_click', {
 				product: bundle,
-				productSlug: getProductSlugForTrackEvent( isFreePlan ),
+				product_slug: getProductSlugForTrackEvent( isFreePlan ),
 			} );
 		},
 		[ recordEvent, bundle, getProductSlugForTrackEvent ]

--- a/projects/packages/my-jetpack/changelog/fix-interstitial-event-property-name
+++ b/projects/packages/my-jetpack/changelog/fix-interstitial-event-property-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: fix interstitial event property malformed name productSlug -> product_slug


### PR DESCRIPTION
Event properties are dropped if name is not well formed

## Proposed changes:
This PR changes `productSlug` event property to `product_slug`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Enable debug: `localStorage.setItem( 'debug', '*' )` and reload the page. Filter console messages by `dops` and enable verbose mode.
Visit any interstitial and select to upgrade or continue free. Before continuing to checkout, an event should be triggered with name: `jetpack_myjetpack_product_interstitial_add_link_click` and should carry a `product_slug` property.