### PR TITLE
Untangle: update launchpad links for newsletter setting to go to Jetpack's

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/untangle-launchpad-newsletter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangle-launchpad-newsletter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Untangle: update launchpad links for newsletter setting to go to Jetpack's

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -456,6 +456,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
+					return admin_url( 'admin.php?page=jetpack#/newsletter' );
+				}
 				return '/settings/newsletter/' . $data['site_slug_encoded'];
 			},
 		),
@@ -465,6 +468,9 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
+					return admin_url( 'admin.php?page=jetpack#/newsletter' );
+				}
 				return '/settings/newsletter/' . $data['site_slug_encoded'];
 			},
 		),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of:

- https://github.com/Automattic/dotcom-forge/issues/5723

## Proposed changes:


This PR updates the links in the Launchpad card in My Home (screenshot below)

<img width="711" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/965f1f6a-254c-4c7c-93bf-a49a22c600a3">

, depending on the value of Settings -> Hosting Configuration -> Admin interface style as follows:

|Task|Default view|Classic view|
|-|-|-|
|Customize welcome message|`/settings/newsletter/:site`|`/wp-admin/admin.php?page=jetpack#/newsletter`|
|Enable subscribers modal|`/settings/newsletter/:site`|`/wp-admin/admin.php?page=jetpack#/newsletter`|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


1. Prepare an Atomic site with the following characteristics:
2. Go to Settings -> Hosting Configuration -> admin interface style, and set to Default
3. Update "WordPress.com Features" in Jetpack Beta Tester to point to the branch in this testing-only PR https://github.com/Automattic/jetpack/pull/36016.
4. Go to `wordpress.com/home/:site`.
5. Go to My Home.
6. Verify that you can see ALL launchpad tasks (they are shown for ease of testing).
7. Verify the links in the table above.
8. Change your site's admin interface style to Classic 
9. Verify the links in the table above.