### PR TITLE
Add/from property to connection call

### DIFF
--- a/projects/js-packages/api/changelog/add-from-property-to-connection-call
+++ b/projects/js-packages/api/changelog/add-from-property-to-connection-call
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add from property to connection call to wpcom

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -83,7 +83,7 @@ function JetpackRestApiClient( root, nonce ) {
 			cacheBusterCallback = callback;
 		},
 
-		registerSite: ( registrationNonce, redirectUri ) => {
+		registerSite: ( registrationNonce, redirectUri, from ) => {
 			const params = {
 				registration_nonce: registrationNonce,
 				no_iframe: true,
@@ -95,6 +95,10 @@ function JetpackRestApiClient( root, nonce ) {
 
 			if ( null !== redirectUri ) {
 				params.redirect_uri = redirectUri;
+			}
+
+			if ( from ) {
+				params.from = from;
 			}
 
 			return postRequest( `${ apiRoot }jetpack/v4/connection/register`, postParams, {

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.17.4",
+	"version": "0.17.5-alpha",
 	"description": "Jetpack Api Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/changelog/add-from-property-to-connection-call
+++ b/projects/js-packages/connection/changelog/add-from-property-to-connection-call
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add from property to connection call to wpcom

--- a/projects/js-packages/connection/components/use-connection/index.jsx
+++ b/projects/js-packages/connection/components/use-connection/index.jsx
@@ -72,7 +72,7 @@ export default ( {
 			return handleConnectUser();
 		}
 
-		return registerSite( { registrationNonce, redirectUri } ).then( () => {
+		return registerSite( { registrationNonce, redirectUri, from } ).then( () => {
 			return handleConnectUser();
 		} );
 	};

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.33.6",
+	"version": "0.33.7-alpha",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/state/actions.jsx
+++ b/projects/js-packages/connection/state/actions.jsx
@@ -90,15 +90,16 @@ function* connectUser( { from, redirectFunc, redirectUri } = {} ) {
  * @param {object} Object - contains registrationNonce and redirectUri
  * @param {string} Object.registrationNonce - Registration nonce
  * @param {string} Object.redirectUri - URI that user will be redirected
+ * @param {string} [Object.from] - Value that represents the origin of the request (optional)
  * @yields {object} Action object that will be yielded
  * @returns {Promise} Resolved or rejected value of registerSite
  */
-function* registerSite( { registrationNonce, redirectUri } ) {
+function* registerSite( { registrationNonce, redirectUri, from = '' } ) {
 	yield clearRegistrationError();
 	yield setSiteIsRegistering( true );
 
 	try {
-		const response = yield { type: REGISTER_SITE, registrationNonce, redirectUri };
+		const response = yield { type: REGISTER_SITE, registrationNonce, redirectUri, from };
 		yield setConnectionStatus( { isRegistered: true } );
 		yield setAuthorizationUrl( response.authorizeUrl );
 		yield setSiteIsRegistering( false );

--- a/projects/js-packages/connection/state/controls.jsx
+++ b/projects/js-packages/connection/state/controls.jsx
@@ -2,8 +2,8 @@ import restApi from '@automattic/jetpack-api';
 import { createRegistryControl } from '@wordpress/data';
 import STORE_ID from './store-id';
 
-const REGISTER_SITE = ( { registrationNonce, redirectUri } ) =>
-	restApi.registerSite( registrationNonce, redirectUri );
+const REGISTER_SITE = ( { registrationNonce, redirectUri, from } ) =>
+	restApi.registerSite( registrationNonce, redirectUri, from );
 
 const CONNECT_USER = createRegistryControl(
 	( { resolveSelect } ) =>

--- a/projects/js-packages/connection/state/test/actions.jsx
+++ b/projects/js-packages/connection/state/test/actions.jsx
@@ -50,7 +50,8 @@ describe( 'actions', () => {
 			const response = { authorizeUrl: 'AUTHORIZE_URL' };
 			const registrationNonce = 'REGISTRATION_NONCE';
 			const redirectUri = 'REDIRECT_URI';
-			const action = actions.registerSite( { registrationNonce, redirectUri } );
+			const from = 'FROM';
+			const action = actions.registerSite( { registrationNonce, redirectUri, from } );
 
 			expect( action.next().value ).toEqual( { type: CLEAR_REGISTRATION_ERROR } );
 			expect( action.next().value ).toEqual( {
@@ -61,6 +62,7 @@ describe( 'actions', () => {
 				type: REGISTER_SITE,
 				registrationNonce,
 				redirectUri,
+				from,
 			} );
 
 			expect( action.next( response ).value ).toEqual( {
@@ -84,7 +86,8 @@ describe( 'actions', () => {
 			const error = new Error( 'failed' );
 			const registrationNonce = 'REGISTRATION_NONCE';
 			const redirectUri = 'REDIRECT_URI';
-			const action = actions.registerSite( { registrationNonce, redirectUri } );
+			const from = 'FROM';
+			const action = actions.registerSite( { registrationNonce, redirectUri, from } );
 
 			expect( action.next().value ).toEqual( { type: CLEAR_REGISTRATION_ERROR } );
 			expect( action.next().value ).toEqual( {
@@ -95,6 +98,7 @@ describe( 'actions', () => {
 				type: REGISTER_SITE,
 				registrationNonce,
 				redirectUri,
+				from,
 			} );
 
 			expect( action.throw( error ).value ).toEqual( {

--- a/projects/js-packages/connection/state/test/controls.jsx
+++ b/projects/js-packages/connection/state/test/controls.jsx
@@ -26,12 +26,13 @@ describe( 'controls', () => {
 		it( 'resolves with result', async () => {
 			const registrationNonce = 'REGISTRATION_NONCE';
 			const redirectUri = 'REDIRECT_URI';
+			const from = 'FROM';
 			const fakeResult = {};
 			stubRegisterSite.mockResolvedValue( fakeResult );
 
-			const result = await registerSite( { registrationNonce, redirectUri } );
+			const result = await registerSite( { registrationNonce, redirectUri, from } );
 			expect( result ).toEqual( fakeResult );
-			expect( stubRegisterSite ).toHaveBeenCalledWith( registrationNonce, redirectUri );
+			expect( stubRegisterSite ).toHaveBeenCalledWith( registrationNonce, redirectUri, from );
 		} );
 
 		it( 'resolves with error', async () => {

--- a/projects/js-packages/partner-coupon/changelog/add-from-property-to-connection-call
+++ b/projects/js-packages/partner-coupon/changelog/add-from-property-to-connection-call
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix test with new from property when registering site

--- a/projects/js-packages/partner-coupon/components/redeem-partner-coupon-pre-connection/test/connection-pass-along.jsx
+++ b/projects/js-packages/partner-coupon/components/redeem-partner-coupon-pre-connection/test/connection-pass-along.jsx
@@ -41,6 +41,7 @@ describe( 'RedeemPartnerCouponPreConnection', () => {
 			expect( stubRegisterSite ).toHaveBeenCalledWith( {
 				registrationNonce: 'REGISTRATION',
 				redirectUri: 'admin.php?page=jetpack&partnerCoupon=TEST_TST_1234',
+				from: 'jetpack-partner-coupon',
 			} );
 
 			expect( stubConnectUser ).toHaveBeenCalledTimes( 1 );

--- a/projects/packages/my-jetpack/_inc/components/connection-screen/body.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/body.tsx
@@ -15,6 +15,7 @@ const ConnectionScreenBody: React.FC< ConnectScreenProps > = props => {
 			buttonLabel={ __( 'Connect your user account', 'jetpack-my-jetpack' ) }
 			loadingLabel={ __( 'Connecting your account…', 'jetpack-my-jetpack' ) }
 			images={ [ connectImage ] }
+			from="my-jetpack"
 			{ ...props }
 			title={
 				title ||

--- a/projects/packages/my-jetpack/changelog/add-from-property-to-connection-call
+++ b/projects/packages/my-jetpack/changelog/add-from-property-to-connection-call
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add from property to connection call to wpcom


### PR DESCRIPTION
## Proposed changes:

* The `wpcom_jpc_register_success` event has the capability to record where the connection request came from, but the `js-packages/connection` package was not recording this to the backend
* Add a `from` property when calling the Connection Screen in My Jetpack
* Pass along the from property to the `registerSite` call in the connection package so the backend can record it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pbNhbs-ajA-p2

## Does this pull request change what data or activity we track or use?

Yes, we will now be tracking when connections come from My Jetpack

## Testing instructions:

1. Create an Ephemeral Site
3. SSH into the new site you just created, and open up `htdocs/wp-config.php`
4. With the other variable declratations, add the following line
```
lang=php
define( 'JETPACK__SANDBOX_DOMAIN', {YOUR_SANDBOX_DOMAIN} );
```
5. in WPCOM, go to fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Szh%2Qcyhtvaf%2Swrgcnpx%2Spynff.wrgcnpx%2Qqngn.cuc%3Se%3Qs1853134%23152-og and log the data to your error logs via `l( $data );` to log the tracks data
6. On your ephemeral site, go to My Jetpack
7. Connect your site like you normally would
8. Check your error logs and see that a `from` attribute of `my-jetpack` is present
![image](https://github.com/Automattic/jetpack/assets/65001528/dc9a0e10-c141-45f9-b908-3ec42f248877)
