### PR TITLE
SSO: disable user invite system on Multisite

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sso-no-multisite
+++ b/projects/plugins/jetpack/changelog/update-sso-no-multisite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Secure Sign-On: disable the WordPress.com invitation setup on Multisite.

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -97,6 +97,7 @@ class Jetpack_SSO {
 		 */
 		if (
 			Jetpack_SSO_Helpers::is_user_connected() &&
+			! is_multisite() &&
 			/**
 			 * Toggle the ability to invite new users to create a WordPress.com account.
 			 *


### PR DESCRIPTION
Fixes #36682

## Proposed changes:

Multisite users can be a bit different from single-site users, since they can be created and only added to a specific site later on. Let'ss disable this feature on Multisite networks for now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Create a new Multisite network, and apply this branch.
* On a secondary site on that network, go to Users > Add New
    * You should not see the notice to invite the new user to WordPress.com.
