### PR TITLE
Boost: Fix broken reference in cache

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Request.php
@@ -5,9 +5,6 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress;
 
-use Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator;
-use Automattic\Jetpack_Boost\Modules\Modules_Index;
-
 class Request {
 	/**
 	 * @var Request - The request instance for current request.
@@ -89,7 +86,7 @@ class Request {
 		// Check if the query parameters `jb-disable-modules` or `jb-generate-critical-css` exist.
 		$query_params = isset( $this->request_parameters['get'] ) ? $this->request_parameters['get'] : array();
 		if ( isset( $query_params ) &&
-			( isset( $query_params[ Modules_Index::DISABLE_MODULE_QUERY_VAR ] ) || isset( $query_params[ Generator::GENERATE_QUERY_ACTION ] ) )
+			( isset( $query_params['jb-disable-modules'] ) || isset( $query_params['jb-generate-critical-css'] ) )
 		) {
 			return true;
 		}

--- a/projects/plugins/boost/changelog/fix-cache-broken-reference
+++ b/projects/plugins/boost/changelog/fix-cache-broken-reference
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed a fatal error due to a broken reference
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36659

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hardcode query var strings so they don't have to reference values outside of pre-wordpress directory

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Enable cache
* Visit front-end and make sure cache is working

