### PR TITLE
Recipe Block: make default texts translatable

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-recipe-block-not-translatable-text
+++ b/projects/plugins/jetpack/changelog/fix-recipe-block-not-translatable-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Recipe Block: make default texts translatable

--- a/projects/plugins/jetpack/extensions/blocks/recipe/details/attributes.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/details/attributes.js
@@ -1,3 +1,5 @@
+import { __ } from '@wordpress/i18n';
+
 export default {
 	prepTime: {
 		type: 'string',
@@ -9,7 +11,8 @@ export default {
 	},
 	prepTimeLabel: {
 		type: 'string',
-		default: 'Prep Time',
+		// translators: Prep Time label for a recipe block.
+		default: __( 'Prep Time', 'jetpack' ),
 	},
 	cookTime: {
 		type: 'string',
@@ -21,7 +24,8 @@ export default {
 	},
 	cookTimeLabel: {
 		type: 'string',
-		default: 'Cook Time',
+		// translators: Cook Time label for a recipe block.
+		default: __( 'Cook Time', 'jetpack' ),
 	},
 	servings: {
 		type: 'number',
@@ -29,6 +33,7 @@ export default {
 	},
 	servingsLabel: {
 		type: 'string',
-		default: 'Servings',
+		// translators: Servings label for a recipe block.
+		default: __( 'Servings', 'jetpack' ),
 	},
 };

--- a/projects/plugins/jetpack/extensions/blocks/recipe/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/recipe/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 function RecipeEdit( { className } ) {
 	const RECIPE_TEMPLATE = [
@@ -10,7 +11,7 @@ function RecipeEdit( { className } ) {
 			'core/heading',
 			{
 				level: 2,
-				placeholder: 'Recipe Title',
+				placeholder: __( 'Recipe Title', 'jetpack' ),
 				className: 'wp-block-jetpack-recipe-title',
 			},
 		],
@@ -25,7 +26,7 @@ function RecipeEdit( { className } ) {
 		[
 			'core/paragraph',
 			{
-				placeholder: 'Recipe Description',
+				placeholder: __( 'Recipe Description', 'jetpack' ),
 				className: 'wp-block-jetpack-recipe-description',
 			},
 		],
@@ -44,7 +45,8 @@ function RecipeEdit( { className } ) {
 							'core/heading',
 							{
 								level: 3,
-								content: 'Ingredients',
+								// translators: Ingredients heading for a recipe block.
+								content: __( 'Ingredients', 'jetpack' ),
 							},
 						],
 						[ 'jetpack/recipe-ingredients-list' ],
@@ -60,7 +62,8 @@ function RecipeEdit( { className } ) {
 							'core/heading',
 							{
 								level: 3,
-								content: 'Instructions',
+								// translators: Instructions heading for a recipe block.
+								content: __( 'Instructions', 'jetpack' ),
 							},
 						],
 						[ 'jetpack/recipe-steps' ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Some default texts in the _Recipe_ block are hardcoded and not translatable. This PR fixes it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-Aw-p2
Part of this issue: https://github.com/Automattic/vulcan/issues/244

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

A code review should be enough. If you want to go the extra mile, verify that the _Recipe_ block works like before.