### PR TITLE
WPCOM Simple Site: Remove add license link in the Search upsell page

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2286,6 +2286,9 @@ importers:
       '@automattic/jetpack-connection':
         specifier: workspace:*
         version: link:../../js-packages/connection
+      '@automattic/jetpack-shared-extension-utils':
+        specifier: workspace:*
+        version: link:../../js-packages/shared-extension-utils
       '@wordpress/base-styles':
         specifier: 4.45.0
         version: 4.45.0

--- a/projects/packages/search/changelog/remove-wpcom-simple-site-search-add-license
+++ b/projects/packages/search/changelog/remove-wpcom-simple-site-search-add-license
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed add Search license link for simple sites due to My Jetpack inavailability.

--- a/projects/packages/search/composer.json
+++ b/projects/packages/search/composer.json
@@ -71,7 +71,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.43.x-dev"
+			"dev-trunk": "0.44.x-dev"
 		},
 		"version-constants": {
 			"::VERSION": "src/class-package.php"

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.43.8",
+	"version": "0.44.0-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -40,6 +40,7 @@
 		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
+		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@wordpress/base-styles": "4.45.0",
 		"@wordpress/block-editor": "12.22.0",
 		"@wordpress/data": "9.24.0",

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.43.8';
+	const VERSION = '0.44.0-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/header.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/header.jsx
@@ -1,4 +1,5 @@
 import { JetpackSearchLogo } from '@automattic/jetpack-components';
+import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -15,17 +16,19 @@ const Header = () => {
 			<span className="jp-search-dashboard-upsell-page__logo">
 				<JetpackSearchLogo />
 			</span>
-			<p>
-				{ createInterpolateElement(
-					__(
-						'Already have an existing plan or license key? <a>Click here to get started</a>',
-						'jetpack-search-pkg'
-					),
-					{
-						a: <a href={ activateLicenseUrl } />,
-					}
-				) }
-			</p>
+			{ ! isSimpleSite() && (
+				<p>
+					{ createInterpolateElement(
+						__(
+							'Already have an existing plan or license key? <a>Click here to get started</a>',
+							'jetpack-search-pkg'
+						),
+						{
+							a: <a href={ activateLicenseUrl } />,
+						}
+					) }
+				</p>
+			) }
 		</div>
 	);
 };

--- a/projects/plugins/jetpack/changelog/remove-wpcom-simple-site-search-add-license
+++ b/projects/plugins/jetpack/changelog/remove-wpcom-simple-site-search-add-license
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2181,7 +2181,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/search",
-				"reference": "b21497d346a5032e99bf9786ed70469543cf1e73"
+				"reference": "2add27c03851b950a0baf0569bbee4869d31ad76"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -2209,7 +2209,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.43.x-dev"
+					"dev-trunk": "0.44.x-dev"
 				},
 				"version-constants": {
 					"::VERSION": "src/class-package.php"

--- a/projects/plugins/search/changelog/remove-wpcom-simple-site-search-add-license
+++ b/projects/plugins/search/changelog/remove-wpcom-simple-site-search-add-license
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1347,7 +1347,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "b21497d346a5032e99bf9786ed70469543cf1e73"
+                "reference": "2add27c03851b950a0baf0569bbee4869d31ad76"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1375,7 +1375,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.43.x-dev"
+                    "dev-trunk": "0.44.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"


### PR DESCRIPTION
## Proposed changes:
This PR removes the link to `admin.php?page=my-jetpack#/add-license` in the Search upsell page for WPCOM Simple sites, due to My Jetpack not being available.

![Screenshot 2024-03-29 at 3 51 33 PM](https://github.com/Automattic/jetpack/assets/797888/bc73cfc7-c357-4b48-acc8-64dbfb570fc5)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the commands in https://github.com/Automattic/jetpack/pull/36658#issuecomment-2026935407 to test this branch on your sandbox.
* In a WPCOM Simple site, head to Jetpack > Search and ensure that the link is no longer available.