### PR TITLE
Dotcom Patterns: Hide categories that start with an underscore

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-hidden-categories-with-underscore-prefix
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-hidden-categories-with-underscore-prefix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dotcom patterns: Hide Dotcom categories that start with underscore

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-hidden-categories-with-underscore-prefix
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-hidden-categories-with-underscore-prefix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6073

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hide Dotcom categories that start with an underscore (in their slug not their title)
* Clean some used code

>[!Note]
> We are hiding the category, not the patterns in it. 

### Other information:

- [X] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This PR does not introduce any visual changes. We still don't have any hidden categories.
* Go to the editor to verify the categories have not changed in
  * the patterns inserter [+]
  * the patterns page 

<img width="358" alt="Screenshot 2567-04-05 at 20 23 59" src="https://github.com/Automattic/jetpack/assets/1881481/c545e6cd-481c-4370-b8cd-f123cbf4ab94">
<img width="352" alt="Screenshot 2567-04-05 at 20 23 10" src="https://github.com/Automattic/jetpack/assets/1881481/6ba66fd8-9028-4575-bc41-5ca0e7f16185">


