### PR TITLE
Speed Scores: Refactor speed score modules

### DIFF
--- a/projects/packages/boost-speed-score/.phan/baseline.php
+++ b/projects/packages/boost-speed-score/.phan/baseline.php
@@ -10,11 +10,10 @@
 return [
     // # Issue statistics:
     // PhanTypeExpectedObjectPropAccess : 4 occurrences
-    // PhanUndeclaredTypeParameter : 3 occurrences
-    // PhanUndeclaredTypeProperty : 3 occurrences
     // PhanTypeMismatchArgumentNullable : 2 occurrences
     // PhanTypeMismatchProperty : 2 occurrences
-    // PhanUndeclaredClassMethod : 2 occurrences
+    // PhanUndeclaredTypeParameter : 2 occurrences
+    // PhanUndeclaredTypeProperty : 2 occurrences
     // PhanRedefineFunction : 1 occurrence
     // PhanTypeMismatchPropertyDefault : 1 occurrence
     // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
@@ -26,7 +25,7 @@ return [
         'src/class-jetpack-boost-modules.php' => ['PhanTypeMismatchPropertyDefault'],
         'src/class-speed-score-graph-history-request.php' => ['PhanTypeMismatchProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
         'src/class-speed-score-request.php' => ['PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyProbablyReal'],
-        'src/class-speed-score.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
+        'src/class-speed-score.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnNullable'],
         'tests/bootstrap.php' => ['PhanRedefineFunction', 'PhanTypeMismatchReturnProbablyReal'],
         'tests/php/lib/test-class-speed-score-history.php' => ['PhanTypeExpectedObjectPropAccess'],
     ],

--- a/projects/packages/boost-speed-score/changelog/update-refactor-speed-score-modules
+++ b/projects/packages/boost-speed-score/changelog/update-refactor-speed-score-modules
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update Speed Score modules to be an array while keeping things backward compatible.
+
+

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -26,9 +26,9 @@ class Speed_Score {
 	const PACKAGE_VERSION = '0.3.9-alpha';
 
 	/**
-	 * An instance of Automatic\Jetpack_Boost\Modules\Modules_Setup passed to the constructor
+	 * Array of module slugs that are currently active and can impact speed score.
 	 *
-	 * @var Modules_Setup
+	 * @var string[]
 	 */
 	protected $modules;
 
@@ -42,8 +42,8 @@ class Speed_Score {
 	/**
 	 * Constructor.
 	 *
-	 * @param Modules_Setup $modules - An instance of Automatic\Jetpack_Boost\Modules\Modules_Setup.
-	 * @param string        $client  - A string representing the client making the request.
+	 * @param string[] $modules - Array of module slugs that are currently active and can impact speed score.
+	 * @param string   $client  - A string representing the client making the request.
 	 */
 	public function __construct( $modules, $client ) {
 		$this->modules = $modules;
@@ -139,8 +139,7 @@ class Speed_Score {
 		}
 
 		// Create and store the Speed Score request.
-		$active_modules = $this->modules->get_ready_active_optimization_modules();
-		$score_request  = new Speed_Score_Request( $url, $active_modules, null, 'pending', null, $this->client );
+		$score_request = new Speed_Score_Request( $url, $this->modules, null, 'pending', null, $this->client );
 		$score_request->store( 1800 ); // Keep the request for 30 minutes even if no one access the results.
 
 		// Send the request.
@@ -241,7 +240,7 @@ class Speed_Score {
 		if (
 			// If there isn't already a pending request.
 			( empty( $score_request ) || ! $score_request->is_pending() )
-			&& $this->modules->have_enabled_modules()
+			&& ! empty( $this->modules )
 			&& $history->is_stale()
 		) {
 			$score_request = new Speed_Score_Request( $url_no_boost, array(), null, 'pending', null, $this->client ); // Dispatch a new speed score request to measure score without boost.

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -47,9 +47,9 @@ class Speed_Score {
 	 */
 	public function __construct( $modules, $client ) {
 		/*
-		 * Plugins using the old version of the package may pass an object instead of an array.
-		 * Keeping it backward compatible by converting the object to an array.
-		 * We will loose the module slugs in case of an object, but it is better than a fatal error.
+		 * Plugins using the old version of the package may pass an object instead of an array. Converting the
+		 * object to an array keeps it backward compatible. We will lose the module slugs in case of an object,
+		 * but it is better than a fatal error.
 		 */
 		if ( ! is_array( $modules ) ) {
 			$modules = array();

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -46,6 +46,15 @@ class Speed_Score {
 	 * @param string   $client  - A string representing the client making the request.
 	 */
 	public function __construct( $modules, $client ) {
+		/*
+		 * Plugins using the old version of the package may pass an object instead of an array.
+		 * Keeping it backward compatible by converting the object to an array.
+		 * We will loose the module slugs in case of an object, but it is better than a fatal error.
+		 */
+		if ( ! is_array( $modules ) ) {
+			$modules = array();
+		}
+
 		$this->modules = $modules;
 		$this->client  = $client;
 

--- a/projects/packages/my-jetpack/changelog/update-refactor-speed-score-modules
+++ b/projects/packages/my-jetpack/changelog/update-refactor-speed-score-modules
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update Speed Score modules to be an array while keeping things backward compatible.
+
+

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -9,7 +9,6 @@ namespace Automattic\Jetpack\My_Jetpack;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Boost_Speed_Score\Jetpack_Boost_Modules;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score_History;
 use Automattic\Jetpack\Connection\Client;
@@ -87,8 +86,7 @@ class Initializer {
 		}
 
 		// Initialize Boost Speed Score
-		$boost_modules = Jetpack_Boost_Modules::init();
-		new Speed_Score( $boost_modules, 'jetpack-my-jetpack' );
+		new Speed_Score( array(), 'jetpack-my-jetpack' );
 
 		// Add custom WP REST API endoints.
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_endpoints' ) );

--- a/projects/plugins/boost/.phan/baseline.php
+++ b/projects/plugins/boost/.phan/baseline.php
@@ -62,7 +62,7 @@ return [
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'app/admin/class-admin.php' => ['PhanNoopNew', 'PhanTypeMismatchArgument'],
+        'app/admin/class-admin.php' => ['PhanNoopNew'],
         'app/admin/class-config.php' => ['PhanTypeMismatchArgument'],
         'app/data-sync/Minify_Excludes_State_Entry.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'app/data-sync/Performance_History_Entry.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument'],

--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -25,7 +25,7 @@ class Admin {
 		Environment_Change_Detector::init();
 
 		// Initiate speed scores.
-		new Speed_Score( $modules, 'boost-plugin' );
+		new Speed_Score( $modules->get_ready_active_optimization_modules(), 'boost-plugin' );
 
 		add_action( 'init', array( new Analytics(), 'init' ) );
 		add_filter( 'plugin_action_links_' . JETPACK_BOOST_PLUGIN_BASE, array( $this, 'plugin_page_settings_link' ) );

--- a/projects/plugins/boost/changelog/update-refactor-speed-score-modules
+++ b/projects/plugins/boost/changelog/update-refactor-speed-score-modules
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update Speed Score modules to be an array while keeping things backward compatible.
+
+

--- a/projects/plugins/jetpack/changelog/update-refactor-speed-score-modules
+++ b/projects/plugins/jetpack/changelog/update-refactor-speed-score-modules
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update Speed Score modules to be an array while keeping things backward compatible.
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -8,7 +8,6 @@
  */
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Boost_Speed_Score\Jetpack_Boost_Modules;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score;
 use Automattic\Jetpack\Config;
 use Automattic\Jetpack\Connection\Client;
@@ -977,8 +976,7 @@ class Jetpack {
 		My_Jetpack_Initializer::init();
 
 		// Initialize Boost Speed Score
-		$modules = Jetpack_Boost_Modules::init();
-		new Speed_Score( $modules, 'jetpack-dashboard' );
+		new Speed_Score( array(), 'jetpack-dashboard' );
 
 		/**
 		 * Fires when Jetpack is fully loaded and ready. This is the point where it's safe


### PR DESCRIPTION
## Proposed changes:
* Pass an array of active modules instead of the whole Modules_Setup object.
* Keep it backward compatible.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1711488520473289-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test stable Boost, trunk Jetpack and vice versa and make sure speed scores work in Jetpack, My Jetpack and Boost correctly