### PR TITLE
Update/my jetpack notices visually link red bubble

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -77,7 +77,9 @@ const GlobalNotice = ( { message, options } ) => {
 			isDismissible={ false }
 			{ ...options }
 			className={
-				styles.notice + ( isBiggerThanMedium ? ' ' + styles[ 'bigger-than-medium' ] : '' )
+				styles.notice +
+				( isBiggerThanMedium && ' ' + styles[ 'bigger-than-medium' ] ) +
+				( options.isRedBubble && ' ' + styles[ 'is-red-bubble' ] )
 			}
 		>
 			<div className={ styles.message }>
@@ -161,9 +163,7 @@ export default function MyJetpackScreen() {
 							<ConnectionError />
 						</Col>
 					) }
-					{ message && ( hasBeenDismissed || ! isNewUser ) && (
-						<Col>{ <GlobalNotice message={ message } options={ options } /> }</Col>
-					) }
+					{ message && <Col>{ <GlobalNotice message={ message } options={ options } /> }</Col> }
 					{ showFullJetpackStatsCard && (
 						<Col
 							className={ classnames( {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -30,6 +30,7 @@ import {
 import useProduct from '../../data/products/use-product';
 import useSimpleQuery from '../../data/use-simple-query';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
+import useWelcomeBanner from '../../data/welcome-banner/use-welcome-banner';
 import useAnalytics from '../../hooks/use-analytics';
 import useNotificationWatcher from '../../hooks/use-notification-watcher';
 import ConnectionsSection from '../connections-section';
@@ -77,10 +78,9 @@ const GlobalNotice = ( { message, options } ) => {
 			isDismissible={ false }
 			{ ...options }
 			className={
-				styles.notice +
-				( isBiggerThanMedium && ' ' + styles[ 'bigger-than-medium' ] ) +
-				( options.isRedBubble && ' ' + styles[ 'is-red-bubble' ] )
+				styles.notice + ( isBiggerThanMedium ? ' ' + styles[ 'bigger-than-medium' ] : '' )
 			}
+			isRedBubble={ options.isRedBubble }
 		>
 			<div className={ styles.message }>
 				{ iconMap?.[ options.status ] && <Icon icon={ iconMap[ options.status ] } /> }
@@ -97,10 +97,10 @@ const GlobalNotice = ( { message, options } ) => {
  */
 export default function MyJetpackScreen() {
 	useNotificationWatcher();
-	const { hasBeenDismissed = false } = getMyJetpackWindowInitialState( 'welcomeBanner' );
 	const { showFullJetpackStatsCard = false } = getMyJetpackWindowInitialState( 'myJetpackFlags' );
 	const { jetpackManage = {}, adminUrl } = getMyJetpackWindowInitialState();
 
+	const { isWelcomeBannerVisible } = useWelcomeBanner();
 	const { currentNotice } = useContext( NoticeContext );
 	const { message, options } = currentNotice || {};
 	const { hasConnectionError } = useConnectionErrorNotice();
@@ -158,12 +158,14 @@ export default function MyJetpackScreen() {
 							{ __( 'Discover all Jetpack Products', 'jetpack-my-jetpack' ) }
 						</Text>
 					</Col>
-					{ hasConnectionError && ( hasBeenDismissed || ! isNewUser ) && (
+					{ hasConnectionError && ! isWelcomeBannerVisible && (
 						<Col>
 							<ConnectionError />
 						</Col>
 					) }
-					{ message && <Col>{ <GlobalNotice message={ message } options={ options } /> }</Col> }
+					{ message && ! isWelcomeBannerVisible && (
+						<Col>{ <GlobalNotice message={ message } options={ options } /> }</Col>
+					) }
 					{ showFullJetpackStatsCard && (
 						<Col
 							className={ classnames( {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -26,6 +26,10 @@
 		padding: 12px 4px;
 		flex-direction: column;
 		align-items: flex-start;
+
+		@media screen and ( min-width: 960px ) {
+			gap: 6rem;
+		}
 	}
 
 	// action button
@@ -51,11 +55,15 @@
 		justify-content: center;
 		align-items: center;
 		padding: 8px 24px;
-		margin-left: calc( var( --spacing-base ) * 2 + 24px ); // 40px
+		margin-left: 0;
 		margin-top: 24px;
 		background: #000000;
 		border-radius: var( --jp-border-radius );
 		height: auto;
+
+		@media screen and ( min-width: 960px ) {
+			margin-left: calc( var( --spacing-base ) * 2 + 24px ); // 40px
+		}
 	}
 
 	&.bigger-than-medium {
@@ -70,28 +78,13 @@
 			align-items: center;
 		}
 	}
-
-	&.is-red-bubble {
-		border-left: 1px solid var(--jp-gray);
-
-		::before {
-			content: '';
-			position: absolute;
-			top: -11px;
-			left: -11px;
-			width: 18px;
-			height: 18px;
-			border-radius: 50%;
-			background-color: var( --jp-red-50 );
-			border: 2px solid var(--jp-white-off);
-		}
-	}
 }
 
 .message {
     margin-right: var( --spacing-base ); // 8px
 	flex-grow: 1;
 	display: flex;
+	text-wrap: balance;
 
 	// left icon
 	& > svg {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -3,6 +3,7 @@
 }
 
 .notice {
+	position: relative;
 	margin: 0;
     padding: calc( var( --spacing-base ) * 2 ) calc( var( --spacing-base ) * 3 ) calc( var( --spacing-base ) * 2 ) calc( var( --spacing-base ) * 3 ); // 16px | 24px | 16px | 24px
 	font-size: 16px;
@@ -67,6 +68,22 @@
 		& :global(.components-notice__content) {
 			flex-direction: row;
 			align-items: center;
+		}
+	}
+
+	&.is-red-bubble {
+		border-left: 1px solid var(--jp-gray);
+
+		::before {
+			content: '';
+			position: absolute;
+			top: -11px;
+			left: -11px;
+			width: 18px;
+			height: 18px;
+			border-radius: 50%;
+			background-color: var( --jp-red-50 );
+			border: 2px solid var(--jp-white-off);
 		}
 	}
 }

--- a/projects/packages/my-jetpack/_inc/components/notice/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/notice/index.tsx
@@ -6,13 +6,17 @@ import { Button, VisuallyHidden, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import classnames from 'classnames';
-import React, { useCallback } from 'react';
-/**
- * Internal dependencies
- */
+import { useCallback } from 'react';
 import type { NoticeAction, NoticeProps } from '@wordpress/components/src/notice/types';
+import type { ReactNode, Component } from 'react';
+
+import './styles.scss';
 
 type NoticeButtonAction = NoticeAction & { isLoading?: boolean; isDisabled?: boolean };
+
+type MyJetpackNoticeProps = NoticeProps & {
+	isRedBubble: boolean;
+};
 
 const noop = () => {};
 
@@ -43,13 +47,14 @@ function getStatusLabel( status: NoticeProps[ 'status' ] ): string {
  * @param {object} props                   - The properties.
  * @param {string} props.className         - The class name.
  * @param {string} props.status            - The message status: 'warning' | 'success' | 'error' | 'info'.
- * @param {React.ReactNode} props.children - Children element
+ * @param {ReactNode} props.children - Children element
  * @param {Function} props.onRemove        - The function to call when the notice is removed.
  * @param {boolean} props.isDismissible    - Whether the notice can be dismissed.
+ * @param {boolean} props.isRedBubble      - Whether the notice is tied to the red bubble notification.
  * @param {Array} props.actions            - An array of actions (buttons) to display in the notice.
  * @param {Function} props.onDismiss       - The function to call when the notice is dismissed.
  *
- * @returns {React.Component} The `Notice` component.
+ * @returns {Component} The `Notice` component.
  */
 function Notice( {
 	className,
@@ -57,14 +62,16 @@ function Notice( {
 	children,
 	onRemove = noop,
 	isDismissible = true,
+	isRedBubble = false,
 	actions = [],
 	// onDismiss is a callback executed when the notice is dismissed.
 	// It is distinct from onRemove, which _looks_ like a callback but is
 	// actually the function to call to remove the notice from the UI.
 	onDismiss = noop,
-}: NoticeProps ): JSX.Element {
+}: MyJetpackNoticeProps ) {
 	const classes = classnames( className, 'components-notice', 'is-' + status, {
 		'is-dismissible': isDismissible,
+		'is-red-bubble': isRedBubble,
 	} );
 
 	const onDismissNotice = useCallback( () => {

--- a/projects/packages/my-jetpack/_inc/components/notice/styles.scss
+++ b/projects/packages/my-jetpack/_inc/components/notice/styles.scss
@@ -1,0 +1,15 @@
+.components-notice.is-red-bubble {
+    border-left: 1px solid var(--jp-gray);
+
+    ::before {
+        content: '';
+        position: absolute;
+        top: -11px;
+        left: -11px;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background-color: var( --jp-red-50 );
+        border: 2px solid var(--jp-white-off);
+    }
+}

--- a/projects/packages/my-jetpack/_inc/components/welcome-banner/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-banner/index.jsx
@@ -4,7 +4,6 @@ import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { useEffect, useCallback, useState } from 'react';
 import { MyJetpackRoutes } from '../../constants';
-import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useWelcomeBanner from '../../data/welcome-banner/use-welcome-banner';
 import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
@@ -17,12 +16,11 @@ import styles from './style.module.scss';
  * @returns {object} The WelcomeBanner component.
  */
 const WelcomeBanner = () => {
-	const isNewUser = getMyJetpackWindowInitialState( 'userIsNewToJetpack' ) === '1';
 	const { recordEvent } = useAnalytics();
-	const { isDismissed, dismissWelcomeBanner } = useWelcomeBanner();
+	const { isWelcomeBannerVisible, dismissWelcomeBanner } = useWelcomeBanner();
 	const { isRegistered, isUserConnected } = useConnection();
 	const navigateToConnectionPage = useMyJetpackNavigate( MyJetpackRoutes.Connection );
-	const [ bannerVisible, setBannerVisible ] = useState( ! isDismissed && isNewUser );
+	const [ bannerVisible, setBannerVisible ] = useState( isWelcomeBannerVisible );
 	const shouldDisplayConnectionButton = ! isRegistered || ! isUserConnected;
 
 	useEffect( () => {

--- a/projects/packages/my-jetpack/_inc/components/welcome-banner/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/welcome-banner/style.module.scss
@@ -6,6 +6,18 @@ $sans-font: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-San
 	& > .banner-card {
 		padding: 0;
 		overflow: hidden;
+
+		&::before {
+			content: '';
+			position: absolute;
+			top: -11px;
+			left: -11px;
+			width: 18px;
+			height: 18px;
+			border-radius: 50%;
+			background-color: var( --jp-red-50 );
+			border: 2px solid var(--jp-white-off);
+		}
 	}
 
 	& > .dismiss {

--- a/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
+++ b/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
@@ -5,8 +5,9 @@ const defaultNotice: Notice = {
 	message: '',
 	options: {
 		status: '',
+		priority: 0,
+		isRedBubble: false,
 	},
-	priority: 0,
 };
 
 export const NoticeContext = createContext< NoticeContextType >( {
@@ -21,7 +22,7 @@ const NoticeContextProvider = ( { children } ) => {
 
 	const setNotice = ( notice: Notice ) => {
 		// Only update notice if there is not already a notice or the new notice has a higher priority
-		if ( ! currentNotice.message || notice.priority > currentNotice.priority ) {
+		if ( ! currentNotice.message || notice.options.priority > currentNotice.options.priority ) {
 			setCurrentNotice( notice );
 		}
 	};

--- a/projects/packages/my-jetpack/_inc/context/notices/types.ts
+++ b/projects/packages/my-jetpack/_inc/context/notices/types.ts
@@ -9,8 +9,9 @@ export type Notice = {
 			onClick: () => void;
 			noDefaultClasses?: boolean;
 		}[];
+		priority: number;
+		isRedBubble?: boolean;
 	};
-	priority: number;
 };
 
 export type NoticeContextType< T = Notice > = {

--- a/projects/packages/my-jetpack/_inc/data/notices/use-fetching-error-notice.ts
+++ b/projects/packages/my-jetpack/_inc/data/notices/use-fetching-error-notice.ts
@@ -38,8 +38,10 @@ export const useFetchingErrorNotice = ( { infoName, isError, overrideMessage }: 
 		if ( isError && errorNoticeWhitelist.includes( infoName ) ) {
 			setNotice( {
 				message,
-				options: { status: 'error' },
-				priority: NOTICE_PRIORITY_LOW,
+				options: {
+					status: 'error',
+					priority: NOTICE_PRIORITY_LOW,
+				},
 			} );
 		}
 	}, [ message, setNotice, isError, infoName ] );

--- a/projects/packages/my-jetpack/_inc/data/welcome-banner/use-welcome-banner.ts
+++ b/projects/packages/my-jetpack/_inc/data/welcome-banner/use-welcome-banner.ts
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
 import {
 	QUERY_DISMISS_WELCOME_BANNER_KEY,
 	REST_API_SITE_DISMISS_BANNER,
@@ -8,19 +7,14 @@ import useSimpleMutation from '../use-simple-mutation';
 import { getMyJetpackWindowInitialState } from '../utils/get-my-jetpack-window-state';
 
 const useWelcomeBanner = () => {
-	const { hasBeenDismissed: welcomeBannerHasBeenDismissed } =
-		getMyJetpackWindowInitialState( 'welcomeBanner' );
-
-	const [ isDismissed, setIsDismissed ] = useState( welcomeBannerHasBeenDismissed );
+	const { redBubbleAlerts } = getMyJetpackWindowInitialState();
+	const isWelcomeBannerVisible = Object.keys( redBubbleAlerts ).includes( 'welcome-banner-active' );
 
 	const { mutate: dismissWelcomeBanner } = useSimpleMutation( {
 		name: QUERY_DISMISS_WELCOME_BANNER_KEY,
 		query: {
 			path: REST_API_SITE_DISMISS_BANNER,
 			method: 'POST',
-		},
-		options: {
-			onSuccess: () => setIsDismissed( true ),
 		},
 		errorMessage: __(
 			'Failed to dismiss the welcome banner. Please try again',
@@ -30,7 +24,7 @@ const useWelcomeBanner = () => {
 
 	return {
 		dismissWelcomeBanner,
-		isDismissed,
+		isWelcomeBannerVisible,
 	};
 };
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-bad-install-notice.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-bad-install-notice.ts
@@ -49,12 +49,13 @@ const useBadInstallNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 					noDefaultClasses: true,
 				},
 			],
+			priority: NOTICE_PRIORITY_MEDIUM,
+			isRedBubble: true,
 		};
 
 		setNotice( {
 			message: errorMessage,
 			options: noticeOptions,
-			priority: NOTICE_PRIORITY_MEDIUM,
 		} );
 	}, [ redBubbleAlerts, setNotice, recordEvent ] );
 };

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.ts
@@ -48,12 +48,13 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 					noDefaultClasses: true,
 				},
 			],
+			priority: NOTICE_PRIORITY_HIGH,
+			isRedBubble: true,
 		};
 
 		setNotice( {
 			message: needsUserConnectionMessage,
 			options: noticeOptions,
-			priority: NOTICE_PRIORITY_HIGH,
 		} );
 	}, [ navToConnection, products, redBubbleAlerts, setNotice ] );
 };

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-notices-visually-link-red-bubble
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-notices-visually-link-red-bubble
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add red bubble to notices tied to red bubble notifications

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -196,9 +196,6 @@ interface Window {
 		topJetpackMenuItemUrl: string;
 		userIsAdmin: string;
 		userIsNewToJetpack: string;
-		welcomeBanner: {
-			hasBeenDismissed: boolean;
-		};
 	};
 	JP_CONNECTION_INITIAL_STATE: {
 		apiRoot: string;

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -186,6 +186,7 @@ interface Window {
 		};
 		redBubbleAlerts: {
 			'missing-site-connection'?: null;
+			'welcome-banner-active'?: null;
 			[ key: `${ string }-bad-installation` ]: {
 				data: {
 					plugin: string;

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -620,7 +620,7 @@ class Initializer {
 	public static function maybe_show_red_bubble() {
 		global $menu;
 		// filters for the items in this file
-		add_filter( 'my_jetpack_red_bubble_notification_slugs', array( __CLASS__, 'alert_if_missing_site_connection' ) );
+		add_filter( 'my_jetpack_red_bubble_notification_slugs', array( __CLASS__, 'add_red_bubble_alerts' ) );
 		$red_bubble_alerts = self::get_red_bubble_alerts();
 
 		// The Jetpack menu item should be on index 3
@@ -651,6 +651,22 @@ class Initializer {
 		$red_bubble_alerts = apply_filters( 'my_jetpack_red_bubble_notification_slugs', $red_bubble_alerts );
 
 		return $red_bubble_alerts;
+	}
+
+	/**
+	 *  Add relevant red bubble notifications
+	 *
+	 * @param array $red_bubble_slugs - slugs that describe the reasons the red bubble is showing.
+	 * @return array
+	 */
+	public static function add_red_bubble_alerts( array $red_bubble_slugs ) {
+		$welcome_banner_dismissed = \Jetpack_Options::get_option( 'dismissed_welcome_banner', false );
+		if ( self::is_jetpack_user_new() && ! $welcome_banner_dismissed ) {
+			$red_bubble_slugs['welcome-banner-active'] = null;
+			return $red_bubble_slugs;
+		} else {
+			return self::alert_if_missing_site_connection( $red_bubble_slugs );
+		}
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -237,9 +237,6 @@ class Initializer {
 				'isUserFromKnownHost'    => self::is_user_from_known_host(),
 				'isCommercial'           => self::is_commercial_site(),
 				'isAtomic'               => ( new Status_Host() )->is_woa_site(),
-				'welcomeBanner'          => array(
-					'hasBeenDismissed' => \Jetpack_Options::get_option( 'dismissed_welcome_banner', false ),
-				),
 				'jetpackManage'          => array(
 					'isEnabled'       => Jetpack_Manage::could_use_jp_manage(),
 					'isAgencyAccount' => Jetpack_Manage::is_agency_account(),


### PR DESCRIPTION
## Proposed changes:

* Add red bubble to top right of notice when tied to a red bubble notification
* Update styling on Notice message so it's not so close to the CTA
* Move priority to the options properity in the notice object
* Conditionally add a "welcome-banner-active" red bubble slug to the red bubble slugs array if the welcome banner is active. In this condition, the site connection notice slug is not added
* Refactor welcome banner hook to rely on red bubble notification to show or hide the welcome banner

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pbNhbs-aby-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Create a new jurassic.ninja site with the jetpack beta plugin and checkout this branch. Do not connect the site yet
2. Go to `/wp-admin/admin.php?page=my-jetpack` and make sure there is a `1` in the red bubble notification, and that the welcome banner has a red bubble in the upper-left-hand corner
![image](https://github.com/Automattic/jetpack/assets/65001528/ad3fe45d-0c42-49e5-a4b4-b6165baf5f8f)
3. Dismiss the banner and reload the page. Make sure you see the site connection notice and that the red bubble notification still shows `1`. Additionally the site connection notice should have a red bubble in the top left
![image](https://github.com/Automattic/jetpack/assets/65001528/866ea81b-b2fd-4071-8db9-3ba0dc2f5126)
4. If you'd like to do some further testing, you can connect the site and, with this branch checked out on your local environment, add the following line of code to `projects/packages/my-jetpack/src/class-rest-purchases.php` line 63
```php
return new \WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
```
5. Go back to My Jetpack and make sure there is no red bubble notification and no red bubble on the notice. The colored line on the left-hand side should also show in this case
![image](https://github.com/Automattic/jetpack/assets/65001528/3911df7d-d2c3-46c6-b088-bcad120f877b)

