### PR TITLE
Jetpack Sync: Prevent Fatal on send upon failing to enable WPCOM REST API feature

### DIFF
--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -22,7 +22,7 @@ return [
     // PhanUndeclaredTypeParameter : 10+ occurrences
     // PhanUndeclaredTypeReturnType : 10+ occurrences
     // PhanPluginSimplifyExpressionBool : 9 occurrences
-    // PhanPossiblyUndeclaredVariable : 9 occurrences
+    // PhanPossiblyUndeclaredVariable : 8 occurrences
     // PhanUndeclaredTypeProperty : 7 occurrences
     // PhanPluginDuplicateSwitchCaseLooseEquality : 6 occurrences
     // PhanUndeclaredMethod : 6 occurrences
@@ -59,7 +59,7 @@ return [
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-actions.php' => ['PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeProperty'],
+        'src/class-actions.php' => ['PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeProperty'],
         'src/class-data-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-dedicated-sender.php' => ['PhanTypeInvalidLeftOperandOfNumericOp'],
         'src/class-functions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],

--- a/projects/packages/sync/changelog/fix-sync-fatal-in-send-errors
+++ b/projects/packages/sync/changelog/fix-sync-fatal-in-send-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+ Jetpack Sync: Prevent Fatal on send upon failing to enable WPCOM REST API feature

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -542,13 +542,14 @@ class Actions {
 				$error_log = array_slice( $error_log, -4, null, true );
 			}
 			// Add new error indexed to time.
-			if ( Settings::is_wpcom_rest_api_enabled() ) {
-				$error_log[ (string) microtime( true ) ] = $error;
-			} else {
+			if ( isset( $rpc ) && ! empty( $rpc->get_last_response() ) ) {
 				$error_with_last_response = clone $error;
 				$error_with_last_response->add_data( $rpc->get_last_response() );
 				$error_log[ (string) microtime( true ) ] = $error_with_last_response;
+			} else {
+				$error_log[ (string) microtime( true ) ] = $error;
 			}
+
 			// Update the error log.
 			update_option( self::ERROR_LOG_PREFIX . $queue_id, $error_log );
 			return $error;
@@ -562,7 +563,7 @@ class Actions {
 			);
 		}
 
-		if ( Settings::is_wpcom_rest_api_enabled() ) { // Return only processed items.
+		if ( isset( $response['processed_items'] ) ) { // Return only processed items.
 			$response = $response['processed_items'];
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This diff fixes the following Fatal: `PHP Fatal error:  Uncaught Error: Call to a member function get_last_response() on null in [READACTED]/jetpack-sync/src/class-actions.php:549`

The above Fatal is related to a race condition, where the WPCOM REST API feature flag is set before sending (aka `Settings::is_wpcom_rest_api_enabled()` returns `true`) but updated to false afterwards. 

Fixes https://github.com/Automattic/vulcan/issues/256

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Actions:send_data`: Rely on the presence of `$rpc` when attaching additional data to the `WP_Error` instead of checking `Settings::is_wpcom_rest_api_enabled()`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
The easiest way to reproduce this would be to tweak your local env by adding `Settings::update_settings['wpcom_rest_api_enabled' => 0]` in https://github.com/Automattic/jetpack/pull/36600/files#diff-7c4317563f9a428b0e605463ec694aa08c5e623f7756b81e294057e62f22532dR528
 