### PR TITLE
Scheduled update logs: Log timestamp as int

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-logs-timestamp-int
+++ b/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-logs-timestamp-int
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Store log timestamp as int

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
@@ -51,7 +51,7 @@ class Scheduled_Updates_Logs {
 	public static function log( $schedule_id, $action, $message = null, $context = null ) {
 		$timestamp = wp_date( 'U' );
 		$log_entry = array(
-			'timestamp' => $timestamp,
+			'timestamp' => intval( $timestamp ),
 			'action'    => $action,
 			'message'   => $message,
 			'context'   => $context,


### PR DESCRIPTION
Discussion p1712224342342979/1712224293.778349-slack-C01A60HCGUA

## Proposed changes:
- Stores the timestamp as int

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Use Jetpack Beta Tester to test this branch on your WoA site
- Run `jetpack-mu-wpcom` trunk on your sandbox: `bin/jetpack-downloader test jetpack-mu-wpcom-plugin trunk`
- Sandbox `public-api.wordpress.com`
- Use API console to add a log (POST `/wpcom/v2/sites/<site-id>/update-schedules/<schedule-id>/logs`)
- Verify the returned log has in an int timestamp (GET `/wpcom/v2/sites/<site-id>/update-schedules/<schedule-id>/logs`)