### PR TITLE
Backport mu-wpcom-plugin 2.1.9, jetpack 13.3-a.7 Changes

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.50.3] - 2024-03-25
+### Added
+- Annotations: Make it possible to interact with them [#36453]
+- Create RadioControl component [#36532]
+
 ## [0.50.2] - 2024-03-14
 ### Added
 - Add Bluesky color [#36181]
@@ -982,6 +987,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.50.3]: https://github.com/Automattic/jetpack-components/compare/0.50.2...0.50.3
 [0.50.2]: https://github.com/Automattic/jetpack-components/compare/0.50.1...0.50.2
 [0.50.1]: https://github.com/Automattic/jetpack-components/compare/0.50.0...0.50.1
 [0.50.0]: https://github.com/Automattic/jetpack-components/compare/0.49.2...0.50.0

--- a/projects/js-packages/components/changelog/add-radio-control
+++ b/projects/js-packages/components/changelog/add-radio-control
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Create RadioControl component

--- a/projects/js-packages/components/changelog/update-make-annotations-clickable
+++ b/projects/js-packages/components/changelog/update-make-annotations-clickable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Annotations: Make it possible to interact with them

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.50.3-alpha",
+	"version": "0.50.3",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.33.4] - 2024-03-25
+### Fixed
+- Fix some redirect after purchase behavior when site is not connected [#36448]
+
 ## [0.33.3] - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36325]
@@ -730,6 +734,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.33.4]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.3...v0.33.4
 [0.33.3]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.2...v0.33.3
 [0.33.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.1...v0.33.2
 [0.33.1]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.0...v0.33.1

--- a/projects/js-packages/connection/changelog/fix-weirdness-with-post-register-redirection-on-purchase
+++ b/projects/js-packages/connection/changelog/fix-weirdness-with-post-register-redirection-on-purchase
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix some redirect after purchase behavior when site is not connected

--- a/projects/js-packages/connection/changelog/refactor-connect-screen-ts
+++ b/projects/js-packages/connection/changelog/refactor-connect-screen-ts
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Refactor connect screen components to use TS
-
-

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.33.4-alpha",
+	"version": "0.33.4",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/packages/backup-helper-script-manager/CHANGELOG.md
+++ b/projects/packages/backup-helper-script-manager/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2024-03-25
+### Fixed
+- Backup: change some error messages to not trigger security scanners [#36496]
+
 ## [0.2.4] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -29,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Initial release (improved helper script installer logging). [#34297]
 
+[0.2.5]: https://github.com/Automattic/jetpack-backup-helper-script-manager/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/Automattic/jetpack-backup-helper-script-manager/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/Automattic/jetpack-backup-helper-script-manager/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Automattic/jetpack-backup-helper-script-manager/compare/v0.2.1...v0.2.2

--- a/projects/packages/backup-helper-script-manager/changelog/backup-change-log-label
+++ b/projects/packages/backup-helper-script-manager/changelog/backup-change-log-label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Backup: change some error messages to not trigger security scanners

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.3] - 2024-03-25
+### Fixed
+- Backup: change some error messages to not trigger security scanners [#36496]
+
 ## [3.3.2] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -585,6 +589,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.3.3]: https://github.com/Automattic/jetpack-backup/compare/v3.3.2...v3.3.3
 [3.3.2]: https://github.com/Automattic/jetpack-backup/compare/v3.3.1...v3.3.2
 [3.3.1]: https://github.com/Automattic/jetpack-backup/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/Automattic/jetpack-backup/compare/v3.2.0...v3.3.0

--- a/projects/packages/backup/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/backup/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/backup/changelog/backup-change-log-label
+++ b/projects/packages/backup/changelog/backup-change-log-label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Backup: change some error messages to not trigger security scanners

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.3.3-alpha';
+	const PACKAGE_VERSION = '3.3.3';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.3] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [0.19.2] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -323,6 +327,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.19.3]: https://github.com/automattic/jetpack-blaze/compare/v0.19.2...v0.19.3
 [0.19.2]: https://github.com/automattic/jetpack-blaze/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/automattic/jetpack-blaze/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/automattic/jetpack-blaze/compare/v0.18.1...v0.19.0

--- a/projects/packages/blaze/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/blaze/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.19.3-alpha",
+	"version": "0.19.3",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.19.3-alpha';
+	const PACKAGE_VERSION = '0.19.3';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/boost-core/CHANGELOG.md
+++ b/projects/packages/boost-core/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [0.2.5] - 2024-03-14
 ### Changed
 - Internal updates.
@@ -49,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Introduce new package. [#31163]
 
+[0.2.6]: https://github.com/Automattic/jetpack-boost-core/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/Automattic/jetpack-boost-core/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/Automattic/jetpack-boost-core/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/Automattic/jetpack-boost-core/compare/v0.2.2...v0.2.3

--- a/projects/packages/boost-core/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/boost-core/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/boost-core/package.json
+++ b/projects/packages/boost-core/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-boost-core",
-	"version": "0.2.6-alpha",
+	"version": "0.2.6",
 	"description": "Core functionality for boost and relevant packages to depend on",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/boost-core/#readme",
 	"bugs": {

--- a/projects/packages/boost-speed-score/CHANGELOG.md
+++ b/projects/packages/boost-speed-score/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.8] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [0.3.7] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -62,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new package for Boost Speed Score [#30914]
 - Add a new argument to `Speed_Score` to identify where the request was made from (e.g. 'boost-plugin', 'jetpack-dashboard', etc). [#31012]
 
+[0.3.8]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.4...v0.3.5

--- a/projects/packages/boost-speed-score/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/boost-speed-score/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -23,7 +23,7 @@ if ( ! defined( 'JETPACK_BOOST_REST_PREFIX' ) ) {
  */
 class Speed_Score {
 
-	const PACKAGE_VERSION = '0.3.8-alpha';
+	const PACKAGE_VERSION = '0.3.8';
 
 	/**
 	 * An instance of Automatic\Jetpack_Boost\Modules\Modules_Setup passed to the constructor

--- a/projects/packages/compat/CHANGELOG.md
+++ b/projects/packages/compat/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2024-03-25
+### Removed
+- General: remove past compatibility layer that is not being used anywhere anymore. [#36157]
+
 ## [2.0.1] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -139,6 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Jetpack 7.5: Back compatibility package
 
+[3.0.0]: https://github.com/Automattic/jetpack-compat/compare/v2.0.1...v3.0.0
 [2.0.1]: https://github.com/Automattic/jetpack-compat/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-compat/compare/v1.7.8...v2.0.0
 [1.7.8]: https://github.com/Automattic/jetpack-compat/compare/v1.7.7...v1.7.8

--- a/projects/packages/compat/changelog/rm-deprecated-files-methods
+++ b/projects/packages/compat/changelog/rm-deprecated-files-methods
@@ -1,4 +1,0 @@
-Significance: major
-Type: removed
-
-General: remove past compatibility layer that is not being used anywhere anymore.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.2] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [2.6.1] - 2024-03-22
 ### Changed
 - yUpdate Phan config. [#36353]
@@ -1000,6 +1004,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.6.2]: https://github.com/Automattic/jetpack-connection/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/Automattic/jetpack-connection/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/Automattic/jetpack-connection/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/Automattic/jetpack-connection/compare/v2.4.1...v2.5.0

--- a/projects/packages/connection/changelog/add-phan-more-constant-stubs
+++ b/projects/packages/connection/changelog/add-phan-more-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update phan baseline for config changes. No change to functionality.
-
-

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.6.2-alpha';
+	const PACKAGE_VERSION = '2.6.2';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/error/CHANGELOG.md
+++ b/projects/packages/error/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [2.0.1] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -136,6 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a jetpack-error package
 
+[2.0.2]: https://github.com/Automattic/jetpack-error/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-error/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-error/compare/v1.3.21...v2.0.0
 [1.3.21]: https://github.com/Automattic/jetpack-error/compare/v1.3.20...v1.3.21

--- a/projects/packages/error/changelog/fix-phan-redefined-errors
+++ b/projects/packages/error/changelog/fix-phan-redefined-errors
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Adjust Phan config to fix PhanRedefinedXXX issues. No change to functionality.
-
-

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.12] - 2024-03-25
+### Changed
+- Made some Contact_Form methods publicly available [#36137]
+
 ## [0.30.11] - 2024-03-18
 ### Fixed
 - Dashboard: add missing Connection state to the page. [#36406]
@@ -519,6 +523,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.30.12]: https://github.com/automattic/jetpack-forms/compare/v0.30.11...v0.30.12
 [0.30.11]: https://github.com/automattic/jetpack-forms/compare/v0.30.10...v0.30.11
 [0.30.10]: https://github.com/automattic/jetpack-forms/compare/v0.30.9...v0.30.10
 [0.30.9]: https://github.com/automattic/jetpack-forms/compare/v0.30.8...v0.30.9

--- a/projects/packages/forms/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/forms/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/forms/changelog/update-contact-form-module-form
+++ b/projects/packages/forms/changelog/update-contact-form-module-form
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Made some Contact_Form methods publicly available

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.12-alpha",
+	"version": "0.30.12",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.12-alpha';
+	const PACKAGE_VERSION = '0.30.12';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.5] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [0.17.4] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -507,6 +511,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.17.5]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.4...v0.17.5
 [0.17.4]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.3...v0.17.4
 [0.17.3]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.2...v0.17.3
 [0.17.2]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.1...v0.17.2

--- a/projects/packages/identity-crisis/changelog/add-phan-more-constant-stubs
+++ b/projects/packages/identity-crisis/changelog/add-phan-more-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update phan baseline for config changes. No change to functionality.
-
-

--- a/projects/packages/identity-crisis/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/identity-crisis/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.17.5-alpha",
+	"version": "0.17.5",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -26,7 +26,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.17.5-alpha';
+	const PACKAGE_VERSION = '0.17.5';
 
 	/**
 	 * Persistent WPCOM blog ID that stays in the options after disconnect.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.20.0] - 2024-03-25
+### Removed
+- Removed Subscribers from Hosting menu [#36513]
+
 ## [5.19.0] - 2024-03-22
 ### Changed
 - Added additional settings for commenting on simple sites [#36367]
@@ -675,6 +679,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.20.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.19.0...v5.20.0
 [5.19.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.18.0...v5.19.0
 [5.18.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.17.0...v5.18.0
 [5.17.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.16.1...v5.17.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-subscribers-from-hosting-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-subscribers-from-hosting-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Removed Subscribers from Hosting menu

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.20.0-alpha",
+	"version": "5.20.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.20.0-alpha';
+	const PACKAGE_VERSION = '5.20.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.2] - 2024-03-25
+### Changed
+- Update Phan baselines [#36441]
+
 ## [3.1.1] - 2024-03-14
 ### Changed
 - Internal updates.
@@ -683,6 +687,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.1.2]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.1...v3.1.2
 [3.1.1]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.5...v3.1.0
 [3.0.5]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.4...v3.0.5

--- a/projects/packages/jitm/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/jitm/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/jitm/changelog/update-global-subscriber-logout
+++ b/projects/packages/jitm/changelog/update-global-subscriber-logout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update Phan baselines

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.1.2-alpha';
+	const PACKAGE_VERSION = '3.1.2';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/licensing/CHANGELOG.md
+++ b/projects/packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [2.0.2] - 2024-03-14
 ### Changed
 - Internal updates.
@@ -260,6 +264,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Licensing: Add support for Jetpack licenses
 
+[2.0.3]: https://github.com/Automattic/jetpack-licensing/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/jetpack-licensing/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-licensing/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-licensing/compare/v1.8.4...v2.0.0

--- a/projects/packages/licensing/changelog/add-phan-more-constant-stubs
+++ b/projects/packages/licensing/changelog/add-phan-more-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update phan baseline for config changes. No change to functionality.
-
-

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.18.0] - 2024-03-25
+### Added
+- Hook into red bubble notification when bad installation is detected [#36449]
+- Jetpack AI: add notices on product page for exhausted requests [#35910]
+- Jetpack AI: add plans/tier information on product page and corresponding CTAs [#35910]
+- Jetpack AI: add support and create post links on product page [#35910]
+- My Jetpack: add AI product page view event [#36488]
+- My Jetpack: add feedback link on Jetpack AI product page [#35910]
+- My Jetpack: AI pricing table is skipped once the user has opted for the free version [#35910]
+- My Jetpack: change AI product for tiered pricing table display [#35910]
+
+### Changed
+- Add notice priorities to My Jetpack [#36438]
+- Jetpack AI: address responsive issues on the styles [#35910]
+- My Jetpack: AI product page styles update and responsive fixes [#35910]
+- My Jetpack: change AI card action button target for upgraded users, point to product page [#35910]
+
+### Removed
+- My Jetpack: remove Jetpack AI code added throughout the new product page project [#35910]
+- Removed reference to Creator Network, which is being deprecated. [#36168]
+
+### Fixed
+- Boost tooltips: fix typo in string. [#36520]
+- My Jetpack: fix AI interstitial "remain free" flow [#35910]
+- My Jetpack: fix interstitial event property malformed name productSlug -> product_slug [#36486]
+- My Jetpack: fix spacing issues on the new product page [#35910]
+- My Jetpack: new AI interstitial margin on admin page was messing with correct top spacing [#35910]
+
 ## [4.17.1] - 2024-03-18
 ### Added
 - Add a loaded event for My Jetpack product cards [#36397]
@@ -1351,6 +1379,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.18.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.17.1...4.18.0
 [4.17.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.17.0...4.17.1
 [4.17.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.16.0...4.17.0
 [4.16.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.15.0...4.16.0

--- a/projects/packages/my-jetpack/changelog/add-bad-installation-notices-to-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-bad-installation-notices-to-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Hook into red bubble notification when bad installation is detected

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-create-post-with-block
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-create-post-with-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Jetpack AI: add support and create post links on product page

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-pricing-table-once
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-pricing-table-once
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-My Jetpack: AI pricing table is skipped once the user has opted for the free version

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-connected-flows
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-connected-flows
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Jetpack AI: add plans/tier information on product page and corresponding CTAs

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-feedback-link
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-feedback-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-My Jetpack: add feedback link on Jetpack AI product page

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-notices
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-notices
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Jetpack AI: add notices on product page for exhausted requests

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-ai-detail-table
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-ai-detail-table
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-My Jetpack: change AI product for tiered pricing table display

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-ai-product-page-view-event
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-ai-product-page-view-event
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-My Jetpack: add AI product page view event

--- a/projects/packages/my-jetpack/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/my-jetpack/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/my-jetpack/changelog/add-priority-notices-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-priority-notices-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Add notice priorities to My Jetpack

--- a/projects/packages/my-jetpack/changelog/change-my-jetpack-point-ai-card-to-product-page
+++ b/projects/packages/my-jetpack/changelog/change-my-jetpack-point-ai-card-to-product-page
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-My Jetpack: change AI card action button target for upgraded users, point to product page

--- a/projects/packages/my-jetpack/changelog/fix-interstitial-event-property-name
+++ b/projects/packages/my-jetpack/changelog/fix-interstitial-event-property-name
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: fix interstitial event property malformed name productSlug -> product_slug

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-interstitial-styles
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-interstitial-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: new AI interstitial margin on admin page was messing with correct top spacing

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-product-page-styles
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-product-page-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: AI product page styles update and responsive fixes

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-product-page-styles-2
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-product-page-styles-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: fix spacing issues on the new product page

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-remain-free-flow
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-remain-free-flow
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-My Jetpack: fix AI interstitial "remain free" flow

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-responsive-styles
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-responsive-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Jetpack AI: address responsive issues on the styles

--- a/projects/packages/my-jetpack/changelog/refactor-connection-screen-duplicate
+++ b/projects/packages/my-jetpack/changelog/refactor-connection-screen-duplicate
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Moved components into their own files
-
-

--- a/projects/packages/my-jetpack/changelog/remove-enhdist
+++ b/projects/packages/my-jetpack/changelog/remove-enhdist
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Removed reference to Creator Network, which is being deprecated.

--- a/projects/packages/my-jetpack/changelog/remove-jetpack-ai-unused-code
+++ b/projects/packages/my-jetpack/changelog/remove-jetpack-ai-unused-code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-My Jetpack: remove Jetpack AI code added throughout the new product page project

--- a/projects/packages/my-jetpack/changelog/update-boost-strings-css
+++ b/projects/packages/my-jetpack/changelog/update-boost-strings-css
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Boost tooltips: fix typo in string.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.18.0-alpha",
+	"version": "4.18.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.18.0-alpha';
+	const PACKAGE_VERSION = '4.18.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/plugins-installer/CHANGELOG.md
+++ b/projects/packages/plugins-installer/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [0.3.2] - 2024-03-14
 ### Changed
 - Internal updates.
@@ -70,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix method logic
 
+[0.3.3]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.2.6...v0.3.0

--- a/projects/packages/plugins-installer/changelog/add-phan-more-constant-stubs
+++ b/projects/packages/plugins-installer/changelog/add-phan-more-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update phan baseline for config changes. No change to functionality.
-
-

--- a/projects/packages/plugins-installer/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/plugins-installer/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.7] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [0.42.6] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -502,6 +506,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.42.7]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.6...v0.42.7
 [0.42.6]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.5...v0.42.6
 [0.42.5]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.4...v0.42.5
 [0.42.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.3...v0.42.4

--- a/projects/packages/publicize/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/publicize/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.7-alpha",
+	"version": "0.42.7",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.7] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [0.43.6] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -917,6 +921,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.43.7]: https://github.com/Automattic/jetpack-search/compare/v0.43.6...v0.43.7
 [0.43.6]: https://github.com/Automattic/jetpack-search/compare/v0.43.5...v0.43.6
 [0.43.5]: https://github.com/Automattic/jetpack-search/compare/v0.43.4...v0.43.5
 [0.43.4]: https://github.com/Automattic/jetpack-search/compare/v0.43.3...v0.43.4

--- a/projects/packages/search/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/search/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.43.7-alpha",
+	"version": "0.43.7",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.43.7-alpha';
+	const VERSION = '0.43.7';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.17.1 - 2024-03-25
+### Changed
+- Internal updates.
+
 ## 0.17.0 - 2024-03-18
 ### Added
 - Stats: Add UTM stats endpoint [#36402]

--- a/projects/packages/stats-admin/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/stats-admin/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.17.1-alpha",
+	"version": "0.17.1",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.17.1-alpha';
+	const VERSION = '0.17.1';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [0.11.1] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -141,6 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.11.2]: https://github.com/Automattic/jetpack-stats/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Automattic/jetpack-stats/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Automattic/jetpack-stats/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/Automattic/jetpack-stats/compare/v0.10.0...v0.10.1

--- a/projects/packages/stats/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/stats/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.3] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [2.10.2] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -1076,6 +1080,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.10.3]: https://github.com/Automattic/jetpack-sync/compare/v2.10.2...v2.10.3
 [2.10.2]: https://github.com/Automattic/jetpack-sync/compare/v2.10.1...v2.10.2
 [2.10.1]: https://github.com/Automattic/jetpack-sync/compare/v2.10.0...v2.10.1
 [2.10.0]: https://github.com/Automattic/jetpack-sync/compare/v2.9.0...v2.10.0

--- a/projects/packages/sync/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/sync/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.10.3-alpha';
+	const PACKAGE_VERSION = '2.10.3';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.11] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [0.23.10] - 2024-03-14
 ### Changed
 - Internal updates.
@@ -1294,6 +1298,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.11]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.10...v0.23.11
 [0.23.10]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.9...v0.23.10
 [0.23.9]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.8...v0.23.9
 [0.23.8]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.7...v0.23.8

--- a/projects/packages/videopress/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/videopress/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.11-alpha",
+	"version": "0.23.11",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.11-alpha';
+	const PACKAGE_VERSION = '0.23.11';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [0.16.0] - 2024-03-22
 ### Added
 - Add data to WAF logs and add toggle for users to opt-in to share more data with us if needed. [#36377]
@@ -289,6 +293,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.16.1]: https://github.com/Automattic/jetpack-waf/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/Automattic/jetpack-waf/compare/v0.15.1...v0.16.0
 [0.15.2]: https://github.com/Automattic/jetpack-waf/compare/v0.15.1...v0.15.2
 [0.15.1]: https://github.com/Automattic/jetpack-waf/compare/v0.15.0...v0.15.1

--- a/projects/packages/waf/changelog/add-phan-more-constant-stubs
+++ b/projects/packages/waf/changelog/add-phan-more-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update phan baseline for config changes. No change to functionality.
-
-

--- a/projects/packages/waf/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/waf/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/woocommerce-analytics/CHANGELOG.md
+++ b/projects/packages/woocommerce-analytics/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2024-03-25
+### Changed
+- Internal updates.
+
 ## [0.1.1] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -19,4 +23,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix namespace issue with WooCommerce class reference. [#35857]
 - General: bail early when WooCommerce is not active. [#36278]
 
+[0.1.2]: https://github.com/Automattic/woocommerce-analytics/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Automattic/woocommerce-analytics/compare/v0.1.0...v0.1.1

--- a/projects/packages/woocommerce-analytics/changelog/add-phan-wp-constant-stubs
+++ b/projects/packages/woocommerce-analytics/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -20,7 +20,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.1.2-alpha';
+	const PACKAGE_VERSION = '0.1.2';
 
 	/**
 	 * Initializer.

--- a/projects/plugins/jetpack/3rd-party/wpcom-reader.php
+++ b/projects/plugins/jetpack/3rd-party/wpcom-reader.php
@@ -8,7 +8,7 @@
  *
  * These hooks were originally part of the now-deprecated Enhanced Distribution.
  *
- * @since $$next-version$$
+ * @since 13.3
  * @package Automattic/jetpack
  */
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.3-a.7 - 2024-03-25
+### Enhancements
+- Block category "Earn" renamed to "Monetize" [#36480]
+- Jetpack AI: when response includes a title and post title is empty, use provided title as post title [#36500]
+- Removed Like button from master bar [#36456]
+- Reorder newsletter settings cards to improve hierarchy [#36465]
+- Trigger red bubble notifiction on My Jetpack when bad install is detected [#36449]
+- Use radio controls instead of toggles on Email Settings [#36532]
+
+### Improved compatibility
+- General: remove methods that were deprecated before the release of Jetpack 10.0, in 2021. [#36157]
+
+### Bug fixes
+- Dashboard: update the sharing button settings to clarify the available options (block or legacy sharing buttons). [#36473]
+- Enhanced Distribution: begin deprecation process as the Firehose is winding down [#36168]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Added the possibility of stating if a new invited user is a contractor. [#36479]
+- Add function exists check for wp_admin_notice [#36511]
+- Add my home menu to atomic sites in classic view using nav unification. [#36431]
+- Add share debug data toggle on WAF settings [#36377]
+- Add sso survey modal for users that disable the module [#36387]
+- Backup: change some error messages to not trigger security scanners [#36496]
+- Contact Form: refactor field to use forms package [#36138]
+- Contact Form: refactor form to use forms package [#36137]
+- Display Subscribers menu on wp-admin and update links to Jetpack Manage [#36510]
+- GitHub Deployments: remove feature flag [#36469]
+- minor change the the menu for selecting images [#36293]
+- Paywall: Switching accounts URL fix [#36337]
+- Register Sharing settings menu page in offline mode or when Classic wp-admin is enabled. [#36490]
+- SSO: only enable WordPress.com invite emails by default on the WordPress.com platform. [#36558]
+- SSO: simplify the logic when inviting new users to WordPress.com. [#36498]
+- Subscriptions: Apply the subscriber logout function globally [#36441]
+- Subscription Site: Release the Subscribe block after the post placement toggle [#36368]
+- Update notification icon in top bar [#36297]
+- Use correct links in Settings -> Traffic -> GA when admin interface is wp-admin [#36493]
+- WPCOM API: avoid PHP warnings when variables are not set. [#36455]
+- WPCOM_JSON_API_List_Comments_Endpoint: Do not prefetch comment meta for large hierarchical threads [#36460]
+
 ## 13.3-a.3 - 2024-03-18
 ### Enhancements
 - AI Assistant: Provide per-block quick actions to make them more relevant. [#36393]

--- a/projects/plugins/jetpack/changelog/add-a4a-source-to-jetpack-connect-url
+++ b/projects/plugins/jetpack/changelog/add-a4a-source-to-jetpack-connect-url
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-ai-promote-post-title-when-safe
+++ b/projects/plugins/jetpack/changelog/add-ai-promote-post-title-when-safe
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Jetpack AI: when response includes a title and post title is empty, use provided title as post title

--- a/projects/plugins/jetpack/changelog/add-bad-installation-notices-to-my-jetpack
+++ b/projects/plugins/jetpack/changelog/add-bad-installation-notices-to-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Trigger red bubble notifiction on My Jetpack when bad install is detected

--- a/projects/plugins/jetpack/changelog/add-ci-phan-run-with-wp-previous
+++ b/projects/plugins/jetpack/changelog/add-ci-phan-run-with-wp-previous
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Add Phan suppressions for new-in-WP-6.4 functions that are checked at runtime. No change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/add-my-home-to-classic-view
+++ b/projects/plugins/jetpack/changelog/add-my-home-to-classic-view
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add my home menu to atomic sites in classic view using nav unification.

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-ai-detail-table
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-ai-detail-table
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-phan-more-constant-stubs
+++ b/projects/plugins/jetpack/changelog/add-phan-more-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update phan baseline for config changes. No change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/add-phan-wp-constant-stubs
+++ b/projects/plugins/jetpack/changelog/add-phan-wp-constant-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update Phan baseline for config change. No change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/add-radio-control
+++ b/projects/plugins/jetpack/changelog/add-radio-control
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Use radio controls instead of toggles on Email Settings

--- a/projects/plugins/jetpack/changelog/add-remote-connect-rest-endpoint
+++ b/projects/plugins/jetpack/changelog/add-remote-connect-rest-endpoint
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-sso-disable-notice
+++ b/projects/plugins/jetpack/changelog/add-sso-disable-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add sso survey modal for users that disable the module

--- a/projects/plugins/jetpack/changelog/backup-change-log-label
+++ b/projects/plugins/jetpack/changelog/backup-change-log-label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Backup: change some error messages to not trigger security scanners

--- a/projects/plugins/jetpack/changelog/delete-like-button-from-admin-bar
+++ b/projects/plugins/jetpack/changelog/delete-like-button-from-admin-bar
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Removed Like button from master bar

--- a/projects/plugins/jetpack/changelog/enable-sharing-settings
+++ b/projects/plugins/jetpack/changelog/enable-sharing-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Register Sharing settings menu page in offline mode or when Classic wp-admin is enabled.

--- a/projects/plugins/jetpack/changelog/fix-memberships-login-code
+++ b/projects/plugins/jetpack/changelog/fix-memberships-login-code
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Filter intended for wpcom use now can accept arguments properly.
-
-

--- a/projects/plugins/jetpack/changelog/fix-phan-redefined-errors
+++ b/projects/plugins/jetpack/changelog/fix-phan-redefined-errors
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Adjust Phan config and add some `@phan-suppress` to fix PhanRedefinedXXX issues. No change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/fix-sharing-block-settings-info
+++ b/projects/plugins/jetpack/changelog/fix-sharing-block-settings-info
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Dashboard: update the sharing button settings to clarify the available options (block or legacy sharing buttons).

--- a/projects/plugins/jetpack/changelog/fix-undefined-variable-api
+++ b/projects/plugins/jetpack/changelog/fix-undefined-variable-api
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-WPCOM API: avoid PHP warnings when variables are not set.

--- a/projects/plugins/jetpack/changelog/github-deployments-remove-feature-flag-call
+++ b/projects/plugins/jetpack/changelog/github-deployments-remove-feature-flag-call
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-GitHub Deployments: remove feature flag

--- a/projects/plugins/jetpack/changelog/improve-waf-logs
+++ b/projects/plugins/jetpack/changelog/improve-waf-logs
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add share debug data toggle on WAF settings

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.3-a.4
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.3-a.8
+
+

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/remove-enhdist
+++ b/projects/plugins/jetpack/changelog/remove-enhdist
@@ -1,4 +1,0 @@
-Significance: minor
-Type: bugfix
-
-Enhanced Distribution: begin deprecation process as the Firehose is winding down

--- a/projects/plugins/jetpack/changelog/rm-deprecated-files-methods
+++ b/projects/plugins/jetpack/changelog/rm-deprecated-files-methods
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-General: remove methods that were deprecated before the release of Jetpack 10.0, in 2021.

--- a/projects/plugins/jetpack/changelog/untangle-google-analytics
+++ b/projects/plugins/jetpack/changelog/untangle-google-analytics
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Use correct links in Settings -> Traffic -> GA when admin interface is wp-admin

--- a/projects/plugins/jetpack/changelog/update-WPCOM_JSON_API_List_Comments_Endpoint
+++ b/projects/plugins/jetpack/changelog/update-WPCOM_JSON_API_List_Comments_Endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-WPCOM_JSON_API_List_Comments_Endpoint: Do not prefetch comment meta for large hierarchical threads

--- a/projects/plugins/jetpack/changelog/update-block-category-earn-monetize
+++ b/projects/plugins/jetpack/changelog/update-block-category-earn-monetize
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Block category "Earn" renamed to "Monetize"

--- a/projects/plugins/jetpack/changelog/update-contact-form-module-field
+++ b/projects/plugins/jetpack/changelog/update-contact-form-module-field
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Contact Form: refactor field to use forms package

--- a/projects/plugins/jetpack/changelog/update-contact-form-module-form
+++ b/projects/plugins/jetpack/changelog/update-contact-form-module-form
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Contact Form: refactor form to use forms package

--- a/projects/plugins/jetpack/changelog/update-global-subscriber-logout
+++ b/projects/plugins/jetpack/changelog/update-global-subscriber-logout
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriptions: Apply the subscriber logout function globally

--- a/projects/plugins/jetpack/changelog/update-jetpack-app-qr-code-media-dropdown-list
+++ b/projects/plugins/jetpack/changelog/update-jetpack-app-qr-code-media-dropdown-list
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-minor change the the menu for selecting images

--- a/projects/plugins/jetpack/changelog/update-jetpack-sso-admin-wp-notice-function-check
+++ b/projects/plugins/jetpack/changelog/update-jetpack-sso-admin-wp-notice-function-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add function exists check for wp_admin_notice

--- a/projects/plugins/jetpack/changelog/update-newsletter-settings-cards-reorder
+++ b/projects/plugins/jetpack/changelog/update-newsletter-settings-cards-reorder
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Reorder newsletter settings cards to improve hierarchy

--- a/projects/plugins/jetpack/changelog/update-notification-icon
+++ b/projects/plugins/jetpack/changelog/update-notification-icon
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update notification icon in top bar

--- a/projects/plugins/jetpack/changelog/update-paywall-switch-accounts-token-fix
+++ b/projects/plugins/jetpack/changelog/update-paywall-switch-accounts-token-fix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Paywall: Switching accounts URL fix

--- a/projects/plugins/jetpack/changelog/update-sso-defaults-wpcom
+++ b/projects/plugins/jetpack/changelog/update-sso-defaults-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-SSO: only enable WordPress.com invite emails by default on the WordPress.com platform.

--- a/projects/plugins/jetpack/changelog/update-sso-invite-logic
+++ b/projects/plugins/jetpack/changelog/update-sso-invite-logic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-SSO: simplify the logic when inviting new users to WordPress.com.

--- a/projects/plugins/jetpack/changelog/update-subscriber-site-release
+++ b/projects/plugins/jetpack/changelog/update-subscriber-site-release
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscription Site: Release the Subscribe block after the post placement toggle

--- a/projects/plugins/jetpack/changelog/update-subscribers-link
+++ b/projects/plugins/jetpack/changelog/update-subscribers-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Display Subscribers menu on wp-admin and update links to Jetpack Manage

--- a/projects/plugins/jetpack/changelog/update-user-new-contractor
+++ b/projects/plugins/jetpack/changelog/update-user-new-contractor
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Added the possibility of stating if a new invited user is a contractor.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_7",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_4",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_7",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.3-a.4
+ * Version: 13.3-a.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.3-a.4' );
+define( 'JETPACK__VERSION', '13.3-a.7' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.3-a.7
+ * Version: 13.3-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.3-a.7' );
+define( 'JETPACK__VERSION', '13.3-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/enhanced-distribution.php
+++ b/projects/plugins/jetpack/modules/enhanced-distribution.php
@@ -7,5 +7,5 @@
  * @package automattic/jetpack
  */
 
-_deprecated_file( basename( __FILE__ ), 'jetpack-$$next-version$$' );
+_deprecated_file( basename( __FILE__ ), 'jetpack-13.3' );
 // Silence is golden. Left here to ensure no fatals on some seemingly misconfigured opcache setups.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.3.0-a.7",
+	"version": "13.3.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.3.0-a.4",
+	"version": "13.3.0-a.7",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -325,16 +325,21 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.3-a.3 - 2024-03-18
+### 13.3-a.7 - 2024-03-25
 #### Enhancements
-- AI Assistant: Provide per-block quick actions to make them more relevant.
-- General: Only show installation errors on plugins page.
-- Newsletters: Ensure blog stats and top posts blocks do not render in email newsletters.
-- Sharing: Add a Bluesky sharing button.
-- Sharing: Add Native (Web Share) button to Sharing Buttons block.
+- Block category "Earn" renamed to "Monetize"
+- Jetpack AI: when response includes a title and post title is empty, use provided title as post title
+- Removed Like button from master bar
+- Reorder newsletter settings cards to improve hierarchy
+- Trigger red bubble notifiction on My Jetpack when bad install is detected
+- Use radio controls instead of toggles on Email Settings
 
 #### Improved compatibility
-- Subscriptions: Remove subscription settings from reading options page.
+- General: remove methods that were deprecated before the release of Jetpack 10.0, in 2021.
+
+#### Bug fixes
+- Dashboard: update the sharing button settings to clarify the available options (block or legacy sharing buttons).
+- Enhanced Distribution: begin deprecation process as the Firehose is winding down
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.9 - 2024-03-25
+### Changed
+- Internal updates.
+
 ## 2.1.8 - 2024-03-22
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/remove-subscribers-from-hosting-menu
+++ b/projects/plugins/mu-wpcom-plugin/changelog/remove-subscribers-from-hosting-menu
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_9_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_9"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.9-alpha
+ * Version: 2.1.9
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.9-alpha",
+	"version": "2.1.9",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.9, jetpack 13.3-a.7

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.