### PR TITLE
Fix untranslated sharing label

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-translation-issues
+++ b/projects/plugins/jetpack/changelog/fix-translation-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix translation issues for default attributes

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -846,7 +846,7 @@ function render_for_website( $data, $classes, $styles ) {
 							esc_attr( $subscribe_field_id ),
 							( ! empty( $data['subscribe_email'] )
 								? 'disabled title="' . esc_attr__( "You're logged in with this email", 'jetpack' ) . '"'
-								: ''
+								: 'title="' . esc_attr__( 'Please fill in this field.', 'jetpack' ) . '"'
 							)
 						);
 						?>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -60,6 +60,88 @@ function register_block() {
 					),
 					'align'   => array( 'wide', 'full' ),
 				),
+				'attributes'      => array(
+					'subscribePlaceholder'            => array(
+						'type'    => 'string',
+						'default' => __( 'Type your email…', 'jetpack' ),
+					),
+					'showSubscribersTotal'            => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'includeSocialFollowers'          => array(
+						'type' => 'boolean',
+					),
+					'buttonOnNewLine'                 => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+					'buttonWidth'                     => array(
+						'type' => 'string',
+					),
+					'submitButtonText'                => array(
+						'type'    => 'string',
+						'default' => __( 'Subscribe', 'jetpack' ),
+					),
+					'emailFieldBackgroundColor'       => array(
+						'type' => 'string',
+					),
+					'customEmailFieldBackgroundColor' => array(
+						'type' => 'string',
+					),
+					'emailFieldGradient'              => array(
+						'type' => 'string',
+					),
+					'customEmailFieldGradient'        => array(
+						'type' => 'string',
+					),
+					'buttonBackgroundColor'           => array(
+						'type' => 'string',
+					),
+					'customButtonBackgroundColor'     => array(
+						'type' => 'string',
+					),
+					'buttonGradient'                  => array(
+						'type' => 'string',
+					),
+					'customButtonGradient'            => array(
+						'type' => 'string',
+					),
+					'textColor'                       => array(
+						'type' => 'string',
+					),
+					'customTextColor'                 => array(
+						'type' => 'string',
+					),
+					'fontSize'                        => array(
+						'type' => 'string',
+					),
+					'customFontSize'                  => array(
+						'type' => 'string',
+					),
+					'borderRadius'                    => array(
+						'type' => 'number',
+					),
+					'borderWeight'                    => array(
+						'type' => 'number',
+					),
+					'borderColor'                     => array(
+						'type' => 'string',
+					),
+					'customBorderColor'               => array(
+						'type' => 'string',
+					),
+					'padding'                         => array(
+						'type' => 'number',
+					),
+					'spacing'                         => array(
+						'type' => 'number',
+					),
+					'successMessage'                  => array(
+						'type'    => 'string',
+						'default' => __( 'Success! An email was just sent to confirm your subscription. Please find the email now and click \'Confirm Follow\' to start subscribing.', 'jetpack' ),
+					),
+				),
 			)
 		);
 	}

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -501,7 +501,7 @@ class Sharing_Service {
 			}
 		}
 
-		if ( false === $this->global['sharing_label'] ) {
+		if ( false === $this->global['sharing_label'] || $this->global['sharing_label'] === 'Share this:' ) {
 			$this->global['sharing_label'] = $this->default_sharing_label;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
This PR fixes various translation issues reported at: p1711987181200529-slack-C02T4NVL4JJ
Fixes #

| Before  | After |
| ------------- | ------------- |
|  ![Screen Shot 2024-04-01 at 11 51 05 AM](https://github.com/Automattic/jetpack/assets/7000684/626aa60d-c916-4e15-9154-40c4effaac28) |  <img width="877" alt="Screenshot 2024-04-02 at 15 35 11" src="https://github.com/Automattic/jetpack/assets/7000684/463157f7-0a31-4169-8d77-e444f77eacc1"> |

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix missing translations

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this PR
* Visit: p8OO8Y-1v-p2
* The "Share this:" string should be properly translated. For some sites this label site setting is set to eng even though locale is different.
* The email placeholder, title and subscribe button should also be translated. Note: the title translation has just been added and it will take a while to get translated.