### PR TITLE
CRM: Fixes Automattic/zero-bs-crm#3425 - Statement PDF broken for long lists

### DIFF
--- a/projects/plugins/crm/changelog/fix-jpcrm-3425-invoice-statement-pdf-cut-off-fix
+++ b/projects/plugins/crm/changelog/fix-jpcrm-3425-invoice-statement-pdf-cut-off-fix
@@ -1,0 +1,5 @@
+Significance: minor
+Type: fixed
+
+Invoices: Fixed display issues for statements with long invoice lists.
+Invoices: Enhanced the PDF generation for statements.

--- a/projects/plugins/crm/changelog/fix-jpcrm-3425-invoice-statement-pdf-cut-off-fix
+++ b/projects/plugins/crm/changelog/fix-jpcrm-3425-invoice-statement-pdf-cut-off-fix
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: fixed
 
 Invoices: Fixed display issues for statements with long invoice lists.

--- a/projects/plugins/crm/templates/invoices/statement-pdf.html
+++ b/projects/plugins/crm/templates/invoices/statement-pdf.html
@@ -5,252 +5,100 @@
     <meta name="viewport" content="width=device-width">
     <title></title>
     <style>
-        
-        /* Globals */
-        * { box-sizing: border-box; }
-        body {
+		body {
             font-family: 'NotoSansGlobal', sans-serif;
             font-weight: normal;
+			font-size: 16px;
         }
-        table th {
-            padding: 10px 7px;
-            text-transform: uppercase;
-            border-radius: 0px;
-            border-top: 2px solid #111;
-            border-bottom: 2px solid #111;
-        }
-        table thead {
-            background-color: transparent;
-            color: #111;            
-        }
-        table td {
-            padding: 8px 8px;
-            line-height: 1;
-        }
-        table tr {
-            margin: 0;
-        }   
-        table.striped {
-            border-bottom: 1px solid #e1def3;
-        }
-        table.striped th {
-            text-align: center;
-        }
-        table.striped tbody tr:nth-child(odd) {
-            background: #f6f5fb;
-        }
-        .zbs-rounded-block {
-            display: inline-block;
-            float: right;
-            background: #111;
-            padding: 4px 8px;
-            padding-top: 0;
-            height: 24px;
-            color: #fff;
-            border-radius: 0px;
-        }     
 
-        /* Invoice Page specific - some are re-used here. */ 
-        .zbs-document-title div {
-            font-size:2.2em !important;
-            text-align: center;
-            padding-bottom: 0.8em;
-        }
-        .zbs-top-right-box {
-            line-height:1.4em;
-            font-size: 1em !important;
-        }
-        .zbs-invoice-number {
-            display: inline-block;
-            float: right;
-            border-bottom: 2px solid #e1def3;
-        }       
-        .zbs-invoice-number {
-            display: inline-block;
-            float: right;
-            border-bottom: 2px solid #111;
-        }   
-        .item-name {
-            font-weight: 700;
-            display: inline-block;
-        }
-        .item-description {
-            font-style: italic;
-        }
-        .invoice-header {
-            background: transparent;
-            border-bottom: 3px solid #000;
-            padding: 20px;
-            padding-bottom: 20px;           
+		.header-image {
+            text-align: right;
             margin-bottom: 20px;
-            border-radius: 0px;
         }
-        .invoice-header td {
-            padding: 0 !important;
-            font-size: 9pt;
-            margin: 0;
-            font-weight: 300;
+
+        .div-table-cell.center {
+            text-align: center;
         }
-        .invoice-title4 {
-            text-transform: uppercase;
-            font-weight: 700;
-            display: inline-block;
-            padding: 6px 40px;
-            padding-left: 0;
-            border-bottom: 3px solid #111;
-            font-size: 13px;
-            margin-bottom: 0;
-            margin-top: 0;
+
+		.div-footer-cell.right,
+		.div-table-heading.right,
+		.div-table-cell.right {
+            text-align: right;
         }
-        .zbs-line-info {
-            font-weight: 300!important;
+
+		.div-table-cell.medium-font {
+			font-size: 14px;
+        }
+
+		.header-image img {
+            max-width: 200px;
+            max-height: 140px;
+        }
+
+		.info-details {
+			font-weight: 300!important;
             margin: 0;
             margin-bottom: 5px;
             font-size: 12px;
             font-style: italic;
-            padding-left: 3px;
-            line-height: 1;
-            padding: 0 !important;
-            height: auto;
-        }
-        .zbs-line-info-title {
-            font-size: 18px;
-            height: 19px;
-            font-style: normal;
-            font-weight: 700!important;
-        }
-        .invoice-infos {
-            padding-left: 20px;
-        }
-        .table-title {
-            display: block;
-            font-size: 12px;
-            font-weight: 700;
-            margin-bottom: 0;
-            text-transform: uppercase;
-        }
-        .item-name {
-            display: block;
-            margin-bottom: 8px;
-        }
-        .item-description {
-            font-style: italic;
-            font-weight: 300;
-            font-size: 12px;
-            display: block;
-        }
-        .cen {
-            font-size: 12px;
-            font-style: italic;
-        }
-        .row-amount {
-            font-size: 12px;
-            font-weight: 300;
-        }
-        .table-totals {
-            margin-top: 8px;
-        }        
-        .table-totals td {
-            font-size: 12px;
-        }
-        .zbs-totals {
-        }
-        .zbs-total {
-            font-size: 16px;
-            font-style: normal;
-            text-transform: uppercase;
-        }
-        .bord {
-            border-bottom: 2px solid #eee;
-        }
-        .bord-l {
-            border-bottom: 0!important;
-        }        
+		}
 
-
-        /*Payment Details*/
-        .zbs-payment-details {
-            margin-top: 20px;
-        }
-        .deets {            
-            text-align: center;
-            padding: 20px;
-            border: 1px solid #111;
+		.div-table {
+            display: table;
             width: 100%;
+            margin: 0;
+            padding: 0;
+            background-color: #fff;
         }
-        .deets h2 {
-            margin-top: 0;
-            text-transform: uppercase;
-            font-weight: 700;
-            font-size: 18px;
-            margin-bottom: 12px;
-            color: #111;
+        .div-table-row-group {
+            display: table-row-group;
         }
-        .deets-line {
-            font-weight: 300;
-            font-size: 12px;
+        .div-table-row {
+            display: table-row;
         }
-        .deets-title {
-            font-weight: 700;
+        .div-table-cell {
+            display: table-cell;
+            padding: 8px;
+            text-align: left;
+            border: 1px solid #e1def3;
         }
-        .deets-content {
-            font-style: italic;
+        .div-table-head {
+            display: table-header-group;
+            font-weight: bold;
+            background-color: #f6f5fb;
         }
-
-        /* Statement stuff */
-        h2.zbs-statement{
-            font-size:28px;
-            font-weight:800;
-        }
-        .zbs-biz-info {
-            text-align:right;
-        }
-        #zbs-statement-table table th {
-            text-align:left;
-        }
-        .zbs-statement-date {
-            font-size:14px;
-            text-align:center;
-        }
-        table tr.zbs-statement-footer td {
-            text-align:right;
-            font-weight:800;
-            font-size:12px;
+        .div-table-heading {
+            display: table-cell;
             padding: 10px 7px;
             text-transform: uppercase;
-            border-radius: 0px;
-            border-top: 3px solid #111;
-            border-bottom: 3px solid #111;
-
+            border-top: 2px solid #111;
+            border-bottom: 2px solid #111;
+            text-align: left;
         }
-        td.zbs-accountant-td, th.zbs-accountant-td {
-            text-align:right;
+        .div-table-row:nth-child(odd) .div-table-cell {
+            background: #f6f5fb;
+        }
+        .div-footer {
+            display: table;
+            font-weight: bold;
+            text-align: right;
+            border-bottom: 2px solid black;
+            border-top: 2px solid black;
+            width: 100%;
+            margin: 0;
+            padding: 0;
+            background-color: #fff;
         }
 
-
-        /* viewport-size specific - catchalls */
-        @media screen and (min-width: 1280px) {
-            body {
-                background: #ccc;
-            }
-            .zbs-statement {
-                max-width: 795px;
-                margin: 0 auto;
-                background: #fff;
-                padding: 20px;
-                position: relative;
-            }
+		.div-footer-cell {
+            display: table-cell;
+            padding: 8px;
         }
-    </style>
+	</style>
 </head>
-
 <body>
     <div class="zbs-statement" style="position: relative;">
-
-        <div class="zbs-statement-wrap">##INVOICE-STATEMENT-HTML##</div>
-        <div style="clear: both;"></div>
-        <!-- =============/statement============= -->
-        
+		##INVOICE-STATEMENT-HTML##
     </div>
 </body>
 </html>


### PR DESCRIPTION
CRM: Fixes Automattic/zero-bs-crm#3425 - Statement PDF broken for long lists

## Proposed changes:
* This PR addresses a key issue with our invoice statement generation:
  * Resolved Display for Long Invoice Lists: A bug causing improper display of statements with long lists of invoices has been fixed.
* While fixing the bug we improved Statement PDF Generation: We've implemented enhancements to the PDF generation process for statements. These improvements lead to a more refined layout and increased readability.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Add 20 (or more) invoices to a contact (`/wp-admin/admin.php?page=manage-invoices`)
* Go to this contact's page and generate a statement using the button `Contact Actions` ( `wp-admin/admin.php?page=zbs-add-edit&action=view&zbstype=contact&zbsid=2` )
![image](https://github.com/Automattic/jetpack/assets/37049295/a4832576-2897-404c-b2ec-a8459bcaa4d3)



In `trunk` the text was cut off:

![image](https://github.com/Automattic/jetpack/assets/37049295/f326cd9d-73c7-4321-b3d6-b1827c277799)

In this branch everything should be displayed and the PDF has been enhanced:

![image](https://github.com/Automattic/jetpack/assets/37049295/45bc50b7-aad9-474c-8f4d-1d931b650b56)

