### PR TITLE
Add Notice component to My Jetpack

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -12,7 +12,7 @@ import {
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
 import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-connection';
-import { Icon, Notice, Path, SVG } from '@wordpress/components';
+import { Icon, Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -35,6 +35,7 @@ import useNotificationWatcher from '../../hooks/use-notification-watcher';
 import ConnectionsSection from '../connections-section';
 import IDCModal from '../idc-modal';
 import JetpackManageBanner from '../jetpack-manage-banner';
+import Notice from '../notice';
 import PlansSection from '../plans-section';
 import { PRODUCT_STATUSES } from '../product-card';
 import ProductCardsSection from '../product-cards-section';

--- a/projects/packages/my-jetpack/_inc/components/notice/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/notice/index.tsx
@@ -6,7 +6,7 @@ import { Button, VisuallyHidden, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import classnames from 'classnames';
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 /**
  * Internal dependencies
  */
@@ -16,6 +16,13 @@ type NoticeButtonAction = NoticeAction & { isLoading?: boolean; isDisabled?: boo
 
 const noop = () => {};
 
+/**
+ *	Returns the label for the notice based on the status.
+ *
+ * @param {string} status - The status of the notice.
+ *
+ * @returns {string} The label based on the status.
+ */
 function getStatusLabel( status: NoticeProps[ 'status' ] ): string {
 	switch ( status ) {
 		case 'warning':
@@ -30,6 +37,20 @@ function getStatusLabel( status: NoticeProps[ 'status' ] ): string {
 	}
 }
 
+/**
+ * Notice component based on the one from @wordpress/components.
+ *
+ * @param {object} props                   - The properties.
+ * @param {string} props.className         - The class name.
+ * @param {string} props.status            - The message status: 'warning' | 'success' | 'error' | 'info'.
+ * @param {React.ReactNode} props.children - Children element
+ * @param {Function} props.onRemove        - The function to call when the notice is removed.
+ * @param {boolean} props.isDismissible    - Whether the notice can be dismissed.
+ * @param {Array} props.actions            - An array of actions (buttons) to display in the notice.
+ * @param {Function} props.onDismiss       - The function to call when the notice is dismissed.
+ *
+ * @returns {React.Component} The `Notice` component.
+ */
 function Notice( {
 	className,
 	status = 'info',

--- a/projects/packages/my-jetpack/_inc/components/notice/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/notice/index.tsx
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+
+import { Button, VisuallyHidden, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { close } from '@wordpress/icons';
+import classnames from 'classnames';
+import { useCallback } from 'react';
+/**
+ * Internal dependencies
+ */
+import type { NoticeAction, NoticeProps } from '@wordpress/components/src/notice/types';
+
+type NoticeButtonAction = NoticeAction & { isLoading?: boolean; isDisabled?: boolean };
+
+const noop = () => {};
+
+/**
+ *
+ * @param status
+ */
+function getStatusLabel( status: NoticeProps[ 'status' ] ): string {
+	switch ( status ) {
+		case 'warning':
+			return __( 'Warning notice', 'jetpack-my-jetpack' );
+		case 'info':
+			return __( 'Information notice', 'jetpack-my-jetpack' );
+		case 'error':
+			return __( 'Error notice', 'jetpack-my-jetpack' );
+		// The default will also catch the 'success' status.
+		default:
+			return __( 'Notice', 'jetpack-my-jetpack' );
+	}
+}
+
+/**
+ *
+ * @param root0
+ * @param root0.className
+ * @param root0.status
+ * @param root0.children
+ * @param root0.onRemove
+ * @param root0.isDismissible
+ * @param root0.actions
+ * @param root0.onDismiss
+ */
+function Notice( {
+	className,
+	status = 'info',
+	children,
+	onRemove = noop,
+	isDismissible = true,
+	actions = [],
+	// onDismiss is a callback executed when the notice is dismissed.
+	// It is distinct from onRemove, which _looks_ like a callback but is
+	// actually the function to call to remove the notice from the UI.
+	onDismiss = noop,
+}: NoticeProps ): JSX.Element {
+	const classes = classnames( className, 'components-notice', 'is-' + status, {
+		'is-dismissible': isDismissible,
+	} );
+
+	const onDismissNotice = useCallback( () => {
+		onDismiss();
+		onRemove();
+	}, [ onDismiss, onRemove ] );
+
+	return (
+		<div className={ classes }>
+			<VisuallyHidden>{ getStatusLabel( status ) }</VisuallyHidden>
+			<div className="components-notice__content">
+				{ children }
+				<div className="components-notice__actions">
+					{ actions.map(
+						(
+							{
+								className: buttonCustomClasses,
+								label,
+								variant,
+								noDefaultClasses = false,
+								onClick,
+								url,
+								isLoading = false,
+								isDisabled = false,
+							}: NoticeButtonAction,
+							index
+						) => {
+							let computedVariant = variant;
+							if ( variant !== 'primary' && ! noDefaultClasses ) {
+								computedVariant = ! url ? 'secondary' : 'link';
+							}
+							if ( typeof computedVariant === 'undefined' ) {
+								computedVariant = 'primary';
+							}
+
+							return (
+								<Button
+									key={ index }
+									href={ url }
+									variant={ computedVariant }
+									onClick={ url ? undefined : onClick }
+									className={ classnames( 'components-notice__action', buttonCustomClasses ) }
+									disabled={ isLoading || isDisabled }
+								>
+									{ isLoading ? <Spinner /> : label }
+								</Button>
+							);
+						}
+					) }
+				</div>
+			</div>
+			{ isDismissible && (
+				<Button
+					className="components-notice__dismiss"
+					icon={ close }
+					label={ __( 'Close', 'jetpack-my-jetpack' ) }
+					onClick={ onDismissNotice }
+				/>
+			) }
+		</div>
+	);
+}
+
+export default Notice;

--- a/projects/packages/my-jetpack/_inc/components/notice/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/notice/index.tsx
@@ -16,10 +16,6 @@ type NoticeButtonAction = NoticeAction & { isLoading?: boolean; isDisabled?: boo
 
 const noop = () => {};
 
-/**
- *
- * @param status
- */
 function getStatusLabel( status: NoticeProps[ 'status' ] ): string {
 	switch ( status ) {
 		case 'warning':
@@ -34,17 +30,6 @@ function getStatusLabel( status: NoticeProps[ 'status' ] ): string {
 	}
 }
 
-/**
- *
- * @param root0
- * @param root0.className
- * @param root0.status
- * @param root0.children
- * @param root0.onRemove
- * @param root0.isDismissible
- * @param root0.actions
- * @param root0.onDismiss
- */
 function Notice( {
 	className,
 	status = 'info',

--- a/projects/packages/my-jetpack/changelog/add-notice-component-to-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-notice-component-to-my-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: add a version of WordPress' Notice component to My Jetpack considering the context of how we use notices on that screen

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -78,7 +78,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.18.x-dev"
+			"dev-trunk": "4.19.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.18.1-alpha",
+	"version": "4.19.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.18.1-alpha';
+	const PACKAGE_VERSION = '4.19.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/backup/changelog/update-move-notice-to-my-jetpack
+++ b/projects/plugins/backup/changelog/update-move-notice-to-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1122,7 +1122,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "29af345affe249b27eceffa31c219057d111e529"
+                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1156,7 +1156,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.18.x-dev"
+                    "dev-trunk": "4.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/update-move-notice-to-my-jetpack
+++ b/projects/plugins/boost/changelog/update-move-notice-to-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1047,7 +1047,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "29af345affe249b27eceffa31c219057d111e529"
+                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1081,7 +1081,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.18.x-dev"
+                    "dev-trunk": "4.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/update-move-notice-to-my-jetpack
+++ b/projects/plugins/jetpack/changelog/update-move-notice-to-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1673,7 +1673,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "29af345affe249b27eceffa31c219057d111e529"
+				"reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1707,7 +1707,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.18.x-dev"
+					"dev-trunk": "4.19.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/update-move-notice-to-my-jetpack
+++ b/projects/plugins/migration/changelog/update-move-notice-to-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1122,7 +1122,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "29af345affe249b27eceffa31c219057d111e529"
+                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1156,7 +1156,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.18.x-dev"
+                    "dev-trunk": "4.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/update-move-notice-to-my-jetpack
+++ b/projects/plugins/protect/changelog/update-move-notice-to-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1035,7 +1035,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "29af345affe249b27eceffa31c219057d111e529"
+                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1069,7 +1069,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.18.x-dev"
+                    "dev-trunk": "4.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/update-move-notice-to-my-jetpack
+++ b/projects/plugins/search/changelog/update-move-notice-to-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "29af345affe249b27eceffa31c219057d111e529"
+                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1012,7 +1012,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.18.x-dev"
+                    "dev-trunk": "4.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/update-move-notice-to-my-jetpack
+++ b/projects/plugins/social/changelog/update-move-notice-to-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -978,7 +978,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "29af345affe249b27eceffa31c219057d111e529"
+				"reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1012,7 +1012,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.18.x-dev"
+					"dev-trunk": "4.19.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/update-move-notice-to-my-jetpack
+++ b/projects/plugins/starter-plugin/changelog/update-move-notice-to-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "29af345affe249b27eceffa31c219057d111e529"
+                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1012,7 +1012,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.18.x-dev"
+                    "dev-trunk": "4.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/update-move-notice-to-my-jetpack
+++ b/projects/plugins/videopress/changelog/update-move-notice-to-my-jetpack
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "29af345affe249b27eceffa31c219057d111e529"
+                "reference": "b958ac6691a274ca9eb210c2e51fa0d005e07eba"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1012,7 +1012,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.18.x-dev"
+                    "dev-trunk": "4.19.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds a custom Notice component based on `@wordpress/components`' that can be extended to fulfill our needs.

<img width="1700" alt="image" src="https://github.com/Automattic/jetpack/assets/5714212/e8cbcebf-1c58-4327-b8d6-97f3f2becb94">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch
* Without connecting, visit `/wp-admin/admin.php?page=my-jetpack`
* Dismiss the Welcome banner, reload the page and confirm the Connection notice looks exactly like the old one
