### PR TITLE
Eventbrite Block: refactor Edit component to function

### DIFF
--- a/projects/plugins/jetpack/changelog/update-bump-block-api-version-2
+++ b/projects/plugins/jetpack/changelog/update-bump-block-api-version-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Eventbrite Block: refactor Edit component to function

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/controls.js
@@ -1,5 +1,26 @@
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
+import BlockStylesSelector from '../../shared/components/block-styles-selector';
+import EventbriteInPageExample from './eventbrite-in-page-example.png';
+
+const embedTypes = [
+	{
+		value: 'inline',
+		label: __( 'In-page Embed', 'jetpack' ),
+		preview: (
+			<div className="block-editor-block-preview__container">
+				<img
+					src={ EventbriteInPageExample }
+					alt={ __( 'In page Eventbrite checkout example', 'jetpack' ) }
+				/>
+			</div>
+		),
+	},
+	{
+		value: 'modal',
+		label: __( 'Button & Modal', 'jetpack' ),
+	},
+];
 
 export const ToolbarControls = ( { setEditingUrl } ) => (
 	<ToolbarGroup>
@@ -10,4 +31,20 @@ export const ToolbarControls = ( { setEditingUrl } ) => (
 			onClick={ () => setEditingUrl( true ) }
 		/>
 	</ToolbarGroup>
+);
+
+export const InspectorControls = ( { attributes, clientId, setAttributes } ) => (
+	<BlockStylesSelector
+		title={ _x(
+			'Embed Type',
+			'option for how the embed displays on a page, e.g. inline or as a modal',
+			'jetpack'
+		) }
+		clientId={ clientId }
+		styleOptions={ embedTypes }
+		onSelectStyle={ setAttributes }
+		activeStyle={ attributes.style }
+		attributes={ attributes }
+		viewportWidth={ 130 }
+	/>
 );

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
@@ -1,31 +1,19 @@
-import {
-	isAtomicSite,
-	isSimpleSite,
-	getBlockIconComponent,
-} from '@automattic/jetpack-shared-extension-utils';
 import { BlockControls, InnerBlocks } from '@wordpress/block-editor';
-import {
-	Placeholder,
-	SandBox,
-	Button,
-	Spinner,
-	ExternalLink,
-	withNotices,
-} from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Button, withNotices } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import BlockStylesSelector from '../../shared/components/block-styles-selector';
+import { useCallback, useEffect, useState } from 'react';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import testEmbedUrl from '../../shared/test-embed-url';
 import metadata from './block.json';
 import { EVENTBRITE_EXAMPLE_URL, URL_REGEX } from './constants';
-import { ToolbarControls } from './controls';
-import EventbriteInPageExample from './eventbrite-in-page-example.png';
+import { ToolbarControls, InspectorControls } from './controls';
+import EmbedForm from './form';
+import Loader from './loader';
+import InlinePreview from './preview';
 import { convertToLink, eventIdFromUrl, normalizeUrlInput } from './utils';
 
 import './editor.scss';
 
