### PR TITLE
Block Patterns: Fix the starter patterns modal isn't shown on a new post

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-start-page-options-modal-for-new-post
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-start-page-options-modal-for-new-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Block Patterns: The modal of the starter patterns isn't shown when you're creating a new post

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -139,7 +139,12 @@ class Wpcom_Block_Patterns_From_Api {
 			}
 		}
 
-		$this->update_pattern_block_types();
+		// We prefer to show the starter page patterns modal of wpcom instead of core
+		// if it's available. Hence, we have to update the block types of patterns
+		// to disable the core's.
+		if ( class_exists( '\A8C\FSE\Starter_Page_Templates' ) ) {
+			$this->update_pattern_block_types();
+		}
 
 		// Temporarily removing the call to `update_pattern_post_types` while we investigate
 		// https://github.com/Automattic/wp-calypso/issues/79145.
@@ -280,7 +285,8 @@ class Wpcom_Block_Patterns_From_Api {
 			}
 
 			$post_content_offset = array_search( 'core/post-content', $pattern['blockTypes'], true );
-			if ( $post_content_offset !== false ) {
+			$is_page_pattern     = empty( $pattern['postTypes'] ) || in_array( 'page', $pattern['postTypes'], true );
+			if ( $post_content_offset !== false && $is_page_pattern ) {
 				unregister_block_pattern( $pattern['name'] );
 
 				array_splice( $pattern['blockTypes'], $post_content_offset, 1 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to p1709838128820069-slack-CBTN58FTJ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the starter patterns modal isn't shown on a new post
* Avoid removing the `blockTypes` of the patterns if the starter patterns modal from **WPCOM** isn't available

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow instructions https://github.com/Automattic/jetpack/pull/36516#issuecomment-2014518529 to apply changes to your sandbox or atomic sites
* Create a page template under the active theme, e.g. twentytwentyfour/patterns/post-example.php
   ```
	<?php
	/**
	* Title: Start Blank
	* Slug: twentytwentyfour/example-pattern
	* Block Types: core/post-content
	* Post Types: post
	*
	*/

	?>
	<!-- wp:paragraph {"placeholder":"Type / to choose a block"} -->
	<p></p>
	<!-- /wp:paragraph -->
   ```
* Create a new post
* Make sure the starter patterns modal from the **CORE** is shown as follows
  ![image](https://github.com/Automattic/jetpack/assets/13596067/3c2a131a-9dc5-4956-9d75-dbe419ccfb5e)
* Create a new page
* Make sure the starter patterns modal from the **WPCOM** is shown as follows
  ![image](https://github.com/Automattic/jetpack/assets/13596067/124c3881-7cfa-40b3-8d66-1681fad4a027)
* Deactivate the ETK plugin and create a new page again
* Make sure the starter patterns modal from the **CORE** is shown as follows
  ![image](https://github.com/Automattic/jetpack/assets/13596067/38cef63c-85ee-4648-abe6-c474df679f3d)