### PR TITLE
Backport mu-wpcom-plugin 2.1.10, jetpack 13.3-a.9 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36539, #36585]
+
 ## [0.10.0] - 2024-03-18
 ### Added
 - Add image generator hook [#36415]
@@ -259,6 +263,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.10.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.8.2...v0.9.0
 [0.8.2]: https://github.com/Automattic/jetpack-ai-client/compare/v0.8.1...v0.8.2

--- a/projects/js-packages/ai-client/changelog/renovate-major-storybook-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.10.1-alpha",
+	"version": "0.10.1",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.17.3] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [0.17.2] - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36325]
@@ -310,6 +314,7 @@
 - Add the API methods left behind by the previous PR.
 - Initial release of jetpack-api package
 
+[0.17.3]: https://github.com/Automattic/jetpack-api/compare/v0.17.2...v0.17.3
 [0.17.2]: https://github.com/Automattic/jetpack-api/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Automattic/jetpack-api/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/Automattic/jetpack-api/compare/v0.16.10...v0.17.0

--- a/projects/js-packages/api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.17.3-alpha",
+	"version": "0.17.3",
 	"description": "Jetpack Api Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.20] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [0.6.19] - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36325]
@@ -258,6 +262,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.20]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.19...0.6.20
 [0.6.19]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.18...0.6.19
 [0.6.18]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.17...0.6.18
 [0.6.17]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.16...0.6.17

--- a/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.20-alpha",
+	"version": "0.6.20",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.27] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [0.1.26] - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36325]
@@ -119,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.27]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.26...v0.1.27
 [0.1.26]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.25...v0.1.26
 [0.1.25]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.24...v0.1.25
 [0.1.24]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.23...v0.1.24

--- a/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.27-alpha",
+	"version": "0.1.27",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.50.4] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36539, #36585]
+
 ## [0.50.3] - 2024-03-25
 ### Added
 - Annotations: Make it possible to interact with them [#36453]
@@ -987,6 +991,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.50.4]: https://github.com/Automattic/jetpack-components/compare/0.50.3...0.50.4
 [0.50.3]: https://github.com/Automattic/jetpack-components/compare/0.50.2...0.50.3
 [0.50.2]: https://github.com/Automattic/jetpack-components/compare/0.50.1...0.50.2
 [0.50.1]: https://github.com/Automattic/jetpack-components/compare/0.50.0...0.50.1

--- a/projects/js-packages/components/changelog/renovate-major-storybook-monorepo
+++ b/projects/js-packages/components/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.50.4-alpha",
+	"version": "0.50.4",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.33.5] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36539, #36585]
+
+### Fixed
+- Fixes some pricing showing twice by connecting sites that select a free option [#36533]
+
 ## [0.33.4] - 2024-03-25
 ### Fixed
 - Fix some redirect after purchase behavior when site is not connected [#36448]
@@ -734,6 +741,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.33.5]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.4...v0.33.5
 [0.33.4]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.3...v0.33.4
 [0.33.3]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.2...v0.33.3
 [0.33.2]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.1...v0.33.2

--- a/projects/js-packages/connection/changelog/fix-boost-pricing-shows-twice
+++ b/projects/js-packages/connection/changelog/fix-boost-pricing-shows-twice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixes some pricing showing twice by connecting sites that select a free option

--- a/projects/js-packages/connection/changelog/renovate-major-storybook-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.33.5-alpha",
+	"version": "0.33.5",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.48] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [2.0.47] - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36325]
@@ -217,6 +221,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.48]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.47...v2.0.48
 [2.0.47]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.46...v2.0.47
 [2.0.46]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.45...v2.0.46
 [2.0.45]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.44...v2.0.45

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.48-alpha",
+	"version": "2.0.48",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.67 - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## 0.10.66 - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36325]

