### PR TITLE
SSO: add package skeleton

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2441,6 +2441,8 @@ importers:
         specifier: 4.9.1
         version: 4.9.1(webpack@5.76.0)
 
+  projects/packages/sso: {}
+
   projects/packages/stats-admin: {}
 
   projects/packages/transport-helper: {}

--- a/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
@@ -9,31 +9,29 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredFunction : 100+ occurrences
+    // PhanUndeclaredFunction : 70+ occurrences
     // PhanUndeclaredClassMethod : 60+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 55+ occurrences
     // PhanTypeMismatchArgument : 40+ occurrences
     // PhanTypeArraySuspicious : 30+ occurrences
     // PhanUndeclaredTypeParameter : 15+ occurrences
-    // PhanRedefinedClassReference : 10+ occurrences
     // PhanUndeclaredFunctionInCallable : 10+ occurrences
-    // PhanUndeclaredTypeReturnType : 10+ occurrences
-    // PhanTypeMismatchReturn : 9 occurrences
+    // PhanUndeclaredTypeReturnType : 9 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 8 occurrences
-    // PhanRedefineClass : 8 occurrences
     // PhanUndeclaredClassConstant : 8 occurrences
+    // PhanTypeMismatchReturn : 7 occurrences
     // PhanTypeMismatchReturnProbablyReal : 7 occurrences
-    // PhanUndeclaredConstant : 7 occurrences
-    // PhanNoopNew : 4 occurrences
-    // PhanParamTooMany : 4 occurrences
     // PhanUndeclaredTypeProperty : 4 occurrences
+    // PhanNoopNew : 3 occurrences
     // PhanUndeclaredClassInCallable : 3 occurrences
     // PhanUndeclaredClassReference : 3 occurrences
+    // PhanUndeclaredConstant : 3 occurrences
     // PhanEmptyFQSENInCallable : 2 occurrences
-    // PhanImpossibleTypeComparison : 2 occurrences
+    // PhanParamTooMany : 2 occurrences
     // PhanTypeMismatchArgumentInternal : 2 occurrences
     // PhanTypeMismatchDefault : 2 occurrences
     // PhanTypeMissingReturn : 2 occurrences
+    // PhanImpossibleTypeComparison : 1 occurrence
     // PhanNonClassMethodCall : 1 occurrence
     // PhanNoopArrayAccess : 1 occurrence
     // PhanPluginDuplicateExpressionAssignmentOperation : 1 occurrence

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-sso-package
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-sso-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+yUpdate Phan config

--- a/projects/packages/sso/.gitattributes
+++ b/projects/packages/sso/.gitattributes
@@ -1,0 +1,17 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+.github/          export-ignore
+package.json      export-ignore
+
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+# /src/js/example.min.js  production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# Remember to end all directories with `/**` to properly tag every file.
+.gitignore        production-exclude
+changelog/**      production-exclude
+phpunit.xml.dist  production-exclude
+.phpcs.dir.xml    production-exclude
+tests/**          production-exclude
+.phpcsignore      production-exclude

--- a/projects/packages/sso/.gitignore
+++ b/projects/packages/sso/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/projects/packages/sso/.phan/baseline.php
+++ b/projects/packages/sso/.phan/baseline.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * This is an automatically generated baseline for Phan issues.
+ *
+ * Use `jetpack phan --update-baseline` to update this file.
+ */
+return [
+    // Currently, file_suppressions and directory_suppressions are the only supported suppressions
+    'file_suppressions' => [],
+    // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
+    // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
+];

