### PR TITLE
ci: Run phan with previous-version WP stubs too

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -318,6 +318,9 @@ jobs:
       - name: Run phan
         run: pnpm jetpack phan --all -v --update-baseline --format github
       - name: Run phan for previous WP version too
+        env:
+          # Don't bother complaining about unused suppressions that may be used with the newer stubs. See .phan/config.base.php for how this gets applied.
+          NO_PHAN_UNUSED_SUPPRESSION: 1
         run: |
           composer update --prefer-lowest php-stubs/wordpress-stubs php-stubs/wordpress-tests-stubs
           # Don't re-update baselines here, only check.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -317,6 +317,11 @@ jobs:
         run: pnpm install
       - name: Run phan
         run: pnpm jetpack phan --all -v --update-baseline --format github
+      - name: Run phan for previous WP version too
+        run: |
+          composer update --prefer-lowest php-stubs/wordpress-stubs php-stubs/wordpress-tests-stubs
+          # Don't re-update baselines here, only check.
+          pnpm jetpack phan --all -v --format github
       - name: Check baselines
         run: |
           # Anything changed (with a side of printing the diff)

--- a/.phan/config.base.php
+++ b/.phan/config.base.php
@@ -57,7 +57,6 @@ function make_phan_config( $dir, $options = array() ) {
 			'RedundantAssignmentPlugin',
 			'SimplifyExpressionPlugin',
 			'UnreachableCodePlugin',
-			'UnusedSuppressionPlugin',
 			'UseReturnValuePlugin',
 			// Others to consider:
 			// https://github.com/wikimedia/mediawiki-tools-phan/blob/master/src/Plugin/RedundantExistenceChecksPlugin.php
@@ -133,6 +132,11 @@ function make_phan_config( $dir, $options = array() ) {
 			"$root/.phan/",
 		),
 	);
+
+	// Only use UnusedSuppressionPlugin if we're not doing the CI run with old core stubs.
+	if ( ! getenv( 'NO_PHAN_UNUSED_SUPPRESSION' ) ) {
+		$config['plugins'][] = 'UnusedSuppressionPlugin';
+	}
 
 	// Read default PHP versions to check against.
 	$versions = file_get_contents( "$root/.github/versions.sh" );

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "1.0.0",
 		"phan/phan": "^5.4",
 		"php-parallel-lint/php-parallel-lint": "1.3.2",
-		"php-stubs/wordpress-stubs": "^6.4.3",
-		"php-stubs/wordpress-tests-stubs": "^6.3",
+		"php-stubs/wordpress-stubs": ">=6.3",
+		"php-stubs/wordpress-tests-stubs": ">=6.3",
 		"php-stubs/wp-cli-stubs": "^2.10",
 		"sirbrillig/phpcs-changed": "2.11.4",
 		"squizlabs/php_codesniffer": "^3.6.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84a3ae0449c3cfc1996aaec7d2ec424c",
