### PR TITLE
Backport mu-wpcom-plugin 2.1.8 Changes

### DIFF
--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1] - 2024-03-22
+### Changed
+- yUpdate Phan config. [#36353]
+
 ## [2.6.0] - 2024-03-20
 ### Added
 - Add the 'remote_connect' REST endpoint. [#36329]
@@ -996,6 +1000,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.6.1]: https://github.com/Automattic/jetpack-connection/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/Automattic/jetpack-connection/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/Automattic/jetpack-connection/compare/v2.4.1...v2.5.0
 [2.4.1]: https://github.com/Automattic/jetpack-connection/compare/v2.4.0...v2.4.1

--- a/projects/packages/connection/changelog/add-a4a-plugin-skeleton
+++ b/projects/packages/connection/changelog/add-a4a-plugin-skeleton
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-yUpdate Phan config.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.6.1-alpha';
+	const PACKAGE_VERSION = '2.6.1';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.19.0] - 2024-03-22
+### Changed
+- Added additional settings for commenting on simple sites [#36367]
+- Releasing Gutenberg to all Verbum users. [#36476]
+
+### Fixed
+- Block Patterns: The modal of the starter patterns isn't shown when you're creating a new post [#36516]
+- Untangle: update launchpad links for newsletter setting to go to Jetpack's [#36495]
+
 ## [5.18.0] - 2024-03-20
 ### Changed
 - The GitHub deployments feature check has been removed. [#36383]
@@ -666,6 +675,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.19.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.18.0...v5.19.0
 [5.18.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.17.0...v5.18.0
 [5.17.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.16.1...v5.17.0
 [5.16.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.16.0...v5.16.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-verbum-settings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-verbum-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Added additional settings for commenting on simple sites

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-start-page-options-modal-for-new-post
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-start-page-options-modal-for-new-post
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Block Patterns: The modal of the starter patterns isn't shown when you're creating a new post

--- a/projects/packages/jetpack-mu-wpcom/changelog/untangle-launchpad-newsletter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangle-launchpad-newsletter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Untangle: update launchpad links for newsletter setting to go to Jetpack's

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-gutenberg-verbum-all-users
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-gutenberg-verbum-all-users
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Releasing Gutenberg to all Verbum users.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.19.0-alpha",
+	"version": "5.19.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.19.0-alpha';
+	const PACKAGE_VERSION = '5.19.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2024-03-22
+### Fixed
+- Fixed a bug where the weekday index was not properly accounted for in list of weekdays. [#36524]
+- Transfer status when editing a schedule. [#36521]
+
 ## [0.5.0] - 2024-03-20
 ### Added
 - Add a new plugin deletion hook that remove the plugin from the scheduled updates. [#36458]
@@ -81,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.5.1]: https://github.com/Automattic/scheduled-updates/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Automattic/scheduled-updates/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/Automattic/scheduled-updates/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Automattic/scheduled-updates/compare/v0.3.4...v0.4.0

--- a/projects/packages/scheduled-updates/changelog/fix-day-of-week
+++ b/projects/packages/scheduled-updates/changelog/fix-day-of-week
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a bug where the weekday index was not properly accounted for in list of weekdays.

--- a/projects/packages/scheduled-updates/changelog/fix-plugin-update-mgr-edit-status
+++ b/projects/packages/scheduled-updates/changelog/fix-plugin-update-mgr-edit-status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Transfer status when editing a schedule.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.5.1-alpha';
+	const PACKAGE_VERSION = '0.5.1';
 	/**
 	 * The cron event hook for the scheduled plugins update.
 	 *

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2024-03-22
+### Added
+- Add support for A8C for Agencies source parameter. [#36491]
+
 ## [2.1.3] - 2024-03-20
 ### Changed
 - Internal updates.
@@ -318,6 +322,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[2.2.0]: https://github.com/Automattic/jetpack-status/compare/v2.1.3...v2.2.0
 [2.1.3]: https://github.com/Automattic/jetpack-status/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/Automattic/jetpack-status/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/Automattic/jetpack-status/compare/v2.1.0...v2.1.1

--- a/projects/packages/status/changelog/add-a4a-source-to-jetpack-connect-url
+++ b/projects/packages/status/changelog/add-a4a-source-to-jetpack-connect-url
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add support for A8C for Agencies source parameter.

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.8 - 2024-03-22
+### Changed
+- Internal updates.
+
 ## 2.1.7 - 2024-03-20
 ### Changed
 - Comment: Updated composer.lock. [#36458]

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-verbum-settings
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-verbum-settings
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_8_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_8"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.8-alpha
+ * Version: 2.1.8
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.8-alpha",
+	"version": "2.1.8",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.8

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.