-const icon = getBlockIconComponent( metadata );
 const innerButtonBlock = {
 	name: 'jetpack/button',
 	attributes: {
@@ -34,61 +22,18 @@ const innerButtonBlock = {
 		uniqueId: 'eventbrite-widget-id',
 	},
 };
-export class EventbriteEdit extends Component {
-	state = {
-		editedUrl: this.props.attributes.url || '',
-		editingUrl: false,
-		isResolvingUrl: false,
-	};
 
-	componentDidMount() {
-		const { url } = this.props.attributes;
+const EventbriteEdit = props => {
+	const { attributes, noticeOperations, onReplace, setAttributes } = props;
+	const { url, style } = attributes;
 
-		this.setUrl( url );
-	}
+	const [ editingUrl, setEditingUrl ] = useState( false );
+	const [ editedUrl, setEditedUrl ] = useState( attributes.url || '' );
+	const [ isResolvingUrl, setIsResolvingUrl ] = useState( false );
 
-	setUrl = url => {
-		const { attributes, noticeOperations, setAttributes } = this.props;
-		const { style } = attributes;
+	const cannotEmbed = ! isResolvingUrl && url && ! URL_REGEX.test( url );
 
-		if ( ! url || EVENTBRITE_EXAMPLE_URL === url || 'modal' === style ) {
-			return;
-		}
-
-		const eventId = eventIdFromUrl( url );
-
-		if ( ! eventId ) {
-			this.setErrorNotice();
-		} else {
-			const newAttributes = {
-				eventId,
-				url,
-			};
-
-			testEmbedUrl( newAttributes.url, this.setIsResolvingUrl )
-				.then( resolvedUrl => {
-					const newValidatedAttributes = getValidatedAttributes( metadata.attributes, {
-						...newAttributes,
-						url: resolvedUrl,
-					} );
-					setAttributes( newValidatedAttributes );
-					this.setState( { editedUrl: resolvedUrl } );
-					noticeOperations.removeAllNotices();
-				} )
-				.catch( () => {
-					setAttributes( { eventId: undefined, url: undefined } );
-					this.setErrorNotice();
-				} );
-		}
-	};
-
-	setIsResolvingUrl = isResolvingUrl => this.setState( { isResolvingUrl } );
-	setEditingUrl = editingUrl => this.setState( { editingUrl } );
-
-	setErrorNotice = () => {
-		const { noticeOperations, onReplace } = this.props;
-		const { editedUrl } = this.state;
-
+	const setErrorNotice = useCallback( () => {
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice(
 			<>
@@ -98,181 +43,73 @@ export class EventbriteEdit extends Component {
 				</Button>
 			</>
 		);
-	};
+	}, [ noticeOperations, onReplace, editedUrl ] );
 
-	submitForm = event => {
-		if ( event ) {
-			event.preventDefault();
-		}
+	const setUrl = useCallback(
+		str => {
+			if ( ! str || EVENTBRITE_EXAMPLE_URL === str || 'modal' === style ) {
+				return;
+			}
 
-		this.setUrl( normalizeUrlInput( this.state.editedUrl ) );
+			const eventId = eventIdFromUrl( str );
 
-		this.setState( { editingUrl: false } );
-	};
+			if ( ! eventId ) {
+				setErrorNotice();
+			} else {
+				const newAttributes = {
+					eventId,
+					url: str,
+				};
 
-	cannotEmbed = () => {
-		const { url } = this.props.attributes;
-		const { isResolvingUrl } = this.state;
+				testEmbedUrl( newAttributes.url, setIsResolvingUrl )
+					.then( resolvedUrl => {
+						const newValidatedAttributes = getValidatedAttributes( metadata.attributes, {
+							...newAttributes,
+							url: resolvedUrl,
+						} );
+						setAttributes( newValidatedAttributes );
+						setEditedUrl( resolvedUrl );
+						noticeOperations.removeAllNotices();
+					} )
+					.catch( () => {
+						setAttributes( { eventId: undefined, url: undefined } );
+						setErrorNotice();
+					} );
+			}
+		},
+		[ style, noticeOperations, setErrorNotice, setAttributes, setEditedUrl, setIsResolvingUrl ]
+	);
 
-		return ! isResolvingUrl && url && ! URL_REGEX.test( url );
-	};
+	useEffect( () => {
+		setUrl( url );
+	}, [ url, setUrl ] );
 
-	renderLoading() {
-		return (
-			<div className="wp-block-embed is-loading">
-				<Spinner />
-				<p>{ __( 'Embedding…', 'jetpack' ) }</p>
-			</div>
-		);
-	}
+	let content;
 
-	renderInspectorControls() {
-		const { style } = this.props.attributes;
-		const { attributes, clientId, setAttributes } = this.props;
+	if ( isResolvingUrl ) {
+		content = <Loader />;
+	} else if ( editingUrl || ! url || cannotEmbed ) {
+		content = (
+			<EmbedForm
+				{ ...props }
+				editedUrl={ editedUrl }
+				onChange={ e => setEditedUrl( e.target.value ) }
+				onSubmit={ e => {
+					if ( e ) {
+						e.preventDefault();
+					}
 
-		const embedTypes = [
-			{
-				value: 'inline',
-				label: __( 'In-page Embed', 'jetpack' ),
-				preview: (
-					<div className="block-editor-block-preview__container">
-						<img
-							src={ EventbriteInPageExample }
-							alt={ __( 'In page Eventbrite checkout example', 'jetpack' ) }
-						/>
-					</div>
-				),
-			},
-			{
-				value: 'modal',
-				label: __( 'Button & Modal', 'jetpack' ),
-			},
-		];
-
-		return (
-			<BlockStylesSelector
-				title={ _x(
-					'Embed Type',
-					'option for how the embed displays on a page, e.g. inline or as a modal',
-					'jetpack'
-				) }
-				clientId={ clientId }
-				styleOptions={ embedTypes }
-				onSelectStyle={ setAttributes }
-				activeStyle={ style }
-				attributes={ attributes }
-				viewportWidth={ 130 }
+					setUrl( normalizeUrlInput( editedUrl ) );
+					setEditingUrl( false );
+				} }
 			/>
 		);
-	}
-
-	renderEditEmbed() {
-		const { className, noticeUI } = this.props;
-		const { editedUrl } = this.state;
-		const supportLink =
-			isSimpleSite() || isAtomicSite()
-				? 'http://support.wordpress.com/wordpress-editor/blocks/eventbrite-block/'
-				: 'https://jetpack.com/support/jetpack-blocks/eventbrite-block/';
-
-		return (
-			<div className={ className }>
-				<Placeholder
-					label={ __( 'Eventbrite Checkout', 'jetpack' ) }
-					instructions={ __(
-						'Paste a link to an Eventbrite event to embed ticket checkout.',
-						'jetpack'
-					) }
-					icon={ icon }
-					notices={ noticeUI }
-				>
-					<form onSubmit={ this.submitForm }>
-						<input
-							type="url"
-							value={ editedUrl }
-							className="components-placeholder__input"
-							aria-label={ __( 'Eventbrite URL', 'jetpack' ) }
-							placeholder={ __( 'Enter an event URL to embed here…', 'jetpack' ) }
-							onChange={ event => this.setState( { editedUrl: event.target.value } ) }
-						/>
-						<Button variant="secondary" type="submit">
-							{ _x( 'Embed', 'submit button label', 'jetpack' ) }
-						</Button>
-					</form>
-
-					<div className="components-placeholder__learn-more">
-						<ExternalLink href={ supportLink }>
-							{ __( 'Learn more about Eventbrite embeds', 'jetpack' ) }
-						</ExternalLink>
-					</div>
-				</Placeholder>
-			</div>
-		);
-	}
-
-	renderInlinePreview() {
-		const { className } = this.props;
-		const { eventId } = this.props.attributes;
-
-		if ( ! eventId ) {
-			return;
-		}
-
-		const widgetId = `eventbrite-widget-${ eventId }`;
-		const html = `
-			<script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>
-			<style>
-				/* Prevent scrollbar on the embed preview */
-				body {
-					overflow: hidden;
-				}
-				/* Eventbrite embeds have a CSS height transition on loading, which causes <Sandbox>
-				to not recognise the resizing. We need to disable that transition. */
-				* {
-					transition: none !important;
-				}
-			</style>
-			<script>
-				window.EBWidgets.createWidget({
-					widgetType: 'checkout',
-					eventId: ${ eventId },
-					iframeContainerId: '${ widgetId }',
-				});
-			</script>
-			<div id="${ widgetId }"></div>
-		`;
-
-		return (
-			<div className={ className }>
-				<SandBox html={ html } />
-				{ /* Use an overlay to prevent interactivity with the preview, since the preview does not always resize correctly. */ }
-				<div className="block-library-embed__interactive-overlay" />
-			</div>
-		);
-	}
-
-	/**
-	 * Render a preview of the Eventbrite embed.
-	 *
-	 * @returns {object} The UI displayed when user edits this block.
-	 */
-	render() {
-		const { attributes } = this.props;
-		const { url, style } = attributes;
-		const { editingUrl, isResolvingUrl } = this.state;
-
-		if ( isResolvingUrl ) {
-			return this.renderLoading();
-		}
-
-		if ( editingUrl || ! url || this.cannotEmbed() ) {
-			return this.renderEditEmbed();
-		}
-
-		return (
+	} else {
+		content = (
 			<>
-				{ this.renderInspectorControls() }
+				<InspectorControls { ...props } />
 				<BlockControls>
-					<ToolbarControls setEditingUrl={ this.setEditingUrl } />
+					<ToolbarControls setEditingUrl={ setEditingUrl } />
 				</BlockControls>
 				{ style === 'modal' ? (
 					<InnerBlocks
@@ -280,11 +117,13 @@ export class EventbriteEdit extends Component {
 						templateLock="all"
 					/>
 				) : (
-					this.renderInlinePreview()
+					<InlinePreview { ...props } />
 				) }
 			</>
 		);
 	}
-}
+
+	return <div>{ content }</div>;
+};
 
 export default withNotices( EventbriteEdit );

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
@@ -23,7 +23,7 @@ const innerButtonBlock = {
 	},
 };
 
-const EventbriteEdit = props => {
+export const EventbriteEdit = props => {
 	const { attributes, noticeOperations, onReplace, setAttributes } = props;
 	const { url, style } = attributes;
 

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/form.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/form.js
@@ -1,0 +1,54 @@
+import {
+	isAtomicSite,
+	isSimpleSite,
+	getBlockIconComponent,
+} from '@automattic/jetpack-shared-extension-utils';
+import { Placeholder, Button, ExternalLink } from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
+import metadata from './block.json';
+import {} from './utils';
+
+const icon = getBlockIconComponent( metadata );
+
+const EmbedForm = ( { className, noticeUI, editedUrl, onChange, onSubmit } ) => {
+	const supportLink =
+		isSimpleSite() || isAtomicSite()
+			? 'http://support.wordpress.com/wordpress-editor/blocks/eventbrite-block/'
+			: 'https://jetpack.com/support/jetpack-blocks/eventbrite-block/';
+
+	return (
+		<div className={ className }>
+			<Placeholder
+				label={ __( 'Eventbrite Checkout', 'jetpack' ) }
+				instructions={ __(
+					'Paste a link to an Eventbrite event to embed ticket checkout.',
+					'jetpack'
+				) }
+				icon={ icon }
+				notices={ noticeUI }
+			>
+				<form onSubmit={ onSubmit }>
+					<input
+						type="url"
+						value={ editedUrl }
+						className="components-placeholder__input"
+						aria-label={ __( 'Eventbrite URL', 'jetpack' ) }
+						placeholder={ __( 'Enter an event URL to embed here…', 'jetpack' ) }
+						onChange={ onChange }
+					/>
+					<Button variant="secondary" type="submit">
+						{ _x( 'Embed', 'submit button label', 'jetpack' ) }
+					</Button>
+				</form>
+
+				<div className="components-placeholder__learn-more">
+					<ExternalLink href={ supportLink }>
+						{ __( 'Learn more about Eventbrite embeds', 'jetpack' ) }
+					</ExternalLink>
+				</div>
+			</Placeholder>
+		</div>
+	);
+};
+
+export default EmbedForm;

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/loader.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/loader.js
@@ -1,0 +1,13 @@
+import { Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const Loader = () => {
+	return (
+		<div className="wp-block-embed is-loading">
+			<Spinner />
+			<p>{ __( 'Embedding…', 'jetpack' ) }</p>
+		</div>
+	);
+};
+
+export default Loader;

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/preview.js
@@ -1,0 +1,43 @@
+import { SandBox } from '@wordpress/components';
+
+const InlinePreview = ( { className, attributes } ) => {
+	const { eventId } = attributes;
+
+	if ( ! eventId ) {
+		return;
+	}
+
+	const widgetId = `eventbrite-widget-${ eventId }`;
+	const html = `
+			<script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>
+			<style>
+				/* Prevent scrollbar on the embed preview */
+				body {
+					overflow: hidden;
+				}
+				/* Eventbrite embeds have a CSS height transition on loading, which causes <Sandbox>
+				to not recognise the resizing. We need to disable that transition. */
+				* {
+					transition: none !important;
+				}
+			</style>
+			<script>
+				window.EBWidgets.createWidget({
+					widgetType: 'checkout',
+					eventId: ${ eventId },
+					iframeContainerId: '${ widgetId }',
+				});
+			</script>
+			<div id="${ widgetId }"></div>
+		`;
+
+	return (
+		<div className={ className }>
+			<SandBox html={ html } />
+			{ /* Use an overlay to prevent interactivity with the preview, since the preview does not always resize correctly. */ }
+			<div className="block-library-embed__interactive-overlay" />
+		</div>
+	);
+};
+
+export default InlinePreview;

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/save.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc */
 import { InnerBlocks } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR refactors the Eventbrite block's Edit component to be a functional component. It's preparatory work for upgrading to block API to version 3. In detail, this PR:

- Transforms `EventbriteEdit` to a functional component
- Create sub-components out of its render functions
- Move these sub-components to their own file for readability

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- If you run it locally, make sure to run `cd projects/plugins/jetpack && pnpm run build-extensions`
- Create a post
- Add the _Eventbrite_ block
- You may use this URL for testing: https://www.eventbrite.ca/e/billets-portrait-du-ux-pour-les-futurs-praticiens-869317440867?aff=ebdssbcitybrowse
- Make sure it behaves as it does in production. Specifically, the following elements should be the same:

_Embed form_
<img width="500" alt="Screenshot 2024-04-04 at 10 57 58 AM" src="https://github.com/Automattic/jetpack/assets/1620183/46178964-ae3b-4992-afcb-4fa436062b1b">


_Embed preview_
<img width="500" alt="Screenshot 2024-04-04 at 10 57 41 AM" src="https://github.com/Automattic/jetpack/assets/1620183/52149397-3e52-4d19-8159-8acab6016f65">



_Sidebar_
<img width="287" alt="Screenshot 2024-04-04 at 10 57 47 AM" src="https://github.com/Automattic/jetpack/assets/1620183/1bf72b93-8b0b-44aa-b771-5d3b12954d23">


