### PR TITLE
Social: Prevent enqueuing of the admin styles on the frontend

### DIFF
--- a/projects/plugins/social/changelog/fix-social-frontend-styling
+++ b/projects/plugins/social/changelog/fix-social-frontend-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent enqueuing of admin styles on the frontend

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -294,7 +294,7 @@ class Jetpack_Social {
 	 * @returns boolean True if the criteria are met.
 	 */
 	public function should_enqueue_block_editor_scripts() {
-		return $this->is_connected() && self::is_publicize_active() && $this->is_supported_post();
+		return is_admin() && $this->is_connected() && self::is_publicize_active() && $this->is_supported_post();
 	}
 
 	/**


### PR DESCRIPTION
We've been hooking into enqueue_block_assets, which sinc 6.3 has meant that the hook runs for frontend requests. This caused us to unnecessarily enqueue some admin CSS, which conflicts with the theme.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This adds an is_admin check to prevent enqueuing of the unnecessary assets

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Jetpack Social (not Jetpack) on a test site, and activate the Twenty Twenty Four theme
* Create a post with a bulleted list
* Without this patch the bullets will not be rendered on the frontend
* Using this PR should fix the issue.

### Before

![CleanShot 2024-03-23 at 07 30 26@2x](https://github.com/Automattic/jetpack/assets/96462/599b7c96-0bd8-4661-92d2-09867b284d11)


### After

![CleanShot 2024-03-23 at 07 31 02@2x](https://github.com/Automattic/jetpack/assets/96462/e8a3e872-144c-45b2-953f-23a6c06e3595)


