### PR TITLE
Blocks: upgrade to API version 3 - Part 2

### DIFF
--- a/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-2
+++ b/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update blocks to use API version 3

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/cookie-consent",
 	"title": "Cookie Consent",
 	"description": "Display a customizable cookie consent banner. To display this block on all pages of your site, please add it inside a Template Part that is present on all your templates, like a Header or a Footer.",

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/eventbrite",
 	"title": "Eventbrite Checkout",
 	"description": "Embed Eventbrite event details and ticket checkout.",

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
@@ -1,4 +1,4 @@
-import { BlockControls, InnerBlocks } from '@wordpress/block-editor';
+import { BlockControls, InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { Button, withNotices } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useCallback, useEffect, useState } from 'react';
@@ -27,6 +27,7 @@ export const EventbriteEdit = props => {
 	const { attributes, noticeOperations, onReplace, setAttributes } = props;
 	const { url, style } = attributes;
 
+	const blockProps = useBlockProps();
 	const [ editingUrl, setEditingUrl ] = useState( false );
 	const [ editedUrl, setEditedUrl ] = useState( attributes.url || '' );
 	const [ isResolvingUrl, setIsResolvingUrl ] = useState( false );
@@ -123,7 +124,7 @@ export const EventbriteEdit = props => {
 		);
 	}
 
-	return <div>{ content }</div>;
+	return <div { ...blockProps }>{ content }</div>;
 };
 
 export default withNotices( EventbriteEdit );

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/save.js
@@ -1,6 +1,7 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
+	const blockProps = useBlockProps.save();
 	const { eventId, style, url } = attributes;
 
 	if ( ! eventId ) {
@@ -9,7 +10,7 @@ export default function save( { attributes } ) {
 
 	if ( style === 'modal' ) {
 		return (
-			<div>
+			<div { ...blockProps }>
 				<InnerBlocks.Content />
 			</div>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/save.js
@@ -8,19 +8,17 @@ export default function save( { attributes } ) {
 		return;
 	}
 
-	if ( style === 'modal' ) {
-		return (
-			<div { ...blockProps }>
-				<InnerBlocks.Content />
-			</div>
-		);
-	}
+	let content;
 
-	return (
-		url && (
+	if ( style === 'modal' ) {
+		content = <InnerBlocks.Content />;
+	} else if ( url ) {
+		content = (
 			<a className="eventbrite__direct-link" href={ url }>
 				{ url }
 			</a>
-		)
-	);
+		);
+	}
+
+	return <div { ...blockProps }>{ content }</div>;
 }

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/test/fixtures/jetpack__eventbrite.json
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/test/fixtures/jetpack__eventbrite.json
@@ -1,14 +1,28 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "jetpack/eventbrite",
-        "isValid": true,
-        "attributes": {
-            "url": "https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445",
-            "eventId": 122642642445,
-            "style": "inline"
-        },
-        "innerBlocks": [],
-        "originalContent": "<a class=\"wp-block-jetpack-eventbrite eventbrite__direct-link\" href=\"https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445\">https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445</a>"
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "jetpack/eventbrite",
+		"isValid": true,
+		"attributes": {
+			"url": "https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445",
+			"eventId": 122642642445,
+			"style": "inline"
+		},
+		"innerBlocks": [
+			{
+				"clientId": "_clientId_0",
+				"name": "jetpack/button",
+				"isValid": true,
+				"attributes": {
+					"element": "a",
+					"saveInPostContent": false,
+					"uniqueId": "eventbrite-widget-id",
+					"text": "Register",
+					"className": ""
+				},
+				"innerBlocks": []
+			}
+		],
+		"originalContent": "<a class=\"wp-block-jetpack-eventbrite eventbrite__direct-link\" href=\"https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445\">https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445</a>"
+	}
 ]

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/test/fixtures/jetpack__eventbrite.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/test/fixtures/jetpack__eventbrite.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:jetpack/eventbrite {"url":"https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445","eventId":122642642445} -->
-<a class="wp-block-jetpack-eventbrite eventbrite__direct-link" href="https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445">https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445</a>
+<div class="wp-block-jetpack-eventbrite"><a class="eventbrite__direct-link" href="https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445">https://www.eventbrite.com.au/e/2021-nsw-open-championship-tickets-122642642445</a></div>
 <!-- /wp:jetpack/eventbrite -->

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/test/fixtures/jetpack__eventbrite__deprecated-1.json
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/test/fixtures/jetpack__eventbrite__deprecated-1.json
@@ -1,14 +1,28 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "jetpack/eventbrite",
-        "isValid": true,
-        "attributes": {
-            "url": "https://www.eventbrite.com.au/e/the-fever-tree-gin-and-tonic-festival-2021-tickets-140737974069",
-            "eventId": 140737974069,
-            "style": "inline"
-        },
-        "innerBlocks": [],
-        "originalContent": "<a class=\"wp-block-jetpack-eventbrite eventbrite__direct-link\" href=\"https://www.eventbrite.com.au/e/the-fever-tree-gin-and-tonic-festival-2021-tickets-140737974069\">https://www.eventbrite.com.au/e/the-fever-tree-gin-and-tonic-festival-2021-tickets-140737974069</a>"
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "jetpack/eventbrite",
+		"isValid": true,
+		"attributes": {
+			"url": "https://www.eventbrite.com.au/e/the-fever-tree-gin-and-tonic-festival-2021-tickets-140737974069",
+			"eventId": 140737974069,
+			"style": "inline"
+		},
+		"innerBlocks": [
+			{
+				"clientId": "_clientId_0",
+				"name": "jetpack/button",
+				"isValid": true,
+				"attributes": {
+					"element": "a",
+					"saveInPostContent": false,
+					"uniqueId": "eventbrite-widget-id",
+					"text": "Register",
+					"className": ""
+				},
+				"innerBlocks": []
+			}
+		],
+		"originalContent": "<a class=\"wp-block-jetpack-eventbrite eventbrite__direct-link\" href=\"https://www.eventbrite.com.au/e/the-fever-tree-gin-and-tonic-festival-2021-tickets-140737974069\">https://www.eventbrite.com.au/e/the-fever-tree-gin-and-tonic-festival-2021-tickets-140737974069</a>"
+	}
 ]

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/test/fixtures/jetpack__eventbrite__deprecated-1.serialized.html
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/test/fixtures/jetpack__eventbrite__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:jetpack/eventbrite {"url":"https://www.eventbrite.com.au/e/the-fever-tree-gin-and-tonic-festival-2021-tickets-140737974069","eventId":140737974069} -->
-<a class="wp-block-jetpack-eventbrite eventbrite__direct-link" href="https://www.eventbrite.com.au/e/the-fever-tree-gin-and-tonic-festival-2021-tickets-140737974069">https://www.eventbrite.com.au/e/the-fever-tree-gin-and-tonic-festival-2021-tickets-140737974069</a>
+<div class="wp-block-jetpack-eventbrite"><a class="eventbrite__direct-link" href="https://www.eventbrite.com.au/e/the-fever-tree-gin-and-tonic-festival-2021-tickets-140737974069">https://www.eventbrite.com.au/e/the-fever-tree-gin-and-tonic-festival-2021-tickets-140737974069</a></div>
 <!-- /wp:jetpack/eventbrite -->

