### PR TITLE
Add "Subscribers" Jetpack menu item and update links for Classic interface

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -21,6 +21,7 @@ import {
 	isSubscriptionSiteEnabled,
 } from 'state/initial-state';
 import { getModule } from 'state/modules';
+import { siteUsesWpAdminInterface } from 'state/site';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
 const trackViewSubsClick = () => {
@@ -38,6 +39,7 @@ function SubscriptionsSettings( props ) {
 		unavailableInOfflineMode,
 		isLinked,
 		isOffline,
+		isWpAdminInterface,
 		isSavingAnyOption,
 		isStbEnabled,
 		isStcEnabled,
@@ -95,12 +97,16 @@ function SubscriptionsSettings( props ) {
 			return '';
 		}
 
+		const source = isWpAdminInterface
+			? 'jetpack-menu-jetpack-manage-subscribers'
+			: 'calypso-subscribers';
+
 		return (
 			<Card
 				compact
 				className="jp-settings-card__configure-link"
 				onClick={ trackViewSubsClick }
-				href={ getRedirectUrl( 'calypso-subscribers', {
+				href={ getRedirectUrl( source, {
 					site: blogID ?? siteRawUrl,
 				} ) }
 				target="_blank"
@@ -249,6 +255,7 @@ export default withModuleSettingsFormHelpers(
 		return {
 			isLinked: isCurrentUserLinked( state ),
 			isOffline: isOfflineMode( state ),
+			isWpAdminInterface: siteUsesWpAdminInterface( state ),
 			isSubscriptionsActive: ownProps.getOptionValue( SUBSCRIPTIONS_MODULE_NAME ),
 			unavailableInOfflineMode: isUnavailableInOfflineMode( state, SUBSCRIPTIONS_MODULE_NAME ),
 			subscriptions: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -98,7 +98,7 @@ function SubscriptionsSettings( props ) {
 		}
 
 		const source = isWpAdminInterface
-			? 'jetpack-menu-jetpack-manage-subscribers'
+			? 'jetpack-settings-jetpack-manage-subscribers'
 			: 'calypso-subscribers';
 
 		return (

--- a/projects/plugins/jetpack/changelog/update-subscribers-link
+++ b/projects/plugins/jetpack/changelog/update-subscribers-link
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Display Subscribers menu on wp-admin and link to Jetpack Manage
+Display Subscribers menu on wp-admin and update links to Jetpack Manage

--- a/projects/plugins/jetpack/changelog/update-subscribers-link
+++ b/projects/plugins/jetpack/changelog/update-subscribers-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Display Subscribers menu on wp-admin and link to Jetpack Manage

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -130,10 +130,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$this->update_submenus( $slug, $submenus_to_update );
 		}
 
-		add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack' ), __( 'Subscribers', 'jetpack' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null );
-
-		// When the interface is not set to wp-admin, we replace the Profile submenu.
 		if ( ! $this->use_wp_admin_interface() ) {
+			// The 'Subscribers' menu exists in the Jetpack menu for Classic wp-admin interface, so only add it for non-wp-admin interfaces.
+			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack' ), __( 'Subscribers', 'jetpack' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null );
+
+			// When the interface is not set to wp-admin, we replace the Profile submenu.
 			remove_submenu_page( 'users.php', 'profile.php' );
 			add_submenu_page( 'users.php', esc_attr__( 'My Profile', 'jetpack' ), __( 'My Profile', 'jetpack' ), 'read', 'https://wordpress.com/me/', null );
 		}

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -994,10 +994,10 @@ class Jetpack_Subscriptions {
 	 */
 	public function add_subscribers_menu() {
 		/*
-		 * Do not display any menu on WoA and WordPress.com Simple sites.
+		 * Do not display any menu on WoA and WordPress.com Simple sites (unless Classic wp-admin is enabled).
 		 * They already get a menu item under Users via nav-unification.
 		 */
-		if ( ( new Host() )->is_wpcom_platform() ) {
+		if ( ( new Host() )->is_wpcom_platform() && get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
 			return;
 		}
 
@@ -1016,8 +1016,13 @@ class Jetpack_Subscriptions {
 
 		$blog_id = Connection_Manager::get_site_id( true );
 
+		$source = 'jetpack-menu-calypso-subscribers';
+		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+			$source = 'jetpack-menu-jetpack-manage-subscribers';
+		}
+
 		$link = Redirect::get_url(
-			'jetpack-menu-calypso-subscribers',
+			$source,
 			array( 'site' => $blog_id ? $blog_id : $status->get_site_suffix() )
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6176

> [!NOTE]  
> Do not merge until Subscribers has launched to production in Jetpack Manage peKye1-Lz-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR displays the "Jetpack" > "Subscribers" menu item on sites with the wp-admin Classic view enabled.
* It links the "Jetpack" > "Subscribers" menu item to `https://cloud.jetpack.com/subscribers/[site]` for sites with the wp-admin Classic view enabled.
* It updates "Manage all subscribers" link on the "Subscriptions" panel in `/wp-admin/admin.php?page=jetpack#/newsletter` to link `https://cloud.jetpack.com/subscribers/[site]` for sites with the wp-admin Classic view enabled.
* It removes (does not add) the "Subscribers" menu item to the "Users" menu on Classic views.

<img width="1939" alt="Screenshot 2024-03-21 at 5 06 13 PM" src="https://github.com/Automattic/jetpack/assets/140841/9708686a-9d2c-4fe0-a3df-aa12dd4f8d7d">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this PR on an Atomic site with the Classic (wp-admin) interface enabled using the Jetpack beta plugin.
* Go to `/wp-admin/admin.php?page=jetpack#/newsletter` and enable Subscriptions.
* Click on the "Manage all subscriptions" link. It should take you to `https://cloud.jetpack.com/subscribers/[site]`
* Back in wp-admin, observe there is a "Subscribers" menu item under the "Jetpack" root menu item.
* Click on the "Subscribers" menu item. It should take you to `https://cloud.jetpack.com/subscribers/[site]`
* On an Atomic site with the Default (calypso) interface enabled, the "Subscribers" menu item under "Jetpack" should not be visible, "Manage all subscriptions" should link to `https://wordpress.com/subscribers/[site]`, and the "Subscribers" menu item under "Users" should exist and link to `https://wordpress.com/subscribers/[site]`

