### PR TITLE
Fix the (no title) link on the post publish panel

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-no-title-link-on-the-post-publish-panel
+++ b/projects/js-packages/publicize-components/changelog/fix-no-title-link-on-the-post-publish-panel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the (no title) link on the post publish panel

--- a/projects/js-packages/publicize-components/src/components/panel/global.scss
+++ b/projects/js-packages/publicize-components/src/components/panel/global.scss
@@ -1,0 +1,8 @@
+// Styles for the Social Notes editor.
+.wp-admin.post-type-jetpack-social-note {
+
+	// Hide "(no title) is now live" on the post-publish panel
+	.post-publish-panel__postpublish-header {
+		display: none;
+	}
+}

--- a/projects/js-packages/publicize-components/src/components/panel/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.jsx
@@ -16,6 +16,7 @@ import PublicizeForm from '../form';
 import { ManualSharing } from '../manual-sharing';
 import { SharePostRow } from '../share-post';
 import styles from './styles.module.scss';
+import './global.scss';
 
 const PublicizePanel = ( { prePublish, children } ) => {
 	const { refresh, hasConnections, hasEnabledConnections } = useSelectSocialMediaConnections();


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the (no title) link on the post publish panel by hiding that post publish header

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Goto Social Notes > Add New
* Publish the note
* On the post publish panel, confirm that you do not see `"(no title) is now live"`


| BEFORE | AFTER |
|--------|--------|
| <img width="279" alt="Screenshot 2024-04-03 at 5 44 37 PM" src="https://github.com/Automattic/jetpack/assets/18226415/6b11ba50-6bd1-46d0-89bf-bc9449a978f4"> | <img width="282" alt="Screenshot 2024-04-03 at 5 44 17 PM" src="https://github.com/Automattic/jetpack/assets/18226415/973e7b66-4f6b-49f5-8354-36baa30b0888"> | 




