### PR TITLE
Scheduled updates: Infer status from logs

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-update-manager-infer-status-from-logs
+++ b/projects/packages/scheduled-updates/changelog/add-update-manager-infer-status-from-logs
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Infer scheduled update status from logs

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -49,7 +49,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.6.x-dev"
+			"dev-trunk": "0.7.x-dev"
 		},
 		"textdomain": "jetpack-scheduled-updates",
 		"version-constants": {

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
@@ -155,6 +155,59 @@ class Scheduled_Updates_Logs {
 	}
 
 	/**
+	 * Infers the status of a plugin update schedule from its logs.
+	 *
+	 * @param int $schedule_id The ID of the plugin update schedule.
+	 *
+	 * @return array|false An array containing the last run timestamp and status, or false if no logs are found.
+	 *                     The array has the following keys:
+	 *                     - 'last_run_timestamp': The timestamp of the last run, or null if the status is 'in-progress'.
+	 *                     - 'last_run_status': The status of the last run, which can be one of the following:
+	 *                       - 'in-progress': The update is currently in progress.
+	 *                       - 'success': The update was successful.
+	 *                       - 'failure': The update failed.
+	 *                       - 'failure-and-rollback': The update failed and a rollback was performed.
+	 *                       - 'failure-and-rollback-fail': The update failed and the rollback also failed.
+	 */
+	public static function infer_status_from_logs( $schedule_id ) {
+		$logs = self::get( $schedule_id );
+		if ( is_wp_error( $logs ) || empty( $logs ) ) {
+			return false;
+		}
+
+		$last_run = end( $logs );
+
+		$status    = 'in-progress';
+		$timestamp = time();
+
+		foreach ( $last_run as $log_entry ) {
+			$timestamp = $log_entry['timestamp'];
+
+			if ( self::PLUGIN_UPDATES_SUCCESS === $log_entry['action'] ) {
+				$status = 'success';
+				break;
+			}
+			if ( self::PLUGIN_UPDATES_FAILURE === $log_entry['action'] ) {
+				$status = 'failure';
+				break;
+			}
+			if ( self::PLUGIN_UPDATE_FAILURE_AND_ROLLBACK === $log_entry['action'] ) {
+				$status = 'failure-and-rollback';
+				break;
+			}
+			if ( self::PLUGIN_UPDATE_FAILURE_AND_ROLLBACK_FAIL === $log_entry['action'] ) {
+				$status = 'failure-and-rollback-fail';
+				break;
+			}
+		}
+
+		return array(
+			'last_run_timestamp' => 'in-progress' === $status ? null : $timestamp,
+			'last_run_status'    => $status,
+		);
+	}
+
+	/**
 	 * Splits the logs into runs based on the PLUGIN_UPDATES_START action.
 	 *
 	 * @param array $logs The logs to split into runs.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
@@ -157,7 +157,7 @@ class Scheduled_Updates_Logs {
 	/**
 	 * Infers the status of a plugin update schedule from its logs.
 	 *
-	 * @param int $schedule_id The ID of the plugin update schedule.
+	 * @param string $schedule_id The ID of the plugin update schedule.
 	 *
 	 * @return array|false An array containing the last run timestamp and status, or false if no logs are found.
 	 *                     The array has the following keys:

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -175,8 +175,12 @@ class Scheduled_Updates {
 	 * @return array|null Last status of the scheduled update or null if not found.
 	 */
 	public static function get_scheduled_update_status( $schedule_id ) {
-		$statuses = get_option( 'jetpack_scheduled_update_statuses', array() );
+		$status = Scheduled_Updates_Logs::infer_status_from_logs( $schedule_id );
+		if ( false !== $status ) {
+			return $status;
+		}
 
+		$statuses = get_option( 'jetpack_scheduled_update_statuses', array() );
 		return $statuses[ $schedule_id ] ?? null;
 	}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.6.0';
+	const PACKAGE_VERSION = '0.7.0-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-update-manager-infer-status-from-logs
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-update-manager-infer-status-from-logs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_12"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_13_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -198,7 +198,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "2a989d1848db4a9ad658ecb04e93a7278a905b23"
+                "reference": "4dbf0c9b0bf8384ef49f5cbd8ab76713a2f41222"
             },
             "require": {
                 "php": ">=7.0"
@@ -221,7 +221,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.6.x-dev"
+                    "dev-trunk": "0.7.x-dev"
                 },
                 "textdomain": "jetpack-scheduled-updates",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.12
+ * Version: 2.1.13-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.12",
+	"version": "2.1.13-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
## Proposed changes:
- Reads the logs to infer the status of scheduled updates, this allows us to provide an additional "in-progress" status

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Checkout this PR on your WoA site using the Jetpack Beta plugin
2. Make sure statuses still return as they used to. 
3. Optional: test with this Calypso PR: https://github.com/Automattic/wp-calypso/pull/89253 

