### PR TITLE
Fix/cache on front end boost scores

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/boost-speed-score.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/boost-speed-score.tsx
@@ -25,7 +25,7 @@ const BoostSpeedScore: FC = () => {
 	const [ isTooltipVisible, setIsTooltipVisible ] = useState( false );
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 
-	const { siteSuffix: siteUrl = '', latestBoostSpeedScores } = getMyJetpackWindowInitialState();
+	const { siteUrl = '', latestBoostSpeedScores } = getMyJetpackWindowInitialState();
 	const { apiRoot, apiNonce, isSiteConnected } = useMyJetpackConnection();
 
 	const getAverageSpeedScore = ( mobileScore, desktopScore ) => {

--- a/projects/packages/my-jetpack/changelog/fix-cache-on-front-end-boost-scores
+++ b/projects/packages/my-jetpack/changelog/fix-cache-on-front-end-boost-scores
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix cache on front end request for boost speed scores

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -6,6 +6,7 @@ declare module '*.scss';
 interface Window {
 	myJetpackInitialState?: {
 		siteSuffix: string;
+		siteUrl: string;
 		latestBoostSpeedScores: {
 			scores: {
 				desktop: number;

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.20.2",
+	"version": "4.20.3-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -214,6 +214,7 @@ class Initializer {
 				'myJetpackCheckoutUri'   => admin_url( 'admin.php?page=my-jetpack' ),
 				'topJetpackMenuItemUrl'  => Admin_Menu::get_top_level_menu_item_url(),
 				'siteSuffix'             => ( new Status() )->get_site_suffix(),
+				'siteUrl'                => get_site_url(),
 				'blogID'                 => Connection_Manager::get_site_id( true ),
 				'myJetpackVersion'       => self::PACKAGE_VERSION,
 				'myJetpackFlags'         => self::get_my_jetpack_flags(),

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -214,7 +214,7 @@ class Initializer {
 				'myJetpackCheckoutUri'   => admin_url( 'admin.php?page=my-jetpack' ),
 				'topJetpackMenuItemUrl'  => Admin_Menu::get_top_level_menu_item_url(),
 				'siteSuffix'             => ( new Status() )->get_site_suffix(),
-				'siteUrl'                => get_site_url(),
+				'siteUrl'                => esc_url( get_site_url() ),
 				'blogID'                 => Connection_Manager::get_site_id( true ),
 				'myJetpackVersion'       => self::PACKAGE_VERSION,
 				'myJetpackFlags'         => self::get_my_jetpack_flags(),

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -36,7 +36,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.20.2';
+	const PACKAGE_VERSION = '4.20.3-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
## Proposed changes:

* Add siteUrl value to initial state for boost speed score caching

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Purchase a Boost paid plan on your site
3. Go to My Jetpack and wait for the scores to be calculated for the first time
![image](https://github.com/Automattic/jetpack/assets/65001528/0938c8b5-d6e5-4602-bb7b-6a020e9ca8c2)
4. Now go to `/wp-admin/admin.php?page=jetpack-boost`
5. Refresh the scores until you get a different average than the initial score shown on My Jetpack
6. Make sure the updated score is reflected in My Jetpack and that the average is correct
![image](https://github.com/Automattic/jetpack/assets/65001528/77fafabd-913b-4844-a508-1d6d2b4cb373)
![image](https://github.com/Automattic/jetpack/assets/65001528/c8d15c8c-641d-443b-8d64-da4fc5e2cebf)