### PR TITLE
Fix/my jetpack logo spacing

### DIFF
--- a/projects/js-packages/components/changelog/fix-my-jetpack-logo-spacing
+++ b/projects/js-packages/components/changelog/fix-my-jetpack-logo-spacing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Style bug
+
+

--- a/projects/js-packages/components/components/admin-section/hero/style.module.scss
+++ b/projects/js-packages/components/components/admin-section/hero/style.module.scss
@@ -1,3 +1,4 @@
 .section-hero {
+	padding-top: 1px; // prevent margin collapse for interior sections
 	background: var( --jp-white-off );
 }

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.50.4",
+	"version": "0.50.5-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes a small style bug when the welcome banner shows on My Jetpack

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Without this PR, when the welcome banner is active, there is too much whitespace below the Jetpack logo in the header on My Jetpack
![Screenshot 2024-03-27 at 9 04 20 AM](https://github.com/Automattic/jetpack/assets/18016357/6d0c53ce-8662-4fcb-be3a-07e8f983d884)

* Fixed with the PR:
![Screenshot 2024-03-27 at 9 04 29 AM](https://github.com/Automattic/jetpack/assets/18016357/136501fe-dc36-4486-ad09-d98894bd1ae0)


