### PR TITLE
SSO: fix PHP notices and remove unnecessary PHPCS ignores.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
@@ -9,31 +9,29 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredFunction : 100+ occurrences
+    // PhanUndeclaredFunction : 70+ occurrences
     // PhanUndeclaredClassMethod : 60+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 55+ occurrences
     // PhanTypeMismatchArgument : 40+ occurrences
     // PhanTypeArraySuspicious : 30+ occurrences
     // PhanUndeclaredTypeParameter : 15+ occurrences
-    // PhanRedefinedClassReference : 10+ occurrences
     // PhanUndeclaredFunctionInCallable : 10+ occurrences
-    // PhanUndeclaredTypeReturnType : 10+ occurrences
-    // PhanTypeMismatchReturn : 9 occurrences
+    // PhanUndeclaredTypeReturnType : 9 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 8 occurrences
-    // PhanRedefineClass : 8 occurrences
     // PhanUndeclaredClassConstant : 8 occurrences
+    // PhanTypeMismatchReturn : 7 occurrences
     // PhanTypeMismatchReturnProbablyReal : 7 occurrences
-    // PhanUndeclaredConstant : 7 occurrences
-    // PhanNoopNew : 4 occurrences
-    // PhanParamTooMany : 4 occurrences
     // PhanUndeclaredTypeProperty : 4 occurrences
+    // PhanNoopNew : 3 occurrences
     // PhanUndeclaredClassInCallable : 3 occurrences
     // PhanUndeclaredClassReference : 3 occurrences
+    // PhanUndeclaredConstant : 3 occurrences
     // PhanEmptyFQSENInCallable : 2 occurrences
-    // PhanImpossibleTypeComparison : 2 occurrences
+    // PhanParamTooMany : 2 occurrences
     // PhanTypeMismatchArgumentInternal : 2 occurrences
     // PhanTypeMismatchDefault : 2 occurrences
     // PhanTypeMissingReturn : 2 occurrences
