### PR TITLE
Boost: Add tribe event tickets compatibility

### DIFF
--- a/projects/plugins/boost/changelog/add-tribe-event-tickets-compatibility
+++ b/projects/plugins/boost/changelog/add-tribe-event-tickets-compatibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+JS Concatenation: Added compatibility with event-tickets by The Events Calendar.

--- a/projects/plugins/boost/compatibility/js-concatenate.php
+++ b/projects/plugins/boost/compatibility/js-concatenate.php
@@ -6,7 +6,9 @@ namespace Automattic\Jetpack_Boost\Compatibility\JS_Concatenate;
 
 function maybe_do_not_concat( $do_concat, $handle ) {
 	$excluded_handles = array(
-		'tribe-tickets-block', // Plugin: `event-tickets`
+		// Plugin: `event-tickets`
+		'tribe-tickets-block',
+		'tribe-tickets-provider',
 	);
 
 	if ( in_array( $handle, $excluded_handles, true ) ) {

--- a/projects/plugins/boost/compatibility/js-concatenate.php
+++ b/projects/plugins/boost/compatibility/js-concatenate.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Exclude known scripts that causes problem when concatenated.
+ */
+namespace Automattic\Jetpack_Boost\Compatibility\JS_Concatenate;
+
+function maybe_do_not_concat( $do_concat, $handle ) {
+	$excluded_handles = array(
+		'tribe-tickets-block', // Plugin: `event-tickets`
+	);
+
+	if ( in_array( $handle, $excluded_handles, true ) ) {
+		return false;
+	}
+
+	return $do_concat;
+}
+
+add_filter( 'js_do_concat', __NAMESPACE__ . '\maybe_do_not_concat', 10, 2 );

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -239,6 +239,9 @@ function include_compatibility_files() {
 	if ( function_exists( 'aioseo' ) ) {
 		require_once __DIR__ . '/compatibility/aioseo.php';
 	}
+
+	// Exclude known scripts that causes problem when concatenated.
+	require_once __DIR__ . '/compatibility/js-concatenate.php';
 }
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\include_compatibility_files' );


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Exclude `tribe-tickets-block` script from concatenation.

It seems like many users are using both Boost and the Event Tickets plugin. Because the script is enqueued in a non-standard way in `event-tickets` it breaks during concatenation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1712278572851129-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Install both [`the-events-calendar`](https://wordpress.org/plugins/the-events-calendar) and [`event-tickets`](https://wordpress.org/plugins/event-tickets/)
* Enable payments on `event-tickets` settings, no need to connect to paypal or stripe.
* Create a ticket for testing on any page or event.
* See the page and make sure you can interact with the ticket block.
![image](https://github.com/Automattic/jetpack/assets/3737780/d2ac7301-8113-475d-bb87-dbafce26fab1)