+    "content-hash": "591ead434f24ced0f6c803183daf90af",
     "packages": [],
     "packages-dev": [
         {

--- a/projects/plugins/jetpack/changelog/add-ci-phan-run-with-wp-previous
+++ b/projects/plugins/jetpack/changelog/add-ci-phan-run-with-wp-previous
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add Phan suppressions for new-in-WP-6.4 functions that are checked at runtime. No change to functionality.
+
+

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -54,8 +54,8 @@ class Jetpack_Google_Font_Face {
 	 * Print fonts that are used in global styles or block-level settings.
 	 */
 	public function print_font_faces() {
-		// @phan-suppress-next-line PhanUndeclaredClassMethod -- This file is only loaded (via modules/google-fonts/load.php) when core's new Font library exists.
 		// @todo Remove suppression when we drop support for core versions without the Font library.
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- This file is only loaded (via modules/google-fonts/load.php) when core's new Font library exists. @phan-suppress-current-line UnusedPluginSuppression
 		$fonts             = WP_Font_Face_Resolver::get_fonts_from_theme_json();
 		$font_slug_aliases = $this->get_font_slug_aliases();
 		$fonts_to_print    = array();
@@ -77,8 +77,8 @@ class Jetpack_Google_Font_Face {
 		}
 
 		if ( ! empty( $fonts_to_print ) ) {
-			// @phan-suppress-next-line PhanUndeclaredFunction -- This file is only loaded (via modules/google-fonts/load.php) when core's new Font library exists.
 			// @todo Remove suppression when we drop support for core versions without the Font library.
+			// @phan-suppress-next-line PhanUndeclaredFunction -- This file is only loaded (via modules/google-fonts/load.php) when core's new Font library exists. @phan-suppress-current-line UnusedPluginSuppression
 			wp_print_font_faces( $fonts_to_print );
 		}
 	}

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -55,6 +55,7 @@ class Jetpack_Google_Font_Face {
 	 */
 	public function print_font_faces() {
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- This file is only loaded (via modules/google-fonts/load.php) when core's new Font library exists.
+		// @todo Remove suppression when we drop support for core versions without the Font library.
 		$fonts             = WP_Font_Face_Resolver::get_fonts_from_theme_json();
 		$font_slug_aliases = $this->get_font_slug_aliases();
 		$fonts_to_print    = array();
@@ -77,6 +78,7 @@ class Jetpack_Google_Font_Face {
 
 		if ( ! empty( $fonts_to_print ) ) {
 			// @phan-suppress-next-line PhanUndeclaredFunction -- This file is only loaded (via modules/google-fonts/load.php) when core's new Font library exists.
+			// @todo Remove suppression when we drop support for core versions without the Font library.
 			wp_print_font_faces( $fonts_to_print );
 		}
 	}

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -54,6 +54,7 @@ class Jetpack_Google_Font_Face {
 	 * Print fonts that are used in global styles or block-level settings.
 	 */
 	public function print_font_faces() {
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- This file is only loaded (via modules/google-fonts/load.php) when core's new Font library exists.
 		$fonts             = WP_Font_Face_Resolver::get_fonts_from_theme_json();
 		$font_slug_aliases = $this->get_font_slug_aliases();
 		$fonts_to_print    = array();
@@ -75,6 +76,7 @@ class Jetpack_Google_Font_Face {
 		}
 
 		if ( ! empty( $fonts_to_print ) ) {
+			// @phan-suppress-next-line PhanUndeclaredFunction -- This file is only loaded (via modules/google-fonts/load.php) when core's new Font library exists.
 			wp_print_font_faces( $fonts_to_print );
 		}
 	}

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -140,6 +140,8 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 
 		/**
 		 * Renders invitations errors/success messages in users.php.
+		 *
+		 * @phan-suppress PhanUndeclaredFunction,UnusedSuppression -- Existence of wp_admin_notice (added in WP 6.4) is checked inline.
 		 */
 		public function handle_invitation_results() {
 			$valid_nonce = isset( $_GET['_wpnonce'] ) ? wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-sso-invite-user' ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WP core doesn't pre-sanitize nonces either.

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -142,6 +142,7 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		 * Renders invitations errors/success messages in users.php.
 		 *
 		 * @phan-suppress PhanUndeclaredFunction,UnusedSuppression -- Existence of wp_admin_notice (added in WP 6.4) is checked inline.
+		 * @todo Remove suppression and function_exists check when we drop support for WP 6.3.
 		 */
 		public function handle_invitation_results() {
 			$valid_nonce = isset( $_GET['_wpnonce'] ) ? wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-sso-invite-user' ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WP core doesn't pre-sanitize nonces either.

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -140,14 +140,14 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 
 		/**
 		 * Renders invitations errors/success messages in users.php.
-		 *
-		 * @phan-suppress PhanUndeclaredFunction,UnusedSuppression -- Existence of wp_admin_notice (added in WP 6.4) is checked inline.
-		 * @todo Remove suppression and function_exists check when we drop support for WP 6.3.
 		 */
 		public function handle_invitation_results() {
 			$valid_nonce = isset( $_GET['_wpnonce'] ) ? wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-sso-invite-user' ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WP core doesn't pre-sanitize nonces either.
 
-			if ( ! $valid_nonce || ! isset( $_GET['jetpack-sso-invite-user'] ) || ! function_exists( 'wp_admin_notice' ) ) {
+			if ( ! function_exists( 'wp_admin_notice' ) ) {
+				return;
+			}
+			if ( ! $valid_nonce || ! isset( $_GET['jetpack-sso-invite-user'] ) ) {
 				return;
 			}
 			if ( $_GET['jetpack-sso-invite-user'] === 'success' ) {

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -140,14 +140,14 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 
 		/**
 		 * Renders invitations errors/success messages in users.php.
+		 *
+		 * @phan-suppress PhanUndeclaredFunction,UnusedSuppression -- Existence of wp_admin_notice (added in WP 6.4) is checked inline.
+		 * @todo Remove suppression and function_exists check when we drop support for WP 6.3.
 		 */
 		public function handle_invitation_results() {
 			$valid_nonce = isset( $_GET['_wpnonce'] ) ? wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-sso-invite-user' ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WP core doesn't pre-sanitize nonces either.
 
-			if ( ! function_exists( 'wp_admin_notice' ) ) {
-				return;
-			}
-			if ( ! $valid_nonce || ! isset( $_GET['jetpack-sso-invite-user'] ) ) {
+			if ( ! $valid_nonce || ! isset( $_GET['jetpack-sso-invite-user'] ) || ! function_exists( 'wp_admin_notice' ) ) {
 				return;
 			}
 			if ( $_GET['jetpack-sso-invite-user'] === 'success' ) {

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -585,6 +585,7 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		 * Render the invitation email message.
 		 */
 		public function render_invitation_email_message() {
+			// @todo Remove function_exists check (and phan suppression below) when we drop support for WP 6.3.
 			if ( ! function_exists( 'wp_admin_notice' ) ) {
 				return;
 			}
@@ -602,6 +603,7 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 					),
 				)
 			);
+			// @phan-suppress-next-line PhanUndeclaredFunction -- Existence of wp_admin_notice (added in WP 6.4) is checked above. @phan-suppress-current-line UnusedPluginSuppression
 			wp_admin_notice(
 				$message,
 				array(
@@ -617,6 +619,7 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		 * Render a note that wp.com invites will be automatically revoked.
 		 */
 		public function render_invitations_notices_for_deleted_users() {
+			// @todo Remove function_exists check (and phan suppression below) when we drop support for WP 6.3.
 			if ( ! function_exists( 'wp_admin_notice' ) ) {
 				return;
 			}
@@ -658,6 +661,7 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 					),
 					array( 'strong' => true )
 				);
+				// @phan-suppress-next-line PhanUndeclaredFunction -- Existence of wp_admin_notice (added in WP 6.4) is checked above. @phan-suppress-current-line UnusedPluginSuppression
 				wp_admin_notice(
 					$message,
 					array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Phan can help us detect accidental addition of calls to PHP functions, classes, and methods added to WordPress core since the supported previous versions if we supply it the right stub files.

Note for this to really work, though, we'll need to clean up the existing baselines, since if a file already has an undefined function being ignored by the baseline then a new undefined function use added in the same file would be ignored too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf4qpu-mj-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* First version of this PR should flag [this call][1], which can serve as a good test for it working.

[1]: https://github.com/Automattic/jetpack/commit/a469a562f357a64201d4200a8e93eb2fdfe86aee#diff-74ac4e9a0967377ce7a8e4eb610c02184c3a662ac224b3dc33395de3ead1b471R59