### PR TITLE
Fix: post endpoint return 404 on trash not found

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-post-endpoint-return-404-on-trash-not-found
+++ b/projects/plugins/jetpack/changelog/fix-post-endpoint-return-404-on-trash-not-found
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Post endpoint: return a 404 if a post is being trashed but does not exist

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-1-endpoint.php
@@ -332,6 +332,11 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 				return new WP_Error( 'invalid_input', 'Invalid request input', 400 );
 			}
 
+			$post = get_post( $post_id );
+			if ( ! $post || is_wp_error( $post ) ) {
+				return new WP_Error( 'unknown_post', 'Unknown post', 404 );
+			}
+
 			if ( isset( $input['status'] ) && 'trash' === $input['status'] && ! current_user_can( 'delete_post', $post_id ) ) {
 				return new WP_Error( 'unauthorized', 'User cannot delete post', 403 );
 			}
@@ -341,12 +346,8 @@ class WPCOM_JSON_API_Update_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_
 				$input['status'] = 'publish';
 			}
 
-			$post       = get_post( $post_id );
 			$_post_type = ( ! empty( $input['type'] ) ) ? $input['type'] : $post->post_type;
 			$post_type  = get_post_type_object( $_post_type );
-			if ( ! $post || is_wp_error( $post ) ) {
-				return new WP_Error( 'unknown_post', 'Unknown post', 404 );
-			}
 
 			if ( ! current_user_can( 'edit_post', $post->ID ) ) {
 				return new WP_Error( 'unauthorized', 'User cannot edit post', 403 );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -258,6 +258,11 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 				return new WP_Error( 'invalid_input', 'Invalid request input', 400 );
 			}
 
+			$post = get_post( $post_id );
+			if ( ! $post || is_wp_error( $post ) ) {
+				return new WP_Error( 'unknown_post', 'Unknown post', 404 );
+			}
+
 			if ( isset( $input['status'] ) && 'trash' === $input['status'] && ! current_user_can( 'delete_post', $post_id ) ) {
 				return new WP_Error( 'unauthorized', 'User cannot delete post', 403 );
 			}
@@ -265,11 +270,6 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 			// 'future' is an alias for 'publish' for now
 			if ( isset( $input['status'] ) && 'future' === $input['status'] ) {
 				$input['status'] = 'publish';
-			}
-
-			$post = get_post( $post_id );
-			if ( ! $post || is_wp_error( $post ) ) {
-				return new WP_Error( 'unknown_post', 'Unknown post', 404 );
 			}
 
 			$_post_type = ( ! empty( $input['type'] ) ) ? $input['type'] : $post->post_type;


### PR DESCRIPTION
This PR fixes an issue what currently exists in the WPCOM REST endpoint 1.1 and 1.2 where when you are trying to trash a post but the post does not exist (or never existed) instead of return the expected 404 error. Like in any other case we return a 403. Permission error. 

This is being fixed as part of the Mobile apps effort to deal with cached data that exist in the app in a more predictable way. 
Currently if we return a 404 when we try to update the post it means that the post has been deleted and the app responds in the correct way when we try to trash it. Currently we get a 403 responds which is unexpected. 


## Proposed changes:
* This PR fixes the issue by first checking for the existence of a post before we return a permission error. 


<img width="1337" alt="Screenshot 2024-04-05 at 2 23 59 PM" src="https://github.com/Automattic/jetpack/assets/115071/b0e10d57-9b97-4e6d-81ab-7f598e3fc1c3">
ibis-of-hermits.jurassic.ninja site has the this PR running while enejtestsite111.wordpress.com is currently running production. 

<img width="1275" alt="Screenshot 2024-04-05 at 2 25 58 PM" src="https://github.com/Automattic/jetpack/assets/115071/7371e007-105e-4469-a4e4-309c7e365330">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p1712344120785279-slack-C06GRKUGDNX discussion.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Load this PR. Connect Jetpack. 
Make the request for a non existent post by trying to trash it. 
Notice that you get back a 404 error instead of a 403.