### PR TITLE
Add async site connection to missing connection Notice

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3282,7 +3282,7 @@ importers:
         specifier: workspace:*
         version: link:../../js-packages/licensing
       '@automattic/jetpack-my-jetpack':
-        specifier: workspace:4.19.1-alpha
+        specifier: workspace:4.20.0-alpha
         version: link:../../packages/my-jetpack
       '@automattic/jetpack-partner-coupon':
         specifier: workspace:*

--- a/projects/packages/my-jetpack/_inc/components/notice/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/notice/index.tsx
@@ -7,12 +7,11 @@ import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useCallback } from 'react';
-import type { NoticeAction, NoticeProps } from '@wordpress/components/src/notice/types';
+import type { NoticeButtonAction } from '../../context/notices/types';
+import type { NoticeProps } from '@wordpress/components/src/notice/types';
 import type { ReactNode, Component } from 'react';
 
 import './styles.scss';
-
-type NoticeButtonAction = NoticeAction & { isLoading?: boolean; isDisabled?: boolean };
 
 type MyJetpackNoticeProps = NoticeProps & {
 	isRedBubble: boolean;
@@ -44,15 +43,15 @@ function getStatusLabel( status: NoticeProps[ 'status' ] ): string {
 /**
  * Notice component based on the one from @wordpress/components.
  *
- * @param {object} props                   - The properties.
- * @param {string} props.className         - The class name.
- * @param {string} props.status            - The message status: 'warning' | 'success' | 'error' | 'info'.
- * @param {ReactNode} props.children - Children element
- * @param {Function} props.onRemove        - The function to call when the notice is removed.
- * @param {boolean} props.isDismissible    - Whether the notice can be dismissed.
- * @param {boolean} props.isRedBubble      - Whether the notice is tied to the red bubble notification.
- * @param {Array} props.actions            - An array of actions (buttons) to display in the notice.
- * @param {Function} props.onDismiss       - The function to call when the notice is dismissed.
+ * @param {object} props                - The properties.
+ * @param {string} props.className      - The class name.
+ * @param {string} props.status         - The message status: 'warning' | 'success' | 'error' | 'info'.
+ * @param {ReactNode} props.children    - Children element
+ * @param {Function} props.onRemove     - The function to call when the notice is removed.
+ * @param {boolean} props.isDismissible - Whether the notice can be dismissed.
+ * @param {boolean} props.isRedBubble   - Whether the notice is tied to the red bubble notification.
+ * @param {Array} props.actions         - An array of actions (buttons) to display in the notice.
+ * @param {Function} props.onDismiss    - The function to call when the notice is dismissed.
  *
  * @returns {Component} The `Notice` component.
  */
@@ -96,9 +95,11 @@ function Notice( {
 								url,
 								isLoading = false,
 								isDisabled = false,
+								loadingText,
 							}: NoticeButtonAction,
 							index
 						) => {
+							const loadingContent = loadingText || <Spinner />;
 							let computedVariant = variant;
 							if ( variant !== 'primary' && ! noDefaultClasses ) {
 								computedVariant = ! url ? 'secondary' : 'link';
@@ -116,7 +117,7 @@ function Notice( {
 									className={ classnames( 'components-notice__action', buttonCustomClasses ) }
 									disabled={ isLoading || isDisabled }
 								>
-									{ isLoading ? <Spinner /> : label }
+									{ isLoading ? loadingContent : label }
 								</Button>
 							);
 						}

--- a/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
+++ b/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
@@ -13,6 +13,7 @@ const defaultNotice: Notice = {
 export const NoticeContext = createContext< NoticeContextType >( {
 	currentNotice: defaultNotice,
 	setNotice: null,
+	resetNotice: null,
 } );
 
 // Maybe todo: Add a clearNotice type function to remove any active notices
@@ -27,11 +28,16 @@ const NoticeContextProvider = ( { children } ) => {
 		}
 	};
 
+	const resetNotice = () => {
+		setCurrentNotice( defaultNotice );
+	};
+
 	return (
 		<NoticeContext.Provider
 			value={ {
 				currentNotice,
 				setNotice,
+				resetNotice,
 			} }
 		>
 			{ children }

--- a/projects/packages/my-jetpack/_inc/context/notices/types.ts
+++ b/projects/packages/my-jetpack/_inc/context/notices/types.ts
@@ -1,5 +1,5 @@
 import type { NoticeAction } from '@wordpress/components/src/notice/types';
-import type { Dispatch, SetStateAction } from 'react';
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
 
 export type NoticeButtonAction = NoticeAction & {
 	isLoading?: boolean;
@@ -8,7 +8,7 @@ export type NoticeButtonAction = NoticeAction & {
 };
 
 export type Notice = {
-	message: string;
+	message: string | ReactNode;
 	options: {
 		status: string;
 		actions?: NoticeButtonAction[];

--- a/projects/packages/my-jetpack/_inc/context/notices/types.ts
+++ b/projects/packages/my-jetpack/_inc/context/notices/types.ts
@@ -1,14 +1,17 @@
+import type { NoticeAction } from '@wordpress/components/src/notice/types';
 import type { Dispatch, SetStateAction } from 'react';
+
+export type NoticeButtonAction = NoticeAction & {
+	isLoading?: boolean;
+	loadingText?: string;
+	isDisabled?: boolean;
+};
 
 export type Notice = {
 	message: string;
 	options: {
 		status: string;
-		actions?: {
-			label: string;
-			onClick: () => void;
-			noDefaultClasses?: boolean;
-		}[];
+		actions?: NoticeButtonAction[];
 		priority: number;
 		isRedBubble?: boolean;
 	};
@@ -17,4 +20,5 @@ export type Notice = {
 export type NoticeContextType< T = Notice > = {
 	currentNotice: T;
 	setNotice: Dispatch< SetStateAction< T > > | null;
+	resetNotice: () => void;
 };

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.ts
@@ -96,6 +96,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 				{
 					label: requiresUserConnection ? userConnectionButtonLabel : siteConnectionButtonLabel,
 					isLoading: siteIsRegistering,
+					loadingText: __( 'Conecting…', 'jetpack-my-jetpack' ),
 					onClick: onActionButtonClick,
 					noDefaultClasses: true,
 				},

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.ts
@@ -45,6 +45,20 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 
 			handleRegisterSite().then( () => {
 				resetNotice();
+				setNotice( {
+					message: __( 'Your site has been successfully connected.', 'jetpack-my-jetpack' ),
+					options: {
+						status: 'success',
+						actions: [
+							{
+								label: __( 'Close', 'jetpack-my-jetpack' ),
+								onClick: resetNotice,
+								noDefaultClasses: true,
+							},
+						],
+					},
+					priority: NOTICE_PRIORITY_HIGH,
+				} );
 			} );
 		};
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.ts
@@ -84,15 +84,17 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			'jetpack-my-jetpack'
 		);
 
-		const buttonLabel = requiresUserConnection
-			? __( 'Connect your user account to fix this', 'jetpack-my-jetpack' )
-			: __( 'Connect your site to fix this', 'jetpack-my-jetpack' );
+		const userConnectionButtonLabel = __(
+			'Connect your user account to fix this',
+			'jetpack-my-jetpack'
+		);
+		const siteConnectionButtonLabel = __( 'Connect your site to fix this', 'jetpack-my-jetpack' );
 
 		const noticeOptions = {
 			status: 'warning',
 			actions: [
 				{
-					label: buttonLabel,
+					label: requiresUserConnection ? userConnectionButtonLabel : siteConnectionButtonLabel,
 					isLoading: siteIsRegistering,
 					onClick: onActionButtonClick,
 					noDefaultClasses: true,

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -1,3 +1,4 @@
+import { Col, TermsOfService, Text } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import { __, sprintf } from '@wordpress/i18n';
 import { useContext, useEffect } from 'react';
@@ -5,10 +6,10 @@ import { MyJetpackRoutes } from '../../constants';
 import { NOTICE_PRIORITY_HIGH } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
 import { useAllProducts } from '../../data/products/use-product';
+import { getMyJetpackWindowRestState } from '../../data/utils/get-my-jetpack-window-state';
 import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
 import useMyJetpackConnection from '../use-my-jetpack-connection';
 import useMyJetpackNavigate from '../use-my-jetpack-navigate';
-import { getMyJetpackWindowRestState } from './../../data/utils/get-my-jetpack-window-state';
 
 type RedBubbleAlerts = Window[ 'myJetpackInitialState' ][ 'redBubbleAlerts' ];
 
@@ -56,8 +57,8 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 								noDefaultClasses: true,
 							},
 						],
+						priority: NOTICE_PRIORITY_HIGH,
 					},
-					priority: NOTICE_PRIORITY_HIGH,
 				} );
 			} );
 		};
@@ -88,7 +89,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			'Connect your user account to fix this',
 			'jetpack-my-jetpack'
 		);
-		const siteConnectionButtonLabel = __( 'Connect your site to fix this', 'jetpack-my-jetpack' );
+		const siteConnectionButtonLabel = __( 'Connect your site', 'jetpack-my-jetpack' );
 
 		const noticeOptions = {
 			status: 'warning',
@@ -106,8 +107,22 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			isRedBubble: true,
 		};
 
+		const messageContent = requiresUserConnection ? (
+			<Col>{ needsUserConnectionMessage }</Col>
+		) : (
+			<Col>
+				<Text variant="title-medium" mb={ 3 }>
+					{ __( 'Missing site connection', 'jetpack-my-jetpack' ) }
+				</Text>
+				<Text mb={ 2 }>{ needsSiteConnectionMessage }</Text>
+				<Text variant="body-extra-small">
+					<TermsOfService agreeButtonLabel={ siteConnectionButtonLabel } />
+				</Text>
+			</Col>
+		);
+
 		setNotice( {
-			message: requiresUserConnection ? needsUserConnectionMessage : needsSiteConnectionMessage,
+			message: messageContent,
 			options: noticeOptions,
 		} );
 	}, [

--- a/projects/packages/my-jetpack/changelog/add-async-site-connection
+++ b/projects/packages/my-jetpack/changelog/add-async-site-connection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: add a way to connect the site asynchronously to WordPress.com through the connection banner.

--- a/projects/packages/my-jetpack/changelog/update-connection-and-notice-behavior
+++ b/projects/packages/my-jetpack/changelog/update-connection-and-notice-behavior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+My Jetpack: update Notice component to allow adding a loading text when an action is in a loading state. Add a new resetNotice action to NoticeContext

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -78,7 +78,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.19.x-dev"
+			"dev-trunk": "4.20.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.19.1-alpha",
+	"version": "4.20.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -36,7 +36,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.19.1-alpha';
+	const PACKAGE_VERSION = '4.20.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/backup/changelog/add-async-site-connection
+++ b/projects/plugins/backup/changelog/add-async-site-connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1122,7 +1122,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
+                "reference": "115d225dfbbf252b4ad13db5fc47902c6b3c89b4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1156,7 +1156,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.19.x-dev"
+                    "dev-trunk": "4.20.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/add-async-site-connection
+++ b/projects/plugins/boost/changelog/add-async-site-connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1047,7 +1047,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
+                "reference": "115d225dfbbf252b4ad13db5fc47902c6b3c89b4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1081,7 +1081,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.19.x-dev"
+                    "dev-trunk": "4.20.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/add-async-site-connection
+++ b/projects/plugins/jetpack/changelog/add-async-site-connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1673,7 +1673,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
+				"reference": "115d225dfbbf252b4ad13db5fc47902c6b3c89b4"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1707,7 +1707,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.19.x-dev"
+					"dev-trunk": "4.20.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -53,7 +53,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-licensing": "workspace:*",
-		"@automattic/jetpack-my-jetpack": "workspace:4.19.1-alpha",
+		"@automattic/jetpack-my-jetpack": "workspace:4.20.0-alpha",
 		"@automattic/jetpack-partner-coupon": "workspace:*",
 		"@automattic/jetpack-publicize-components": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",

--- a/projects/plugins/migration/changelog/add-async-site-connection
+++ b/projects/plugins/migration/changelog/add-async-site-connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1122,7 +1122,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
+                "reference": "115d225dfbbf252b4ad13db5fc47902c6b3c89b4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1156,7 +1156,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.19.x-dev"
+                    "dev-trunk": "4.20.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/add-async-site-connection
+++ b/projects/plugins/protect/changelog/add-async-site-connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1035,7 +1035,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
+                "reference": "115d225dfbbf252b4ad13db5fc47902c6b3c89b4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1069,7 +1069,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.19.x-dev"
+                    "dev-trunk": "4.20.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/add-async-site-connection
+++ b/projects/plugins/search/changelog/add-async-site-connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
+                "reference": "115d225dfbbf252b4ad13db5fc47902c6b3c89b4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1012,7 +1012,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.19.x-dev"
+                    "dev-trunk": "4.20.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/add-async-site-connection
+++ b/projects/plugins/social/changelog/add-async-site-connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -978,7 +978,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
+				"reference": "115d225dfbbf252b4ad13db5fc47902c6b3c89b4"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1012,7 +1012,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.19.x-dev"
+					"dev-trunk": "4.20.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/add-async-site-connection
+++ b/projects/plugins/starter-plugin/changelog/add-async-site-connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
+                "reference": "115d225dfbbf252b4ad13db5fc47902c6b3c89b4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1012,7 +1012,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.19.x-dev"
+                    "dev-trunk": "4.20.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/add-async-site-connection
+++ b/projects/plugins/videopress/changelog/add-async-site-connection
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
+                "reference": "115d225dfbbf252b4ad13db5fc47902c6b3c89b4"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1012,7 +1012,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.19.x-dev"
+                    "dev-trunk": "4.20.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See linked issue

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates the site connection button to perform an async site connection, instead of directing to the user connection screen. After a user clicks on the button, the button will get into a loading state and the site will try to connect to WordPress.com in the background. After the connection, it will add a confirmation notice, stating that the site has been successfully connected.

<img width="1698" alt="image" src="https://github.com/Automattic/jetpack/assets/5714212/05887382-60ba-40aa-9aa9-369b2f471315">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-qKY-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch
* Visit `/wp-admin/admin.php?page=my-jetpack`
* Dismiss the Welcome banner and refresh the page
* You'll now see a banner saying "Some products need a connection to WordPress.com to be able to work.". Click on "Connect your site to fix this"
* The label will change to the loading icon
* After that loading, you'll see a success notice with the following message: "Your site has been successfully connected."

NOTE: error handling and the state of the cards will be handled in a different PR