### PR TITLE
Projects: remove editor-extensions folder

### DIFF
--- a/.github/files/lint-project-structure.sh
+++ b/.github/files/lint-project-structure.sh
@@ -22,7 +22,6 @@ for F in README.md .gitkeep .gitignore; do
 done
 
 declare -A PROJECT_PREFIXES=(
-	['editor-extensions']='Block'
 	['github-actions']='Action'
 	['packages']='Package'
 	['plugins']='Plugin'

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -20,12 +20,11 @@ Welcome to the Jetpack Monorepo! This document will give you some idea of the la
 
 ## Layout
 
-Projects are divided into WordPress plugins, Composer packages, JS packages, and Gutenberg editor extensions.
+Projects are divided into WordPress plugins, Composer packages, JS packages, and GitHub Actions.
 
 * WordPress plugins live in subdirectories of `projects/plugins/`. The directory name should probably match the WordPress plugin name, with a leading "jetpack-" removed if applicable.
 * Composer packages live in subdirectories of `projects/packages/`. The directory name should probably match the package name with the leading "Automattic/jetpack-" removed.
 * JS packages live in subdirectories of `projects/js-packages/`. The directory name should probably match the package name with the leading "Automattic/jetpack-" removed.
-* Editor extensions live in subdirectories of `projects/editor-extensions/`. The directory name should match the feature name (without a "jetpack/" prefix).
 * GitHub Actions live in subdirectories of `projects/github-actions/`. The directory name should match the action name with the leading "Automattic/action-" removed.
 
 Tooling that's applicable to the monorepo as a whole, including tooling for generically handling projects, lives in `tools/`.

--- a/projects/github-actions/repo-gardening/changelog/fix-garage-remove_unused_editor_extensions_folder
+++ b/projects/github-actions/repo-gardening/changelog/fix-garage-remove_unused_editor_extensions_folder
@@ -1,0 +1,5 @@
+Significance: patch
+Type: deprecated
+Comment: Editor Extensions: Removed unused folder and references.
+
+

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -76,7 +76,6 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 		const project = file.match( /^projects\/(?<ptype>[^/]*)\/(?<pname>[^/]*)\// );
 		if ( project && project.groups.ptype && project.groups.pname ) {
 			const prefix = {
-				'editor-extensions': 'Block',
 				'github-actions': 'Action',
 				packages: 'Package',
 				plugins: 'Plugin',

--- a/tools/cli/helpers/projectHelpers.js
+++ b/tools/cli/helpers/projectHelpers.js
@@ -8,7 +8,6 @@ export const dirs = ( source, prefix = '' ) =>
 		.map( dirent => prefix + dirent.name );
 
 export const projectTypes = [ 'github-actions', 'js-packages', 'packages', 'plugins' ];
-// export const projectTypes = [ 'editor-extensions', 'js-packages', 'packages', 'plugins' ], // Swap out line above once there's editor-extensions in place.
 
 /**
  * Returns an array of all projects.

--- a/tools/cli/tests/unit/helpers/projectHelpers.test.js
+++ b/tools/cli/tests/unit/helpers/projectHelpers.test.js
@@ -23,7 +23,7 @@ describe( 'projectHelpers', () => {
 	} );
 	test( 'dirs should output number of subfolders for the given path', () => {
 		// The repo-root projects dir.
-		expect( dirs( 'projects' ) ).toHaveLength( 5 );
+		expect( dirs( 'projects' ) ).toHaveLength( 4 );
 	} );
 	test( 'dirs should output a subfolder of given path', () => {
 		expect( dirs( 'projects/plugins' ) ).toContain( 'jetpack' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

While working through docs, I ran across the `/projects/editor-extensions` folder, which was empty. Given this was for a yet-unimplemented initiative (p1711550814672179-slack-C05Q5HSS013), I propose we remove it.

This PR simply removes the folder and the few code and doc references to it.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Make sure the folder is removed, the removed references are correct, and there aren't any missed references.