### PR TITLE
Fix/boost pricing shows twice

### DIFF
--- a/projects/js-packages/connection/changelog/fix-boost-pricing-shows-twice
+++ b/projects/js-packages/connection/changelog/fix-boost-pricing-shows-twice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes some pricing showing twice by connecting sites that select a free option

--- a/projects/js-packages/connection/components/use-connection/index.jsx
+++ b/projects/js-packages/connection/components/use-connection/index.jsx
@@ -77,6 +77,16 @@ export default ( {
 		} );
 	};
 
+	const handleRegisterSiteOnly = e => {
+		e && e.preventDefault();
+
+		if ( isRegistered ) {
+			return new Promise( resolve => resolve() );
+		}
+
+		return registerSite( { registrationNonce, redirectUri } );
+	};
+
 	/**
 	 * Initialize/Setup the REST API.
 	 */
@@ -96,6 +106,7 @@ export default ( {
 
 	return {
 		handleRegisterSite,
+		handleRegisterSiteOnly,
 		handleConnectUser,
 		refreshConnectedPlugins,
 		isRegistered,

--- a/projects/js-packages/connection/components/use-connection/index.jsx
+++ b/projects/js-packages/connection/components/use-connection/index.jsx
@@ -77,16 +77,6 @@ export default ( {
 		} );
 	};
 
-	const handleRegisterSiteOnly = e => {
-		e && e.preventDefault();
-
-		if ( isRegistered ) {
-			return new Promise( resolve => resolve() );
-		}
-
-		return registerSite( { registrationNonce, redirectUri } );
-	};
-
 	/**
 	 * Initialize/Setup the REST API.
 	 */
@@ -106,7 +96,6 @@ export default ( {
 
 	return {
 		handleRegisterSite,
-		handleRegisterSiteOnly,
 		handleConnectUser,
 		refreshConnectedPlugins,
 		isRegistered,

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -72,7 +72,7 @@ export default function ProductInterstitial( {
 	const { recordEvent } = useAnalytics();
 	const { onClickGoBack } = useGoBack( { slug } );
 	const { myJetpackCheckoutUri = '' } = getMyJetpackWindowInitialState();
-	const { siteIsRegistering, handleRegisterSiteOnly } = useConnection();
+	const { siteIsRegistering, handleRegisterSite } = useConnection( { skipUserConnection: true } );
 
 	useEffect( () => {
 		recordEvent( 'jetpack_myjetpack_product_interstitial_view', { product: slug } );
@@ -157,7 +157,7 @@ export default function ProductInterstitial( {
 						// If no purchase is needed, redirect the user to the product screen.
 						if ( ! needsPurchase ) {
 							// for free products, we still initiate the site connection
-							handleRegisterSiteOnly().then( () => {
+							handleRegisterSite().then( () => {
 								if ( postActivationUrl ) {
 									window.location.href = postActivationUrl;
 									return;
@@ -183,7 +183,7 @@ export default function ProductInterstitial( {
 			slug,
 			myJetpackCheckoutUri,
 			ctaCallback,
-			handleRegisterSiteOnly,
+			handleRegisterSite,
 		]
 	);
 

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -159,9 +159,11 @@ export default function ProductInterstitial( {
 						// If no purchase is needed, redirect the user to the product screen.
 						if ( ! needsPurchase ) {
 							// for free products, we still initiate the site connection
-							handleRegisterSite().catch( () => {
-								// Fall back to the My Jetpack overview page.
-								return navigateToMyJetpackOverviewPage();
+							handleRegisterSite().then( redirectUri => {
+								if ( ! redirectUri ) {
+									// Fall back to the My Jetpack overview page.
+									return navigateToMyJetpackOverviewPage();
+								}
 							} );
 
 							return;

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -72,7 +72,10 @@ export default function ProductInterstitial( {
 	const { recordEvent } = useAnalytics();
 	const { onClickGoBack } = useGoBack( { slug } );
 	const { myJetpackCheckoutUri = '' } = getMyJetpackWindowInitialState();
-	const { siteIsRegistering, handleRegisterSite } = useConnection( { skipUserConnection: true } );
+	const { siteIsRegistering, handleRegisterSite } = useConnection( {
+		skipUserConnection: true,
+		redirectUri: detail.postActivationUrl ? detail.postActivationUrl : null,
+	} );
 
 	useEffect( () => {
 		recordEvent( 'jetpack_myjetpack_product_interstitial_view', { product: slug } );
@@ -137,7 +140,6 @@ export default function ProductInterstitial( {
 						postCheckoutUrl = activatedProduct?.post_checkout_url
 							? activatedProduct.post_checkout_url
 							: myJetpackCheckoutUri;
-						const postActivationUrl = product?.postActivationUrl;
 						const hasRequiredPlan = tier
 							? product?.hasRequiredTier?.[ tier ]
 							: product?.hasRequiredPlan;
@@ -157,12 +159,7 @@ export default function ProductInterstitial( {
 						// If no purchase is needed, redirect the user to the product screen.
 						if ( ! needsPurchase ) {
 							// for free products, we still initiate the site connection
-							handleRegisterSite().then( () => {
-								if ( postActivationUrl ) {
-									window.location.href = postActivationUrl;
-									return;
-								}
-
+							handleRegisterSite().catch( () => {
 								// Fall back to the My Jetpack overview page.
 								return navigateToMyJetpackOverviewPage();
 							} );

--- a/projects/packages/my-jetpack/changelog/fix-boost-pricing-shows-twice
+++ b/projects/packages/my-jetpack/changelog/fix-boost-pricing-shows-twice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes some pricing showing twice by connecting sites that select a free option


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR connects sites that choose to start for free with a product from My Jetpack. This helps resolve some practical issues like showing two pricing screens for some products

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-rBs-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to a test site
* Do not connect Jetpack to start with
* Navigate to My Jetpack and select "Boost your site" on the boost product card
![Screenshot 2024-03-22 at 12 24 37 PM](https://github.com/Automattic/jetpack/assets/18016357/1c431890-54d6-4d21-9883-fd8fbdea17f3)

* Click on "start for free" on the Boost product interstitial page. 
![Screenshot 2024-03-22 at 12 24 43 PM](https://github.com/Automattic/jetpack/assets/18016357/4495c89f-f961-401f-adad-cb21c052e606)

* After some time, you should be redirected to the boost plugin page - confirm that you do NOT see another pricing grid here, but the main Boost plugin interface.
![Screenshot 2024-03-22 at 12 25 40 PM](https://github.com/Automattic/jetpack/assets/18016357/164c80cf-5396-496c-978c-09c9a6b904ca)

* Confirm that your site is now also connected to Jetpack