### PR TITLE
E2E: Support for custom tunnel URL

### DIFF
--- a/tools/e2e-commons/README.md
+++ b/tools/e2e-commons/README.md
@@ -71,6 +71,8 @@ If you're an a11n you can find the key in the secret store and set it in the `CO
 To bypass the offline mode you will need your site to have a publicly accessible url that will proxy all requests to your locally running WordPress installation.
 We use `localtunnel` library to expose `localhost:8889` via a public url.
 
+You can pass `TUNNEL_URL` environment variable to override the tunnel url. This is useful when running e2e tests locally and have already established a custom tunnel to `localhost:8889` manually.
+
 ```shell
 ## Decrypt default config file
 CONFIG_KEY=secret_key pnpm config:decrypt


### PR DESCRIPTION
## Proposed changes:
- Allow passing a custom tunnel URL through the `TUNNEL_URL` environment variable
- Updated README to include instructions about using the `TUNNEL_URL` environment variable
- Refactored `tunnelChild` function to support custom tunnel URL and abstracted `saveTunnelUrlToFile` function

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
pc9hqz-2IT-p2

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Setup a custom tunnel to `localhost:8889` (via something like ngrok or your own localtunnel instance`
- Set the `TUNNEL_URL` environment variable to a custom tunnel URL
- Run the e2e tests locally
- Verify that the custom tunnel URL is used instead of the default localtunnel