--- a/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.67-alpha",
+	"version": "0.10.67",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.8 - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## 0.12.7 - 2024-03-18
 ### Fixed
 - Fixed how we check if a plugin is active [#35420]

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.12.8-alpha",
+	"version": "0.12.8",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.73 - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## 0.2.72 - 2024-03-12
 ### Changed
 - Update dependencies. [#36243]

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.73-alpha",
+	"version": "0.2.73",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.5] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [0.48.4] - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36325]
@@ -620,6 +624,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.48.5]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.48.4...v0.48.5
 [0.48.4]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.48.3...v0.48.4
 [0.48.3]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.48.2...v0.48.3
 [0.48.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.48.1...v0.48.2

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.48.5-alpha",
+	"version": "0.48.5",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.8] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [0.14.7] - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36325]
@@ -360,6 +364,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.14.8]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.7...0.14.8
 [0.14.7]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.6...0.14.7
 [0.14.6]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.5...0.14.6
 [0.14.5]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.4...0.14.5

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.14.8-alpha",
+	"version": "0.14.8",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.2.3 - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## 3.2.2 - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36325]

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.2.3-alpha",
+	"version": "3.2.3",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.6] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [2.1.5] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -423,6 +427,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[2.1.6]: https://github.com/Automattic/jetpack-assets/compare/v2.1.5...v2.1.6
 [2.1.5]: https://github.com/Automattic/jetpack-assets/compare/v2.1.4...v2.1.5
 [2.1.4]: https://github.com/Automattic/jetpack-assets/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/Automattic/jetpack-assets/compare/v2.1.2...v2.1.3

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.4] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [3.3.3] - 2024-03-25
 ### Fixed
 - Backup: change some error messages to not trigger security scanners [#36496]
@@ -589,6 +593,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.3.4]: https://github.com/Automattic/jetpack-backup/compare/v3.3.3...v3.3.4
 [3.3.3]: https://github.com/Automattic/jetpack-backup/compare/v3.3.2...v3.3.3
 [3.3.2]: https://github.com/Automattic/jetpack-backup/compare/v3.3.1...v3.3.2
 [3.3.1]: https://github.com/Automattic/jetpack-backup/compare/v3.3.0...v3.3.1

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.3.4-alpha';
+	const PACKAGE_VERSION = '3.3.4';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2024-03-27
+### Added
+- Adds the atomic flag to the Jetpack Blaze base site's configuration [#36562]
+
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [0.19.3] - 2024-03-25
 ### Changed
 - Internal updates.
@@ -327,6 +334,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.20.0]: https://github.com/automattic/jetpack-blaze/compare/v0.19.3...v0.20.0
 [0.19.3]: https://github.com/automattic/jetpack-blaze/compare/v0.19.2...v0.19.3
 [0.19.2]: https://github.com/automattic/jetpack-blaze/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/automattic/jetpack-blaze/compare/v0.19.0...v0.19.1

