### PR TITLE
AI Featured Image: Add event tracking for generating, regenerating and using images

### DIFF
--- a/projects/plugins/jetpack/changelog/update-featured-image-add-event-tracking
+++ b/projects/plugins/jetpack/changelog/update-featured-image-add-event-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Featured Image: track events for generating, regenerating and using images

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useImageGenerator } from '@automattic/jetpack-ai-client';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, Spinner } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -24,6 +25,8 @@ export default function FeaturedImage() {
 	const [ imageURL, setImageURL ] = useState( null );
 	const { generateImage } = useImageGenerator();
 	const { isLoading: isSavingToMediaLibrary, saveToMediaLibrary } = useSaveToMediaLibrary();
+	const { tracks } = useAnalytics();
+	const { recordEvent } = tracks;
 
 	const postContent = usePostContent();
 
@@ -57,20 +60,29 @@ export default function FeaturedImage() {
 	}, [ isFeaturedImageModalVisible, setIsFeaturedImageModalVisible ] );
 
 	const handleGenerate = useCallback( () => {
+		// track the generate image event
+		recordEvent( 'jetpack_ai_featured_image_generation_generate_image' );
+
 		toggleFeaturedImageModal();
 		processImageGeneration();
-	}, [ toggleFeaturedImageModal, processImageGeneration ] );
+	}, [ toggleFeaturedImageModal, processImageGeneration, recordEvent ] );
 
 	const handleRegenerate = useCallback( () => {
+		// track the regenerate image event
+		recordEvent( 'jetpack_ai_featured_image_generation_generate_another_image' );
+
 		processImageGeneration();
-	}, [ processImageGeneration ] );
+	}, [ processImageGeneration, recordEvent ] );
 
 	const handleAccept = useCallback( () => {
+		// track the accept/use image event
+		recordEvent( 'jetpack_ai_featured_image_generation_use_image' );
+
 		saveToMediaLibrary( imageURL ).then( image => {
 			editPost( { featured_media: image.id } );
 			toggleFeaturedImageModal();
 		} );
-	}, [ editPost, imageURL, saveToMediaLibrary, toggleFeaturedImageModal ] );
+	}, [ editPost, imageURL, saveToMediaLibrary, toggleFeaturedImageModal, recordEvent ] );
 
 	const modalTitleWhenGenerating = __( 'Generating featured image…', 'jetpack' );
 	const modalTitleWhenDone = __( 'Featured Image Generation', 'jetpack' );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -17,6 +17,7 @@ import useSaveToMediaLibrary from '../../hooks/use-save-to-media-library';
 import AiAssistantModal from '../modal';
 
 const FEATURED_IMAGE_FEATURE_NAME = 'featured-post-image';
+const JETPACK_SIDEBAR_PLACEMENT = 'jetpack-sidebar';
 
 export default function FeaturedImage() {
 	const { editPost } = useDispatch( editorStore );
@@ -61,7 +62,9 @@ export default function FeaturedImage() {
 
 	const handleGenerate = useCallback( () => {
 		// track the generate image event
-		recordEvent( 'jetpack_ai_featured_image_generation_generate_image' );
+		recordEvent( 'jetpack_ai_featured_image_generation_generate_image', {
+			placement: JETPACK_SIDEBAR_PLACEMENT,
+		} );
 
 		toggleFeaturedImageModal();
 		processImageGeneration();
@@ -69,14 +72,18 @@ export default function FeaturedImage() {
 
 	const handleRegenerate = useCallback( () => {
 		// track the regenerate image event
-		recordEvent( 'jetpack_ai_featured_image_generation_generate_another_image' );
+		recordEvent( 'jetpack_ai_featured_image_generation_generate_another_image', {
+			placement: JETPACK_SIDEBAR_PLACEMENT,
+		} );
 
 		processImageGeneration();
 	}, [ processImageGeneration, recordEvent ] );
 
 	const handleAccept = useCallback( () => {
 		// track the accept/use image event
-		recordEvent( 'jetpack_ai_featured_image_generation_use_image' );
+		recordEvent( 'jetpack_ai_featured_image_generation_use_image', {
+			placement: JETPACK_SIDEBAR_PLACEMENT,
+		} );
 
 		saveToMediaLibrary( imageURL ).then( image => {
 			editPost( { featured_media: image.id } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36637.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add event tracking to the buttons of the UI:
   * generate an image: `jetpack_ai_featured_image_generation_generate_image`
   * regenerate an image: `jetpack_ai_featured_image_generation_generate_another_image`
   * use an image: `jetpack_ai_featured_image_generation_use_image`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes. We start tracking three actions from the AI Featured Image tool:

* generate an image: `jetpack_ai_featured_image_generation_generate_image`
* regenerate an image: `jetpack_ai_featured_image_generation_generate_another_image`
* use an image: `jetpack_ai_featured_image_generation_use_image`

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure your test site has beta extensions enabled
* Go to the block editor, insert some content on it (tip: use the AI Assistant block to request 2 paragraphs about something)
* Open the browser console and enable all debug messages with `localStorage.setItem( 'debug', '*' )`
* Filter the console messages using `dops:analytics`
* Open the Jetpack sidebar on the editor, and then open the AI Assistant section inside it
* Click the "Generate image" button; notice that a debug line shows up on the console
* When the image is done, click the "Generate another image" button; notice that another debug message will show up
* Finally, when the second image is ready, click the "Save and use image" button; notice that a third debug message will show up
* The messages should be related to the action being triggered (see list on the Proposed changes section above)
* The messages should include the property `placement` with the value `jetpack-sidebar`, to indicate that the generation started from the Jetpack sidebar entrypoint

<img width="500" alt="Screenshot 2024-03-28 at 10 08 31" src="https://github.com/Automattic/jetpack/assets/6760046/3482cc31-0786-4dae-80b1-da329289f220">
