### PR TITLE
AI Featured Image: handle posts longer than Dall-e's prompt limit

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-featured-image-handle-posts-longer-than-the-limit
+++ b/projects/js-packages/ai-client/changelog/update-featured-image-handle-posts-longer-than-the-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Featured Image: handle posts longer than the limit of Dall-e generation prompt.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.11.0",
+	"version": "0.11.1-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/hooks/use-image-generator/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-image-generator/index.ts
@@ -45,7 +45,7 @@ Do not add text to the image.
 
 This is the post content:
 
-` + postContent;
+` + ( postContent.length > 3000 ? postContent.substring( 0, 3000 ) + ` [...]` : postContent ); // truncating the content so the whole prompt is not longer than 4000 characters, the model limit.
 
 			const URL = 'https://public-api.wordpress.com/wpcom/v2/jetpack-ai-image';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36702.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When the post content is longer than 3000 chars, truncate it on 3000 chars so the whole prompt is not longer than 4000 chars (3000 for the content and <= 1000 for the prompt instructions)
* Since Dall-e will try to get the main idea from the text, it will probably find it on the first 3000 chars of the post
* This is a simple solution; ideally, we could use GPT to summarize the post, and then request dall-e, but this can be implemented in the future

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and insert a long post on it (longer than 3000 chars); tip: use the AI Assistant block to generate 10 paragraphs about some random subject, and ask it to keep writing the post until you get at least 3000 chars, or more
* Make sure your testing site is running the beta blocks variation
* Make sure your browser's console is open and showing the network activity
* Open the Jetpack sidebar, then open the AI Assistant section, and click the "Generate image" button
* Before this fix, when the content is longer than ~3200 chars, the request would fail
* After this fix, the content will be truncated at 3000 chars, and the request should work properly
* You can confirm the content was truncated by the presence of the `[...]` marker on the request body for the `jetpack-ai-image` endpoint:

<img width="500" alt="Screenshot 2024-04-02 at 15 45 15" src="https://github.com/Automattic/jetpack/assets/6760046/1fddfc21-08eb-49ef-bbb1-9016c96ac332">

* Confirm the generated image makes sense for the post