### PR TITLE
Scheduled Updates: Pass status fields directly

### DIFF
--- a/projects/packages/scheduled-updates/changelog/move-status-fields
+++ b/projects/packages/scheduled-updates/changelog/move-status-fields
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: No functional changes, just moved some code around
+
+


### PR DESCRIPTION
I don't think we need to register rest field to add status information to the schedule response.

This PR started by me moving the callback to the `Scheduled_Updates` class, but the more I thought about it the less sense it made to keep it separate. I also copied over the `prepare_response_for_collection()` from Core's Plugins endpoint—not sure how good of an idea that is. Just found it odd that we'd create a `WP_REST_Response` object and then pull the `data` property? Don't know.

For the healthcheck paths that we'll add in i2 we'll have to think about something similar.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove register_rest_field callback
* Add status information to the response data directly.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Unit tests should cover it.

