### PR TITLE
Subscription login block: switch to singular "manage subscription"

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscription-manage-label
+++ b/projects/plugins/jetpack/changelog/fix-subscription-manage-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscription login block: switch to singular "manage subscription"

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
@@ -43,7 +43,7 @@ function SubscriberLoginEdit( { attributes, setAttributes, className } ) {
 						id={ manageSubscriptionsInputId }
 					>
 						<TextControl
-							placeholder={ __( 'Manage subscriptions', 'jetpack' ) }
+							placeholder={ __( 'Manage subscription', 'jetpack' ) }
 							onChange={ value => setAttributes( { manageSubscriptionsLabel: value } ) }
 							value={ manageSubscriptionsLabel }
 							id={ manageSubscriptionsInputId }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up https://github.com/Automattic/jetpack/pull/36602#issuecomment-2022340972

## Proposed changes:

Switch the default label in the editor to singular form, as it's already in PHP:

https://github.com/Automattic/jetpack/blob/fd507a5154a1531785b416efeea45dd147078d21/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php#L105

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Editor and frontend default label matches for logged in subscriber

