### PR TITLE
Clean up duplicate names in package.json

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-duplicate-package-json-names
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-duplicate-package-json-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unnecessary `name` in `tests/e2e/package.json`. No change to functionality.
+
+

--- a/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
+++ b/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
@@ -1,5 +1,4 @@
 {
-	"name": "jetpack-starter-e2e-tests",
 	"private": true,
 	"type": "module",
 	"description": "Easily connect your clients sites to the Automattic for Agencies portal and enable portal features like plugin updates, downtime monitoring, and more..",

--- a/projects/plugins/boost/changelog/fix-duplicate-package-json-names
+++ b/projects/plugins/boost/changelog/fix-duplicate-package-json-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unnecessary `name` in `tests/e2e/package.json`. No change to functionality.
+
+

--- a/projects/plugins/boost/tests/e2e/package.json
+++ b/projects/plugins/boost/tests/e2e/package.json
@@ -1,5 +1,4 @@
 {
-	"name": "jetpack-boost-e2e-tests",
 	"private": true,
 	"type": "module",
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack.",

--- a/projects/plugins/jetpack/changelog/fix-duplicate-package-json-names
+++ b/projects/plugins/jetpack/changelog/fix-duplicate-package-json-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Remove unnecessary `name` in `tests/e2e/package.json`. No change to functionality.
+
+

--- a/projects/plugins/jetpack/tests/e2e/package.json
+++ b/projects/plugins/jetpack/tests/e2e/package.json
@@ -1,5 +1,4 @@
 {
-	"name": "jetpack-e2e-tests",
 	"private": true,
 	"type": "module",
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",

--- a/projects/plugins/migration/changelog/fix-duplicate-package-json-names
+++ b/projects/plugins/migration/changelog/fix-duplicate-package-json-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unnecessary `name` in `tests/e2e/package.json`. No change to functionality.
+
+

--- a/projects/plugins/migration/tests/e2e/package.json
+++ b/projects/plugins/migration/tests/e2e/package.json
@@ -1,5 +1,4 @@
 {
-	"name": "wpcom-migration-e2e-tests",
 	"private": true,
 	"type": "module",
 	"description": "A WordPress plugin that helps users to migrate their sites to WordPress.com.",

--- a/projects/plugins/search/changelog/fix-duplicate-package-json-names
+++ b/projects/plugins/search/changelog/fix-duplicate-package-json-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unnecessary `name` in `tests/e2e/package.json`. No change to functionality.
+
+

--- a/projects/plugins/search/tests/e2e/package.json
+++ b/projects/plugins/search/tests/e2e/package.json
@@ -1,5 +1,4 @@
 {
-	"name": "jetpack-search-e2e-tests",
 	"private": true,
 	"type": "module",
 	"description": "A cloud-powered replacement for WordPress' search.",

--- a/projects/plugins/social/changelog/fix-duplicate-package-json-names
+++ b/projects/plugins/social/changelog/fix-duplicate-package-json-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unnecessary `name` in `tests/e2e/package.json`. No change to functionality.
+
+

--- a/projects/plugins/social/tests/e2e/package.json
+++ b/projects/plugins/social/tests/e2e/package.json
@@ -1,5 +1,4 @@
 {
-	"name": "jetpack-social-e2e-tests",
 	"private": true,
 	"type": "module",
 	"description": "plugin--description.",

--- a/projects/plugins/starter-plugin/changelog/fix-duplicate-package-json-names
+++ b/projects/plugins/starter-plugin/changelog/fix-duplicate-package-json-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unnecessary `name` in `tests/e2e/package.json`. No change to functionality.
+
+

--- a/projects/plugins/starter-plugin/tests/e2e/package.json
+++ b/projects/plugins/starter-plugin/tests/e2e/package.json
@@ -1,5 +1,4 @@
 {
-	"name": "jetpack-starter-e2e-tests",
 	"private": true,
 	"type": "module",
 	"description": "plugin--description.",

--- a/projects/plugins/super-cache/changelog/fix-duplicate-package-json-names
+++ b/projects/plugins/super-cache/changelog/fix-duplicate-package-json-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unnecessary `name` in `tests/e2e/package.json`. No change to functionality.
+
+

--- a/projects/plugins/super-cache/tests/e2e/package.json
+++ b/projects/plugins/super-cache/tests/e2e/package.json
@@ -1,5 +1,4 @@
 {
-	"name": "super-cache-e2e-tests",
 	"private": true,
 	"type": "module",
 	"description": "E2E test suite for Super Cache",

--- a/projects/plugins/videopress/changelog/fix-duplicate-package-json-names
+++ b/projects/plugins/videopress/changelog/fix-duplicate-package-json-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove unnecessary `name` in `tests/e2e/package.json`. No change to functionality.
+
+

--- a/projects/plugins/videopress/tests/e2e/package.json
+++ b/projects/plugins/videopress/tests/e2e/package.json
@@ -1,5 +1,4 @@
 {
-	"name": "jetpack-videopress-e2e-tests",
 	"private": true,
 	"type": "module",
 	"description": "High quality, ad-free video.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When plugins/automattic-for-agencies-client was added, the CLI `jetpack generate` seems to not have adjusted the `name` field in `tests/e2e/package.json` from `tests/e2e/package.json` due to it not having a name matching what the CLI searches and replaces for. This caused some other scripts to start complaining about the duplication.

It seems unlikely that the names in these files are actually needed for anything, since we leave them out of various other files. So let's remove them from all the `tests/e2e/package.json` files.

Also, for good measure, let's have `lint-project-structure.sh` check for duplicate package.json names like it already does for duplicate composer.json names.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
