### PR TITLE
MailChimp Block: refactor Edit component to function

### DIFF
--- a/projects/plugins/jetpack/changelog/update-refactor-mailchimp-block
+++ b/projects/plugins/jetpack/changelog/update-refactor-mailchimp-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+MailChimp block: refactor Edit component to function

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/body.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/body.js
@@ -1,0 +1,79 @@
+import { InnerBlocks, RichText } from '@wordpress/block-editor';
+import { TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import {
+	BLOCK_CLASS,
+	NOTIFICATION_ERROR,
+	NOTIFICATION_PROCESSING,
+	NOTIFICATION_SUCCESS,
+	DEFAULT_EMAIL_PLACEHOLDER,
+	DEFAULT_CONSENT_TEXT,
+	DEFAULT_PROCESSING_LABEL,
+	DEFAULT_SUCCESS_LABEL,
+	DEFAULT_ERROR_LABEL,
+} from './constants';
+
+const innerButtonBlock = {
+	name: 'jetpack/button',
+	attributes: {
+		element: 'button',
+		text: __( 'Join my Mailchimp audience', 'jetpack' ),
+		uniqueId: 'mailchimp-widget-id',
+	},
+};
+
+const Body = ( { attributes, setAttributes, className, audition } ) => {
+	const {
+		emailPlaceholder = DEFAULT_EMAIL_PLACEHOLDER,
+		consentText = DEFAULT_CONSENT_TEXT,
+		processingLabel = DEFAULT_PROCESSING_LABEL,
+		successLabel = DEFAULT_SUCCESS_LABEL,
+		errorLabel = DEFAULT_ERROR_LABEL,
+	} = attributes;
+
+	const notification = {
+		[ NOTIFICATION_PROCESSING ]: processingLabel,
+		[ NOTIFICATION_SUCCESS ]: successLabel,
+		[ NOTIFICATION_ERROR ]: errorLabel,
+	}[ audition ];
+
+	return (
+		<div
+			className={ classnames( className, {
+				[ `${ BLOCK_CLASS }_notication-audition` ]: audition,
+			} ) }
+		>
+			<TextControl
+				aria-label={ emailPlaceholder }
+				className={ `${ BLOCK_CLASS }_text-input` }
+				disabled
+				onChange={ () => false }
+				placeholder={ emailPlaceholder }
+				title={ __( 'You can edit the email placeholder in the sidebar.', 'jetpack' ) }
+				type="email"
+			/>
+			<InnerBlocks
+				template={ [ [ innerButtonBlock.name, innerButtonBlock.attributes ] ] }
+				templateLock="all"
+			/>
+			<RichText
+				tagName="p"
+				placeholder={ __( 'Write consent text', 'jetpack' ) }
+				value={ consentText }
+				onChange={ value => setAttributes( { consentText: value } ) }
+				inlineToolbar
+			/>
+			{ audition && (
+				<div
+					className={ `${ BLOCK_CLASS }_notification ${ BLOCK_CLASS }_${ audition }` }
+					role={ audition === NOTIFICATION_ERROR ? 'alert' : 'status' }
+				>
+					{ notification }
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default Body;

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/constants.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/constants.js
@@ -4,6 +4,12 @@ export const NOTIFICATION_PROCESSING = 'processing';
 export const NOTIFICATION_SUCCESS = 'success';
 export const NOTIFICATION_ERROR = 'error';
 
+export const BLOCK_CLASS = 'wp-block-jetpack-mailchimp';
+
+export const API_STATE_LOADING = 0;
+export const API_STATE_CONNECTED = 1;
+export const API_STATE_NOTCONNECTED = 2;
+
 export const DEFAULT_EMAIL_PLACEHOLDER = __( 'Enter your email', 'jetpack' );
 export const DEFAULT_CONSENT_TEXT = __(
 	'By clicking submit, you agree to share your email address with the site owner and Mailchimp to receive marketing, updates, and other emails from the site owner. Use the unsubscribe link in those emails to opt out at any time.',

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/controls.js
@@ -1,5 +1,7 @@
+import { InspectorControls } from '@wordpress/block-editor';
 import { ExternalLink, PanelBody, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useRef } from 'react';
 import {
 	NOTIFICATION_PROCESSING,
 	NOTIFICATION_SUCCESS,
@@ -11,7 +13,7 @@ import {
 } from './constants';
 import MailchimpGroups from './mailchimp-groups';
 
-export function MailChimpBlockControls( {
+export const MailChimpBlockControls = ( {
 	auditionNotification,
 	clearAudition,
 	setAttributes,
@@ -23,7 +25,7 @@ export function MailChimpBlockControls( {
 	signupFieldTag,
 	signupFieldValue,
 	connectURL,
-} ) {
+} ) => {
 	const updateProcessingText = processing => {
 		setAttributes( { processingLabel: processing } );
 		auditionNotification( NOTIFICATION_PROCESSING );
@@ -111,4 +113,51 @@ export function MailChimpBlockControls( {
 			</PanelBody>
 		</>
 	);
-}
+};
+
+export const MailChimpInspectorControls = ( {
+	connectURL,
+	attributes,
+	setAttributes,
+	setAudition,
+} ) => {
+	const {
+		emailPlaceholder = DEFAULT_EMAIL_PLACEHOLDER,
+		processingLabel = DEFAULT_PROCESSING_LABEL,
+		successLabel = DEFAULT_SUCCESS_LABEL,
+		errorLabel = DEFAULT_ERROR_LABEL,
+		interests,
+		signupFieldTag,
+		signupFieldValue,
+	} = attributes;
+
+	const timeout = useRef( null );
+
+	const clearAudition = () => setAudition( null );
+	const auditionNotification = notification => {
+		setAudition( notification );
+
+		if ( timeout.current ) {
+			clearTimeout( timeout.current );
+		}
+		timeout.current = setTimeout( clearAudition, 3000 );
+	};
+
+	return (
+		<InspectorControls>
+			<MailChimpBlockControls
+				auditionNotification={ auditionNotification }
+				clearAudition={ clearAudition }
+				emailPlaceholder={ emailPlaceholder }
+				processingLabel={ processingLabel }
+				successLabel={ successLabel }
+				errorLabel={ errorLabel }
+				interests={ interests }
+				setAttributes={ setAttributes }
+				signupFieldTag={ signupFieldTag }
+				signupFieldValue={ signupFieldValue }
+				connectURL={ connectURL }
+			/>
+		</InspectorControls>
+	);
+};

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
@@ -3,79 +3,48 @@ import {
 	getBlockIconComponent,
 } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
-import { InnerBlocks, InspectorControls, RichText } from '@wordpress/block-editor';
-import { Button, Placeholder, Spinner, TextControl, withNotices } from '@wordpress/components';
-import { Fragment, Component } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { withNotices } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
-import classnames from 'classnames';
+import { useCallback, useEffect, useState } from 'react';
 import metadata from './block.json';
-import {
-	NOTIFICATION_PROCESSING,
-	NOTIFICATION_SUCCESS,
-	NOTIFICATION_ERROR,
-	DEFAULT_EMAIL_PLACEHOLDER,
-	DEFAULT_CONSENT_TEXT,
-	DEFAULT_PROCESSING_LABEL,
-	DEFAULT_SUCCESS_LABEL,
-	DEFAULT_ERROR_LABEL,
-} from './constants';
-import { MailChimpBlockControls } from './controls';
-
-const API_STATE_LOADING = 0;
-const API_STATE_CONNECTED = 1;
-const API_STATE_NOTCONNECTED = 2;
+import Body from './body';
+import { API_STATE_CONNECTED, API_STATE_NOTCONNECTED, API_STATE_LOADING } from './constants';
+import { MailChimpInspectorControls } from './controls';
+import Loader from './loader';
+import { UserConnectedPlaceholder, UserNotConnectedPlaceholder } from './placeholders';
 
 const icon = getBlockIconComponent( metadata );
-const innerButtonBlock = {
-	name: 'jetpack/button',
-	attributes: {
-		element: 'button',
-		text: __( 'Join my Mailchimp audience', 'jetpack' ),
-		uniqueId: 'mailchimp-widget-id',
-	},
-};
 
-class MailchimpSubscribeEdit extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			audition: null,
-			connected: API_STATE_LOADING,
-			connectURL: null,
-			currentUserConnected: null,
-		};
-		this.timeout = null;
-	}
+export const MailchimpSubscribeEdit = ( {
+	className,
+	attributes,
+	setAttributes,
+	notices,
+	noticeUI,
+	noticeOperations,
+} ) => {
+	const [ audition, setAudition ] = useState( null );
+	const [ connected, setConnected ] = useState( API_STATE_LOADING );
+	const [ connectURL, setConnectURL ] = useState( null );
+	const [ currentUserConnected, setCurrentUserconnected ] = useState( null );
 
-	componentDidMount = () => {
-		this.apiCall();
-	};
+	const apiCall = useCallback( () => {
+		const isUserConnected = isCurrentUserConnected();
 
-	onError = message => {
-		const { noticeOperations } = this.props;
-		noticeOperations.removeAllNotices();
-		noticeOperations.createErrorNotice( message );
-	};
-
-	apiCall = () => {
-		const currentUserConnected = isCurrentUserConnected();
-		if ( currentUserConnected ) {
-			const path = '/wpcom/v2/mailchimp';
-			const method = 'GET';
-			const fetch = { path, method };
-			apiFetch( fetch ).then(
-				result => {
-					const connectURL = result.connect_url;
-					const connected =
-						result.code === 'connected' ? API_STATE_CONNECTED : API_STATE_NOTCONNECTED;
-					this.setState( { currentUserConnected, connected, connectURL } );
+		if ( isUserConnected ) {
+			apiFetch( { path: '/wpcom/v2/mailchimp', method: 'GET' } ).then(
+				( { connect_url: url, code } ) => {
+					setConnectURL( url );
+					setConnected( code === 'connected' ? API_STATE_CONNECTED : API_STATE_NOTCONNECTED );
+					setCurrentUserconnected( isUserConnected );
 				},
-				result => {
-					const connectURL = null;
-					const connected = API_STATE_NOTCONNECTED;
-					this.setState( { currentUserConnected, connected, connectURL } );
-					this.onError( result.message );
+				( { message } ) => {
+					setConnectURL( null );
+					setConnected( API_STATE_NOTCONNECTED );
+					setCurrentUserconnected( isUserConnected );
+
+					noticeOperations.removeAllNotices();
+					noticeOperations.createErrorNotice( message );
 				}
 			);
 		} else {
@@ -84,183 +53,71 @@ class MailchimpSubscribeEdit extends Component {
 					from: 'jetpack-block-editor',
 					redirect: window.location.href,
 				} ),
-			} ).then( connectUrl => {
-				const connectURL = connectUrl;
-				const connected = API_STATE_NOTCONNECTED;
-				this.setState( { currentUserConnected, connected, connectURL } );
+			} ).then( url => {
+				setConnectURL( url );
+				setConnected( API_STATE_NOTCONNECTED );
+				setCurrentUserconnected( isUserConnected );
 			} );
 		}
-	};
+	}, [ setConnectURL, setConnected, setCurrentUserconnected, noticeOperations ] );
 
-	auditionNotification = notification => {
-		this.setState( { audition: notification } );
-		if ( this.timeout ) {
-			clearTimeout( this.timeout );
-		}
-		this.timeout = setTimeout( this.clearAudition, 3000 );
-	};
+	useEffect( () => {
+		apiCall();
+	}, [ apiCall ] );
 
-	clearAudition = () => {
-		this.setState( { audition: null } );
-	};
+	let content;
 
-	labelForAuditionType = audition => {
-		const { attributes } = this.props;
-		const {
-			processingLabel = DEFAULT_PROCESSING_LABEL,
-			successLabel = DEFAULT_SUCCESS_LABEL,
-			errorLabel = DEFAULT_ERROR_LABEL,
-		} = attributes;
-		if ( audition === NOTIFICATION_PROCESSING ) {
-			return processingLabel;
-		} else if ( audition === NOTIFICATION_SUCCESS ) {
-			return successLabel;
-		} else if ( audition === NOTIFICATION_ERROR ) {
-			return errorLabel;
-		}
-		return null;
-	};
-
-	roleForAuditionType = audition => {
-		if ( audition === NOTIFICATION_ERROR ) {
-			return 'alert';
-		}
-		return 'status';
-	};
-
-	render = () => {
-		const { attributes, className, notices, noticeUI, setAttributes } = this.props;
-		const { audition, connected, connectURL, currentUserConnected } = this.state;
-		const {
-			emailPlaceholder = DEFAULT_EMAIL_PLACEHOLDER,
-			consentText = DEFAULT_CONSENT_TEXT,
-			interests,
-			processingLabel = DEFAULT_PROCESSING_LABEL,
-			successLabel = DEFAULT_SUCCESS_LABEL,
-			errorLabel = DEFAULT_ERROR_LABEL,
-			preview,
-			signupFieldTag,
-			signupFieldValue,
-		} = attributes;
-		const classPrefix = 'wp-block-jetpack-mailchimp';
-		const waiting = (
-			<Placeholder
-				icon={ icon }
-				notices={ notices }
-				className="wp-block-jetpack-mailchimp"
-				label={ __( 'Mailchimp', 'jetpack' ) }
-			>
-				<div className="align-center">
-					<Spinner />
-				</div>
-			</Placeholder>
+	if ( attributes.preview ) {
+		content = (
+			<Body
+				className={ className }
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				audition={ audition }
+			/>
 		);
-		const placeholder = (
-			<Placeholder
-				className="wp-block-jetpack-mailchimp"
-				icon={ icon }
-				label={ __( 'Mailchimp', 'jetpack' ) }
-				notices={ notices }
-				instructions={ __(
-					'You need to connect your Mailchimp account and choose an audience in order to start collecting Email subscribers.',
-					'jetpack'
-				) }
-			>
-				<Button variant="secondary" href={ connectURL } target="_blank">
-					{ __( 'Set up Mailchimp form', 'jetpack' ) }
-				</Button>
-				<div className={ `${ classPrefix }-recheck` }>
-					<Button variant="link" onClick={ this.apiCall }>
-						{ __( 'Re-check Connection', 'jetpack' ) }
-					</Button>
-				</div>
-			</Placeholder>
-		);
-		const placeholderNotUserConnected = (
-			<Placeholder
-				className="wp-block-jetpack-mailchimp"
-				icon={ icon }
-				label={ __( 'Mailchimp', 'jetpack' ) }
-				notices={ notices }
-				instructions={ __(
-					"First, you'll need to connect your WordPress.com account.",
-					'jetpack'
-				) }
-			>
-				<Button variant="secondary" href={ connectURL }>
-					{ __( 'Connect to WordPress.com', 'jetpack' ) }
-				</Button>
-			</Placeholder>
-		);
-		const inspectorControls = (
-			<InspectorControls>
-				<MailChimpBlockControls
-					auditionNotification={ this.auditionNotification }
-					clearAudition={ this.clearAudition }
-					emailPlaceholder={ emailPlaceholder }
-					processingLabel={ processingLabel }
-					successLabel={ successLabel }
-					errorLabel={ errorLabel }
-					interests={ interests }
-					setAttributes={ this.props.setAttributes }
-					signupFieldTag={ signupFieldTag }
-					signupFieldValue={ signupFieldValue }
+	} else if ( connected === API_STATE_LOADING ) {
+		content = <Loader icon={ icon } notices={ notices } />;
+	} else if ( connected === API_STATE_NOTCONNECTED ) {
+		if ( currentUserConnected ) {
+			content = (
+				<UserConnectedPlaceholder
+					icon={ icon }
+					notices={ notices }
 					connectURL={ connectURL }
+					apiCall={ apiCall }
 				/>
-			</InspectorControls>
+			);
+		} else {
+			content = (
+				<UserNotConnectedPlaceholder icon={ icon } notices={ notices } connectURL={ connectURL } />
+			);
+		}
+	} else if ( connected === API_STATE_CONNECTED ) {
+		content = (
+			<>
+				<MailChimpInspectorControls
+					connectURL={ connectURL }
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					setAudition={ setAudition }
+				/>
+				<Body
+					className={ className }
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+					audition={ audition }
+				/>
+			</>
 		);
-		const blockClasses = classnames( className, {
-			[ `${ classPrefix }_notication-audition` ]: audition,
-		} );
-		const blockContent = (
-			<div className={ blockClasses }>
-				<TextControl
-					aria-label={ emailPlaceholder }
-					className="wp-block-jetpack-mailchimp_text-input"
-					disabled
-					onChange={ () => false }
-					placeholder={ emailPlaceholder }
-					title={ __( 'You can edit the email placeholder in the sidebar.', 'jetpack' ) }
-					type="email"
-				/>
-				<InnerBlocks
-					template={ [ [ innerButtonBlock.name, innerButtonBlock.attributes ] ] }
-					templateLock="all"
-				/>
-				<RichText
-					tagName="p"
-					placeholder={ __( 'Write consent text', 'jetpack' ) }
-					value={ consentText }
-					onChange={ value => setAttributes( { consentText: value } ) }
-					inlineToolbar
-				/>
-				{ audition && (
-					<div
-						className={ `${ classPrefix }_notification ${ classPrefix }_${ audition }` }
-						role={ this.roleForAuditionType( audition ) }
-					>
-						{ this.labelForAuditionType( audition ) }
-					</div>
-				) }
-			</div>
-		);
-		const previewUI = blockContent;
+	}
 
-		return (
-			<Fragment>
-				{ noticeUI }
-				{ preview && previewUI }
-				{ ! preview && connected === API_STATE_LOADING && waiting }
-				{ ! preview && connected === API_STATE_NOTCONNECTED && currentUserConnected && placeholder }
-				{ ! preview &&
-					connected === API_STATE_NOTCONNECTED &&
-					! currentUserConnected &&
-					placeholderNotUserConnected }
-				{ ! preview && connected === API_STATE_CONNECTED && inspectorControls }
-				{ ! preview && connected === API_STATE_CONNECTED && blockContent }
-			</Fragment>
-		);
-	};
-}
+	return (
+		<>
+			{ noticeUI }
+			{ content }
+		</>
+	);
+};
 
 export default withNotices( MailchimpSubscribeEdit );

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/loader.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/loader.js
@@ -1,0 +1,18 @@
+import { Placeholder, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { BLOCK_CLASS } from './constants';
+
+const Loader = ( { icon, notices } ) => (
+	<Placeholder
+		icon={ icon }
+		notices={ notices }
+		className={ BLOCK_CLASS }
+		label={ __( 'Mailchimp', 'jetpack' ) }
+	>
+		<div className="align-center">
+			<Spinner />
+		</div>
+	</Placeholder>
+);
+
+export default Loader;

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/placeholders.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/placeholders.js
@@ -1,0 +1,39 @@
+import { Button, Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { BLOCK_CLASS } from './constants';
+
+export const UserConnectedPlaceholder = ( { icon, notices, connectURL, apiCall } ) => (
+	<Placeholder
+		className={ BLOCK_CLASS }
+		icon={ icon }
+		label={ __( 'Mailchimp', 'jetpack' ) }
+		notices={ notices }
+		instructions={ __(
+			'You need to connect your Mailchimp account and choose an audience in order to start collecting Email subscribers.',
+			'jetpack'
+		) }
+	>
+		<Button variant="secondary" href={ connectURL } target="_blank">
+			{ __( 'Set up Mailchimp form', 'jetpack' ) }
+		</Button>
+		<div className={ `${ BLOCK_CLASS }-recheck` }>
+			<Button variant="link" onClick={ apiCall }>
+				{ __( 'Re-check Connection', 'jetpack' ) }
+			</Button>
+		</div>
+	</Placeholder>
+);
+
+export const UserNotConnectedPlaceholder = ( { icon, notices, connectURL } ) => (
+	<Placeholder
+		className={ BLOCK_CLASS }
+		icon={ icon }
+		label={ __( 'Mailchimp', 'jetpack' ) }
+		notices={ notices }
+		instructions={ __( "First, you'll need to connect your WordPress.com account.", 'jetpack' ) }
+	>
+		<Button variant="secondary" href={ connectURL }>
+			{ __( 'Connect to WordPress.com', 'jetpack' ) }
+		</Button>
+	</Placeholder>
+);

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/view.js
@@ -4,10 +4,9 @@ import emailValidator from 'email-validator';
 //       Do not import the entire lodash library!
 // eslint-disable-next-line lodash/import-scope
 import debounce from 'lodash/debounce';
+import { BLOCK_CLASS } from './constants';
 
 import './view.scss';
-
-const blockClassName = 'wp-block-jetpack-mailchimp';
 
 function fetchSubscription( blogId, email, params ) {
 	let url =
@@ -60,9 +59,9 @@ const handleEmailValidation = ( form, emailField ) => {
 function activateSubscription( block, blogId ) {
 	const form = block.querySelector( 'form' );
 	const emailField = block.querySelector( 'input[name=email]' );
-	const processingEl = block.querySelector( '.' + blockClassName + '_processing' );
-	const errorEl = block.querySelector( '.' + blockClassName + '_error' );
-	const successEl = block.querySelector( '.' + blockClassName + '_success' );
+	const processingEl = block.querySelector( '.' + BLOCK_CLASS + '_processing' );
+	const errorEl = block.querySelector( '.' + BLOCK_CLASS + '_error' );
+	const successEl = block.querySelector( '.' + BLOCK_CLASS + '_success' );
 	emailField.addEventListener( 'input', handleEmailValidation( form, emailField ) );
 	form.addEventListener( 'submit', e => {
 		e.preventDefault();
@@ -94,7 +93,7 @@ function activateSubscription( block, blogId ) {
 }
 
 const initializeMailchimpBlocks = () => {
-	const mailchimpBlocks = Array.from( document.querySelectorAll( '.' + blockClassName ) );
+	const mailchimpBlocks = Array.from( document.querySelectorAll( '.' + BLOCK_CLASS ) );
 	mailchimpBlocks.forEach( block => {
 		if ( block.getAttribute( 'data-jetpack-block-initialized' ) === 'true' ) {
 			return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR refactors the MailChimp block's Edit component to be a functional component. It's preparatory work for upgrading to block API to version 3. In detail, this PR:

- Transforms `MailchimpSubscribeEdit` to a functional component
- Create sub-components out of its render functions
- Move these sub-components to their own file for readability

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- If you run it locally, make sure to run `cd projects/plugins/jetpack && pnpm run build-extensions`
- Create a post
- Add the _MailChimp_ block
- Make sure it behaves as it does in production