### PR TITLE
AI Client: fix change handler

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-ai-client-change-handler
+++ b/projects/js-packages/ai-client/changelog/fix-ai-client-change-handler
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Client: fix a bug where quick prompts would not work after getting suggested content

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -18,7 +18,8 @@
 		"build": "pnpm run clean && pnpm run compile-ts",
 		"clean": "rm -rf build/",
 		"compile-ts": "tsc --pretty",
-		"test": "NODE_OPTIONS=--experimental-vm-modules jest"
+		"test": "NODE_OPTIONS=--experimental-vm-modules jest",
+		"watch": "tsc --watch --pretty"
 	},
 	"type": "module",
 	"devDependencies": {

--- a/projects/js-packages/ai-client/src/components/ai-control/index.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/index.tsx
@@ -8,8 +8,8 @@ import { useImperativeHandle, useRef, useEffect, useCallback } from '@wordpress/
 import { __ } from '@wordpress/i18n';
 import { Icon, closeSmall, check, arrowUp, trash, reusableBlock } from '@wordpress/icons';
 import classNames from 'classnames';
-import { forwardRef } from 'react';
-import React from 'react';
+import debugFactory from 'debug';
+import React, { forwardRef } from 'react';
 /**
  * Internal dependencies
  */
@@ -44,6 +44,8 @@ type AiControlProps = {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
+
+const debug = debugFactory( 'jetpack-ai-client:ai-control' );
 
 /**
  * AI Control component.
@@ -84,11 +86,7 @@ export function AIControl(
 		if ( editRequest ) {
 			promptUserInputRef?.current?.focus();
 		}
-
-		if ( ! editRequest && lastValue !== null && value !== lastValue ) {
-			onChange?.( lastValue );
-		}
-	}, [ editRequest, lastValue, value ] );
+	}, [ editRequest ] );
 
 	const sendRequest = useCallback( () => {
 		setLastValue( value );
@@ -119,6 +117,7 @@ export function AIControl(
 	}, [] );
 
 	const cancelEdit = useCallback( () => {
+		debug( 'cancelEdit, revert to last value', lastValue );
 		onChange( lastValue || '' );
 		setEditRequest( false );
 	}, [ lastValue ] );


### PR DESCRIPTION
Fixes #36623 

## Proposed changes:
This PR removes a double check performed on a useEffect that was reverting changes to the input (quick prompts).

It also updates the scripts to have the "watch" option available

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1711567732138669-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert an AI Assistant block and request some suggestion (haiku on whatever). Once the suggestion is back, use the "Write with AI..." button on the toolbar and click on any of the options.
The prompt should change to the selected option.
Verify the usual workflows (edit prompt, cancel, discard) and functionality remain.