### PR TITLE
Protect: Ensured that the "Go to cloud" link and the promotion around it is hidden on non-supporting platforms.

### DIFF
--- a/projects/plugins/protect/changelog/dont-show-go-to-cloud-link-on-non-supported-envs
+++ b/projects/plugins/protect/changelog/dont-show-go-to-cloud-link-on-non-supported-envs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Protect footer: Ensured that links to the cloud and the promotion around it are not shown if you are on a platform where the firewall is not supported.

--- a/projects/plugins/protect/src/js/components/scan-footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/scan-footer/index.jsx
@@ -4,6 +4,8 @@ import {
 	Title,
 	getRedirectUrl,
 	ContextualUpgradeTrigger,
+	Col,
+	Container,
 } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
@@ -112,12 +114,19 @@ const FooterInfo = () => {
 };
 
 const ScanFooter = () => {
-	return (
+	const { waf } = window.jetpackProtectInitialState || {};
+	return waf.wafSupported ? (
 		<SeventyFiveLayout
 			main={ <ProductPromotion /> }
 			secondary={ <FooterInfo /> }
 			preserveSecondaryOnMobile={ true }
 		/>
+	) : (
+		<Container horizontalSpacing={ 0 } horizontalGap={ 0 } fluid={ false }>
+			<Col>
+				<FooterInfo />
+			</Col>
+		</Container>
 	);
 };
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 994-gh-Automattic/jetpack-scan-team



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* On environments where the firewall is not supported, we don't need to show a link to calypso, as that is not supported either. The check for that happens on the calypso side already, but the links would still show here without this change.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Essentially:
* Check out this branch
* Change the code in `\Automattic\Jetpack\Waf\Waf_Runner::is_supported_environment()` to return false
* Build
* Connect site with protect plan
* Verify the section is not shown anymore

One way to do this is also:
* Create JN site with
* Select Jetpack Beta -> protect -> this branch
* Lauch
* SSH into the site and comment out [this `return true;` ](https://github.com/Automattic/jetpack/blob/871bf1bc261bc5080d5b1b1687eab7bbd0853287/projects/packages/waf/src/class-waf-runner.php#L102)
* Verify the block does not show anymore
