### PR TITLE
Repeat Visitor Block: refactor Edit component to function

### DIFF
--- a/projects/plugins/jetpack/changelog/update-refactor-repeat-visitor-block
+++ b/projects/plugins/jetpack/changelog/update-refactor-repeat-visitor-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Repeat Visitor Block: refactor Edit component to function 

--- a/projects/plugins/jetpack/extensions/blocks/repeat-visitor/components/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/repeat-visitor/components/edit.js
@@ -2,7 +2,7 @@ import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-util
 import { InnerBlocks } from '@wordpress/block-editor';
 import { Notice, TextControl, RadioControl, Placeholder } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import classNames from 'classnames';
 import metadata from '../block.json';
@@ -20,24 +20,24 @@ const RADIO_OPTIONS = [
 ];
 const icon = getBlockIconComponent( metadata );
 
-export class RepeatVisitorEdit extends Component {
-	state = {
-		isThresholdValid: true,
-	};
+export const RepeatVisitorEdit = ( { className, isSelected, attributes, setAttributes } ) => {
+	const { criteria, threshold } = attributes;
 
-	setCriteria = criteria => this.props.setAttributes( { criteria } );
-	setThreshold = threshold => {
-		if ( /^\d+$/.test( threshold ) && +threshold > 0 ) {
-			this.props.setAttributes( { threshold: +threshold } );
-			this.setState( { isThresholdValid: true } );
-			return;
+	const [ isThresholdValid, setIsThresholdValid ] = useState( true );
+
+	const onVisibilityChange = val => setAttributes( { criteria: val } );
+	const onThresholdChange = val => {
+		if ( /^\d+$/.test( val ) && +val > 0 ) {
+			setAttributes( { threshold: +val } );
+			setIsThresholdValid( true );
+		} else {
+			setIsThresholdValid( false );
 		}
-		this.setState( { isThresholdValid: false } );
 	};
 
-	getNoticeLabel() {
-		if ( this.props.attributes.criteria === CRITERIA_AFTER ) {
-			if ( 1 === this.props.attributes.threshold ) {
+	const getNoticeLabel = () => {
+		if ( criteria === CRITERIA_AFTER ) {
+			if ( 1 === threshold ) {
 				return __(
 					'This block will only appear to people who have visited this page more than once.',
 					'jetpack'
@@ -49,14 +49,14 @@ export class RepeatVisitorEdit extends Component {
 				_n(
 					'This block will only appear to people who have visited this page more than %d time.',
 					'This block will only appear to people who have visited this page more than %d times.',
-					+this.props.attributes.threshold,
+					+threshold,
 					'jetpack'
 				),
-				this.props.attributes.threshold
+				threshold
 			);
 		}
 
-		if ( 1 === this.props.attributes.threshold ) {
+		if ( 1 === threshold ) {
 			return __(
 				'This block will only appear to people who are visiting this page for the first time.',
 				'jetpack'
@@ -68,59 +68,56 @@ export class RepeatVisitorEdit extends Component {
 			_n(
 				'This block will only appear to people who are visiting this page for %d time.',
 				'This block will only appear to people who have visited this page at most %d times.',
-				+this.props.attributes.threshold,
+				+threshold,
 				'jetpack'
 			),
-			this.props.attributes.threshold
+			threshold
 		);
-	}
+	};
 
-	render() {
-		return (
-			<div
-				className={ classNames( this.props.className, {
-					'wp-block-jetpack-repeat-visitor--is-unselected': ! this.props.isSelected,
-				} ) }
+	return (
+		<div
+			className={ classNames( className, {
+				'wp-block-jetpack-repeat-visitor--is-unselected': ! isSelected,
+			} ) }
+		>
+			<Placeholder
+				icon={ icon }
+				label={ __( 'Repeat Visitor', 'jetpack' ) }
+				className="wp-block-jetpack-repeat-visitor-placeholder"
 			>
-				<Placeholder
-					icon={ icon }
-					label={ __( 'Repeat Visitor', 'jetpack' ) }
-					className="wp-block-jetpack-repeat-visitor-placeholder"
-				>
-					<TextControl
-						className="wp-block-jetpack-repeat-visitor-threshold"
-						defaultValue={ this.props.attributes.threshold }
-						help={
-							this.state.isThresholdValid ? '' : __( 'Please enter a valid number.', 'jetpack' )
-						}
-						label={ __( 'Visit count threshold', 'jetpack' ) }
-						min="1"
-						onChange={ this.setThreshold }
-						pattern="[0-9]"
-						type="number"
-					/>
+				<TextControl
+					className="wp-block-jetpack-repeat-visitor-threshold"
+					defaultValue={ threshold }
+					help={ isThresholdValid ? '' : __( 'Please enter a valid number.', 'jetpack' ) }
+					label={ __( 'Visit count threshold', 'jetpack' ) }
+					min="1"
+					onChange={ onThresholdChange }
+					pattern="[0-9]"
+					type="number"
+				/>
 
-					<RadioControl
-						label={ __( 'Visibility', 'jetpack' ) }
-						selected={ this.props.attributes.criteria }
-						options={ RADIO_OPTIONS }
-						onChange={ this.setCriteria }
-					/>
-				</Placeholder>
+				<RadioControl
+					label={ __( 'Visibility', 'jetpack' ) }
+					selected={ criteria }
+					options={ RADIO_OPTIONS }
+					onChange={ onVisibilityChange }
+				/>
+			</Placeholder>
 
-				<Notice status="info" isDismissible={ false }>
-					{ this.getNoticeLabel() }
-				</Notice>
-				<div className="wp-block-jetpack-repeat-visitor__inner-container">
-					<InnerBlocks />
-				</div>
+			<Notice status="info" isDismissible={ false }>
+				{ getNoticeLabel() }
+			</Notice>
+			<div className="wp-block-jetpack-repeat-visitor__inner-container">
+				<InnerBlocks />
 			</div>
-		);
-	}
-}
+		</div>
+	);
+};
 
 export default withSelect( ( select, ownProps ) => {
 	const { isBlockSelected, hasSelectedInnerBlock } = select( 'core/block-editor' );
+
 	return {
 		isSelected: isBlockSelected( ownProps.clientId ) || hasSelectedInnerBlock( ownProps.clientId ),
 	};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR refactors the Reapt Visitor block's Edit component to be a functional component. It's preparatory work for upgrading to block API to version 3.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- If you run it locally, make sure to run `cd projects/plugins/jetpack && pnpm run build-extensions`
- Create a post
- Add the _Reapt Visitor_ block
- Make sure it behaves as it does in production
