### PR TITLE
Blocks: upgrade to API version 3 - Part 1

### DIFF
--- a/projects/plugins/jetpack/changelog/update-bump-block-api-version
+++ b/projects/plugins/jetpack/changelog/update-bump-block-api-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update blocks to use API version 3

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/blog-stats",
 	"title": "Blog Stats",
 	"description": "Show a stats counter for your blog.",

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/edit.js
@@ -1,7 +1,7 @@
 import { numberFormat } from '@automattic/jetpack-components';
 import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
-import { InspectorControls, RichText } from '@wordpress/block-editor';
+import { InspectorControls, RichText, useBlockProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __, _n } from '@wordpress/i18n';
@@ -9,6 +9,7 @@ import { BlogStatsInspectorControls } from './controls';
 import { InactiveStatsPlaceholder } from './inactive-placeholder';
 
 function BlogStatsEdit( { attributes, className, setAttributes } ) {
+	const blockProps = useBlockProps();
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'stats' );
 	const { label, statsData, statsOption } = attributes;
@@ -64,7 +65,7 @@ function BlogStatsEdit( { attributes, className, setAttributes } ) {
 		_n( 'hit', 'hits', parseInt( stats ), 'jetpack', 0 );
 
 	return (
-		<>
+		<div { ...blockProps }>
 			<InspectorControls>
 				<BlogStatsInspectorControls attributes={ attributes } setAttributes={ setAttributes } />
 			</InspectorControls>
@@ -85,7 +86,7 @@ function BlogStatsEdit( { attributes, className, setAttributes } ) {
 					</p>
 				) }
 			</div>
-		</>
+		</div>
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/edit.js
@@ -9,13 +9,13 @@ import { BlogStatsInspectorControls } from './controls';
 import { InactiveStatsPlaceholder } from './inactive-placeholder';
 
 function BlogStatsEdit( { attributes, className, setAttributes } ) {
-	const blockProps = useBlockProps();
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'stats' );
 	const { label, statsData, statsOption } = attributes;
 	const [ blogViews, setBlogViews ] = useState( null );
 	const [ blogVisitors, setBlogVisitors ] = useState();
 	const [ postViews, setPostViews ] = useState();
+	const blockProps = useBlockProps();
 
 	const blogStats = statsData === 'views' ? blogViews : blogVisitors;
 	const stats = statsOption === 'post' ? postViews : blogStats;

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/test/edit.js
@@ -15,6 +15,11 @@ useSelect.mockImplementation( () => {
 	};
 } );
 
