### PR TITLE
Jetpack Sync: Use get error message when handling jetpack sync wpcom rest api enable test error

### DIFF
--- a/projects/packages/sync/changelog/fix-use-get-error-message-when-handling-jetpack_sync_wpcom_rest_api_enable_test-error
+++ b/projects/packages/sync/changelog/fix-use-get-error-message-when-handling-jetpack_sync_wpcom_rest_api_enable_test-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix handling of error message when sync wpcom rest api could not be enabled

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.10.3';
+	const PACKAGE_VERSION = '2.10.4-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/class-settings.php
+++ b/projects/packages/sync/src/class-settings.php
@@ -316,7 +316,7 @@ class Settings {
 					$data = array(
 						'timestamp'     => microtime( true ),
 						'response_code' => $items->get_error_code(),
-						'response_body' => $items->get_error_data() ? trim( $items->get_error_data() ) : '',
+						'response_body' => $items->get_error_message() ?? '',
 					);
 					$sender->send_action( 'jetpack_sync_wpcom_rest_api_enable_error', $data );
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prior PR #36210 introduced a bug when filling the response body when sending the`jetpack_sync_wpcom_rest_api_enable_error` action after a failure when testing the enable of the Sync REST API feature. get_error_data didn't need to be a string and trimming it was causing a Fatal.
* Now we use [get_error_message](https://developer.wordpress.org/reference/classes/wp_error/get_error_message/) to send the error information. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Attempt to enable the REST API feature but modify the response to return an error.
* Without this branch you should be seeing a Fatal like `PHP Fatal error:  Uncaught TypeError: trim(): Argument #1 ($string) must be of type string, array given in /usr/local/src/jetpack-monorepo/projects/packages/sync/src/class-settings.php:319`
* With this branch no fatal should be shown.

