### PR TITLE
Phan: Add stub for wpcom functions

### DIFF
--- a/.phan/config.base.php
+++ b/.phan/config.base.php
@@ -95,7 +95,7 @@ function make_phan_config( $dir, $options = array() ) {
 				"$root/vendor/php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php",
 				"$root/vendor/php-stubs/wp-cli-stubs/wp-cli-i18n-stubs.php",
 				"$root/.phan/stubs/wordpress-constants.php",
-				"$root/.phan/stubs/wordpress-functions.php",
+				"$root/.phan/stubs/wpcom-functions.php",
 			) : array(),
 			$options['file_list'],
 			$options['parse_file_list']

--- a/.phan/config.base.php
+++ b/.phan/config.base.php
@@ -95,6 +95,7 @@ function make_phan_config( $dir, $options = array() ) {
 				"$root/vendor/php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php",
 				"$root/vendor/php-stubs/wp-cli-stubs/wp-cli-i18n-stubs.php",
 				"$root/.phan/stubs/wordpress-constants.php",
+				"$root/.phan/stubs/wordpress-functions.php",
 			) : array(),
 			$options['file_list'],
 			$options['parse_file_list']

--- a/.phan/stubs/wordpress-functions.php
+++ b/.phan/stubs/wordpress-functions.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Phan stubs for WordPress-defined functions.
+ *
+ * @package automattic/jetpack-monorepo
+ */
+
+/**
+ * Whether to enable the nav redesign.
+ *
+ * @phan-return bool Returns true if the nav redesign is enabled, false otherwise.
+ */
+function wpcom_is_nav_redesign_enabled(): bool {}

--- a/.phan/stubs/wpcom-functions.php
+++ b/.phan/stubs/wpcom-functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Phan stubs for WordPress-defined functions.
+ * Phan stubs for WPCOM-defined functions.
  *
  * @package automattic/jetpack-monorepo
  */

--- a/projects/packages/blaze/.phan/baseline.php
+++ b/projects/packages/blaze/.phan/baseline.php
@@ -10,8 +10,8 @@
 return [
     // # Issue statistics:
     // PhanUndeclaredTypeParameter : 25+ occurrences
-    // PhanUndeclaredFunction : 8 occurrences
     // PhanUndeclaredClassMethod : 7 occurrences
+    // PhanUndeclaredFunction : 7 occurrences
     // PhanTypeArraySuspicious : 5 occurrences
     // PhanUndeclaredClassProperty : 4 occurrences
     // PhanTypeMismatchArgument : 3 occurrences

--- a/projects/packages/blaze/changelog/add-phan-stub-wordpress-functions
+++ b/projects/packages/blaze/changelog/add-phan-stub-wordpress-functions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Change Phan baselines.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.20.0",
+	"version": "0.20.1-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.20.0';
+	const PACKAGE_VERSION = '0.20.1-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
@@ -9,7 +9,7 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredFunction : 70+ occurrences
+    // PhanUndeclaredFunction : 65+ occurrences
     // PhanUndeclaredClassMethod : 60+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 55+ occurrences
     // PhanTypeMismatchArgument : 40+ occurrences
@@ -54,11 +54,10 @@ return [
         'src/class-jetpack-mu-wpcom.php' => ['PhanNoopNew', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction'],
         'src/features/100-year-plan/enhanced-ownership.php' => ['PhanEmptyFQSENInCallable', 'PhanUndeclaredClassConstant', 'PhanUndeclaredFunction'],
         'src/features/100-year-plan/locked-mode.php' => ['PhanEmptyFQSENInCallable', 'PhanUndeclaredClassConstant', 'PhanUndeclaredFunction'],
-        'src/features/admin-color-schemes/admin-color-schemes.php' => ['PhanUndeclaredConstant', 'PhanUndeclaredFunction'],
+        'src/features/admin-color-schemes/admin-color-schemes.php' => ['PhanUndeclaredConstant'],
         'src/features/block-patterns/block-patterns.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredTypeParameter'],
         'src/features/block-patterns/class-wpcom-block-patterns-from-api.php' => ['PhanRedundantConditionInLoop'],
         'src/features/block-patterns/class-wpcom-block-patterns-utils.php' => ['PhanTypeMismatchReturnNullable', 'PhanUndeclaredFunction'],
-        'src/features/block-theme-previews/block-theme-previews.php' => ['PhanUndeclaredFunction'],
         'src/features/coming-soon/coming-soon.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable'],
         'src/features/coming-soon/fallback-coming-soon-page.php' => ['PhanTypeMismatchArgument', 'PhanTypeVoidArgument', 'PhanUndeclaredFunction'],
         'src/features/error-reporting/error-reporting.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredFunction'],