--- a/projects/packages/sso/.phan/baseline.php
+++ b/projects/packages/sso/.phan/baseline.php
@@ -1,12 +1,17 @@
 <?php
 /**
  * This is an automatically generated baseline for Phan issues.
+ * When Phan is invoked with --load-baseline=path/to/baseline.php,
+ * The pre-existing issues listed in this file won't be emitted.
  *
- * Use `jetpack phan --update-baseline` to update this file.
+ * This file can be updated by invoking Phan with --save-baseline=path/to/baseline.php
+ * (can be combined with --load-baseline)
  */
 return [
+    // This baseline has no suppressions
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
-    'file_suppressions' => [],
+    'file_suppressions' => [
+    ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
 ];

--- a/projects/packages/sso/.phan/config.php
+++ b/projects/packages/sso/.phan/config.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command-line arguments will be applied
+ * after this file is read.
+ *
+ * @package automattic/jetpack-sso
+ */
+
+// Require base config.
+require __DIR__ . '/../../../../.phan/config.base.php';
+
+return make_phan_config( dirname( __DIR__ ) );

--- a/projects/packages/sso/.phpcs.dir.xml
+++ b/projects/packages/sso/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-sso" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-sso" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-sso" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/sso/CHANGELOG.md
+++ b/projects/packages/sso/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+

--- a/projects/packages/sso/README.md
+++ b/projects/packages/sso/README.md
@@ -1,0 +1,24 @@
+# sso
+
+Allow users to log in to this site using WordPress.com accounts
+
+## How to install sso
+
+### Installation From Git Repo
+
+## Contribute
+
+## Get Help
+
+## Using this package in your WordPress plugin
+
+If you plan on using this package in your WordPress plugin, we would recommend that you use [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader. This will allow for maximum interoperability with other plugins that use this package as well.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+sso is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)
+

--- a/projects/packages/sso/changelog/initial-version
+++ b/projects/packages/sso/changelog/initial-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Initial version.

--- a/projects/packages/sso/composer.json
+++ b/projects/packages/sso/composer.json
@@ -1,0 +1,56 @@
+{
+	"name": "automattic/jetpack-sso",
+	"description": "Allow users to log in to this site using WordPress.com accounts",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.0"
+	},
+	"require-dev": {
+		"yoast/phpunit-polyfills": "1.1.0",
+		"automattic/jetpack-changelogger": "@dev"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"build-development": "echo 'Add your build step to composer.json, please!'",
+		"build-production": "echo 'Add your build step to composer.json, please!'",
+		"phpunit": [
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		],
+		"test-php": [
+			"@composer phpunit"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"autotagger": true,
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		},
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-sso/compare/v${old}...v${new}"
+		},
+		"mirror-repo": "Automattic/jetpack-sso",
+		"textdomain": "jetpack-sso",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-sso.php"
+		}
+	},
+	"suggest": {
+		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+	}
+}

--- a/projects/packages/sso/package.json
+++ b/projects/packages/sso/package.json
@@ -1,0 +1,25 @@
+{
+	"private": true,
+	"name": "@automattic/jetpack-sso",
+	"version": "0.1.0-alpha",
+	"description": "Allow users to log in to this site using WordPress.com accounts",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/sso/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[Package] Sso"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/packages/sso"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "echo 'Not implemented.'",
+		"build-js": "echo 'Not implemented.'",
+		"build-production": "echo 'Not implemented.'",
+		"build-production-js": "echo 'Not implemented.'",
+		"clean": "true"
+	},
+	"devDependencies": {}
+}

--- a/projects/packages/sso/phpunit.xml.dist
+++ b/projects/packages/sso/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true" convertDeprecationsToExceptions="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+	<filter>
+		<whitelist processUncoveredFilesFromWhitelist="false">
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/projects/packages/sso/src/class-sso.php
+++ b/projects/packages/sso/src/class-sso.php
@@ -12,5 +12,5 @@ namespace Automattic\Jetpack;
  */
 class Sso {
 
-	const PACKAGE_VERSION = '1.0.0-alpha';
+	const PACKAGE_VERSION = '0.1.0-alpha';
 }

--- a/projects/packages/sso/src/class-sso.php
+++ b/projects/packages/sso/src/class-sso.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Package description here
+ *
+ * @package automattic/jetpack-sso
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Class description.
+ */
+class Sso {
+
+	const PACKAGE_VERSION = '1.0.0-alpha';
+}

--- a/projects/packages/sso/tests/.phpcs.dir.xml
+++ b/projects/packages/sso/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/sso/tests/php/bootstrap.php
+++ b/projects/packages/sso/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';


### PR DESCRIPTION
Fixes https://github.com/Automattic/vulcan/issues/252

## Proposed changes:

Add the necessary skeleton for a new SSO package.

This package can then be used in multiple standalone plugins.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* https://github.com/Automattic/vulcan/issues/251

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to check just yet, this package doesn't do anything yet, and isn't required anywhere.

* Is CI happy?
