### PR TITLE
Create a wrapper component for RadioControl

### DIFF
--- a/projects/js-packages/components/changelog/add-radio-control
+++ b/projects/js-packages/components/changelog/add-radio-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Create RadioControl component

--- a/projects/js-packages/components/components/radio-control/README.md
+++ b/projects/js-packages/components/components/radio-control/README.md
@@ -1,0 +1,5 @@
+# RadioControl
+
+A wrapper component for applying Jetpack Emerald styles to the [RadioControl](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/radio-control) component from `@wordpress/components`.
+
+The documentation for the base `RadioControl` component can be found via the [Gutenberg Handbook](https://developer.wordpress.org/block-editor/reference-guides/components/radio-control/).

--- a/projects/js-packages/components/components/radio-control/index.tsx
+++ b/projects/js-packages/components/components/radio-control/index.tsx
@@ -1,0 +1,55 @@
+import { RadioControl as WPRadioControl } from '@wordpress/components';
+import classNames from 'classnames';
+import styles from './styles.module.scss';
+
+interface RadioControlProps {
+	/** The current value. */
+	selected: string;
+
+	/** Custom class name to append to the component. */
+	className?: string;
+
+	/** Whether or not the radio control is currently disabled. */
+	disabled?: boolean;
+
+	/** Additional information to display below the radio control. */
+	help?: React.ReactNode;
+
+	/** The label for the radio control. */
+	label?: React.ReactNode;
+
+	/** If true, the label will only be visible to screen readers. */
+	hideLabelFromVision?: boolean;
+
+	/** A list of options to show. */
+	options: { label: string; value: string }[];
+
+	/** A callback function invoked when the value is changed. */
+	onChange: ( value: string ) => void;
+}
+
+const RadioControl: React.FC< RadioControlProps > = ( {
+	selected,
+	className,
+	disabled,
+	help,
+	label,
+	hideLabelFromVision,
+	options,
+	onChange,
+} ) => {
+	return (
+		<WPRadioControl
+			selected={ selected }
+			className={ classNames( styles.radio, className ) }
+			disabled={ disabled }
+			help={ help }
+			label={ label }
+			hideLabelFromVision={ hideLabelFromVision }
+			options={ options }
+			onChange={ onChange }
+		/>
+	);
+};
+
+export default RadioControl;

--- a/projects/js-packages/components/components/radio-control/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/radio-control/stories/index.stories.tsx
@@ -1,0 +1,55 @@
+import React, { useCallback, useState } from 'react';
+import RadioControl from '..';
+
+export default {
+	title: 'JS Packages/Components/Radio Control',
+	component: RadioControl,
+	parameters: {
+		layout: 'centered',
+	},
+	argTypes: {
+		disabled: {
+			control: 'boolean',
+			defaultValue: false,
+			description: 'Whether or not the radio control is currently disabled.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: false },
+			},
+		},
+		help: {
+			control: 'text',
+			description: 'Additional information to display below the radio control.',
+		},
+		label: {
+			control: 'text',
+			description: 'The label for the radio control.',
+		},
+		hideLabelFromVision: {
+			control: 'boolean',
+			defaultValue: false,
+			description: 'If true, the label will only be visible to screen readers.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: false },
+			},
+		},
+	},
+};
+
+const options = [
+	{ label: 'One', value: 'one' },
+	{ label: 'Two', value: 'two' },
+];
+
+export const Default = args => {
+	const [ selected, setSelected ] = useState( 'one' );
+
+	const handleChange = useCallback( value => {
+		setSelected( value );
+	}, [] );
+
+	return (
+		<RadioControl { ...args } selected={ selected } options={ options } onChange={ handleChange } />
+	);
+};

