### PR TITLE
Subscriber login block: allow hiding manage link and show only login/logout

### DIFF
--- a/projects/plugins/jetpack/changelog/update-login-block-no-manage-link
+++ b/projects/plugins/jetpack/changelog/update-login-block-no-manage-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Member login block: add ability to hide manage subscription -link.

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/block.json
@@ -42,7 +42,7 @@
 		"logOutLabel": {
 			"type": "string"
 		},
-		"showLinkToManageSubscriptions": {
+		"showManageSubscriptionsLink": {
 			"type": "boolean",
 			"default": true
 		},

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/block.json
@@ -42,6 +42,10 @@
 		"logOutLabel": {
 			"type": "string"
 		},
+		"showLinkToManageSubscriptions": {
+			"type": "boolean",
+			"default": true
+		},
 		"manageSubscriptionsLabel": {
 			"type": "string"
 		}

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
@@ -44,7 +44,7 @@ function SubscriberLoginEdit( { attributes, setAttributes, className } ) {
 						/>
 					</BaseControl>
 					<ToggleControl
-						label={ __( 'Show manage subscription link', 'jetpack' ) }
+						label={ __( 'Show "Manage subscription" link', 'jetpack' ) }
 						checked={ showManageSubscriptionsLink }
 						onChange={ () =>
 							setAttributes( { showManageSubscriptionsLink: ! showManageSubscriptionsLink } )

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
@@ -14,7 +14,7 @@ function SubscriberLoginEdit( { attributes, setAttributes, className } ) {
 		redirectToCurrent,
 		logInLabel,
 		logOutLabel,
-		showLinkToManageSubscriptions,
+		showManageSubscriptionsLink,
 		manageSubscriptionsLabel,
 	} = validatedAttributes;
 
@@ -45,16 +45,16 @@ function SubscriberLoginEdit( { attributes, setAttributes, className } ) {
 					</BaseControl>
 					<ToggleControl
 						label={ __( 'Manage subscription link', 'jetpack' ) }
-						checked={ showLinkToManageSubscriptions }
+						checked={ showManageSubscriptionsLink }
 						onChange={ () =>
-							setAttributes( { showLinkToManageSubscriptions: ! showLinkToManageSubscriptions } )
+							setAttributes( { showManageSubscriptionsLink: ! showManageSubscriptionsLink } )
 						}
 					/>
-					{ showLinkToManageSubscriptions && (
-					<BaseControl
-						label={ __( 'Manage subscription label', 'jetpack' ) }
-						id={ manageSubscriptionsInputId }
-					>
+					{ showManageSubscriptionsLink && (
+						<BaseControl
+							label={ __( 'Manage subscription label', 'jetpack' ) }
+							id={ manageSubscriptionsInputId }
+						>
 							<TextControl
 								placeholder={ __( 'Manage subscription', 'jetpack' ) }
 								onChange={ value => setAttributes( { manageSubscriptionsLabel: value } ) }

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
@@ -10,8 +10,13 @@ function SubscriberLoginEdit( { attributes, setAttributes, className } ) {
 	const logOutInputId = useInstanceId( TextControl, 'inspector-text-control' );
 	const manageSubscriptionsInputId = useInstanceId( TextControl, 'inspector-text-control' );
 	const validatedAttributes = getValidatedAttributes( metadata.attributes, attributes );
-	const { redirectToCurrent, logInLabel, logOutLabel, manageSubscriptionsLabel } =
-		validatedAttributes;
+	const {
+		redirectToCurrent,
+		logInLabel,
+		logOutLabel,
+		showLinkToManageSubscriptions,
+		manageSubscriptionsLabel,
+	} = validatedAttributes;
 
 	return (
 		<>
@@ -38,17 +43,26 @@ function SubscriberLoginEdit( { attributes, setAttributes, className } ) {
 							id={ logOutInputId }
 						/>
 					</BaseControl>
-					<BaseControl
-						label={ __( 'Manage subscriptions label', 'jetpack' ) }
-						id={ manageSubscriptionsInputId }
-					>
-						<TextControl
-							placeholder={ __( 'Manage subscriptions', 'jetpack' ) }
-							onChange={ value => setAttributes( { manageSubscriptionsLabel: value } ) }
-							value={ manageSubscriptionsLabel }
+					<ToggleControl
+						label={ __( 'Manage subscriptions link', 'jetpack' ) }
+						checked={ showLinkToManageSubscriptions }
+						onChange={ () =>
+							setAttributes( { showLinkToManageSubscriptions: ! showLinkToManageSubscriptions } )
+						}
+					/>
+					{ showLinkToManageSubscriptions && (
+						<BaseControl
+							label={ __( 'Manage subscriptions label', 'jetpack' ) }
 							id={ manageSubscriptionsInputId }
-						/>
-					</BaseControl>
+						>
+							<TextControl
+								placeholder={ __( 'Manage subscriptions', 'jetpack' ) }
+								onChange={ value => setAttributes( { manageSubscriptionsLabel: value } ) }
+								value={ manageSubscriptionsLabel }
+								id={ manageSubscriptionsInputId }
+							/>
+						</BaseControl>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<div className={ className }>

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
@@ -44,7 +44,7 @@ function SubscriberLoginEdit( { attributes, setAttributes, className } ) {
 						/>
 					</BaseControl>
 					<ToggleControl
-						label={ __( 'Manage subscription link', 'jetpack' ) }
+						label={ __( 'Show manage subscription link', 'jetpack' ) }
 						checked={ showManageSubscriptionsLink }
 						onChange={ () =>
 							setAttributes( { showManageSubscriptionsLink: ! showManageSubscriptionsLink } )

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -102,6 +102,7 @@ function render_block( $attributes ) {
 	$redirect_url               = ! empty( $attributes['redirectToCurrent'] ) ? get_current_url() : get_site_url();
 	$log_in_label               = ! empty( $attributes['logInLabel'] ) ? sanitize_text_field( $attributes['logInLabel'] ) : esc_html__( 'Log in', 'jetpack' );
 	$log_out_label              = ! empty( $attributes['logOutLabel'] ) ? sanitize_text_field( $attributes['logOutLabel'] ) : esc_html__( 'Log out', 'jetpack' );
+	$show_manage_link           = ! empty( $attributes['showLinkToManageSubscriptions'] );
 	$manage_subscriptions_label = ! empty( $attributes['manageSubscriptionsLabel'] ) ? sanitize_text_field( $attributes['manageSubscriptionsLabel'] ) : esc_html__( 'Manage subscription', 'jetpack' );
 
 	if ( ! is_subscriber_logged_in() ) {
@@ -113,7 +114,7 @@ function render_block( $attributes ) {
 		);
 	}
 
-	if ( Jetpack_Memberships::is_current_user_subscribed() ) {
+	if ( $show_manage_link && Jetpack_Memberships::is_current_user_subscribed() ) {
 		return sprintf(
 			$block_template,
 			get_block_wrapper_attributes(),

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -102,7 +102,7 @@ function render_block( $attributes ) {
 	$redirect_url               = ! empty( $attributes['redirectToCurrent'] ) ? get_current_url() : get_site_url();
 	$log_in_label               = ! empty( $attributes['logInLabel'] ) ? sanitize_text_field( $attributes['logInLabel'] ) : esc_html__( 'Log in', 'jetpack' );
 	$log_out_label              = ! empty( $attributes['logOutLabel'] ) ? sanitize_text_field( $attributes['logOutLabel'] ) : esc_html__( 'Log out', 'jetpack' );
-	$show_manage_link           = ! empty( $attributes['showLinkToManageSubscriptions'] );
+	$show_manage_link           = ! empty( $attributes['showManageSubscriptionsLink'] );
 	$manage_subscriptions_label = ! empty( $attributes['manageSubscriptionsLabel'] ) ? sanitize_text_field( $attributes['manageSubscriptionsLabel'] ) : esc_html__( 'Manage subscription', 'jetpack' );
 
 	if ( ! is_subscriber_logged_in() ) {


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/34884

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds the ability to hide the "manage subscription" link, exposing only login/logout links to subscribers.

Publishers sometimes want to create more complex layouts with separate manage/login links visible at the same time.

Publishers also want to focus on login/logout aspects at their site, and leave "manage" links just to subscription emails.

Allowing only "login/logout" links will be useful for combining the block later when we want to use the login button for the paid content block (https://github.com/Automattic/jetpack/pull/35441#issuecomment-1952390591).

## Proposed changes:

- Adds toggle to hide manage link; enabled by default. Disabling also hides the manage label -input.

<img width="288" alt="Screenshot 2024-03-27 at 20 52 47" src="https://github.com/Automattic/jetpack/assets/87168/f25bdb7b-032f-4b8e-951a-5641aae50228">
<img width="291" alt="Screenshot 2024-03-27 at 20 52 53" src="https://github.com/Automattic/jetpack/assets/87168/3408bae3-4486-43bc-835d-b090d0c00d91">


At the site:

<img width="474" alt="Screenshot 2024-03-27 at 10 35 31" src="https://github.com/Automattic/jetpack/assets/87168/59a6f497-d80f-4b86-89b1-18949631236e">

Because default attribute value is set to "true" = no attribute becomes truthy = no need to add block deprecation to handle previously inserted blocks. The toggle value gets saved in attributes when it's false.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In editor, add member login block and see settings. Publish the page and see the page as logged out and logged in subscriber.