--- a/projects/plugins/jetpack/extensions/blocks/goodreads/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/goodreads/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/goodreads",
 	"title": "Goodreads",
 	"description": "Features books from the shelves of your Goodreads account.",

--- a/projects/plugins/jetpack/extensions/blocks/goodreads/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/goodreads/edit.js
@@ -1,5 +1,5 @@
 import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
-import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import { BlockControls, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { Placeholder, SandBox, Button, Spinner, withNotices } from '@wordpress/components';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -14,6 +14,7 @@ const GoodreadsEdit = props => {
 	const [ url, setUrl ] = useState( '' );
 	const [ isResolvingUrl, setIsResolvingUrl ] = useState( false );
 	const prevPropsRef = useRef( null );
+	const blockProps = useBlockProps();
 
 	const { isFetchingData, goodreadsUserId, isError } = useFetchGoodreadsData( url );
 
@@ -134,12 +135,12 @@ const GoodreadsEdit = props => {
 		);
 	};
 
-	if ( isResolvingUrl ) {
-		return renderLoading();
-	}
+	let content;
 
-	if ( attributes.goodreadsId ) {
-		return (
+	if ( isResolvingUrl ) {
+		content = renderLoading();
+	} else if ( attributes.goodreadsId ) {
+		content = (
 			<>
 				<InspectorControls>
 					<GoodreadsInspectorControls attributes={ attributes } setAttributes={ setAttributes } />
@@ -152,9 +153,11 @@ const GoodreadsEdit = props => {
 				{ renderInlinePreview() }
 			</>
 		);
+	} else {
+		content = renderEditEmbed();
 	}
 
-	return renderEditEmbed();
+	return <div { ...blockProps }>{ content }</div>;
 };
 
 export default withNotices( GoodreadsEdit );

--- a/projects/plugins/jetpack/extensions/blocks/goodreads/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/goodreads/save.js
@@ -1,9 +1,10 @@
-/* eslint-disable jsdoc/require-jsdoc */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save() {
+	const blockProps = useBlockProps.save();
+
 	return (
-		<div>
+		<div { ...blockProps }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/instagram-gallery",
 	"title": "Latest Instagram Posts",
 	"description": "Display an automatically updating list of the latest posts from your Instagram feed.",

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/edit.js
@@ -1,5 +1,5 @@
 import { isCurrentUserConnected } from '@automattic/jetpack-shared-extension-utils';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { Button, Placeholder, RadioControl, Spinner, withNotices } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -16,9 +16,9 @@ import useInstagramGallery from './use-instagram-gallery';
 import './editor.scss';
 
 const InstagramGalleryEdit = props => {
-	const { attributes, className, isSelected, noticeOperations, noticeUI, setAttributes } = props;
+	const blockProps = useBlockProps();
+	const { attributes, isSelected, noticeOperations, noticeUI, setAttributes } = props;
 	const { accessToken, align, columns, count, isStackedOnMobile, spacing } = attributes;
-
 	useEffect( () => {
 		const validatedAttributes = getValidatedAttributes( metadata.attributes, attributes );
 		if ( ! isEqual( validatedAttributes, attributes ) ) {
@@ -57,7 +57,7 @@ const InstagramGalleryEdit = props => {
 	const showLoadingSpinner = accessToken && isLoadingGallery && isEmpty( images );
 	const showGallery = ! showPlaceholder && ! showLoadingSpinner;
 
-	const blockClasses = classnames( className, { [ `align${ align }` ]: align } );
+	const blockClasses = classnames( blockProps.className, { [ `align${ align }` ]: align } );
 	const gridClasses = classnames(
 		'wp-block-jetpack-instagram-gallery__grid',
 		`wp-block-jetpack-instagram-gallery__grid-columns-${ columns }`,
@@ -159,7 +159,7 @@ const InstagramGalleryEdit = props => {
 	};
 
 	return (
-		<div className={ blockClasses }>
+		<div { ...blockProps } className={ blockClasses }>
 			{ showPlaceholder && (
 				<Placeholder
 					icon="instagram"

--- a/projects/plugins/jetpack/extensions/blocks/instagram-gallery/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/instagram-gallery/save.js
@@ -1,10 +1,17 @@
-export default ( { attributes: { instagramUser } } ) =>
-	instagramUser && (
-		<div>
-			<a
-				href={ `https://www.instagram.com/${ instagramUser }/` }
-				rel="noopener noreferrer"
-				target="_blank"
-			>{ `https://www.instagram.com/${ instagramUser }/` }</a>
-		</div>
+import { useBlockProps } from '@wordpress/block-editor';
+
+export default ( { attributes: { instagramUser } } ) => {
+	const blockProps = useBlockProps.save();
+
+	return (
+		instagramUser && (
+			<div { ...blockProps }>
+				<a
+					href={ `https://www.instagram.com/${ instagramUser }/` }
+					rel="noopener noreferrer"
+					target="_blank"
+				>{ `https://www.instagram.com/${ instagramUser }/` }</a>
+			</div>
+		)
 	);
+};

--- a/projects/plugins/jetpack/extensions/blocks/opentable/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/opentable",
 	"title": "OpenTable",
 	"description": "Book a reservation with OpenTable.",

--- a/projects/plugins/jetpack/extensions/blocks/opentable/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/edit.js
@@ -3,7 +3,11 @@ import {
 	isSimpleSite,
 	getBlockIconComponent,
 } from '@automattic/jetpack-shared-extension-utils';
-import { InspectorControls, InspectorAdvancedControls } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	InspectorAdvancedControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import {
 	getBlockDefaultClassName,
 	registerBlockStyle,
@@ -36,7 +40,6 @@ const icon = getBlockIconComponent( metadata );
 
 function OpenTableEdit( {
 	attributes,
-	className,
 	clientId,
 	isSelected,
 	name,
@@ -44,6 +47,8 @@ function OpenTableEdit( {
 	noticeUI,
 	setAttributes,
 } ) {
+	const blockProps = useBlockProps();
+
 	const defaultClassName = getBlockDefaultClassName( name );
 	const validatedAttributes = getValidatedAttributes( metadata.attributes, attributes );
 
@@ -241,9 +246,8 @@ function OpenTableEdit( {
 		</Placeholder>
 	);
 
-	const editClasses = classnames( className, {
-		[ `is-style-${ style }` ]:
-			! isPlaceholder && styleValues.includes( style ) && className.indexOf( 'is-style' ) === -1,
+	const editClasses = classnames( {
+		[ `is-style-${ style }` ]: ! isPlaceholder && styleValues.includes( style ),
 		'is-placeholder': isPlaceholder,
 		'is-multi': 'multi' === getTypeAndTheme( style )[ 0 ],
 		[ `align${ align }` ]: align,
@@ -251,13 +255,13 @@ function OpenTableEdit( {
 	} );
 
 	return (
-		<>
+		<div { ...blockProps }>
 			{ noticeUI }
 			<div className={ editClasses }>
 				{ ! isPlaceholder && inspectorControls }
 				{ ! isPlaceholder ? blockPreview() : blockPlaceholder }
 			</div>
-		</>
+		</div>
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/opentable/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/editor.js
@@ -1,3 +1,4 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
@@ -12,18 +13,22 @@ import './view.scss';
 
 registerJetpackBlockFromMetadata( metadata, {
 	edit,
-	save: ( { attributes: { rid } } ) => (
-		<div>
-			{ rid?.map( ( restaurantId, restaurantIndex ) => (
-				<a
-					href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
-					key={ `${ restaurantId }-${ restaurantIndex }` }
-				>
-					{ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
-				</a>
-			) ) }
-		</div>
-	),
+	save: ( { attributes: { rid } } ) => {
+		const blockProps = useBlockProps.save();
+
+		return (
+			<div { ...blockProps }>
+				{ rid?.map( ( restaurantId, restaurantIndex ) => (
+					<a
+						href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
+						key={ `${ restaurantId }-${ restaurantIndex }` }
+					>
+						{ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
+					</a>
+				) ) }
+			</div>
+		);
+	},
 	attributes: metadata.attributes,
 	styles: getStyleOptions(),
 	transforms: {

--- a/projects/plugins/jetpack/extensions/blocks/opentable/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/editor.scss
@@ -9,8 +9,8 @@
 	display: inline-block;
 	position: relative;
 
-	&.is-style-wide,
-	&.is-placeholder {
+	& > .is-style-wide,
+	& > .is-placeholder {
 		display: block;
 	}
 
@@ -117,7 +117,7 @@
 		}
 	}
 
-	&.is-style-button {
+	& > .is-style-button {
 		&.has-no-margin {
 			iframe {
 				margin: -14px;
@@ -132,7 +132,7 @@
 		margin: 0;
 	}
 
-	.wp-block > &.is-style-wide {
+	&.wp-block > .is-style-wide {
 		&.alignright {
 			left: auto;
 			right: 0;

--- a/projects/plugins/jetpack/extensions/blocks/opentable/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/view.scss
@@ -6,11 +6,11 @@
 		margin: 0; /* Override margins in AMP legacy Reader mode. */
 	}
 
-	&.aligncenter iframe {
+	& > .aligncenter iframe {
 		margin: 0 auto;
 	}
 
-	&.is-style-standard, &.is-style-wide.is-style-mobile {
+	& > .is-style-standard, & > .is-style-wide.is-style-mobile {
 		height: 301px;
 
 		&.is-multi {
@@ -22,7 +22,7 @@
 		}
 	}
 
-	&.is-style-tall {
+	& > .is-style-tall {
 		height: 490px;
 
 		&.is-multi {
@@ -34,7 +34,7 @@
 		}
 	}
 
-	&.is-style-wide {
+	& > .is-style-wide {
 		height: 150px;
 		iframe {
 			width: 840px !important;
@@ -52,7 +52,7 @@
 		}
 	}
 
-	&.is-style-button {
+	& > .is-style-button {
 		height: 113px;
 		&.aligncenter iframe {
 			width: 210px !important;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the following blocks to use version 3 of the block API: 
- Eventbrite
- OpenTable
- Cookie Consent
- Instagram Gallery
- Goodreads

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/34120

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check that the blocks above work as expected with a self-hosted site and on WordPress.com (the Cookie Consent block is available from the site editor).