+    // PhanImpossibleTypeComparison : 1 occurrence
     // PhanNonClassMethodCall : 1 occurrence
     // PhanNoopArrayAccess : 1 occurrence
     // PhanPluginDuplicateExpressionAssignmentOperation : 1 occurrence

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-sso-errors
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-sso-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update Phan configuration
+
+

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -30,8 +30,8 @@ return [
     // PhanTypeExpectedObjectPropAccess : 50+ occurrences
     // PhanTypeMismatchArgumentInternal : 50+ occurrences
     // PhanUndeclaredClassProperty : 50+ occurrences
-    // PhanUndeclaredProperty : 50+ occurrences
     // PhanParamTooMany : 45+ occurrences
+    // PhanUndeclaredProperty : 45+ occurrences
     // PhanPluginDuplicateAdjacentStatement : 40+ occurrences
     // PhanUndeclaredStaticProperty : 40+ occurrences
     // PhanUndeclaredTypeReturnType : 40+ occurrences
@@ -67,9 +67,9 @@ return [
     // PhanUndeclaredTypeProperty : 10+ occurrences
     // PhanCommentParamWithoutRealParam : 9 occurrences
     // PhanDeprecatedClass : 9 occurrences
-    // PhanNonClassMethodCall : 9 occurrences
     // PhanPluginRedundantAssignment : 8 occurrences
     // PhanUndeclaredClassReference : 8 occurrences
+    // PhanNonClassMethodCall : 7 occurrences
     // PhanRedefineFunction : 7 occurrences
     // PhanTypeArraySuspiciousNull : 7 occurrences
     // PhanTypeMismatchArgumentInternalReal : 7 occurrences
@@ -496,7 +496,7 @@ return [
         'modules/sitemaps/sitemap-librarian.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'modules/sitemaps/sitemap-logger.php' => ['PhanTypeMismatchProperty'],
         'modules/sitemaps/sitemaps.php' => ['PhanNoopNew', 'PhanTypeMismatchArgument'],
-        'modules/sso.php' => ['PhanNonClassMethodCall', 'PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
+        'modules/sso.php' => ['PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'modules/sso/class-jetpack-force-2fa.php' => ['PhanDeprecatedFunction'],
         'modules/sso/class.jetpack-sso-helpers.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
         'modules/sso/class.jetpack-sso-user-admin.php' => ['PhanPluginUnreachableCode', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUnextractableAnnotation'],

--- a/projects/plugins/jetpack/changelog/fix-sso-errors
+++ b/projects/plugins/jetpack/changelog/fix-sso-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SSO: fix PHP notices and remove unnecessary PHPCS ignores.

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -30,6 +30,13 @@ require_once JETPACK__PLUGIN_DIR . 'modules/sso/class.jetpack-sso-user-admin.php
  */
 class Jetpack_SSO {
 	/**
+	 * WordPress.com User information.
+	 *
+	 * @var false|object
+	 */
+	private $user_data;
+
+	/**
 	 * Jetpack_SSO instance.
 	 *
 	 * @var Jetpack_SSO
@@ -701,6 +708,8 @@ class Jetpack_SSO {
 
 	/**
 	 * Retrieves nonce used for SSO form.
+	 *
+	 * @return string|WP_Error
 	 */
 	public static function request_initial_nonce() {
 		$nonce = ! empty( $_COOKIE['jetpack_sso_nonce'] )
@@ -1048,7 +1057,7 @@ class Jetpack_SSO {
 	 * Build WordPress.com SSO URL with appropriate query parameters.
 	 *
 	 * @param array $args Optional query parameters.
-	 * @return string WordPress.com SSO URL
+	 * @return string|WP_Error WordPress.com SSO URL
 	 */
 	public function build_sso_url( $args = array() ) {
 		$sso_nonce = ! empty( $args['sso_nonce'] ) ? $args['sso_nonce'] : self::request_initial_nonce();
@@ -1061,8 +1070,8 @@ class Jetpack_SSO {
 
 		$args = wp_parse_args( $args, $defaults );
 
-		if ( is_wp_error( $args['sso_nonce'] ) ) {
-			return $args['sso_nonce'];
+		if ( is_wp_error( $sso_nonce ) ) {
+			return $sso_nonce;
 		}
 
 		return add_query_arg( $args, 'https://wordpress.com/wp-login.php' );
@@ -1074,7 +1083,7 @@ class Jetpack_SSO {
 	 * on WordPress.com.
 	 *
 	 * @param array $args Optional query parameters.
-	 * @return string WordPress.com SSO URL
+	 * @return string|WP_Error WordPress.com SSO URL
 	 */
 	public function build_reauth_and_sso_url( $args = array() ) {
 		$sso_nonce = ! empty( $args['sso_nonce'] ) ? $args['sso_nonce'] : self::request_initial_nonce();

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -147,7 +147,9 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		 * @todo Remove suppression and function_exists check when we drop support for WP 6.3.
 		 */
 		public function handle_invitation_results() {
-			$valid_nonce = isset( $_GET['_wpnonce'] ) ? wp_verify_nonce( $_GET['_wpnonce'], 'jetpack-sso-invite-user' ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WP core doesn't pre-sanitize nonces either.
+			$valid_nonce = isset( $_GET['_wpnonce'] )
+				? wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'jetpack-sso-invite-user' )
+				: false;
 
 			if ( ! $valid_nonce || ! isset( $_GET['jetpack-sso-invite-user'] ) || ! function_exists( 'wp_admin_notice' ) ) {
 				return;
@@ -763,7 +765,9 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		 */
 		public function render_custom_email_message_form_field( $type ) {
 			if ( $type === 'add-new-user' ) {
-				$valid_nonce          = isset( $_POST['_wpnonce_create-user'] ) ? wp_verify_nonce( $_POST['_wpnonce_create-user'], 'create-user' ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WP core doesn't pre-sanitize nonces either.
+				$valid_nonce          = isset( $_POST['_wpnonce_create-user'] )
+					? wp_verify_nonce( sanitize_key( $_POST['_wpnonce_create-user'] ), 'create-user' )
+					: false;
 				$custom_email_message = ( $valid_nonce && isset( $_POST['custom_email_message'] ) ) ? sanitize_text_field( wp_unslash( $_POST['custom_email_message'] ) ) : '';
 				?>
 			<table class="form-table">

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -580,7 +580,9 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 				);
 			}
 
-			unset( $actions['resetpassword'] );
+			if ( current_user_can( 'promote_users' ) && $has_pending_invite ) {
+				unset( $actions['resetpassword'] );
+			}
 
 			return $actions;
 		}

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -580,7 +580,13 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 				);
 			}
 
-			if ( current_user_can( 'promote_users' ) && $has_pending_invite ) {
+			if (
+				current_user_can( 'promote_users' )
+				&& (
+					$has_pending_invite
+					|| Jetpack::connection()->is_user_connected( $user_id )
+				)
+			) {
 				unset( $actions['resetpassword'] );
 			}
 

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -1027,7 +1027,7 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 				self::rebuild_invite_cache();
 			}
 
-			if ( ! empty( self::$cached_invites ) ) {
+			if ( ! empty( self::$cached_invites ) && is_array( self::$cached_invites ) ) {
 				$index = array_search( $email, array_column( self::$cached_invites, 'email_or_username' ), true );
 				if ( $index !== false ) {
 					return self::$cached_invites[ $index ];

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -27,7 +27,7 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		private static $cached_invites = null;
 
 		/**
-		 * Instance of JetPack Tracking.
+		 * Instance of Jetpack Tracking.
 		 *
 		 * @var $instance
 		 */


### PR DESCRIPTION
## Proposed changes:

This is a small set of changes to the WordPress.com user management interface recently added to the SSO feature. It is mostly small nitpicks I found while working on #36572.

In this PR, we:

- only hide the password reset action when the admin has sent a WordPress.com invite or when the user is already connected to WordPress.com. -> **this is the only interface change that should occur with this PR**.
- add sanitizing for nonces.
- avoid a static analysis error and type errors.
- switch to lowercase P for "Jetpack"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings and enable the SSO feature.
* Go to Users > Add New and create a new user. **do not check the box to invite the user to WordPress.com**
* Go back to the Users screen, and move your mouse hover the new user
    * You should see the option to send a password reset email to that user.
 * Go to Users > Add New and create a new user. Invite that user to WordPress.com.
 * Now in another browser, log in with that user and accept the invite
 * Back to the browser with the connected admin, you should not see a password reset action item when moving your mouse hover that user.

