### PR TITLE
Blog Stats Block: Fix next-version

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blog-stats-version
+++ b/projects/plugins/jetpack/changelog/fix-blog-stats-version
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: fix release version number listed in the Blog Stats block.

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
@@ -2,7 +2,7 @@
 /**
  * Blog Stats Block.
  *
- * @since $$next_version$$
+ * @since 13.0
  *
  * @package automattic/jetpack
  */


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Tiny change I noticed when checking something in the Blog Stats block. I meant to use `$$next-version$$`, but used `$$next_version$$` by mistake. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

Just check the code - it was the same cycle as the Top Posts block release, which was 13.0. 

https://github.com/Automattic/jetpack/blob/3b4da5c78110324926b427717c852bb7c2e1dcb8/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php#L5

