### PR TITLE
a4a: display warning modal when deactivating the plugin

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/add-a4a-plugin-deactivationn
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-a4a-plugin-deactivationn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+General: add modal displayed when deactivating the plugin.

--- a/projects/plugins/automattic-for-agencies-client/composer.json
+++ b/projects/plugins/automattic-for-agencies-client/composer.json
@@ -10,6 +10,7 @@
 		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-identity-crisis": "@dev",
+		"automattic/jetpack-plugin-deactivation": "@dev",
 		"automattic/jetpack-plugins-installer": "@dev",
 		"automattic/jetpack-sync": "@dev"
 	},

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84193362ebcb355342fa10fac4a2e0c1",
+    "content-hash": "e66cc876c2ac74a035fbe75e1887e010",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -713,6 +713,71 @@
             }
         },
         {
+            "name": "automattic/jetpack-plugin-deactivation",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/plugin-deactivation",
+                "reference": "f79b33e19916f3efb0339e32af0936ccfa47d5cf"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-plugin-deactivation",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-plugin-deactivation/compare/v${old}...v${new}"
+                },
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.2.x-dev"
+                },
+                "textdomain": "jetpack-plugin-deactivation",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-deactivation-handler.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "NODE_ENV=production pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Ask for feedback while deactivating a plugin",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-plugins-installer",
             "version": "dev-trunk",
             "dist": {
@@ -1350,16 +1415,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.6.9",
+            "version": "1.6.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06"
+                "reference": "81a161d0b135df89951abd52296adf97deb0723d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06",
-                "reference": "0cc058854b3195ba21dc6b1f7b1f60f4ef3a9c06",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/81a161d0b135df89951abd52296adf97deb0723d",
+                "reference": "81a161d0b135df89951abd52296adf97deb0723d",
                 "shasum": ""
             },
             "require": {
@@ -1371,8 +1436,8 @@
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.6.10",
-                "symplify/easy-coding-standard": "^12.0.8"
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
             },
             "type": "library",
             "autoload": {
@@ -1429,7 +1494,7 @@
                 "security": "https://github.com/mockery/mockery/security/advisories",
                 "source": "https://github.com/mockery/mockery"
             },
-            "time": "2023-12-10T02:24:34+00:00"
+            "time": "2024-03-21T18:34:15+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1987,16 +2052,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.17",
+            "version": "9.6.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd"
+                "reference": "32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1a156980d78a6666721b7e8e8502fe210b587fcd",
-                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04",
+                "reference": "32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04",
                 "shasum": ""
             },
             "require": {
@@ -2070,7 +2135,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.17"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.18"
             },
             "funding": [
                 {
@@ -2086,7 +2151,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-23T13:14:51+00:00"
+            "time": "2024-03-21T12:07:32+00:00"
         },
         {
             "name": "psr/container",
@@ -3127,16 +3192,16 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
@@ -3148,7 +3213,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3169,8 +3234,7 @@
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
             },
             "funding": [
                 {
@@ -3178,7 +3242,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2024-03-14T16:00:52+00:00"
         },
         {
             "name": "sebastian/type",
@@ -4117,6 +4181,7 @@
         "automattic/jetpack-config": 20,
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-identity-crisis": 20,
+        "automattic/jetpack-plugin-deactivation": 20,
         "automattic/jetpack-plugins-installer": 20,
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-changelogger": 20

--- a/projects/plugins/automattic-for-agencies-client/src/admin/deactivation-dialog.php
+++ b/projects/plugins/automattic-for-agencies-client/src/admin/deactivation-dialog.php
@@ -43,17 +43,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		align-items: start;
 
-		padding: 1rem 1rem 0;
+		padding: 2rem 2rem 0;
 	}
 
 	#jp-plugin-deactivation-automattic-for-agencies-client .jp-plugin-deactivation__dialog__content h1 {
 		font-size: 20px;
-		line-height: 24px
+		line-height: 24px;
+
+		margin: 0;
 	}
 
 	#jp-plugin-deactivation-automattic-for-agencies-client .jp-plugin-deactivation__dialog__content p {
 		font-size: 14px;
-		line-height: 20px
+		line-height: 20px;
+
+		margin: 2rem 0;
 	}
 
 	#jp-plugin-deactivation-automattic-for-agencies-client footer {
@@ -62,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		text-align: right;
 		border: none;
 
-		padding: 0 1rem 1rem;
+		padding: 0 2rem 2rem;
 	}
 
 	#jp-plugin-deactivation-automattic-for-agencies-client footer .jp-plugin-deactivation__button:first-child {

