### PR TITLE
Load Stats on Simple sites during admin_menu hook

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/load-simple-stats-on-admin-menu-hook
+++ b/projects/packages/jetpack-mu-wpcom/changelog/load-simple-stats-on-admin-menu-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Load Stats on admin_menu hook for Simple sites so Jetpack menu loads for admin-menu API

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -46,7 +46,7 @@ class Jetpack_Mu_Wpcom {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_comments' ) );
 			add_action( 'wp_loaded', array( __CLASS__, 'load_verbum_comments_admin' ) );
-			add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_simple_odyssey_stats' ) );
+			add_action( 'admin_menu', array( __CLASS__, 'load_wpcom_simple_odyssey_stats' ) );
 		}
 
 		// Unified navigation fix for changes in WordPress 6.2.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related https://github.com/Automattic/dotcom-forge/issues/6388

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Loads Jetpack Stats earlier on `admin_menu` for Simple sites so that the Jetpack menu item will be loaded in time for the admin-menu API endpoint response.
* This relates to D144093-code and makes it so that the Jetpack menu will load on early-classic Simple sites when in the unified-nav (aka the Calypso/Hosting menu).

<img width="901" alt="Screenshot 2024-04-03 at 10 14 18 AM" src="https://github.com/Automattic/jetpack/assets/140841/1da08dea-d773-4fdb-bd83-bc650d2d5bcb">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your Sandbox
* Test with a Simple site with the early and Classic options set.
* Go to https://wordpress.com/home/[site] and observe the Jetpack menu exists just as it does on https://[site].wordpress.com/wp-admin
* Ensure that Jetpack Stats on Simple sites continues to work without regressions
* Test this PR on an Atomic site to ensure there are no regressions