### PR TITLE
Dotcom patterns: Show v2 pattern library with all themes

### DIFF
--- a/.phan/stubs/wpcom-functions.php
+++ b/.phan/stubs/wpcom-functions.php
@@ -15,6 +15,7 @@ function wpcom_is_nav_redesign_enabled(): bool {}
 /**
  * Whether the user is an Automattician
  *
+ * @param int|null $user_id The user id.
  * @phan-return bool Returns true if the user is Automattician, false otherwise.
  */
-function is_automattician(): bool {}
+function is_automattician( $user_id = null ): bool {} // phpcs:ignore

--- a/.phan/stubs/wpcom-functions.php
+++ b/.phan/stubs/wpcom-functions.php
@@ -11,3 +11,10 @@
  * @phan-return bool Returns true if the nav redesign is enabled, false otherwise.
  */
 function wpcom_is_nav_redesign_enabled(): bool {}
+
+/**
+ * Whether the user is an Automattician
+ *
+ * @phan-return bool Returns true if the user is Automattician, false otherwise.
+ */
+function is_automattician(): bool {}

--- a/.phan/stubs/wpcom-functions.php
+++ b/.phan/stubs/wpcom-functions.php
@@ -18,4 +18,4 @@ function wpcom_is_nav_redesign_enabled(): bool {}
  * @param int|null $user_id The user id.
  * @phan-return bool Returns true if the user is Automattician, false otherwise.
  */
-function is_automattician( $user_id = null ): bool {} // phpcs:ignore
+function is_automattician( $user_id = null ): bool {} // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable

--- a/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
@@ -38,7 +38,6 @@ return [
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanRedefineFunction : 1 occurrence
     // PhanRedundantCondition : 1 occurrence
-    // PhanRedundantConditionInLoop : 1 occurrence
     // PhanTypeComparisonToArray : 1 occurrence
     // PhanTypeInvalidLeftOperandOfNumericOp : 1 occurrence
     // PhanTypeMismatchDimFetch : 1 occurrence
@@ -56,7 +55,6 @@ return [
         'src/features/100-year-plan/locked-mode.php' => ['PhanEmptyFQSENInCallable', 'PhanUndeclaredClassConstant', 'PhanUndeclaredFunction'],
         'src/features/admin-color-schemes/admin-color-schemes.php' => ['PhanUndeclaredConstant'],
         'src/features/block-patterns/block-patterns.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredTypeParameter'],
-        'src/features/block-patterns/class-wpcom-block-patterns-from-api.php' => ['PhanRedundantConditionInLoop'],
         'src/features/block-patterns/class-wpcom-block-patterns-utils.php' => ['PhanTypeMismatchReturnNullable', 'PhanUndeclaredFunction'],
         'src/features/coming-soon/coming-soon.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable'],
         'src/features/coming-soon/fallback-coming-soon-page.php' => ['PhanTypeMismatchArgument', 'PhanTypeVoidArgument', 'PhanUndeclaredFunction'],

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-use-dotcom-wp-block-patterns
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-use-dotcom-wp-block-patterns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dotcom patterns: use wp_block post type patterns in editor

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-use-dotcom-wp-block-patterns
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-use-dotcom-wp-block-patterns
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Dotcom patterns: use wp_block post type patterns in editor with all themes and remove core and Jetpack form patterns
+Dotcom patterns: use wp_block post type patterns in editor with all themes and hide core and Jetpack form patterns

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-use-dotcom-wp-block-patterns
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-use-dotcom-wp-block-patterns
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Dotcom patterns: use wp_block post type patterns in editor
+Dotcom patterns: use wp_block post type patterns in editor with all themes and remove core and Jetpack form patterns

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -51,7 +51,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.21.x-dev"
+			"dev-trunk": "5.22.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.21.1-alpha",
+	"version": "5.22.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.21.1-alpha';
+	const PACKAGE_VERSION = '5.22.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/block-patterns.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/block-patterns.php
@@ -6,19 +6,24 @@
  */
 
 /**
- * Re-register some core patterns to push them down in the inserter list.
- * The reason is that Dotcom curate the pattern list based on their look.
+ * Hide Jetpack form patterns.
+ * The reason is to show only the Dotcom pattern library.
  */