+jest.mock( '@wordpress/block-editor', () => ( {
+	...jest.requireActual( '@wordpress/block-editor' ),
+	useBlockProps: jest.fn(),
+} ) );
+
 const defaultAttributes = {
 	label: '',
 	statsOption: 'site',

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/buttons/index.js
@@ -6,7 +6,7 @@ import save from './save';
 
 const name = 'premium-content/buttons';
 const settings = {
-	apiVersion: 2,
+	apiVersion: 3,
 	title: __( 'Premium Content buttons', 'jetpack' ),
 	description: __(
 		'Prompt Premium Content visitors to take action with a group of button-style links.',

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "jetpack/recurring-payments",
 	"title": "Payment Button",
 	"description": "Button allowing you to sell products and subscriptions.",

--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/send-a-message",
 	"title": "Send A Message",
 	"description": "Let your visitors send you messages with the tap of a button.",

--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/edit.js
@@ -1,13 +1,14 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-export default function SendAMessageEdit( { className } ) {
+export default function SendAMessageEdit() {
+	const blockProps = useBlockProps();
 	// Default template is single WhatsApp block until we offer
 	// more services
 	const DEFAULT_TEMPLATE = [ [ 'jetpack/whatsapp-button', {} ] ];
 	const ALLOWED_BLOCKS = [ 'jetpack/whatsapp-button' ];
 
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			<InnerBlocks template={ DEFAULT_TEMPLATE } allowedBlocks={ ALLOWED_BLOCKS } />
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/send-a-message/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/send-a-message/save.js
@@ -1,8 +1,10 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-export default props => {
+export default () => {
+	const blockProps = useBlockProps.save();
+
 	return (
-		<div className={ props.className }>
+		<div { ...blockProps }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/wordads/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/wordads",
 	"title": "Ad",
 	"description": "Earn income by adding high quality ads to your post.",

--- a/projects/plugins/jetpack/extensions/blocks/wordads/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/edit.js
@@ -1,5 +1,6 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
+import { useBlockProps } from '@wordpress/block-editor';
 import { WordAdsPlaceholder } from './components/jetpack-wordads-placeholder';
 import { WordAdsSkeletonLoader } from './components/jetpack-wordads-skeleton-loader';
 import { AD_FORMATS } from './constants';
@@ -12,6 +13,7 @@ import leaderboardExample from './example_728x90.png';
 import './editor.scss';
 
 const WordAdsEdit = ( { attributes, setAttributes } ) => {
+	const blockProps = useBlockProps();
 	const { format } = attributes;
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'wordads' );
@@ -30,40 +32,44 @@ const WordAdsEdit = ( { attributes, setAttributes } ) => {
 		}
 	};
 
+	let content;
+
 	if ( ! isModuleActive ) {
 		if ( isLoadingModules ) {
-			return (
+			content = (
 				<ThemeProvider>
 					<WordAdsSkeletonLoader />
 				</ThemeProvider>
 			);
+		} else {
+			content = (
+				<WordAdsPlaceholder
+					changeStatus={ changeStatus }
+					isModuleActive={ isModuleActive }
+					isLoading={ isChangingStatus }
+				/>
+			);
 		}
-
-		return (
-			<WordAdsPlaceholder
-				changeStatus={ changeStatus }
-				isModuleActive={ isModuleActive }
-				isLoading={ isChangingStatus }
-			/>
+	} else {
+		content = (
+			<>
+				<AdControls { ...{ attributes, setAttributes } } />
+				<div className={ `wp-block-jetpack-wordads jetpack-wordads-${ format }` }>
+					<div
+						className="jetpack-wordads__ad"
+						style={ {
+							width: selectedFormatObject.width,
+							height: selectedFormatObject.height,
+							backgroundImage: `url( ${ getExampleAd( format ) } )`,
+							backgroundSize: 'cover',
+						} }
+					></div>
+				</div>
+			</>
 		);
 	}
 
-	return (
-		<>
-			<AdControls { ...{ attributes, setAttributes } } />
-			<div className={ `wp-block-jetpack-wordads jetpack-wordads-${ format }` }>
-				<div
-					className="jetpack-wordads__ad"
-					style={ {
-						width: selectedFormatObject.width,
-						height: selectedFormatObject.height,
-						backgroundImage: `url( ${ getExampleAd( format ) } )`,
-						backgroundSize: 'cover',
-					} }
-				></div>
-			</div>
-		</>
-	);
+	return <div { ...blockProps }>{ content }</div>;
 };
 
 export default WordAdsEdit;

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/__snapshots__/edit.js.snap
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/__snapshots__/edit.js.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WordAdsEdit renders wrapper with correct css class: WordAdsEdit classes 1`] = `
+<body>
+  <p
+    class="a11y-speak-intro-text"
+    hidden="hidden"
+    id="a11y-speak-intro-text"
+    style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+  >
+    Notifications
+  </p>
+  <div
+    aria-atomic="true"
+    aria-live="assertive"
+    aria-relevant="additions text"
+    class="a11y-speak-region"
+    id="a11y-speak-assertive"
+    style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+  />
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    aria-relevant="additions text"
+    class="a11y-speak-region"
+    id="a11y-speak-polite"
+    style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+  />
+  <div>
+    <div
+      aria-label="Block: undefined"
+      class="block-editor-block-list__block wp-block"
+      id="block-undefined"
+      role="document"
+      tabindex="0"
+    >
+      <div
+        class="wp-block-jetpack-wordads jetpack-wordads-mrec"
+      >
+        <div
+          class="jetpack-wordads__ad"
+          style="width: 300px; height: 250px; background-size: cover;"
+        />
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/__snapshots__/edit.js.snap
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/__snapshots__/edit.js.snap
@@ -1,48 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WordAdsEdit renders wrapper with correct css class: WordAdsEdit classes 1`] = `
-<body>
-  <p
-    class="a11y-speak-intro-text"
-    hidden="hidden"
-    id="a11y-speak-intro-text"
-    style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
+exports[`WordAdsEdit matches snapshot: WordAdsEdit 1`] = `
+<div>
+  <div
+    aria-label="Block: undefined"
+    class="block-editor-block-list__block wp-block"
+    id="block-undefined"
+    role="document"
+    tabindex="0"
   >
-    Notifications
-  </p>
-  <div
-    aria-atomic="true"
-    aria-live="assertive"
-    aria-relevant="additions text"
-    class="a11y-speak-region"
-    id="a11y-speak-assertive"
-    style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
-  />
-  <div
-    aria-atomic="true"
-    aria-live="polite"
-    aria-relevant="additions text"
-    class="a11y-speak-region"
-    id="a11y-speak-polite"
-    style="position: absolute;margin: -1px;padding: 0;height: 1px;width: 1px;overflow: hidden;clip: rect(1px, 1px, 1px, 1px);-webkit-clip-path: inset(50%);clip-path: inset(50%);border: 0;word-wrap: normal !important;"
-  />
-  <div>
     <div
-      aria-label="Block: undefined"
-      class="block-editor-block-list__block wp-block"
-      id="block-undefined"
-      role="document"
-      tabindex="0"
+      class="wp-block-jetpack-wordads jetpack-wordads-mrec"
     >
       <div
-        class="wp-block-jetpack-wordads jetpack-wordads-mrec"
-      >
-        <div
-          class="jetpack-wordads__ad"
-          style="width: 300px; height: 250px; background-size: cover;"
-        />
-      </div>
+        class="jetpack-wordads__ad"
+        style="width: 300px; height: 250px; background-size: cover;"
+      />
     </div>
   </div>
-</body>
+</div>
 `;

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/edit.js
@@ -47,10 +47,10 @@ describe( 'WordAdsEdit', () => {
 		return { placeholder, selectedFormat };
 	};
 
-	test( 'renders wrapper with correct css class', () => {
-		const { baseElement } = render( <WordAdsEdit { ...defaultProps } /> );
+	test( 'matches snapshot', () => {
+		const { container } = render( <WordAdsEdit { ...defaultProps } /> );
 
-		expect( baseElement ).toMatchSnapshot( 'WordAdsEdit classes' );
+		expect( container ).toMatchSnapshot( 'WordAdsEdit' );
 	} );
 
 	test( 'renders ad placeholder with correct css class and styles', () => {

--- a/projects/plugins/jetpack/extensions/blocks/wordads/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/wordads/test/edit.js
@@ -30,8 +30,8 @@ describe( 'WordAdsEdit', () => {
 	const renderWordAdsEdit = props => {
 		const { container } = render( <WordAdsEdit { ...props } /> );
 
-		// eslint-disable-next-line testing-library/no-node-access
-		return container.firstChild.firstChild;
+		// eslint-disable-next-line testing-library/no-node-access,testing-library/no-container
+		return container.querySelector( '.jetpack-wordads__ad' );
 	};
 
 	// Renders the component, extracting the inner placeholder element and finding
@@ -48,12 +48,9 @@ describe( 'WordAdsEdit', () => {
 	};
 
 	test( 'renders wrapper with correct css class', () => {
-		const { container } = render( <WordAdsEdit { ...defaultProps } /> );
+		const { baseElement } = render( <WordAdsEdit { ...defaultProps } /> );
 
-		// eslint-disable-next-line testing-library/no-node-access
-		expect( container.firstChild ).toHaveClass( 'wp-block-jetpack-wordads' );
-		// eslint-disable-next-line testing-library/no-node-access
-		expect( container.firstChild ).toHaveClass( `jetpack-wordads-${ defaultAttributes.format }` );
+		expect( baseElement ).toMatchSnapshot( 'WordAdsEdit classes' );
 	} );
 
 	test( 'renders ad placeholder with correct css class and styles', () => {
@@ -61,7 +58,6 @@ describe( 'WordAdsEdit', () => {
 		const placeholder = renderWordAdsEdit( defaultProps );
 		const selectedFormat = getFormat( defaultAttributes.format );
 
-		expect( placeholder ).toHaveClass( 'jetpack-wordads__ad' );
 		expect( placeholder ).toHaveStyle( `width: ${ selectedFormat.width }px` );
 		expect( placeholder ).toHaveStyle( `height: ${ selectedFormat.height }px` );
 		expect( placeholder ).toHaveStyle( `backgroundImage: url( ${ rectangleExample } )` );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the following blocks to use version 3 of the block API: 
- Blog Stats
- Paid Content
- Payment Button
- Send A Message/WhatsApp Button
- Ads

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/34120

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check that the blocks above work as expected with a self-hosted site and on WordPress.com. Words Ads requires a paid plan (I tested with Complete) to be available on a self-hosted site.

