### PR TITLE
CI: Disable 8.4 PHPCompatibility rule in dev run

### DIFF
--- a/.github/files/phpcompatibility-dev-phpcs.xml
+++ b/.github/files/phpcompatibility-dev-phpcs.xml
@@ -8,5 +8,8 @@
 	<rule ref="PHPCompatibilityWP">
 		<!-- Doesn't hurt anything, earlier versions ignore attributes. -->
 		<exclude name="PHPCompatibility.Attributes.NewAttributes.Found" />
+
+		<!-- We're not ready for 8.4 yet. Hopefully https://core.trac.wordpress.org/ticket/58719 will happen before we are. -->
+		<exclude name="PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated" />
 	</rule>
 </ruleset>

--- a/projects/packages/identity-crisis/changelog/fix-phpcompatibility-dev-phpcs
+++ b/projects/packages/identity-crisis/changelog/fix-phpcompatibility-dev-phpcs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Version bump after https://github.com/Automattic/jetpack/pull/36655
+
+

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.18.0",
+	"version": "0.18.1-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -26,7 +26,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.18.0';
+	const PACKAGE_VERSION = '0.18.1-alpha';
 
 	/**
 	 * Package Slug

--- a/projects/packages/my-jetpack/changelog/fix-phpcompatibility-dev-phpcs
+++ b/projects/packages/my-jetpack/changelog/fix-phpcompatibility-dev-phpcs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Version bump after https://github.com/Automattic/jetpack/pull/36655
+
+

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.20.0",
+	"version": "4.20.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -36,7 +36,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.20.0';
+	const PACKAGE_VERSION = '4.20.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/boost/changelog/fix-phpcompatibility-dev-phpcs
+++ b/projects/plugins/boost/changelog/fix-phpcompatibility-dev-phpcs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Version bump after https://github.com/Automattic/jetpack/pull/36655
+
+

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "3.2.1",
+	"version": "3.2.2-alpha",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -73,7 +73,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_2_1",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_2_2_alpha",
 		"allow-plugins": {
 			"roots/wordpress-core-installer": true,
 			"automattic/jetpack-autoloader": true,

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5660ce4110b6eb8d5a301b0d63544f5b",
+    "content-hash": "eee808f5a3df537d4ca2fc636f2a820a",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 3.2.1
+ * Version: 3.2.2-alpha
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'JETPACK_BOOST_VERSION', '3.2.1' );
+define( 'JETPACK_BOOST_VERSION', '3.2.2-alpha' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-boost",
-	"version": "3.2.1",
+	"version": "3.2.2-alpha",
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"directories": {
 		"test": "tests"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We run PHPCompatibility's develop branch against our stuff, because they haven't done a release since 2019 because (as far as I know) they're still waiting on getting PHP 8.0 support completely finished before they release 10.0.0.

It seems they've now added a rule for PHP 8.4's deprecation of declaring parameters as nullable like `ClassName $param = null`. The ideal solution would be to change those to `?ClassName $param = null`, but until we can drop PHP 7.0 support we can't do that.

So for now let's disable that sniff. Hopefully by the time we start looking at PHP 8.4 support https://core.trac.wordpress.org/ticket/58719 will have happened so we can do the right thing instead of having to change those to be like `$param = null` instead.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1711976022933969-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is the "PHP Compatibility / dev branch for PHP 8.0" check happy now?