### PR TITLE
CRM: Init new release cycle - 6.4.3-alpha

### DIFF
--- a/projects/plugins/crm/ZeroBSCRM.php
+++ b/projects/plugins/crm/ZeroBSCRM.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack CRM
  * Plugin URI: https://jetpackcrm.com
  * Description: Jetpack CRM is the simplest CRM for WordPress. Self host your own Customer Relationship Manager using WP.
- * Version: 6.4.2
+ * Version: 6.4.3-alpha
  * Author: Automattic - Jetpack CRM team
  * Author URI: https://jetpackcrm.com
  * Text Domain: zero-bs-crm

--- a/projects/plugins/crm/changelog/init-release-cycle
+++ b/projects/plugins/crm/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Init 6.4.3-alpha
+
+

--- a/projects/plugins/crm/composer.json
+++ b/projects/plugins/crm/composer.json
@@ -42,7 +42,7 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_4_2",
+		"autoloader-suffix": "06c775433a83ed276f0a1d8ac25f93ba_crmⓥ6_4_3_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-crm",
-	"version": "6.4.2",
+	"version": "6.4.3-alpha",
 	"description": "The CRM for WordPress",
 	"author": "Automattic",
 	"license": "GPL-2.0",

--- a/projects/plugins/crm/readme.txt
+++ b/projects/plugins/crm/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, kallehauge, cleacos, diegogarciarodrigues, bradshawtm, wpkaren, robertf4, woodyhayday, mikemayhem3030
 Tags: CRM, Invoice, Woocommerce CRM, Clients, Lead Generation, contacts, customers, billing, email marketing, Marketing Automation, contact form, automations
 Tested up to: 6.5
-Stable tag: 6.4.1
+Stable tag: 6.4.2
 Requires at least: 6.0
 Requires PHP: 7.4
 License: GPLv2


### PR DESCRIPTION

## Proposed changes:

* This PR sets the next release version to 6.4.3-alpha. Also, it fixes the stable version on readme.txt to 6.4.2.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Check next version is 6.4.2-alpha
* Check the stable version in readme.txt is 6.4.2

