### PR TITLE
Actually fix color deprecation notices.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.color.php
+++ b/projects/plugins/jetpack/_inc/lib/class.color.php
@@ -93,19 +93,16 @@ class Jetpack_Color {
 		if ( $red < 0 || $red > 255 ) {
 			throw new RangeException( 'Red value ' . $red . ' out of valid color code range' );
 		}
-		$red = intval( $red );
 
 		if ( $green < 0 || $green > 255 ) {
 			throw new RangeException( 'Green value ' . $green . ' out of valid color code range' );
 		}
-		$green = intval( $green );
 
 		if ( $blue < 0 || $blue > 255 ) {
 			throw new RangeException( 'Blue value ' . $blue . ' out of valid color code range' );
 		}
-		$blue = intval( $blue );
 
-		$this->color = ( $red << 16 ) + ( $green << 8 ) + $blue;
+		$this->color = ( intval( $red ) << 16 ) + ( intval( $green ) << 8 ) + intval( $blue );
 
 		return $this;
 	}

--- a/projects/plugins/jetpack/_inc/lib/class.color.php
+++ b/projects/plugins/jetpack/_inc/lib/class.color.php
@@ -93,16 +93,19 @@ class Jetpack_Color {
 		if ( $red < 0 || $red > 255 ) {
 			throw new RangeException( 'Red value ' . $red . ' out of valid color code range' );
 		}
+		$red = intval( $red );
 
 		if ( $green < 0 || $green > 255 ) {
 			throw new RangeException( 'Green value ' . $green . ' out of valid color code range' );
 		}
+		$green = intval( $green );
 
 		if ( $blue < 0 || $blue > 255 ) {
 			throw new RangeException( 'Blue value ' . $blue . ' out of valid color code range' );
 		}
+		$blue = intval( $blue );
 
-		$this->color = intval( ( $red << 16 ) + ( $green << 8 ) + $blue );
+		$this->color = ( $red << 16 ) + ( $green << 8 ) + $blue;
 
 		return $this;
 	}

--- a/projects/plugins/jetpack/changelog/fix-color-deprecation-notice-actually
+++ b/projects/plugins/jetpack/changelog/fix-color-deprecation-notice-actually
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Theme Tools: fix deprecation notices in the color management library.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes the deprecation notices:

```
PHP Deprecated:  Implicit conversion from float 24.2 to int loses precision in /home/lousy/www/wp-content/plugins/jetpack/_inc/lib/class.color.php on line 105

```

## Proposed changes:
* Fixes deprecation notices for good.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

