### PR TITLE
Fix PHP 8.1 error in youtube shortcode

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-youtube-shortcode-error
+++ b/projects/plugins/jetpack/changelog/fix-youtube-shortcode-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+PHP 8.1: Fix error trying to run preg_split on array

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -235,7 +235,7 @@ function youtube_id( $url ) {
 	} elseif ( isset( $args['t'] ) ) {
 		if ( is_numeric( $args['t'] ) ) {
 			$start = (int) $args['t'];
-		} else {
+		} elseif ( is_string( $args['t'] ) ) {
 			$time_pieces = preg_split( '/(?<=\D)(?=\d+)/', $args['t'] );
 
 			foreach ( $time_pieces as $time_piece ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We recently noticed some errors where `preg_split` was being called on an array instead of a string. This change ensures that we only call it on strings to avoid PHP errors. 

## Proposed changes:
This adds a check to make sure we only try to run `preg_split` if the `$args['t']` is a string.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
no.

## Testing instructions:
ensure existing unit tests pass
