### PR TITLE
Untangling: Create /wpcom/v2/admin-color endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-color.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-color.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * REST API endpoint for admin color.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Admin_Color
+ */
+class WPCOM_REST_API_V2_Endpoint_Admin_Color extends WP_REST_Controller {
+
+	/**
+	 * Namespace prefix.
+	 *
+	 * @var string
+	 */
+	public $namespace = 'wpcom/v2';
+
+	/**
+	 * Endpoint base route.
+	 *
+	 * @var string
+	 */
+	public $rest_base = 'admin-color';
+
+	/**
+	 * WPCOM_REST_API_V2_Endpoint_Admin_Color constructor.
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to admin color.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! current_user_can( 'read' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to view admin color on this site.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves the admin color.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$admin_color = get_user_option( 'admin_color' );
+		return rest_ensure_response( array( 'admin_color' => $admin_color ) );
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Admin_Color' );

--- a/projects/plugins/jetpack/changelog/untangling-nav-reunification-color
+++ b/projects/plugins/jetpack/changelog/untangling-nav-reunification-color
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Create endpoint /wpcom/v2/admin-color that returns admin color scheme


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/6354

## Proposed changes:

This PR creates a new `/wpcom/v2/admin-color` endpoint that simply returns the current user's admin color scheme.

### Other approaches considered

This is the only way I can make this work. Other approaches that I considered:

1. Adding `admin_color` to the response of `/sites/:siteId` endpoint, so that it lives in Calypso's sites redux store. This didn't work because there is another  endpoint public-api `/me/sites` (get all sites) that  also updates the redux store. However, this endpoint is only called in wpcom. It can't get the correct `admin_color` from the Jetpack site, so it will always store the wrong value in the redux store. We didn't sync the user option `admin_color` to wpcom. (Not sure how to sync an user option)
2. Adding `admin_color` the the existing `/wpcom/v2/admin-menu` endpoint. However, this endpoint already returns an array as JSON body. It is impossible to add a new field.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

See:

- https://github.com/Automattic/wp-calypso/pull/89261

