### PR TITLE
My Jetpack: remove red dot from notice component

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -54,7 +54,6 @@ const GlobalNotice = ( { message, options } ) => {
 		<div
 			className={ classnames( styles.notice, {
 				[ styles[ 'bigger-than-medium' ] ]: isBiggerThanMedium,
-				[ styles[ 'is-red-bubble' ] ]: options.isRedBubble,
 			} ) }
 		>
 			<Notice hideCloseButton={ true } { ...options } actions={ actionButtons }>

--- a/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
+++ b/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
@@ -6,7 +6,6 @@ const defaultNotice: Notice = {
 	options: {
 		level: '',
 		priority: 0,
-		isRedBubble: false,
 	},
 };
 

--- a/projects/packages/my-jetpack/_inc/context/notices/types.ts
+++ b/projects/packages/my-jetpack/_inc/context/notices/types.ts
@@ -13,7 +13,6 @@ export type Notice = {
 		level: string;
 		actions?: NoticeButtonAction[];
 		priority: number;
-		isRedBubble?: boolean;
 	};
 };
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-bad-install-notice.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-bad-install-notice.ts
@@ -50,7 +50,6 @@ const useBadInstallNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 				},
 			],
 			priority: NOTICE_PRIORITY_MEDIUM,
-			isRedBubble: true,
 		};
 
 		setNotice( {

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.ts
@@ -49,7 +49,6 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 				},
 			],
 			priority: NOTICE_PRIORITY_HIGH,
-			isRedBubble: true,
 		};
 
 		setNotice( {

--- a/projects/packages/my-jetpack/changelog/remove-red-bubble-logic-connection-notice
+++ b/projects/packages/my-jetpack/changelog/remove-red-bubble-logic-connection-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+My Jetpack: remove red bubble from connection notice in favor of using the status of the Notice component


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* After discussion in pbNhbs-ag3-p2 we have decided that using a red dot specifically in the Notice may not be required, since the Notice status (error, warning, etc) is enough to give context and link the user to the underlying issue presented in the notice.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbNhbs-ag3-p2#comment-21411 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With the usage of the new component for the notice (from `@automattic/jetpack-components`), we'll rely on the icon and status of the Notice to emphasize the connection to the red bubble on the menu, instead of using the red dot