### PR TITLE
Boost: Fix fatal error due to #36534

### DIFF
--- a/projects/packages/boost-speed-score/changelog/fix-fatal-error
+++ b/projects/packages/boost-speed-score/changelog/fix-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Updated Jetpack_Boost_Modules placeholder class to match Boost interface

--- a/projects/packages/boost-speed-score/src/class-jetpack-boost-modules.php
+++ b/projects/packages/boost-speed-score/src/class-jetpack-boost-modules.php
@@ -37,11 +37,11 @@ class Jetpack_Boost_Modules {
 		return self::$instance;
 	}
 	/**
-	 * Returns status of all active boost modules
+	 * Returns status of all active boost modules that are also ready
 	 *
 	 * @return array - An empty array. The user will never have active modules when using the Boost Score API
 	 */
-	public function get_status() {
+	public function get_ready_active_optimization_modules() {
 		return array();
 	}
 


### PR DESCRIPTION
## Proposed changes:
* Update a placeholder class to fix fatal error in Jetpack

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1711488520473289-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Install Jetpack without Boost
* Check the speed scores
* Make sure it works without any fatal errors