### PR TITLE
Janitorial: update to the most recent version of Color Studio

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,8 +929,8 @@ importers:
         version: 4.0.1
     devDependencies:
       '@automattic/color-studio':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.6.0
+        version: 2.6.0
       '@automattic/jetpack-base-styles':
         specifier: workspace:*
         version: link:../base-styles
@@ -1817,8 +1817,8 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@automattic/color-studio':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.6.0
+        version: 2.6.0
       '@automattic/jetpack-base-styles':
         specifier: workspace:*
         version: link:../../js-packages/base-styles
@@ -2266,8 +2266,8 @@ importers:
         specifier: 3.1.3
         version: 3.1.3
       '@automattic/color-studio':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.6.0
+        version: 2.6.0
       '@automattic/format-currency':
         specifier: 1.0.1
         version: 1.0.1
@@ -2635,8 +2635,8 @@ importers:
         specifier: 3.1.3
         version: 3.1.3
       '@automattic/color-studio':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.6.0
+        version: 2.6.0
       '@automattic/jetpack-analytics':
         specifier: workspace:*
         version: link:../../js-packages/analytics
@@ -3473,8 +3473,8 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@automattic/color-studio':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.6.0
+        version: 2.6.0
       '@automattic/jetpack-base-styles':
         specifier: workspace:*
         version: link:../../js-packages/base-styles
@@ -3882,8 +3882,8 @@ importers:
         specifier: 3.1.3
         version: 3.1.3
       '@automattic/color-studio':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.6.0
+        version: 2.6.0
       '@automattic/jetpack-webpack-config':
         specifier: workspace:*
         version: link:../../js-packages/webpack-config
@@ -4508,8 +4508,8 @@ packages:
   /@automattic/calypso-color-schemes@3.1.3:
     resolution: {integrity: sha512-nzs36yfxUOcsD3HvB72IHgdUfIzTRnT7QmF78CBXEREawTEs0uDyELdx/rAOtW/PauxRYRGQ4zeK5c67FWqLxw==}
 
-  /@automattic/color-studio@2.5.0:
-    resolution: {integrity: sha512-gZWaJbx3p1oennAIoJtMGluTmoM95Efk4rc44TSBxWSZZ8gH3Am2eh1o3i1NhrZmg2Zt3AiVFeZZ4AJccIpBKQ==}
+  /@automattic/color-studio@2.6.0:
+    resolution: {integrity: sha512-2LzB6bbQw1vayZxZy5Y+DnCYU7x8tPu+rZhNkWD7V8QZTSJMJO65XKZhYaCByC+C5OegXyGyZzcqEOHHdj5iiQ==}
 
   /@automattic/format-currency@1.0.1:
     resolution: {integrity: sha512-RY2eiUlDiqNSHiJzz2YmH/mw4IjAUO5hkxbwcVGHJkBZowdq/WcSG2yhXc8N9cV9N1fTO/ryCuJvGnpHUe+mAg==}

--- a/projects/js-packages/publicize-components/changelog/update-color-studio-260
+++ b/projects/js-packages/publicize-components/changelog/update-color-studio-260
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update to the most recent version of Color Studio, 2.6.0.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -44,7 +44,7 @@
 		"rememo": "4.0.1"
 	},
 	"devDependencies": {
-		"@automattic/color-studio": "2.5.0",
+		"@automattic/color-studio": "2.6.0",
 		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@babel/core": "7.24.0",

--- a/projects/packages/forms/changelog/update-color-studio-260
+++ b/projects/packages/forms/changelog/update-color-studio-260
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update to the most recent version of Color Studio, 2.6.0.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.13",
+	"version": "0.30.14-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {
@@ -58,7 +58,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"devDependencies": {
-		"@automattic/color-studio": "2.5.0",
+		"@automattic/color-studio": "2.6.0",
 		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@automattic/remove-asset-webpack-plugin": "workspace:*",

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.13';
+	const PACKAGE_VERSION = '0.30.14-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/search/changelog/update-color-studio-260
+++ b/projects/packages/search/changelog/update-color-studio-260
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update to the most recent version of Color Studio, 2.6.0.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -33,7 +33,7 @@
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/search/#readme",
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "3.1.3",
-		"@automattic/color-studio": "2.5.0",
+		"@automattic/color-studio": "2.6.0",
 		"@automattic/format-currency": "1.0.1",
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-api": "workspace:*",

--- a/projects/packages/wordads/changelog/update-color-studio-260
+++ b/projects/packages/wordads/changelog/update-color-studio-260
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update to the most recent version of Color Studio, 2.6.0.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.13",
+	"version": "0.3.14-alpha",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",
@@ -31,7 +31,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "3.1.3",
-		"@automattic/color-studio": "2.5.0",
+		"@automattic/color-studio": "2.6.0",
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-api": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.13';
+	const VERSION = '0.3.14-alpha';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-color-studio-260
+++ b/projects/plugins/jetpack/changelog/update-color-studio-260
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Janitorial: update to the most recent version of Color Studio, 2.6.0.
+
+

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -115,7 +115,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"devDependencies": {
-		"@automattic/color-studio": "2.5.0",
+		"@automattic/color-studio": "2.6.0",
 		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@automattic/remove-asset-webpack-plugin": "workspace:*",

--- a/projects/plugins/social/changelog/update-color-studio-260
+++ b/projects/plugins/social/changelog/update-color-studio-260
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update to the most recent version of Color Studio, 2.6.0.

--- a/projects/plugins/social/package.json
+++ b/projects/plugins/social/package.json
@@ -44,7 +44,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-color-schemes": "3.1.3",
-		"@automattic/color-studio": "2.5.0",
+		"@automattic/color-studio": "2.6.0",
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@babel/core": "7.24.0",
 		"@babel/preset-env": "7.24.0",


### PR DESCRIPTION
## Proposed changes:

See:

- https://github.com/Automattic/color-studio/pull/633
- https://github.com/Automattic/color-studio/commit/6d4c32071f0c7b4205c884a4cc278428ab02384d

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Check some of the places where the Studio color are used, e.g. in the post editor, when looking for a Jetpack block in the block inserter -> the Jetpack blocks' icons should be green.
