### PR TITLE
Fix obviously wrong class name references

### DIFF
--- a/projects/packages/abtest/.phan/baseline.php
+++ b/projects/packages/abtest/.phan/baseline.php
@@ -10,13 +10,12 @@
 return [
     // # Issue statistics:
     // PhanUndeclaredProperty : 10+ occurrences
-    // PhanUndeclaredTypeReturnType : 2 occurrences
     // PhanDeprecatedFunction : 1 occurrence
     // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-abtest.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredTypeReturnType'],
+        'src/class-abtest.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/test-abtest.php' => ['PhanDeprecatedFunction', 'PhanUndeclaredProperty'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/abtest/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/abtest/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/abtest/src/class-abtest.php
+++ b/projects/packages/abtest/src/class-abtest.php
@@ -47,7 +47,7 @@ class Abtest {
 	 * @access protected
 	 *
 	 * @param string $test_name Name of the A/B test.
-	 * @return mixed|Automattic\Jetpack\Error A/B test variation, or Automattic\Jetpack\Error on failure.
+	 * @return mixed|\Automattic\Jetpack\Error A/B test variation, or Automattic\Jetpack\Error on failure.
 	 */
 	protected function fetch_variation( $test_name ) {
 		// Make sure test name exists.
@@ -93,7 +93,7 @@ class Abtest {
 	 * @access protected
 	 *
 	 * @param string $test_name Name of the A/B test.
-	 * @return mixed|Automattic\Jetpack\Error A/B test variation, or Automattic\Jetpack\Error on failure.
+	 * @return mixed|\Automattic\Jetpack\Error A/B test variation, or Automattic\Jetpack\Error on failure.
 	 */
 	protected function request_variation( $test_name ) {
 		return Client::wpcom_json_api_request_as_blog( sprintf( '/abtest/%s', $test_name ), '2', array(), null, 'wpcom' );

--- a/projects/packages/analyzer/.phan/baseline.php
+++ b/projects/packages/analyzer/.phan/baseline.php
@@ -11,7 +11,7 @@ return [
     // # Issue statistics:
     // PhanUndeclaredProperty : 30+ occurrences
     // PhanTypeMismatchArgument : 10+ occurrences
-    // PhanUndeclaredClassMethod : 10+ occurrences
+    // PhanUndeclaredClassMethod : 9 occurrences
     // PhanPossiblyUndeclaredVariable : 7 occurrences
     // PhanParamSignatureMismatch : 6 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 6 occurrences
@@ -24,7 +24,6 @@ return [
     // PhanNonClassMethodCall : 2 occurrences
     // PhanPluginDuplicateCatchStatementBody : 2 occurrences
     // PhanTypeMismatchDeclaredParam : 2 occurrences
-    // PhanUndeclaredClassCatch : 2 occurrences
     // PhanUndeclaredClassStaticProperty : 2 occurrences
     // PhanUnextractableAnnotationElementName : 2 occurrences
     // PhanUnextractableAnnotationSuffix : 2 occurrences
@@ -36,8 +35,8 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'data/example-external.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassStaticProperty', 'PhanUndeclaredFunction'],
-        'scripts/core-calls.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchDeclaredParam', 'PhanUndeclaredClassCatch', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
-        'scripts/core-definitions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchDeclaredParam', 'PhanUndeclaredClassCatch', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
+        'scripts/core-calls.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchDeclaredParam', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
+        'scripts/core-definitions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchDeclaredParam', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
         'scripts/example.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'scripts/jetpack-slurper.php' => ['PhanDeprecatedEncapsVar'],
         'scripts/jetpack-svn.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable'],
@@ -55,7 +54,7 @@ return [
         'src/api/class-controller.php' => ['PhanUndeclaredMethod'],
         'src/api/class-model.php' => ['PhanTypeArraySuspiciousNullable'],
         'src/api/class-plugin-downloader.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanUndeclaredProperty'],
-        'src/class-declarations.php' => ['PhanPluginDuplicateCatchStatementBody', 'PhanUndeclaredClassMethod'],
+        'src/class-declarations.php' => ['PhanPluginDuplicateCatchStatementBody'],
         'src/class-differences.php' => ['PhanNonClassMethodCall', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable'],
         'src/class-invocations.php' => ['PhanPluginDuplicateCatchStatementBody'],
         'src/class-utils.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter', 'PhanUnextractableAnnotationElementName', 'PhanUnextractableAnnotationSuffix'],

--- a/projects/packages/analyzer/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/analyzer/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/analyzer/scripts/core-calls.php
+++ b/projects/packages/analyzer/scripts/core-calls.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Analyzer;
 
 use Composer\Script\Event;
+use Exception;
 
 /**
  * This class holds the callback for the WordPress API function analyzer.

--- a/projects/packages/analyzer/scripts/core-definitions.php
+++ b/projects/packages/analyzer/scripts/core-definitions.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Analyzer;
 
 use Composer\Script\Event;
+use Exception;
 
 /**
  * This class holds the callback for the WordPress API function definition finder.

--- a/projects/packages/analyzer/src/class-declarations.php
+++ b/projects/packages/analyzer/src/class-declarations.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\Jetpack\Analyzer;
 
+use Exception;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;

--- a/projects/packages/backup-helper-script-manager/.phan/baseline.php
+++ b/projects/packages/backup-helper-script-manager/.phan/baseline.php
@@ -12,13 +12,10 @@ return [
     // PhanTypeMismatchArgumentProbablyReal : 15+ occurrences
     // PhanTypeMismatchArgumentInternal : 3 occurrences
     // PhanTypeMismatchForeach : 2 occurrences
-    // PhanUndeclaredClassMethod : 1 occurrence
-    // PhanUndeclaredTypeThrowsType : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-helper-script-manager-impl.php' => ['PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchForeach'],
-        'tests/php/test-class-helper-script-manager-impl.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredTypeThrowsType'],
         'tests/php/test-class-throw-on-errors.php' => ['PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/backup-helper-script-manager/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/backup-helper-script-manager/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/backup-helper-script-manager/tests/php/test-class-helper-script-manager-impl.php
+++ b/projects/packages/backup-helper-script-manager/tests/php/test-class-helper-script-manager-impl.php
@@ -6,6 +6,7 @@
 // are installed, or in some other cases).
 namespace Automattic\Jetpack\Backup\V0004;
 
+use Exception;
 use WorDBless\BaseTestCase;
 use WP_Error;
 use function get_site_url;

--- a/projects/packages/backup/.phan/baseline.php
+++ b/projects/packages/backup/.phan/baseline.php
@@ -12,17 +12,14 @@ return [
     // PhanTypeMismatchReturnProbablyReal : 15+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 8 occurrences
     // PhanTypeMismatchReturn : 6 occurrences
-    // PhanUndeclaredClassMethod : 6 occurrences
+    // PhanUndeclaredClassMethod : 5 occurrences
     // PhanUndeclaredClassReference : 5 occurrences
-    // PhanTypeMismatchArgument : 3 occurrences
-    // PhanTypeArraySuspicious : 2 occurrences
     // PhanUndeclaredStaticMethod : 2 occurrences
     // PhanPossiblyUndeclaredVariable : 1 occurrence
-    // PhanUndeclaredTypeParameter : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-jetpack-backup.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredStaticMethod', 'PhanUndeclaredTypeParameter'],
+        'src/class-jetpack-backup.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredStaticMethod'],
         'src/class-rest-controller.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/backup/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/backup/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -714,7 +714,7 @@ class Jetpack_Backup {
 	/**
 	 * Get the best addon offer for this site, including pricing details
 	 *
-	 * @param WP_Request $request Object including storage usage.
+	 * @param \WP_REST_Request $request Object including storage usage.
 	 *
 	 * @return string|WP_Error A JSON object with the suggested storage addon details if the request was successful,
 	 *                         or a WP_Error otherwise.

--- a/projects/packages/blaze/.phan/baseline.php
+++ b/projects/packages/blaze/.phan/baseline.php
@@ -9,23 +9,20 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredTypeParameter : 25+ occurrences
-    // PhanUndeclaredClassMethod : 7 occurrences
     // PhanUndeclaredFunction : 7 occurrences
-    // PhanTypeArraySuspicious : 5 occurrences
-    // PhanUndeclaredClassProperty : 4 occurrences
-    // PhanTypeMismatchArgument : 3 occurrences
-    // PhanTypeArrayUnsetSuspicious : 2 occurrences
+    // PhanTypeMismatchArgument : 2 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
+    // PhanTypeMismatchReturn : 2 occurrences
     // PhanParamTooMany : 1 occurrence
-    // PhanTypeMismatchReturn : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
+    // PhanTypeNoAccessiblePropertiesForeach : 1 occurrence
     // PhanUndeclaredClassInstanceof : 1 occurrence
+    // PhanUndeclaredClassMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-blaze.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassProperty', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
-        'src/class-dashboard-rest-controller.php' => ['PhanTypeArraySuspicious', 'PhanTypeArrayUnsetSuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
+        'src/class-blaze.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],
+        'src/class-dashboard-rest-controller.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeNoAccessiblePropertiesForeach', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
         'src/class-rest-controller.php' => ['PhanParamTooMany'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/blaze/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/blaze/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -16,6 +16,7 @@ use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Status as Jetpack_Status;
 use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Sync\Settings as Sync_Settings;
+use WP_Post;
 
 /**
  * Class for promoting posts.

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status\Host;
 use WC_Product;
 use WP_Error;
+use WP_REST_Request;
 use WP_REST_Server;
 
 /**

--- a/projects/packages/blocks/.phan/baseline.php
+++ b/projects/packages/blocks/.phan/baseline.php
@@ -9,7 +9,6 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassProperty : 7 occurrences
     // PhanTypeMismatchArgument : 2 occurrences
     // PhanUndeclaredClassMethod : 2 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 1 occurrence
@@ -17,12 +16,11 @@ return [
     // PhanUndeclaredClassInCallable : 1 occurrence
     // PhanUndeclaredClassReference : 1 occurrence
     // PhanUndeclaredFunction : 1 occurrence
-    // PhanUndeclaredTypeReturnType : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-blocks.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeReturnType'],
-        'tests/php/test-blocks.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassProperty'],
+        'src/class-blocks.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction'],
+        'tests/php/test-blocks.php' => ['PhanTypeMismatchArgument'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/blocks/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/blocks/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -38,7 +38,7 @@ class Blocks {
 	 *     @type bool  $plan_check           Should we check for a specific plan before registering the block.
 	 * }
 	 *
-	 * @return WP_Block_Type|false The registered block type on success, or false on failure.
+	 * @return \WP_Block_Type|false The registered block type on success, or false on failure.
 	 */
 	public static function jetpack_register_block( $slug, $args = array() ) {
 		// Slug doesn't start with `jetpack/`, isn't an absolute path, or doesn't contain a slash

--- a/projects/packages/boost-speed-score/.phan/baseline.php
+++ b/projects/packages/boost-speed-score/.phan/baseline.php
@@ -12,8 +12,6 @@ return [
     // PhanTypeExpectedObjectPropAccess : 4 occurrences
     // PhanTypeMismatchArgumentNullable : 2 occurrences
     // PhanTypeMismatchProperty : 2 occurrences
-    // PhanUndeclaredTypeParameter : 2 occurrences
-    // PhanUndeclaredTypeProperty : 2 occurrences
     // PhanRedefineFunction : 1 occurrence
     // PhanTypeMismatchPropertyDefault : 1 occurrence
     // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
@@ -23,7 +21,7 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-jetpack-boost-modules.php' => ['PhanTypeMismatchPropertyDefault'],
-        'src/class-speed-score-graph-history-request.php' => ['PhanTypeMismatchProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
+        'src/class-speed-score-graph-history-request.php' => ['PhanTypeMismatchProperty'],
         'src/class-speed-score-request.php' => ['PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyProbablyReal'],
         'src/class-speed-score.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnNullable'],
         'tests/bootstrap.php' => ['PhanRedefineFunction', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/boost-speed-score/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/boost-speed-score/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/boost-speed-score/src/class-speed-score-graph-history-request.php
+++ b/projects/packages/boost-speed-score/src/class-speed-score-graph-history-request.php
@@ -22,14 +22,14 @@ class Speed_Score_Graph_History_Request extends Cacheable {
 	/**
 	 * The timestamp start windown in ms.
 	 *
-	 * @var number $start timestamp start windown in ms.
+	 * @var int|float $start timestamp start windown in ms.
 	 */
 	private $start;
 
 	/**
 	 * The timestamp end windown in ms.
 	 *
-	 * @var number $end timestamp end windown in ms.
+	 * @var int|float $end timestamp end windown in ms.
 	 */
 	private $end;
 
@@ -57,9 +57,9 @@ class Speed_Score_Graph_History_Request extends Cacheable {
 	/**
 	 * Constructor.
 	 *
-	 * @param number $start timestamp start windown in ms.
-	 * @param number $end timestamp end windown in ms.
-	 * @param array  $error Speed Scores error.
+	 * @param int|float $start timestamp start windown in ms.
+	 * @param int|float $end timestamp end windown in ms.
+	 * @param array     $error Speed Scores error.
 	 */
 	public function __construct( $start, $end, $error ) {
 		$this->start       = $start;

--- a/projects/packages/connection/.phan/baseline.php
+++ b/projects/packages/connection/.phan/baseline.php
@@ -9,29 +9,27 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 60+ occurrences
+    // PhanTypeMismatchArgument : 55+ occurrences
     // PhanParamTooMany : 40+ occurrences
     // PhanUndeclaredMethod : 35+ occurrences
-    // PhanUndeclaredClassMethod : 25+ occurrences
-    // PhanTypeMismatchReturn : 20+ occurrences
     // PhanDeprecatedFunction : 15+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 15+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 15+ occurrences
-    // PhanUndeclaredTypeReturnType : 10+ occurrences
+    // PhanTypeMismatchReturn : 15+ occurrences
+    // PhanUndeclaredClassMethod : 15+ occurrences
     // PhanTypeMismatchProperty : 9 occurrences
     // PhanTypeMismatchPropertyProbablyReal : 9 occurrences
     // PhanTypeMismatchReturnProbablyReal : 8 occurrences
     // PhanUndeclaredProperty : 8 occurrences
-    // PhanUndeclaredTypeParameter : 8 occurrences
     // PhanNoopNew : 6 occurrences
     // PhanTypeArraySuspiciousNullable : 5 occurrences
     // PhanTypeMismatchDefault : 5 occurrences
-    // PhanUndeclaredTypeThrowsType : 5 occurrences
     // PhanRedundantCondition : 4 occurrences
     // PhanTypeMismatchArgumentInternal : 4 occurrences
     // PhanTypeMismatchArgumentNullable : 4 occurrences
     // PhanTypeObjectUnsetDeclaredProperty : 3 occurrences
     // PhanUndeclaredMethodInCallable : 3 occurrences
+    // PhanUndeclaredTypeReturnType : 3 occurrences
     // PhanCommentParamWithoutRealParam : 2 occurrences
     // PhanImpossibleCondition : 2 occurrences
     // PhanNonClassMethodCall : 2 occurrences
@@ -40,6 +38,7 @@ return [
     // PhanTypeMismatchReturnNullable : 2 occurrences
     // PhanTypePossiblyInvalidDimOffset : 2 occurrences
     // PhanUndeclaredTypeProperty : 2 occurrences
+    // PhanUndeclaredTypeThrowsType : 2 occurrences
     // PhanUnextractableAnnotationSuffix : 2 occurrences
     // PhanAccessMethodInternal : 1 occurrence
     // PhanImpossibleTypeComparison : 1 occurrence
@@ -47,51 +46,49 @@ return [
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanTypeMismatchDeclaredParamNullable : 1 occurrence
     // PhanTypeSuspiciousStringExpression : 1 occurrence
-    // PhanUndeclaredClassProperty : 1 occurrence
     // PhanUndeclaredClassReference : 1 occurrence
     // PhanUndeclaredFunction : 1 occurrence
     // PhanUndeclaredFunctionInCallable : 1 occurrence
+    // PhanUndeclaredTypeParameter : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'legacy/class-jetpack-ixr-client.php' => ['PhanUndeclaredClassMethod'],
         'legacy/class-jetpack-ixr-clientmulticall.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'legacy/class-jetpack-options.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal'],
         'legacy/class-jetpack-signature.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentInternal'],
         'legacy/class-jetpack-tracks-client.php' => ['PhanNonClassMethodCall', 'PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyProbablyReal'],
         'legacy/class-jetpack-xmlrpc-server.php' => ['PhanAccessMethodInternal', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredProperty'],
-        'src/class-client.php' => ['PhanImpossibleCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
+        'src/class-client.php' => ['PhanImpossibleCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
         'src/class-error-handler.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-heartbeat.php' => ['PhanTypeMismatchPropertyDefault'],
-        'src/class-manager.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredTypeReturnType'],
+        'src/class-manager.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredTypeReturnType'],
         'src/class-nonce-handler.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchReturnNullable'],
         'src/class-package-version-tracker.php' => ['PhanUndeclaredClassMethod'],
         'src/class-partner-coupon.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-partner.php' => ['PhanTypeMismatchPropertyProbablyReal'],
         'src/class-plugin-storage.php' => ['PhanUndeclaredClassMethod'],
-        'src/class-rest-authentication.php' => ['PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
+        'src/class-rest-authentication.php' => ['PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal'],
         'src/class-rest-connector.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeReturnType', 'PhanUnextractableAnnotationSuffix'],
         'src/class-secrets.php' => ['PhanCommentParamWithoutRealParam', 'PhanNonClassMethodCall', 'PhanTypeMismatchArgument'],
-        'src/class-server-sandbox.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
-        'src/class-tokens.php' => ['PhanImpossibleTypeComparison', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
-        'src/class-tracking.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
+        'src/class-server-sandbox.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
+        'src/class-tokens.php' => ['PhanImpossibleTypeComparison', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
+        'src/class-tracking.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod'],
         'src/class-urls.php' => ['PhanTypeSuspiciousStringExpression', 'PhanUndeclaredFunctionInCallable'],
-        'src/class-webhooks.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
+        'src/class-webhooks.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'src/class-xmlrpc-connector.php' => ['PhanUndeclaredTypeReturnType'],
-        'src/webhooks/class-authorize-redirect.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
+        'src/webhooks/class-authorize-redirect.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredTypeProperty'],
         'tests/php/test-class-nonce-handler.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchArgument'],
         'tests/php/test-class-plugin.php' => ['PhanUndeclaredTypeThrowsType'],
         'tests/php/test-class-webhooks.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeThrowsType'],
         'tests/php/test-partner-coupon.php' => ['PhanDeprecatedFunction', 'PhanUndeclaredMethodInCallable'],
-        'tests/php/test-partner.php' => ['PhanUndeclaredTypeThrowsType'],
-        'tests/php/test-rest-endpoints.php' => ['PhanNoopNew', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethodInCallable', 'PhanUndeclaredTypeReturnType'],
+        'tests/php/test-rest-endpoints.php' => ['PhanNoopNew', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethodInCallable'],
         'tests/php/test-terms-of-service.php' => ['PhanTypeMismatchProperty', 'PhanUndeclaredMethod'],
         'tests/php/test-tracking.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanUndeclaredMethod'],
         'tests/php/test_Error_Handler.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument'],
         'tests/php/test_Manager_integration.php' => ['PhanParamTooMany'],
         'tests/php/test_Manager_unit.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredMethod'],
         'tests/php/test_Rest_Authentication.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanUndeclaredMethod'],
-        'tests/php/test_Server_Sandbox.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument'],
+        'tests/php/test_Server_Sandbox.php' => ['PhanTypeArraySuspiciousNullable'],
         'tests/php/test_Signature.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/test_Tokens.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchProperty', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredMethod'],
         'tests/php/test_jetpack_xmlrpc_server.php' => ['PhanDeprecatedFunction', 'PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanUndeclaredMethodInCallable'],

--- a/projects/packages/connection/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/connection/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/connection/legacy/class-jetpack-ixr-client.php
+++ b/projects/packages/connection/legacy/class-jetpack-ixr-client.php
@@ -146,10 +146,10 @@ class Jetpack_IXR_Client extends IXR_Client {
 			$code    = $match[1];
 			$message = $match[2];
 			$status  = $fault_code;
-			return new \WP_Error( $code, $message, $status );
+			return new WP_Error( $code, $message, $status );
 		}
 
-		return new \WP_Error( "IXR_{$fault_code}", $fault_string );
+		return new WP_Error( "IXR_{$fault_code}", $fault_string );
 	}
 
 	/**

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Constants;
+use WP_Error;
 
 /**
  * The Client class that is used to connect to WordPress.com Jetpack API.
@@ -107,7 +108,7 @@ class Client {
 
 		$token = ( new Tokens() )->get_access_token( $args['user_id'] );
 		if ( ! $token ) {
-			return new \WP_Error( 'missing_token' );
+			return new WP_Error( 'missing_token' );
 		}
 
 		$method = strtoupper( $args['method'] );
@@ -123,7 +124,7 @@ class Client {
 
 		@list( $token_key, $secret ) = explode( '.', $token->secret ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		if ( empty( $token ) || empty( $secret ) ) {
-			return new \WP_Error( 'malformed_token' );
+			return new WP_Error( 'malformed_token' );
 		}
 
 		$token_key = sprintf(
@@ -166,7 +167,7 @@ class Client {
 			}
 
 			if ( ! is_string( $body_to_hash ) ) {
-				return new \WP_Error( 'invalid_body', 'Body is malformed.' );
+				return new WP_Error( 'invalid_body', 'Body is malformed.' );
 			}
 			$body_hash = base64_encode( sha1( $body_to_hash, true ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		}

--- a/projects/packages/connection/src/class-rest-authentication.php
+++ b/projects/packages/connection/src/class-rest-authentication.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use WP_Error;
+
 /**
  * The Jetpack Connection Rest Authentication class.
  */
@@ -118,7 +120,7 @@ class Rest_Authentication {
 			}
 
 			if ( ! isset( $_SERVER['REQUEST_METHOD'] ) ) {
-				$this->rest_authentication_status = new \WP_Error(
+				$this->rest_authentication_status = new WP_Error(
 					'rest_invalid_request',
 					__( 'The request method is missing.', 'jetpack-connection' ),
 					array( 'status' => 400 )
@@ -131,7 +133,7 @@ class Rest_Authentication {
 			// can be passed to the WP REST API via the '?_method=' parameter if
 			// needed.
 			if ( 'GET' !== $_SERVER['REQUEST_METHOD'] && 'POST' !== $_SERVER['REQUEST_METHOD'] ) {
-				$this->rest_authentication_status = new \WP_Error(
+				$this->rest_authentication_status = new WP_Error(
 					'rest_invalid_request',
 					__( 'This request method is not supported.', 'jetpack-connection' ),
 					array( 'status' => 400 )
@@ -139,7 +141,7 @@ class Rest_Authentication {
 				return null;
 			}
 			if ( 'POST' !== $_SERVER['REQUEST_METHOD'] && ! empty( file_get_contents( 'php://input' ) ) ) {
-				$this->rest_authentication_status = new \WP_Error(
+				$this->rest_authentication_status = new WP_Error(
 					'rest_invalid_request',
 					__( 'This request method does not support body parameters.', 'jetpack-connection' ),
 					array( 'status' => 400 )
@@ -173,7 +175,7 @@ class Rest_Authentication {
 			}
 
 			// Something else went wrong.  Probably a signature error.
-			$this->rest_authentication_status = new \WP_Error(
+			$this->rest_authentication_status = new WP_Error(
 				'rest_invalid_signature',
 				__( 'The request is not signed correctly.', 'jetpack-connection' ),
 				array( 'status' => 400 )

--- a/projects/packages/connection/src/class-server-sandbox.php
+++ b/projects/packages/connection/src/class-server-sandbox.php
@@ -223,7 +223,7 @@ class Server_Sandbox {
 	 *
 	 * Attached to the `admin_bar_menu` action.
 	 *
-	 * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
 	 */
 	public function admin_bar_add_sandbox_item( $wp_admin_bar ) {
 		if ( ! Constants::get_constant( 'JETPACK__SANDBOX_DOMAIN' ) ) {

--- a/projects/packages/connection/src/class-tracking.php
+++ b/projects/packages/connection/src/class-tracking.php
@@ -38,8 +38,8 @@ class Tracking {
 	/**
 	 * Creates the Tracking object.
 	 *
-	 * @param String                                $product_name the slug of the product that we are tracking.
-	 * @param Automattic\Jetpack\Connection\Manager $connection   the connection manager object.
+	 * @param String                                 $product_name the slug of the product that we are tracking.
+	 * @param \Automattic\Jetpack\Connection\Manager $connection   the connection manager object.
 	 */
 	public function __construct( $product_name = 'jetpack', $connection = null ) {
 		$this->product_name = $product_name;
@@ -159,7 +159,7 @@ class Tracking {
 	 *
 	 * @param string $event_type         Type of the event.
 	 * @param array  $data               Data to send with the event.
-	 * @param mixed  $user               Username, user_id, or WP_user object.
+	 * @param mixed  $user               Username, user_id, or WP_User object.
 	 * @param bool   $use_product_prefix Whether to use the object's product name as a prefix to the event type. If
 	 *                                   set to false, the prefix will be 'jetpack_'.
 	 */
@@ -189,7 +189,7 @@ class Tracking {
 	/**
 	 * Record an event in Tracks - this is the preferred way to record events from PHP.
 	 *
-	 * @param mixed  $user                   username, user_id, or WP_user object.
+	 * @param mixed  $user                   username, user_id, or WP_User object.
 	 * @param string $event_name             The name of the event.
 	 * @param array  $properties             Custom properties to send with the event.
 	 * @param int    $event_timestamp_millis The time in millis since 1970-01-01 00:00:00 when the event occurred.
@@ -221,8 +221,8 @@ class Tracking {
 	/**
 	 * Determines whether tracking should be enabled.
 	 *
-	 * @param Automattic\Jetpack\Terms_Of_Service $terms_of_service A Terms_Of_Service object.
-	 * @param Automattic\Jetpack\Status           $status A Status object.
+	 * @param \Automattic\Jetpack\Terms_Of_Service $terms_of_service A Terms_Of_Service object.
+	 * @param \Automattic\Jetpack\Status           $status A Status object.
 	 *
 	 * @return boolean True if tracking should be enabled, else false.
 	 */
@@ -238,10 +238,10 @@ class Tracking {
 	 * Procedurally build a Tracks Event Object.
 	 * NOTE: Use this only when the simpler Automattic\Jetpack\Tracking->jetpack_tracks_record_event() function won't work for you.
 	 *
-	 * @param WP_user $user                   WP_user object.
-	 * @param string  $event_name             The name of the event.
-	 * @param array   $properties             Custom properties to send with the event.
-	 * @param int     $event_timestamp_millis The time in millis since 1970-01-01 00:00:00 when the event occurred.
+	 * @param \WP_User $user                   WP_User object.
+	 * @param string   $event_name             The name of the event.
+	 * @param array    $properties             Custom properties to send with the event.
+	 * @param int      $event_timestamp_millis The time in millis since 1970-01-01 00:00:00 when the event occurred.
 	 *
 	 * @return \Jetpack_Tracks_Event|\WP_Error
 	 */

--- a/projects/packages/connection/src/webhooks/class-authorize-redirect.php
+++ b/projects/packages/connection/src/webhooks/class-authorize-redirect.php
@@ -28,7 +28,7 @@ class Authorize_Redirect {
 	/**
 	 * Constructs the object
 	 *
-	 * @param Automattic\Jetpack\Connection\Manager $connection The Connection Manager object.
+	 * @param \Automattic\Jetpack\Connection\Manager $connection The Connection Manager object.
 	 */
 	public function __construct( $connection ) {
 		$this->connection = $connection;

--- a/projects/packages/connection/tests/php/test-partner.php
+++ b/projects/packages/connection/tests/php/test-partner.php
@@ -65,7 +65,7 @@ class Partner_Test extends TestCase {
 	 * @param string $code_type Partner code type.
 	 * @param string $option_name Option and filter name.
 	 *
-	 * @throws Monkey\Expectation\Exception\ExpectationArgsRequired Function requires args.
+	 * @throws \Brain\Monkey\Expectation\Exception\ExpectationArgsRequired Function requires args.
 	 */
 	public function test_partner_code_is_empty_by_default( $code_type, $option_name ) {
 		$call_counter  = 0;
@@ -92,7 +92,7 @@ class Partner_Test extends TestCase {
 	 * @param string $code_type Partner code type.
 	 * @param string $option_name Option and filter name.
 	 *
-	 * @throws Monkey\Expectation\Exception\ExpectationArgsRequired Function requires args.
+	 * @throws \Brain\Monkey\Expectation\Exception\ExpectationArgsRequired Function requires args.
 	 */
 	public function test_partner_code_is_set_via_option( $code_type, $option_name ) {
 		$call_counter  = 0;
@@ -119,7 +119,7 @@ class Partner_Test extends TestCase {
 	 * @param string $code_type Partner code type.
 	 * @param string $option_name Option and filter name.
 	 *
-	 * @throws Monkey\Expectation\Exception\ExpectationArgsRequired Function requires args.
+	 * @throws \Brain\Monkey\Expectation\Exception\ExpectationArgsRequired Function requires args.
 	 */
 	public function test_partner_code_is_set_via_filter( $code_type, $option_name ) {
 		$call_counter  = 0;

--- a/projects/packages/connection/tests/php/test-rest-endpoints.php
+++ b/projects/packages/connection/tests/php/test-rest-endpoints.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
 use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
 

--- a/projects/packages/device-detection/.phan/baseline.php
+++ b/projects/packages/device-detection/.phan/baseline.php
@@ -10,8 +10,8 @@
 return [
     // # Issue statistics:
     // PhanTypeMismatchReturn : 10+ occurrences
+    // PhanPluginSimplifyExpressionBool : 4 occurrences
     // PhanRedundantCondition : 4 occurrences
-    // PhanPluginSimplifyExpressionBool : 3 occurrences
     // PhanTypeMismatchProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions

--- a/projects/packages/device-detection/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/device-detection/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update phan baseline.
+
+

--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -9,58 +9,52 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassMethod : 40+ occurrences
+    // PhanUndeclaredClassMethod : 35+ occurrences
     // PhanTypeMismatchArgument : 30+ occurrences
-    // PhanTypeMismatchReturn : 15+ occurrences
-    // PhanUndeclaredClassProperty : 15+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 10+ occurrences
-    // PhanTypeArraySuspicious : 10+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 10+ occurrences
-    // PhanUndeclaredTypeParameter : 10+ occurrences
-    // PhanUndeclaredTypeReturnType : 10+ occurrences
     // PhanUndeclaredFunction : 9 occurrences
     // PhanTypeMismatchArgumentInternal : 7 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 7 occurrences
+    // PhanUndeclaredClassProperty : 7 occurrences
     // PhanDeprecatedFunction : 5 occurrences
     // PhanUndeclaredMethod : 5 occurrences
     // PhanRedundantCondition : 4 occurrences
+    // PhanUndeclaredTypeParameter : 4 occurrences
+    // PhanTypeMismatchReturn : 3 occurrences
     // PhanTypePossiblyInvalidDimOffset : 3 occurrences
     // PhanUnextractableAnnotationElementName : 3 occurrences
-    // PhanParamSignatureMismatch : 2 occurrences
     // PhanPluginRedundantAssignment : 2 occurrences
     // PhanTypeConversionFromArray : 2 occurrences
     // PhanTypeMismatchArgumentNullableInternal : 2 occurrences
-    // PhanTypeMismatchProperty : 2 occurrences
     // PhanUndeclaredClassReference : 2 occurrences
-    // PhanUndeclaredTypeProperty : 2 occurrences
+    // PhanUndeclaredTypeReturnType : 2 occurrences
     // PhanParamTooMany : 1 occurrence
     // PhanPluginDuplicateAdjacentStatement : 1 occurrence
     // PhanPluginMixedKeyNoKey : 1 occurrence
     // PhanPossiblyNullTypeMismatchProperty : 1 occurrence
     // PhanPossiblyUndeclaredVariable : 1 occurrence
     // PhanTypeArraySuspiciousNullable : 1 occurrence
+    // PhanTypeMismatchProperty : 1 occurrence
     // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
     // PhanUndeclaredConstant : 1 occurrence
     // PhanUndeclaredProperty : 1 occurrence
+    // PhanUndeclaredTypeProperty : 1 occurrence
     // PhanUnreferencedUseNormal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/blocks/contact-form/class-contact-form-block.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
-        'src/class-wpcom-rest-api-v2-endpoint-forms.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/contact-form/class-admin.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
-        'src/contact-form/class-contact-form-endpoint.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/contact-form/class-contact-form-field.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyNullTypeMismatchProperty', 'PhanTypeConversionFromArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredProperty'],
-        'src/contact-form/class-contact-form-plugin.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginRedundantAssignment', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeReturnType'],
+        'src/class-wpcom-rest-api-v2-endpoint-forms.php' => ['PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredFunction'],
+        'src/contact-form/class-admin.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod'],
+        'src/contact-form/class-contact-form-field.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyNullTypeMismatchProperty', 'PhanTypeConversionFromArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredProperty'],
+        'src/contact-form/class-contact-form-plugin.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginRedundantAssignment', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction'],
         'src/contact-form/class-contact-form-shortcode.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginRedundantAssignment', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty', 'PhanUnextractableAnnotationElementName'],
-        'src/contact-form/class-editor-view.php' => ['PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
-        'src/contact-form/class-util.php' => ['PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
         'src/dashboard/class-dashboard-view-switch.php' => ['PhanUnreferencedUseNormal'],
         'src/dashboard/class-dashboard.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredConstant'],
         'src/service/class-google-drive.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
-        'src/service/class-post-to-url.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
         'tests/php/contact-form/test-class.contact-form-plugin.php' => ['PhanPluginMixedKeyNoKey'],
         'tests/php/contact-form/test-class.contact-form.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
     ],

--- a/projects/packages/forms/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/forms/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
+++ b/projects/packages/forms/src/class-wpcom-rest-api-v2-endpoint-forms.php
@@ -12,7 +12,10 @@ use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
 use WP_Error;
 use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
+
 /**
  * Handles the REST routes for Form Responses, aka Feedback.
  */
@@ -365,7 +368,7 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			);
 		}
 
-		return new \WP_REST_Response( array(), 200 );
+		return new WP_REST_Response( array(), 200 );
 	}
 
 	/**
@@ -408,7 +411,7 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			);
 		}
 
-		return new \WP_REST_Response( array(), 200 );
+		return new WP_REST_Response( array(), 200 );
 	}
 
 	/**
@@ -431,7 +434,7 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			}
 		}
 
-		return new \WP_REST_Response( array(), 200 );
+		return new WP_REST_Response( array(), 200 );
 	}
 
 	/**
@@ -454,7 +457,7 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			}
 		}
 
-		return new \WP_REST_Response( array(), 200 );
+		return new WP_REST_Response( array(), 200 );
 	}
 
 	/**
@@ -477,18 +480,18 @@ class WPCOM_REST_API_V2_Endpoint_Forms extends WP_REST_Controller {
 			}
 		}
 
-		return new \WP_REST_Response( array(), 200 );
+		return new WP_REST_Response( array(), 200 );
 	}
 
 	/**
-	 * Returns a \WP_REST_Response containing the given error message and code.
+	 * Returns a WP_REST_Response containing the given error message and code.
 	 *
 	 * @param  string $message Error message.
 	 * @param  int    $code    Error code.
-	 * @return \WP_REST_Response
+	 * @return WP_REST_Response
 	 */
 	private function error_response( $message, $code ) {
-		return new \WP_REST_Response( array( 'error' => $message ), $code );
+		return new WP_REST_Response( array( 'error' => $message ), $code );
 	}
 }
 

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -839,7 +839,7 @@ class Admin {
 	/**
 	 * Filter feedback posts by parent_id if present.
 	 *
-	 * @param WP_Query $query Current query.
+	 * @param \WP_Query $query Current query.
 	 *
 	 * @return void
 	 */

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -7,6 +7,9 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use WP_Error;
+use WP_REST_Request;
+
 /**
  * Class Contact_Form_Endpoint
  * Used as 'rest_controller_class' parameter when 'feedback' post type is registered in \Automattic\Jetpack\Forms\ContactForm\Contact_Form.
@@ -20,7 +23,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 */
 	public function get_items_permissions_check( $request ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( ! is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'rest_cannot_view',
 				esc_html__( 'Sorry, you cannot view this resource.', 'jetpack-forms' ),
 				array( 'status' => 401 )
@@ -38,7 +41,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 */
 	public function get_item_permissions_check( $request ) { //phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( ! is_user_member_of_blog( get_current_user_id(), get_current_blog_id() ) ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'rest_cannot_view',
 				esc_html__( 'Sorry, you cannot view this resource.', 'jetpack-forms' ),
 				array( 'status' => 401 )

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\Forms\Service\Post_To_Url;
+use WP_Error;
 
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
@@ -1033,7 +1034,7 @@ class Contact_Form_Plugin {
 		$result = false;
 
 		if ( isset( $response[0]['x-akismet-pro-tip'] ) && 'discard' === trim( $response[0]['x-akismet-pro-tip'] ) && get_option( 'akismet_strictness' ) === '1' ) {
-			$result = new \WP_Error( 'feedback-discarded', __( 'Feedback discarded.', 'jetpack-forms' ) );
+			$result = new WP_Error( 'feedback-discarded', __( 'Feedback discarded.', 'jetpack-forms' ) );
 		} elseif ( isset( $response[1] ) && 'true' === trim( $response[1] ) ) { // 'true' is spam
 			$result = true;
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Sync\Settings;
+use WP_Error;
 
 /**
  * Class for the contact-form shortcode.

--- a/projects/packages/forms/src/contact-form/class-editor-view.php
+++ b/projects/packages/forms/src/contact-form/class-editor-view.php
@@ -19,7 +19,7 @@ class Editor_View {
 	/**
 	 * Add hooks according to screen.
 	 *
-	 * @param WP_Screen $screen Data about current screen.
+	 * @param \WP_Screen $screen Data about current screen.
 	 */
 	public static function add_hooks( $screen ) {
 		if ( isset( $screen->base ) && 'post' === $screen->base ) {

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -193,9 +193,9 @@ class Util {
 	/**
 	 * Sets the 'widget' attribute on all instances of the contact form in the widget block.
 	 *
-	 * @param string          $content  Existing widget block content.
-	 * @param array           $instance Array of settings for the current widget.
-	 * @param WP_Widget_Block $widget   Current Block widget instance.
+	 * @param string           $content  Existing widget block content.
+	 * @param array            $instance Array of settings for the current widget.
+	 * @param \WP_Widget_Block $widget   Current Block widget instance.
 	 * @return string
 	 */
 	public static function grunion_contact_form_filter_widget_block_content( $content, $instance, $widget ) {

--- a/projects/packages/forms/src/service/class-post-to-url.php
+++ b/projects/packages/forms/src/service/class-post-to-url.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Forms\Service;
 
+use WP_Error;
+
 /**
  * Class Post_To_Url
  *
@@ -165,8 +167,8 @@ class Post_To_Url {
 	 * Gather fields key/value pairs from the form
 	 * Sanitizes the hidden fields values
 	 *
-	 * @param Automattic\Jetpack\Forms\ContactForm\Contact_Form $form The form instance being processed/submitted.
-	 * @param array                                             $entry_values The feedback entry values.
+	 * @param \Automattic\Jetpack\Forms\ContactForm\Contact_Form $form The form instance being processed/submitted.
+	 * @param array                                              $entry_values The feedback entry values.
 	 */
 	private function get_form_data( $form, $entry_values ) {
 		$fields = array();

--- a/projects/packages/identity-crisis/.phan/baseline.php
+++ b/projects/packages/identity-crisis/.phan/baseline.php
@@ -22,11 +22,10 @@ return [
     // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
     // PhanTypeMismatchProperty : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
-    // PhanUndeclaredTypeProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-identity-crisis.php' => ['PhanDeprecatedFunction', 'PhanPluginRedundantAssignment', 'PhanRedundantCondition', 'PhanUndeclaredTypeProperty'],
+        'src/class-identity-crisis.php' => ['PhanDeprecatedFunction', 'PhanPluginRedundantAssignment', 'PhanRedundantCondition'],
         'src/class-rest-endpoints.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'src/class-url-secret.php' => ['PhanTypeMismatchProperty', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClassMethod'],
         'tests/php/test-identity-crisis.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredTypeReturnType'],

--- a/projects/packages/identity-crisis/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/identity-crisis/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -63,7 +63,7 @@ class Identity_Crisis {
 	/**
 	 * The current screen, which is set if the current user is a non-admin and this is an admin page.
 	 *
-	 * @var WP_Screen
+	 * @var \WP_Screen
 	 */
 	public static $current_screen;
 

--- a/projects/packages/image-cdn/.phan/baseline.php
+++ b/projects/packages/image-cdn/.phan/baseline.php
@@ -15,11 +15,10 @@ return [
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
     // PhanUndeclaredFunctionInCallable : 4 occurrences
     // PhanPossiblyUndeclaredVariable : 3 occurrences
-    // PhanTypeMismatchReturn : 3 occurrences
     // PhanUndeclaredClassMethod : 3 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
     // PhanTypeMismatchPropertyProbablyReal : 2 occurrences
-    // PhanUndeclaredTypeProperty : 2 occurrences
+    // PhanTypeMismatchReturn : 2 occurrences
     // PhanNonClassMethodCall : 1 occurrence
     // PhanTypeArraySuspicious : 1 occurrence
     // PhanTypeMismatchArgumentInternal : 1 occurrence
@@ -31,12 +30,12 @@ return [
     // PhanUndeclaredClassInCallable : 1 occurrence
     // PhanUndeclaredMethod : 1 occurrence
     // PhanUndeclaredStaticMethod : 1 occurrence
+    // PhanUndeclaredTypeProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-image-cdn-core.php' => ['PhanTypeMismatchReturn'],
         'src/class-image-cdn-image-sizes.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty'],
-        'src/class-image-cdn-image.php' => ['PhanTypeMismatchReturn', 'PhanUndeclaredTypeProperty'],
         'src/class-image-cdn.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod'],
         'src/compatibility/photon.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredFunctionInCallable'],
         'tests/php/test_class.image_cdn.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod', 'PhanUndeclaredStaticMethod'],

--- a/projects/packages/image-cdn/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/image-cdn/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/image-cdn/src/class-image-cdn-image.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-image.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Image_CDN;
 
+use WP_Error;
+
 /**
  * Represents a resizable image, exposing properties necessary for properly generating srcset.
  */
@@ -69,8 +71,8 @@ class Image_CDN_Image {
 	 *  width  : int    Image width
 	 *  height : int    Image height
 	 *
-	 * @param array            $data                Array of attachment metadata, typically value of _wp_attachment_metadata postmeta.
-	 * @param string|\WP_Error $mime_type Typically value returned from get_post_mime_type function.
+	 * @param array           $data                Array of attachment metadata, typically value of _wp_attachment_metadata postmeta.
+	 * @param string|WP_Error $mime_type Typically value returned from get_post_mime_type function.
 	 */
 	public function __construct( $data, $mime_type ) {
 		$this->filename        = $data['file'];
@@ -86,18 +88,18 @@ class Image_CDN_Image {
 	 *
 	 * @param array $size_data Array of width, height, and crop properties of a size.
 	 *
-	 * @return bool|\WP_Error True if resize was successful, WP_Error on failure.
+	 * @return bool|WP_Error True if resize was successful, WP_Error on failure.
 	 */
 	public function resize( $size_data ) {
 
 		$dimensions = $this->image_resize_dimensions( $size_data['width'], $size_data['height'], $size_data['crop'] );
 
 		if ( true === is_wp_error( $dimensions ) ) {
-			return $dimensions; // Returns \WP_Error.
+			return $dimensions; // Returns WP_Error.
 		}
 
 		if ( true === is_wp_error( $this->mime_type ) ) {
-			return $this->mime_type; // Returns \WP_Error.
+			return $this->mime_type; // Returns WP_Error.
 		}
 
 		$this->set_width_height( $dimensions );
@@ -112,7 +114,7 @@ class Image_CDN_Image {
 	 *
 	 * @param array $size_data Array of width, height, and crop properties of a size.
 	 *
-	 * @return array|\WP_Error An array containing file, width, height, and mime-type keys and it's values. WP_Error on failure.
+	 * @return array|WP_Error An array containing file, width, height, and mime-type keys and it's values. WP_Error on failure.
 	 */
 	public function get_size( $size_data ) {
 
@@ -184,7 +186,7 @@ class Image_CDN_Image {
 	/**
 	 * Returns image mime type.
 	 *
-	 * @return string|\WP_Error Image's mime type or WP_Error if it was not determined.
+	 * @return string|WP_Error Image's mime type or WP_Error if it was not determined.
 	 */
 	public function get_mime_type() {
 		return $this->mime_type;
@@ -229,12 +231,12 @@ class Image_CDN_Image {
 	 * @param int        $max_height Maximum height.
 	 * @param bool|array $crop       Cropping parameters.
 	 *
-	 * @return array|\WP_Error Array of dimensions matching the parameters to imagecopyresampled. WP_Error on failure.
+	 * @return array|WP_Error Array of dimensions matching the parameters to imagecopyresampled. WP_Error on failure.
 	 */
 	protected function image_resize_dimensions( $max_width, $max_height, $crop ) {
 		$dimensions = image_resize_dimensions( $this->original_width, $this->original_height, $max_width, $max_height, $crop );
 		if ( ! $dimensions ) {
-			return new \WP_Error( 'error_getting_dimensions', __( 'Could not calculate resized image dimensions', 'jetpack-image-cdn' ), $this->filename );
+			return new WP_Error( 'error_getting_dimensions', __( 'Could not calculate resized image dimensions', 'jetpack-image-cdn' ), $this->filename );
 		}
 
 		return array_combine(

--- a/projects/packages/import/.phan/baseline.php
+++ b/projects/packages/import/.phan/baseline.php
@@ -9,40 +9,31 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredTypeReturnType : 35+ occurrences
-    // PhanTypeArraySuspicious : 25+ occurrences
-    // PhanTypeMismatchArgument : 25+ occurrences
-    // PhanUndeclaredTypeParameter : 20+ occurrences
-    // PhanParamSignatureMismatch : 15+ occurrences
-    // PhanTypeMismatchReturn : 10+ occurrences
-    // PhanUndeclaredClassMethod : 10+ occurrences
     // PhanPluginMixedKeyNoKey : 4 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 3 occurrences
+    // PhanTypeMismatchReturn : 2 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
     // PhanUndeclaredProperty : 2 occurrences
     // PhanAccessMethodInternal : 1 occurrence
     // PhanImpossibleTypeComparison : 1 occurrence
     // PhanRedundantArrayValuesCall : 1 occurrence
     // PhanTraitParentReference : 1 occurrence
+    // PhanUndeclaredClassMethod : 1 occurrence
     // PhanUndeclaredMethod : 1 occurrence
+    // PhanUndeclaredTypeReturnType : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/endpoints/class-attachment.php' => ['PhanParamSignatureMismatch', 'PhanPluginMixedKeyNoKey', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-category.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-comment.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-custom-css.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-end.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-global-style.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-menu-item.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-menu.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-page.php' => ['PhanTypeArraySuspicious', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-post.php' => ['PhanAccessMethodInternal', 'PhanImpossibleTypeComparison', 'PhanParamSignatureMismatch', 'PhanRedundantArrayValuesCall', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-start.php' => ['PhanParamSignatureMismatch', 'PhanPluginMixedKeyNoKey', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-tag.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/class-template.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/trait-import-id.php' => ['PhanParamSignatureMismatch', 'PhanTraitParentReference', 'PhanTypeArraySuspicious', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/endpoints/trait-import.php' => ['PhanPluginMixedKeyNoKey', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeParameter'],
+        'src/endpoints/class-attachment.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeReturnType'],
+        'src/endpoints/class-category.php' => ['PhanTypeMismatchArgumentProbablyReal'],
+        'src/endpoints/class-end.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchReturnProbablyReal'],
+        'src/endpoints/class-global-style.php' => ['PhanTypeMismatchReturn'],
+        'src/endpoints/class-menu.php' => ['PhanTypeMismatchArgumentProbablyReal'],
+        'src/endpoints/class-post.php' => ['PhanAccessMethodInternal', 'PhanImpossibleTypeComparison', 'PhanRedundantArrayValuesCall', 'PhanUndeclaredClassMethod'],
+        'src/endpoints/class-start.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchReturnProbablyReal'],
+        'src/endpoints/class-tag.php' => ['PhanTypeMismatchArgumentProbablyReal'],
+        'src/endpoints/trait-import-id.php' => ['PhanTraitParentReference'],
+        'src/endpoints/trait-import.php' => ['PhanPluginMixedKeyNoKey', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/import/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/import/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/import/package.json
+++ b/projects/packages/import/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-import",
-	"version": "0.8.2",
+	"version": "0.8.3-alpha",
 	"description": "Set of REST API routes used in WPCOM Unified Importer.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/import/#readme",
 	"bugs": {

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.8.2';
+	const PACKAGE_VERSION = '0.8.3-alpha';
 
 	/**
 	 * A list of all the routes.

--- a/projects/packages/import/src/endpoints/class-attachment.php
+++ b/projects/packages/import/src/endpoints/class-attachment.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 /**
  * Class Attachment
  */
@@ -110,7 +114,7 @@ class Attachment extends \WP_REST_Attachments_Controller {
 				return $response;
 			}
 
-			return new \WP_Error(
+			return new WP_Error(
 				'attachment_exists',
 				__( 'The attachment already exists.', 'jetpack-import' ),
 				array(
@@ -178,7 +182,7 @@ class Attachment extends \WP_REST_Attachments_Controller {
 	/**
 	 * Add a filter that rewrites the upload path.
 	 *
-	 * @param \WP_REST_Request $request Full details about the request.
+	 * @param WP_REST_Request $request Full details about the request.
 	 *
 	 * @return void
 	 * @throws \Exception If the date is invalid.

--- a/projects/packages/import/src/endpoints/class-category.php
+++ b/projects/packages/import/src/endpoints/class-category.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 /**
  * Class Category
  */

--- a/projects/packages/import/src/endpoints/class-comment.php
+++ b/projects/packages/import/src/endpoints/class-comment.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 /**
  * Class Comment
  */

--- a/projects/packages/import/src/endpoints/class-custom-css.php
+++ b/projects/packages/import/src/endpoints/class-custom-css.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 require_once ABSPATH . 'wp-includes/theme.php';
 
 /**

--- a/projects/packages/import/src/endpoints/class-end.php
+++ b/projects/packages/import/src/endpoints/class-end.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 /**
  * Class End
  *

--- a/projects/packages/import/src/endpoints/class-global-style.php
+++ b/projects/packages/import/src/endpoints/class-global-style.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 require_once ABSPATH . 'wp-includes/class-wp-theme-json-resolver.php';
 require_once ABSPATH . 'wp-includes/theme.php';
 
@@ -75,7 +79,7 @@ class Global_Style extends \WP_REST_Posts_Controller {
 
 		// Check if the theme exists.
 		if ( ! $theme->exists() ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'theme_not_found',
 				__( 'Theme not found.', 'jetpack-import' ),
 				array(

--- a/projects/packages/import/src/endpoints/class-menu-item.php
+++ b/projects/packages/import/src/endpoints/class-menu-item.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 /**
  * Class Menu_Item
  */

--- a/projects/packages/import/src/endpoints/class-menu.php
+++ b/projects/packages/import/src/endpoints/class-menu.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 /**
  * Class Menu
  */

--- a/projects/packages/import/src/endpoints/class-page.php
+++ b/projects/packages/import/src/endpoints/class-page.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 /**
  * Class Page
  */

--- a/projects/packages/import/src/endpoints/class-post.php
+++ b/projects/packages/import/src/endpoints/class-post.php
@@ -8,6 +8,9 @@
 namespace Automattic\Jetpack\Import\Endpoints;
 
 use Automattic\Jetpack\Sync\Settings;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 
 if ( ! function_exists( 'post_exists' ) ) {
 	require_once ABSPATH . 'wp-admin/includes/post.php';
@@ -81,7 +84,7 @@ class Post extends \WP_REST_Posts_Controller {
 		);
 
 		if ( $post_id ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'post_exists',
 				__( 'Cannot create existing post.', 'jetpack-import' ),
 				array(

--- a/projects/packages/import/src/endpoints/class-start.php
+++ b/projects/packages/import/src/endpoints/class-start.php
@@ -8,6 +8,9 @@
 namespace Automattic\Jetpack\Import\Endpoints;
 
 use Automattic\Jetpack\Import\Main;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * Class Start

--- a/projects/packages/import/src/endpoints/class-tag.php
+++ b/projects/packages/import/src/endpoints/class-tag.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 /**
  * Class Tag
  */

--- a/projects/packages/import/src/endpoints/class-template.php
+++ b/projects/packages/import/src/endpoints/class-template.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 /**
  * Class Template
  */

--- a/projects/packages/import/src/endpoints/trait-import-id.php
+++ b/projects/packages/import/src/endpoints/trait-import-id.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
 /**
  * Import ID trait. Add a unique import ID to the items schema.
  */

--- a/projects/packages/import/src/endpoints/trait-import.php
+++ b/projects/packages/import/src/endpoints/trait-import.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Import\Endpoints;
 
+use WP_Error;
+
 /**
  * Import trait. Base class for all import endpoints.
  */
@@ -35,7 +37,7 @@ trait Import {
 	/**
 	 * Ensure that the user has permissions to import.
 	 *
-	 * @return bool|\WP_Error
+	 * @return bool|WP_Error
 	 */
 	public function import_permissions_callback() {
 		// The permission check is done in the REST API authentication. It's the same
@@ -49,7 +51,7 @@ trait Import {
 			'jetpack-import'
 		);
 
-		return new \WP_Error( 'rest_forbidden', $error_msg, array( 'status' => \rest_authorization_required_code() ) );
+		return new WP_Error( 'rest_forbidden', $error_msg, array( 'status' => \rest_authorization_required_code() ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
@@ -10,27 +10,28 @@
 return [
     // # Issue statistics:
     // PhanUndeclaredFunction : 65+ occurrences
-    // PhanUndeclaredClassMethod : 60+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 55+ occurrences
-    // PhanTypeMismatchArgument : 40+ occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 60+ occurrences
+    // PhanUndeclaredClassMethod : 55+ occurrences
+    // PhanTypeMismatchArgument : 35+ occurrences
     // PhanTypeArraySuspicious : 30+ occurrences
     // PhanUndeclaredTypeParameter : 15+ occurrences
     // PhanUndeclaredFunctionInCallable : 10+ occurrences
-    // PhanUndeclaredTypeReturnType : 9 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 8 occurrences
     // PhanUndeclaredClassConstant : 8 occurrences
-    // PhanTypeMismatchReturn : 7 occurrences
     // PhanTypeMismatchReturnProbablyReal : 7 occurrences
-    // PhanUndeclaredTypeProperty : 4 occurrences
+    // PhanUndeclaredTypeReturnType : 6 occurrences
+    // PhanTypeMismatchReturn : 5 occurrences
     // PhanNoopNew : 3 occurrences
     // PhanUndeclaredClassInCallable : 3 occurrences
     // PhanUndeclaredClassReference : 3 occurrences
     // PhanUndeclaredConstant : 3 occurrences
+    // PhanUndeclaredTypeProperty : 3 occurrences
     // PhanEmptyFQSENInCallable : 2 occurrences
     // PhanParamTooMany : 2 occurrences
     // PhanTypeMismatchArgumentInternal : 2 occurrences
     // PhanTypeMismatchDefault : 2 occurrences
     // PhanTypeMissingReturn : 2 occurrences
+    // PhanDeprecatedFunction : 1 occurrence
     // PhanImpossibleTypeComparison : 1 occurrence
     // PhanNonClassMethodCall : 1 occurrence
     // PhanNoopArrayAccess : 1 occurrence
@@ -42,7 +43,6 @@ return [
     // PhanTypeInvalidLeftOperandOfNumericOp : 1 occurrence
     // PhanTypeMismatchDimFetch : 1 occurrence
     // PhanTypeMismatchProperty : 1 occurrence
-    // PhanTypeMismatchPropertyDefault : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
     // PhanTypeNonVarPassByRef : 1 occurrence
     // PhanTypeVoidArgument : 1 occurrence
@@ -73,8 +73,8 @@ return [
         'src/features/wpcom-site-menu/wpcom-site-menu.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunctionInCallable'],
         'src/utils.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
         'tests/lib/functions-wordpress.php' => ['PhanRedefineFunction'],
-        'tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeReturnType'],
-        'tests/php/features/coming-soon/class-coming-soon-test.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyDefault', 'PhanUndeclaredTypeProperty'],
+        'tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
+        'tests/php/features/coming-soon/class-coming-soon-test.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/features/launchpad/class-launchpad-jetpack-connection-client-mock.php' => ['PhanTypeMissingReturn'],
         'tests/php/features/launchpad/class-launchpad-task-list-validation-test.php' => ['PhanNonClassMethodCall', 'PhanTypeMismatchArgument'],
         'tests/php/features/launchpad/class-launchpad-task-lists-test.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeNonVarPassByRef'],

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -10,6 +10,8 @@
 
 namespace Automattic\Jetpack;
 
+use WP_Error;
+
 require_once __DIR__ . '/assets/class-wpcom-rest-api-v2-verbum-auth.php';
 require_once __DIR__ . '/assets/class-wpcom-rest-api-v2-verbum-oembed.php';
 require_once __DIR__ . '/assets/class-verbum-gutenberg-editor.php';
@@ -385,20 +387,20 @@ HTML;
 		$data = isset( $_COOKIE['wpc_fbc'] ) ? wp_parse_args( sanitize_text_field( wp_unslash( $_COOKIE['wpc_fbc'] ) ) ) : array();
 
 		if ( empty( $data['access_token'] ) ) {
-			return new \WP_Error( 'facebook', __( 'Error: your Facebook login has expired.', 'jetpack-mu-wpcom' ) );
+			return new WP_Error( 'facebook', __( 'Error: your Facebook login has expired.', 'jetpack-mu-wpcom' ) );
 		}
 
 		// Make a new request using the access token we were given.
 		$request = wp_remote_get( 'https://graph.facebook.com/v6.0/me?fields=name,email,picture,id&access_token=' . rawurlencode( $data['access_token'] ) );
 		if ( 200 !== wp_remote_retrieve_response_code( $request ) ) {
-			return new \WP_Error( 'facebook', __( 'Error: your Facebook login has expired.', 'jetpack-mu-wpcom' ) );
+			return new WP_Error( 'facebook', __( 'Error: your Facebook login has expired.', 'jetpack-mu-wpcom' ) );
 		}
 
 		$body = wp_remote_retrieve_body( $request );
 		$json = json_decode( $body );
 
 		if ( ! $body || ! $json ) {
-			return new \WP_Error( 'facebook', __( 'Error: your Facebook login has expired.', 'jetpack-mu-wpcom' ) );
+			return new WP_Error( 'facebook', __( 'Error: your Facebook login has expired.', 'jetpack-mu-wpcom' ) );
 		}
 
 		return $json;
@@ -460,7 +462,7 @@ HTML;
 			return;
 		}
 
-		return new \WP_Error( 'verbum', __( 'Error: please try commenting again.', 'jetpack-mu-wpcom' ) );
+		return new WP_Error( 'verbum', __( 'Error: please try commenting again.', 'jetpack-mu-wpcom' ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php
@@ -55,10 +55,11 @@ class Wpcom_Block_Patterns_From_Api_Test extends TestCase {
 	 * @param bool       $cache_add                 What we want Wpcom_Block_Patterns_Utils->cache_add() to return.
 	 * @param string     $get_patterns_cache_key    What we want Wpcom_Block_Patterns_Utils->get_patterns_cache_key() to return.
 	 * @param string     $get_block_patterns_locale What we want Wpcom_Block_Patterns_Utils->get_block_patterns_locale() to return.
-	 * @return obj PHP Unit mock object.
+	 * @return Wpcom_Block_Patterns_Utils&\PHPUnit\Framework\MockObject\MockObject PHP Unit mock object.
 	 */
 	public function createBlockPatternsUtilsMock( $pattern_mock_response, $cache_get = false, $cache_add = true, $get_patterns_cache_key = 'key-largo', $get_block_patterns_locale = 'fr' ) {
 		$mock = $this->createMock( Wpcom_Block_Patterns_Utils::class );
+		'@phan-var Wpcom_Block_Patterns_Utils&\PHPUnit\Framework\MockObject\MockObject $mock'; // PHPUnit 9.6 only declares `@psalm-template` and not `@template` and such so Phan can't know the right types.
 
 		$mock->method( 'remote_get' )
 			->willReturn( $pattern_mock_response );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/coming-soon/class-coming-soon-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/coming-soon/class-coming-soon-test.php
@@ -18,7 +18,7 @@ class Coming_Soon_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Preview links used to test bypassing Coming Soon using the URL with share code provided as GET parameter.
 	 *
-	 * @var \string[][]
+	 * @var string[][]
 	 */
 	private static $preview_links = array(
 		array(

--- a/projects/packages/jitm/.phan/baseline.php
+++ b/projects/packages/jitm/.phan/baseline.php
@@ -9,26 +9,20 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeArraySuspicious : 5 occurrences
     // PhanTypeExpectedObjectPropAccess : 3 occurrences
-    // PhanTypeMismatchReturn : 3 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
-    // PhanUndeclaredClassMethod : 2 occurrences
-    // PhanUndeclaredMethod : 2 occurrences
-    // PhanUndeclaredTypeParameter : 2 occurrences
+    // PhanTypeMismatchReturn : 2 occurrences
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanTypeInvalidDimOffset : 1 occurrence
     // PhanTypeMismatchArgument : 1 occurrence
-    // PhanTypeMismatchProperty : 1 occurrence
     // PhanUndeclaredFunction : 1 occurrence
-    // PhanUndeclaredTypeProperty : 1 occurrence
-    // PhanUndeclaredTypeReturnType : 1 occurrence
+    // PhanUndeclaredMethod : 1 occurrence
     // PhanUnreferencedUseNormal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-post-connection-jitm.php' => ['PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeProperty'],
-        'src/class-rest-api-endpoints.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspicious', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
+        'src/class-post-connection-jitm.php' => ['PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredFunction'],
+        'src/class-rest-api-endpoints.php' => ['PhanPluginSimplifyExpressionBool'],
         'tests/php/test_JITM.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUnreferencedUseNormal'],
         'tests/php/test_pre_connection_jitm.php' => ['PhanTypeInvalidDimOffset', 'PhanUndeclaredMethod'],
     ],

--- a/projects/packages/jitm/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/jitm/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -27,7 +27,7 @@ class Post_Connection_JITM extends JITM {
 	/**
 	 * Tracking object.
 	 *
-	 * @var Automattic\Jetpack\Tracking
+	 * @var \Automattic\Jetpack\Tracking
 	 *
 	 * @access private
 	 */

--- a/projects/packages/jitm/src/class-rest-api-endpoints.php
+++ b/projects/packages/jitm/src/class-rest-api-endpoints.php
@@ -8,6 +8,8 @@
 namespace Automattic\Jetpack\JITMS;
 
 use Automattic\Jetpack\Connection\REST_Connector;
+use WP_Error;
+use WP_REST_Request;
 use WP_REST_Server;
 
 /**
@@ -91,6 +93,6 @@ class Rest_Api_Endpoints {
 			return true;
 		}
 
-		return new \WP_Error( 'invalid_user_permission_jetpack_delete_jitm_message', REST_Connector::get_user_permissions_error_msg(), array( 'status' => rest_authorization_required_code() ) );
+		return new WP_Error( 'invalid_user_permission_jetpack_delete_jitm_message', REST_Connector::get_user_permissions_error_msg(), array( 'status' => rest_authorization_required_code() ) );
 	}
 }

--- a/projects/packages/licensing/.phan/baseline.php
+++ b/projects/packages/licensing/.phan/baseline.php
@@ -10,25 +10,16 @@
 return [
     // # Issue statistics:
     // PhanUndeclaredMethod : 10+ occurrences
-    // PhanTypeArraySuspicious : 7 occurrences
-    // PhanUndeclaredTypeParameter : 7 occurrences
-    // PhanUndeclaredClassMethod : 6 occurrences
-    // PhanUndeclaredTypeReturnType : 4 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 3 occurrences
     // PhanTypeMismatchArgument : 2 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
-    // PhanTypeMismatchProperty : 1 occurrence
     // PhanTypeMismatchPropertyDefault : 1 occurrence
-    // PhanTypeMismatchReturn : 1 occurrence
     // PhanTypeSuspiciousNonTraversableForeach : 1 occurrence
-    // PhanUndeclaredClassProperty : 1 occurrence
-    // PhanUndeclaredTypeProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-endpoints.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
+        'src/class-endpoints.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-licensing.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyDefault', 'PhanTypeSuspiciousNonTraversableForeach'],
-        'tests/php/class-test-licensing-endpoints.php' => ['PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredTypeReturnType'],
         'tests/php/class-test-licensing.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/licensing/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/licensing/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/licensing/src/class-endpoints.php
+++ b/projects/packages/licensing/src/class-endpoints.php
@@ -13,6 +13,8 @@ use Automattic\Jetpack\Licensing;
 use Automattic\Jetpack\Status\Visitor;
 use Jetpack_Options;
 use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * Class Endpoints.

--- a/projects/packages/licensing/tests/php/class-test-licensing-endpoints.php
+++ b/projects/packages/licensing/tests/php/class-test-licensing-endpoints.php
@@ -8,6 +8,9 @@
 namespace Automattic\Jetpack;
 
 use WorDBless\BaseTestCase;
+use WP_REST_Response;
+use WP_REST_Server;
+use WP_User;
 
 /**
  * Class Test_Licensing

--- a/projects/packages/my-jetpack/.phan/baseline.php
+++ b/projects/packages/my-jetpack/.phan/baseline.php
@@ -16,16 +16,14 @@ return [
     // PhanTypeMismatchReturnProbablyReal : 10+ occurrences
     // PhanAbstractStaticMethodCallInStatic : 8 occurrences
     // PhanUndeclaredClassMethod : 8 occurrences
-    // PhanTypeMismatchReturn : 7 occurrences
     // PhanNoopNew : 6 occurrences
+    // PhanTypeMismatchReturn : 6 occurrences
     // PhanUndeclaredStaticProperty : 6 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 5 occurrences
-    // PhanUndeclaredTypeParameter : 4 occurrences
-    // PhanUndeclaredTypeReturnType : 4 occurrences
     // PhanUnextractableAnnotation : 4 occurrences
     // PhanTypeArraySuspicious : 3 occurrences
-    // PhanTypeMismatchArgument : 3 occurrences
     // PhanTypeMismatchReturnNullable : 3 occurrences
+    // PhanUndeclaredTypeParameter : 3 occurrences
     // PhanImpossibleCondition : 2 occurrences
     // PhanNonClassMethodCall : 2 occurrences
     // PhanPluginMixedKeyNoKey : 1 occurrence
@@ -42,20 +40,20 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-activitylog.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'src/class-initializer.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanParamTooMany', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredTypeReturnType'],
+        'src/class-initializer.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanParamTooMany', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeProperty'],
         'src/class-jetpack-manage.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'src/class-products.php' => ['PhanNonClassMethodCall'],
         'src/class-rest-product-data.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
         'src/class-rest-products.php' => ['PhanParamTooMany', 'PhanPluginMixedKeyNoKey', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/class-rest-purchases.php' => ['PhanParamTooMany', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredTypeReturnType'],
+        'src/class-rest-purchases.php' => ['PhanParamTooMany', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-rest-zendesk-chat.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction', 'PhanUnextractableAnnotationSuffix'],
         'src/class-wpcom-products.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUnextractableAnnotation'],
         'src/products/class-anti-spam.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
         'src/products/class-backup.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyDefault'],
-        'src/products/class-boost.php' => ['PhanTypeMismatchPropertyDefault', 'PhanUndeclaredTypeParameter'],
+        'src/products/class-boost.php' => ['PhanTypeMismatchPropertyDefault'],
         'src/products/class-creator.php' => ['PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturnProbablyReal'],
         'src/products/class-crm.php' => ['PhanTypeMismatchPropertyDefault'],
-        'src/products/class-extras.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault', 'PhanUndeclaredTypeReturnType'],
+        'src/products/class-extras.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
         'src/products/class-hybrid-product.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredStaticProperty'],
         'src/products/class-jetpack-ai.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
         'src/products/class-module-product.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],

--- a/projects/packages/my-jetpack/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/my-jetpack/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -25,6 +25,7 @@ use Automattic\Jetpack\Status\Host as Status_Host;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
 use Jetpack;
+use WP_Error;
 
 /**
  * The main Initializer class that registers the admin menu and eneuque the assets.
@@ -499,7 +500,7 @@ class Initializer {
 		$body              = json_decode( wp_remote_retrieve_body( $response ) );
 
 		if ( is_wp_error( $response ) || empty( $response['body'] ) ) {
-			return new \WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ) );
+			return new WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ) );
 		}
 
 		return rest_ensure_response( $body, 200 );

--- a/projects/packages/my-jetpack/src/class-rest-purchases.php
+++ b/projects/packages/my-jetpack/src/class-rest-purchases.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\My_Jetpack;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use WP_Error;
 
 /**
  * Registers the REST routes for Purchases.
@@ -42,7 +43,7 @@ class REST_Purchases {
 		$is_site_connected = $connection->is_connected();
 
 		if ( ! $is_site_connected ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'not_connected',
 				__( 'Your site is not connected to Jetpack.', 'jetpack-my-jetpack' ),
 				array(
@@ -68,7 +69,7 @@ class REST_Purchases {
 		$body              = json_decode( wp_remote_retrieve_body( $response ) );
 
 		if ( is_wp_error( $response ) || empty( $response['body'] ) || 200 !== $response_code ) {
-			return new \WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
+			return new WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
 		}
 
 		return rest_ensure_response( $body, 200 );

--- a/projects/packages/my-jetpack/src/products/class-boost.php
+++ b/projects/packages/my-jetpack/src/products/class-boost.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\My_Jetpack\Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
+use WP_Error;
 
 /**
  * Class responsible for handling the Boost product
@@ -303,7 +304,7 @@ class Boost extends Product {
 	 * Activates the product by installing and activating its plugin
 	 *
 	 * @param bool|WP_Error $current_result Is the result of the top level activation actions. You probably won't do anything if it is an WP_Error.
-	 * @return boolean|\WP_Error
+	 * @return boolean|WP_Error
 	 */
 	public static function do_product_specific_activation( $current_result ) {
 

--- a/projects/packages/my-jetpack/src/products/class-extras.php
+++ b/projects/packages/my-jetpack/src/products/class-extras.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\My_Jetpack\Product;
+use WP_Error;
 
 /**
  * Class responsible for handling the Extras product.

--- a/projects/packages/phpcs-filter/.phan/baseline.php
+++ b/projects/packages/phpcs-filter/.phan/baseline.php
@@ -18,7 +18,6 @@ return [
     // PhanPluginLoopVariableReuse : 1 occurrence
     // PhanTypeArraySuspiciousNullable : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
-    // PhanUndeclaredClassMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
@@ -36,7 +35,7 @@ return [
         'tests/fixtures/perdir/file.php' => ['PhanUndeclaredFunction'],
         'tests/fixtures/perdir/severity-to-0/file.php' => ['PhanUndeclaredFunction'],
         'tests/php/PhpcsFilterTest.php' => ['PhanPluginLoopVariableReuse', 'PhanPossiblyUndeclaredVariable'],
-        'tests/php/StdinBootstrapTest.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable', 'PhanUndeclaredClassMethod'],
+        'tests/php/StdinBootstrapTest.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/phpcs-filter/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/phpcs-filter/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/phpcs-filter/tests/php/StdinBootstrapTest.php
+++ b/projects/packages/phpcs-filter/tests/php/StdinBootstrapTest.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\PhpcsFilter\Tests;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use RuntimeException;
 
 /**
  * Tests for stdin-bootstrap.php.

--- a/projects/packages/plans/.phan/baseline.php
+++ b/projects/packages/plans/.phan/baseline.php
@@ -9,17 +9,18 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassMethod : 4 occurrences
     // PhanUndeclaredFunction : 2 occurrences
     // PhanPluginMixedKeyNoKey : 1 occurrence
+    // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
     // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
     // PhanTypeMismatchReturn : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
+    // PhanUndeclaredClassMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-current-plan.php' => ['PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredFunction'],
-        'src/class-plans.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
+        'src/class-plans.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
         'tests/php/test-current-plan.php' => ['PhanPluginMixedKeyNoKey'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/plans/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/plans/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.4.3",
+	"version": "0.4.4-alpha",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/plans/src/class-plans.php
+++ b/projects/packages/plans/src/class-plans.php
@@ -32,7 +32,7 @@ class Plans {
 		}
 
 		// We're on Jetpack, so it's safe to use this namespace.
-		$request = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+		$request = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
 			'/plans?_locale=' . get_user_locale(),
 			// We're using version 1.5 of the endpoint rather than the default version 2
 			// since the latter only returns Jetpack Plans, but we're also interested in
@@ -41,7 +41,7 @@ class Plans {
 			array(
 				'method'  => 'GET',
 				'headers' => array(
-					'X-Forwarded-For' => ( new Automattic\Jetpack\Status\Visitor() )->get_ip( true ),
+					'X-Forwarded-For' => ( new \Automattic\Jetpack\Status\Visitor() )->get_ip( true ),
 				),
 			),
 			null,

--- a/projects/packages/plugins-installer/.phan/baseline.php
+++ b/projects/packages/plugins-installer/.phan/baseline.php
@@ -9,18 +9,14 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassMethod : 4 occurrences
-    // PhanTypeMismatchArgument : 2 occurrences
     // PhanUndeclaredMethod : 2 occurrences
-    // PhanUndeclaredTypeParameter : 2 occurrences
-    // PhanCompatibleAttributeGroupOnSameLine : 1 occurrence
-    // PhanParamSignatureMismatch : 1 occurrence
+    // PhanTypeMismatchArgument : 1 occurrence
     // PhanTypeMismatchArgumentNullable : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-automatic-install-skin.php' => ['PhanCompatibleAttributeGroupOnSameLine', 'PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
+        'src/class-automatic-install-skin.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable'],
         'src/class-plugins-installer.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/plugins-installer/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/plugins-installer/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/plugins-installer/src/class-automatic-install-skin.php
+++ b/projects/packages/plugins-installer/src/class-automatic-install-skin.php
@@ -8,6 +8,8 @@
 namespace Automattic\Jetpack;
 
 use Automatic_Upgrader_Skin;
+use WP_Error;
+use WP_Upgrader;
 
 /**
  * Include required files from wp-admin.
@@ -54,7 +56,7 @@ class Automatic_Install_Skin extends Automatic_Upgrader_Skin {
 	/**
 	 * Overwrites the error function
 	 *
-	 * @param \WP_Error|mixed $error The error object.
+	 * @param WP_Error|mixed $error The error object.
 	 */
 	public function error( $error ) {
 		if ( is_wp_error( $error ) ) {

--- a/projects/packages/post-list/.phan/baseline.php
+++ b/projects/packages/post-list/.phan/baseline.php
@@ -9,17 +9,14 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassProperty : 4 occurrences
-    // PhanTypeMismatchArgument : 2 occurrences
-    // PhanUndeclaredTypeParameter : 2 occurrences
     // PhanTypeArraySuspicious : 1 occurrence
+    // PhanTypeMismatchArgument : 1 occurrence
     // PhanTypeMismatchArgumentNullable : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-post-list.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
         'src/class-post-thumbnail.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/post-list/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/post-list/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -7,6 +7,9 @@
 
 namespace Automattic\Jetpack\Post_List;
 
+use WP_Post;
+use WP_Screen;
+
 /**
  * The Post_List Admin Area
  */

--- a/projects/packages/post-list/src/class-post-list.php
+++ b/projects/packages/post-list/src/class-post-list.php
@@ -15,7 +15,7 @@ use WP_Screen;
  */
 class Post_List {
 
-	const PACKAGE_VERSION = '0.6.1';
+	const PACKAGE_VERSION = '0.6.2-alpha';
 	const FEATURE         = 'enhanced_post_list';
 
 	/**

--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -9,26 +9,23 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassMethod : 35+ occurrences
+    // PhanUndeclaredClassMethod : 20+ occurrences
     // PhanTypeMismatchArgument : 15+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 15+ occurrences
-    // PhanUndeclaredClassProperty : 15+ occurrences
-    // PhanUndeclaredTypeParameter : 15+ occurrences
-    // PhanUndeclaredTypeReturnType : 10+ occurrences
     // PhanDeprecatedFunction : 9 occurrences
-    // PhanTypeMismatchReturn : 9 occurrences
-    // PhanTypeArraySuspicious : 8 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 7 occurrences
     // PhanTypeMismatchProperty : 7 occurrences
     // PhanUndeclaredStaticMethod : 6 occurrences
     // PhanUndeclaredMethod : 5 occurrences
     // PhanTypeMismatchArgumentNullable : 3 occurrences
+    // PhanTypeMismatchReturn : 3 occurrences
     // PhanUndeclaredTypeProperty : 3 occurrences
     // PhanPluginMixedKeyNoKey : 2 occurrences
     // PhanPossiblyUndeclaredVariable : 2 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
     // PhanTypeMissingReturn : 2 occurrences
     // PhanUndeclaredFunction : 2 occurrences
+    // PhanUndeclaredTypeReturnType : 2 occurrences
     // PhanImpossibleCondition : 1 occurrence
     // PhanParamSignatureMismatch : 1 occurrence
     // PhanPluginDuplicateExpressionAssignmentOperation : 1 occurrence
@@ -41,26 +38,23 @@ return [
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/auto-conversion-settings/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeArraySuspicious', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/class-connections-post-field.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
+        'src/auto-conversion-settings/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],
+        'src/class-connections-post-field.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeReturnType'],
         'src/class-keyring-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanUndeclaredTypeReturnType'],
-        'src/class-publicize-base.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
+        'src/class-publicize-base.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
         'src/class-publicize-setup.php' => ['PhanTypeMismatchArgument', 'PhanUnextractableAnnotationSuffix'],
         'src/class-publicize-ui.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
-        'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredFunction', 'PhanUndeclaredStaticMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
+        'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredStaticMethod'],
+        'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod'],
         'src/social-image-generator/class-post-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'src/social-image-generator/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeArraySuspicious', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/social-image-generator/class-rest-token-controller.php' => ['PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
+        'src/social-image-generator/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/social-image-generator/class-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/social-image-generator/class-setup.php' => ['PhanTypeMismatchArgumentNullable'],
-        'src/social-image-generator/utilities.php' => ['PhanUndeclaredTypeReturnType'],
         'tests/php/jetpack-social-settings/test-auto-conversion.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty'],
         'tests/php/jetpack-social-settings/test-jetpack-social-settings.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty'],
         'tests/php/jetpack-social-settings/test-social-image-generator-settings.php' => ['PhanTypeMismatchProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty'],
         'tests/php/test-connections-post-field.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanUndeclaredMethod'],
         'tests/php/test-publicize-og-optimization.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchReturn', 'PhanUndeclaredMethod'],
-        'tests/php/test-publicize-rest-controller.php' => ['PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeReturnType'],
         'tests/php/test-social-image-generator/test-post-settings.php' => ['PhanDeprecatedFunction', 'PhanUndeclaredMethod'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/publicize/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/publicize/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/publicize/src/auto-conversion-settings/class-rest-settings-controller.php
+++ b/projects/packages/publicize/src/auto-conversion-settings/class-rest-settings-controller.php
@@ -14,6 +14,8 @@ namespace Automattic\Jetpack\Publicize\Auto_Conversion;
 use Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings as Jetpack_Social_Settings;
 use WP_Error;
 use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 
 /**

--- a/projects/packages/publicize/src/class-connections-post-field.php
+++ b/projects/packages/publicize/src/class-connections-post-field.php
@@ -7,6 +7,10 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use WP_Error;
+use WP_Post;
+use WP_REST_Request;
+
 /**
  * The class to register the field and augment requests
  * to Publicize supported post types.
@@ -143,7 +147,7 @@ class Connections_Post_Field {
 		global $publicize;
 
 		if ( ! $publicize ) {
-			return new \WP_Error(
+			return new WP_Error(
 				'publicize_not_available',
 				__( 'Sorry, Jetpack Social is not available on your site right now.', 'jetpack-publicize-pkg' ),
 				array( 'status' => rest_authorization_required_code() )
@@ -154,7 +158,7 @@ class Connections_Post_Field {
 			return true;
 		}
 
-		return new \WP_Error(
+		return new WP_Error(
 			'invalid_user_permission_publicize',
 			__( 'Sorry, you are not allowed to access Jetpack Social data for this post.', 'jetpack-publicize-pkg' ),
 			array( 'status' => rest_authorization_required_code() )
@@ -416,7 +420,7 @@ class Connections_Post_Field {
 			// If we return this for the top level object, Core
 			// correctly remove the top level object from the response
 			// for us.
-			return new \WP_Error( '__wrong-context__' );
+			return new WP_Error( '__wrong-context__' );
 		}
 
 		switch ( $schema['type'] ) {

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -14,6 +14,8 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
+use WP_Error;
+use WP_Post;
 
 /**
  * Base class for Publicize.

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -11,6 +11,8 @@ use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Redirect;
 use Jetpack_IXR_Client;
 use Jetpack_Options;
+use WP_Error;
+use WP_Post;
 
 /**
  * Extend the base class with Jetpack-specific functionality.
@@ -621,7 +623,7 @@ class Publicize extends Publicize_Base {
 			'refresh_url'      => $refresh_url,
 		);
 
-		$this->test_connection_results[ $id ] = new \WP_Error( $connection_error_code, $connection_test_message, $error_data );
+		$this->test_connection_results[ $id ] = new WP_Error( $connection_error_code, $connection_test_message, $error_data );
 
 		return $this->test_connection_results[ $id ];
 	}
@@ -654,8 +656,8 @@ class Publicize extends Publicize_Base {
 	 * Save a flag locally to indicate that this post has already been Publicized via the selected
 	 * connections.
 	 *
-	 * @param int      $post_ID Post ID.
-	 * @param \WP_Post $post Post object.
+	 * @param int     $post_ID Post ID.
+	 * @param WP_Post $post Post object.
 	 */
 	public function save_publicized( $post_ID, $post = null ) {
 		if ( $post === null ) {
@@ -673,8 +675,8 @@ class Publicize extends Publicize_Base {
 	/**
 	 * Set post flags for Publicize.
 	 *
-	 * @param array    $flags List of flags.
-	 * @param \WP_Post $post Post object.
+	 * @param array   $flags List of flags.
+	 * @param WP_Post $post Post object.
 	 * @return array
 	 */
 	public function set_post_flags( $flags, $post ) {

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -11,6 +11,8 @@ namespace Automattic\Jetpack\Publicize;
 use Automattic\Jetpack\Connection\Client;
 use Jetpack_Options;
 use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 
 /**
@@ -250,7 +252,7 @@ class REST_Controller {
 	/**
 	 * Dismisses a notice to prevent it from appearing again.
 	 *
-	 * @param WP_Request $request The request object, which includes the parameters.
+	 * @param WP_REST_Request $request The request object, which includes the parameters.
 	 * @return WP_REST_Response|WP_Error True if the request was successful, or a WP_Error otherwise.
 	 */
 	public function update_dismissed_notices( $request ) {
@@ -277,7 +279,7 @@ class REST_Controller {
 	 *
 	 * POST jetpack/v4/publicize/(?P<postId>\d+)
 	 *
-	 * @param WP_Request $request The request object, which includes the parameters.
+	 * @param WP_REST_Request $request The request object, which includes the parameters.
 	 */
 	public function share_post( $request ) {
 		$post_id             = $request->get_param( 'postId' );

--- a/projects/packages/publicize/src/social-image-generator/class-rest-settings-controller.php
+++ b/projects/packages/publicize/src/social-image-generator/class-rest-settings-controller.php
@@ -14,6 +14,8 @@ namespace Automattic\Jetpack\Publicize\Social_Image_Generator;
 use Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings as Jetpack_Social_Settings;
 use WP_Error;
 use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 
 /**

--- a/projects/packages/publicize/src/social-image-generator/class-rest-token-controller.php
+++ b/projects/packages/publicize/src/social-image-generator/class-rest-token-controller.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize\Social_Image_Generator;
 
 use WP_Error;
 use WP_REST_Controller;
+use WP_REST_Request;
 use WP_REST_Server;
 
 /**
@@ -38,7 +39,7 @@ class REST_Token_Controller extends WP_REST_Controller {
 	/**
 	 * Passes the request parameters to the WPCOM endpoint to generate a preview image token.
 	 *
-	 * @param WP_Request $request The request object, which includes the parameters.
+	 * @param WP_REST_Request $request The request object, which includes the parameters.
 	 * @return array|WP_Error The token or an error.
 	 */
 	public function generate_preview_token( $request ) {

--- a/projects/packages/publicize/src/social-image-generator/utilities.php
+++ b/projects/packages/publicize/src/social-image-generator/utilities.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Publicize\Social_Image_Generator;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Publicize\REST_Controller;
 use Automattic\Jetpack\Redirect;
+use WP_Error;
 
 /**
  * Given a post ID, returns the image URL for the generated image.

--- a/projects/packages/publicize/tests/php/test-publicize-rest-controller.php
+++ b/projects/packages/publicize/tests/php/test-publicize-rest-controller.php
@@ -8,6 +8,7 @@ use WorDBless\Options as WorDBless_Options;
 use WorDBless\Posts as WorDBless_Posts;
 use WorDBless\Users as WorDBless_Users;
 use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 
 /**

--- a/projects/packages/search/.phan/baseline.php
+++ b/projects/packages/search/.phan/baseline.php
@@ -9,28 +9,27 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassMethod : 45+ occurrences
     // PhanUnextractableAnnotation : 45+ occurrences
-    // PhanTypeMismatchArgument : 20+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 10+ occurrences
+    // PhanTypeMismatchArgument : 10+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
-    // PhanUndeclaredTypeParameter : 10+ occurrences
-    // PhanUndeclaredTypeProperty : 10+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 9 occurrences
+    // PhanUndeclaredClassMethod : 8 occurrences
+    // PhanUndeclaredTypeProperty : 7 occurrences
     // PhanRedundantCondition : 6 occurrences
     // PhanTypeMismatchProperty : 6 occurrences
-    // PhanTypeMismatchReturn : 6 occurrences
     // PhanUndeclaredProperty : 6 occurrences
-    // PhanUndeclaredClassProperty : 5 occurrences
+    // PhanTypeMismatchReturn : 5 occurrences
     // PhanDeprecatedFunction : 4 occurrences
     // PhanImpossibleCondition : 4 occurrences
     // PhanPluginMixedKeyNoKey : 3 occurrences
     // PhanTypeSuspiciousEcho : 3 occurrences
     // PhanNoopNew : 2 occurrences
     // PhanTypePossiblyInvalidDimOffset : 2 occurrences
+    // PhanUndeclaredClassProperty : 2 occurrences
     // PhanUndeclaredFunctionInCallable : 2 occurrences
+    // PhanUndeclaredTypeParameter : 2 occurrences
     // PhanDeprecatedPartiallySupportedCallable : 1 occurrence
-    // PhanParamSignatureMismatch : 1 occurrence
     // PhanPluginRedundantAssignment : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanPossiblyUndeclaredVariable : 1 occurrence
@@ -41,26 +40,23 @@ return [
     // PhanTypeMismatchDimAssignment : 1 occurrence
     // PhanUndeclaredClassReference : 1 occurrence
     // PhanUndeclaredFunction : 1 occurrence
-    // PhanUndeclaredTypeReturnType : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'compatibility/jetpack.php' => ['PhanUndeclaredClassMethod'],
         'src/class-cli.php' => ['PhanTypeMismatchArgument'],
         'src/class-helper.php' => ['PhanDeprecatedPartiallySupportedCallable', 'PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
-        'src/class-module-control.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
         'src/class-options.php' => ['PhanPluginSimplifyExpressionBool'],
         'src/class-plan.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUnextractableAnnotation'],
         'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/class-stats.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'src/class-template-tags.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
-        'src/classic-search/class-classic-search.php' => ['PhanImpossibleCondition', 'PhanPluginRedundantAssignment', 'PhanRedundantCondition', 'PhanTypeComparisonToArray', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
-        'src/customizer/class-customizer.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
+        'src/classic-search/class-classic-search.php' => ['PhanImpossibleCondition', 'PhanPluginRedundantAssignment', 'PhanRedundantCondition', 'PhanTypeComparisonToArray', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty'],
         'src/customizer/customize-controls/class-excluded-post-types-control.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/dashboard/class-dashboard.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty', 'PhanUnextractableAnnotation'],
+        'src/dashboard/class-dashboard.php' => ['PhanUnextractableAnnotation'],
         'src/dashboard/class-initial-state.php' => ['PhanTypeMismatchArgument'],
         'src/initializers/class-initializer.php' => ['PhanNoopNew', 'PhanUndeclaredFunctionInCallable'],
-        'src/instant-search/class-instant-search.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUnextractableAnnotation'],
+        'src/instant-search/class-instant-search.php' => ['PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUnextractableAnnotation'],
         'src/widgets/class-search-widget.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeSuspiciousEcho', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty'],
         'src/wpes/class-query-builder.php' => ['PhanImpossibleCondition', 'PhanRedundantCondition', 'PhanTypeMismatchDimAssignment', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
         'src/wpes/class-query-parser.php' => ['PhanUndeclaredProperty'],
@@ -68,7 +64,7 @@ return [
         'tests/php/test-helpers.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredTypeProperty', 'PhanUnextractableAnnotation'],
         'tests/php/test-module-control.php' => ['PhanTypeMismatchArgument'],
         'tests/php/test-plan.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/test-rest-controller.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeReturnType'],
+        'tests/php/test-rest-controller.php' => ['PhanTypeMismatchArgument'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/search/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/search/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -26,7 +26,7 @@ class Module_Control {
 	/**
 	 * Connection_Manager object
 	 *
-	 * @var Automattic\Jetpack\Connection\Manager
+	 * @var \Automattic\Jetpack\Connection\Manager
 	 */
 	protected $connection_manager;
 
@@ -40,8 +40,8 @@ class Module_Control {
 	/**
 	 * Contructor
 	 *
-	 * @param Plan|null                                  $plan - Plan object.
-	 * @param Automattic\Jetpack\Connection\Manager|null $connection_manager - Connection_Manager object.
+	 * @param Plan|null                                   $plan - Plan object.
+	 * @param \Automattic\Jetpack\Connection\Manager|null $connection_manager - Connection_Manager object.
 	 */
 	public function __construct( $plan = null, $connection_manager = null ) {
 		$this->plan               = $plan === null ? new Plan() : $plan;

--- a/projects/packages/search/src/classic-search/class-classic-search.php
+++ b/projects/packages/search/src/classic-search/class-classic-search.php
@@ -1219,8 +1219,8 @@ class Classic_Search {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param array                                        $aggregations Array of aggregations (filters) to add to the query builder.
-	 * @param Automattic\Jetpack\Search\WPES\Query_Builder $builder      The builder instance that is creating the Elasticsearch query.
+	 * @param array                                         $aggregations Array of aggregations (filters) to add to the query builder.
+	 * @param \Automattic\Jetpack\Search\WPES\Query_Builder $builder      The builder instance that is creating the Elasticsearch query.
 	 */
 	public function add_aggregations_to_es_query_builder( array $aggregations, $builder ) {
 		foreach ( $aggregations as $label => $aggregation ) {
@@ -1256,9 +1256,9 @@ class Classic_Search {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param array                                        $aggregation The aggregation to add to the query builder.
-	 * @param string                                       $label       The 'label' (unique id) for this aggregation.
-	 * @param Automattic\Jetpack\Search\WPES\Query_Builder $builder     The builder instance that is creating the Elasticsearch query.
+	 * @param array                                         $aggregation The aggregation to add to the query builder.
+	 * @param string                                        $label       The 'label' (unique id) for this aggregation.
+	 * @param \Automattic\Jetpack\Search\WPES\Query_Builder $builder     The builder instance that is creating the Elasticsearch query.
 	 */
 	public function add_taxonomy_aggregation_to_es_query_builder( array $aggregation, $label, $builder ) {
 		$field = null;
@@ -1293,9 +1293,9 @@ class Classic_Search {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param array                                        $aggregation The aggregation to add to the query builder.
-	 * @param string                                       $label       The 'label' (unique id) for this aggregation.
-	 * @param Automattic\Jetpack\Search\WPES\Query_Builder $builder     The builder instance that is creating the Elasticsearch query.
+	 * @param array                                         $aggregation The aggregation to add to the query builder.
+	 * @param string                                        $label       The 'label' (unique id) for this aggregation.
+	 * @param \Automattic\Jetpack\Search\WPES\Query_Builder $builder     The builder instance that is creating the Elasticsearch query.
 	 */
 	public function add_post_type_aggregation_to_es_query_builder( array $aggregation, $label, $builder ) {
 		$builder->add_aggs(
@@ -1314,9 +1314,9 @@ class Classic_Search {
 	 *
 	 * @since 0.20.0
 	 *
-	 * @param array                                        $aggregation The aggregation to add to the query builder.
-	 * @param string                                       $label       The 'label' (unique id) for this aggregation.
-	 * @param Automattic\Jetpack\Search\WPES\Query_Builder $builder     The builder instance that is creating the Elasticsearch query.
+	 * @param array                                         $aggregation The aggregation to add to the query builder.
+	 * @param string                                        $label       The 'label' (unique id) for this aggregation.
+	 * @param \Automattic\Jetpack\Search\WPES\Query_Builder $builder     The builder instance that is creating the Elasticsearch query.
 	 */
 	public function add_author_aggregation_to_es_query_builder( array $aggregation, $label, $builder ) {
 		$builder->add_aggs(
@@ -1335,9 +1335,9 @@ class Classic_Search {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param array                                        $aggregation The aggregation to add to the query builder.
-	 * @param string                                       $label       The 'label' (unique id) for this aggregation.
-	 * @param Automattic\Jetpack\Search\WPES\Query_Builder $builder     The builder instance that is creating the Elasticsearch query.
+	 * @param array                                         $aggregation The aggregation to add to the query builder.
+	 * @param string                                        $label       The 'label' (unique id) for this aggregation.
+	 * @param \Automattic\Jetpack\Search\WPES\Query_Builder $builder     The builder instance that is creating the Elasticsearch query.
 	 */
 	public function add_date_histogram_aggregation_to_es_query_builder( array $aggregation, $label, $builder ) {
 		$args = array(

--- a/projects/packages/search/src/customizer/class-customizer.php
+++ b/projects/packages/search/src/customizer/class-customizer.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Search;
 
 use Automattic\Jetpack\Assets;
 use WP_Customize_Color_Control;
+use WP_Customize_Manager;
 
 /**
  * Class to customize search on the site.

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -28,21 +28,21 @@ class Dashboard {
 	/**
 	 * Plan instance
 	 *
-	 * @var Automattic\Jetpack\Search\Plan
+	 * @var \Automattic\Jetpack\Search\Plan
 	 */
 	protected $plan;
 
 	/**
 	 * Connection manager instance
 	 *
-	 * @var Automattic\Jetpack\Connection\Manager
+	 * @var \Automattic\Jetpack\Connection\Manager
 	 */
 	protected $connection_manager;
 
 	/**
 	 * Module_Control instance
 	 *
-	 * @var Automattic\Jetpack\Search\Module_Control
+	 * @var \Automattic\Jetpack\Search\Module_Control
 	 */
 	protected $module_control;
 
@@ -58,9 +58,9 @@ class Dashboard {
 	/**
 	 * Contructor
 	 *
-	 * @param Automattic\Jetpack\Search\Plan           $plan - Plan instance.
-	 * @param Automattic\Jetpack\Connection\Manager    $connection_manager - Connection Manager instance.
-	 * @param Automattic\Jetpack\Search\Module_Control $module_control - Module_Control instance.
+	 * @param \Automattic\Jetpack\Search\Plan           $plan - Plan instance.
+	 * @param \Automattic\Jetpack\Connection\Manager    $connection_manager - Connection Manager instance.
+	 * @param \Automattic\Jetpack\Search\Module_Control $module_control - Module_Control instance.
 	 */
 	public function __construct( $plan = null, $connection_manager = null, $module_control = null ) {
 		$this->plan               = $plan ? $plan : new Plan();
@@ -204,7 +204,7 @@ class Dashboard {
 	/**
 	 * Deactivate search module if plan doesn't support search.
 	 *
-	 * @param WP_Screen $current_screen Creent screen object.
+	 * @param \WP_Screen $current_screen Creent screen object.
 	 */
 	public function check_plan_deactivate_search_module( $current_screen ) {
 		// Only run on Jetpack admin pages.

--- a/projects/packages/search/src/instant-search/class-instant-search.php
+++ b/projects/packages/search/src/instant-search/class-instant-search.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Assets;
 use WP_Block_Parser;
 use WP_Block_Patterns_Registry;
 use WP_Error;
+use WP_Query;
 use WP_REST_Templates_Controller;
 
 /**

--- a/projects/packages/search/tests/php/test-rest-controller.php
+++ b/projects/packages/search/tests/php/test-rest-controller.php
@@ -5,6 +5,7 @@ namespace Automattic\Jetpack\Search;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\Search\Test_Case as Search_Test_Case;
 use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 
 /**

--- a/projects/packages/stats-admin/.phan/baseline.php
+++ b/projects/packages/stats-admin/.phan/baseline.php
@@ -9,21 +9,17 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassMethod : 60+ occurrences
-    // PhanUndeclaredTypeParameter : 20+ occurrences
     // PhanTypeMismatchReturn : 8 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 7 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
-    // PhanTypeMismatchArgument : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
     // PhanUndeclaredStaticProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-main.php' => ['PhanTypeMismatchArgument'],
         'src/class-notices.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
-        'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
+        'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-wpcom-client.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'tests/php/test-stats-dashboard.php' => ['PhanUndeclaredStaticProperty'],
     ],

--- a/projects/packages/stats-admin/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/stats-admin/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Stats\WPCOM_Stats;
 use Jetpack_Options;
 use WP_Error;
+use WP_REST_Request;
 use WP_REST_Server;
 
 /**

--- a/projects/packages/stats/.phan/baseline.php
+++ b/projects/packages/stats/.phan/baseline.php
@@ -13,23 +13,22 @@ return [
     // PhanParamTooMany : 7 occurrences
     // PhanUnextractableAnnotationSuffix : 5 occurrences
     // PhanTypeVoidAssignment : 4 occurrences
-    // PhanUndeclaredTypeProperty : 3 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 2 occurrences
-    // PhanTypeMismatchProperty : 2 occurrences
     // PhanUndeclaredFunction : 2 occurrences
     // PhanDeprecatedFunction : 1 occurrence
+    // PhanTypeMismatchProperty : 1 occurrence
     // PhanTypeMismatchReturn : 1 occurrence
-    // PhanUndeclaredClassInCallable : 1 occurrence
+    // PhanUndeclaredTypeProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-options.php' => ['PhanUnextractableAnnotationSuffix'],
         'src/class-tracking-pixel.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredFunction', 'PhanUnextractableAnnotationSuffix'],
         'src/class-wpcom-stats.php' => ['PhanTypeMismatchReturn', 'PhanUnextractableAnnotationSuffix'],
-        'tests/php/test-main.php' => ['PhanParamTooMany', 'PhanTypeVoidAssignment', 'PhanUndeclaredTypeProperty'],
+        'tests/php/test-main.php' => ['PhanParamTooMany', 'PhanTypeVoidAssignment'],
         'tests/php/test-options.php' => ['PhanTypeVoidAssignment'],
         'tests/php/test-wpcom-stats.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty'],
-        'tests/php/test-xmlrpc-provider.php' => ['PhanParamTooMany', 'PhanTypeMismatchProperty', 'PhanTypeVoidAssignment', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty'],
+        'tests/php/test-xmlrpc-provider.php' => ['PhanParamTooMany', 'PhanTypeVoidAssignment'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/stats/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/stats/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/stats/src/class-package-version.php
+++ b/projects/packages/stats/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Stats;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '0.12.0';
+	const PACKAGE_VERSION = '0.12.1-alpha';
 
 	const PACKAGE_SLUG = 'stats';
 

--- a/projects/packages/stats/tests/php/test-main.php
+++ b/projects/packages/stats/tests/php/test-main.php
@@ -20,7 +20,7 @@ class Test_Main extends StatsBaseTestCase {
 	/**
 	 * An instance of Main class.
 	 *
-	 * @var Automattic\Jetpack\Stats\Main
+	 * @var \Automattic\Jetpack\Stats\Main
 	 */
 	protected $stats;
 

--- a/projects/packages/stats/tests/php/test-xmlrpc-provider.php
+++ b/projects/packages/stats/tests/php/test-xmlrpc-provider.php
@@ -18,7 +18,7 @@ class Test_XMLRPC_Provider extends StatsBaseTestCase {
 	/**
 	 * An instance of XMLRPC_Provider class.
 	 *
-	 * @var Automattic\Jetpack\Stats\XMLRPC_Provider
+	 * @var \Automattic\Jetpack\Stats\XMLRPC_Provider
 	 */
 	protected $xmlrpc_instance;
 

--- a/projects/packages/status/.phan/baseline.php
+++ b/projects/packages/status/.phan/baseline.php
@@ -9,8 +9,8 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassMethod : 30+ occurrences
     // PhanTypeMismatchArgument : 10+ occurrences
+    // PhanUndeclaredClassMethod : 10+ occurrences
     // PhanUndeclaredConstant : 6 occurrences
     // PhanUndeclaredProperty : 6 occurrences
     // PhanUndeclaredMethod : 5 occurrences
@@ -30,9 +30,7 @@ return [
     // PhanTypeArraySuspicious : 1 occurrence
     // PhanTypeMismatchArgumentNullable : 1 occurrence
     // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
-    // PhanTypeMismatchProperty : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
-    // PhanUndeclaredTypeProperty : 1 occurrence
     // PhanUnextractableAnnotation : 1 occurrence
     // PhanUnextractableAnnotationSuffix : 1 occurrence
 
@@ -46,7 +44,7 @@ return [
         'src/class-status.php' => ['PhanRedundantCondition', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty'],
         'tests/php/bootstrap.php' => ['PhanRedefineFunction', 'PhanTypeMismatchReturnProbablyReal'],
         'tests/php/test-host.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanUndeclaredMethod'],
-        'tests/php/test-status.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeProperty'],
+        'tests/php/test-status.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentInternal', 'PhanUndeclaredProperty'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/status/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/status/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/status/tests/php/test-status.php
+++ b/projects/packages/status/tests/php/test-status.php
@@ -26,7 +26,7 @@ class Test_Status extends TestCase {
 	/**
 	 * Status instance.
 	 *
-	 * @var Automattic\Jetpack\Status
+	 * @var \Automattic\Jetpack\Status
 	 */
 	private $status_obj;
 

--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -9,31 +9,27 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassMethod : 55+ occurrences
-    // PhanTypeMismatchArgument : 45+ occurrences
+    // PhanTypeMismatchArgument : 40+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 35+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 30+ occurrences
     // PhanTypeMismatchReturn : 20+ occurrences
     // PhanUndeclaredProperty : 20+ occurrences
     // PhanParamSignatureMismatch : 15+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 15+ occurrences
-    // PhanUndeclaredClassProperty : 15+ occurrences
-    // PhanTypeMismatchProperty : 10+ occurrences
-    // PhanUndeclaredTypeParameter : 10+ occurrences
-    // PhanUndeclaredTypeReturnType : 10+ occurrences
+    // PhanUndeclaredMethod : 15+ occurrences
     // PhanPluginSimplifyExpressionBool : 9 occurrences
+    // PhanUndeclaredClassMethod : 9 occurrences
     // PhanPossiblyUndeclaredVariable : 8 occurrences
-    // PhanUndeclaredTypeProperty : 7 occurrences
     // PhanPluginDuplicateSwitchCaseLooseEquality : 6 occurrences
-    // PhanUndeclaredMethod : 6 occurrences
     // PhanUndeclaredFunction : 5 occurrences
     // PhanRedundantCondition : 4 occurrences
     // PhanTypeExpectedObjectPropAccess : 4 occurrences
-    // PhanUndeclaredClassInCallable : 4 occurrences
+    // PhanTypeMismatchArgumentInternal : 4 occurrences
+    // PhanUndeclaredClassProperty : 4 occurrences
+    // PhanUndeclaredTypeReturnType : 4 occurrences
     // PhanNonClassMethodCall : 3 occurrences
     // PhanTypeArraySuspicious : 3 occurrences
     // PhanTypeArraySuspiciousNullable : 3 occurrences
-    // PhanTypeMismatchArgumentInternal : 3 occurrences
     // PhanUndeclaredClassReference : 3 occurrences
     // PhanAccessMethodInternal : 2 occurrences
     // PhanCommentVarInsteadOfParam : 2 occurrences
@@ -44,6 +40,7 @@ return [
     // PhanTypeMismatchReturnNullable : 2 occurrences
     // PhanTypePossiblyInvalidDimOffset : 2 occurrences
     // PhanTypeSuspiciousStringExpression : 2 occurrences
+    // PhanUndeclaredTypeParameter : 2 occurrences
     // PhanDeprecatedFunction : 1 occurrence
     // PhanNoopNew : 1 occurrence
     // PhanParamTooManyCallable : 1 occurrence
@@ -53,39 +50,41 @@ return [
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanTypeMismatchDeclaredParam : 1 occurrence
     // PhanTypeMismatchDefault : 1 occurrence
+    // PhanTypeMismatchProperty : 1 occurrence
     // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
     // PhanUndeclaredClassInstanceof : 1 occurrence
+    // PhanUndeclaredMethodInCallable : 1 occurrence
     // PhanUndeclaredStaticMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-actions.php' => ['PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeProperty'],
+        'src/class-actions.php' => ['PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod'],
         'src/class-data-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-dedicated-sender.php' => ['PhanTypeInvalidLeftOperandOfNumericOp'],
         'src/class-functions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
         'src/class-json-deflate-array-codec.php' => ['PhanTypeMismatchArgument'],
         'src/class-listener.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-lock.php' => ['PhanTypeMismatchReturn'],
-        'src/class-modules.php' => ['PhanTypeMismatchReturn', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/class-queue.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
+        'src/class-modules.php' => ['PhanUndeclaredMethodInCallable'],
+        'src/class-queue.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredClassProperty'],
         'src/class-replicastore.php' => ['PhanAccessMethodInternal', 'PhanParamSignatureMismatch', 'PhanPluginDuplicateSwitchCaseLooseEquality', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredStaticMethod'],
-        'src/class-rest-endpoints.php' => ['PhanParamTooMany', 'PhanParamTooManyCallable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod'],
-        'src/class-rest-sender.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod'],
-        'src/class-sender.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredTypeReturnType'],
-        'src/class-server.php' => ['PhanTypeMismatchDeclaredParam', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredTypeProperty'],
+        'src/class-rest-endpoints.php' => ['PhanParamTooMany', 'PhanParamTooManyCallable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredMethod'],
+        'src/class-rest-sender.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
+        'src/class-sender.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeReturnType'],
+        'src/class-server.php' => ['PhanTypeMismatchDeclaredParam', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-settings.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod'],
         'src/class-utils.php' => ['PhanTypeExpectedObjectPropAccess'],
         'src/modules/class-callables.php' => ['PhanParamSignatureMismatch', 'PhanParamTooMany', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod'],
-        'src/modules/class-comments.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
+        'src/modules/class-comments.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod'],
         'src/modules/class-constants.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
-        'src/modules/class-full-sync-immediately.php' => ['PhanCommentVarInsteadOfParam', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod'],
+        'src/modules/class-full-sync-immediately.php' => ['PhanCommentVarInsteadOfParam', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchReturn', 'PhanUndeclaredMethod'],
         'src/modules/class-full-sync.php' => ['PhanCommentVarInsteadOfParam', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeComparisonFromArray', 'PhanUndeclaredMethod'],
         'src/modules/class-import.php' => ['PhanTypeMismatchArgumentInternal'],
         'src/modules/class-meta.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/modules/class-module.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-network-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
-        'src/modules/class-plugins.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter'],
+        'src/modules/class-plugins.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredMethod'],
         'src/modules/class-posts.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginUseReturnValueInternalKnown', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
         'src/modules/class-protect.php' => ['PhanUndeclaredClassMethod'],
         'src/modules/class-term-relationships.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument'],
@@ -95,7 +94,7 @@ return [
         'src/modules/class-users.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-woocommerce-hpos-orders.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
         'src/modules/class-woocommerce.php' => ['PhanTypeMismatchReturnProbablyReal'],
-        'src/replicastore/class-table-checksum-usermeta.php' => ['PhanUndeclaredClassMethod'],
+        'src/replicastore/class-table-checksum-usermeta.php' => ['PhanUndeclaredMethod'],
         'src/replicastore/class-table-checksum.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal'],
         'src/sync-queue/class-queue-storage-table.php' => ['PhanUndeclaredClassProperty', 'PhanUndeclaredTypeReturnType'],
         'tests/php/test-actions.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],

--- a/projects/packages/sync/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/sync/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -57,7 +57,7 @@ class Actions {
 	 * @access public
 	 * @static
 	 *
-	 * @var Automattic\Jetpack\Sync\Sender
+	 * @var \Automattic\Jetpack\Sync\Sender
 	 */
 	public static $sender = null;
 
@@ -67,7 +67,7 @@ class Actions {
 	 * @access public
 	 * @static
 	 *
-	 * @var Automattic\Jetpack\Sync\Listener
+	 * @var \Automattic\Jetpack\Sync\Listener
 	 */
 	public static $listener = null;
 

--- a/projects/packages/sync/src/class-modules.php
+++ b/projects/packages/sync/src/class-modules.php
@@ -90,7 +90,7 @@ class Modules {
 	 *
 	 * @param string $module_name A module name.
 	 *
-	 * @return bool|Automattic\Jetpack\Sync\Modules\Module
+	 * @return bool|\Automattic\Jetpack\Sync\Modules\Module
 	 */
 	public static function get_module( $module_name ) {
 		foreach ( self::get_modules() as $module ) {
@@ -134,7 +134,7 @@ class Modules {
 	 *
 	 * @param string $module_class The classname of a Jetpack sync module.
 	 *
-	 * @return Automattic\Jetpack\Sync\Modules\Module
+	 * @return \Automattic\Jetpack\Sync\Modules\Module
 	 */
 	public static function load_module( $module_class ) {
 		return new $module_class();
@@ -146,9 +146,9 @@ class Modules {
 	 * @access public
 	 * @static
 	 *
-	 * @param Automattic\Jetpack\Sync\Modules\Module $module Instance of a Jetpack sync module.
+	 * @param \Automattic\Jetpack\Sync\Modules\Module $module Instance of a Jetpack sync module.
 	 *
-	 * @return Automattic\Jetpack\Sync\Modules\Module
+	 * @return \Automattic\Jetpack\Sync\Modules\Module
 	 */
 	public static function set_module_defaults( $module ) {
 		$module->set_defaults();

--- a/projects/packages/sync/src/class-queue.php
+++ b/projects/packages/sync/src/class-queue.php
@@ -199,7 +199,7 @@ class Queue {
 	 *
 	 * @param int $buffer_size Size of the buffer to checkout.
 	 *
-	 * @return Automattic\Jetpack\Sync\Queue_Buffer|bool|int|\WP_Error
+	 * @return \Automattic\Jetpack\Sync\Queue_Buffer|bool|int|\WP_Error
 	 */
 	public function checkout( $buffer_size ) {
 		if ( $this->get_checkout_id() ) {
@@ -348,7 +348,7 @@ class Queue {
 	/**
 	 * Check in the queue.
 	 *
-	 * @param Automattic\Jetpack\Sync\Queue_Buffer $buffer Queue_Buffer object.
+	 * @param \Automattic\Jetpack\Sync\Queue_Buffer $buffer Queue_Buffer object.
 	 *
 	 * @return bool|\WP_Error
 	 */
@@ -367,8 +367,8 @@ class Queue {
 	/**
 	 * Close the buffer.
 	 *
-	 * @param Automattic\Jetpack\Sync\Queue_Buffer $buffer Queue_Buffer object.
-	 * @param null|array                           $ids_to_remove Ids to remove from the queue.
+	 * @param \Automattic\Jetpack\Sync\Queue_Buffer $buffer Queue_Buffer object.
+	 * @param null|array                            $ids_to_remove Ids to remove from the queue.
 	 *
 	 * @return bool|\WP_Error
 	 */
@@ -653,7 +653,7 @@ class Queue {
 	/**
 	 * Return true if the buffer is still valid or an Error other wise.
 	 *
-	 * @param Automattic\Jetpack\Sync\Queue_Buffer $buffer The Queue_Buffer.
+	 * @param \Automattic\Jetpack\Sync\Queue_Buffer $buffer The Queue_Buffer.
 	 *
 	 * @return bool|WP_Error
 	 */

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -128,7 +128,7 @@ class Sender {
 	 *
 	 * @access private
 	 *
-	 * @var Automattic\Jetpack\Sync\Queue
+	 * @var \Automattic\Jetpack\Sync\Queue
 	 */
 	private $sync_queue;
 
@@ -137,7 +137,7 @@ class Sender {
 	 *
 	 * @access private
 	 *
-	 * @var Automattic\Jetpack\Sync\Queue
+	 * @var \Automattic\Jetpack\Sync\Queue
 	 */
 	private $full_sync_queue;
 
@@ -146,7 +146,7 @@ class Sender {
 	 *
 	 * @access private
 	 *
-	 * @var Automattic\Jetpack\Sync\Codec_Interface
+	 * @var \Automattic\Jetpack\Sync\Codec_Interface
 	 */
 	private $codec;
 
@@ -165,7 +165,7 @@ class Sender {
 	 * @access private
 	 * @static
 	 *
-	 * @var Automattic\Jetpack\Sync\Sender
+	 * @var \Automattic\Jetpack\Sync\Sender
 	 */
 	private static $instance;
 
@@ -439,7 +439,7 @@ class Sender {
 	 *
 	 * @access public
 	 *
-	 * @param Automattic\Jetpack\Sync\Queue $queue Queue object.
+	 * @param \Automattic\Jetpack\Sync\Queue $queue Queue object.
 	 *
 	 * @return boolean|WP_Error True if this sync sending was successful, error object otherwise.
 	 */
@@ -507,8 +507,8 @@ class Sender {
 	 *
 	 * @access public
 	 *
-	 * @param (array|Automattic\Jetpack\Sync\Queue_Buffer) $buffer_or_items Queue buffer or array of objects.
-	 * @param boolean                                      $encode Whether to encode the items.
+	 * @param (array|\Automattic\Jetpack\Sync\Queue_Buffer) $buffer_or_items Queue buffer or array of objects.
+	 * @param boolean                                       $encode Whether to encode the items.
 	 * @return array Sync items to send.
 	 */
 	public function get_items_to_send( $buffer_or_items, $encode = true ) {
@@ -587,7 +587,7 @@ class Sender {
 	 *
 	 * @access public
 	 *
-	 * @param Automattic\Jetpack\Sync\Queue $queue Queue object.
+	 * @param \Automattic\Jetpack\Sync\Queue $queue Queue object.
 	 *
 	 * @return boolean|WP_Error True if this sync sending was successful, error object otherwise.
 	 */
@@ -790,7 +790,7 @@ class Sender {
 	 *
 	 * @access public
 	 *
-	 * @return Automattic\Jetpack\Sync\Queue Queue object.
+	 * @return \Automattic\Jetpack\Sync\Queue Queue object.
 	 */
 	public function get_sync_queue() {
 		return $this->sync_queue;
@@ -801,7 +801,7 @@ class Sender {
 	 *
 	 * @access public
 	 *
-	 * @return Automattic\Jetpack\Sync\Queue Queue object.
+	 * @return \Automattic\Jetpack\Sync\Queue Queue object.
 	 */
 	public function get_full_sync_queue() {
 		return $this->full_sync_queue;
@@ -812,7 +812,7 @@ class Sender {
 	 *
 	 * @access public
 	 *
-	 * @return Automattic\Jetpack\Sync\Codec_Interface Codec object.
+	 * @return \Automattic\Jetpack\Sync\Codec_Interface Codec object.
 	 */
 	public function get_codec() {
 		return $this->codec;

--- a/projects/packages/sync/src/class-server.php
+++ b/projects/packages/sync/src/class-server.php
@@ -19,7 +19,7 @@ class Server {
 	 *
 	 * @access private
 	 *
-	 * @var Automattic\Jetpack\Sync\Codec_Interface
+	 * @var \Automattic\Jetpack\Sync\Codec_Interface
 	 */
 	private $codec;
 

--- a/projects/packages/sync/src/modules/class-plugins.php
+++ b/projects/packages/sync/src/modules/class-plugins.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
+use WP_Error;
 
 /**
  * Class to handle sync for plugins.

--- a/projects/packages/videopress/.phan/baseline.php
+++ b/projects/packages/videopress/.phan/baseline.php
@@ -10,31 +10,27 @@
 return [
     // # Issue statistics:
     // PhanPluginDuplicateConditionalNullCoalescing : 20+ occurrences
-    // PhanUndeclaredClassMethod : 20+ occurrences
-    // PhanUndeclaredTypeParameter : 15+ occurrences
-    // PhanTypeArraySuspicious : 10+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
-    // PhanTypeMismatchReturn : 10+ occurrences
-    // PhanUndeclaredClassProperty : 10+ occurrences
+    // PhanUndeclaredClassMethod : 10+ occurrences
     // PhanUndeclaredFunction : 10+ occurrences
-    // PhanTypeMismatchArgument : 8 occurrences
+    // PhanTypeMismatchReturn : 8 occurrences
     // PhanUndeclaredProperty : 8 occurrences
+    // PhanTypeArraySuspicious : 6 occurrences
     // PhanTypeMismatchReturnProbablyReal : 6 occurrences
     // PhanUnextractableAnnotation : 5 occurrences
     // PhanCommentOverrideOnNonOverrideMethod : 4 occurrences
     // PhanNonClassMethodCall : 4 occurrences
     // PhanTypeArraySuspiciousNullable : 4 occurrences
+    // PhanTypeMismatchArgument : 4 occurrences
     // PhanNoopNew : 3 occurrences
     // PhanParamTooMany : 3 occurrences
     // PhanUndeclaredMethod : 3 occurrences
-    // PhanUndeclaredTypeReturnType : 3 occurrences
     // PhanPossiblyUndeclaredVariable : 2 occurrences
     // PhanTypeInvalidDimOffset : 2 occurrences
     // PhanUndeclaredClassConstant : 2 occurrences
     // PhanUndeclaredConstant : 2 occurrences
     // PhanUndeclaredExtendedClass : 2 occurrences
     // PhanUndeclaredMethodInCallable : 2 occurrences
-    // PhanUndeclaredTypeProperty : 2 occurrences
     // PhanUndeclaredTypeThrowsType : 2 occurrences
     // PhanAccessMethodInternal : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
@@ -45,20 +41,21 @@ return [
     // PhanTypeMismatchProperty : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
     // PhanUndeclaredClass : 1 occurrence
-    // PhanUndeclaredClassInstanceof : 1 occurrence
     // PhanUndeclaredClassReference : 1 occurrence
+    // PhanUndeclaredTypeProperty : 1 occurrence
+    // PhanUndeclaredTypeReturnType : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-access-control.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredClassReference', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
-        'src/class-admin-ui.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod'],
+        'src/class-access-control.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction'],
+        'src/class-admin-ui.php' => ['PhanUndeclaredClassMethod'],
         'src/class-ajax.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],
-        'src/class-attachment-handler.php' => ['PhanNonClassMethodCall', 'PhanTypeArraySuspicious', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/class-block-editor-content.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
+        'src/class-attachment-handler.php' => ['PhanNonClassMethodCall', 'PhanTypeArraySuspicious'],
+        'src/class-block-editor-content.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-block-editor-extensions.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-data.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeMismatchReturn', 'PhanUndeclaredFunction'],
         'src/class-divi.php' => ['PhanUndeclaredProperty'],
-        'src/class-initializer.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredClassProperty', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter'],
+        'src/class-initializer.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredMethod'],
         'src/class-jwt-token-bridge.php' => ['PhanTypeMismatchReturn'],
         'src/class-plan.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUnextractableAnnotation'],
         'src/class-site.php' => ['PhanTypeMismatchArgumentProbablyReal'],
@@ -67,13 +64,11 @@ return [
         'src/class-uploader-rest-endpoints.php' => ['PhanParamTooMany'],
         'src/class-uploader.php' => ['PhanTypeMismatchArgument'],
         'src/class-utils.php' => ['PhanUnextractableAnnotation'],
-        'src/class-videopress-rest-api-v1-settings.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
-        'src/class-videopress-rest-api-v1-site.php' => ['PhanTypeMismatchReturn', 'PhanUndeclaredTypeReturnType'],
-        'src/class-videopresstoken.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod'],
-        'src/class-wpcom-rest-api-v2-attachment-field-videopress.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassProperty', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
-        'src/class-wpcom-rest-api-v2-attachment-videopress-data.php' => ['PhanTypeArraySuspicious', 'PhanUndeclaredClassProperty', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
-        'src/class-wpcom-rest-api-v2-endpoint-videopress.php' => ['PhanAccessMethodInternal', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
-        'src/class-xmlrpc.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
+        'src/class-videopresstoken.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
+        'src/class-wpcom-rest-api-v2-attachment-field-videopress.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
+        'src/class-wpcom-rest-api-v2-attachment-videopress-data.php' => ['PhanUndeclaredFunction'],
+        'src/class-wpcom-rest-api-v2-endpoint-videopress.php' => ['PhanAccessMethodInternal', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],
+        'src/class-xmlrpc.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/tus/class-transient-store.php' => ['PhanParamTooMany'],
         'src/tus/class-tus-abstract-cache.php' => ['PhanTypeMismatchArgumentInternal'],
         'src/tus/class-tus-client.php' => ['PhanNonClassMethodCall', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredTypeReturnType'],

--- a/projects/packages/videopress/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/videopress/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\VideoPress;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
 use Automattic\Jetpack\Modules;
 use VIDEOPRESS_PRIVACY;
+use WP_Post;
 
 /**
  * VideoPress video access control utilities.

--- a/projects/packages/videopress/src/class-attachment-handler.php
+++ b/projects/packages/videopress/src/class-attachment-handler.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Current_Plan;
+use WP_Error;
+use WP_Post;
 
 /**
  * VideoPress Attachment_Handler class.

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
+use WP_Post;
+
 /**
  * VideoPress block editor class for content generation
  */

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
+use WP_Block;
+
 /**
  * Initialized the VideoPress package
  */

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-settings.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-settings.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\VideoPress;
 
 use WP_Error;
+use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-site.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-site.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
+use WP_REST_Response;
+
 /**
  * VideoPress rest api class for fetching site information
  */

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-field-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-field-videopress.php
@@ -10,6 +10,9 @@
 namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * Add per-attachment VideoPress data.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-attachment-videopress-data.php
@@ -10,6 +10,9 @@
 namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
+use WP_Post;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * Add per-attachment VideoPress data.
@@ -88,8 +91,8 @@ class WPCOM_REST_API_V2_Attachment_VideoPress_Data {
 	 *
 	 * `no_videopress`: the returned attachments should not have a videopress_guid
 	 *
-	 * @param array      $args The original list of args before the filtering.
-	 * @param WP_Request $request The original request data.
+	 * @param array           $args The original list of args before the filtering.
+	 * @param WP_REST_Request $request The original request data.
 	 */
 	public function filter_attachments_by_jetpack_videopress_fields( $args, $request ) {
 

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Constants;
 use WP_Error;
 use WP_REST_Controller;
+use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 

--- a/projects/packages/videopress/src/class-xmlrpc.php
+++ b/projects/packages/videopress/src/class-xmlrpc.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
+use WP_User;
+
 /**
  * VideoPress playback module markup generator.
  *

--- a/projects/packages/waf/.phan/baseline.php
+++ b/projects/packages/waf/.phan/baseline.php
@@ -10,29 +10,24 @@
 return [
     // # Issue statistics:
     // PhanUndeclaredMethod : 25+ occurrences
-    // PhanTypeMismatchArgument : 15+ occurrences
-    // PhanTypeArraySuspicious : 10+ occurrences
+    // PhanTypeMismatchArgument : 10+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
     // PhanUnextractableAnnotationSuffix : 10+ occurrences
     // PhanDeprecatedFunction : 9 occurrences
-    // PhanTypeMismatchReturn : 8 occurrences
+    // PhanTypeMismatchReturn : 7 occurrences
     // PhanNoopNew : 6 occurrences
     // PhanTypeMismatchDefault : 5 occurrences
     // PhanTypeMismatchReturnProbablyReal : 5 occurrences
-    // PhanUndeclaredClassMethod : 5 occurrences
     // PhanUndeclaredConstant : 5 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
     // PhanRedefineFunction : 4 occurrences
     // PhanTypeMismatchArgumentInternal : 4 occurrences
     // PhanGenericConstructorTypes : 3 occurrences
-    // PhanUndeclaredClassProperty : 3 occurrences
-    // PhanUndeclaredTypeReturnType : 3 occurrences
     // PhanUnextractableAnnotationElementName : 3 occurrences
     // PhanPluginRedundantAssignment : 2 occurrences
     // PhanStaticCallToNonStatic : 2 occurrences
     // PhanTypeArraySuspiciousNullable : 2 occurrences
     // PhanTypeMismatchArgumentNullable : 2 occurrences
-    // PhanUndeclaredTypeParameter : 2 occurrences
     // PhanCoalescingNeverNull : 1 occurrence
     // PhanImpossibleTypeComparison : 1 occurrence
     // PhanNonClassMethodCall : 1 occurrence
@@ -54,9 +49,7 @@ return [
         'src/brute-force-protection/class-shared-functions.php' => ['PhanTypeComparisonToArray', 'PhanTypeMismatchReturnProbablyReal', 'PhanUnextractableAnnotationSuffix'],
         'src/class-brute-force-protection.php' => ['PhanNoopNew', 'PhanStaticCallToNonStatic', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUnextractableAnnotationSuffix'],
         'src/class-compatibility.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal'],
-        'src/class-rest-controller.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
         'src/class-waf-constants.php' => ['PhanCoalescingNeverNull', 'PhanUndeclaredConstant'],
-        'src/class-waf-initializer.php' => ['PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
         'src/class-waf-operators.php' => ['PhanTypeMismatchReturn'],
         'src/class-waf-request.php' => ['PhanGenericConstructorTypes', 'PhanUnextractableAnnotationSuffix'],
         'src/class-waf-rules-manager.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
@@ -66,7 +59,6 @@ return [
         'src/class-waf-transforms.php' => ['PhanPluginInvalidPregRegex', 'PhanTypeInvalidDimOffset'],
         'src/functions.php' => ['PhanUnextractableAnnotationSuffix'],
         'tests/php/integration/test-waf-compatibility.php' => ['PhanParamTooMany'],
-        'tests/php/integration/test-waf-rest-api.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty'],
         'tests/php/integration/test-waf-unsupported-environment.php' => ['PhanTypeMismatchArgument'],
         'tests/php/unit/functions-wordpress.php' => ['PhanRedefineFunction'],
         'tests/php/unit/test-waf-operators.php' => ['PhanTypeMismatchArgumentInternal'],

--- a/projects/packages/waf/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/waf/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/waf/src/class-rest-controller.php
+++ b/projects/packages/waf/src/class-rest-controller.php
@@ -10,6 +10,8 @@ namespace Automattic\Jetpack\Waf;
 use Automattic\Jetpack\Connection\REST_Connector;
 use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
 use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 
 /**

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Waf;
 
 use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
 use WP_Error;
+use WP_Upgrader;
 
 /**
  * Initializes the module

--- a/projects/packages/wordads/.phan/baseline.php
+++ b/projects/packages/wordads/.phan/baseline.php
@@ -9,15 +9,12 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassMethod : 1 occurrence
     // PhanUndeclaredFunctionInCallable : 1 occurrence
-    // PhanUndeclaredTypeParameter : 1 occurrence
-    // PhanUndeclaredTypeProperty : 1 occurrence
     // PhanUnextractableAnnotation : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/dashboard/class-dashboard.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty', 'PhanUnextractableAnnotation'],
+        'src/dashboard/class-dashboard.php' => ['PhanUnextractableAnnotation'],
         'src/initializers/class-initializer.php' => ['PhanUndeclaredFunctionInCallable'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/wordads/changelog/fix-obvious-wrong-class-names
+++ b/projects/packages/wordads/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/packages/wordads/src/dashboard/class-dashboard.php
+++ b/projects/packages/wordads/src/dashboard/class-dashboard.php
@@ -22,14 +22,14 @@ class Dashboard {
 	/**
 	 * Connection manager instance
 	 *
-	 * @var Automattic\Jetpack\Connection\Manager
+	 * @var \Automattic\Jetpack\Connection\Manager
 	 */
 	protected $connection_manager;
 
 	/**
 	 * Contructor
 	 *
-	 * @param Automattic\Jetpack\Connection\Manager $connection_manager - Connection Manager instance.
+	 * @param \Automattic\Jetpack\Connection\Manager $connection_manager - Connection Manager instance.
 	 */
 	public function __construct( $connection_manager = null ) {
 		$this->connection_manager = $connection_manager ? $connection_manager : new Connection_Manager( Package::SLUG );

--- a/projects/plugins/boost/.phan/baseline.php
+++ b/projects/plugins/boost/.phan/baseline.php
@@ -10,20 +10,17 @@
 return [
     // # Issue statistics:
     // PhanTypeArraySuspiciousNullable : 20+ occurrences
-    // PhanTypeMismatchArgument : 20+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 10+ occurrences
     // PhanTypeMismatchArgumentNullableInternal : 10+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 10+ occurrences
     // PhanTypeMissingReturn : 10+ occurrences
-    // PhanUndeclaredClassProperty : 10+ occurrences
     // PhanTypeArraySuspicious : 9 occurrences
+    // PhanTypeMismatchArgument : 9 occurrences
     // PhanUndeclaredFunction : 8 occurrences
     // PhanParamTooMany : 7 occurrences
     // PhanPossiblyUndeclaredVariable : 6 occurrences
     // PhanUndeclaredClassMethod : 6 occurrences
-    // PhanUndeclaredTypeParameter : 6 occurrences
     // PhanUndeclaredConstant : 5 occurrences
-    // PhanUndeclaredTypeReturnType : 5 occurrences
     // PhanCommentParamOnEmptyParamList : 3 occurrences
     // PhanPluginUseReturnValueInternalKnown : 3 occurrences
     // PhanTypeMismatchArgumentInternal : 3 occurrences
@@ -32,7 +29,6 @@ return [
     // PhanUndeclaredClassConstant : 3 occurrences
     // PhanNoopNew : 2 occurrences
     // PhanRedundantCondition : 2 occurrences
-    // PhanTypeMismatchReturn : 2 occurrences
     // PhanUndeclaredFunctionInCallable : 2 occurrences
     // PhanUndeclaredMethodInCallable : 2 occurrences
     // PhanUndeclaredStaticMethod : 2 occurrences
@@ -56,6 +52,7 @@ return [
     // PhanUndeclaredClassReference : 1 occurrence
     // PhanUndeclaredConstantOfClass : 1 occurrence
     // PhanUndeclaredMethod : 1 occurrence
+    // PhanUndeclaredTypeParameter : 1 occurrence
     // PhanUndeclaredTypeProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
@@ -63,16 +60,15 @@ return [
         'app/admin/class-admin.php' => ['PhanNoopNew'],
         'app/admin/class-config.php' => ['PhanTypeMismatchArgument'],
         'app/data-sync/Minify_Excludes_State_Entry.php' => ['PhanTypeMismatchReturnProbablyReal'],
-        'app/data-sync/Performance_History_Entry.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument'],
+        'app/data-sync/Performance_History_Entry.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious'],
         'app/features/setup-prompt/Setup_Prompt.php' => ['PhanTypeMissingReturn'],
         'app/lib/Environment_Change_Detector.php' => ['PhanCommentParamOutOfOrder'],
         'app/lib/Status.php' => ['PhanTypeArraySuspiciousNullable', 'PhanUndeclaredMethodInCallable'],
         'app/lib/Super_Cache_Info.php' => ['PhanUndeclaredFunction'],
-        'app/lib/class-analytics.php' => ['PhanTypeMismatchArgument'],
         'app/lib/class-cli.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanUndeclaredConstantOfClass'],
         'app/lib/class-minify.php' => ['PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredMethod'],
         'app/lib/class-viewport.php' => ['PhanTypeMismatchArgument'],
-        'app/lib/critical-css/Critical_CSS_State.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeReturnType'],
+        'app/lib/critical-css/Critical_CSS_State.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable'],
         'app/lib/critical-css/Regenerate.php' => ['PhanParamTooMany'],
         'app/lib/critical-css/source-providers/Source_Providers.php' => ['PhanCommentParamOnEmptyParamList'],
         'app/lib/critical-css/source-providers/providers/Archive_Provider.php' => ['PhanTypeMismatchReturnProbablyReal'],
@@ -98,10 +94,9 @@ return [
         'app/modules/optimizations/minify/class-minify-css.php' => ['PhanTypeMissingReturn'],
         'app/modules/optimizations/minify/class-minify-js.php' => ['PhanTypeMissingReturn'],
         'app/modules/optimizations/page-cache/Page_Cache.php' => ['PhanTypeMissingReturn'],
-        'app/modules/optimizations/page-cache/Page_Cache_Setup.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredTypeReturnType'],
+        'app/modules/optimizations/page-cache/Page_Cache_Setup.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn'],
         'app/modules/optimizations/page-cache/data-sync/Page_Cache_Entry.php' => ['PhanTypeMismatchReturnProbablyReal'],
-        'app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php' => ['PhanCommentParamOnEmptyParamList', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache_Utils.php' => ['PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
+        'app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php' => ['PhanCommentParamOnEmptyParamList', 'PhanTypeMismatchReturnProbablyReal'],
         'app/modules/optimizations/page-cache/pre-wordpress/Filesystem_Utils.php' => ['PhanTypeSuspiciousStringExpression'],
         'app/modules/optimizations/page-cache/pre-wordpress/Logger.php' => ['PhanCoalescingNeverNull', 'PhanPluginDuplicateConditionalNullCoalescing'],
         'app/modules/optimizations/page-cache/pre-wordpress/Request.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchPropertyDefault'],

--- a/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
+++ b/projects/plugins/boost/app/lib/critical-css/Critical_CSS_State.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack_Boost\Lib\Critical_CSS;
 
+use WP_Error;
+
 class Critical_CSS_State {
 
 	const GENERATION_STATES = array(
@@ -47,12 +49,12 @@ class Critical_CSS_State {
 
 	public function set_provider_error_dismissed( $provider_key, $dismissed ) {
 		if ( empty( $this->state['providers'] ) ) {
-			return new \WP_Error( 'invalid_provider_key', 'No providers exist' );
+			return new WP_Error( 'invalid_provider_key', 'No providers exist' );
 		}
 
 		$provider_index = array_search( $provider_key, array_column( $this->state['providers'], 'key' ), true );
 		if ( $provider_index === false ) {
-			return new \WP_Error( 'invalid_provider_key', 'Invalid provider key' );
+			return new WP_Error( 'invalid_provider_key', 'Invalid provider key' );
 		}
 
 		$this->state['providers'][ $provider_index ]['error_status'] = $dismissed ? 'dismissed' : 'active';
@@ -69,12 +71,12 @@ class Critical_CSS_State {
 	 */
 	private function update_provider_state( $provider_key, $state ) {
 		if ( empty( $this->state['providers'] ) ) {
-			return new \WP_Error( 'invalid_provider_key', 'No providers exist' );
+			return new WP_Error( 'invalid_provider_key', 'No providers exist' );
 		}
 
 		$provider_index = array_search( $provider_key, array_column( $this->state['providers'], 'key' ), true );
 		if ( $provider_index === false ) {
-			return new \WP_Error( 'invalid_provider_key', 'Invalid provider key' );
+			return new WP_Error( 'invalid_provider_key', 'Invalid provider key' );
 		}
 
 		$this->state['providers'][ $provider_index ] = array_merge(

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -278,7 +278,7 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 	/**
 	 * Deletes the WP_CACHE define from wp-config.php
 	 *
-	 * @return WP_Error if an error occurred.
+	 * @return \WP_Error if an error occurred.
 	 */
 	public static function delete_wp_cache_constant() {
 		$config_file = self::find_wp_config();

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -5,6 +5,10 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress;
 
+use WP_Comment;
+use WP_Error;
+use WP_Post;
+
 /*
  * Require all pre-wordpress files here. These files aren't autoloaded as they are loaded before WordPress is fully initialized.
  * pre-wordpress files assume all other pre-wordpress files are loaded here.

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache_Utils.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache_Utils.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Pre_WordPress;
 
+use WP_Post;
+
 class Boost_Cache_Utils {
 
 	/**

--- a/projects/plugins/boost/changelog/fix-obvious-wrong-class-names
+++ b/projects/plugins/boost/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -9,16 +9,16 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredClassMethod : 700+ occurrences
-    // PhanTypeMismatchArgument : 610+ occurrences
+    // PhanTypeMismatchArgument : 550+ occurrences
+    // PhanUndeclaredMethod : 370+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 360+ occurrences
+    // PhanUndeclaredClassMethod : 340+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 290+ occurrences
     // PhanUndeclaredFunction : 290+ occurrences
     // PhanNoopNew : 210+ occurrences
-    // PhanTypeMismatchReturn : 180+ occurrences
-    // PhanTypeMismatchReturnProbablyReal : 180+ occurrences
+    // PhanTypeMismatchReturn : 170+ occurrences
+    // PhanTypeMismatchReturnProbablyReal : 170+ occurrences
     // PhanDeprecatedFunction : 140+ occurrences
-    // PhanUndeclaredMethod : 130+ occurrences
     // PhanTypePossiblyInvalidDimOffset : 110+ occurrences
     // PhanTypeArraySuspiciousNullable : 95+ occurrences
     // PhanRedundantCondition : 70+ occurrences
@@ -26,27 +26,24 @@ return [
     // PhanPossiblyUndeclaredVariable : 65+ occurrences
     // PhanTypeMismatchArgumentNullable : 55+ occurrences
     // PhanUndeclaredGlobalVariable : 55+ occurrences
-    // PhanUndeclaredTypeParameter : 55+ occurrences
+    // PhanParamTooMany : 50+ occurrences
     // PhanTypeExpectedObjectPropAccess : 50+ occurrences
     // PhanTypeMismatchArgumentInternal : 50+ occurrences
-    // PhanUndeclaredClassProperty : 50+ occurrences
-    // PhanParamTooMany : 45+ occurrences
     // PhanUndeclaredProperty : 45+ occurrences
     // PhanPluginDuplicateAdjacentStatement : 40+ occurrences
     // PhanUndeclaredStaticProperty : 40+ occurrences
-    // PhanUndeclaredTypeReturnType : 40+ occurrences
     // PhanTypeInvalidDimOffset : 35+ occurrences
     // PhanParamSignatureMismatch : 30+ occurrences
     // PhanTypeMismatchPropertyProbablyReal : 30+ occurrences
     // PhanUndeclaredFunctionInCallable : 30+ occurrences
     // PhanDeprecatedProperty : 25+ occurrences
     // PhanPluginSimplifyExpressionBool : 25+ occurrences
-    // PhanTypeArraySuspicious : 25+ occurrences
     // PhanTypeMismatchDefault : 25+ occurrences
     // PhanTypeMissingReturn : 25+ occurrences
     // PhanUnextractableAnnotation : 25+ occurrences
     // PhanUnextractableAnnotationSuffix : 25+ occurrences
     // PhanMisspelledAnnotation : 20+ occurrences
+    // PhanTypeArraySuspicious : 20+ occurrences
     // PhanTypeMismatchArgumentNullableInternal : 20+ occurrences
     // PhanTypeMismatchDimFetch : 20+ occurrences
     // PhanTypeSuspiciousNonTraversableForeach : 20+ occurrences
@@ -57,6 +54,7 @@ return [
     // PhanTypeExpectedObjectPropAccessButGotNull : 15+ occurrences
     // PhanTypeMismatchProperty : 15+ occurrences
     // PhanTypeMismatchPropertyDefault : 15+ occurrences
+    // PhanUndeclaredClassProperty : 15+ occurrences
     // PhanRedefineClass : 10+ occurrences
     // PhanRedundantConditionInLoop : 10+ occurrences
     // PhanTypeComparisonToArray : 10+ occurrences
@@ -64,7 +62,8 @@ return [
     // PhanTypeMismatchReturnNullable : 10+ occurrences
     // PhanUndeclaredClassInstanceof : 10+ occurrences
     // PhanUndeclaredMethodInCallable : 10+ occurrences
-    // PhanUndeclaredTypeProperty : 10+ occurrences
+    // PhanUndeclaredTypeParameter : 10+ occurrences
+    // PhanUndeclaredTypeReturnType : 10+ occurrences
     // PhanCommentParamWithoutRealParam : 9 occurrences
     // PhanDeprecatedClass : 9 occurrences
     // PhanPluginRedundantAssignment : 8 occurrences
@@ -73,15 +72,15 @@ return [
     // PhanRedefineFunction : 7 occurrences
     // PhanTypeArraySuspiciousNull : 7 occurrences
     // PhanTypeMismatchArgumentInternalReal : 7 occurrences
-    // PhanUndeclaredClassInCallable : 7 occurrences
+    // PhanUndeclaredTypeProperty : 7 occurrences
     // PhanCommentAbstractOnInheritedMethod : 6 occurrences
     // PhanUndeclaredVariableDim : 6 occurrences
     // PhanUnextractableAnnotationElementName : 6 occurrences
     // PhanImpossibleCondition : 5 occurrences
     // PhanPluginUnreachableCode : 5 occurrences
     // PhanTypeMismatchDimAssignment : 5 occurrences
-    // PhanTypeSuspiciousEcho : 5 occurrences
     // PhanTypeSuspiciousStringExpression : 5 occurrences
+    // PhanUndeclaredClassInCallable : 5 occurrences
     // PhanAccessMethodInternal : 4 occurrences
     // PhanContextNotObject : 4 occurrences
     // PhanImpossibleTypeComparison : 4 occurrences
@@ -122,6 +121,7 @@ return [
     // PhanTypeInvalidCallableArraySize : 1 occurrence
     // PhanTypeMismatchForeach : 1 occurrence
     // PhanTypeMismatchReturnSuperType : 1 occurrence
+    // PhanTypeSuspiciousEcho : 1 occurrence
     // PhanTypeVoidArgument : 1 occurrence
     // PhanUndeclaredClassStaticProperty : 1 occurrence
     // PhanUndeclaredConstantOfClass : 1 occurrence
@@ -132,14 +132,13 @@ return [
         '3rd-party/bbpress.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],
         '3rd-party/class-domain-mapping.php' => ['PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunctionInCallable', 'PhanUndeclaredTypeReturnType'],
         '3rd-party/class-jetpack-bbpress-rest-api.php' => ['PhanUndeclaredFunction', 'PhanUnextractableAnnotationSuffix'],
-        '3rd-party/class-salesforce-lead-form.php' => ['PhanUndeclaredTypeReturnType'],
         '3rd-party/class.jetpack-amp-support.php' => ['PhanParamTooMany', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable'],
         '3rd-party/debug-bar/class-jetpack-search-debug-bar.php' => ['PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod'],
         '3rd-party/qtranslate-x.php' => ['PhanTypeMismatchReturn'],
         '3rd-party/woocommerce.php' => ['PhanParamTooMany', 'PhanUndeclaredFunction'],
         '3rd-party/wpml.php' => ['PhanUndeclaredFunction'],
         '_inc/blogging-prompts.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod'],
-        '_inc/class.jetpack-provision.php' => ['PhanAccessMethodInternal', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeReturnType'],
+        '_inc/class.jetpack-provision.php' => ['PhanAccessMethodInternal', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnNullable'],
         '_inc/genericons.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         '_inc/jetpack-server-sandbox.php' => ['PhanSuspiciousMagicConstant', 'PhanUndeclaredClassMethod'],
         '_inc/lib/admin-pages/class-jetpack-about-page.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
@@ -151,13 +150,13 @@ return [
         '_inc/lib/class-jetpack-instagram-gallery-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
         '_inc/lib/class-jetpack-mapbox-helper.php' => ['PhanTypeMismatchArgumentNullable', 'PhanUndeclaredFunction'],
         '_inc/lib/class-jetpack-podcast-feed-locator.php' => ['PhanDeprecatedFunctionInternal'],
-        '_inc/lib/class-jetpack-podcast-helper.php' => ['PhanMisspelledAnnotation', 'PhanStaticCallToNonStatic', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredTypeParameter'],
+        '_inc/lib/class-jetpack-podcast-helper.php' => ['PhanMisspelledAnnotation', 'PhanStaticCallToNonStatic', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousStringExpression'],
         '_inc/lib/class-jetpack-recommendations.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition'],
         '_inc/lib/class-jetpack-top-posts-helper.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         '_inc/lib/class.color.php' => ['PhanImpossibleTypeComparison', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeInvalidDimOffset', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeInvalidRightOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDefault'],
         '_inc/lib/class.core-rest-api-endpoints.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUnextractableAnnotationSuffix'],
         '_inc/lib/class.jetpack-keyring-service-helper.php' => ['PhanEmptyForeach', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeReturnType'],
-        '_inc/lib/class.jetpack-password-checker.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredTypeReturnType'],
+        '_inc/lib/class.jetpack-password-checker.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal'],
         '_inc/lib/class.media-extractor.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchDefault', 'PhanTypePossiblyInvalidDimOffset'],
         '_inc/lib/class.media-summary.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNull', 'PhanTypeMismatchArgument', 'PhanUndeclaredFunction'],
         '_inc/lib/class.media.php' => ['PhanTypeMismatchArgument', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredTypeParameter', 'PhanUnextractableAnnotation'],
@@ -170,7 +169,7 @@ return [
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php' => ['PhanPluginMixedKeyNoKey', 'PhanPluginSimplifyExpressionBool', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunctionInCallable'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-blog-stats.php' => ['PhanTypeMismatchReturnProbablyReal'],
-        '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod'],
+        '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-following.php' => ['PhanUndeclaredFunction'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-newsletter-categories-list.php' => ['PhanUndeclaredFunction', 'PhanUndeclaredMethod'],
@@ -191,8 +190,8 @@ return [
         '_inc/lib/core-api/wpcom-endpoints/trait-wpcom-rest-api-proxy-request-trait.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredProperty'],
         '_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMissingReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeReturnType'],
         '_inc/lib/debugger/class-jetpack-cxn-test-base.php' => ['PhanDeprecatedFunctionInternal', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn'],
-        '_inc/lib/debugger/class-jetpack-cxn-tests.php' => ['PhanPluginSimplifyExpressionBool', 'PhanUndeclaredClassMethod'],
-        '_inc/lib/debugger/class-jetpack-debug-data.php' => ['PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanUndeclaredClassMethod'],
+        '_inc/lib/debugger/class-jetpack-cxn-tests.php' => ['PhanPluginSimplifyExpressionBool'],
+        '_inc/lib/debugger/class-jetpack-debug-data.php' => ['PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanUndeclaredMethod'],
         '_inc/lib/debugger/class-jetpack-debugger.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/debugger/debug-functions.php' => ['PhanCommentParamOnEmptyParamList', 'PhanTypeMismatchReturnProbablyReal'],
         '_inc/lib/functions.wp-notify.php' => ['PhanTypeMismatchReturn'],
@@ -209,7 +208,7 @@ return [
         'class.jetpack-admin.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredConstant'],
         'class.jetpack-autoupdate.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'class.jetpack-cli.php' => ['PhanAccessMethodInternal', 'PhanParamTooMany', 'PhanParamTooManyCallable', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunctionInCallable'],
-        'class.jetpack-gutenberg.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
+        'class.jetpack-gutenberg.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredClassMethod'],
         'class.jetpack-heartbeat.php' => ['PhanTypeMismatchPropertyDefault'],
         'class.jetpack-modules-list-table.php' => ['PhanCommentAbstractOnInheritedMethod'],
         'class.jetpack-network-sites-list-table.php' => ['PhanCommentAbstractOnInheritedMethod'],
@@ -217,7 +216,7 @@ return [
         'class.jetpack-post-images.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
         'class.jetpack-twitter-cards.php' => ['PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredFunction'],
         'class.jetpack-user-agent.php' => ['PhanUndeclaredStaticMethod'],
-        'class.jetpack.php' => ['PhanAccessMethodInternal', 'PhanDeprecatedFunction', 'PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantConditionInLoop', 'PhanTypeArraySuspiciousNullable', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunctionInCallable', 'PhanUndeclaredTypeReturnType', 'PhanUnextractableAnnotation', 'PhanUnextractableAnnotationSuffix'],
+        'class.jetpack.php' => ['PhanAccessMethodInternal', 'PhanDeprecatedFunction', 'PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantConditionInLoop', 'PhanTypeArraySuspiciousNullable', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunctionInCallable', 'PhanUnextractableAnnotation', 'PhanUnextractableAnnotationSuffix'],
         'class.json-api-endpoints.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredClassStaticProperty', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUnextractableAnnotationElementName', 'PhanUnextractableAnnotationSuffix'],
         'class.json-api.php' => ['PhanPluginDuplicateSwitchCaseLooseEquality', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
         'enhanced-open-graph.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable'],
@@ -227,7 +226,7 @@ return [
         'extensions/blocks/calendly/calendly.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/contact-info/class-jetpack-contact-info-block.php' => ['PhanTypeMismatchReturn'],
         'extensions/blocks/cookie-consent/cookie-consent.php' => ['PhanParamTooMany', 'PhanUndeclaredFunction'],
-        'extensions/blocks/donations/donations.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchForeach', 'PhanUndeclaredClassProperty', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
+        'extensions/blocks/donations/donations.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchForeach', 'PhanUndeclaredFunction'],
         'extensions/blocks/gif/gif.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/google-calendar/google-calendar.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/google-docs-embed/google-docs-embed.php' => ['PhanRedundantCondition', 'PhanUndeclaredFunction'],
@@ -251,11 +250,10 @@ return [
         'extensions/blocks/premium-content/premium-content.php' => ['PhanUndeclaredFunction'],
         'extensions/blocks/rating-star/rating-meta.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/rating-star/rating-star.php' => ['PhanTypeMismatchArgumentNullableInternal'],
-        'extensions/blocks/related-posts/related-posts.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredTypeParameter'],
         'extensions/blocks/repeat-visitor/repeat-visitor.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'extensions/blocks/sharing-button/class-sharing-source-block.php' => ['PhanCommentParamWithoutRealParam', 'PhanImpossibleTypeComparison', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
-        'extensions/blocks/sharing-button/sharing-button.php' => ['PhanRedundantCondition', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
-        'extensions/blocks/simple-payments/simple-payments.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassProperty', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
+        'extensions/blocks/sharing-button/class-sharing-source-block.php' => ['PhanCommentParamWithoutRealParam', 'PhanImpossibleTypeComparison', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
+        'extensions/blocks/sharing-button/sharing-button.php' => ['PhanRedundantCondition'],
+        'extensions/blocks/simple-payments/simple-payments.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredFunction'],
         'extensions/blocks/slideshow/slideshow.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/story/story.php' => ['PhanImpossibleCondition', 'PhanMisspelledAnnotation', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable'],
         'extensions/blocks/subscriber-login/subscriber-login.php' => ['PhanUndeclaredFunction'],
@@ -267,17 +265,17 @@ return [
         'extensions/plugins/launchpad-save-modal/launchpad-save-modal.php' => ['PhanUndeclaredFunction'],
         'extensions/plugins/sharing/sharing.php' => ['PhanRedundantCondition'],
         'functions.compat.php' => ['PhanRedefineFunction', 'PhanTypeMismatchReturn'],
-        'functions.global.php' => ['PhanRedundantCondition', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanUndeclaredTypeParameter'],
+        'functions.global.php' => ['PhanRedundantCondition', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument'],
         'functions.opengraph.php' => ['PhanTypeArraySuspicious', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable'],
         'json-endpoints/class.wpcom-json-api-add-widget-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-autosave-post-v1-1-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-bulk-delete-post-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
-        'json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php' => ['PhanNoopNew', 'PhanParamSignatureMismatch', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeParameter'],
+        'json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php' => ['PhanNoopNew', 'PhanParamSignatureMismatch', 'PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-bulk-update-comments-endpoint.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'json-endpoints/class.wpcom-json-api-comment-endpoint.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod'],
         'json-endpoints/class.wpcom-json-api-delete-media-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-delete-media-v1-1-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchReturn'],
-        'json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod', 'PhanUnextractableAnnotation'],
+        'json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod', 'PhanUnextractableAnnotation'],
         'json-endpoints/class.wpcom-json-api-get-autosave-v1-1-endpoint.php' => ['PhanNoopNew'],
         'json-endpoints/class.wpcom-json-api-get-comment-counts-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-get-comment-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
@@ -288,8 +286,8 @@ return [
         'json-endpoints/class.wpcom-json-api-get-customcss.php' => ['PhanNoopNew', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod'],
         'json-endpoints/class.wpcom-json-api-get-media-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-get-media-v1-1-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchReturn'],
-        'json-endpoints/class.wpcom-json-api-get-media-v1-2-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchArgument'],
-        'json-endpoints/class.wpcom-json-api-get-post-counts-v1-1-endpoint.php' => ['PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredTypeProperty'],
+        'json-endpoints/class.wpcom-json-api-get-media-v1-2-endpoint.php' => ['PhanNoopNew'],
+        'json-endpoints/class.wpcom-json-api-get-post-counts-v1-1-endpoint.php' => ['PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'json-endpoints/class.wpcom-json-api-get-post-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php' => ['PhanNoopNew', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
         'json-endpoints/class.wpcom-json-api-get-site-endpoint.php' => ['PhanNoopNew', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanUndeclaredMethod', 'PhanUndeclaredMethodInCallable'],
@@ -341,7 +339,7 @@ return [
         'json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php' => ['PhanNonClassMethodCall', 'PhanNoopNew', 'PhanRedundantCondition', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable', 'PhanUndeclaredMethod'],
         'json-endpoints/jetpack/class-jetpack-json-api-delete-backup-helper-script-endpoint.php' => ['PhanParamSignatureMismatch'],
         'json-endpoints/jetpack/class-jetpack-json-api-install-backup-helper-script-endpoint.php' => ['PhanParamSignatureMismatch'],
-        'json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredTypeParameter'],
+        'json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'json-endpoints/jetpack/class.jetpack-json-api-core-modify-endpoint.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'json-endpoints/jetpack/class.jetpack-json-api-cron-endpoint.php' => ['PhanTypeComparisonToArray', 'PhanTypeMismatchArgument'],
         'json-endpoints/jetpack/class.jetpack-json-api-endpoint.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
@@ -362,7 +360,7 @@ return [
         'json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php' => ['PhanNoopNew', 'PhanTypeInvalidLeftOperandOfBitwiseOp', 'PhanTypeInvalidRightOperandOfBitwiseOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
         'json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php' => ['PhanNoopNew', 'PhanTypeInvalidLeftOperandOfBitwiseOp', 'PhanTypeInvalidRightOperandOfBitwiseOp'],
         'json-endpoints/jetpack/class.jetpack-json-api-plugins-new-endpoint.php' => ['PhanNoopNew', 'PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeMissingReturn', 'PhanUndeclaredMethod'],
-        'json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php' => ['PhanParamSignatureMismatch', 'PhanParamTooManyCallable', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod'],
+        'json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php' => ['PhanParamSignatureMismatch', 'PhanParamTooManyCallable', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredMethod'],
         'json-endpoints/jetpack/class.jetpack-json-api-themes-active-endpoint.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'json-endpoints/jetpack/class.jetpack-json-api-themes-endpoint.php' => ['PhanParamSignatureMismatch', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty'],
         'json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php' => ['PhanTypeMismatchArgumentProbablyReal'],
@@ -374,15 +372,13 @@ return [
         'json-endpoints/jetpack/class.wpcom-json-api-update-option-endpoint.php' => ['PhanTypeMismatchPropertyProbablyReal'],
         'json-endpoints/jetpack/json-api-jetpack-endpoints.php' => ['PhanNoopNew'],
         'modules/calypsoify/class-jetpack-calypsoify.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyDefault'],
-        'modules/carousel/jetpack-carousel.php' => ['PhanDeprecatedProperty', 'PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
+        'modules/carousel/jetpack-carousel.php' => ['PhanDeprecatedProperty', 'PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn'],
         'modules/comments/admin.php' => ['PhanTypeMismatchReturn', 'PhanUndeclaredProperty'],
         'modules/comments/base.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
         'modules/comments/comments.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanUndeclaredFunction'],
         'modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnNullable'],
         'modules/contact-form/admin.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredMethod'],
-        'modules/contact-form/class-grunion-contact-form-endpoint.php' => ['PhanTypeMismatchArgument'],
         'modules/contact-form/grunion-contact-form.php' => ['PhanDeprecatedClass', 'PhanDeprecatedFunction', 'PhanDeprecatedProperty', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredStaticProperty', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty', 'PhanUnextractableAnnotationElementName'],
-        'modules/contact-form/grunion-editor-view.php' => ['PhanTypeMismatchArgument'],
         'modules/copy-post.php' => ['PhanNoopNew'],
         'modules/custom-css/csstidy/class.csstidy-ctype.php' => ['PhanRedefineFunctionInternal'],
         'modules/custom-css/csstidy/class.csstidy-optimise.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginSimplifyExpressionBool', 'PhanTypeComparisonFromArray', 'PhanTypeConversionFromArray', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeInvalidRightOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchReturnProbablyReal'],
@@ -391,7 +387,7 @@ return [
         'modules/custom-css/custom-css.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable'],
         'modules/custom-post-types/comics.php' => ['PhanParamTooMany', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable'],
         'modules/custom-post-types/nova.php' => ['PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredFunction'],
-        'modules/custom-post-types/portfolios.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousEcho', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeReturnType'],
+        'modules/custom-post-types/portfolios.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredFunction'],
         'modules/custom-post-types/testimonial.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'modules/geo-location.php' => ['PhanTypeMismatchArgumentNullable'],
         'modules/geo-location/class.jetpack-geo-location.php' => ['PhanTypeMismatchArgument'],
@@ -404,7 +400,7 @@ return [
         'modules/google-fonts/current/class-jetpack-google-font-face.php' => ['PhanUndeclaredFunctionInCallable'],
         'modules/google-fonts/current/load-google-fonts.php' => ['PhanNoopNew', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturnProbablyReal'],
         'modules/google-fonts/wordpress-6.3/load-google-fonts.php' => ['PhanUndeclaredFunction'],
-        'modules/gravatar-hovercards.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredTypeParameter', 'PhanUnextractableAnnotationSuffix'],
+        'modules/gravatar-hovercards.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUnextractableAnnotationSuffix'],
         'modules/infinite-scroll.php' => ['PhanUndeclaredClassMethod'],
         'modules/infinite-scroll/infinity.php' => ['PhanNoopNew', 'PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction'],
         'modules/latex.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
@@ -424,7 +420,7 @@ return [
         'modules/masterbar/admin-menu/load.php' => ['PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable'],
         'modules/masterbar/inline-help/class-inline-help.php' => ['PhanTypeSuspiciousEcho'],
         'modules/masterbar/inline-help/inline-help-template.php' => ['PhanUndeclaredGlobalVariable'],
-        'modules/masterbar/masterbar/class-masterbar.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
+        'modules/masterbar/masterbar/class-masterbar.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'modules/masterbar/profile-edit/bootstrap.php' => ['PhanNoopNew'],
         'modules/memberships/class-jetpack-memberships.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod'],
         'modules/module-headings.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
@@ -435,7 +431,7 @@ return [
         'modules/publicize.php' => ['PhanNoopNew', 'PhanPluginSimplifyExpressionBool', 'PhanRedefineFunction', 'PhanTypeMismatchProperty', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredTypeReturnType'],
         'modules/related-posts/class.related-posts-customize.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing'],
         'modules/related-posts/jetpack-related-posts.php' => ['PhanMisspelledAnnotation', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction'],
-        'modules/scan/class-admin-bar-notice.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
+        'modules/scan/class-admin-bar-notice.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal'],
         'modules/scan/class-admin-sidebar-link.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'modules/search.php' => ['PhanTypeMismatchArgument'],
         'modules/seo-tools.php' => ['PhanNoopNew'],
@@ -473,7 +469,7 @@ return [
         'modules/shortcodes/untappd-menu.php' => ['PhanNoopNew'],
         'modules/shortcodes/ustream.php' => ['PhanTypeMismatchArgument'],
         'modules/shortcodes/vimeo.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
-        'modules/shortcodes/vr.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeReturnType'],
+        'modules/shortcodes/vr.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction'],
         'modules/shortcodes/wordads.php' => ['PhanNoopNew'],
         'modules/shortcodes/youtube.php' => ['PhanRedefineFunction', 'PhanTypeMismatchArgument', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction'],
         'modules/shortlinks.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal'],
@@ -501,7 +497,6 @@ return [
         'modules/sso/class.jetpack-sso-helpers.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
         'modules/sso/class.jetpack-sso-user-admin.php' => ['PhanPluginUnreachableCode', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUnextractableAnnotation'],
         'modules/stats.php' => ['PhanDeprecatedFunction', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanUnextractableAnnotationSuffix'],
-        'modules/stats/class-jetpack-stats-upgrade-nudges.php' => ['PhanTypeMismatchArgument'],
         'modules/subscriptions.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredFunctionInCallable'],
         'modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php' => ['PhanTypeMismatchReturnNullable'],
         'modules/subscriptions/views.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
@@ -515,7 +510,7 @@ return [
         'modules/theme-tools/content-options/post-details.php' => ['PhanTypeArraySuspiciousNullable'],
         'modules/theme-tools/featured-content.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeComparisonToArray', 'PhanTypeInvalidCallableArraySize', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanTypePossiblyInvalidDimOffset'],
         'modules/theme-tools/site-breadcrumbs.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
-        'modules/theme-tools/site-logo/inc/class-site-logo.php' => ['PhanRedundantCondition', 'PhanTypeComparisonToArray', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeParameter'],
+        'modules/theme-tools/site-logo/inc/class-site-logo.php' => ['PhanRedundantCondition', 'PhanTypeComparisonToArray', 'PhanTypeMismatchReturn'],
         'modules/theme-tools/site-logo/inc/functions.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'modules/theme-tools/social-links.php' => ['PhanMisspelledAnnotation', 'PhanNoopNew', 'PhanTypeMismatchArgumentInternal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeProperty'],
         'modules/theme-tools/social-menu.php' => ['PhanTypeMismatchArgumentNullable'],
@@ -533,13 +528,13 @@ return [
         'modules/tiled-gallery/tiled-gallery/tiled-gallery-shape.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'modules/tiled-gallery/tiled-gallery/tiled-gallery-square.php' => ['PhanTypeMismatchArgument'],
         'modules/videopress/class-videopress-attachment-metadata.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
-        'modules/videopress/class.jetpack-videopress.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchDefault'],
+        'modules/videopress/class.jetpack-videopress.php' => ['PhanTypeMismatchDefault'],
         'modules/videopress/class.videopress-cli.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredFunctionInCallable'],
         'modules/videopress/class.videopress-edit-attachment.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantConditionInLoop', 'PhanTypeMismatchArgumentProbablyReal'],
         'modules/videopress/class.videopress-gutenberg.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
-        'modules/videopress/class.videopress-player.php' => ['PhanImpossibleCondition', 'PhanPluginMixedKeyNoKey', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty', 'PhanUndeclaredTypeReturnType'],
+        'modules/videopress/class.videopress-player.php' => ['PhanImpossibleCondition', 'PhanPluginMixedKeyNoKey', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentNullable', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty'],
         'modules/videopress/class.videopress-video.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
-        'modules/videopress/editor-media-view.php' => ['PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument'],
+        'modules/videopress/editor-media-view.php' => ['PhanSuspiciousMagicConstant'],
         'modules/videopress/shortcode.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'modules/widget-visibility/widget-conditions.php' => ['PhanCommentParamWithoutRealParam', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeComparisonToArray', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach'],
         'modules/widgets/authors.php' => ['PhanTypeMismatchArgument', 'PhanTypeMissingReturn'],
@@ -566,7 +561,7 @@ return [
         'modules/widgets/milestone/class-milestone-widget.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeMissingReturn', 'PhanTypePossiblyInvalidDimOffset'],
         'modules/widgets/my-community.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'modules/widgets/rsslinks-widget.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal'],
-        'modules/widgets/simple-payments.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeReturnType'],
+        'modules/widgets/simple-payments.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredFunction'],
         'modules/widgets/simple-payments/form.php' => ['PhanAccessPropertyPrivate', 'PhanUndeclaredGlobalVariable', 'PhanUndeclaredThis'],
         'modules/widgets/simple-payments/widget.php' => ['PhanTypeArraySuspiciousNullable'],
         'modules/widgets/social-icons.php' => ['PhanPluginSimplifyExpressionBool'],
@@ -580,13 +575,13 @@ return [
         'modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php' => ['PhanDeprecatedFunction', 'PhanDeprecatedTrait', 'PhanUndeclaredFunction'],
         'modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php' => ['PhanDeprecatedFunction', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter'],
         'modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php' => ['PhanDeprecatedFunction', 'PhanDeprecatedTrait', 'PhanPluginRedundantAssignment', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUnextractableAnnotationSuffix'],
-        'modules/wordads/class-wordads.php' => ['PhanNonClassMethodCall', 'PhanPluginRedundantAssignment', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeReturnType', 'PhanUnextractableAnnotation'],
+        'modules/wordads/class-wordads.php' => ['PhanNonClassMethodCall', 'PhanPluginRedundantAssignment', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUnextractableAnnotation'],
         'modules/wordads/php/class-wordads-admin.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'modules/wordads/php/class-wordads-api.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'modules/wordads/php/class-wordads-params.php' => ['PhanTypeMismatchReturn'],
         'modules/wordads/php/class-wordads-sidebar-widget.php' => ['PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeMismatchArgument'],
         'modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php' => ['PhanPluginUseReturnValueInternalKnown'],
-        'modules/wpcom-block-editor/functions.editor-type.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassProperty', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
+        'modules/wpcom-block-editor/functions.editor-type.php' => ['PhanUndeclaredFunction'],
         'modules/wpcom-tos/wpcom-tos.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'sal/class.json-api-date.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentInternalProbablyReal'],
         'sal/class.json-api-links.php' => ['PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
@@ -595,7 +590,7 @@ return [
         'sal/class.json-api-site-jetpack-base.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal'],
         'sal/class.json-api-site-jetpack.php' => ['PhanParamSignatureMismatch', 'PhanUndeclaredFunction'],
         'sal/class.json-api-token.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanSuspiciousValueComparison', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredVariable'],
-        'src/class-jetpack-crm-data.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeReturnType'],
+        'src/class-jetpack-crm-data.php' => ['PhanUndeclaredFunction'],
         'src/class-jetpack-modules-overrides.php' => ['PhanRedundantCondition'],
         'src/class-tracking.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeParameter'],
         'tests/php/3rd-party/test__atomic.php' => ['PhanTypeMismatchArgument'],
@@ -609,14 +604,13 @@ return [
         'tests/php/core-api/test_class-wpcom-rest-field-controller.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php' => ['PhanUndeclaredMethod'],
         'tests/php/core-api/test_class.jetpack-core-api-xmlrpc-consumer-endpoint.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeReturnType'],
+        'tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchReturn'],
         'tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-external-media.php' => ['PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument'],
         'tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-publicize-share-post.php' => ['PhanTypeMismatchArgument'],
         'tests/php/core-api/wpcom-fields/class-test-wpcom-rest-api-v2-attachment-videopress-data.php' => ['PhanDeprecatedFunction', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod'],
-        'tests/php/core-api/wpcom-fields/test-attachment-fields-videopress.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument', 'PhanUndeclaredMethod'],
+        'tests/php/core-api/wpcom-fields/test-attachment-fields-videopress.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
         'tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeComparisonToArray', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredTypeProperty'],
         'tests/php/extensions/blocks/premium-content/test_class.jetpack-premium-content.php' => ['PhanDeprecatedProperty', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredClassMethod'],
-        'tests/php/extensions/blocks/test-repeat-visitor.php' => ['PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredTypeProperty'],
         'tests/php/extensions/blocks/test-story.php' => ['PhanUndeclaredMethodInCallable'],
         'tests/php/general/test-class.jetpack-gutenberg.php' => ['PhanPluginDuplicateAdjacentStatement'],
         'tests/php/general/test-class.jetpack-options.php' => ['PhanTypeMismatchArgument'],
@@ -624,7 +618,6 @@ return [
         'tests/php/general/test_class.jetpack-user-agent.php' => ['PhanDeprecatedFunction'],
         'tests/php/general/test_class.jetpack-xmlrpc-server.php' => ['PhanDeprecatedFunction', 'PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeMismatchArgument'],
         'tests/php/general/test_class.jetpack.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyDefault', 'PhanTypeVoidArgument'],
-        'tests/php/json-api/test-class.json-api-jetpack-endpoints-accessibility.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredTypeProperty'],
         'tests/php/json-api/test-class.json-api-jetpack-endpoints.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/json-api/test-class.json-api-jetpack-site-endpoints.php' => ['PhanImpossibleConditionInLoop'],
         'tests/php/json-api/test-class.json-api-plugins-endpoints.php' => ['PhanTypeMismatchArgument'],
@@ -638,7 +631,6 @@ return [
         'tests/php/modules/geo-location/test_class.jetpack-geo-location.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeReturnType'],
         'tests/php/modules/google-analytics/test-class.google-analytics.php' => ['PhanDeprecatedFunction', 'PhanUndeclaredMethod'],
         'tests/php/modules/google-analytics/test-class.jetpack-google-amp-analytics.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable', 'PhanUndeclaredTypeProperty', 'PhanUndeclaredTypeReturnType'],
-        'tests/php/modules/masterbar/data/admin-menu.php' => ['PhanTypeMismatchReturn', 'PhanUndeclaredTypeReturnType'],
         'tests/php/modules/masterbar/test-class-admin-color-schemes.php' => ['PhanNoopNew'],
         'tests/php/modules/masterbar/test-class-admin-menu.php' => ['PhanTypeArraySuspiciousNull', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidDimOffset', 'PhanTypePossiblyInvalidDimOffset'],
         'tests/php/modules/masterbar/test-class-atomic-admin-menu.php' => ['PhanRedefineFunction', 'PhanTypeArraySuspiciousNull', 'PhanTypeInvalidDimOffset'],
@@ -672,40 +664,39 @@ return [
         'tests/php/modules/widgets/test_contact-info-widget.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/modules/widgets/test_wordpress-post-widget.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunctionInCallable', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty'],
         'tests/php/sync/class-test-jetpack-sync-search.php' => ['PhanStaticCallToNonStatic', 'PhanTypeMismatchArgumentInternal'],
-        'tests/php/sync/class-wp-test-jetpack-sync-queue-base-tests.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod'],
+        'tests/php/sync/class-wp-test-jetpack-sync-queue-base-tests.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
         'tests/php/sync/server/class.jetpack-sync-server-eventstore.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'tests/php/sync/server/class.jetpack-sync-server-replicator.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanUndeclaredMethod'],
         'tests/php/sync/server/class.jetpack-sync-test-object-factory.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/sync/server/class.jetpack-sync-test-replicastore.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeInvalidLeftOperandOfAdd'],
         'tests/php/sync/test-class.jetpack-sync-checksum-smoke.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
         'tests/php/sync/test-class.jetpack-sync-checksum.php' => ['PhanNoopNew', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchReturn', 'PhanUndeclaredProperty'],
-        'tests/php/sync/test_class.jetpack-sync-actions.php' => ['PhanUndeclaredClassMethod'],
+        'tests/php/sync/test_class.jetpack-sync-actions.php' => ['PhanUndeclaredMethod'],
         'tests/php/sync/test_class.jetpack-sync-base.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod'],
-        'tests/php/sync/test_class.jetpack-sync-callables.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunctionInCallable'],
-        'tests/php/sync/test_class.jetpack-sync-comments.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod'],
-        'tests/php/sync/test_class.jetpack-sync-constants.php' => ['PhanUndeclaredClassMethod'],
-        'tests/php/sync/test_class.jetpack-sync-full-immediately.php' => ['PhanParamTooMany', 'PhanPluginDuplicateAdjacentStatement', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredVariableDim'],
-        'tests/php/sync/test_class.jetpack-sync-full.php' => ['PhanParamTooMany', 'PhanPluginDuplicateAdjacentStatement', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchArgumentReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredProperty'],
+        'tests/php/sync/test_class.jetpack-sync-callables.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredFunctionInCallable', 'PhanUndeclaredMethod'],
+        'tests/php/sync/test_class.jetpack-sync-comments.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredMethod'],
+        'tests/php/sync/test_class.jetpack-sync-constants.php' => ['PhanUndeclaredMethod'],
+        'tests/php/sync/test_class.jetpack-sync-full-immediately.php' => ['PhanParamTooMany', 'PhanPluginDuplicateAdjacentStatement', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod', 'PhanUndeclaredVariableDim'],
+        'tests/php/sync/test_class.jetpack-sync-full.php' => ['PhanParamTooMany', 'PhanPluginDuplicateAdjacentStatement', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchArgumentReal', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty'],
         'tests/php/sync/test_class.jetpack-sync-import.php' => ['PhanRedefineClass'],
-        'tests/php/sync/test_class.jetpack-sync-integration.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredClassMethod'],
+        'tests/php/sync/test_class.jetpack-sync-integration.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredMethod'],
         'tests/php/sync/test_class.jetpack-sync-menus.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/sync/test_class.jetpack-sync-meta.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod'],
+        'tests/php/sync/test_class.jetpack-sync-meta.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument'],
         'tests/php/sync/test_class.jetpack-sync-module-protect.php' => ['PhanTypeMismatchArgument'],
         'tests/php/sync/test_class.jetpack-sync-modules-stats.php' => ['PhanParamTooMany'],
-        'tests/php/sync/test_class.jetpack-sync-network-options.php' => ['PhanUndeclaredClassMethod'],
-        'tests/php/sync/test_class.jetpack-sync-options.php' => ['PhanUndeclaredClassMethod'],
+        'tests/php/sync/test_class.jetpack-sync-network-options.php' => ['PhanUndeclaredMethod'],
+        'tests/php/sync/test_class.jetpack-sync-options.php' => ['PhanUndeclaredMethod'],
         'tests/php/sync/test_class.jetpack-sync-plugins-updates.php' => ['PhanTypeMismatchArgument'],
-        'tests/php/sync/test_class.jetpack-sync-posts.php' => ['PhanDeprecatedFunction', 'PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethodInCallable'],
+        'tests/php/sync/test_class.jetpack-sync-posts.php' => ['PhanDeprecatedFunction', 'PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod', 'PhanUndeclaredMethodInCallable'],
         'tests/php/sync/test_class.jetpack-sync-queue-custom-table.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/sync/test_class.jetpack-sync-queue-options-table.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/sync/test_class.jetpack-sync-queue.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod'],
-        'tests/php/sync/test_class.jetpack-sync-sender.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod'],
-        'tests/php/sync/test_class.jetpack-sync-term-relationships.php' => ['PhanPluginUnreachableCode', 'PhanUndeclaredClassMethod'],
-        'tests/php/sync/test_class.jetpack-sync-terms.php' => ['PhanUndeclaredClassMethod'],
-        'tests/php/sync/test_class.jetpack-sync-themes.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanUndeclaredClassMethod'],
-        'tests/php/sync/test_class.jetpack-sync-updates.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod'],
-        'tests/php/sync/test_class.jetpack-sync-users.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod'],
-        'tests/php/sync/test_class.jetpack-sync-woocommerce.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
+        'tests/php/sync/test_class.jetpack-sync-queue.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
+        'tests/php/sync/test_class.jetpack-sync-sender.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
+        'tests/php/sync/test_class.jetpack-sync-term-relationships.php' => ['PhanPluginUnreachableCode', 'PhanUndeclaredMethod'],
+        'tests/php/sync/test_class.jetpack-sync-themes.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanUndeclaredMethod'],
+        'tests/php/sync/test_class.jetpack-sync-updates.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredMethod', 'PhanUndeclaredMethodInCallable'],
+        'tests/php/sync/test_class.jetpack-sync-users.php' => ['PhanTypeMismatchArgument'],
+        'tests/php/sync/test_class.jetpack-sync-woocommerce.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod'],
         'tests/php/sync/test_class.jetpack-sync-wp_super_cache.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspiciousNullable'],
         'tests/php/sync/test_interface.jetpack-sync-replicastore.php' => ['PhanRedundantConditionInLoop', 'PhanTypeObjectUnsetDeclaredProperty', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod'],
         'tests/php/test_class.functions.opengraph.php' => ['PhanTypeMismatchArgumentProbablyReal'],

--- a/projects/plugins/jetpack/3rd-party/class-salesforce-lead-form.php
+++ b/projects/plugins/jetpack/3rd-party/class-salesforce-lead-form.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack;
 
+use WP_Error;
+
 /**
  * Class Salesforce_Lead_Form
  *

--- a/projects/plugins/jetpack/_inc/class.jetpack-provision.php
+++ b/projects/plugins/jetpack/_inc/class.jetpack-provision.php
@@ -267,7 +267,7 @@ class Jetpack_Provision {
 	 *
 	 * @param string $access_token Access token.
 	 *
-	 * @return array|\Automattic\Jetpack\Connection\WP_Error|bool|WP_Error
+	 * @return array|bool|WP_Error
 	 */
 	private static function verify_token( $access_token ) {
 		$request = array(

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-podcast-helper.php
@@ -496,7 +496,7 @@ class Jetpack_Podcast_Helper {
 	/**
 	 * Returns the track duration as a formatted string.
 	 *
-	 * @param number $duration of the track in seconds.
+	 * @param int|float $duration of the track in seconds.
 	 * @return string
 	 */
 	protected function format_track_duration( $duration ) {

--- a/projects/plugins/jetpack/_inc/lib/class.jetpack-password-checker.php
+++ b/projects/plugins/jetpack/_inc/lib/class.jetpack-password-checker.php
@@ -410,7 +410,7 @@ class Jetpack_Password_Checker {
 	 *
 	 * @param Mixed $needle the needle.
 	 * @param array $haystack the haystack.
-	 * @return is the needle not in the haystack?
+	 * @return bool is the needle not in the haystack?
 	 */
 	protected function negative_in_array( $needle, $haystack ) {
 		if ( in_array( $needle, $haystack, true ) ) {

--- a/projects/plugins/jetpack/_inc/lib/class.media.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media.php
@@ -37,7 +37,7 @@ class Jetpack_Media {
 	 * The hash is built according to the filename trying to avoid name collisions
 	 * with other media files.
 	 *
-	 * @param  number $media_id - media post ID.
+	 * @param  int    $media_id - media post ID.
 	 * @param  string $new_filename - the new filename.
 	 * @return string A random filename.
 	 */
@@ -237,7 +237,7 @@ class Jetpack_Media {
 	/**
 	 * Return the `revision_history` of the given media.
 	 *
-	 * @param  number $media_id - media post ID.
+	 * @param  int $media_id - media post ID.
 	 * @return array `revision_history` array
 	 */
 	public static function get_revision_history( $media_id ) {
@@ -433,8 +433,8 @@ class Jetpack_Media {
 	 *
 	 * Note this does not support sideloads, only uploads.
 	 *
-	 * @param  number $media_id - media post ID.
-	 * @param  array  $file_array - Data derived from `$_FILES` for an uploaded file.
+	 * @param  int   $media_id - media post ID.
+	 * @param  array $file_array - Data derived from `$_FILES` for an uploaded file.
 	 * @return {Post|WP_Error} Updated media item or a WP_Error is something went wrong.
 	 */
 	public static function edit_media_file( $media_id, $file_array ) {

--- a/projects/plugins/jetpack/changelog/fix-obvious-wrong-class-names
+++ b/projects/plugins/jetpack/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -928,7 +928,7 @@ class Jetpack_Gutenberg {
 	 *
 	 * @since 8.1.0
 	 *
-	 * @param obj    $preset_extensions_manifest List of extensions available in Jetpack.
+	 * @param object $preset_extensions_manifest List of extensions available in Jetpack.
 	 * @param string $blocks_variation           Subset of blocks. production|beta|experimental.
 	 *
 	 * @return array $preset_extensions Array of extensions for that variation

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1332,7 +1332,7 @@ class Jetpack {
 	/**
 	 * Does the network allow admins to add new users.
 	 *
-	 * @return boolian
+	 * @return bool
 	 */
 	public static function network_add_new_users() {
 		return (bool) get_site_option( 'add_new_users' );
@@ -1341,7 +1341,7 @@ class Jetpack {
 	 * File upload psace left per site in MB.
 	 *  -1 means NO LIMIT.
 	 *
-	 * @return number
+	 * @return int
 	 */
 	public static function network_site_upload_space() {
 		// value in MB.
@@ -1360,7 +1360,7 @@ class Jetpack {
 	/**
 	 * Maximum file upload size set by the network.
 	 *
-	 * @return number
+	 * @return int
 	 */
 	public static function network_max_upload_file_size() {
 		// value in KB.

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -11,6 +11,7 @@ namespace Automattic\Jetpack\Extensions\Donations;
 
 use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
+use WP_Post;
 
 /**
  * Registers the block for use in Gutenberg

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -9,6 +9,7 @@
 namespace Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service;
 
 use Automattic\Jetpack\Extensions\Premium_Content\JWT;
+use WP_Post;
 use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_TIER_ID_SETTINGS;
 
 /**
@@ -249,14 +250,14 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	/**
 	 * Find metadata in post
 	 *
-	 * @param WP_Post|StdClass $post        Post.
-	 * @param string           $meta_key    Meta to retrieve.
+	 * @param WP_Post|object $post        Post.
+	 * @param string         $meta_key    Meta to retrieve.
 	 *
 	 * @return mixed|null
 	 */
 	private function find_metadata( $post, $meta_key ) {
 
-		if ( is_a( $post, '\WP_Post' ) ) {
+		if ( $post instanceof WP_Post ) {
 			return $post->{$meta_key};
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/related-posts.php
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/related-posts.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
+use WP_Block;
 
 /**
  * Registers the block for use in Gutenberg

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/class-sharing-source-block.php
@@ -13,6 +13,7 @@ namespace Automattic\Jetpack\Extensions\Sharing_Button_Block;
 
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 use Jetpack_PostImages;
+use WP_Post;
 
 /**
  * Base class for sharing sources.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
+use WP_Block_Template;
 
 require_once __DIR__ . '/class-sharing-source-block.php';
 require_once __DIR__ . '/components/social-icons.php';
@@ -257,7 +258,7 @@ function add_block_to_single_posts_template( $hooked_block_types, $relative_posi
 
 	// Only hook into page and single post templates.
 	if (
-		! $context instanceof \WP_Block_Template
+		! $context instanceof WP_Block_Template
 		|| ! property_exists( $context, 'slug' )
 		|| empty( $context->slug )
 		|| ! preg_match( '/^(page|single)/', $context->slug )

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/simple-payments.php
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/simple-payments.php
@@ -11,6 +11,7 @@ namespace Automattic\Jetpack\Extensions\SimplePayments;
 
 use Automattic\Jetpack\Blocks;
 use Jetpack_Simple_Payments;
+use WP_Post;
 
 const FEATURE_NAME = 'simple-payments';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -335,8 +335,8 @@ add_filter( 'upgrader_pre_download', 'jetpack_upgrader_pre_download' );
 
  * @deprecated Automattic\Jetpack\Sync\Functions::json_wrap
  *
- * @param array|obj $any        Source data to be cleaned up.
- * @param array     $seen_nodes Built array of nodes.
+ * @param array|object $any        Source data to be cleaned up.
+ * @param array        $seen_nodes Built array of nodes.
  *
  * @return array
  */

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-bulk-restore-post-endpoint.php
@@ -47,7 +47,7 @@ class WPCOM_JSON_API_Bulk_Restore_Post_Endpoint extends WPCOM_JSON_API_Update_Po
 	 *
 	 * @param string $path - the path.
 	 * @param int    $blog_id - the blog ID.
-	 * @param obj    $object - parameter is for making the method signature compatible with its parent class method.
+	 * @param object $object - parameter is for making the method signature compatible with its parent class method.
 	 */
 	public function callback( $path = '', $blog_id = 0, $object = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-counts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-counts-v1-1-endpoint.php
@@ -39,7 +39,7 @@ class WPCOM_JSON_API_GET_Post_Counts_V1_1_Endpoint extends WPCOM_JSON_API_Endpoi
 	/**
 	 * Whitelist array.
 	 *
-	 * @var allowlist
+	 * @var string[]
 	 */
 	private $allowlist = array( 'publish' );
 

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-check-capabilities-endpoint.php
@@ -12,7 +12,7 @@ class Jetpack_JSON_API_Check_Capabilities_Endpoint extends Jetpack_JSON_API_Modu
 	 *
 	 * @param string $path - the path.
 	 * @param int    $_blog_id - the blog ID.
-	 * @param obj    $object - parameter is for making the method signature compatible with its parent class method.
+	 * @param object $object - parameter is for making the method signature compatible with its parent class method.
 	 * @return bool|bool[]|WP_Error
 	 */
 	public function callback( $path = '', $_blog_id = 0, $object = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -1460,7 +1460,7 @@ class Jetpack_Carousel {
 	 *
 	 * @param mixed $value User input setting value.
 	 *
-	 * @return number Sanitized value, only 1 or 0.
+	 * @return int Sanitized value, only 1 or 0.
 	 */
 	public function carousel_display_exif_sanitize( $value ) {
 		return $this->sanitize_1or0_option( $value );
@@ -1469,9 +1469,9 @@ class Jetpack_Carousel {
 	/**
 	 * Return sanitized option for value that controls whether comments will be hidden or not.
 	 *
-	 * @param number $value Value to sanitize.
+	 * @param mixed $value Value to sanitize.
 	 *
-	 * @return number Sanitized value, only 1 or 0.
+	 * @return int Sanitized value, only 1 or 0.
 	 */
 	public function carousel_display_comments_sanitize( $value ) {
 		return $this->sanitize_1or0_option( $value );
@@ -1513,7 +1513,7 @@ class Jetpack_Carousel {
 	 *
 	 * @param mixed $value User input.
 	 *
-	 * @return number Sanitized value, only 1 or 0.
+	 * @return int Sanitized value, only 1 or 0.
 	 */
 	public function carousel_enable_it_sanitize( $value ) {
 		return $this->sanitize_1or0_option( $value );

--- a/projects/plugins/jetpack/modules/custom-post-types/portfolios.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/portfolios.php
@@ -694,7 +694,7 @@ class Jetpack_Portfolio {
 	 *
 	 * @param array $atts Shortcode attributes.
 	 *
-	 * @return portfolio_shortcode_html
+	 * @return string html
 	 */
 	public static function portfolio_shortcode( $atts ) {
 		// Default attributes.
@@ -860,7 +860,7 @@ class Jetpack_Portfolio {
 	 *
 	 * @param array $atts Shortcode attributes.
 	 *
-	 * @return html
+	 * @return string html
 	 */
 	private static function portfolio_shortcode_html( $atts ) {
 		$query                  = self::portfolio_query( $atts );
@@ -1011,7 +1011,7 @@ class Jetpack_Portfolio {
 	 *
 	 * @param int $post_id Post ID.
 	 *
-	 * @return html
+	 * @return string html
 	 */
 	private static function get_project_type( $post_id ) {
 		$project_types = get_the_terms( $post_id, self::CUSTOM_TAXONOMY_TYPE );
@@ -1044,7 +1044,7 @@ class Jetpack_Portfolio {
 	 *
 	 * @param int $post_id Post ID.
 	 *
-	 * @return html
+	 * @return string html
 	 */
 	private static function get_project_tags( $post_id ) {
 		$project_tags = get_the_terms( $post_id, self::CUSTOM_TAXONOMY_TAG );
@@ -1075,7 +1075,7 @@ class Jetpack_Portfolio {
 	/**
 	 * Displays the author of the current portfolio project.
 	 *
-	 * @return html
+	 * @return string html
 	 */
 	private static function get_project_author() {
 		$html  = '<div class="project-author">';
@@ -1095,7 +1095,7 @@ class Jetpack_Portfolio {
 	 *
 	 * @param int $post_id Post ID.
 	 *
-	 * @return html
+	 * @return string html
 	 */
 	private static function get_portfolio_thumbnail_link( $post_id ) {
 		if ( has_post_thumbnail( $post_id ) ) {

--- a/projects/plugins/jetpack/modules/gravatar-hovercards.php
+++ b/projects/plugins/jetpack/modules/gravatar-hovercards.php
@@ -381,7 +381,7 @@ function grofiles_hovercards_data_callbacks() {
 /**
  * Keyed JSON object containing all profile data provided by registered callbacks
  *
- * @param int|strung $author User ID or email address.
+ * @param int|string $author User ID or email address.
  *
  * @return array( data_key => data, ... )
  */

--- a/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-bar-notice.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Scan;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Redirect;
+use WP_Admin_Bar;
 
 /**
  * Class Main

--- a/projects/plugins/jetpack/modules/shortcodes/vr.php
+++ b/projects/plugins/jetpack/modules/shortcodes/vr.php
@@ -122,7 +122,7 @@ function jetpack_vr_viewer_get_html( $url_params ) {
  *
  * @param array $atts Shortcode attributes.
  *
- * @return html - complete vr viewer html
+ * @return string complete vr viewer html
  */
 function jetpack_vr_viewer_shortcode( $atts ) {
 	$params = shortcode_atts(

--- a/projects/plugins/jetpack/modules/theme-tools/site-logo/inc/class-site-logo.php
+++ b/projects/plugins/jetpack/modules/theme-tools/site-logo/inc/class-site-logo.php
@@ -365,7 +365,7 @@ class Site_Logo {
 	/**
 	 * Sanitize our header text Customizer setting.
 	 *
-	 * @param any $input The input value to sanitize.
+	 * @param mixed $input The input value to sanitize.
 	 * @return bool|string 1 if checked, empty string if not checked.
 	 */
 	public function sanitize_checkbox( $input ) {
@@ -375,7 +375,7 @@ class Site_Logo {
 	/**
 	 * Validate and sanitize a new site logo setting.
 	 *
-	 * @param any $input Logo setting value to sanitize.
+	 * @param mixed $input Logo setting value to sanitize.
 	 * @return int Attachment post ID, or 0 if invalid.
 	 */
 	public function sanitize_logo_setting( $input ) {

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -869,7 +869,7 @@ class VideoPress_Player {
 	 * Double-baked Flash object markup for Internet Explorer and more standards-friendly consuming agents.
 	 *
 	 * @since 1.1
-	 * @return HTML markup. Object and children.
+	 * @return string HTML markup. Object and children.
 	 */
 	private function flash_object() {
 		wp_enqueue_script( 'videopress' );

--- a/projects/plugins/jetpack/modules/widgets/simple-payments.php
+++ b/projects/plugins/jetpack/modules/widgets/simple-payments.php
@@ -344,7 +344,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 * Returns the number of decimal places on string representing a price.
 		 *
 		 * @param string $number Price to check.
-		 * @return number number of decimal places.
+		 * @return int|null number of decimal places.
 		 */
 		private function get_decimal_places( $number ) {
 			$parts = explode( '.', $number );

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -134,7 +134,7 @@ class WordAds {
 	 *
 	 * @param  string $option the option to grab.
 	 * @param  mixed  $default (optional).
-	 * @return option or $default if not set
+	 * @return mixed option or $default if not set
 	 *
 	 * @since 4.5.0
 	 */

--- a/projects/plugins/jetpack/modules/wpcom-block-editor/functions.editor-type.php
+++ b/projects/plugins/jetpack/modules/wpcom-block-editor/functions.editor-type.php
@@ -8,6 +8,8 @@
 
 namespace Jetpack\EditorType;
 
+use WP_Block_Editor_Context;
+
 /**
  * Remember when the classic editor was used to edit a post.
  *

--- a/projects/plugins/jetpack/src/class-jetpack-crm-data.php
+++ b/projects/plugins/jetpack/src/class-jetpack-crm-data.php
@@ -9,6 +9,8 @@
 
 namespace Automattic\Jetpack;
 
+use WP_Error;
+
 /**
  * Provides Jetpack CRM plugin data.
  */

--- a/projects/plugins/jetpack/src/class-tracking.php
+++ b/projects/plugins/jetpack/src/class-tracking.php
@@ -10,6 +10,8 @@ namespace Automattic\Jetpack\Plugin;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\IP\Utils as IP_Utils;
 use Automattic\Jetpack\Tracking as Tracks;
+use WP_Error;
+use WP_User;
 
 /**
  * Tracks class.
@@ -114,8 +116,8 @@ class Tracking {
 	 *
 	 * @access public
 	 *
-	 * @param string   $action Type of secret (one of 'register', 'authorize', 'publicize').
-	 * @param \WP_User $user The user object.
+	 * @param string  $action Type of secret (one of 'register', 'authorize', 'publicize').
+	 * @param WP_User $user The user object.
 	 */
 	public function jetpack_verify_secrets_begin( $action, $user ) {
 		$this->tracking->record_user_event( "jpc_verify_{$action}_begin", array(), $user );
@@ -126,8 +128,8 @@ class Tracking {
 	 *
 	 * @access public
 	 *
-	 * @param string   $action Type of secret (one of 'register', 'authorize', 'publicize').
-	 * @param \WP_User $user The user object.
+	 * @param string  $action Type of secret (one of 'register', 'authorize', 'publicize').
+	 * @param WP_User $user The user object.
 	 */
 	public function jetpack_verify_secrets_success( $action, $user ) {
 		$this->tracking->record_user_event( "jpc_verify_{$action}_success", array(), $user );
@@ -138,9 +140,9 @@ class Tracking {
 	 *
 	 * @access public
 	 *
-	 * @param string    $action Type of secret (one of 'register', 'authorize', 'publicize').
-	 * @param \WP_User  $user The user object.
-	 * @param \WP_Error $error Error object.
+	 * @param string   $action Type of secret (one of 'register', 'authorize', 'publicize').
+	 * @param WP_User  $user The user object.
+	 * @param WP_Error $error Error object.
 	 */
 	public function jetpack_verify_secrets_fail( $action, $user, $error ) {
 		$this->tracking->record_user_event(
@@ -176,7 +178,7 @@ class Tracking {
 	 * @access public
 	 *
 	 * @param string|int $error      The error code.
-	 * @param \WP_Error  $registered The error object.
+	 * @param WP_Error   $registered The error object.
 	 */
 	public function jetpack_connection_register_fail( $error, $registered ) {
 		$this->tracking->record_user_event(

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/test-class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -160,7 +160,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	/**
 	 * Data provider for test_prepare_menu_item.
 	 *
-	 * @return \string[][][]
+	 * @return string[][][]
 	 */
 	public function menu_item_data() {
 		return array(
@@ -233,7 +233,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	/**
 	 * Data provider for test_prepare_submenu_item.
 	 *
-	 * @return \string[][][]
+	 * @return string[][][]
 	 */
 	public function submenu_item_data() {
 		$plugin_slug = defined( 'IS_WPCOM' ) && IS_WPCOM ? 'akismet/akismet.png' : 'jetpack/jetpack.php';
@@ -368,7 +368,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	/**
 	 * Data provider for test_prepare_submenu_item.
 	 *
-	 * @return \string[][]
+	 * @return string[][]
 	 */
 	public function menu_item_icon_data() {
 		return array(
@@ -448,7 +448,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	/**
 	 * Data provider for test_prepare_menu_item_url.
 	 *
-	 * @return \string[][]
+	 * @return string[][]
 	 */
 	public function menu_item_url_data() {
 		$plugin_slug = defined( 'IS_WPCOM' ) && IS_WPCOM ? 'akismet/akismet.png' : 'jetpack/jetpack.php';
@@ -576,7 +576,7 @@ class WP_Test_WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_Test_Jetpack_REST
 	/**
 	 * Data provider for test_prepare_menu_item_url.
 	 *
-	 * @return \string[][]
+	 * @return string[][]
 	 */
 	public function menu_item_update_data() {
 		return array(

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/test-repeat-visitor.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/test-repeat-visitor.php
@@ -43,7 +43,7 @@ class Repeat_Visitor_Block_Test extends \Jetpack_Block_Fixture_TestCase {
 	 *
 	 * @access private
 	 *
-	 * @var number
+	 * @var int
 	 */
 	private $original_visit_counter;
 

--- a/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-endpoints-accessibility.php
+++ b/projects/plugins/jetpack/tests/php/json-api/test-class.json-api-jetpack-endpoints-accessibility.php
@@ -22,13 +22,13 @@ class WP_Test_Jetpack_Json_Api_Endpoints_Accessibility extends WP_UnitTestCase {
 	/**
 	 * An admin user_id.
 	 *
-	 * @var number $admin_user_id.
+	 * @var int $admin_user_id.
 	 */
 	private static $admin_user_id;
 	/**
 	 * The user_id of a user without read capabilities.
 	 *
-	 * @var number $no_read_user_id.
+	 * @var int $no_read_user_id.
 	 */
 	private static $no_read_user_id;
 

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/data/admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/data/admin-menu.php
@@ -8,7 +8,7 @@
 /**
  * Menu fixture data.
  *
- * @return \string[][]
+ * @return string[][]
  */
 function get_menu_fixture() {
 	return array(
@@ -158,7 +158,7 @@ function get_menu_fixture() {
 /**
  * WPCom Menu fixture data.
  *
- * @return \string[][]
+ * @return string[][]
  */
 function get_wpcom_menu_fixture() {
 	$gutenberg_menus = array(
@@ -178,7 +178,7 @@ function get_wpcom_menu_fixture() {
 /**
  * Submenu fixture data.
  *
- * @return \string[][][]
+ * @return string[][][]
  */
 function get_submenu_fixture() {
 	return array(

--- a/projects/plugins/migration/.phan/baseline.php
+++ b/projects/plugins/migration/.phan/baseline.php
@@ -9,18 +9,14 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 3 occurrences
     // PhanNoopNew : 2 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 1 occurrence
     // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
-    // PhanTypeMismatchReturn : 1 occurrence
-    // PhanUndeclaredTypeParameter : 1 occurrence
-    // PhanUndeclaredTypeReturnType : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeReturnType'],
-        'src/class-wpcom-migration.php' => ['PhanNoopNew', 'PhanTypeMismatchArgument'],
+        'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
+        'src/class-wpcom-migration.php' => ['PhanNoopNew'],
         'wpcom-migration.php' => ['PhanNoopNew'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/plugins/migration/changelog/fix-obvious-wrong-class-names
+++ b/projects/plugins/migration/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/plugins/migration/src/class-rest-controller.php
+++ b/projects/plugins/migration/src/class-rest-controller.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Migration;
 
 use Automattic\Jetpack\Connection\Client;
+use WP_Error;
 
 /**
  * Makes REST API Endpoints for Migration
@@ -71,7 +72,7 @@ class REST_Controller {
 			'wpcom-migration'
 		);
 
-		return new \WP_Error( 'rest_forbidden', $error_msg, array( 'status' => rest_authorization_required_code() ) );
+		return new WP_Error( 'rest_forbidden', $error_msg, array( 'status' => rest_authorization_required_code() ) );
 	}
 
 	/**
@@ -91,7 +92,7 @@ class REST_Controller {
 			return $body;
 		}
 
-		return new \WP_Error(
+		return new WP_Error(
 			isset( $body['error'] ) ? 'remote-error-' . $body['error'] : 'remote-error',
 			isset( $body['message'] ) ? $body['message'] : 'unknown remote error',
 			array( 'status' => $status_code )

--- a/projects/plugins/protect/.phan/baseline.php
+++ b/projects/plugins/protect/.phan/baseline.php
@@ -10,11 +10,9 @@
 return [
     // # Issue statistics:
     // PhanPluginDuplicateConditionalNullCoalescing : 45+ occurrences
-    // PhanTypeArraySuspicious : 8 occurrences
     // PhanParamTooMany : 6 occurrences
     // PhanTypeMismatchArgument : 5 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 5 occurrences
-    // PhanUndeclaredTypeParameter : 5 occurrences
     // PhanTypeMismatchProperty : 2 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
     // PhanNoopNew : 1 occurrence
@@ -27,7 +25,7 @@ return [
         'src/class-credentials.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-plan.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-protect-status.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
-        'src/class-rest-controller.php' => ['PhanParamTooMany', 'PhanTypeArraySuspicious', 'PhanUndeclaredTypeParameter'],
+        'src/class-rest-controller.php' => ['PhanParamTooMany'],
         'src/class-scan-status.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty'],
         'src/class-status.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument'],
         'src/class-threats.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgumentProbablyReal'],

--- a/projects/plugins/protect/changelog/fix-obvious-wrong-class-names
+++ b/projects/plugins/protect/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/plugins/protect/src/class-rest-controller.php
+++ b/projects/plugins/protect/src/class-rest-controller.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authent
 use Automattic\Jetpack\Waf\Waf_Runner;
 use Jetpack_Protect;
 use WP_Error;
+use WP_REST_Request;
 use WP_REST_Response;
 
 /**

--- a/projects/plugins/social/.phan/baseline.php
+++ b/projects/plugins/social/.phan/baseline.php
@@ -10,21 +10,17 @@
 return [
     // # Issue statistics:
     // PhanUndeclaredProperty : 20+ occurrences
-    // PhanTypeMismatchArgument : 4 occurrences
-    // PhanUndeclaredTypeParameter : 3 occurrences
     // PhanMisspelledAnnotation : 2 occurrences
-    // PhanUndeclaredClassMethod : 2 occurrences
     // PhanDeprecatedFunction : 1 occurrence
     // PhanNoopNew : 1 occurrence
+    // PhanTypeMismatchArgument : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'jetpack-social.php' => ['PhanNoopNew'],
-        'src/class-jetpack-social.php' => ['PhanMisspelledAnnotation', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/class-meta-tags.php' => ['PhanUndeclaredTypeParameter'],
+        'src/class-jetpack-social.php' => ['PhanMisspelledAnnotation', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-note.php' => ['PhanTypeMismatchArgument'],
-        'src/class-rest-social-note-controller.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredTypeParameter'],
         'tests/php/test-class-jetpack-social.php' => ['PhanDeprecatedFunction', 'PhanUndeclaredProperty'],
         'tests/php/test-class-meta-tags.php' => ['PhanUndeclaredProperty'],
     ],

--- a/projects/plugins/social/changelog/fix-obvious-wrong-class-names
+++ b/projects/plugins/social/changelog/fix-obvious-wrong-class-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix phpdoc class references. Should be no change to functionality.
+
+

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Social;
 
+use WP_Post;
+
 /**
  * Adds the meta tags.
  */

--- a/projects/plugins/social/src/class-rest-social-note-controller.php
+++ b/projects/plugins/social/src/class-rest-social-note-controller.php
@@ -11,6 +11,8 @@ namespace Automattic\Jetpack\Social;
 use Automattic\Jetpack\Connection\Rest_Authentication;
 use WP_Error;
 use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
 use WP_REST_Server;
 
 /**
@@ -64,7 +66,7 @@ class REST_Social_Note_Controller extends WP_REST_Controller {
 
 		if ( $post && $post->post_type === Note::JETPACK_SOCIAL_NOTE_CPT && $post->post_status === 'publish' && isset( $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] ) ) {
 			update_post_meta( $post_id, self::SOCIAL_SHARES_POST_META_KEY, $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] );
-			return rest_ensure_response( new \WP_REST_Response() );
+			return rest_ensure_response( new WP_REST_Response() );
 		}
 
 		return new WP_Error(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Almost all are phpdoc comments where the class was missing a `use` or leading `\`. More specifically, I searched for cases where Phan was complaining about classes named like `\Automattic\...\Automattic\`, or `\WP_...`, or `Exception` classes, and fixed all the obvious ones.

Then I also searched for "undeclared {class|type} \\[a-z]" and fixed the obvious ones out of that too (e.g. "obj", "number", and various typos).

Note that having the correct typing allows Phan to complain about possibly-real issues in some cases. Those will have to be reviewed later.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Everything should continue to work as it did before. If there are any actual code changes, it's fixing someplace where something was trying to catch a nonexistent exception or it was in a rare or unused code path.