### PR TITLE
Add Hosting menu to Simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-hosting-menu-to-simple
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-hosting-menu-to-simple
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow Simple sites access to the Hosting menu

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -51,7 +51,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.22.x-dev"
+			"dev-trunk": "5.23.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.22.0",
+	"version": "5.23.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.22.0';
+	const PACKAGE_VERSION = '5.23.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -18,11 +18,11 @@ function current_user_has_wpcom_account() {
 	$user_id = get_current_user_id();
 
 	if ( function_exists( '\A8C\Billingdaddy\Users\get_wpcom_user' ) ) {
-		// On Simple sites, we can use the get_wpcom_user function to check if the user has a WordPress.com account.
+		// @phan-suppress-next-line PhanUndeclaredFunction -- On Simple sites, use get_wpcom_user function to check if the user has a WordPress.com account.
 		$user        = \A8C\Billingdaddy\Users\get_wpcom_user( $user_id );
 		$has_account = isset( $user->ID );
 	} else {
-		// On Atomic sites, we need to use the Connection Manager to check if the user has a WordPress.com account.
+		// On Atomic sites, use the Connection Manager to check if the user has a WordPress.com account.
 		$connection_manager = new Connection_Manager();
 		$wpcom_user_data    = $connection_manager->get_connected_user_data( $user_id );
 		$has_account        = isset( $wpcom_user_data['ID'] );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -15,13 +15,20 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
  * @return bool
  */
 function current_user_has_wpcom_account() {
-	$user_id            = get_current_user_id();
-	$connection_manager = new Connection_Manager();
-	$wpcom_user_data    = $connection_manager->get_connected_user_data( $user_id );
-	if ( ! isset( $wpcom_user_data['ID'] ) ) {
-		return false;
+	$user_id = get_current_user_id();
+
+	if ( function_exists( '\A8C\Billingdaddy\Users\get_wpcom_user' ) ) {
+		// On Simple sites, we can use the get_wpcom_user function to check if the user has a WordPress.com account.
+		$user        = \A8C\Billingdaddy\Users\get_wpcom_user( $user_id );
+		$has_account = isset( $user->ID );
+	} else {
+		// On Atomic sites, we need to use the Connection Manager to check if the user has a WordPress.com account.
+		$connection_manager = new Connection_Manager();
+		$wpcom_user_data    = $connection_manager->get_connected_user_data( $user_id );
+		$has_account        = isset( $wpcom_user_data['ID'] );
 	}
-	return true;
+
+	return $has_account;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -18,7 +18,8 @@ function current_user_has_wpcom_account() {
 	$user_id = get_current_user_id();
 
 	if ( function_exists( '\A8C\Billingdaddy\Users\get_wpcom_user' ) ) {
-		// @phan-suppress-next-line PhanUndeclaredFunction -- On Simple sites, use get_wpcom_user function to check if the user has a WordPress.com account.
+		// On Simple sites, use get_wpcom_user function to check if the user has a WordPress.com account.
+		// @phan-suppress-next-line PhanUndeclaredFunction
 		$user        = \A8C\Billingdaddy\Users\get_wpcom_user( $user_id );
 		$has_account = isset( $user->ID );
 	} else {

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-hosting-menu-to-simple
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-hosting-menu-to-simple
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_11"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_12_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -129,7 +129,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "0b49970bdde8c3c05388592c86db00b2888f6dd4"
+                "reference": "6afd8e193ad433131247e6cba33ba6d3d926c055"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -152,7 +152,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.22.x-dev"
+                    "dev-trunk": "5.23.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.11
+ * Version: 2.1.12-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.11",
+	"version": "2.1.12-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6230

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates `current_user_has_wpcom_account` so it will check if the user on a Simple site has a wpcom account.
* Making this check on a Simple site makes the Hosting menu available on wp-admin if `wpcom_classic_early_release = 1` and `wpcom_admin_interface = 'wp-admin'`

<img width="1233" alt="Screenshot 2024-04-01 at 5 20 08 PM" src="https://github.com/Automattic/jetpack/assets/140841/fceabd73-93c8-476a-9958-a861fb13ca88">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your Sandbox with the instruction found in the comment below: https://github.com/Automattic/jetpack/pull/36684#issuecomment-2030636856
* On an Atomic site with `wpcom_classic_early_release = 1` and `wpcom_admin_interface = 'wp-admin'`, the testing instructions on https://github.com/Automattic/jetpack/pull/36405 should still apply, and no regressions should be introduced.
* On a Simple site with `wpcom_classic_early_release = 1` and `wpcom_admin_interface = 'wp-admin'` the behavior should be the same as on Atomic site (in the instructions above). However, I don't think it is possible to have a non-WordPress.com Simple site user login. Please correct me if I'm wrong.
* Ensure the Hosting menu does not appear on non-early release or non-Classic Simple sites.