### PR TITLE
Blogging Prompt: preserve language on answers link

### DIFF
--- a/projects/plugins/jetpack/changelog/preserve-language-on-answers-link
+++ b/projects/plugins/jetpack/changelog/preserve-language-on-answers-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blogging Prompt: preserve language on answers link

--- a/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js
@@ -7,6 +7,7 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import './editor.scss';
+import { languageToLocale } from '../../shared/locale';
 import { usePromptTags } from './use-prompt-tags';
 
 function BloggingPromptEdit( { attributes, noticeOperations, noticeUI, setAttributes } ) {
@@ -101,9 +102,10 @@ function BloggingPromptEdit( { attributes, noticeOperations, noticeUI, setAttrib
 		apiFetch( { path } )
 			.then( prompts => {
 				const promptData = promptId ? prompts : prompts[ 0 ];
+				const locale = languageToLocale( siteLanguage );
 
 				setAttributes( {
-					answersLink: promptData.answered_link,
+					answersLink: promptData.answered_link + `?locale=${ locale }`,
 					answersLinkText: promptData.answered_link_text,
 					gravatars: promptData.answered_users_sample.map( ( { avatar } ) => ( { url: avatar } ) ),
 					promptFetched: true,

--- a/projects/plugins/jetpack/extensions/shared/locale.js
+++ b/projects/plugins/jetpack/extensions/shared/locale.js
@@ -1,0 +1,22 @@
+/**
+ * languageToLocale converts a language tag to an ISO 639 conforming locale string.
+ *
+ * @param {string} language - a language tag to be converted, e.g. "en_US".
+ * @return {string} ISO 639 locale string, e.g. "en".
+ */
+export function languageToLocale( language ) {
+	const withCountryCode = [ 'pt_br', 'pt-br', 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ];
+
+	language = language.toLowerCase();
+	if ( withCountryCode.includes( language ) ) {
+		language = language.replace( '_', '-' );
+	} else {
+		language = language.replace( /([-_].*)$/i, '' );
+	}
+
+	if ( language === '' ) {
+		return 'en';
+	}
+
+	return language;
+}

--- a/projects/plugins/jetpack/extensions/shared/test/locale.test.js
+++ b/projects/plugins/jetpack/extensions/shared/test/locale.test.js
@@ -1,0 +1,25 @@
+import { languageToLocale } from '../locale';
+
+describe( 'languageToLocale', () => {
+	test( 'empty string should return en', () => {
+		expect( languageToLocale( '' ) ).toBe( 'en' );
+	} );
+
+	test( 'underscores should be replaced', () => {
+		expect( languageToLocale( 'pt_BR' ) ).toBe( 'pt-br' );
+		expect( languageToLocale( 'zh_CN' ) ).toBe( 'zh-cn' );
+		expect( languageToLocale( 'zh_TW' ) ).toBe( 'zh-tw' );
+	} );
+
+	test( 'country codes should be dropped', () => {
+		expect( languageToLocale( 'en-GB' ) ).toBe( 'en' );
+		expect( languageToLocale( 'en_US' ) ).toBe( 'en' );
+		expect( languageToLocale( 'es-ES' ) ).toBe( 'es' );
+	} );
+
+	test( 'locales should be lowercase', () => {
+		expect( languageToLocale( 'EN' ) ).toBe( 'en' );
+		expect( languageToLocale( 'FR' ) ).toBe( 'fr' );
+		expect( languageToLocale( 'PL' ) ).toBe( 'pl' );
+	} );
+} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36648

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
A locale parameter was added to the answers link on the Blogging Prompt block. This will ensure that the language shown in the external `wordpress.com` link will be the same as the one used in the embedded suggestions.

Example:

* **Before**: https://wordpress.com/tag/dailyprompt-1898
* **Now**: https://wordpress.com/tag/dailyprompt-1898?locale=pt-br

Pinging @monsieur-z, the original issue reporter and @valterlorran, with whom I discussed the approach before implementing it.

---

I found the query parameter when debugging logged-in queries in the `wordpress.com` webapp to the `/read/tags/dailyprompt` endpoint, which were in the following format:

`https://public-api.wordpress.com/rest/v1.2/read/tags/dailyprompt?http_envelope=1&locale=pt-br`

Appending the `locale=pt-br` query parameter to the webapp URL yielded the same results for unauthenticated visits, which is what was specified in the scope of the issue.

It wasn't possible to use the [existing `siteLanguage` variable][siteLanguage] directly, as it is returning the language tag in a different format (e.g. `pt_BR`) than the expected locale (e.g. `pt-br`) in the `wordpress.com` side. Turns out that there's a PHP implementation that does exactly the same in this repository:

https://github.com/Automattic/jetpack/blob/a7c6d7ddd411c4c70fa4d66fccb1092d4cc23d8d/projects/packages/jetpack-mu-wpcom/src/common/index.php#L11-L17

So I translated it to JavaScript, gave it a more descriptive name and added a few tests, which can be executed with:

```
$ cd projects/plugins/jetpack/
$ pnpm jest ./extensions/shared/test/locale.test.js
 PASS  extensions/shared/test/locale.test.js
  languageToLocale
    ✓ empty string should return en (3 ms)
    ✓ underscores should be replaced (1 ms)
    ✓ country codes should be dropped (9 ms)
    ✓ locales should be lowercase (2 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        0.69 s, estimated 1 s
Ran all test suites matching /.\/extensions\/shared\/test\/locale.test.js/i.
```

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On the WP-Admin dashboard:

* Change the `Site Language` in `Settings -> General`.
* Create a new post in `Posts -> Add New Post` or edit an existing one under `Posts -> All Posts`.
* Add a new `Writing Prompt` block.
* Check the generated `View all responses` link, which should now contain the `locale` query parameter.


[siteLanguage]: https://github.com/Automattic/jetpack/blob/a7c6d7ddd411c4c70fa4d66fccb1092d4cc23d8d/projects/plugins/jetpack/extensions/blocks/blogging-prompt/edit.js#L97
