### PR TITLE
Stats: add package version to composer

### DIFF
--- a/projects/packages/stats/changelog/add-version-constant-composer
+++ b/projects/packages/stats/changelog/add-version-constant-composer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Composer: added version constant for ststs package.

--- a/projects/packages/stats/composer.json
+++ b/projects/packages/stats/composer.json
@@ -46,6 +46,9 @@
 	"extra": {
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-package-version.php"
+		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
 		},

--- a/projects/plugins/jetpack/changelog/add-version-constant-composer
+++ b/projects/plugins/jetpack/changelog/add-version-constant-composer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2265,7 +2265,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/stats",
-				"reference": "c3085980c8bf62c83110babfb35b1a56a7690a9a"
+				"reference": "a73f14c137cb5bfa1ed40ff0927573261dee3d1b"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2285,6 +2285,9 @@
 			"extra": {
 				"autotagger": true,
 				"mirror-repo": "Automattic/jetpack-stats",
+				"version-constants": {
+					"::PACKAGE_VERSION": "src/class-package-version.php"
+				},
 				"changelogger": {
 					"link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
 				},

--- a/projects/plugins/search/changelog/add-version-constant-composer
+++ b/projects/plugins/search/changelog/add-version-constant-composer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1431,7 +1431,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "c3085980c8bf62c83110babfb35b1a56a7690a9a"
+                "reference": "a73f14c137cb5bfa1ed40ff0927573261dee3d1b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1451,6 +1451,9 @@
             "extra": {
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
                 },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
In https://github.com/Automattic/jetpack/pull/36571 package version constant was added to the stats package but version tracking was missing from composer. I added it here.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

