### PR TITLE
Fix scheduled updates deletion/saving

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-saving
+++ b/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-saving
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Force cache cleaning before scheduling a new job.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -21,6 +21,7 @@ class Scheduled_Updates {
 	 * @var string
 	 */
 	const PACKAGE_VERSION = '0.6.0-alpha';
+
 	/**
 	 * The cron event hook for the scheduled plugins update.
 	 *

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -102,7 +102,7 @@ class Scheduled_Updates {
 	 * @param int    $timestamp Timestamp of the first run.
 	 * @param string $interval  Interval of the update.
 	 * @param array  $plugins   List of plugins to update.
-	 * @return WP_Error|bool True on success, WP_Error on failure.
+	 * @return \WP_Error|bool True on success, WP_Error on failure.
 	 */
 	public static function create_scheduled_update( $timestamp, $interval, $plugins ) {
 		return wp_schedule_event( $timestamp, $interval, self::PLUGIN_CRON_HOOK, $plugins, true );
@@ -113,7 +113,7 @@ class Scheduled_Updates {
 	 *
 	 * @param int   $timestamp Timestamp of the first run.
 	 * @param array $plugins   List of plugins to update.
-	 * @return WP_Error|bool True on success, WP_Error on failure.
+	 * @return \WP_Error|bool True on success, WP_Error on failure.
 	 */
 	public static function delete_scheduled_update( $timestamp, $plugins ) {
 		// Be sure to clear the cron cache before removing a cron entry.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -246,7 +246,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$plugins  = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );
 
-		$event = wp_schedule_event( $schedule['timestamp'], $schedule['interval'], Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins, true );
+		$event = Scheduled_Updates::create_scheduled_update( $schedule['timestamp'], $schedule['interval'], $plugins );
 		if ( is_wp_error( $event ) ) {
 			return $event;
 		}
@@ -428,7 +428,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 
 		$event = $events[ $request['schedule_id'] ];
 
-		$result = wp_unschedule_event( $event->timestamp, Scheduled_Updates::PLUGIN_CRON_HOOK, $event->args, true );
+		$result = Scheduled_Updates::delete_scheduled_update( $event->timestamp, $event->args );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -570,6 +570,82 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test clear CRON cache.
+	 *
+	 * @covers ::clear_cron_cache
+	 */
+	public function test_clear_cron_cache() {
+		$plugins = $this->create_plugins_for_deletion( 3 );
+		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$params  = array(
+			'plugins'  => array(),
+			'schedule' => array(
+				'timestamp' => strtotime( 'next Monday 8:00' ),
+				'interval'  => 'weekly',
+			),
+		);
+
+		wp_set_current_user( $this->admin_id );
+
+		$params['plugins']               = array( $plugins[0] );
+		$params['schedule']['timestamp'] = strtotime( 'next Monday 8:00' );
+		$request->set_body_params( $params );
+
+		// Create first event.
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+
+		$id_1 = $result->get_data();
+		$this->assertIsString( $id_1 );
+
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertCount( 1, $events );
+
+		$params['plugins']               = array( $plugins[1], $plugins[2] );
+		$params['schedule']['timestamp'] = strtotime( 'next Monday 9:00' );
+		$request->set_body_params( $params );
+
+		// Create second event.
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+
+		$id_2 = $result->get_data();
+		$this->assertIsString( $id_2 );
+
+		// Get scheduled events.
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertCount( 2, $events );
+
+		$request = new \WP_REST_Request( 'GET', '/wpcom/v2/update-schedules' );
+		$result  = rest_do_request( $request );
+		$data    = $result->get_data();
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertArrayHasKey( $id_1, $data );
+		$this->assertArrayHasKey( $id_2, $data );
+
+		$request = new \WP_REST_Request( 'DELETE', '/wpcom/v2/update-schedules/' . $id_1 );
+		$result  = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertTrue( $result->get_data() );
+
+		// Get scheduled events.
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertCount( 1, $events );
+
+		$request = new \WP_REST_Request( 'GET', '/wpcom/v2/update-schedules' );
+		$result  = rest_do_request( $request );
+		$data    = $result->get_data();
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertArrayNotHasKey( $id_1, $data );
+		$this->assertArrayHasKey( $id_2, $data );
+	}
+
+	/**
 	 * Data provider for test_get_scheduled_update_text.
 	 *
 	 * @return array[]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
We read the `cron` option during the scheduled update creation, we change it (removing an entry), and then the core reads the same thing in `_get_cron_array.` The option is `autoload` so sometimes, the cron function loads an old version saved into memory, and the old array is used and not the new one.

Fixes https://github.com/Automattic/dotcom-forge/issues/5948

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Force cache cleaning before scheduling a new job. See rWPGIT24e50b1b82d2-code
* Move `wp_schedule_event` and `wp_unschedule_event` to the same class. So that if we need to do something every time, there will be no need to decouple the code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure to have a functioning test environment.
* `Go to http://calypso.localhost:3000/plugins/scheduled-updates/__BLOG__`
* Create a scheduled update and quickly (< 10 seconds) another one.
* Wait for some seconds, and reload the page a couple of times.
* Delete an update and re-add it.
* Ensure every operation does what it must do.
* Install a plugin, add it to a scheduled update, create a schedule with only that plugin, and remove it.
* Repeat the same test 3-4 times.