--- a/projects/packages/blaze/changelog/add-blaze-site-atomic-flag
+++ b/projects/packages/blaze/changelog/add-blaze-site-atomic-flag
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Adds the atomic flag to the Jetpack Blaze base site's configuration

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.20.0-alpha",
+	"version": "0.20.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.20.0-alpha';
+	const PACKAGE_VERSION = '0.20.0';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/boost-speed-score/CHANGELOG.md
+++ b/projects/packages/boost-speed-score/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.9] - 2024-03-27
+### Added
+- Use `jetpack_boost_critical_css_environment_changed` hook instead of `handle_environment_change` [#36519]
+
+### Changed
+- Speed Score: More accurately detect which modules are active when a speed score is requested. [#36534]
+
+### Fixed
+- Updated Jetpack_Boost_Modules placeholder class to match Boost interface [#36598]
+
 ## [0.3.8] - 2024-03-25
 ### Changed
 - Internal updates.
@@ -66,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new package for Boost Speed Score [#30914]
 - Add a new argument to `Speed_Score` to identify where the request was made from (e.g. 'boost-plugin', 'jetpack-dashboard', etc). [#31012]
 
+[0.3.9]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.8...v0.3.9
 [0.3.8]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/Automattic/jetpack-boost-speed-score/compare/v0.3.5...v0.3.6

--- a/projects/packages/boost-speed-score/changelog/add-module-active-status
+++ b/projects/packages/boost-speed-score/changelog/add-module-active-status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Speed Score: More accurately detect which modules are active when a speed score is requested.

--- a/projects/packages/boost-speed-score/changelog/fix-fatal-error
+++ b/projects/packages/boost-speed-score/changelog/fix-fatal-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Updated Jetpack_Boost_Modules placeholder class to match Boost interface

--- a/projects/packages/boost-speed-score/changelog/update-hook
+++ b/projects/packages/boost-speed-score/changelog/update-hook
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Use `jetpack_boost_critical_css_environment_changed` hook instead of `handle_environment_change`

--- a/projects/packages/boost-speed-score/changelog/update-refactor-speed-score-modules
+++ b/projects/packages/boost-speed-score/changelog/update-refactor-speed-score-modules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update Speed Score modules to be an array while keeping things backward compatible.
-
-

--- a/projects/packages/boost-speed-score/src/class-speed-score.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score.php
@@ -23,7 +23,7 @@ if ( ! defined( 'JETPACK_BOOST_REST_PREFIX' ) ) {
  */
 class Speed_Score {
 
-	const PACKAGE_VERSION = '0.3.9-alpha';
+	const PACKAGE_VERSION = '0.3.9';
 
 	/**
 	 * Array of module slugs that are currently active and can impact speed score.
@@ -64,7 +64,7 @@ class Speed_Score {
 		/**
 		 * Mark the speed score history as stale when the environment changes.
 		 *
-		 * @since $$next-version$$ - This hook replaced `handle_environment_change` action.
+		 * @since 0.3.9 - This hook replaced `handle_environment_change` action.
 		 */
 		add_action( 'jetpack_boost_critical_css_environment_changed', array( Speed_Score_History::class, 'mark_stale' ) );
 		/**

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2024-03-27
+### Added
+- Add 'test_connection' endpoint to check for blog token validity. [#36471]
+- Add the 'get_heartbeat_data' REST endpoint. [#36553]
+
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [2.6.2] - 2024-03-25
 ### Changed
 - Internal updates.
@@ -1004,6 +1012,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.7.0]: https://github.com/Automattic/jetpack-connection/compare/v2.6.2...v2.7.0
 [2.6.2]: https://github.com/Automattic/jetpack-connection/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/Automattic/jetpack-connection/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/Automattic/jetpack-connection/compare/v2.5.0...v2.6.0

--- a/projects/packages/connection/changelog/add-get-heartbeat-data-rest-endpoint
+++ b/projects/packages/connection/changelog/add-get-heartbeat-data-rest-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the 'get_heartbeat_data' REST endpoint.

--- a/projects/packages/connection/changelog/add-test-connection-rest-endpoint
+++ b/projects/packages/connection/changelog/add-test-connection-rest-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add 'test_connection' endpoint to check for blog token validity.

--- a/projects/packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/src/class-heartbeat.php
+++ b/projects/packages/connection/src/class-heartbeat.php
@@ -285,7 +285,7 @@ class Heartbeat {
 	 *
 	 * @param WP_REST_Request $request The request data.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.7.0
 	 *
 	 * @return array
 	 */

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.7.0-alpha';
+	const PACKAGE_VERSION = '2.7.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -991,7 +991,7 @@ class REST_Connector {
 	/**
 	 * The endpoint verifies blog connection and blog token validity.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.7.0
 	 *
 	 * @return mixed|null
 	 */

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.13] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
+### Fixed
+- Enable undoing adding a contact form [#36485]
+
 ## [0.30.12] - 2024-03-25
 ### Changed
 - Made some Contact_Form methods publicly available [#36137]
@@ -523,6 +530,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.30.13]: https://github.com/automattic/jetpack-forms/compare/v0.30.12...v0.30.13
 [0.30.12]: https://github.com/automattic/jetpack-forms/compare/v0.30.11...v0.30.12
 [0.30.11]: https://github.com/automattic/jetpack-forms/compare/v0.30.10...v0.30.11
 [0.30.10]: https://github.com/automattic/jetpack-forms/compare/v0.30.9...v0.30.10

--- a/projects/packages/forms/changelog/fix-contact-form-block-undo
+++ b/projects/packages/forms/changelog/fix-contact-form-block-undo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Enable undoing adding a contact form

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.13-alpha",
+	"version": "0.30.13",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.13-alpha';
+	const PACKAGE_VERSION = '0.30.13';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.6] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [0.17.5] - 2024-03-25
 ### Changed
 - Internal updates.
@@ -511,6 +515,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.17.6]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.5...v0.17.6
 [0.17.5]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.4...v0.17.5
 [0.17.4]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.3...v0.17.4
 [0.17.3]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.2...v0.17.3

--- a/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.17.6-alpha",
+	"version": "0.17.6",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -26,7 +26,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.17.6-alpha';
+	const PACKAGE_VERSION = '0.17.6';
 
 	/**
 	 * Persistent WPCOM blog ID that stays in the options after disconnect.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.21.0] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+- Updated Verbum Highlander Comment form prompt value [#36505]
+
+### Fixed
+- Untangle: update launchpad links for subscribers to go to Jetpack Cloud [#36573]
+
 ## [5.20.0] - 2024-03-25
 ### Removed
 - Removed Subscribers from Hosting menu [#36513]
@@ -679,6 +687,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.21.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.20.0...v5.21.0
 [5.20.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.19.0...v5.20.0
 [5.19.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.18.0...v5.19.0
 [5.18.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.17.0...v5.18.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-sso-errors
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-sso-errors
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan configuration
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jetpack-mu-wpcom/changelog/untangle-subscribers
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangle-subscribers
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Untangle: update launchpad links for subscribers to go to Jetpack Cloud

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-phan-baseline
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-phan-baseline
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-site-settings-endpoint-verbum-settings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-site-settings-endpoint-verbum-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated Verbum Highlander Comment form prompt value

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.21.0-alpha",
+	"version": "5.21.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.21.0-alpha';
+	const PACKAGE_VERSION = '5.21.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.3] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [3.1.2] - 2024-03-25
 ### Changed
 - Update Phan baselines [#36441]
@@ -687,6 +691,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.1.3]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.2...v3.1.3
 [3.1.2]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.1...v3.1.2
 [3.1.1]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/Automattic/jetpack-jitm/compare/v3.0.5...v3.1.0

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.1.3-alpha';
+	const PACKAGE_VERSION = '3.1.3';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.19.0] - 2024-03-27
+### Added
+- Add red bubble to notices tied to red bubble notifications [#36543]
+- My Jetpack: add a version of WordPress' Notice component to My Jetpack considering the context of how we use notices on that screen [#36551]
+
+### Changed
+- Updated package dependencies. [#36539, #36585]
+
+### Fixed
+- Fixed Jetpack Creator going to the wrong screen when the free version is selected" [#36547]
+- Fixes some pricing showing twice by connecting sites that select a free option [#36533]
+
 ## [4.18.0] - 2024-03-25
 ### Added
 - Hook into red bubble notification when bad installation is detected [#36449]
@@ -1379,6 +1391,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.19.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.18.0...4.19.0
 [4.18.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.17.1...4.18.0
 [4.17.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.17.0...4.17.1
 [4.17.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.16.0...4.17.0

--- a/projects/packages/my-jetpack/changelog/add-notice-component-to-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-notice-component-to-my-jetpack
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-My Jetpack: add a version of WordPress' Notice component to My Jetpack considering the context of how we use notices on that screen

--- a/projects/packages/my-jetpack/changelog/fix-boost-pricing-shows-twice
+++ b/projects/packages/my-jetpack/changelog/fix-boost-pricing-shows-twice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixes some pricing showing twice by connecting sites that select a free option

--- a/projects/packages/my-jetpack/changelog/fix-creator-goes-to-blank-page-after-jetpack-install
+++ b/projects/packages/my-jetpack/changelog/fix-creator-goes-to-blank-page-after-jetpack-install
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed Jetpack Creator going to the wrong screen when the free version is selected"

--- a/projects/packages/my-jetpack/changelog/renovate-major-storybook-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-notices-visually-link-red-bubble
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-notices-visually-link-red-bubble
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add red bubble to notices tied to red bubble notifications

--- a/projects/packages/my-jetpack/changelog/update-refactor-speed-score-modules
+++ b/projects/packages/my-jetpack/changelog/update-refactor-speed-score-modules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update Speed Score modules to be an array while keeping things backward compatible.
-
-

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.19.0-alpha",
+	"version": "4.19.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -36,7 +36,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.19.0-alpha';
+	const PACKAGE_VERSION = '4.19.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.8] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [0.42.7] - 2024-03-25
 ### Changed
 - Internal updates.
@@ -506,6 +510,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.42.8]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.7...v0.42.8
 [0.42.7]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.6...v0.42.7
 [0.42.6]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.5...v0.42.6
 [0.42.5]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.4...v0.42.5

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.8-alpha",
+	"version": "0.42.8",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2024-03-27
+### Changed
+- Internal updates.
+
 ## [0.5.1] - 2024-03-22
 ### Fixed
 - Fixed a bug where the weekday index was not properly accounted for in list of weekdays. [#36524]
@@ -86,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.5.2]: https://github.com/Automattic/scheduled-updates/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Automattic/scheduled-updates/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Automattic/scheduled-updates/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/Automattic/scheduled-updates/compare/v0.4.0...v0.4.1

--- a/projects/packages/scheduled-updates/changelog/update-phan-baseline
+++ b/projects/packages/scheduled-updates/changelog/update-phan-baseline
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.5.2-alpha';
+	const PACKAGE_VERSION = '0.5.2';
 	/**
 	 * The cron event hook for the scheduled plugins update.
 	 *

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.43.8] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [0.43.7] - 2024-03-25
 ### Changed
 - Internal updates.
@@ -921,6 +925,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.43.8]: https://github.com/Automattic/jetpack-search/compare/v0.43.7...v0.43.8
 [0.43.7]: https://github.com/Automattic/jetpack-search/compare/v0.43.6...v0.43.7
 [0.43.6]: https://github.com/Automattic/jetpack-search/compare/v0.43.5...v0.43.6
 [0.43.5]: https://github.com/Automattic/jetpack-search/compare/v0.43.4...v0.43.5

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.43.8-alpha",
+	"version": "0.43.8",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.43.8-alpha';
+	const VERSION = '0.43.8';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.4] - 2024-03-27
+### Fixed
+- Fix handling of error message when sync wpcom rest api could not be enabled [#36578]
+- Jetpack Sync: Prevent Fatal on send upon failing to enable WPCOM REST API feature [#36600]
+
 ## [2.10.3] - 2024-03-25
 ### Changed
 - Internal updates.
@@ -1080,6 +1085,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.10.4]: https://github.com/Automattic/jetpack-sync/compare/v2.10.3...v2.10.4
 [2.10.3]: https://github.com/Automattic/jetpack-sync/compare/v2.10.2...v2.10.3
 [2.10.2]: https://github.com/Automattic/jetpack-sync/compare/v2.10.1...v2.10.2
 [2.10.1]: https://github.com/Automattic/jetpack-sync/compare/v2.10.0...v2.10.1

--- a/projects/packages/sync/changelog/fix-sync-fatal-in-send-errors
+++ b/projects/packages/sync/changelog/fix-sync-fatal-in-send-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
- Jetpack Sync: Prevent Fatal on send upon failing to enable WPCOM REST API feature

--- a/projects/packages/sync/changelog/fix-use-get-error-message-when-handling-jetpack_sync_wpcom_rest_api_enable_test-error
+++ b/projects/packages/sync/changelog/fix-use-get-error-message-when-handling-jetpack_sync_wpcom_rest_api_enable_test-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix handling of error message when sync wpcom rest api could not be enabled

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.10.4-alpha';
+	const PACKAGE_VERSION = '2.10.4';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.12] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36539, #36585]
+
 ## [0.23.11] - 2024-03-25
 ### Changed
 - Internal updates.
@@ -1298,6 +1302,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.12]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.11...v0.23.12
 [0.23.11]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.10...v0.23.11
 [0.23.10]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.9...v0.23.10
 [0.23.9]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.8...v0.23.9

--- a/projects/packages/videopress/changelog/renovate-major-storybook-monorepo
+++ b/projects/packages/videopress/changelog/renovate-major-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.12-alpha",
+	"version": "0.23.12",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.12-alpha';
+	const PACKAGE_VERSION = '0.23.12';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.13] - 2024-03-27
+### Changed
+- Updated package dependencies. [#36585]
+
 ## [0.3.12] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -326,6 +330,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.13]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.12...v0.3.13
 [0.3.12]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.11...v0.3.12
 [0.3.11]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.10...v0.3.11
 [0.3.10]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.9...v0.3.10

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.13-alpha",
+	"version": "0.3.13",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.13-alpha';
+	const VERSION = '0.3.13';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.3-a.9 - 2024-03-27
+### Bug fixes
+- Disable WPCOM invitation functionality for non-connected users. [#36572]
+- Fix paid content block subscriber view content not rendering in WordPress.com reader. [#36512]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add a function to clear the static cache for Jetpack_Memberships. [#36545]
+- Add instructions to test the new AI interstitial and product page [#36566]
+- Add Verbum options to site settings endpoint [#36505]
+- AI Assistant: remove "Experimental" label on block name [#36535]
+- AI Assistant: store function typo fix Aync -> Async [#36544]
+- AI Proofread: improve upgrade prompt format and translation according to current tier [#36542]
+- Fixed Jetpack Creator going to the wrong screen when the free version is selected [#36547]
+- Map Block: Fix styling in Row and Stack layout [#36447]
+- SSO: add filter allowing one to disable the WordPress.com invite interface. [#36572]
+- SSO: fix PHP notices and remove unnecessary PHPCS ignores. [#36589]
+- Updated package dependencies. [#36585]
+
 ## 13.3-a.7 - 2024-03-25
 ### Enhancements
 - Blocks: "Earn" category renamed to "Monetize". [#36480]

--- a/projects/plugins/jetpack/changelog/add-blaze-site-atomic-flag
+++ b/projects/plugins/jetpack/changelog/add-blaze-site-atomic-flag
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-get-heartbeat-data-rest-endpoint
+++ b/projects/plugins/jetpack/changelog/add-get-heartbeat-data-rest-endpoint
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-module-active-status
+++ b/projects/plugins/jetpack/changelog/add-module-active-status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-

--- a/projects/plugins/jetpack/changelog/add-static-cache-clearing-function-for-jetpack-memberships
+++ b/projects/plugins/jetpack/changelog/add-static-cache-clearing-function-for-jetpack-memberships
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add a function to clear the static cache for Jetpack_Memberships.

--- a/projects/plugins/jetpack/changelog/add-test-connection-rest-endpoint
+++ b/projects/plugins/jetpack/changelog/add-test-connection-rest-endpoint
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Hook into the `jetpack_rest_test_connection_response` filter to provide Jetpack version.
-
-

--- a/projects/plugins/jetpack/changelog/add-test-instructions-for-release
+++ b/projects/plugins/jetpack/changelog/add-test-instructions-for-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add instructions to test the new AI interstitial and product page

--- a/projects/plugins/jetpack/changelog/fix-access-check-for-paid-content-block-in-reader
+++ b/projects/plugins/jetpack/changelog/fix-access-check-for-paid-content-block-in-reader
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix paid content block subscriber view content not rendering in WordPress.com reader.

--- a/projects/plugins/jetpack/changelog/fix-ai-proofread-pre-publish-upgrade-prompt
+++ b/projects/plugins/jetpack/changelog/fix-ai-proofread-pre-publish-upgrade-prompt
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Proofread: improve upgrade prompt format and translation according to current tier

--- a/projects/plugins/jetpack/changelog/fix-aync-typo-fix
+++ b/projects/plugins/jetpack/changelog/fix-aync-typo-fix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: store function typo fix Aync -> Async

--- a/projects/plugins/jetpack/changelog/fix-creator-goes-to-blank-page-after-jetpack-install
+++ b/projects/plugins/jetpack/changelog/fix-creator-goes-to-blank-page-after-jetpack-install
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixed Jetpack Creator going to the wrong screen when the free version is selected

--- a/projects/plugins/jetpack/changelog/fix-invite-to-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-invite-to-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Disable WPCOM invitation functionality for non-connected users. 

--- a/projects/plugins/jetpack/changelog/fix-map-block-stack-row
+++ b/projects/plugins/jetpack/changelog/fix-map-block-stack-row
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Map Block: Fix styling in Row and Stack layout

--- a/projects/plugins/jetpack/changelog/fix-sso-errors
+++ b/projects/plugins/jetpack/changelog/fix-sso-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-SSO: fix PHP notices and remove unnecessary PHPCS ignores.

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.3-a.10
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.3-a.8
-
-

--- a/projects/plugins/jetpack/changelog/remove-ai-assistant-experimental-label
+++ b/projects/plugins/jetpack/changelog/remove-ai-assistant-experimental-label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: remove "Experimental" label on block name

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/update-move-notice-to-my-jetpack
+++ b/projects/plugins/jetpack/changelog/update-move-notice-to-my-jetpack
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-refactor-speed-score-modules
+++ b/projects/plugins/jetpack/changelog/update-refactor-speed-score-modules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update Speed Score modules to be an array while keeping things backward compatible.
-
-

--- a/projects/plugins/jetpack/changelog/update-site-settings-endpoint-verbum-settings
+++ b/projects/plugins/jetpack/changelog/update-site-settings-endpoint-verbum-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add Verbum options to site settings endpoint

--- a/projects/plugins/jetpack/changelog/update-sso-invite-logic-filter
+++ b/projects/plugins/jetpack/changelog/update-sso-invite-logic-filter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-SSO: add filter allowing one to disable the WordPress.com invite interface.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_9",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_10",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_8",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_9",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.3-a.8
+ * Version: 13.3-a.9
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.3-a.8' );
+define( 'JETPACK__VERSION', '13.3-a.9' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.3-a.9
+ * Version: 13.3-a.10
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.3-a.9' );
+define( 'JETPACK__VERSION', '13.3-a.10' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -102,7 +102,7 @@ class Jetpack_SSO {
 			 *
 			 * @module sso
 			 *
-			 * @since $$next-version$$
+			 * @since 13.3
 			 *
 			 * @param bool true Whether to allow admins to invite new users to create a WordPress.com account.
 			 */

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-helpers.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-helpers.php
@@ -432,7 +432,7 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		/**
 		 * Check if a local user is already connected to WordPress.com.
 		 *
-		 * @since $$next-version$$
+		 * @since 13.3
 		 *
 		 * @param int $user_id Local User information.
 		 */

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.3.0-a.9",
+	"version": "13.3.0-a.10",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.3.0-a.8",
+	"version": "13.3.0-a.9",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -325,21 +325,10 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.3-a.7 - 2024-03-25
-#### Enhancements
-- Blocks: "Earn" category renamed to "Monetize".
-- Jetpack AI: When the response includes a title and post title is empty, use provided title as post title.
-- My Jetpack: Trigger red bubble notification when a broken installation is detected.
-- Newsletters: Reorder settings cards to improve hierarchy.
-- Newsletters: Use radio buttons instead of toggles on Email Settings.
-- Sharing: Remove Like button from master bar.
-
-#### Improved compatibility
-- General: Remove methods that were deprecated before the release of Jetpack 10.0, in 2021.
-
+### 13.3-a.9 - 2024-03-27
 #### Bug fixes
-- Dashboard: Update the sharing button settings to clarify the available options (block or legacy sharing buttons).
-- Enhanced Distribution: begin deprecation process as the Firehose is winding down.
+- Disable WPCOM invitation functionality for non-connected users.
+- Fix paid content block subscriber view content not rendering in WordPress.com reader.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.10 - 2024-03-27
+### Changed
+- Internal updates.
+
 ## 2.1.9 - 2024-03-25
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-site-settings-endpoint-verbum-settings
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-site-settings-endpoint-verbum-settings
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_10_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_10"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.10-alpha
+ * Version: 2.1.10
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.10-alpha",
+	"version": "2.1.10",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.10, jetpack 13.3-a.9

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.