### PR TITLE
Untangle: Use correct links in Settings -> Traffic -> GA when admin interface is wp-admin

### DIFF
--- a/projects/plugins/jetpack/_inc/client/state/site/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/reducer.js
@@ -345,6 +345,18 @@ export function siteHasFeature( state, featureId ) {
 }
 
 /**
+ * Check if the site's admin interface style is set to wp-admin.
+ *
+ * @param  {object}  state     - Global state tree
+ * @returns {boolean}            Whether the admin interface style is set to wp-admin.
+ */
+export function siteUsesWpAdminInterface( state ) {
+	return (
+		get( state.jetpack.siteData, [ 'data', 'options', 'wpcom_admin_interface' ] ) === 'wp-admin'
+	);
+}
+
+/**
  * Returns the purchase data for a site
  *
  * @param {object} state - Global state tree

--- a/projects/plugins/jetpack/_inc/client/traffic/google-analytics.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/google-analytics.jsx
@@ -42,9 +42,13 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 							{
 								a: (
 									<a
-										href={ getRedirectUrl( 'calypso-stats-day', {
-											site: this.props.siteRawUrl,
-										} ) }
+										href={
+											this.props.siteUsesWpAdminInterface
+												? this.props.siteAdminUrl + 'admin.php?page=jetpack#/stats'
+												: getRedirectUrl( 'calypso-stats-day', {
+														site: this.props.siteRawUrl,
+												  } )
+										}
 									/>
 								),
 							}
@@ -55,7 +59,15 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 							compact
 							className="jp-settings-card__configure-link"
 							onClick={ this.trackConfigureClick }
-							href={ this.props.configureUrl }
+							href={ getRedirectUrl(
+								this.props.siteUsesWpAdminInterface
+									? 'calypso-marketing-connections'
+									: 'calypso-marketing-traffic',
+								{
+									site: this.props.site,
+									anchor: 'analytics',
+								}
+							) }
 							target="_blank"
 						>
 							{ __( 'Configure your Google Analytics settings', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/traffic/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/index.jsx
@@ -13,6 +13,7 @@ import { getLastPostUrl, currentThemeIsBlockTheme, getSiteId } from 'state/initi
 import { getModule, getModuleOverride } from 'state/modules';
 import { isModuleFound } from 'state/search';
 import { getSettings } from 'state/settings';
+import { siteUsesWpAdminInterface } from 'state/site';
 import Blaze from './blaze';
 import { GoogleAnalytics } from './google-analytics';
 import { RelatedPosts } from './related-posts';
@@ -38,6 +39,7 @@ export class Traffic extends React.Component {
 			hasConnectedOwner: this.props.hasConnectedOwner,
 			lastPostUrl: this.props.lastPostUrl,
 			siteAdminUrl: this.props.siteAdminUrl,
+			siteUsesWpAdminInterface: this.props.siteUsesWpAdminInterface,
 		};
 
 		const foundSeo = this.props.isModuleFound( 'seo-tools' ),
@@ -90,13 +92,7 @@ export class Traffic extends React.Component {
 				) }
 				{ foundStats && <SiteStats { ...commonProps } /> }
 				{ foundAnalytics && (
-					<GoogleAnalytics
-						{ ...commonProps }
-						configureUrl={ getRedirectUrl( 'calypso-marketing-traffic', {
-							site: this.props.blogID ?? this.props.siteRawUrl,
-							anchor: 'analytics',
-						} ) }
-					/>
+					<GoogleAnalytics { ...commonProps } site={ this.props.blogID ?? this.props.siteRawUrl } />
 				) }
 				{ foundBlaze && <Blaze { ...commonProps } /> }
 				{ foundShortlinks && <Shortlinks { ...commonProps } /> }
@@ -120,5 +116,6 @@ export default connect( state => {
 		getModuleOverride: module_name => getModuleOverride( state, module_name ),
 		hasConnectedOwner: hasConnectedOwner( state ),
 		blogID: getSiteId( state ),
+		siteUsesWpAdminInterface: siteUsesWpAdminInterface( state ),
 	};
 } )( Traffic );

--- a/projects/plugins/jetpack/changelog/untangle-google-analytics
+++ b/projects/plugins/jetpack/changelog/untangle-google-analytics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Use correct links in Settings -> Traffic -> GA when admin interface is wp-admin


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/6105

## Proposed changes:

This PR updates the following two links in Jetpack -> Settings -> Traffic -> Google Analytics form, when the admin interface style is set to Classic:

<img width="842" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/ab51fa75-d6ee-4985-bbeb-48213d9b5243">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare an Atomic site.
2. Patch this branch to your Beta Tester.
3. Set the Settings -> Hosting Configuration -> Admin interface style to Default.
    - Go to `/wp-admin/admin.php?page=jetpack#/traffic`.
    - Click the `Jetpack Stats` link, verify it goes to `https://wordpress.com/stats/day/:site`.
    - Click the `Configure your GA settings` link, verify it goes to `https://wordpress.com/marketing/traffic/:site#analytics`
3. Set the Settings -> Hosting Configuration -> Admin interface style to Classic.
    - Go to `/wp-admin/admin.php?page=jetpack#/traffic`.
    - Click the `Jetpack Stats` link, verify it goes to `/wp-admin/admin.php?page=jetpack#/stats`.
    - Click the `Configure your GA settings` link, verify it goes to `https://wordpress.com/marketing/connections/:site#analytics`.
       - See also https://github.com/Automattic/wp-calypso/pull/88742 to test the nav redesign early release.

