### PR TITLE
AI Assistant: promote post title when safe

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-promote-post-title-when-safe
+++ b/projects/plugins/jetpack/changelog/add-ai-promote-post-title-when-safe
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: when response includes a title and post title is empty, use provided title as post title

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -98,7 +98,8 @@ const quickActionsList = {
 			aiSuggestion: PROMPT_TYPE_USER_PROMPT,
 			icon: post,
 			options: {
-				userPrompt: 'Write a post based on the list items. Try to use a heading for each entry',
+				userPrompt:
+					'Write a post based on the list items. Include a title as first order heading and try to use secondary headings for each entry',
 			},
 		},
 	],

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -338,11 +338,25 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 			 * - Get HTML code from markdown content
 			 * - Create blocks from HTML code
 			 */
-			const HTML = markdownConverter
+			let HTML = markdownConverter
 				.render( attributes.content || '' )
 				// Fix list indentation
 				.replace( /<li>\s+<p>/g, '<li>' )
 				.replace( /<\/p>\s+<\/li>/g, '</li>' );
+
+			const seemsToIncludeTitle =
+				HTML?.split( '\n' ).length > 1 && HTML?.split( '\n' )?.[ 0 ]?.match( /^<h1>.*<\/h1>$/ );
+
+			if ( seemsToIncludeTitle && ! postTitle ) {
+				// split HTML on new line characters
+				const htmlLines = HTML.split( '\n' );
+				// take the first line as title
+				const title = htmlLines.shift();
+				// rejoin the rest of the lines on HTML
+				HTML = htmlLines.join( '\n' );
+				// set the title as post title
+				editPost( { title: title.replace( /<[^>]*>/g, '' ) } );
+			}
 			newGeneratedBlocks = rawHandler( { HTML: HTML } );
 		} else {
 			/*


### PR DESCRIPTION
When asking the assistant to write a post or an article, most of the time AI will respond including a title within the body of the post.

## Proposed changes:
This PR adds a little chunk of code to try and safely set the post title when the AI response includes one.
The effect will only trigger if the post has no title yet and if the response includes a first order heading (`<h1>` or single `#` on markdown).
The effect triggers when the user accepts the AI suggestion.

The code is quite simple and only addresses the described scenario, should be safe.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1710767429864509-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Start a new post. Insert an AI Assistant block and ask it to write a post about something. Before accepting, see that:
- [ ] the first "block" on the AI response is a heading
- [ ] the post has no title yet

Accept the suggestion, check if the title has been set to the first heading shown on the suggestion.

Attempt the same but have the post have a title set before accepting: the title should not be set even if the first suggestion block was a heading. 