### PR TITLE
Untangle: update launchpad links for subscribers to go to Jetpack Cloud for classic Atomic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/untangle-subscribers
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangle-subscribers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Untangle: update launchpad links for subscribers to go to Jetpack Cloud

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -577,6 +577,11 @@ class Launchpad_Task_Lists {
 			return true;
 		}
 
+		// Allow Jetpack Cloud URLs.
+		if ( strpos( $input, 'https://cloud.jetpack.com' ) === 0 ) {
+			return true;
+		}
+
 		// Checks if the string is URL starting with the admin URL.
 		if ( strpos( $input, admin_url() ) === 0 ) {
 			return true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -16,6 +16,17 @@ function wpcom_launchpad_should_use_wp_admin_link() {
 }
 
 /**
+ * Returns whether the task link should point to Jetpack Cloud page
+ * instead of Calypso page.
+ *
+ * @return bool
+ */
+function wpcom_launchpad_should_use_jetpack_cloud_link() {
+	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
+	return $is_atomic_site && get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+}
+
+/**
  * Get the task definitions for the Launchpad.
  *
  * @return array
@@ -218,6 +229,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
+					return 'https://cloud.jetpack.com/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
+				}
 				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
 			},
 		),
@@ -483,6 +497,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'target_repetitions'        => 10,
 			'repetition_count_callback' => 'wpcom_launchpad_get_newsletter_subscriber_count',
 			'get_calypso_path'          => function ( $task, $default, $data ) {
+				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
+					return 'https://cloud.jetpack.com/subscribers/' . $data['site_slug_encoded'];
+				}
 				return '/subscribers/' . $data['site_slug_encoded'];
 			},
 		),
@@ -506,6 +523,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
+					return 'https://cloud.jetpack.com/subscribers/' . $data['site_slug_encoded'];
+				}
 				return '/subscribers/' . $data['site_slug_encoded'];
 			},
 		),
@@ -622,6 +642,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
+					return 'https://cloud.jetpack.com/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
+				}
 				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
 			},
 		),


### PR DESCRIPTION
Part of:

- https://github.com/Automattic/dotcom-forge/issues/6176

This PR updates the following Launchpad task links, depending on the value of Settings -> Hosting Configuration -> Admin interface style as follows:

|Task|Default view|Classic view|
|-|-|-|
|Get your first 10 subscribers<br><br>Manage your subscribers|`/subscribers/:site`|`https://cloud.jetpack.com/subscribers/:site`|
|Add subscribers<br><br>Import existing subscribers|`/subscribers/:site#add-subscribers`|`https://cloud.jetpack.com/subscribers/:site#add-subscribers`|

Note: not using jetpack redirect link because this change is on mu-wpcom, not Jetpack the plugin, so using redirect link is not necessary.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare an Atomic site.
2. Go to Settings -> Hosting Configuration -> admin interface style, and set to Default
3. Update "WordPress.com Features" in Jetpack Beta Tester to point to the branch in this testing-only PR https://github.com/Automattic/jetpack/pull/36016.
4. Go to `wordpress.com/home/:site`.
5. Go to My Home.
6. Verify that you can see ALL launchpad tasks (they are shown for ease of testing).
7. Verify the links in the table above.
8. Change your site's admin interface style to Classic 
9. Verify the links in the table above.

