### PR TITLE
Photon: update filter docblock to match possible types

### DIFF
--- a/projects/packages/image-cdn/changelog/update-photon-filter-doc
+++ b/projects/packages/image-cdn/changelog/update-photon-filter-doc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update filter docblock to match possible types.

--- a/projects/packages/image-cdn/package.json
+++ b/projects/packages/image-cdn/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-image-cdn",
-	"version": "0.3.3",
+	"version": "0.3.4-alpha",
 	"description": "Serve images through Jetpack's powerful CDN",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/image-cdn/#readme",
 	"bugs": {

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Assets;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.3.3';
+	const PACKAGE_VERSION = '0.3.4-alpha';
 
 	/**
 	 * Singleton.
@@ -368,9 +368,9 @@ final class Image_CDN {
 				 *
 				 * @since 2.0.3
 				 *
-				 * @param bool false Should Photon ignore this image. Default to false.
-				 * @param string $src Image URL.
-				 * @param string $tag Image Tag (Image HTML output).
+				 * @param bool              false Should Photon ignore this image. Default to false.
+				 * @param string            $src  Image URL.
+				 * @param string|array|null $tag  Image Tag (Image HTML output) or array of image details for srcset.
 				 */
 				if ( apply_filters( 'jetpack_photon_skip_image', false, $src, $tag ) ) {
 					continue;


### PR DESCRIPTION
## Proposed changes:

If you browse through that file, you will see that we can pass a string, an array, or even null to `jetpack_photon_skip_image`. Let's update the docblock to reflect that.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test here. I would only recommend to browse for usage of `jetpack_photon_skip_image` and see that it matches the updated docblock.
