### PR TITLE
Business Hours Block: refactor Edit component to function

### DIFF
--- a/projects/plugins/jetpack/changelog/update-refactor-business-hours
+++ b/projects/plugins/jetpack/changelog/update-refactor-business-hours
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Business Hours Block: refactor Edit component to function 

--- a/projects/plugins/jetpack/extensions/blocks/business-hours/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/business-hours/edit.js
@@ -2,7 +2,7 @@ import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-util
 import apiFetch from '@wordpress/api-fetch';
 import { Placeholder } from '@wordpress/components';
 import { getSettings } from '@wordpress/date';
-import { Component } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import metadata from './block.json';
@@ -24,71 +24,58 @@ export const defaultLocalization = {
 	startOfWeek: 0,
 };
 
-class BusinessHours extends Component {
-	state = {
-		localization: defaultLocalization,
-		hasFetched: false,
-	};
+const BusinessHours = props => {
+	const { attributes, className, isSelected } = props;
+	const [ localization, setLocalization ] = useState( defaultLocalization );
+	const [ hasFetched, setHasFetched ] = useState( false );
 
-	componentDidMount() {
-		this.apiFetch();
-	}
+	const { days } = attributes;
+	const { startOfWeek } = localization;
+	const localizedWeek = days.concat( days.slice( 0, startOfWeek ) ).slice( startOfWeek );
 
-	apiFetch() {
-		this.setState( { data: defaultLocalization }, () => {
-			apiFetch( { path: '/wpcom/v2/business-hours/localized-week' } ).then(
-				data => {
-					this.setState( { localization: data, hasFetched: true } );
-				},
-				() => {
-					this.setState( { localization: defaultLocalization, hasFetched: true } );
-				}
-			);
-		} );
-	}
+	useEffect( () => {
+		apiFetch( { path: '/wpcom/v2/business-hours/localized-week' } ).then(
+			data => {
+				setLocalization( data );
+				setHasFetched( true );
+			},
+			() => {
+				setLocalization( defaultLocalization );
+				setHasFetched( true );
+			}
+		);
+	}, [] );
 
-	render() {
-		const { attributes, className, isSelected } = this.props;
-		const { days } = attributes;
-		const { localization, hasFetched } = this.state;
-		const { startOfWeek } = localization;
-		const localizedWeek = days.concat( days.slice( 0, startOfWeek ) ).slice( startOfWeek );
+	let content;
 
-		if ( ! hasFetched ) {
-			return <Placeholder icon={ icon } label={ __( 'Loading business hours', 'jetpack' ) } />;
-		}
+	if ( ! hasFetched ) {
+		content = <Placeholder icon={ icon } label={ __( 'Loading business hours', 'jetpack' ) } />;
+	} else if ( ! isSelected ) {
+		const settings = getSettings();
+		const {
+			formats: { time },
+		} = settings;
 
-		if ( ! isSelected ) {
-			const settings = getSettings();
-			const {
-				formats: { time },
-			} = settings;
-			return (
-				<dl className={ classNames( className, 'jetpack-business-hours' ) }>
-					{ localizedWeek.map( ( day, key ) => {
-						return (
-							<DayPreview
-								key={ key }
-								day={ day }
-								localization={ localization }
-								timeFormat={ time }
-							/>
-						);
-					} ) }
-				</dl>
-			);
-		}
-
-		return (
-			<div className={ classNames( className, 'is-edit' ) }>
+		content = (
+			<dl className={ classNames( className, 'jetpack-business-hours' ) }>
 				{ localizedWeek.map( ( day, key ) => {
 					return (
-						<DayEdit key={ key } day={ day } localization={ localization } { ...this.props } />
+						<DayPreview key={ key } day={ day } localization={ localization } timeFormat={ time } />
 					);
+				} ) }
+			</dl>
+		);
+	} else {
+		content = (
+			<div className={ classNames( className, 'is-edit' ) }>
+				{ localizedWeek.map( ( day, key ) => {
+					return <DayEdit key={ key } day={ day } localization={ localization } { ...props } />;
 				} ) }
 			</div>
 		);
 	}
-}
+
+	return content;
+};
 
 export default BusinessHours;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR refactors the Business Hours block's Edit component to be a functional component. It's preparatory work for upgrading to block API to version 3.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/36765

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- If you run it locally, make sure to run `cd projects/plugins/jetpack && pnpm run build-extensions`
- Create a post
- Add the _Business Hours_ block
- Make sure it behaves as it does in production

_Note: the hour discrepancy between edit and preview mode has already been reported here: https://github.com/Automattic/jetpack/issues/36647_
