### PR TITLE
Boost: fix typo in tooltip string.

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/use-boost-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/use-boost-tooltip-copy.ts
@@ -37,12 +37,12 @@ export const useBoostTooltipCopy = ( { speedLetterGrade } ): string => {
 		switch ( speedLetterGrade ) {
 			case 'A':
 				return __(
-					'Your site is fast! But maintaining a high speed isn’t easy. Upgrade Boost to use automated CCS and image optimization tools to improve your performance on the go.',
+					'Your site is fast! But maintaining a high speed isn’t easy. Upgrade Boost to use automated CSS and image optimization tools to improve your performance on the go.',
 					'jetpack-my-jetpack'
 				);
 			case 'B':
 				return __(
-					'You are one step away from making your site blazing fast. Upgrade Boost to use automated CCS and image optimization tools to improve your performance.',
+					'You are one step away from making your site blazing fast. Upgrade Boost to use automated CSS and image optimization tools to improve your performance.',
 					'jetpack-my-jetpack'
 				);
 			default:

--- a/projects/packages/my-jetpack/changelog/update-boost-strings-css
+++ b/projects/packages/my-jetpack/changelog/update-boost-strings-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Boost tooltips: fix typo in string.


### PR DESCRIPTION
Follow-up to #35863

## Proposed changes:

This changes "CCS" into "CSS".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* See instructions in #35863
