### PR TITLE
Fix product card tracks loading issue

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -16,7 +16,7 @@ import {
 import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useLayoutEffect, useState } from 'react';
 /*
  * Internal dependencies
  */
@@ -98,7 +98,7 @@ export default function MyJetpackScreen() {
 	const { recordEvent } = useAnalytics();
 	const [ reloading, setReloading ] = useState( false );
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		recordEvent( 'jetpack_myjetpack_page_view', {
 			red_bubble_alerts: Object.keys( redBubbleAlerts ).join( ',' ),
 		} );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -98,6 +98,8 @@ export default function MyJetpackScreen() {
 	const { recordEvent } = useAnalytics();
 	const [ reloading, setReloading ] = useState( false );
 
+	// useLayoutEffect gets called before useEffect.
+	// We are using it here to ensure the `page_view` event gets triggered first.
 	useLayoutEffect( () => {
 		recordEvent( 'jetpack_myjetpack_page_view', {
 			red_bubble_alerts: Object.keys( redBubbleAlerts ).join( ',' ),

--- a/projects/packages/my-jetpack/changelog/fix-product-card-tracks-loading-issue
+++ b/projects/packages/my-jetpack/changelog/fix-product-card-tracks-loading-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure page_view gets loaded before product_card_loaded


### PR DESCRIPTION
## Proposed changes:

* Use useLayoutEffect instead of useEffect for `page_view` track
* The useLayoutEffect hook fires before useEffect. This should ensure the page_view track gets recorded first

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

panfyZ-3tS-p2#comment-8765

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack and look at track Vigilante
3. Make sure the `jetpack_myjetpack_page_view` is recorded before any of the `jetpack_myjetpack_product_card_loaded` tracks
![image](https://github.com/Automattic/jetpack/assets/65001528/82a74522-16c5-46bb-b90a-9c354d53f0c3)
4. Refresh the page a couple of times and make sure it is always recorded first