-function wpcom_reorder_curated_core_patterns() {
-	$pattern_names = array( 'core/social-links-shared-background-color' );
+function wpcom_unregister_jetpack_patterns() {
+	// @TODO: It would be better to add 'source: jetpack' when registering them in https://github.com/Automattic/jetpack/blob/3c4c16b8e9b34c8b6e798839ddf029a5c9a59e77/projects/plugins/jetpack/modules/contact-form.php#L152
+	// and then here just filter them by source rather than by name.
+	$pattern_names = array(
+		'contact-form',
+		'newsletter-form',
+		'rsvp-form',
+		'registration-form',
+		'appointment-form',
+		'feedback-form',
+	);
 	foreach ( $pattern_names as $pattern_name ) {
 		$pattern = \WP_Block_Patterns_Registry::get_instance()->get_registered( $pattern_name );
 		if ( $pattern ) {
 			unregister_block_pattern( $pattern_name );
-			register_block_pattern(
-				$pattern_name,
-				$pattern
-			);
 		}
 	}
 }
@@ -59,7 +64,7 @@ function register_patterns_on_api_request( $register_patterns_func ) {
 
 		$register_patterns_func();
 
-		wpcom_reorder_curated_core_patterns();
+		wpcom_unregister_jetpack_patterns();
 
 		return $response;
 	};
@@ -75,3 +80,13 @@ add_filter(
 	11,
 	2
 );
+
+/**
+ * Hide patterns bundled in core and from the Dotorg pattern directory.
+ * The reason is to show only the Dotcom pattern library.
+ */
+function wpcom_unregister_core_block_patterns() {
+	remove_theme_support( 'core-block-patterns' );
+}
+
+add_action( 'after_setup_theme', 'wpcom_unregister_core_block_patterns' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -169,9 +169,8 @@ class Wpcom_Block_Patterns_From_Api {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
-						'site'         => $override_source_site,
-						'tags'         => 'pattern',
-						'pattern_meta' => 'is_web',
+						'site'      => $override_source_site,
+						'post_type' => 'wp_block',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->utils->get_block_patterns_locale()
 				)
@@ -182,23 +181,12 @@ class Wpcom_Block_Patterns_From_Api {
 
 		$block_patterns = $this->utils->cache_get( $patterns_cache_key, 'ptk_patterns' );
 
-		// Enable testing v2 patterns on sites with Assembler theme active
-		$enable_testing_v2_patterns = in_array( get_stylesheet(), array( 'pub/assembler', 'assembler' ), true );
-
 		// Load fresh data if we don't have any patterns.
-		if ( $enable_testing_v2_patterns || false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
-			if ( $enable_testing_v2_patterns ) {
-				$request_params = array(
-					'site'      => 'dotcompatterns.wordpress.com',
-					'post_type' => 'wp_block',
-				);
-			}
+		if ( false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
 			$request_url = esc_url_raw(
 				add_query_arg(
-					$request_params ?? array(
-						'tags'            => 'pattern',
-						'pattern_meta'    => 'is_web',
-						'patterns_source' => $patterns_source,
+					array(
+						'post_type' => 'wp_block',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->utils->get_block_patterns_locale()
 				)
@@ -206,9 +194,7 @@ class Wpcom_Block_Patterns_From_Api {
 
 			$block_patterns = $this->utils->remote_get( $request_url );
 
-			if ( ! $enable_testing_v2_patterns ) {
-				$this->utils->cache_add( $patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
-			}
+			$this->utils->cache_add( $patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
 		}
 
 		return $block_patterns;

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -84,7 +84,7 @@ class Wpcom_Block_Patterns_From_Api {
 		}
 
 		// Register categories (and re-register existing categories).
-		foreach ( (array) $pattern_categories as $slug => &$category_properties ) {
+		foreach ( $pattern_categories as $slug => &$category_properties ) {
 			// Rename category labels.
 			if ( 'posts' === $slug ) {
 				$category_properties['label'] = __(

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-from-api.php
@@ -17,13 +17,6 @@ class Wpcom_Block_Patterns_From_Api {
 	const PATTERN_NAMESPACE = 'a8c/';
 
 	/**
-	 * Patterns source sites. A array of strings, each of which matches a valid source for retrieving patterns.
-	 *
-	 * @var array
-	 */
-	private $patterns_sources;
-
-	/**
 	 * A collection of utility methods.
 	 *
 	 * @var Wpcom_Block_Patterns_Utils
@@ -36,8 +29,6 @@ class Wpcom_Block_Patterns_From_Api {
 	 * @param Wpcom_Block_Patterns_Utils|null $utils       A class dependency containing utils methods.
 	 */
 	public function __construct( Wpcom_Block_Patterns_Utils $utils = null ) {
-		$this->patterns_sources = array( 'block_patterns' );
-
 		$this->utils = empty( $utils ) ? new Wpcom_Block_Patterns_Utils() : $utils;
 	}
 
@@ -50,92 +41,89 @@ class Wpcom_Block_Patterns_From_Api {
 		// Used to track which patterns we successfully register.
 		$results = array();
 
-		// For every pattern source site, fetch the patterns.
-		foreach ( $this->patterns_sources as $patterns_source ) {
-			$patterns_cache_key = $this->utils->get_patterns_cache_key( $patterns_source );
+		$patterns_cache_key = $this->utils->get_patterns_cache_key();
 
-			$pattern_categories = array();
-			$block_patterns     = $this->get_patterns( $patterns_cache_key, $patterns_source );
+		$pattern_categories = array();
+		$block_patterns     = $this->get_patterns( $patterns_cache_key );
 
-			foreach ( (array) $block_patterns as $pattern ) {
-				foreach ( (array) $pattern['categories'] as $slug => $category ) {
-					// Register categories from first pattern in each category.
-					if ( ! isset( $pattern_categories[ $slug ] ) ) {
-						$pattern_categories[ $slug ] = array(
-							'label'       => $category['title'],
-							'description' => $category['description'],
-						);
-					}
-				}
-			}
-
-			// Unregister existing categories so that we can insert them in the desired order (alphabetically).
-			$existing_categories = array();
-			foreach ( \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered() as $existing_category ) {
-				$existing_categories[ $existing_category['name'] ] = $existing_category;
-				unregister_block_pattern_category( $existing_category['name'] );
-			}
-
-			// Existing categories are registered in Gutenberg or other plugins.
-			// We overwrite them with the categories from Dotcom patterns.
-			$pattern_categories = array_merge( $existing_categories, $pattern_categories );
-
-			// Order categories alphabetically by their label.
-			uasort(
-				$pattern_categories,
-				function ( $a, $b ) {
-					return strnatcasecmp( $a['label'], $b['label'] );
-				}
-			);
-
-			// Move the Featured category to be the first category.
-			if ( isset( $pattern_categories['featured'] ) ) {
-				$featured_category  = $pattern_categories['featured'];
-				$pattern_categories = array( 'featured' => $featured_category ) + $pattern_categories;
-			}
-
-			// Register categories (and re-register existing categories).
-			foreach ( (array) $pattern_categories as $slug => &$category_properties ) {
-				// Rename category labels.
-				if ( 'posts' === $slug ) {
-					$category_properties['label'] = __(
-						'Blog Posts',
-						'jetpack-mu-wpcom'
+		foreach ( (array) $block_patterns as $pattern ) {
+			foreach ( (array) $pattern['categories'] as $slug => $category ) {
+				// Register categories from first pattern in each category.
+				if ( ! isset( $pattern_categories[ $slug ] ) ) {
+					$pattern_categories[ $slug ] = array(
+						'label'       => $category['title'],
+						'description' => $category['description'],
 					);
 				}
-				register_block_pattern_category( $slug, $category_properties );
 			}
+		}
 
-			foreach ( (array) $block_patterns as &$pattern ) {
-				if ( $this->can_register_pattern( $pattern ) ) {
-					$is_premium = isset( $pattern['pattern_meta']['is_premium'] ) ? boolval( $pattern['pattern_meta']['is_premium'] ) : false;
+		// Unregister existing categories so that we can insert them in the desired order (alphabetically).
+		$existing_categories = array();
+		foreach ( \WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered() as $existing_category ) {
+			$existing_categories[ $existing_category['name'] ] = $existing_category;
+			unregister_block_pattern_category( $existing_category['name'] );
+		}
 
-					// Set custom viewport width for the pattern preview with a
-					// default width of 1280 and ensure a safe minimum width of 320.
-					$viewport_width = isset( $pattern['pattern_meta']['viewport_width'] ) ? intval( $pattern['pattern_meta']['viewport_width'] ) : 1280;
-					$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
-					$pattern_name   = self::PATTERN_NAMESPACE . $pattern['name'];
-					$block_types    = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $pattern );
-					if ( empty( $block_types ) ) {
-						// For wp_block patterns because don't use pattern meta for block types.
-						$block_types = $this->utils->get_block_types_from_categories( $pattern );
-					}
+		// Existing categories are registered in Gutenberg or other plugins.
+		// We overwrite them with the categories from Dotcom patterns.
+		$pattern_categories = array_merge( $existing_categories, $pattern_categories );
 
-					$results[ $pattern_name ] = register_block_pattern(
-						$pattern_name,
-						array(
-							'title'         => $pattern['title'],
-							'description'   => $pattern['description'],
-							'content'       => $pattern['html'],
-							'viewportWidth' => $viewport_width,
-							'categories'    => array_keys(
-								$pattern['categories']
-							),
-							'isPremium'     => $is_premium,
-							'blockTypes'    => $block_types,
-						)
-					);
+		// Order categories alphabetically by their label.
+		uasort(
+			$pattern_categories,
+			function ( $a, $b ) {
+				return strnatcasecmp( $a['label'], $b['label'] );
+			}
+		);
+
+		// Move the Featured category to be the first category.
+		if ( isset( $pattern_categories['featured'] ) ) {
+			$featured_category  = $pattern_categories['featured'];
+			$pattern_categories = array( 'featured' => $featured_category ) + $pattern_categories;
+		}
+
+		// Register categories (and re-register existing categories).
+		foreach ( (array) $pattern_categories as $slug => &$category_properties ) {
+			// Rename category labels.
+			if ( 'posts' === $slug ) {
+				$category_properties['label'] = __(
+					'Blog Posts',
+					'jetpack-mu-wpcom'
+				);
+			}
+			register_block_pattern_category( $slug, $category_properties );
+		}
+
+		foreach ( (array) $block_patterns as &$pattern ) {
+			if ( $this->can_register_pattern( $pattern ) ) {
+				$is_premium = isset( $pattern['pattern_meta']['is_premium'] ) ? boolval( $pattern['pattern_meta']['is_premium'] ) : false;
+
+				// Set custom viewport width for the pattern preview with a
+				// default width of 1280 and ensure a safe minimum width of 320.
+				$viewport_width = isset( $pattern['pattern_meta']['viewport_width'] ) ? intval( $pattern['pattern_meta']['viewport_width'] ) : 1280;
+				$viewport_width = $viewport_width < 320 ? 320 : $viewport_width;
+				$pattern_name   = self::PATTERN_NAMESPACE . $pattern['name'];
+				$block_types    = $this->utils->maybe_get_pattern_block_types_from_pattern_meta( $pattern );
+				if ( empty( $block_types ) ) {
+					// For wp_block patterns because don't use pattern meta for block types.
+					$block_types = $this->utils->get_block_types_from_categories( $pattern );
 				}
+
+				$results[ $pattern_name ] = register_block_pattern(
+					$pattern_name,
+					array(
+						'title'         => $pattern['title'],
+						'description'   => $pattern['description'],
+						'content'       => $pattern['html'],
+						'viewportWidth' => $viewport_width,
+						'categories'    => array_keys(
+							$pattern['categories']
+						),
+						'isPremium'     => $is_premium,
+						'blockTypes'    => $block_types,
+					)
+				);
 			}
 		}
 
@@ -156,36 +144,20 @@ class Wpcom_Block_Patterns_From_Api {
 	 * Returns a list of patterns.
 	 *
 	 * @param string $patterns_cache_key Key to store responses to and fetch responses from cache.
-	 * @param string $patterns_source    Slug for valid patterns source site, e.g., `block_patterns`.
-	 * @return array                      The list of translated patterns.
+	 * @return array The list of patterns.
 	 */
-	private function get_patterns( $patterns_cache_key, $patterns_source ) {
+	private function get_patterns( $patterns_cache_key ) {
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
-		if ( $override_source_site ) {
-			// Skip caching and request all patterns from a specified source site.
-			// This allows testing patterns in development with immediate feedback
-			// while avoiding polluting the cache. Note that this request gets
-			// all patterns on the source site, not just those with the 'pattern' tag.
-			$request_url = esc_url_raw(
-				add_query_arg(
-					array(
-						'site'      => $override_source_site,
-						'post_type' => 'wp_block',
-					),
-					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->utils->get_block_patterns_locale()
-				)
-			);
-
-			return $this->utils->remote_get( $request_url );
-		}
 
 		$block_patterns = $this->utils->cache_get( $patterns_cache_key, 'ptk_patterns' );
+		$disable_cache  = ( function_exists( 'is_automattician' ) && is_automattician() ) || $override_source_site || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE );
 
-		// Load fresh data if we don't have any patterns.
-		if ( false === $block_patterns || ( defined( 'WP_DISABLE_PATTERN_CACHE' ) && WP_DISABLE_PATTERN_CACHE ) ) {
+		// Load fresh data if is automattician or we don't have any data.
+		if ( $disable_cache || false === $block_patterns ) {
 			$request_url = esc_url_raw(
 				add_query_arg(
 					array(
+						'site'      => $override_source_site ?? 'dotcompatterns.wordpress.com',
 						'post_type' => 'wp_block',
 					),
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $this->utils->get_block_patterns_locale()
@@ -194,7 +166,10 @@ class Wpcom_Block_Patterns_From_Api {
 
 			$block_patterns = $this->utils->remote_get( $request_url );
 
-			$this->utils->cache_add( $patterns_cache_key, $block_patterns, 'ptk_patterns', DAY_IN_SECONDS );
+			// Only save to cache when is not disabled.
+			if ( ! $disable_cache ) {
+				$this->utils->cache_add( $patterns_cache_key, $block_patterns, 'ptk_patterns', 5 * MINUTE_IN_SECONDS );
+			}
 		}
 
 		return $block_patterns;

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/class-wpcom-block-patterns-utils.php
@@ -5,7 +5,6 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
 
 /**
@@ -59,22 +58,12 @@ class Wpcom_Block_Patterns_Utils {
 	}
 
 	/**
-	 * Returns the sha1 hash of a concatenated string to use as a cache key.
+	 * Returns a cache key per locale.
 	 *
-	 * @param string $patterns_slug A slug for a patterns source site, e.g., `block_patterns`.
 	 * @return string locale slug
 	 */
-	public function get_patterns_cache_key( $patterns_slug ) {
-		return sha1(
-			implode(
-				'_',
-				array(
-					$patterns_slug,
-					Jetpack_Mu_Wpcom::PACKAGE_VERSION,
-					$this->get_block_patterns_locale(),
-				)
-			)
-		);
+	public function get_patterns_cache_key() {
+		return 'wpcom_block_patterns_' . $this->get_block_patterns_locale();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -102,7 +102,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->withConsecutive(
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?post_type=wp_block&patterns_source=block_patterns' )
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?post_type=wp_block' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -87,7 +87,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 
 		$utils_mock->expects( $this->once() )
 			->method( 'cache_add' )
-			->with( $this->stringContains( 'key-largo' ), array( $this->pattern_mock_object ), 'ptk_patterns', DAY_IN_SECONDS );
+			->with( $this->stringContains( 'key-largo' ), array( $this->pattern_mock_object ), 'ptk_patterns', 5 * MINUTE_IN_SECONDS );
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 	}
@@ -136,9 +136,6 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		add_filter( 'a8c_override_patterns_source_site', $example_site );
 		$utils_mock              = $this->createBlockPatternsUtilsMock( array( $this->pattern_mock_object ) );
 		$block_patterns_from_api = new Wpcom_Block_Patterns_From_Api( $utils_mock );
-
-		$utils_mock->expects( $this->never() )
-			->method( 'cache_get' );
 
 		$utils_mock->expects( $this->never() )
 			->method( 'cache_add' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -102,7 +102,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->withConsecutive(
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcompatterns.wordpress.com&post_type=wp_block' )
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?post_type=wp_block' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -102,7 +102,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->withConsecutive(
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?tags=pattern&pattern_meta=is_web&patterns_source=block_patterns' )
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?post_type=wp_block&patterns_source=block_patterns' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
@@ -145,7 +145,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
-			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcom&tags=pattern&pattern_meta=is_web' );
+			->with( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcom&post_type=wp_block' );
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -102,7 +102,7 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 		$utils_mock->expects( $this->once() )
 			->method( 'remote_get' )
 			->withConsecutive(
-				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?post_type=wp_block' )
+				array( 'https://public-api.wordpress.com/rest/v1/ptk/patterns/fr?site=dotcompatterns.wordpress.com&post_type=wp_block' )
 			);
 
 		$this->assertEquals( array( 'a8c/' . $this->pattern_mock_object['name'] => true ), $block_patterns_from_api->register_patterns() );

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-use-dotcom-pattern-library
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-use-dotcom-pattern-library
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_10"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_11_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -129,7 +129,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "ffb0929d64dac5ad55847b4b4ed74469efaea15e"
+                "reference": "0b49970bdde8c3c05388592c86db00b2888f6dd4"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -152,7 +152,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.21.x-dev"
+                    "dev-trunk": "5.22.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.10
+ * Version: 2.1.11-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.10",
+	"version": "2.1.11-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/pull/88985

## Proposed changes:


<!--- Explain what functional changes your PR includes -->
* Show the v2 pattern library in the editor for all themes
* Hide core and Jetpack form patterns


|BEFORE|AFTER|
|-|-|
|<img width="651" alt="Screenshot 2567-01-16 at 17 48 16" src="https://github.com/Automattic/jetpack/assets/1881481/d1d5c261-0134-4fdc-a2e2-b23ee0b6bc58">|<img width="653" alt="Screenshot 2567-03-26 at 18 53 23" src="https://github.com/Automattic/jetpack/assets/1881481/934a1523-f9ea-4946-a801-4f685c2f0bab">|



### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

### Does this pull request change what data or activity we track or use?
No
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**How to test on Atomic**
* Use the Jetpack beta plugin with the branch `fix/use-dotcom-pattern-library` for the plugin "WordPress.com Features" 
* Make sure to add `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` to your `wp-config.php` file.

**How to test on Simple**
* Make sure `wpcom/public_html` repo is updated 
* Sandbox a simple site and the public api
* Apply this patch with `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/use-dotcom-pattern-library`

**Verify the following**
* Make sure you have a theme other than Assembler active on your site
* Access the editor on that site and click the button `[ + ]` on the topbar to explore the patterns from the editor inserter
* Verify you see the same patterns and categories as when you have the Assembler theme active 
* Verify you don't see the "Forms" category (these are Jetpack forms)
<img width="649" alt="Screenshot 2567-03-29 at 00 35 44" src="https://github.com/Automattic/jetpack/assets/1881481/d4ac9994-b61e-4ba3-a7b6-d6cb5d57e20a">

* Verify you don't see these patterns in the "Banners" category (they are from the Dotorg pattern directory)
<img width="651" alt="Screenshot 2567-03-29 at 00 36 01" src="https://github.com/Automattic/jetpack/assets/1881481/edd5a307-7fee-472c-8496-66ae306f0967">

* Verify you cannot find a pattern named "Social links with a shared background color" (this is pattern bundled in core)
<img width="351" alt="Screenshot 2567-03-29 at 00 37 27" src="https://github.com/Automattic/jetpack/assets/1881481/92e1b65d-9d4b-404f-8b95-bfc0bb796e90">


