### PR TITLE
Add/track for product activations from my jetpack

### DIFF
--- a/projects/packages/my-jetpack/_inc/data/products/use-activate.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-activate.ts
@@ -3,8 +3,21 @@ import useAnalytics from '../../hooks/use-analytics';
 import { REST_API_SITE_PRODUCTS_ENDPOINT } from '../constants';
 import { QUERY_ACTIVATE_PRODUCT_KEY } from '../constants';
 import useSimpleMutation from '../use-simple-mutation';
+import { getMyJetpackWindowInitialState } from '../utils/get-my-jetpack-window-state';
 import useProduct from './use-product';
 import type { ProductCamelCase } from '../types';
+
+const setPluginActiveState = ( productId: string ) => {
+	const { items } = getMyJetpackWindowInitialState( 'products' );
+	if ( items[ productId ]?.standalone_plugin_info.has_standalone_plugin ) {
+		window.myJetpackInitialState.products.items[
+			productId
+		].standalone_plugin_info.is_standalone_active = true;
+		window.myJetpackInitialState.products.items[
+			productId
+		].standalone_plugin_info.is_standalone_installed = true;
+	}
+};
 
 const getIsPluginAlreadyActive = ( detail: ProductCamelCase ) => {
 	const { standalonePluginInfo, isPluginActive } = detail;
@@ -32,6 +45,11 @@ const useActivate = ( productId: string ) => {
 					recordEvent( 'jetpack_myjetpack_product_activated', {
 						product: productId,
 					} );
+
+					// This is to handle an edge case where a user is redirected somewhere after activation
+					// and goes back in the browser and "activates" the product again. This will manually update
+					// the window state so that the tracking is not recorded twice for one activation.
+					setPluginActiveState( productId );
 				}
 				refetch();
 			},

--- a/projects/packages/my-jetpack/_inc/data/products/use-activate.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-activate.ts
@@ -9,7 +9,7 @@ import type { ProductCamelCase } from '../types';
 const getIsPluginAlreadyActive = ( detail: ProductCamelCase ) => {
 	const { standalonePluginInfo, isPluginActive } = detail;
 
-	if ( standalonePluginInfo?.hasStandalonePlugin && standalonePluginInfo?.isStandaloneInstalled ) {
+	if ( standalonePluginInfo?.hasStandalonePlugin ) {
 		return standalonePluginInfo?.isStandaloneActive;
 	}
 

--- a/projects/packages/my-jetpack/changelog/add-track-for-product-activations-from-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/add-track-for-product-activations-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add new tracking event for product activations made through My Jetpack


### PR DESCRIPTION
## Proposed changes:

* Add a tracks event for activations made from my jetpack

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pbNhbs-ajA-p2

## Does this pull request change what data or activity we track or use?

Yes, this adds a new event to track product activations through My Jetpack

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Install but do not activate the Jetpack Protect and Jetpack Search plugins
3. Go to My Jetpack  and activate the Protect plugin from My Jetpack
![image](https://github.com/Automattic/jetpack/assets/65001528/3657713b-fc22-444b-b5bd-a4c508f494cd)
4. Make sure a track gets recorded for the activation with the correct plugin slug
![image](https://github.com/Automattic/jetpack/assets/65001528/0b05f8e3-1d12-4285-925d-2f4458b02ea7)
5. Now go to `/wp-admin/admin.php?page=my-jetpack#/add-search` and select `Get Jetpack Search`
![image](https://github.com/Automattic/jetpack/assets/65001528/3c58374c-99c7-406a-a887-091d0fd27be5)
6. Make sure the same track gets recorded but with the search slug
![image](https://github.com/Automattic/jetpack/assets/65001528/14ff6686-085b-4266-bbb9-e4c23e78ad28)
7. Do not checkout and go back to `/wp-admin/admin.php?page=my-jetpack#/add-search`. Select `Get Jetpack Search` again. The track should not be recorded as the plugin is now already active
![image](https://github.com/Automattic/jetpack/assets/65001528/5e032bd5-e77f-4704-ae51-b3d0029a27e0)

