### PR TITLE
Extract browser and platform from user agent

### DIFF
--- a/projects/packages/device-detection/changelog/Add get_browser capability for device stats
+++ b/projects/packages/device-detection/changelog/Add get_browser capability for device stats
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Added functionality for extracting the browser from a user agent
+Added functionality for extracting the browser and desktop platform from a user agent

--- a/projects/packages/device-detection/changelog/Add get_browser capability for device stats
+++ b/projects/packages/device-detection/changelog/Add get_browser capability for device stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added functionality for extracting the browser from a user agent

--- a/projects/packages/device-detection/src/class-device-detection.php
+++ b/projects/packages/device-detection/src/class-device-detection.php
@@ -49,6 +49,7 @@ class Device_Detection {
 			'is_smartphone'       => self::is_mobile( 'smart', false, $ua_info ),
 			'is_tablet'           => $ua_info->is_tablet(),
 			'platform'            => $ua_info->get_platform(),
+			'browser'             => $ua_info->get_browser(),
 		);
 
 		$info['is_handheld'] = $info['is_phone'] || $info['is_tablet'];

--- a/projects/packages/device-detection/src/class-device-detection.php
+++ b/projects/packages/device-detection/src/class-device-detection.php
@@ -49,6 +49,7 @@ class Device_Detection {
 			'is_smartphone'       => self::is_mobile( 'smart', false, $ua_info ),
 			'is_tablet'           => $ua_info->is_tablet(),
 			'platform'            => $ua_info->get_platform(),
+			'desktop_platform'    => $ua_info->get_desktop_platform(),
 			'browser'             => $ua_info->get_browser(),
 		);
 

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -278,6 +278,34 @@ class User_Agent_Info {
 	}
 
 	/**
+	 * A simple pattern matching method for extracting the browser from the user agent.
+	 *
+	 * @return false|string
+	 */
+	public function get_browser() {
+		$ua = $this->useragent;
+		if ( empty( $ua ) ) {
+			return false;
+		}
+
+		if ( strpos( $ua, 'Opera' ) || strpos( $ua, 'OPR/' ) ) {
+			return 'opera';
+		} elseif ( strpos( $ua, 'Edge' ) ) {
+			return 'edge';
+		} elseif ( strpos( $ua, 'Chrome' ) ) {
+			return 'chrome';
+		} elseif ( strpos( $ua, 'Safari' ) ) {
+			return 'safari';
+		} elseif ( strpos( $ua, 'Firefox' ) ) {
+			return 'firefox';
+		} elseif ( strpos( $ua, 'MSIE' ) || strpos( $ua, 'Trident/7' ) ) {
+			return 'ie';
+		}
+
+		return 'other';
+	}
+
+	/**
 	 * This method detects for UA which can display iPhone-optimized web content.
 	 * Includes iPhone, iPod Touch, Android, WebOS, Fennec (Firefox mobile), etc.
 	 */

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -280,12 +280,12 @@ class User_Agent_Info {
 	/**
 	 * A simple pattern matching method for extracting the browser from the user agent.
 	 *
-	 * @return false|string
+	 * @return string
 	 */
 	public function get_browser() {
 		$ua = $this->useragent;
 		if ( empty( $ua ) ) {
-			return false;
+			return 'other';
 		}
 
 		if ( strpos( $ua, 'Opera' ) || strpos( $ua, 'OPR/' ) ) {

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -278,6 +278,27 @@ class User_Agent_Info {
 	}
 
 	/**
+	 * Returns the platform for desktops
+	 *
+	 * @return string
+	 */
+	public function get_desktop_platform() {
+		$ua       = $this->useragent;
+		$platform = 'other';
+
+		if ( preg_match( '/linux/i', $ua ) ) {
+			$platform = 'linux';
+		} elseif ( preg_match( '/macintosh|mac os x/i', $ua ) ) {
+			$platform = 'mac';
+		} elseif ( preg_match( '/windows|win32/i', $ua ) ) {
+			$platform = 'windows';
+		} elseif ( preg_match( '/chrome/i', $ua ) ) {
+			$platform = 'chrome';
+		}
+		return $platform;
+	}
+
+	/**
 	 * A simple pattern matching method for extracting the browser from the user agent.
 	 *
 	 * @return string

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -64,19 +64,30 @@ class User_Agent_Info {
 	 *
 	 * @var null|string
 	 */
-	private $platform             = null;
-	const PLATFORM_WINDOWS        = 'windows';
-	const PLATFORM_IPHONE         = 'iphone';
-	const PLATFORM_IPOD           = 'ipod';
-	const PLATFORM_IPAD           = 'ipad';
-	const PLATFORM_BLACKBERRY     = 'blackberry';
-	const PLATFORM_BLACKBERRY_10  = 'blackberry_10';
-	const PLATFORM_SYMBIAN        = 'symbian_series60';
-	const PLATFORM_SYMBIAN_S40    = 'symbian_series40';
-	const PLATFORM_J2ME_MIDP      = 'j2me_midp';
-	const PLATFORM_ANDROID        = 'android';
-	const PLATFORM_ANDROID_TABLET = 'android_tablet';
-	const PLATFORM_FIREFOX_OS     = 'firefoxOS';
+	private $platform              = null;
+	const PLATFORM_WINDOWS         = 'windows';
+	const PLATFORM_IPHONE          = 'iphone';
+	const PLATFORM_IPOD            = 'ipod';
+	const PLATFORM_IPAD            = 'ipad';
+	const PLATFORM_BLACKBERRY      = 'blackberry';
+	const PLATFORM_BLACKBERRY_10   = 'blackberry_10';
+	const PLATFORM_SYMBIAN         = 'symbian_series60';
+	const PLATFORM_SYMBIAN_S40     = 'symbian_series40';
+	const PLATFORM_J2ME_MIDP       = 'j2me_midp';
+	const PLATFORM_ANDROID         = 'android';
+	const PLATFORM_ANDROID_TABLET  = 'android_tablet';
+	const PLATFORM_FIREFOX_OS      = 'firefoxOS';
+	const PLATFORM_DESKTOP_LINUX   = 'linux';
+	const PLATFORM_DESKTOP_MAC     = 'mac';
+	const PLATFORM_DESKTOP_WINDOWS = 'windows';
+	const PLATFORM_DESKTOP_CHROME  = 'chrome';
+	const BROWSER_CHROME           = 'chrome';
+	const BROWSER_FIREFOX          = 'firefox';
+	const BROWSER_SAFARI           = 'safari';
+	const BROWSER_EDGE             = 'edge';
+	const BROWSER_OPERA            = 'opera';
+	const BROWSER_IE               = 'ie';
+	const OTHER                    = 'other';
 
 	/**
 	 * A list of dumb-phone user agent parts.
@@ -283,17 +294,20 @@ class User_Agent_Info {
 	 * @return string
 	 */
 	public function get_desktop_platform() {
-		$ua       = $this->useragent;
-		$platform = 'other';
+		$ua = $this->useragent;
+		if ( empty( $ua ) ) {
+			return false;
+		}
+		$platform = self::OTHER;
 
-		if ( preg_match( '/linux/i', $ua ) ) {
-			$platform = 'linux';
-		} elseif ( preg_match( '/macintosh|mac os x/i', $ua ) ) {
-			$platform = 'mac';
-		} elseif ( preg_match( '/windows|win32/i', $ua ) ) {
-			$platform = 'windows';
-		} elseif ( preg_match( '/chrome/i', $ua ) ) {
-			$platform = 'chrome';
+		if ( static::is_linux_desktop() ) {
+			$platform = self::PLATFORM_DESKTOP_LINUX;
+		} elseif ( static::is_mac_desktop() ) {
+			$platform = self::PLATFORM_DESKTOP_MAC;
+		} elseif ( static::is_windows_desktop() ) {
+			$platform = self::PLATFORM_DESKTOP_WINDOWS;
+		} elseif ( static::is_chrome_desktop() ) {
+			$platform = self::PLATFORM_DESKTOP_CHROME;
 		}
 		return $platform;
 	}
@@ -306,24 +320,23 @@ class User_Agent_Info {
 	public function get_browser() {
 		$ua = $this->useragent;
 		if ( empty( $ua ) ) {
-			return 'other';
+			return self::OTHER;
 		}
 
-		if ( strpos( $ua, 'Opera' ) || strpos( $ua, 'OPR/' ) ) {
-			return 'opera';
-		} elseif ( strpos( $ua, 'Edge' ) ) {
-			return 'edge';
-		} elseif ( strpos( $ua, 'Chrome' ) ) {
-			return 'chrome';
-		} elseif ( strpos( $ua, 'Safari' ) ) {
-			return 'safari';
-		} elseif ( strpos( $ua, 'Firefox' ) ) {
-			return 'firefox';
-		} elseif ( strpos( $ua, 'MSIE' ) || strpos( $ua, 'Trident/7' ) ) {
-			return 'ie';
+		if ( static::is_opera_mini() || static::is_opera_mobile() || static::is_opera_desktop() || static::is_opera_mini_dumb() ) {
+			return self::BROWSER_OPERA;
+		} elseif ( static::is_edge_browser() ) {
+			return self::BROWSER_EDGE;
+		} elseif ( static::is_chrome_desktop() || self::is_chrome_for_iOS() ) {
+			return self::BROWSER_CHROME;
+		} elseif ( static::is_safari_browser() ) {
+			return self::BROWSER_SAFARI;
+		} elseif ( static::is_firefox_mobile() || static::is_firefox_desktop() ) {
+			return self::BROWSER_FIREFOX;
+		} elseif ( static::is_ie_browser() ) {
+			return self::BROWSER_IE;
 		}
-
-		return 'other';
+		return self::OTHER;
 	}
 
 	/**
@@ -761,6 +774,46 @@ class User_Agent_Info {
 		} else {
 			return false;
 		}
+	}
+
+	/**
+	 * Detect Safari browser
+	 */
+	public static function is_safari_browser() {
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+		if ( false === strpos( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ), 'Safari' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Detect Edge browser
+	 */
+	public static function is_edge_browser() {
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+		if ( false === strpos( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ), 'Edge' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Detect Edge browser
+	 */
+	public static function is_ie_browser() {
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+		$ua = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+		if ( false === ( strpos( $ua, 'MSIE' ) || strpos( $ua, 'Trident/7' ) ) ) {
+			return false;
+		}
+		return true;
 	}
 
 	/**
@@ -1318,6 +1371,66 @@ class User_Agent_Info {
 		}
 		$agent = strtolower( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
 		return ( strpos( $agent, 'bb10' ) !== false ) && ( strpos( $agent, 'mobile' ) !== false );
+	}
+
+	/**
+	 * Determines whether a desktop platform is Linux OS
+	 *
+	 * @return bool
+	 */
+	public static function is_linux_desktop() {
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+		if ( ! preg_match( '/linux/i', wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Determines whether a desktop platform is Mac OS
+	 *
+	 * @return bool
+	 */
+	public static function is_mac_desktop() {
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+		if ( ! preg_match( '/macintosh|mac os x/i', wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Determines whether a desktop platform is Windows OS
+	 *
+	 * @return bool
+	 */
+	public static function is_windows_desktop() {
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+		if ( ! preg_match( '/windows|win32/i', wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Determines whether a desktop platform is Chrome OS
+	 *
+	 * @return bool
+	 */
+	public static function is_chrome_desktop() {
+		if ( empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+		if ( ! preg_match( '/chrome/i', wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- This is validating.
+			return false;
+		}
+		return true;
 	}
 
 	/**

--- a/projects/packages/device-detection/tests/php/test_DeviceDetection.php
+++ b/projects/packages/device-detection/tests/php/test_DeviceDetection.php
@@ -48,6 +48,25 @@ class Test_Device_Detection extends TestCase {
 	}
 
 	/**
+	 * The get_browser tests.
+	 *
+	 * @param string      $ua User agent string.
+	 * @param array       $expected_types Not used.
+	 * @param string|bool $expected_ua_returned Not used.
+	 * @param string      $expected_browser Expected value for browser returned by the method.
+	 * @return void
+	 *
+	 * @dataProvider ua_provider
+	 */
+	public function test_get_browser( string $ua, array $expected_types, string|bool $expected_ua_returned, string $expected_browser ) {
+		$_SERVER['HTTP_USER_AGENT'] = $ua;
+
+		$device_info    = Device_Detection::get_info( $ua );
+		$actual_browser = $device_info['browser'];
+		$this->assertEquals( $expected_browser, $actual_browser );
+	}
+
+	/**
 	 * Data provider for test_is_mobile.
 	 *
 	 * @return array
@@ -63,6 +82,7 @@ class Test_Device_Detection extends TestCase {
 					'is_handheld',
 				),
 				'nokia',
+				'other',
 			),
 
 			// Samsung Galaxy S8 smart phone.
@@ -74,6 +94,7 @@ class Test_Device_Detection extends TestCase {
 					'is_handheld',
 				),
 				'android',
+				'chrome',
 			),
 
 			// iPhone X smart phone.
@@ -85,6 +106,7 @@ class Test_Device_Detection extends TestCase {
 					'is_handheld',
 				),
 				'iphone',
+				'safari',
 			),
 
 			// iPad 2 10.5 tablet.
@@ -95,6 +117,7 @@ class Test_Device_Detection extends TestCase {
 					'is_handheld',
 				),
 				false,
+				'other',
 			),
 
 			// Kindle 3.
@@ -107,6 +130,7 @@ class Test_Device_Detection extends TestCase {
 					'is_handheld',
 				),
 				'android',
+				'safari',
 			),
 
 			// Huawei p20 smartphone.
@@ -118,6 +142,7 @@ class Test_Device_Detection extends TestCase {
 					'is_handheld',
 				),
 				'android',
+				'chrome',
 			),
 
 			// Googlebot smartphone.
@@ -129,6 +154,7 @@ class Test_Device_Detection extends TestCase {
 					'is_handheld',
 				),
 				'android',
+				'chrome',
 			),
 
 			// Googlebot desktop.
@@ -138,6 +164,7 @@ class Test_Device_Detection extends TestCase {
 					'is_desktop',
 				),
 				false,
+				'other',
 			),
 		);
 	}

--- a/projects/packages/device-detection/tests/php/test_DeviceDetection.php
+++ b/projects/packages/device-detection/tests/php/test_DeviceDetection.php
@@ -50,15 +50,15 @@ class Test_Device_Detection extends TestCase {
 	/**
 	 * The get_browser tests.
 	 *
-	 * @param string      $ua User agent string.
-	 * @param array       $expected_types Not used.
-	 * @param string|bool $expected_ua_returned Not used.
-	 * @param string      $expected_browser Expected value for browser returned by the method.
+	 * @param string $ua User agent string.
+	 * @param array  $expected_types Not used.
+	 * @param bool   $expected_ua_returned Not used.
+	 * @param string $expected_browser Expected value for browser returned by the method.
 	 * @return void
 	 *
 	 * @dataProvider ua_provider
 	 */
-	public function test_get_browser( string $ua, array $expected_types, string|bool $expected_ua_returned, string $expected_browser ) {
+	public function test_get_browser( string $ua, array $expected_types, $expected_ua_returned, string $expected_browser ) {
 		$_SERVER['HTTP_USER_AGENT'] = $ua;
 
 		$device_info    = Device_Detection::get_info( $ua );

--- a/projects/packages/device-detection/tests/php/test_DeviceDetection.php
+++ b/projects/packages/device-detection/tests/php/test_DeviceDetection.php
@@ -67,6 +67,23 @@ class Test_Device_Detection extends TestCase {
 	}
 
 	/**
+	 * The get_desktop_platform tests.
+	 *
+	 * @param string $ua User agent string.
+	 * @param string $expected_platform Expected value for platform returned by the method.
+	 * @return void
+	 *
+	 * @dataProvider ua_desktop_provider
+	 */
+	public function test_get_desktop_platform( string $ua, string $expected_platform ) {
+		$_SERVER['HTTP_USER_AGENT'] = $ua;
+
+		$device_info     = Device_Detection::get_info( $ua );
+		$actual_platform = $device_info['desktop_platform'];
+		$this->assertEquals( $expected_platform, $actual_platform );
+	}
+
+	/**
 	 * Data provider for test_is_mobile.
 	 *
 	 * @return array
@@ -165,6 +182,46 @@ class Test_Device_Detection extends TestCase {
 				),
 				false,
 				'other',
+			),
+		);
+	}
+
+	/**
+	 * Data provider for get_desktop_platform.
+	 *
+	 * @return array
+	 */
+	public function ua_desktop_provider() {
+		return array(
+
+			// Windows 10-based PC using Edge browser.
+			array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246',
+				'windows',
+			),
+
+			// Chrome OS-based laptop using Chrome browser (Chromebook)
+			array(
+				'Mozilla/5.0 (X11; CrOS x86_64 8172.45.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.64 Safari/537.36',
+				'chrome',
+			),
+
+			// Mac OS X-based computer using a Safari browser
+			array(
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9',
+				'mac',
+			),
+
+			// Windows 7-based PC using a Chrome browser
+			array(
+				'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36',
+				'windows',
+			),
+
+			// Linux-based PC using a Firefox browser
+			array(
+				'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1',
+				'linux',
 			),
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Additionally to the get_platform method which is for mobile only, we are introducing a get_desktop_platform
* A new method is added which given a user agent returns the browser

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
It's more like extracting information (browser, platform) from data that we were already having (user agent).

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The added functionality is covered by unit tests in this PR. To perform a manual integration test with the rest of WordPress.com, as the bot explains, you can: `bin/jetpack-downloader test jetpack get_browser` which will add this code  to your wpcom branch. From there you can see that 1. the CI tests are fine and 2. the added functionality works as expected.
