### PR TITLE
Backport mu-wpcom-plugin 2.1.11, jetpack 13.3-beta Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2024-04-01
+### Added
+- AI Client: include prompt to generate featured image based on post content. [#36591]
+- Support different responses in image hook [#36626]
+
+### Fixed
+- AI Client: fix a bug where quick prompts would not work after getting suggested content [#36651]
+- AI Client: set request content type as JSON on image generation hook and use rectangular images instead of square images. [#36620]
+
 ## [0.10.1] - 2024-03-27
 ### Changed
 - Updated package dependencies. [#36539, #36585]
@@ -263,6 +272,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.11.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.8.2...v0.9.0

--- a/projects/js-packages/ai-client/changelog/add-format-response-image-hook
+++ b/projects/js-packages/ai-client/changelog/add-format-response-image-hook
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Support different responses in image hook

--- a/projects/js-packages/ai-client/changelog/fix-ai-client-change-handler
+++ b/projects/js-packages/ai-client/changelog/fix-ai-client-change-handler
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Client: fix a bug where quick prompts would not work after getting suggested content

--- a/projects/js-packages/ai-client/changelog/update-ai-client-image-generation-prompt
+++ b/projects/js-packages/ai-client/changelog/update-ai-client-image-generation-prompt
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-AI Client: include prompt to generate featured image based on post content.

--- a/projects/js-packages/ai-client/changelog/update-feature-image-connect-image-generation
+++ b/projects/js-packages/ai-client/changelog/update-feature-image-connect-image-generation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Client: set request content type as JSON on image generation hook and use rectangular images instead of square images.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.11.0-alpha",
+	"version": "0.11.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.5] - 2024-04-01
+### Changed
+- Update dependencies. [#36655]
+
 ## [3.3.4] - 2024-03-27
 ### Changed
 - Updated package dependencies. [#36585]
@@ -593,6 +597,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.3.5]: https://github.com/Automattic/jetpack-backup/compare/v3.3.4...v3.3.5
 [3.3.4]: https://github.com/Automattic/jetpack-backup/compare/v3.3.3...v3.3.4
 [3.3.3]: https://github.com/Automattic/jetpack-backup/compare/v3.3.2...v3.3.3
 [3.3.2]: https://github.com/Automattic/jetpack-backup/compare/v3.3.1...v3.3.2

--- a/projects/packages/backup/changelog/force-a-release
+++ b/projects/packages/backup/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.3.5-alpha';
+	const PACKAGE_VERSION = '3.3.5';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1] - 2024-04-01
+### Added
+- Change Phan baselines. [#36627]
+
 ## [0.20.0] - 2024-03-27
 ### Added
 - Adds the atomic flag to the Jetpack Blaze base site's configuration [#36562]
@@ -334,6 +338,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.20.1]: https://github.com/automattic/jetpack-blaze/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/automattic/jetpack-blaze/compare/v0.19.3...v0.20.0
 [0.19.3]: https://github.com/automattic/jetpack-blaze/compare/v0.19.2...v0.19.3
 [0.19.2]: https://github.com/automattic/jetpack-blaze/compare/v0.19.1...v0.19.2

--- a/projects/packages/blaze/changelog/add-phan-stub-wordpress-functions
+++ b/projects/packages/blaze/changelog/add-phan-stub-wordpress-functions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Change Phan baselines.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.20.1-alpha",
+	"version": "0.20.1",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.20.1-alpha';
+	const PACKAGE_VERSION = '0.20.1';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] - 2024-04-01
+### Changed
+- Tests: moved tests from a separate files to the main tests file. [#36656]
+
 ## [0.18.0] - 2024-03-29
 ### Added
 - Packages: added version tracking for identity-crisis. [#36635]
@@ -520,6 +524,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.18.1]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.6...v0.18.0
 [0.17.6]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.5...v0.17.6
 [0.17.5]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.17.4...v0.17.5

--- a/projects/packages/identity-crisis/changelog/fix-idc-tests-cleanup
+++ b/projects/packages/identity-crisis/changelog/fix-idc-tests-cleanup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Tests: moved tests from a separate files to the main tests file.

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.18.1-alpha",
+	"version": "0.18.2-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.18.0",
+	"version": "0.18.1",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -26,7 +26,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.18.1-alpha';
+	const PACKAGE_VERSION = '0.18.2-alpha';
 
 	/**
 	 * Package Slug

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -26,7 +26,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.18.0';
+	const PACKAGE_VERSION = '0.18.1';
 
 	/**
 	 * Package Slug

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.22.0] - 2024-04-01
+### Added
+- Add Odyssey Stats to wpcom Simple Site [#36628]
+- Change Phan baselines. [#36627]
+
+### Changed
+- Dotcom patterns: use wp_block post type patterns in editor with all themes and hide core and Jetpack form patterns [#36588]
+- General: update Phan configuration. [#36528]
+
 ## [5.21.0] - 2024-03-27
 ### Changed
 - Updated package dependencies. [#36585]
@@ -687,6 +696,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.22.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.21.0...v5.22.0
 [5.21.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.20.0...v5.21.0
 [5.20.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.19.0...v5.20.0
 [5.19.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.18.0...v5.19.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-phan-stub-wordpress-functions
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-phan-stub-wordpress-functions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Change Phan baselines.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-use-dotcom-wp-block-patterns
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-use-dotcom-wp-block-patterns
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Dotcom patterns: use wp_block post type patterns in editor with all themes and hide core and Jetpack form patterns

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-simple-odyssey-stats
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-simple-odyssey-stats
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add Odyssey Stats to wpcom Simple Site

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-seo-settings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-seo-settings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: update Phan configuration.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.22.0-alpha",
+	"version": "5.22.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.22.0-alpha';
+	const PACKAGE_VERSION = '5.22.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.20.1] - 2024-04-01
+### Added
+- Change Phan baselines. [#36627]
+
 ## [4.20.0] - 2024-03-29
 ### Added
 - Track active red bubble slugs on My Jetpack page view [#36611]
@@ -1399,6 +1403,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.20.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.20.0...4.20.1
 [4.20.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.19.0...4.20.0
 [4.19.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.18.0...4.19.0
 [4.18.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.17.1...4.18.0

--- a/projects/packages/my-jetpack/changelog/add-phan-stub-wordpress-functions
+++ b/projects/packages/my-jetpack/changelog/add-phan-stub-wordpress-functions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Change Phan baselines.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.20.0",
+	"version": "4.20.1",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.20.1-alpha",
+	"version": "4.20.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -36,7 +36,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.20.1-alpha';
+	const PACKAGE_VERSION = '4.20.2-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -36,7 +36,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.20.0';
+	const PACKAGE_VERSION = '4.20.1';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2024-04-01
+### Changed
+- General: update Phan configuration. [#36528]
+
 ## [0.5.2] - 2024-03-27
 ### Changed
 - Internal updates.
@@ -90,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.5.3]: https://github.com/Automattic/scheduled-updates/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/Automattic/scheduled-updates/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Automattic/scheduled-updates/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Automattic/scheduled-updates/compare/v0.4.1...v0.5.0

--- a/projects/packages/scheduled-updates/changelog/update-seo-settings
+++ b/projects/packages/scheduled-updates/changelog/update-seo-settings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: update Phan configuration.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.5.3-alpha';
+	const PACKAGE_VERSION = '0.5.3';
 	/**
 	 * The cron event hook for the scheduled plugins update.
 	 *

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.18.0 - 2024-04-01
+### Added
+- Change Phan baselines. [#36627]
+- Stats: Add commercial classification endpoint [#36597]
+
+### Changed
+- Add config fields for odyssey stats to be loaded in Simple Site Classic. [#36633]
+
 ## 0.17.1 - 2024-03-25
 ### Changed
 - Internal updates.

--- a/projects/packages/stats-admin/changelog/add-phan-stub-wordpress-functions
+++ b/projects/packages/stats-admin/changelog/add-phan-stub-wordpress-functions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Change Phan baselines.

--- a/projects/packages/stats-admin/changelog/update-commercial-classification-endpoint
+++ b/projects/packages/stats-admin/changelog/update-commercial-classification-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Stats: Add commercial classification endpoint

--- a/projects/packages/stats-admin/changelog/update-odyssey-stats-config
+++ b/projects/packages/stats-admin/changelog/update-odyssey-stats-config
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Add config fields for odyssey stats to be loaded in Simple Site Classic.

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.18.0-alpha",
+	"version": "0.18.0",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.18.0-alpha';
+	const VERSION = '0.18.0';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2024-04-01
+### Added
+- Add the 'stats/blog' REST endpoint. [#36571]
+- Composer: added version constant for ststs package. [#36657]
+
 ## [0.11.2] - 2024-03-25
 ### Changed
 - Internal updates.
@@ -145,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.12.0]: https://github.com/Automattic/jetpack-stats/compare/v0.11.2...v0.12.0
 [0.11.2]: https://github.com/Automattic/jetpack-stats/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Automattic/jetpack-stats/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Automattic/jetpack-stats/compare/v0.10.1...v0.11.0

--- a/projects/packages/stats/changelog/add-rest-endpoint-get-blog
+++ b/projects/packages/stats/changelog/add-rest-endpoint-get-blog
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the 'stats/blog' REST endpoint.

--- a/projects/packages/stats/changelog/add-version-constant-composer
+++ b/projects/packages/stats/changelog/add-version-constant-composer
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Composer: added version constant for ststs package.

--- a/projects/packages/stats/src/class-package-version.php
+++ b/projects/packages/stats/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Stats;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '0.12.0-alpha';
+	const PACKAGE_VERSION = '0.12.0';
 
 	const PACKAGE_SLUG = 'stats';
 

--- a/projects/packages/stats/src/class-rest-provider.php
+++ b/projects/packages/stats/src/class-rest-provider.php
@@ -15,7 +15,7 @@ use WP_REST_Server;
 /**
  * The REST API provider class.
  *
- * @since $$next-version$$
+ * @since 0.12.0
  */
 class REST_Provider {
 	/**
@@ -69,7 +69,7 @@ class REST_Provider {
 	/**
 	 * Get the stats blog data.
 	 *
-	 * @since $$next-version$$
+	 * @since 0.12.0
 	 *
 	 * @return array
 	 */

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "3.2.1",
+	"version": "3.2.2-alpha",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -73,7 +73,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_2_1",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_2_2_alpha",
 		"allow-plugins": {
 			"roots/wordpress-core-installer": true,
 			"automattic/jetpack-autoloader": true,

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5660ce4110b6eb8d5a301b0d63544f5b",
+    "content-hash": "eee808f5a3df537d4ca2fc636f2a820a",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 3.2.1
+ * Version: 3.2.2-alpha
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'JETPACK_BOOST_VERSION', '3.2.1' );
+define( 'JETPACK_BOOST_VERSION', '3.2.2-alpha' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-boost",
-	"version": "3.2.1",
+	"version": "3.2.2-alpha",
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"directories": {
 		"test": "tests"

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.3-beta - 2024-04-01
+### Enhancements
+- Member login block: add ability to hide manage subscription -link. [#36602]
+
+### Improved compatibility
+- Carousel: disable WordPress' lightbox option when Jetpack's Carousel feature is activated. [#36565]
+- SEO Tools: make the feature available on non-connected sites. [#36528]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add Phan stub for wordpress functions. [#36627]
+- AI Assistant: remove dead code from the suggestions hook [#36625]
+- AI Assistant: Remove unused code [#36621]
+- AI Featured Image: connect the image generation hook to the UI. [#36620]
+- AI Featured Image: track events for generating, regenerating and using images [#36638]
+- AI Plugin: Add modal and featured image usage [#36613]
+- Disable AI Featured Image button if requires upgrade or no post content [#36653]
+- Google Embed blocks: make proportion values translatable [#36641]
+- Improve UX when setting AI Featured Image [#36643]
+- Packages: add version tracking for identity-crisis package. [#36635]
+- Recipe Block: make default texts translatable [#36624]
+- Save generated AI image to library and set as featured image [#36626]
+- SSO: remove jQuery dependency for improved performance. [#36605]
+- Subscription login block: switch to singular "manage subscription" [#36603]
+- Subscriptions: Add missing padding param to the Subscriber popup markup [#36619]
+- Subscriptions: Fix Subscribe block invalid content [#36617]
+- Subscription Site: Hook Subscriber Login block into the navigation [#36487]
+- Untangling: return untangled admin menu from wpcom/v2/admin-menu endpoint for early classic view [#36601]
+
 ## 13.3-a.9 - 2024-03-27
 ### Bug fixes
 - Paid Content Block: Fix subscriber view content not rendering in WordPress.com reader. [#36512]

--- a/projects/plugins/jetpack/changelog/add-disable-ai-featured-image-button
+++ b/projects/plugins/jetpack/changelog/add-disable-ai-featured-image-button
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Disable AI Featured Image button if requires upgrade or no post content

--- a/projects/plugins/jetpack/changelog/add-featured-image-modal
+++ b/projects/plugins/jetpack/changelog/add-featured-image-modal
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-AI Plugin: Add modal and featured image usage

--- a/projects/plugins/jetpack/changelog/add-idc-package-version-tracking
+++ b/projects/plugins/jetpack/changelog/add-idc-package-version-tracking
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Packages: add version tracking for identity-crisis package.

--- a/projects/plugins/jetpack/changelog/add-idc-package-version-tracking#2
+++ b/projects/plugins/jetpack/changelog/add-idc-package-version-tracking#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-jetpack.idcUrlValidation_to_rest
+++ b/projects/plugins/jetpack/changelog/add-jetpack.idcUrlValidation_to_rest
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-phan-stub-wordpress-functions
+++ b/projects/plugins/jetpack/changelog/add-phan-stub-wordpress-functions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add Phan stub for wordpress functions.

--- a/projects/plugins/jetpack/changelog/add-re-identification-commercial-endpoints
+++ b/projects/plugins/jetpack/changelog/add-re-identification-commercial-endpoints
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-rest-endpoint-get-blog
+++ b/projects/plugins/jetpack/changelog/add-rest-endpoint-get-blog
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-set-featured-image
+++ b/projects/plugins/jetpack/changelog/add-set-featured-image
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Save generated AI image to library and set as featured image

--- a/projects/plugins/jetpack/changelog/add-version-constant-composer
+++ b/projects/plugins/jetpack/changelog/add-version-constant-composer
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-blog-stats-version
+++ b/projects/plugins/jetpack/changelog/fix-blog-stats-version
@@ -1,3 +1,0 @@
-Significance: patch
-Type: other
-Comment: fix release version number listed in the Blog Stats block.

--- a/projects/plugins/jetpack/changelog/fix-carousel-lightbox-disable
+++ b/projects/plugins/jetpack/changelog/fix-carousel-lightbox-disable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Carousel: disable WordPress' lightbox option when Jetpack's Carousel feature is activated.

--- a/projects/plugins/jetpack/changelog/fix-google-embed-blocks-not-translatable-text
+++ b/projects/plugins/jetpack/changelog/fix-google-embed-blocks-not-translatable-text
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Google Embed blocks: make proportion values translatable

--- a/projects/plugins/jetpack/changelog/fix-jetpack-my-jetpack-version-ref
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-my-jetpack-version-ref
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fixed a pnpm version reference for internal dependency
-
-

--- a/projects/plugins/jetpack/changelog/fix-mapkit-accuracy
+++ b/projects/plugins/jetpack/changelog/fix-mapkit-accuracy
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Minor bugfix
-
-

--- a/projects/plugins/jetpack/changelog/fix-recipe-block-not-translatable-text
+++ b/projects/plugins/jetpack/changelog/fix-recipe-block-not-translatable-text
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Recipe Block: make default texts translatable

--- a/projects/plugins/jetpack/changelog/fix-subscription-manage-label
+++ b/projects/plugins/jetpack/changelog/fix-subscription-manage-label
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscription login block: switch to singular "manage subscription"

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.4-a.0
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.3-a.10
-
-

--- a/projects/plugins/jetpack/changelog/refactor-jetpacl-plugin-connect-screen
+++ b/projects/plugins/jetpack/changelog/refactor-jetpacl-plugin-connect-screen
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Refactor the Jetpack plugin connect screen
-
-

--- a/projects/plugins/jetpack/changelog/remove-ai-assistant-hook-dead-code
+++ b/projects/plugins/jetpack/changelog/remove-ai-assistant-hook-dead-code
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-AI Assistant: remove dead code from the suggestions hook

--- a/projects/plugins/jetpack/changelog/untangling-nav-reunification
+++ b/projects/plugins/jetpack/changelog/untangling-nav-reunification
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Untangling: return untangled admin menu from wpcom/v2/admin-menu endpoint for early classic view

--- a/projects/plugins/jetpack/changelog/update-add-stats-utm-endpoints
+++ b/projects/plugins/jetpack/changelog/update-add-stats-utm-endpoints
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-feature-image-connect-image-generation
+++ b/projects/plugins/jetpack/changelog/update-feature-image-connect-image-generation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Featured Image: connect the image generation hook to the UI.

--- a/projects/plugins/jetpack/changelog/update-featured-image-add-event-tracking
+++ b/projects/plugins/jetpack/changelog/update-featured-image-add-event-tracking
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Featured Image: track events for generating, regenerating and using images

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-remove-unused-code
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-remove-unused-code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Remove unused code

--- a/projects/plugins/jetpack/changelog/update-login-block-no-manage-link
+++ b/projects/plugins/jetpack/changelog/update-login-block-no-manage-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Member login block: add ability to hide manage subscription -link.

--- a/projects/plugins/jetpack/changelog/update-redirect-from-interstitial-if-product-active
+++ b/projects/plugins/jetpack/changelog/update-redirect-from-interstitial-if-product-active
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-seo-settings
+++ b/projects/plugins/jetpack/changelog/update-seo-settings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-SEO Tools: make the feature available on non-connected sites.

--- a/projects/plugins/jetpack/changelog/update-set-ai-featured-image-ux
+++ b/projects/plugins/jetpack/changelog/update-set-ai-featured-image-ux
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Improve UX when setting AI Featured Image

--- a/projects/plugins/jetpack/changelog/update-sso-no-jquery
+++ b/projects/plugins/jetpack/changelog/update-sso-no-jquery
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-SSO: remove jQuery dependency for improved performance.

--- a/projects/plugins/jetpack/changelog/update-subscribe-block-invalid-content
+++ b/projects/plugins/jetpack/changelog/update-subscribe-block-invalid-content
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Fix Subscribe block invalid content

--- a/projects/plugins/jetpack/changelog/update-subscriber-popup-invalid-content-fix
+++ b/projects/plugins/jetpack/changelog/update-subscriber-popup-invalid-content-fix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Add missing padding param to the Subscriber popup markup

--- a/projects/plugins/jetpack/changelog/update-subscription-site-login-navigation
+++ b/projects/plugins/jetpack/changelog/update-subscription-site-login-navigation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscription Site: Hook Subscriber Login block into the navigation

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_beta",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_a_10",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_3_beta",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.3-a.10
+ * Version: 13.3-beta
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.3-a.10' );
+define( 'JETPACK__VERSION', '13.3-beta' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.3-beta
+ * Version: 13.4-a.0
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.3-beta' );
+define( 'JETPACK__VERSION', '13.4-a.0' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -213,7 +213,7 @@ class Jetpack_Carousel {
 	 * Disable the "Lightbox" option offered in WordPress core
 	 * whenever Jetpack's Carousel feature is enabled.
 	 *
-	 * @since $$next-version$$
+	 * @since 13.3
 	 *
 	 * @param WP_Theme_JSON_Data $theme_json Class to access and update theme.json data.
 	 */

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.3.0-beta",
+	"version": "13.4.0-a.0",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.3.0-a.10",
+	"version": "13.3.0-beta",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -327,11 +327,35 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 == Changelog ==
 ### 13.3-beta - 2024-04-01
 #### Enhancements
+- AI Assistant: Provide per-block quick actions to make them more relevant.
+- Blocks: "Earn" category renamed to "Monetize".
+- General: Only show installation errors on Plugins page.
+- Jetpack AI: When the response includes a title and post title is empty, use provided title as post title.
 - Member login block: add ability to hide manage subscription -link.
+- My Jetpack: Trigger red bubble notification when a broken installation is detected.
+- Newsletters: Display Email settings on Newsletter settings page.
+- Newsletters: Ensure blog stats and top posts blocks do not render in email newsletters.
+- Newsletters: Reorder settings cards to improve hierarchy.
+- Newsletters: Use radio buttons instead of toggles on Email Settings.
+- Sharing: Add a Bluesky sharing button.
+- Sharing: add a Threads sharing button and a Threads sharing button block.
+- Sharing: Add Native (Web Share) button to Sharing Buttons block.
+- Sharing: Remove Like button from master bar.
+- Social: Add support for an SMS button.
 
 #### Improved compatibility
 - Carousel: disable WordPress' lightbox option when Jetpack's Carousel feature is activated.
+- General: Remove methods that were deprecated before the release of Jetpack 10.0, in 2021.
 - SEO Tools: make the feature available on non-connected sites.
+- Subscriptions: Remove subscription settings from reading options page.
+
+#### Bug fixes
+- Dashboard: Update the sharing button settings to clarify the available options (block or legacy sharing buttons).
+- Enhanced Distribution: begin deprecation process as the Firehose is winding down.
+- Paid Content Block: Fix subscriber view content not rendering in WordPress.com reader.
+- Sharing: avoid PHP warnings when using custom post types.
+- Sharing: fix the display of the sharing block in some classic themes.
+- SSO: Disable WordPress.com invitation functionality for non-connected users.
 
 --------
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -325,10 +325,13 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.3-a.9 - 2024-03-27
-#### Bug fixes
-- Paid Content Block: Fix subscriber view content not rendering in WordPress.com reader.
-- SSO: Disable WordPress.com invitation functionality for non-connected users.
+### 13.3-beta - 2024-04-01
+#### Enhancements
+- Member login block: add ability to hide manage subscription -link.
+
+#### Improved compatibility
+- Carousel: disable WordPress' lightbox option when Jetpack's Carousel feature is activated.
+- SEO Tools: make the feature available on non-connected sites.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.11 - 2024-04-01
+### Changed
+- Internal updates.
+
 ## 2.1.10 - 2024-03-27
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-wpcom-simple-odyssey-stats
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-wpcom-simple-odyssey-stats
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-use-dotcom-pattern-library
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-use-dotcom-pattern-library
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_11_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_11"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.11-alpha
+ * Version: 2.1.11
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.11-alpha",
+	"version": "2.1.11",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.11, jetpack 13.3-beta

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.