### PR TITLE
Load Odyssey Stats for simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/.phan/config.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/config.php
@@ -10,4 +10,14 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+$root = dirname( __DIR__, 4 );
+
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'parse_file_list' => array(
+			"$root/projects/packages/stats-admin/src/class-dashboard.php",
+			"$root/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php",
+		),
+	)
+);

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-simple-odyssey-stats
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-simple-odyssey-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Odyssey Stats to wpcom Simple Site

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -51,7 +51,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.21.x-dev"
+			"dev-trunk": "5.22.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.21.0",
+	"version": "5.22.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -284,6 +284,6 @@ class Jetpack_Mu_Wpcom {
 	 * Load Odyssey Stats in Simple sites.
 	 */
 	public static function load_wpcom_simple_odyssey_stats() {
-		require_once __DIR__ . '/features/wpcom-odyssey-stats/wpcom-odyssey-stats.php';
+		require_once __DIR__ . '/features/wpcom-simple-odyssey-stats/wpcom-simple-odyssey-stats.php';
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.21.0';
+	const PACKAGE_VERSION = '5.22.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -284,6 +284,8 @@ class Jetpack_Mu_Wpcom {
 	 * Load Odyssey Stats in Simple sites.
 	 */
 	public static function load_wpcom_simple_odyssey_stats() {
-		require_once __DIR__ . '/features/wpcom-simple-odyssey-stats/wpcom-simple-odyssey-stats.php';
+		if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
+			require_once __DIR__ . '/features/wpcom-simple-odyssey-stats/wpcom-simple-odyssey-stats.php';
+		}
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -46,6 +46,7 @@ class Jetpack_Mu_Wpcom {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_comments' ) );
 			add_action( 'wp_loaded', array( __CLASS__, 'load_verbum_comments_admin' ) );
+			add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_simple_odyssey_stats' ) );
 		}
 
 		// Unified navigation fix for changes in WordPress 6.2.
@@ -277,5 +278,12 @@ class Jetpack_Mu_Wpcom {
 	 */
 	public static function load_wpcom_command_palette() {
 		require_once __DIR__ . '/features/wpcom-command-palette/wpcom-command-palette.php';
+	}
+
+	/**
+	 * Load Odyssey Stats in Simple sites.
+	 */
+	public static function load_wpcom_simple_odyssey_stats() {
+		require_once __DIR__ . '/features/wpcom-odyssey-stats/wpcom-odyssey-stats.php';
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-simple-odyssey-stats/wpcom-simple-odyssey-stats.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-simple-odyssey-stats/wpcom-simple-odyssey-stats.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Load the Odyssey stats feature on WordPress.com Simple Site.
+ * See https://github.com/Automattic/jetpack/tree/trunk/projects/packages/stats-admin
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Stats_Admin\Dashboard as OdysseyStats;
+OdysseyStats::init();
+
+/**
+ * Load the Odyssey stats widget in the Dashboard.
+ */
+require_once JETPACK_PLUGIN_LOADER_PATH . '/class-jetpack-stats-dashboard-widget.php';
+add_action( 'wp_dashboard_setup', array( new Jetpack_Stats_Dashboard_Widget(), 'init' ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-simple-odyssey-stats/wpcom-simple-odyssey-stats.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-simple-odyssey-stats/wpcom-simple-odyssey-stats.php
@@ -12,5 +12,7 @@ OdysseyStats::init();
 /**
  * Load the Odyssey stats widget in the Dashboard.
  */
-require_once JETPACK_PLUGIN_LOADER_PATH . '/class-jetpack-stats-dashboard-widget.php';
-add_action( 'wp_dashboard_setup', array( new Jetpack_Stats_Dashboard_Widget(), 'init' ) );
+if ( defined( 'JETPACK_PLUGIN_LOADER_PATH' ) ) {
+	require_once JETPACK_PLUGIN_LOADER_PATH . '/class-jetpack-stats-dashboard-widget.php';
+	add_action( 'wp_dashboard_setup', array( new Jetpack_Stats_Dashboard_Widget(), 'init' ) );
+}

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-wpcom-simple-odyssey-stats
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-wpcom-simple-odyssey-stats
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_10"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_11_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -129,7 +129,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "ffb0929d64dac5ad55847b4b4ed74469efaea15e"
+                "reference": "0b49970bdde8c3c05388592c86db00b2888f6dd4"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -152,7 +152,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.21.x-dev"
+                    "dev-trunk": "5.22.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.10
+ * Version: 2.1.11-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.10",
+	"version": "2.1.11-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6213

> [!WARNING]  
> https://github.com/Automattic/wp-calypso/pull/88788 and https://github.com/Automattic/jetpack/pull/36633 needs to be merged first.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Load Odyssey Stats for WP.com Simple Site Classic view

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See testing instructions in https://github.com/Automattic/wp-calypso/pull/88788