### PR TITLE
Plugin update manager: transfers the status when editing a schedule

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-plugin-update-mgr-edit-status
+++ b/projects/packages/scheduled-updates/changelog/fix-plugin-update-mgr-edit-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Transfer status when editing a schedule.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.5.0';
+	const PACKAGE_VERSION = '0.5.1-alpha';
 	/**
 	 * The cron event hook for the scheduled plugins update.
 	 *

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -331,12 +331,21 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return $result;
 		}
 
+		$previous_schedule_status = Scheduled_Updates::get_scheduled_update_status( $request['schedule_id'] );
+
 		$deleted = $this->delete_item( $request );
 		if ( is_wp_error( $deleted ) ) {
 			return $deleted;
 		}
 
-		return $this->create_item( $request );
+		$item = $this->create_item( $request );
+
+		// Sets the previous status
+		if ( $previous_schedule_status ) {
+			Scheduled_Updates::set_scheduled_update_status( $item->data, $previous_schedule_status['last_run_timestamp'], $previous_schedule_status['last_run_status'] );
+		}
+
+		return $item;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -605,8 +605,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		if ( $updated_status === null ) {
 			$this->fail( 'Scheduled_Updates::get_scheduled_update_status() returned null.' );
 		} else {
-			$this->assertSame( $timestamp, $updated_status['last_run_timestamp'] );
-			$this->assertSame( $status, $updated_status['last_run_status'] );
+			$this->assertIsArray( $updated_status, 'Scheduled_Updates::get_scheduled_update_status() should return an array.' );
+			// doing these null checks for the static analyzer
+			$this->assertSame( $timestamp, $updated_status['last_run_timestamp'] ?? null );
+			$this->assertSame( $status, $updated_status['last_run_status'] ?? null );
 		}
 	}
 

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -602,9 +602,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		// Get the updated status
 		$updated_status = Scheduled_Updates::get_scheduled_update_status( $schedule_id );
-
-		$this->assertSame( $timestamp, $updated_status['last_run_timestamp'] );
-		$this->assertSame( $status, $updated_status['last_run_status'] );
+		if ( $updated_status === null ) {
+			$this->fail( 'Scheduled_Updates::get_scheduled_update_status() returned null.' );
+		} else {
+			$this->assertSame( $timestamp, $updated_status['last_run_timestamp'] );
+			$this->assertSame( $status, $updated_status['last_run_status'] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6198

## Proposed changes:
* Transfers the status when editing a schedule

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Using the Beta Tester plugin, check out this branch `fix/plugin-update-mgr-edit-status` for WordPress.com Features
- Create a schedule
- Wait for it to run (or run it through the API) so it gets a status
- Edit the schedule
- The status should transfer.

![CleanShot 2024-03-22 at 10 29 30](https://github.com/Automattic/jetpack/assets/528287/c06da067-eebe-4150-bfcb-b5cdac15f80d)
