### PR TITLE
Enable Sharing settings page in wp-admin for Classic nav-redesign

### DIFF
--- a/projects/plugins/jetpack/_inc/client/sharing/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/index.jsx
@@ -20,16 +20,18 @@ import {
 import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import { getSettings } from 'state/settings';
-import { siteHasFeature, getActiveFeatures } from 'state/site';
+import { siteHasFeature, getActiveFeatures, siteUsesWpAdminInterface } from 'state/site';
 import { Likes } from './likes';
 import { Publicize } from './publicize';
 import { ShareButtons } from './share-buttons';
+
 class Sharing extends Component {
 	render() {
 		const commonProps = {
 			settings: this.props.settings,
 			getModule: this.props.module,
 			isOfflineMode: this.props.isOfflineMode,
+			siteUsesWpAdminInterface: this.props.siteUsesWpAdminInterface,
 			isUnavailableInOfflineMode: this.props.isUnavailableInOfflineMode,
 			isLinked: this.props.isLinked,
 			connectUrl: this.props.connectUrl,
@@ -84,6 +86,7 @@ export default connect( state => {
 		module: module_name => getModule( state, module_name ),
 		settings: getSettings( state ),
 		isOfflineMode: isOfflineMode( state ),
+		siteUsesWpAdminInterface: siteUsesWpAdminInterface( state ),
 		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
 		isModuleFound: module_name => _isModuleFound( state, module_name ),
 		isLinked: isCurrentUserLinked( state ),

--- a/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
@@ -26,6 +26,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 				blogID = this.props.blogID,
 				siteAdminUrl = this.props.siteAdminUrl,
 				isOfflineMode = this.props.isOfflineMode,
+				siteUsesWpAdminInterface = this.props.siteUsesWpAdminInterface,
 				hasSharingBlock = this.props.hasSharingBlock,
 				isBlockTheme = this.props.isBlockTheme,
 				isActive = this.props.getOptionValue( 'sharedaddy' );
@@ -54,7 +55,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 
 				if ( shouldShowSharingBlock ) {
 					cardProps.href = `${ siteAdminUrl }site-editor.php?path=%2Fwp_template`;
-				} else if ( isLinked && ! isOfflineMode ) {
+				} else if ( isLinked && ! isOfflineMode && ! siteUsesWpAdminInterface ) {
 					cardProps.href = getRedirectUrl( 'calypso-marketing-sharing-buttons', {
 						site: blogID ?? siteRawUrl,
 					} );

--- a/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
@@ -43,6 +43,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 			 * - Do you use a block-based theme and is the sharing block available?
 			 * - Is the site connected to WordPress.com?
 			 * - Is the site in offline mode?
+			 * - Is the site using the classic admin interface?
 			 *
 			 * @returns {React.ReactNode} A card with the sharing configuration link.
 			 */

--- a/projects/plugins/jetpack/changelog/enable-sharing-settings
+++ b/projects/plugins/jetpack/changelog/enable-sharing-settings
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Register Sharing settings menu page in offline mode or when nav redesign is enabled
+Register Sharing settings menu page in offline mode or when Classic wp-admin is enabled.

--- a/projects/plugins/jetpack/changelog/enable-sharing-settings
+++ b/projects/plugins/jetpack/changelog/enable-sharing-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Register Sharing settings menu page in offline mode or when nav redesign is enabled

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -122,12 +122,12 @@ class Sharing_Admin {
 	}
 
 	/**
-	 * Register Sharing settings menu page in offline mode or when Classic nav redesign is enabled.
+	 * Register Sharing settings menu page in offline mode or when wp-admin interface is enabled.
 	 */
 	public function subscription_menu() {
-		// @phan-suppress-next-line PhanUndeclaredFunction -- Defined in wpcomsh, which Phan doesn't know about.
-		$wpcom_is_nav_redesign_enabled = function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled();
-		if ( ( new Status() )->is_offline_mode() || $wpcom_is_nav_redesign_enabled ) {
+		$wpcom_is_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+
+		if ( ( new Status() )->is_offline_mode() || $wpcom_is_wp_admin_interface ) {
 			add_submenu_page(
 				'options-general.php',
 				__( 'Sharing Settings', 'jetpack' ),

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -122,13 +122,12 @@ class Sharing_Admin {
 	}
 
 	/**
-	 * Register Sharing settings menu page in offline mode or when nav redesign is enabled.
+	 * Register Sharing settings menu page in offline mode or when Classic nav redesign is enabled.
 	 */
 	public function subscription_menu() {
-		if (
-			( new Status() )->is_offline_mode() ||
-			( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() )
-		) {
+		// @phan-suppress-next-line PhanUndeclaredFunction -- Defined in wpcomsh, which Phan doesn't know about.
+		$wpcom_is_nav_redesign_enabled = function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled();
+		if ( ( new Status() )->is_offline_mode() || $wpcom_is_nav_redesign_enabled ) {
 			add_submenu_page(
 				'options-general.php',
 				__( 'Sharing Settings', 'jetpack' ),

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -122,21 +122,22 @@ class Sharing_Admin {
 	}
 
 	/**
-	 * Register Sharing settings menu page in offline mode.
+	 * Register Sharing settings menu page in offline mode or when nav redesign is enabled.
 	 */
 	public function subscription_menu() {
-		if ( ! ( new Status() )->is_offline_mode() ) {
-			return;
+		if (
+			( new Status() )->is_offline_mode() ||
+			( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() )
+		) {
+			add_submenu_page(
+				'options-general.php',
+				__( 'Sharing Settings', 'jetpack' ),
+				__( 'Sharing', 'jetpack' ),
+				'manage_options',
+				'sharing',
+				array( $this, 'wrapper_admin_page' )
+			);
 		}
-
-		add_submenu_page(
-			'options-general.php',
-			__( 'Sharing Settings', 'jetpack' ),
-			__( 'Sharing', 'jetpack' ),
-			'manage_options',
-			'sharing',
-			array( $this, 'wrapper_admin_page' )
-		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6175

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enable "Sharing Settings" wp-admin page (pic below) in offline mode or when Classic (wp-admin) interface is enabled.
  * Note: the "Sharing Settings" page appears different depending on if your site has a blocks or classic theme enabled.
* Update the Jetpack > Settings > Sharing > "Configure your sharing buttons" link that appears at the bottom of the "Sharing buttons" panel to redirect to the "Sharing Settings" wp-admin page when Classic (wp-admin) interface is enabled.

<img width="1723" alt="Screenshot 2024-03-21 at 12 36 42 PM" src="https://github.com/Automattic/jetpack/assets/140841/cb313adf-0b0f-43ec-a22e-a057ade6e80a">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Atomic Sites:
* To test on Atomic sites use the Jetpack Beta plugin and load this PR
* On a "Default" admin interface (non wp-admin) nothing should have changed.
* On a "Classic" admin interface (wp-admin) the "Sharing settings" wp-admin page should be registered. To test this:
* Go to Appearance > Themes and install / activate a classic theme, e.g.: "Classic"
* Go to Jetpack > Settings > Sharing and enable sharing buttons.
* Click the the "Configure your sharing buttons" link that appears at the bottom of the "Sharing buttons" panel.
* It should direct you to the "Sharing Settings" wp-admin page located here: /wp-admin/options-general.php?page=sharing
* If your site is using a block theme the "Configure your sharing buttons" will link you to the site editor.

Simple Sites:
* To test on Simple sites load this PR on your sandbox with the command: bin/jetpack-downloader test jetpack enable/sharing-settings
* Enable "Classic" admin interface by adding this option to your Simple site `add_option('wpcom_admin_interface', 'wp-admin');`
* View the page in loaded in the menu: Settings > Sharing
* The CSS can be fixed in a followup https://github.com/Automattic/jetpack/issues/36507

Jetpack Sites:
* Nothing should have changed for WPCOM connected Jetpack sites. Meaning the "Sharing Settings" wp-admin page should not be registered and the "Configure your sharing buttons" should link you to Calypso here: /marketing/sharing-buttons/[site_slug]
* To test this on Jetpack sites use Jurassic Ninja, the Jetpack Beta plugin, and load this PR.

