### PR TITLE
SSO: Add function exists check for wp_admin_notice

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-sso-admin-wp-notice-function-check
+++ b/projects/plugins/jetpack/changelog/update-jetpack-sso-admin-wp-notice-function-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add function exists check for wp_admin_notice

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -137,7 +137,7 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		public function handle_invitation_results() {
 			$valid_nonce = isset( $_GET['_wpnonce'] ) ? wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-sso-invite-user' ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WP core doesn't pre-sanitize nonces either.
 
-			if ( ! $valid_nonce || ! isset( $_GET['jetpack-sso-invite-user'] ) ) {
+			if ( ! $valid_nonce || ! isset( $_GET['jetpack-sso-invite-user'] ) || ! function_exists( 'wp_admin_notice' ) ) {
 				return;
 			}
 			if ( $_GET['jetpack-sso-invite-user'] === 'success' ) {
@@ -575,6 +575,9 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		 * Render the invitation email message.
 		 */
 		public function render_invitation_email_message() {
+			if ( ! function_exists( 'wp_admin_notice' ) ) {
+				return;
+			}
 			$message = wp_kses(
 				__(
 					'We highly recommend inviting users to join WordPress.com and log in securely using <a class="jetpack-sso-admin-create-user-invite-message-link-sso" rel="noopener noreferrer" target="_blank" href="https://jetpack.com/support/sso/">Secure Sign On</a> to ensure maximum security and efficiency.',
@@ -604,6 +607,9 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		 * Render a note that wp.com invites will be automatically revoked.
 		 */
 		public function render_invitations_notices_for_deleted_users() {
+			if ( ! function_exists( 'wp_admin_notice' ) ) {
+				return;
+			}
 			check_admin_referer( 'bulk-users' );
 
 			// When one user is deleted, the param is `user`, when multiple users are deleted, the param is `users`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The `wp_admin_notice` function was causing a fatal error on WP 6.3 (and below)
These changes add a `function_exists` check for `wp_admin_notice` to fix the fatal error on versions below WP 6.4

<img width="417" alt="CleanShot 2024-03-21 at 17 27 33@2x" src="https://github.com/Automattic/jetpack/assets/10482592/bfbd9b2f-b8fc-4828-9fd4-474ff2f93f58">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Downgrade to WP 6.3
* Verify youre seeing a fatal error for `wp_admin_notice` when loading `/wp-admin/user-new.php`
* Sync this branch to your atomic site
* Verify the fatal error is no longer appearing
* Add a new user and verify there are no longer any fatal errors on the `wp-admin/users.php` page.
* Test the different user actions (Send Invite, Revoke Invite, Resend Invite)

