### PR TITLE
Jetpack CRM: Font reinstallation improvements

### DIFF
--- a/projects/plugins/crm/admin/settings/locale.page.php
+++ b/projects/plugins/crm/admin/settings/locale.page.php
@@ -27,11 +27,18 @@ if(!isset($whwpCountryList)) require_once( ZEROBSCRM_INCLUDE_PATH . 'wh.countryc
 
 // check for default font reinstalls
 if ( isset( $_GET['reinstall_default_font'] ) && zeroBSCRM_isZBSAdminOrAdmin() ) {
-
 	// check nonce
 	check_admin_referer( 'zbs-update-settings-reinstall-font' );
 
 	// hard reinstall
+	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+	require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+	$fonts_dir = jpcrm_storage_fonts_dir_path();
+	if ( $fonts_dir ) {
+		$filesystem_direct = new WP_Filesystem_Direct( false );
+		$filesystem_direct->rmdir( $fonts_dir, true );
+	}
+
 	$fonts = $zbs->get_fonts();
 	$fonts->extract_and_install_default_fonts();
 	$default_font_reinstalled = true;

--- a/projects/plugins/crm/changelog/fix-jpcrm-3458-broken-pdf-due-to-fonts
+++ b/projects/plugins/crm/changelog/fix-jpcrm-3458-broken-pdf-due-to-fonts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+PDF: Improved font reinstallation.


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3458

## Proposed changes:

* This PR aims to mitigate PDF rendering issues by enhancing the reinstallation process: it deletes the fonts directory prior to reinstalling. Some users experience perfect PDF generation after a CRM reinstall. Consequently, this fix focuses solely on removing and then reinstalling the PDF fonts directory to guarantee fresh font related file generation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3458

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Testing this fix is challenging due to the difficulty of replicating a broken environment, which even our users have difficult doing. Some experience perfect PDF generation after a CRM reinstall. Consequently, this fix focuses solely on removing and then reinstalling the PDF fonts directory to guarantee fresh font related file generation.

* To validate the fix, simply reinstall the fonts using our `Settings` -> ` Locale` tab ( `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=locale`) and verify that all files in the font directory (`/public/wp-content/jpcrm-storage/fonts`) have a new creation date in the filesystem, and ensure PDFs continue to be generated correctly.
