### PR TITLE
Subscriptions: Fix Subscribe block invalid content

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-block-invalid-content
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-invalid-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Fix Subscribe block invalid content

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -124,7 +124,7 @@ class Jetpack_Subscription_Site {
 	<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" style="margin-bottom:24px"/>
 	<!-- /wp:separator -->
 
-	<!-- wp:heading {"textAlign":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"4px","bottom":"10px"}}}} -->
+	<!-- wp:heading {"textAlign":"center","level":3,"style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"4px","bottom":"10px"}}}} -->
 	<h3 class="wp-block-heading has-text-align-center" style="margin-top:4px;margin-bottom:10px">$discover_more_from_text</h3>
 	<!-- /wp:heading -->
 
@@ -201,7 +201,7 @@ HTML
 	<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" style="margin-bottom:36px"/>
 	<!-- /wp:separator -->
 
-	<!-- wp:heading {"textAlign":"center","style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"4px","bottom":"10px"}}}} -->
+	<!-- wp:heading {"textAlign":"center","level":3,"style":{"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"4px","bottom":"10px"}}}} -->
 	<h3 class="wp-block-heading has-text-align-center" style="margin-top:4px;margin-bottom:10px">$discover_more_from_text</h3>
 	<!-- /wp:heading -->
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/issues/36616

## Proposed changes:

It fixes the "This block contains unexpected or invalid content." error for the Subscribe block by adding the correct heading level.

### Before

<img width="679" alt="Screenshot 2024-03-27 at 18 37 47" src="https://github.com/Automattic/jetpack/assets/4068554/dd6121f6-17c5-4a89-bbda-758d47aa8ced">

### After

<img width="679" alt="Screenshot 2024-03-27 at 18 37 17" src="https://github.com/Automattic/jetpack/assets/4068554/dfa48345-6d4b-49c9-a9be-4dd22a46e326">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Newsletter settings
* Click the "Preview and edit" link next to the "Add the Subscribe Block at the end of each post" toggle
* Make sure the block is rendered correctly without any errors

