### PR TITLE
Jetpack Live Branches: Add option for drop-in-cache

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -173,6 +173,13 @@
 									name: 'dev-pool',
 								},
 								{
+									checked: true,
+									label: 'Drop-in Cache Plugins',
+									name: 'cache-drop-in',
+									invert: true,
+									value: 'false',
+								},
+								{
 									label: 'Multisite based on subdirectories',
 									name: 'subdir_multisite',
 								},

--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.35
+// @version      1.36
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      betadownload.jetpack.me


### PR DESCRIPTION
## Proposed changes:
* Allow disabling drop-in-cache to test Boost and SuperCache

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1711385672681639-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- See if you have the option to uncheck "Drop-in Cache Plugins"
- Uncheck and create a JN site using the link
- Go to Boost and activate cache
- The cache module should be able to activate
<img width="758" alt="image" src="https://github.com/Automattic/jetpack/assets/3737780/2f00fe61-ccd8-4ada-877e-7a4f40b1bb88">
