### PR TITLE
jetpack-mu-wpcom: Fix test for WP 6.5

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-test-for-wp-6.5
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-test-for-wp-6.5
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix a unit test for changed output in WordPress 6.5. No change to functionality.
+
+

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/class-verbum-block-utils-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/class-verbum-block-utils-test.php
@@ -45,7 +45,7 @@ class Verbum_Block_Utils_Test extends \WorDBless\BaseTestCase {
 		$comment_content  = '<!-- wp:paragraph --><p>test</p><!-- /wp:paragraph --><!-- wp:list --><ul><!-- wp:list-item --><li>1</li><!-- /wp:list-item --><!-- wp:list-item --><li>2</li><!-- /wp:list-item --><!-- wp:list-item --><li>3</li><!-- /wp:list-item --></ul><!-- /wp:list --><!-- wp:quote --><blockquote class="wp-block-quote"><!-- wp:paragraph --><p>something</p><!-- /wp:paragraph --><cite>someone</cite></blockquote><!-- /wp:quote -->';
 		$filtered_content = preg_replace( '/\R+/', '', Verbum_Block_Utils::render_verbum_blocks( $comment_content ) );
 
-		$expected_content = '<p>test</p><ul><li>1</li><li>2</li><li>3</li></ul><blockquote class="wp-block-quote"><p>something</p><cite>someone</cite></blockquote>';
+		$expected_content = '<p>test</p><ul><li>1</li><li>2</li><li>3</li></ul><blockquote class="wp-block-quote is-layout-flow wp-block-quote-is-layout-flow"><p>something</p><cite>someone</cite></blockquote>';
 		$this->assertEquals( $expected_content, $filtered_content );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Now that WordPress 6.5 is released, WorDBless is bringing in that version for package tests. This resulted in a failure in one of the tests in packages/jetpack-mu-wpcom due to some extra classes on an HTML tag.

Update the test to expect these extra classes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1712150744255409/1712147420.012969-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?