### PR TITLE
Fix/tier upgrades my jetpack

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -142,10 +142,14 @@ export default function ProductInterstitial( {
 							: myJetpackCheckoutUri;
 						// there is a separate hasRequiredTier, but it is not implemented
 						const hasPaidPlanForProduct = product?.hasPaidPlanForProduct;
+						const isUpgradeToHigherTier =
+							tier &&
+							product?.pricingForUi?.tiers?.[ tier ] &&
+							! product?.pricingForUi?.tiers?.[ tier ]?.isFree;
 						const isFree = tier
 							? product?.pricingForUi?.tiers?.[ tier ]?.isFree
 							: product?.pricingForUi?.isFree;
-						const needsPurchase = ! isFree && ! hasPaidPlanForProduct;
+						const needsPurchase = ( ! isFree && ! hasPaidPlanForProduct ) || isUpgradeToHigherTier;
 
 						// If the product is CRM, redirect the user to the Jetpack CRM pricing page.
 						// This is done because CRM is not part of the WP billing system

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -142,13 +142,11 @@ export default function ProductInterstitial( {
 							: myJetpackCheckoutUri;
 						// there is a separate hasRequiredTier, but it is not implemented
 						const hasPaidPlanForProduct = product?.hasPaidPlanForProduct;
-						const isUpgradeToHigherTier =
-							tier &&
-							product?.pricingForUi?.tiers?.[ tier ] &&
-							! product?.pricingForUi?.tiers?.[ tier ]?.isFree;
 						const isFree = tier
 							? product?.pricingForUi?.tiers?.[ tier ]?.isFree
 							: product?.pricingForUi?.isFree;
+						const isUpgradeToHigherTier =
+							tier && product?.pricingForUi?.tiers?.[ tier ] && ! isFree && product?.isUpgradable;
 						const needsPurchase = ( ! isFree && ! hasPaidPlanForProduct ) || isUpgradeToHigherTier;
 
 						// If the product is CRM, redirect the user to the Jetpack CRM pricing page.

--- a/projects/packages/my-jetpack/changelog/fix-tier-upgrades-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/fix-tier-upgrades-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+fix tier upgrades in my Jetpack

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -141,6 +141,7 @@ abstract class Product {
 			'pricing_for_ui'            => static::get_pricing_for_ui(),
 			'is_bundle'                 => static::is_bundle_product(),
 			'is_plugin_active'          => static::is_plugin_active(),
+			'is_upgradable'             => static::is_upgradable(),
 			'is_upgradable_by_bundle'   => static::is_upgradable_by_bundle(),
 			'supported_products'        => static::get_supported_products(),
 			'wpcom_product_slug'        => static::get_wpcom_product_slug(),


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes tiered upgrades from My Jetpack interstitial pages

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a test site, obtain the first tier of AI plan
* Then, go to `wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai`
* Make sure the upgrade button takes you to the cart with the next tier
* Confirm that other purchase and start for free buttons work for other My Jetpack products

