### PR TITLE
Fix deprecation warnings in the Color library.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.color.php
+++ b/projects/plugins/jetpack/_inc/lib/class.color.php
@@ -102,7 +102,7 @@ class Jetpack_Color {
 			throw new RangeException( 'Blue value ' . $blue . ' out of valid color code range' );
 		}
 
-		$this->color = (int) ( ( $red << 16 ) + ( $green << 8 ) + $blue );
+		$this->color = floor( ( $red << 16 ) + ( $green << 8 ) + $blue );
 
 		return $this;
 	}

--- a/projects/plugins/jetpack/_inc/lib/class.color.php
+++ b/projects/plugins/jetpack/_inc/lib/class.color.php
@@ -102,7 +102,7 @@ class Jetpack_Color {
 			throw new RangeException( 'Blue value ' . $blue . ' out of valid color code range' );
 		}
 
-		$this->color = floor( ( $red << 16 ) + ( $green << 8 ) + $blue );
+		$this->color = (int) floor( ( $red << 16 ) + ( $green << 8 ) + $blue );
 
 		return $this;
 	}

--- a/projects/plugins/jetpack/_inc/lib/class.color.php
+++ b/projects/plugins/jetpack/_inc/lib/class.color.php
@@ -102,7 +102,7 @@ class Jetpack_Color {
 			throw new RangeException( 'Blue value ' . $blue . ' out of valid color code range' );
 		}
 
-		$this->color = (int) floor( ( $red << 16 ) + ( $green << 8 ) + $blue );
+		$this->color = intval( ( $red << 16 ) + ( $green << 8 ) + $blue );
 
 		return $this;
 	}

--- a/projects/plugins/jetpack/changelog/fix-deprecation-warnings-color
+++ b/projects/plugins/jetpack/changelog/fix-deprecation-warnings-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Theme tools: Use integer casting method that doesn't cause deprecation notices.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes deprecation notices like:

```
PHP Deprecated:  Implicit conversion from float 152.81980000000001 to int loses precision in /_inc/lib/class.color.php on line 105
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `floor` instead of integer casting to avoid deprecation notices.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* I couldn't reproduce the problem, but I'd appreciate it if you added a way to make Jetpack go through that flow. I have tried adding a theme [with support for tonesque](https://wordpress.org/themes/ryu/) , but it seems to be not enough on its own.