--- a/projects/plugins/automattic-for-agencies-client/src/admin/deactivation-dialog.php
+++ b/projects/plugins/automattic-for-agencies-client/src/admin/deactivation-dialog.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Contents of the modal displayed when one clicks on the deactivate link for the plugin.
+ *
+ * This setup relies on the automattic/jetpack-plugin-deactivation package.
+ *
+ * @package automattic/automattic-for-agencies-client-plugin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+?>
+<main class="jp-plugin-deactivation__dialog__content">
+	<h1><?php esc_html_e( 'Are you sure you want to disconnect this site?', 'automattic-for-agencies-client' ); ?></h1>
+	<p><?php esc_html_e( 'It will no longer show up in the Automattic for Agencies dashboard and you won’t be able to update plugins with one click or be notified of any downtime.', 'automattic-for-agencies-client' ); ?></p>
+</main>
+<footer class="jp-plugin-deactivation__dialog__actions">
+	<button
+		type="button"
+		class="jp-plugin-deactivation__button"
+		data-jp-plugin-deactivation-action="close"
+	><?php esc_html_e( 'Keep the site connected', 'automattic-for-agencies-client' ); ?></button>
+	<button
+		type="button"
+		class="jp-plugin-deactivation__button jp-plugin-deactivation__button--destructive"
+		data-jp-plugin-deactivation-action="deactivate"
+	><?php esc_html_e( 'Yes, disconnect site', 'automattic-for-agencies-client' ); ?></button>
+</footer>
+
+<style>
+	#jp-plugin-deactivation-automattic-for-agencies-client footer {
+		text-align: center;
+	}
+</style>

--- a/projects/plugins/automattic-for-agencies-client/src/admin/deactivation-dialog.php
+++ b/projects/plugins/automattic-for-agencies-client/src/admin/deactivation-dialog.php
@@ -57,6 +57,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 
 	#jp-plugin-deactivation-automattic-for-agencies-client footer {
+		font-weight: 600;
+
 		text-align: right;
 		border: none;
 

--- a/projects/plugins/automattic-for-agencies-client/src/admin/deactivation-dialog.php
+++ b/projects/plugins/automattic-for-agencies-client/src/admin/deactivation-dialog.php
@@ -29,7 +29,49 @@ if ( ! defined( 'ABSPATH' ) ) {
 </footer>
 
 <style>
+	#jp-plugin-deactivation-automattic-for-agencies-client .jp-plugin-deactivation__dialog {
+		height: fit-content;
+		width: calc(100% - 32px);
+		
+		max-width: 512px;
+
+		border-radius: 12px;
+	}
+	
+	#jp-plugin-deactivation-automattic-for-agencies-client .jp-plugin-deactivation__dialog__content {
+		background: none;
+
+		align-items: start;
+
+		padding: 1rem 1rem 0;
+	}
+
+	#jp-plugin-deactivation-automattic-for-agencies-client .jp-plugin-deactivation__dialog__content h1 {
+		font-size: 20px;
+		line-height: 24px
+	}
+
+	#jp-plugin-deactivation-automattic-for-agencies-client .jp-plugin-deactivation__dialog__content p {
+		font-size: 14px;
+		line-height: 20px
+	}
+
 	#jp-plugin-deactivation-automattic-for-agencies-client footer {
-		text-align: center;
+		text-align: right;
+		border: none;
+
+		padding: 0 1rem 1rem;
+	}
+
+	#jp-plugin-deactivation-automattic-for-agencies-client footer .jp-plugin-deactivation__button:first-child {
+		color: var(--btn-color);
+		background: none;
+		border: 1px solid var(--Gray-Gray-5, #DCDCDE);
+		border-radius: 4px;
+	}
+
+	#jp-plugin-deactivation-automattic-for-agencies-client footer .jp-plugin-deactivation__button:last-child {
+		border-radius: 4px;
+		background: var(--Red-Red-60, #B32D2E);
 	}
 </style>

--- a/projects/plugins/automattic-for-agencies-client/src/class-automattic-for-agencies-client.php
+++ b/projects/plugins/automattic-for-agencies-client/src/class-automattic-for-agencies-client.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+use Automattic\Jetpack\Plugin_Deactivation\Deactivation_Handler;
 use Automattic\Jetpack\Sync\Data_Settings;
 
 /**
@@ -34,6 +35,9 @@ class Automattic_For_Agencies_Client {
 
 		// Add scripts and styles to our admin page.
 		add_action( 'load-settings_page_' . AUTOMATTIC_FOR_AGENCIES_CLIENT_SLUG, array( static::class, 'load_scripts_styles' ) );
+
+		// Display a modal when trying to deactivate the plugin.
+		Deactivation_Handler::init( AUTOMATTIC_FOR_AGENCIES_CLIENT_SLUG, __DIR__ . '/admin/deactivation-dialog.php' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

This PR adds a modal displayed when one wants to deactivate the plugin. It warns folks of the lost functionality when deactivating the plugin.

<img width="926" alt="image" src="https://github.com/Automattic/jetpack/assets/3418513/2c387f0a-9892-432d-90bd-49302c423b13">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

- pfunGA-sQ-p2#comment-1126
- 129-gh-automattic-for-agencies-dev

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Activate the a4a plugin.
* Go to the Plugins menu
* Click on "Deactivate"
    * See the modal that opens.
