### PR TITLE
Phan: try using 6.3 stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "1.0.0",
 		"phan/phan": "^5.4",
 		"php-parallel-lint/php-parallel-lint": "1.3.2",
-		"php-stubs/wordpress-stubs": "^6.4.3",
+		"php-stubs/wordpress-stubs": "6.3.0",
 		"php-stubs/wordpress-tests-stubs": "^6.3",
 		"php-stubs/wp-cli-stubs": "^2.10",
 		"sirbrillig/phpcs-changed": "2.11.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84a3ae0449c3cfc1996aaec7d2ec424c",
+    "content-hash": "436cac9d140bb7d7763d17a1f2c7db3b",
     "packages": [],
     "packages-dev": [
         {
@@ -227,16 +227,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "4775f35b2d70865807c89d32c8e7385b86eb0ace"
+                "reference": "5b16e25a5355f1f3afdfc2f954a0a80aec4826a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/4775f35b2d70865807c89d32c8e7385b86eb0ace",
-                "reference": "4775f35b2d70865807c89d32c8e7385b86eb0ace",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/5b16e25a5355f1f3afdfc2f954a0a80aec4826a8",
+                "reference": "5b16e25a5355f1f3afdfc2f954a0a80aec4826a8",
                 "shasum": ""
             },
             "require": {
@@ -278,7 +278,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.2"
+                "source": "https://github.com/composer/pcre/tree/3.1.3"
             },
             "funding": [
                 {
@@ -294,7 +294,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-07T15:38:35+00:00"
+            "time": "2024-03-19T10:26:25+00:00"
         },
         {
             "name": "composer/semver",
@@ -981,31 +981,28 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.4.3",
+            "version": "v6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "6105bdab2f26c0204fe90ecc53d5684754550e8f"
+                "reference": "adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/6105bdab2f26c0204fe90ecc53d5684754550e8f",
-                "reference": "6105bdab2f26c0204fe90ecc53d5684754550e8f",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c",
+                "reference": "adda7609e71d5f4dc7b87c74f8ec9e3437d2e92c",
                 "shasum": ""
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "nikic/php-parser": "^4.13",
                 "php": "^7.4 || ~8.0.0",
                 "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.3",
-                "phpstan/phpstan": "^1.10.49",
-                "phpunit/phpunit": "^9.5",
-                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.11"
+                "phpstan/phpstan": "^1.10.12",
+                "phpunit/phpunit": "^9.5"
             },
             "suggest": {
                 "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
-                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
                 "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
             },
             "type": "library",
@@ -1022,9 +1019,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.4.3"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.3.0"
             },
-            "time": "2024-02-11T18:56:19+00:00"
+            "time": "2023-08-10T16:34:11+00:00"
         },
         {
             "name": "php-stubs/wordpress-tests-stubs",
@@ -1605,16 +1602,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.26.0",
+            "version": "1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "231e3186624c03d7e7c890ec662b81e6b0405227"
+                "reference": "86e4d5a4b036f8f0be1464522f4c6b584c452757"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/231e3186624c03d7e7c890ec662b81e6b0405227",
-                "reference": "231e3186624c03d7e7c890ec662b81e6b0405227",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/86e4d5a4b036f8f0be1464522f4c6b584c452757",
+                "reference": "86e4d5a4b036f8f0be1464522f4c6b584c452757",
                 "shasum": ""
             },
             "require": {
@@ -1646,9 +1643,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.26.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.27.0"
             },
-            "time": "2024-02-23T16:05:55+00:00"
+            "time": "2024-03-21T13:14:53+00:00"
         },
         {
             "name": "psr/container",

--- a/projects/plugins/jetpack/changelog/update-phan-stubs-63
+++ b/projects/plugins/jetpack/changelog/update-phan-stubs-63
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: only adding phan suppression
+
+

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -52,9 +52,11 @@ class Jetpack_Google_Font_Face {
 
 	/**
 	 * Print fonts that are used in global styles or block-level settings.
+	 *
+	 * @todo Remove phan suppression when the WP_Font_Face_Resolver class is available in the minimum WordPress version.
 	 */
 	public function print_font_faces() {
-		$fonts             = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+		$fonts             = WP_Font_Face_Resolver::get_fonts_from_theme_json(); // // @phan-suppress-current-line PhanUndeclaredClassMethod
 		$font_slug_aliases = $this->get_font_slug_aliases();
 		$fonts_to_print    = array();
 
@@ -75,7 +77,7 @@ class Jetpack_Google_Font_Face {
 		}
 
 		if ( ! empty( $fonts_to_print ) ) {
-			wp_print_font_faces( $fonts_to_print );
+			wp_print_font_faces( $fonts_to_print ); // @phan-suppress-current-line PhanUndeclaredFunction
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -133,6 +133,9 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 
 		/**
 		 * Renders invitations errors/success messages in users.php.
+		 *
+		 * @phan-suppress PhanUndeclaredFunction
+		 * @todo When WordPress 6.4 is the minimum version, remove the suppression above and function_exists check.
 		 */
 		public function handle_invitation_results() {
 			$valid_nonce = isset( $_GET['_wpnonce'] ) ? wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-sso-invite-user' ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WP core doesn't pre-sanitize nonces either.
@@ -573,6 +576,9 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 
 		/**
 		 * Render the invitation email message.
+		 *
+		 * @phan-suppress PhanUndeclaredFunction
+		 * @todo When WordPress 6.4 is the minimum version, remove the suppression above and function_exists check.
 		 */
 		public function render_invitation_email_message() {
 			if ( ! function_exists( 'wp_admin_notice' ) ) {
@@ -605,6 +611,9 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 
 		/**
 		 * Render a note that wp.com invites will be automatically revoked.
+		 *
+		 * @phan-suppress PhanUndeclaredFunction
+		 * @todo When WordPress 6.4 is the minimum version, remove the suppression above and function_exists check.
 		 */
 		public function render_invitations_notices_for_deleted_users() {
 			if ( ! function_exists( 'wp_admin_notice' ) ) {
@@ -679,10 +688,10 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 									<span><?php esc_html_e( 'Invite user', 'jetpack' ); ?></span>
 								</legend>
 								<label for="invite_user_wpcom">
-									<input 
-										name="invite_user_wpcom" 
-										type="checkbox" 
-										id="invite_user_wpcom" 
+									<input
+										name="invite_user_wpcom"
+										type="checkbox"
+										id="invite_user_wpcom"
 										<?php checked( ! class_exists( 'WooCommerce' ) ); ?>
 										>
 									<?php esc_html_e( 'Invite user to WordPress.com', 'jetpack' ); ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Supports #36514

Does not address how to ensure this is updated when it should be.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Downgrade stubs to WP 6.3 for Phan.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf4qpu-mj-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `jetpack phan` when using the trunk version of the two JP files changed by this PR with this PR's version of composer.*