@@ -73,7 +72,7 @@ return [
         'src/features/wpcom-command-palette/wpcom-command-palette.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
         'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-migrate-guru-key.php' => ['PhanUndeclaredClassMethod'],
-        'src/features/wpcom-site-menu/wpcom-site-menu.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable'],
+        'src/features/wpcom-site-menu/wpcom-site-menu.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunctionInCallable'],
         'src/utils.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
         'tests/lib/functions-wordpress.php' => ['PhanRedefineFunction'],
         'tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeReturnType'],

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-phan-stub-wordpress-functions
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-phan-stub-wordpress-functions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Change Phan baselines.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.21.0",
+	"version": "5.21.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.21.0';
+	const PACKAGE_VERSION = '5.21.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/my-jetpack/.phan/baseline.php
+++ b/projects/packages/my-jetpack/.phan/baseline.php
@@ -20,11 +20,11 @@ return [
     // PhanNoopNew : 6 occurrences
     // PhanUndeclaredStaticProperty : 6 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 5 occurrences
-    // PhanTypeMismatchArgument : 4 occurrences
     // PhanUndeclaredTypeParameter : 4 occurrences
     // PhanUndeclaredTypeReturnType : 4 occurrences
     // PhanUnextractableAnnotation : 4 occurrences
     // PhanTypeArraySuspicious : 3 occurrences
+    // PhanTypeMismatchArgument : 3 occurrences
     // PhanTypeMismatchReturnNullable : 3 occurrences
     // PhanImpossibleCondition : 2 occurrences
     // PhanNonClassMethodCall : 2 occurrences

--- a/projects/packages/my-jetpack/changelog/add-phan-stub-wordpress-functions
+++ b/projects/packages/my-jetpack/changelog/add-phan-stub-wordpress-functions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Change Phan baselines.

--- a/projects/packages/stats-admin/.phan/baseline.php
+++ b/projects/packages/stats-admin/.phan/baseline.php
@@ -12,7 +12,7 @@ return [
     // PhanUndeclaredClassMethod : 60+ occurrences
     // PhanUndeclaredTypeParameter : 20+ occurrences
     // PhanTypeMismatchReturn : 8 occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 6 occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 7 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
     // PhanTypeMismatchArgument : 1 occurrence

--- a/projects/packages/stats-admin/changelog/add-phan-stub-wordpress-functions
+++ b/projects/packages/stats-admin/changelog/add-phan-stub-wordpress-functions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Change Phan baselines.

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -412,7 +412,7 @@ return [
         'modules/likes/jetpack-likes-master-iframe.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'modules/likes/jetpack-likes-settings.php' => ['PhanDeprecatedFunction', 'PhanRedundantCondition'],
         'modules/markdown/easy-markdown.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanUndeclaredProperty'],
-        'modules/masterbar.php' => ['PhanNoopNew', 'PhanUndeclaredFunction'],
+        'modules/masterbar.php' => ['PhanNoopNew'],
         'modules/masterbar/admin-menu/class-admin-menu.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'modules/masterbar/admin-menu/class-atomic-admin-menu.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredFunctionInCallable'],
         'modules/masterbar/admin-menu/class-base-admin-menu.php' => ['PhanEmptyFQSENInCallable', 'PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInstantiateAbstract', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypePossiblyInvalidDimOffset'],

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -83,8 +83,6 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
-		// @phan-suppress-next-line PhanUndeclaredFunction
 		if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
 			require_once JETPACK__PLUGIN_DIR . '/modules/masterbar/admin-menu/load.php';
 		}

--- a/projects/plugins/jetpack/changelog/add-phan-stub-wordpress-functions
+++ b/projects/plugins/jetpack/changelog/add-phan-stub-wordpress-functions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add Phan stub for wordpress functions.


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR adds the wpcom function `wpcom_is_nav_redesign_enabled` as a Phan stub. See pdWQjU-Jb-p2 for more context. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure that all the tests pass, except for Storybook tests. See pdWQjU-Ip-p2.