### PR TITLE
AI Featured Image: Improve UX on accepting image

### DIFF
--- a/projects/plugins/jetpack/changelog/update-set-ai-featured-image-ux
+++ b/projects/plugins/jetpack/changelog/update-set-ai-featured-image-ux
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Improve UX when setting AI Featured Image

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -96,7 +96,7 @@ export default function FeaturedImage() {
 		processImageGeneration();
 	}, [ processImageGeneration, recordEvent ] );
 
-	const triggerComplemenetaryArea = useCallback( () => {
+	const triggerComplementaryArea = useCallback( () => {
 		enableComplementaryArea( 'core/edit-post', 'edit-post/document' );
 	}, [ enableComplementaryArea ] );
 
@@ -115,10 +115,10 @@ export default function FeaturedImage() {
 				// If the panel is not opened, open it and then trigger the complementary area.
 				if ( ! isEditorPanelOpened( 'featured-image' ) ) {
 					toggleEditorPanelOpened?.( 'featured-image' ).then( () => {
-						triggerComplemenetaryArea();
+						triggerComplementaryArea();
 					} );
 				} else {
-					triggerComplemenetaryArea();
+					triggerComplementaryArea();
 				}
 			}, 500 );
 		} );
@@ -130,7 +130,7 @@ export default function FeaturedImage() {
 		saveToMediaLibrary,
 		toggleEditorPanelOpened,
 		toggleFeaturedImageModal,
-		triggerComplemenetaryArea,
+		triggerComplementaryArea,
 	] );
 
 	const modalTitleWhenGenerating = __( 'Generating featured image…', 'jetpack' );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/hooks/use-save-to-media-library.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/hooks/use-save-to-media-library.ts
@@ -2,48 +2,75 @@
  * External dependencies
  */
 import { isBlobURL } from '@wordpress/blob';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
+import debugFactory from 'debug';
 /**
  * Types
  */
 import type { BlockEditorStore } from '../../../blocks/ai-assistant/types';
 
+const debug = debugFactory( 'jetpack-ai-assistant-plugin:save-to-media-library' );
+
 export default function useSaveToMediaLibrary() {
 	const [ isLoading, setIsLoading ] = useState( false );
-	const { getSettings } = useSelect( blockEditorStore, [] ) as BlockEditorStore[ 'selectors' ];
+	const { getSettings } = useSelect(
+		select => select( 'core/block-editor' ),
+		[]
+	) as BlockEditorStore[ 'selectors' ];
 
 	const saveToMediaLibrary = ( url: string ): Promise< { id: string } > => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const settings = getSettings() as any;
 
 		return new Promise( ( resolve, reject ) => {
-			fetch( url ).then( response => {
-				response.blob().then( ( blob: Blob ) => {
-					const filesList = [ blob ];
-					settings.mediaUpload( {
-						allowedTypes: [ 'image' ],
-						filesList,
-						onFileChange( [ image ] ) {
-							if ( isBlobURL( image?.url ) ) {
-								setIsLoading( true );
-								return;
-							}
+			setIsLoading( true );
 
-							if ( image ) {
-								resolve( image );
-							}
+			debug( 'Fetching image from URL' );
 
+			fetch( url )
+				.then( response => {
+					debug( 'Transforming response to blob' );
+
+					response
+						.blob()
+						.then( ( blob: Blob ) => {
+							debug( 'Uploading blob to media library' );
+
+							const filesList = [ blob ];
+							settings.mediaUpload( {
+								allowedTypes: [ 'image' ],
+								filesList,
+								onFileChange( [ image ] ) {
+									if ( isBlobURL( image?.url ) ) {
+										return;
+									}
+
+									if ( image ) {
+										debug( 'Image uploaded to media library' );
+										resolve( image );
+									}
+
+									setIsLoading( false );
+								},
+								onError( message ) {
+									debug( 'Error uploading image to media library:', message );
+									reject( message );
+									setIsLoading( false );
+								},
+							} );
+						} )
+						.catch( e => {
+							debug( 'Error transforming response to blob:', e?.message );
+							reject( e?.message );
 							setIsLoading( false );
-						},
-						onError( message ) {
-							// TODO: Handle error
-							reject( message );
-						},
-					} );
+						} );
+				} )
+				.catch( e => {
+					debug( 'Error fetching image from URL:', e?.message );
+					reject( e?.message );
+					setIsLoading( false );
 				} );
-			} );
 		} );
 	};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Based on the comments from #36626.

Improving UX when accepting the image, by including the loading at the beginning of the action and showing the featured panel after user uses it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move `setLoading` to top action in `useSaveToMediaLibrary`.
* Add `debug` calls in `useSaveToMediaLibrary`.
* Open `Editor` sidebar and `Featured Image` panel after using the image.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you have the beta blocks enable.
* Create a post with content and then generate an image.
* Here we have two scenarios:

_if Featured Image panel was already opened_
* It should open the Editor sidebar and Featured Image panel will stayed opened.

_if Featured Image panel was closed_
* It should open the panel and then open the Editor sidebar.

_Make sure both scenarios are working_

* You should be able to see the `debug` in console too.

### Demo 💻 

https://github.com/Automattic/jetpack/assets/1663717/17d52e0d-149a-411e-be78-84cb1b58e50c




