### PR TITLE
AI Assistant: remove dead code on the use suggestion hook

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-ai-assistant-hook-dead-code
+++ b/projects/plugins/jetpack/changelog/remove-ai-assistant-hook-dead-code
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Assistant: remove dead code from the suggestions hook

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-suggestions-from-openai/index.js
@@ -4,7 +4,7 @@
 import { askQuestion } from '@automattic/jetpack-ai-client';
 import { parse } from '@wordpress/blocks';
 import { useSelect, useDispatch, dispatch } from '@wordpress/data';
-import { useEffect, useState, useRef } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 /**
@@ -50,75 +50,7 @@ const useSuggestionsFromOpenAI = ( {
 		select( 'core/editor' ).getEditedPostAttribute( 'title' )
 	);
 
-	//TODO: decide if we still want to load categories and tags now user is providing the prompt by default.
-	// If not the following can be removed.
-	let loading = false;
-	const categories =
-		useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'categories' ) ) || [];
-
-	const categoryObjects = useSelect(
-		select => {
-			return categories
-				.map( categoryId => {
-					const category = select( 'core' ).getEntityRecord( 'taxonomy', 'category', categoryId );
-
-					if ( ! category ) {
-						// Data is not yet loaded
-						loading = true;
-						return;
-					}
-
-					return category;
-				} )
-				.filter( Boolean ); // Remove undefined values
-		},
-		[ categories ]
-	);
-
-	const tags =
-		useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'tags' ), [] ) || [];
-	const tagObjects = useSelect(
-		select => {
-			return tags
-				.map( tagId => {
-					const tag = select( 'core' ).getEntityRecord( 'taxonomy', 'post_tag', tagId );
-
-					if ( ! tag ) {
-						// Data is not yet loaded
-						loading = true;
-						return;
-					}
-
-					return tag;
-				} )
-				.filter( Boolean ); // Remove undefined values
-		},
-		[ tags ]
-	);
-
-	useEffect( () => {
-		setIsLoadingCategories( loading );
-
-		/*
-		 * Returning a cleanup function that will stop
-		 * the suggestion if it's still rolling.
-		 */
-		return () => {
-			if ( source?.current ) {
-				debug( 'Cleaning things up...' );
-				source?.current?.close();
-			}
-		};
-	}, [ loading, source ] );
-
 	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId() );
-	// eslint-disable-next-line no-unused-vars
-	const categoryNames = categoryObjects
-		.filter( cat => cat.id !== 1 )
-		.map( ( { name } ) => name )
-		.join( ', ' );
-	// eslint-disable-next-line no-unused-vars
-	const tagNames = tagObjects.map( ( { name } ) => name ).join( ', ' );
 
 	const getStreamedSuggestionFromOpenAI = async ( type, options = {} ) => {
 		/*


### PR DESCRIPTION
Janitorial: removing old dead code

## Proposed changes:
This PR removes a whole chunk of code that has been lying around since the beginning of the project. The code seems to fetch/wait for categories and tags, but those are not used anywhere and serve no purpose.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1711568932854769-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
As with janitorial/removal PRs, the main objective is that nothing is broken and no regressions happen.
Insert the AI Assistant block and use as many functions/features as possible, keep an eye on the console to see no new errors can be seen (besides the usual ones from the editor)