### PR TITLE
Add red bubble slugs to page view track in My Jetpack

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -127,7 +127,7 @@ export default function MyJetpackScreen() {
 
 	useEffect( () => {
 		recordEvent( 'jetpack_myjetpack_page_view', {
-			red_bubble_alerts: Object.keys( redBubbleAlerts ),
+			red_bubble_alerts: Object.keys( redBubbleAlerts ).join( ',' ),
 		} );
 	}, [ recordEvent, redBubbleAlerts ] );
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -97,6 +97,7 @@ const GlobalNotice = ( { message, options } ) => {
  */
 export default function MyJetpackScreen() {
 	useNotificationWatcher();
+	const { redBubbleAlerts } = getMyJetpackWindowInitialState();
 	const { showFullJetpackStatsCard = false } = getMyJetpackWindowInitialState( 'myJetpackFlags' );
 	const { jetpackManage = {}, adminUrl } = getMyJetpackWindowInitialState();
 
@@ -125,8 +126,10 @@ export default function MyJetpackScreen() {
 	const [ reloading, setReloading ] = useState( false );
 
 	useEffect( () => {
-		recordEvent( 'jetpack_myjetpack_page_view' );
-	}, [ recordEvent ] );
+		recordEvent( 'jetpack_myjetpack_page_view', {
+			red_bubble_alerts: Object.keys( redBubbleAlerts ),
+		} );
+	}, [ recordEvent, redBubbleAlerts ] );
 
 	if ( window.location.hash.includes( '?reload=true' ) ) {
 		// Clears the query string and reloads the page.

--- a/projects/packages/my-jetpack/changelog/add-red-bubble-slugs-to-page-view-track
+++ b/projects/packages/my-jetpack/changelog/add-red-bubble-slugs-to-page-view-track
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Track active red bubble slugs on My Jetpack page view


### PR DESCRIPTION
## Proposed changes:

* Add array of red bubble slugs to the My Jetpack page view track

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

Yes, we are tracking the red bubble slugs active when the user views My Jetpack

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Make sure your site is disconnected
3. Go to `/wp-admin/admin.php?page=my-jetpack`
4. In tracks Vigilante, make sure the red bubble slug is in the data
![image](https://github.com/Automattic/jetpack/assets/65001528/78a7067e-e7b3-45de-92fb-e6e40a7fd824)


