### PR TITLE
Masterbar: be more defensive when fetching site menus

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-masterbar-fatal-menu
+++ b/projects/plugins/jetpack/changelog/fix-masterbar-fatal-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+WordPress.com Toolbar: avoid Fatal errors when using other menu management plugins and the WordPress.com Toolbar feature.

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -504,7 +504,7 @@ abstract class Base_Admin_Menu {
 			$has_submenus = isset( $submenu[ $menu_item[2] ] );
 
 			// Skip if the menu doesn't have submenus.
-			if ( ! $has_submenus ) {
+			if ( ! $has_submenus || ! is_array( $submenu[ $menu_item[2] ] ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Fixes #36780

## Proposed changes:

This is a bit more defensive and should avoid fatals like the one outlined in the issue above.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* You can test this on a WoA site where you have installed the `ditty-news-ticker` plugin.
* Once the plugin is activated, you should not see any fatal error on the site.
