### PR TITLE
My Jetpack: add AI product page view event

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -129,6 +129,13 @@ export default function () {
 	const onNoticeClose = useCallback( () => setShowNotice( false ), [] );
 
 	useEffect( () => {
+		recordEvent( 'jetpack_ai_myjetpack_product_page_view', {
+			current_tier_slug: currentTier?.slug || '',
+			requests_count: allTimeRequests,
+		} );
+	}, [ allTimeRequests, currentTier?.slug, recordEvent ] );
+
+	useEffect( () => {
 		setShowNotice( showRenewalNotice || showUpgradeNotice );
 	}, [ showRenewalNotice, showUpgradeNotice ] );
 

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-ai-product-page-view-event
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-ai-product-page-view-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: add AI product page view event


### PR DESCRIPTION
Need to keep watch on the page views

## Proposed changes:
This PR adds the page view event for the new product page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Enable debug: `localStorage.setItem( 'debug', '*' )` and reload the page. Filter console messages by `dops` and enable verbose mode.
Visit AI product page `wp-admin/admin.php?page=my-jetpack#/jetpack-ai` an event should be triggered with name:`jetpack_ai_myjetpack_product_page_view` and should carry `current_tier_slug` and `requests_count` properties