--- a/projects/js-packages/components/components/radio-control/styles.module.scss
+++ b/projects/js-packages/components/components/radio-control/styles.module.scss
@@ -1,0 +1,22 @@
+/// Radio Control
+///
+/// Overrides the @wordpress/components RadioControl component.
+/// @link https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/radio-control
+
+.radio {
+	:global {
+		.components-radio-control {
+			&__input[type="radio"] {
+				&:checked {
+					background: var( --jp-green-40 );
+					border-color: var( --jp-green-40 );
+				}
+
+				&:focus {
+					border-color: var( --jp-green-50 );
+					box-shadow: 0 0 0 2px var( --jp-white ), 0 0 0 4px var( --jp-green-50 );
+				}
+			}
+		}
+	}
+}

--- a/projects/js-packages/components/index.ts
+++ b/projects/js-packages/components/index.ts
@@ -72,3 +72,4 @@ export { default as ZendeskChat } from './components/zendesk-chat';
 export { default as ProgressBar } from './components/progress-bar';
 export { default as UpsellBanner } from './components/upsell-banner';
 export { getUserLocale, cleanLocale } from './lib/locale';
+export { default as RadioControl } from './components/radio-control';

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -1,4 +1,4 @@
-import { ToggleControl } from '@automattic/jetpack-components';
+import { RadioControl, ToggleControl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import { FormLegend } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
@@ -34,16 +34,12 @@ const EmailSettings = props => {
 		);
 	}, [ isFeaturedImageInEmailEnabled, updateFormStateAndSaveOptionValue ] );
 
-	const handleSubscriptionEmailsUseFullTextChange = useCallback(
-		value => {
-			updateFormStateAndSaveOptionValue( SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION, ! value );
-		},
-		[ updateFormStateAndSaveOptionValue ]
-	);
-
 	const handleSubscriptionEmailsUseExcerptChange = useCallback(
 		value => {
-			updateFormStateAndSaveOptionValue( SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION, value );
+			updateFormStateAndSaveOptionValue(
+				SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION,
+				value === 'excerpt'
+			);
 		},
 		[ updateFormStateAndSaveOptionValue ]
 	);
@@ -101,19 +97,13 @@ const EmailSettings = props => {
 					{ __( 'For each new post email, include', 'jetpack' ) }
 				</FormLegend>
 
-				<ToggleControl
+				<RadioControl
+					selected={ subscriptionEmailsUseExcerpt ? 'excerpt' : 'full' }
 					disabled={ excerptInputDisabled }
-					checked={ ! subscriptionEmailsUseExcerpt }
-					toogling={ isSavingAnyOption( [ SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION ] ) }
-					label={ __( 'Full text', 'jetpack' ) }
-					onChange={ handleSubscriptionEmailsUseFullTextChange }
-				/>
-
-				<ToggleControl
-					disabled={ excerptInputDisabled }
-					checked={ subscriptionEmailsUseExcerpt }
-					toogling={ isSavingAnyOption( [ SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION ] ) }
-					label={ __( 'Excerpt', 'jetpack' ) }
+					options={ [
+						{ label: __( 'Full text', 'jetpack' ), value: 'full' },
+						{ label: __( 'Excerpt', 'jetpack' ), value: 'excerpt' },
+					] }
 					onChange={ handleSubscriptionEmailsUseExcerptChange }
 				/>
 			</SettingsGroup>

--- a/projects/plugins/jetpack/changelog/add-radio-control
+++ b/projects/plugins/jetpack/changelog/add-radio-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Use radio controls instead of toggles on Email Settings


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack/issues/36352

## Proposed changes:

* Create a wrapper component for RadioControl, applying Jetpack styles
* Apply RadioControl to Email Settings

<img width="1056" alt="Screenshot 2024-03-22 at 11 46 11" src="https://github.com/Automattic/jetpack/assets/3113712/bd3f435f-4fa6-40d5-a596-4c57d53d8b53">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Apply this PR to your local
* Open your JT testing site
* Go to `wp-admin/admin.php?page=jetpack#/newsletter`
* The Email configurations card should have radio controls displayed as the input for "For each new post email, include" field
* Make changes on the field and verify if the changes are applied and synced as expected

**Storybook**
* Go to `projects/js-packages/storybook/`
* Run `yarn storybook:dev`
* When the storybook opens, search for the RadioControl (the jetpack version)
* Check if the RadioControl storybook works as expected

