### PR TITLE
Google Embed blocks: make proportion values translatable

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-google-embed-blocks-not-translatable-text
+++ b/projects/plugins/jetpack/changelog/fix-google-embed-blocks-not-translatable-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Google Embed blocks: make proportion values translatable

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/edit.js
@@ -141,9 +141,12 @@ const GsuiteBlockEdit = props => {
 	};
 
 	const aspectRatios = [
-		{ label: 'Default', value: '' },
-		{ label: '100% - Show the whole document', value: 'ar-100' },
-		{ label: '50% - Show half of the document', value: 'ar-50' },
+		// translators: default aspect ratio for the embedded Google document.
+		{ label: __( 'Default', 'jetpack' ), value: '' },
+		// translators: aspect ratio for the embedded Google document.
+		{ label: __( '100% - Show the whole document', 'jetpack' ), value: 'ar-100' },
+		// translators: aspect ratio for the embedded Google document.
+		{ label: __( '50% - Show half of the document', 'jetpack' ), value: 'ar-50' },
 	];
 
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Some texts in the Google Doc embed blocks are hardcoded and not translatable. This PR fixes it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-Aw-p2
Part of this issue: https://github.com/Automattic/vulcan/issues/244

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

A code review should be enough. If you want to go the extra mile, verify that the Google Doc block works like before.
