### PR TITLE
Fix/sync between boost scores

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-sync-between-boost-scores
+++ b/projects/packages/my-jetpack/changelog/fix-sync-between-boost-scores
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Boost score inconsistency

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -198,7 +198,7 @@ class Initializer {
 		);
 		$modules             = new Modules();
 		$connection          = new Connection_Manager();
-		$speed_score_history = new Speed_Score_History( wp_parse_url( get_site_url(), PHP_URL_HOST ) );
+		$speed_score_history = new Speed_Score_History( get_site_url() );
 		wp_localize_script(
 			'my_jetpack_main_app',
 			'myJetpackInitialState',


### PR DESCRIPTION
## Proposed changes:

* Send unparsed URL to Boost History class from My Jetpack

The Boost plugin itself does not send a parsed URL and includes the "https://", but My Jetpack currently parses it and does not include that part of the URL. This is causing 2 cache objects to be created. One for Boost and one for My Jetpack, which caused the inconsistent scores seen in My Jetpack

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pbNhbs-9Nt-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Purchase a Boost paid plan on your site
3. Go to My Jetpack and wait for the scores to be calculated for the first time
![image](https://github.com/Automattic/jetpack/assets/65001528/0938c8b5-d6e5-4602-bb7b-6a020e9ca8c2)
4. Now go to `/wp-admin/admin.php?page=jetpack-boost`
5. Refresh the scores until you get a different average than the initial score shown on My Jetpack
6. Make sure the updated score is reflected in My Jetpack and that the average is correct
![image](https://github.com/Automattic/jetpack/assets/65001528/77fafabd-913b-4844-a508-1d6d2b4cb373)
![image](https://github.com/Automattic/jetpack/assets/65001528/c8d15c8c-641d-443b-8d64-da4fc5e2cebf)
