### PR TITLE
Fix: delete logs after scheduled update deletion

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-scheduled-update-delete-logs
+++ b/projects/packages/scheduled-updates/changelog/fix-scheduled-update-delete-logs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Delete logs after scheduled update deletion.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
@@ -131,17 +131,18 @@ class Scheduled_Updates_Logs {
 	 * Clears the logs for a specific schedule_id or all logs if no schedule_id is provided.
 	 *
 	 * @param string|null $schedule_id Optional. The ID of the schedule. If not provided, all logs will be cleared.
+	 * @param bool        $skip_validation Optional. Whether to skip the validation of the schedule_id.
 	 *
 	 * @return WP_Error|null
 	 */
-	public static function clear( string $schedule_id = null ) {
+	public static function clear( string $schedule_id = null, $skip_validation = false ) {
 		$logs = get_option( self::OPTION_NAME, array() );
 
 		if ( null === $schedule_id ) {
 			// Clear all logs if no schedule_id is provided
 			$logs = array();
 		} else {
-			if ( ! self::is_valid_schedule( $schedule_id ) ) {
+			if ( ! $skip_validation && ! self::is_valid_schedule( $schedule_id ) ) {
 				return new WP_Error( 'invalid_schedule_id', 'Invalid schedule ID' );
 			}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.7.0';
+	const PACKAGE_VERSION = '0.7.1-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -548,6 +548,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			update_option( 'auto_update_plugins', $auto_update_plugins );
 		}
 
+		// Delete logs
+		Scheduled_Updates_Logs::clear( $request['schedule_id'], true );
+
 		return rest_ensure_response( true );
 	}
 


### PR DESCRIPTION
When a scheduled update is deleted, `Scheduled_Updates_Logs::clear( $schedule_id );` must be run. Otherwise if you create another scheduled update with the same plugins it will be shown with the infer status of the deleted one.

Fixes https://github.com/Automattic/dotcom-forge/issues/6459

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Force a log deletion after a scheduled update deletion.
* New unit tests.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Be sure to have a dev-site with Jetpack beta installed.
* On `/wp-admin/admin.php?page=jetpack-beta&plugin=jetpack-mu-wpcom-plugin` install `fix/scheduled-update-delete-logs`.
* On `https://wordpress.com/plugins/scheduled-updates/__BLOG__` create a scheduled update.
* Run it or force run it using the instruction found in pcmemI-2Ww-p2.
* Wait for the email and ensure to see logs generated on Calypso.
* Delete the scheduled update.
* Create a new one with the same plugins.
* Ensure the brand-new scheduled update has no logs attached.