### PR TITLE
Backport mu-wpcom-plugin 2.1.12 Changes

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.23.0] - 2024-04-04
+### Added
+- Allow Simple sites access to the Hosting menu [#36684]
+
+### Changed
+- Load Stats on admin_menu hook for Simple sites so Jetpack menu loads for admin-menu API [#36712]
+
 ## [5.22.0] - 2024-04-01
 ### Added
 - Add Odyssey Stats to wpcom Simple Site [#36628]
@@ -696,6 +703,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.23.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.22.0...v5.23.0
 [5.22.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.21.0...v5.22.0
 [5.21.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.20.0...v5.21.0
 [5.20.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.19.0...v5.20.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-hosting-menu-to-simple
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-hosting-menu-to-simple
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Allow Simple sites access to the Hosting menu

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-test-for-wp-6.5
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-test-for-wp-6.5
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix a unit test for changed output in WordPress 6.5. No change to functionality.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/load-simple-stats-on-admin-menu-hook
+++ b/projects/packages/jetpack-mu-wpcom/changelog/load-simple-stats-on-admin-menu-hook
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Load Stats on admin_menu hook for Simple sites so Jetpack menu loads for admin-menu API

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.23.0-alpha",
+	"version": "5.23.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.23.0-alpha';
+	const PACKAGE_VERSION = '5.23.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-04-04
+### Added
+- Add backend infrastructure to log scheduled update events [#36676]
+- Add scheduled updates logging endpoints [#36687]
+
+### Fixed
+- Force cache cleaning before scheduling a new job. [#36697]
+- Store log timestamp as int [#36736]
+
 ## [0.5.3] - 2024-04-01
 ### Changed
 - General: update Phan configuration. [#36528]
@@ -94,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.6.0]: https://github.com/Automattic/scheduled-updates/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/Automattic/scheduled-updates/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/Automattic/scheduled-updates/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Automattic/scheduled-updates/compare/v0.5.0...v0.5.1

--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-logs
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-logs
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add backend infrastructure to log scheduled update events

--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-logs-endpoint
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-logs-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add scheduled updates logging endpoints

--- a/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-logs-timestamp-int
+++ b/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-logs-timestamp-int
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Store log timestamp as int

--- a/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-saving
+++ b/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-saving
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Force cache cleaning before scheduling a new job.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.6.0-alpha';
+	const PACKAGE_VERSION = '0.6.0';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.12 - 2024-04-04
+### Changed
+- Internal updates.
+
 ## 2.1.11 - 2024-04-01
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-hosting-menu-to-simple
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-hosting-menu-to-simple
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-updates-logs
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-updates-logs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-updates-logs#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-updates-logs#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_12_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_12"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.12-alpha
+ * Version: 2.1.12
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.12-alpha",
+	"version": "2.1.12",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.12

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.