### PR TITLE
Scheduled Updates: Fix off-by-one error for Sunday schedules

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-day-of-week
+++ b/projects/packages/scheduled-updates/changelog/fix-day-of-week
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a bug where the weekday index was not properly accounted for in list of weekdays.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -227,23 +227,23 @@ class Scheduled_Updates {
 			// Not getting smart about passing in weekdays makes it easier to translate.
 			$weekdays = array(
 				/* translators: %s is the time of day. Mondays at 10 am. */
-				__( 'Mondays at %s.', 'jetpack-scheduled-updates' ),
+				1 => __( 'Mondays at %s.', 'jetpack-scheduled-updates' ),
 				/* translators: %s is the time of day. Tuesdays at 10 am. */
-				__( 'Tuesdays at %s.', 'jetpack-scheduled-updates' ),
+				2 => __( 'Tuesdays at %s.', 'jetpack-scheduled-updates' ),
 				/* translators: %s is the time of day. Wednesdays at 10 am. */
-				__( 'Wednesdays at %s.', 'jetpack-scheduled-updates' ),
+				3 => __( 'Wednesdays at %s.', 'jetpack-scheduled-updates' ),
 				/* translators: %s is the time of day. Thursdays at 10 am. */
-				__( 'Thursdays at %s.', 'jetpack-scheduled-updates' ),
+				4 => __( 'Thursdays at %s.', 'jetpack-scheduled-updates' ),
 				/* translators: %s is the time of day. Fridays at 10 am. */
-				__( 'Fridays at %s.', 'jetpack-scheduled-updates' ),
+				5 => __( 'Fridays at %s.', 'jetpack-scheduled-updates' ),
 				/* translators: %s is the time of day. Saturdays at 10 am. */
-				__( 'Saturdays at %s.', 'jetpack-scheduled-updates' ),
+				6 => __( 'Saturdays at %s.', 'jetpack-scheduled-updates' ),
 				/* translators: %s is the time of day. Sundays at 10 am. */
-				__( 'Sundays at %s.', 'jetpack-scheduled-updates' ),
+				7 => __( 'Sundays at %s.', 'jetpack-scheduled-updates' ),
 			);
 
 			$html = sprintf(
-				$weekdays[ date_i18n( 'N', $schedule->timestamp ) - 1 ],
+				$weekdays[ date_i18n( 'N', $schedule->timestamp ) ],
 				get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $schedule->timestamp ), get_option( 'time_format' ) )
 			);
 		}

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -221,7 +221,7 @@ class Scheduled_Updates {
 			$html = sprintf(
 				/* translators: %s is the time of day. Daily at 10 am. */
 				esc_html__( 'Daily at %s.', 'jetpack-scheduled-updates' ),
-				get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $schedule->timestamp ), get_option( 'time_format' ) )
+				wp_date( get_option( 'time_format' ), $schedule->timestamp )
 			);
 		} else {
 			// Not getting smart about passing in weekdays makes it easier to translate.
@@ -243,8 +243,8 @@ class Scheduled_Updates {
 			);
 
 			$html = sprintf(
-				$weekdays[ date_i18n( 'N', $schedule->timestamp ) ],
-				get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $schedule->timestamp ), get_option( 'time_format' ) )
+				$weekdays[ wp_date( 'N', $schedule->timestamp ) ],
+				wp_date( get_option( 'time_format' ), $schedule->timestamp )
 			);
 		}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -226,8 +226,6 @@ class Scheduled_Updates {
 		} else {
 			// Not getting smart about passing in weekdays makes it easier to translate.
 			$weekdays = array(
-				/* translators: %s is the time of day. Sundays at 10 am. */
-				__( 'Sundays at %s.', 'jetpack-scheduled-updates' ),
 				/* translators: %s is the time of day. Mondays at 10 am. */
 				__( 'Mondays at %s.', 'jetpack-scheduled-updates' ),
 				/* translators: %s is the time of day. Tuesdays at 10 am. */
@@ -240,10 +238,12 @@ class Scheduled_Updates {
 				__( 'Fridays at %s.', 'jetpack-scheduled-updates' ),
 				/* translators: %s is the time of day. Saturdays at 10 am. */
 				__( 'Saturdays at %s.', 'jetpack-scheduled-updates' ),
+				/* translators: %s is the time of day. Sundays at 10 am. */
+				__( 'Sundays at %s.', 'jetpack-scheduled-updates' ),
 			);
 
 			$html = sprintf(
-				$weekdays[ date_i18n( 'N', $schedule->timestamp ) ],
+				$weekdays[ date_i18n( 'N', $schedule->timestamp ) - 1 ],
 				get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $schedule->timestamp ), get_option( 'time_format' ) )
 			);
 		}

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -555,6 +555,50 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test get_scheduled_update_text.
+	 *
+	 * @dataProvider update_text_provider
+	 * @covers ::get_scheduled_update_text
+	 *
+	 * @param object $schedule The schedule object.
+	 * @param string $expected The expected text.
+	 */
+	public function test_get_scheduled_update_text( $schedule, $expected ) {
+		$this->assertSame( $expected, Scheduled_Updates::get_scheduled_update_text( $schedule ) );
+	}
+
+	/**
+	 * Data provider for test_get_scheduled_update_text.
+	 *
+	 * @return array[]
+	 */
+	private function update_text_provider() {
+		return array(
+			array(
+				(object) array(
+					'timestamp' => strtotime( 'next Monday 00:00' ),
+					'interval'  => WEEK_IN_SECONDS,
+				),
+				sprintf( 'Mondays at %s.', gmdate( get_option( 'time_format' ), strtotime( 'next Monday 8:00' ) ) ),
+			),
+			array(
+				(object) array(
+					'timestamp' => strtotime( 'next Tuesday 00:00' ),
+					'interval'  => DAY_IN_SECONDS,
+				),
+				sprintf( 'Daily at %s.', gmdate( get_option( 'time_format' ), strtotime( 'next Tuesday 8:00' ) ) ),
+			),
+			array(
+				(object) array(
+					'timestamp' => strtotime( 'next Sunday 00:00' ),
+					'interval'  => WEEK_IN_SECONDS,
+				),
+				sprintf( 'Sundays at %s.', gmdate( get_option( 'time_format' ), strtotime( 'next Sunday 8:00' ) ) ),
+			),
+		);
+	}
+
+	/**
 	 * Create a list of plugins to be deleted.
 	 *
 	 * @param int $count The number of plugins to create.

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -63,7 +63,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		// Ensure plugin directory exists.
 		$this->wp_filesystem->mkdir( $this->plugin_dir );
 
-		// init the hook
+		// Init the hook.
 		add_action( 'rest_api_init', array( 'Automattic\Jetpack\Scheduled_Updates', 'add_is_managed_extension_field' ) );
 
 		do_action( 'rest_api_init' );
@@ -75,10 +75,10 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 * @after
 	 */
 	protected function tear_down() {
-		// Clean up the temporary plugin directory
+		// Clean up the temporary plugin directory.
 		$this->wp_filesystem->rmdir( $this->plugin_dir, true );
 
-		// Clean up the plugins cache created by get_plugins()
+		// Clean up the plugins cache created by get_plugins().
 		wp_cache_delete( 'plugins', 'plugins' );
 
 		wp_clear_scheduled_hook( Scheduled_Updates::PLUGIN_CRON_HOOK );
@@ -94,12 +94,12 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 * @covers ::add_is_managed_extension_field
 	 */
 	public function test_unmanaged_plugins() {
-		// direct
+		// Direct.
 		$plugin_name = 'direct-plugin';
 		$this->wp_filesystem->mkdir( "$this->plugin_dir/$plugin_name" );
 		$this->populate_file_with_plugin_header( "$this->plugin_dir/$plugin_name/$plugin_name.php", 'direct-plugin' );
 
-		// make sure the directory exists
+		// Make sure the directory exists.
 		$this->assertTrue( $this->wp_filesystem->is_dir( "$this->plugin_dir/direct-plugin" ) );
 
 		$request       = new \WP_REST_Request( 'GET', '/wp/v2/plugins' );
@@ -117,7 +117,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 * @covers ::add_is_managed_extension_field
 	 */
 	public function test_unmanaged_plugins_not_in_root_directory() {
-		// we simulate a symlink to a subdirectory inside a wp directory
+		// We simulate a symlink to a subdirectory inside a wp directory.
 		$plugin_name = 'managed-plugin';
 		$target_dir  = "$this->plugin_dir/wordpress";
 		$this->wp_filesystem->mkdir( $target_dir );
@@ -125,7 +125,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$this->populate_file_with_plugin_header( "$target_dir/$plugin_name/$plugin_name.php", 'managed-plugin' );
 		symlink( "$target_dir/$plugin_name", "$this->plugin_dir/$plugin_name" );
 
-		// make sure the symlink exists
+		// Make sure the symlink exists.
 		$this->assertFalse( $this->wp_filesystem->is_dir( "$this->plugin_dir/direct-plugin" ) );
 		$this->assertTrue( is_link( "$this->plugin_dir/managed-plugin" ) );
 
@@ -144,7 +144,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 * @covers ::add_is_managed_extension_field
 	 */
 	public function test_managed_plugins() {
-		// we simulate a symlink to a subdirectory inside a wp directory
+		// We simulate a symlink to a subdirectory inside a wp directory.
 		$plugin_name = 'managed-plugin';
 		$target_dir  = "$this->plugin_dir/wordpress";
 		$this->wp_filesystem->mkdir( $target_dir );
@@ -152,11 +152,11 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$this->populate_file_with_plugin_header( "$target_dir/$plugin_name/$plugin_name.php", 'managed-plugin' );
 		symlink( "$target_dir/$plugin_name", "$this->plugin_dir/$plugin_name" );
 
-		// make sure the symlink exists
+		// Make sure the symlink exists.
 		$this->assertFalse( $this->wp_filesystem->is_dir( "$this->plugin_dir/direct-plugin" ) );
 		$this->assertTrue( is_link( "$this->plugin_dir/managed-plugin" ) );
 
-		// tweak realpath so that it returns `/wordpress/...`
+		// Tweak realpath so that it returns `/wordpress/...`.
 		$realpath = $this->getFunctionMock( __NAMESPACE__, 'realpath' );
 		$realpath->expects( $this->once() )->willReturn( "/wordpress/plugins/$plugin_name" );
 

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -572,7 +572,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 *
 	 * @return array[]
 	 */
-	private function update_text_provider() {
+	public function update_text_provider() {
 		return array(
 			array(
 				(object) array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6218

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make array keys explicit for weekday list.
* Move Sundays entry to the end of the list to correspond to ISO 8601 numeric representation of the day of the week. See https://www.php.net/manual/en/datetime.format.php
* Add unit test that fails without these changes.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch on a test site in Jetpack Beta.
* Create a Schedule for Monday 0:00.
* Navigate to the plugin list in wp-admin and make sure the Autoupdate column displays the correct schedule string.

