### PR TITLE
Markdown Block: refactor Edit component to function

### DIFF
--- a/projects/plugins/jetpack/changelog/update-refactor-markdown-block
+++ b/projects/plugins/jetpack/changelog/update-refactor-markdown-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Markdown block: refactor Edit component to function

--- a/projects/plugins/jetpack/extensions/blocks/markdown/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/controls.js
@@ -1,0 +1,15 @@
+import classnames from 'classnames';
+
+const ToolbarButton = ( { className, label, isPressed, onClick } ) => {
+	const buttonClassnames = classnames( className, 'components-button components-tab-button', {
+		'is-pressed': isPressed,
+	} );
+
+	return (
+		<button className={ buttonClassnames } onClick={ onClick }>
+			<span>{ label }</span>
+		</button>
+	);
+};
+
+export default ToolbarButton;

--- a/projects/plugins/jetpack/extensions/blocks/markdown/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/edit.js
@@ -1,9 +1,9 @@
 import { BlockControls, PlainText } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import classnames from 'classnames';
+import { useEffect, useRef, useState } from 'react';
+import ToolbarButton from './controls';
 import MarkdownRenderer from './renderer';
 
 /**
@@ -12,44 +12,15 @@ import MarkdownRenderer from './renderer';
 const PANEL_EDITOR = 'editor';
 const PANEL_PREVIEW = 'preview';
 
-class MarkdownEdit extends Component {
-	input = null;
+const MarkdownEdit = ( { attributes, setAttributes, className, isSelected, removeBlock } ) => {
+	const { source } = attributes;
+	const isEmpty = ! source || source.trim() === '';
 
-	state = {
-		activePanel: PANEL_EDITOR,
-	};
+	const [ activePanel, setActivePanel ] = useState( PANEL_EDITOR );
+	const input = useRef( null );
 
-	bindInput = ref => void ( this.input = ref );
-
-	componentDidUpdate( prevProps ) {
-		if (
-			prevProps.isSelected &&
-			! this.props.isSelected &&
-			this.state.activePanel === PANEL_PREVIEW
-		) {
-			this.toggleMode( PANEL_EDITOR )();
-		}
-		if (
-			! prevProps.isSelected &&
-			this.props.isSelected &&
-			this.state.activePanel === PANEL_EDITOR &&
-			this.input
-		) {
-			this.input.focus();
-		}
-	}
-
-	isEmpty() {
-		const source = this.props.attributes.source;
-		return ! source || source.trim() === '';
-	}
-
-	updateSource = source => this.props.setAttributes( { source } );
-
-	handleKeyDown = e => {
-		const { attributes, removeBlock } = this.props;
-		const { source } = attributes;
-
+	const onChange = s => setAttributes( { source: s } );
+	const onKeyDown = e => {
 		// Remove the block if source is empty and we're pressing the Backspace key
 		if ( e.keyCode === 8 && source === '' ) {
 			removeBlock();
@@ -57,41 +28,41 @@ class MarkdownEdit extends Component {
 		}
 	};
 
-	toggleMode = mode => () => this.setState( { activePanel: mode } );
-
-	renderToolbarButton( mode, label ) {
-		const { activePanel } = this.state;
-		const { className } = this.props;
-		const buttonClassnames = classnames( className, 'components-button components-tab-button', {
-			'is-pressed': activePanel === mode,
-		} );
-
-		return (
-			<button className={ buttonClassnames } onClick={ this.toggleMode( mode ) }>
-				<span>{ label }</span>
-			</button>
-		);
-	}
-
-	render() {
-		const { attributes, className, isSelected } = this.props;
-		const { source } = attributes;
-		const { activePanel } = this.state;
-
-		if ( ! isSelected && this.isEmpty() ) {
-			return (
-				<p className={ `${ className }__placeholder` }>
-					{ __( 'Write your _Markdown_ **here**…', 'jetpack' ) }
-				</p>
-			);
+	useEffect( () => {
+		if ( isSelected ) {
+			if ( activePanel === PANEL_EDITOR ) {
+				input?.current.focus();
+			}
+		} else if ( activePanel === PANEL_PREVIEW ) {
+			setActivePanel( PANEL_EDITOR );
 		}
+	}, [ isSelected, activePanel, setActivePanel ] );
 
-		return (
+	let content;
+
+	if ( ! isSelected && isEmpty ) {
+		content = (
+			<p className={ `${ className }__placeholder` }>
+				{ __( 'Write your _Markdown_ **here**…', 'jetpack' ) }
+			</p>
+		);
+	} else {
+		content = (
 			<div className={ className }>
 				<BlockControls>
 					<div className="components-toolbar">
-						{ this.renderToolbarButton( PANEL_EDITOR, __( 'Markdown', 'jetpack' ) ) }
-						{ this.renderToolbarButton( PANEL_PREVIEW, __( 'Preview', 'jetpack' ) ) }
+						<ToolbarButton
+							className={ className }
+							label={ __( 'Markdown', 'jetpack' ) }
+							isPressed={ activePanel === PANEL_EDITOR }
+							onClick={ () => setActivePanel( PANEL_EDITOR ) }
+						/>
+						<ToolbarButton
+							className={ className }
+							label={ __( 'Preview', 'jetpack' ) }
+							isPressed={ activePanel === PANEL_PREVIEW }
+							onClick={ () => setActivePanel( PANEL_PREVIEW ) }
+						/>
 					</div>
 				</BlockControls>
 
@@ -100,17 +71,19 @@ class MarkdownEdit extends Component {
 				) : (
 					<PlainText
 						className={ `${ className }__editor` }
-						onChange={ this.updateSource }
-						onKeyDown={ this.handleKeyDown }
+						onChange={ onChange }
+						onKeyDown={ onKeyDown }
 						aria-label={ __( 'Markdown', 'jetpack' ) }
-						innerRef={ this.bindInput }
+						ref={ input }
 						value={ source }
 					/>
 				) }
 			</div>
 		);
 	}
-}
+
+	return content;
+};
 
 export default compose( [
 	withSelect( select => ( {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR refactors the Markdown block's Edit component to be a functional component. It's preparatory work for upgrading to block API to version 3. In detail, this PR:

- Transforms `MarkdownEdit` to a functional component
- Create sub-components out of its render functions
- Move these sub-components to their own file for readability

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- If you run it locally, make sure to run `cd projects/plugins/jetpack && pnpm run build-extensions`
- Create a post
- Add the _Markdown_ block
- Make sure it behaves as it does in production