### PR TITLE
Memberships: Add cache to get_post_access_level

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-membership-performance
+++ b/projects/plugins/jetpack/changelog/fix-membership-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Improve performance of memberships checks

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -110,13 +110,6 @@ class Jetpack_Memberships {
 	private static $user_is_paid_subscriber_cache = array();
 
 	/**
-	 * Cached results of get_post_access_level method.
-	 *
-	 * @var array
-	 */
-	private static $post_access_level_cache = array();
-
-	/**
 	 * Currencies we support and Stripe's minimum amount for a transaction in that currency.
 	 *
 	 * @link https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
@@ -546,11 +539,11 @@ class Jetpack_Memberships {
 			return Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY;
 		}
 
-		$blog_id   = get_current_blog_id();
-		$cache_key = $blog_id . '_' . $post_id;
+		$cache_key = 'post_access_level_' . $post_id;
 
-		if ( isset( self::$post_access_level_cache[ $cache_key ] ) ) {
-			return self::$post_access_level_cache[ $cache_key ];
+		$post_access_level = wp_cache_get( $cache_key, 'jetpack-memberships' );
+		if ( false !== $post_access_level ) {
+			return $post_access_level;
 		}
 
 		$post_access_level = get_post_meta( $post_id, self::$post_access_level_meta_name, true );
@@ -558,7 +551,7 @@ class Jetpack_Memberships {
 			$post_access_level = Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY;
 		}
 
-		self::$post_access_level_cache[ $cache_key ] = $post_access_level;
+		wp_cache_set( $cache_key, $post_access_level, 'jetpack-memberships' );
 
 		return $post_access_level;
 	}

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -110,6 +110,13 @@ class Jetpack_Memberships {
 	private static $user_is_paid_subscriber_cache = array();
 
 	/**
+	 * Cached results of get_post_access_level method.
+	 *
+	 * @var array
+	 */
+	private static $post_access_level_cache = array();
+
+	/**
 	 * Currencies we support and Stripe's minimum amount for a transaction in that currency.
 	 *
 	 * @link https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
@@ -539,10 +546,17 @@ class Jetpack_Memberships {
 			return Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY;
 		}
 
+		if ( isset( self::$post_access_level_cache[ $post_id ] ) ) {
+			return self::$post_access_level_cache[ $post_id ];
+		}
+
 		$post_access_level = get_post_meta( $post_id, self::$post_access_level_meta_name, true );
 		if ( empty( $post_access_level ) ) {
 			$post_access_level = Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY;
 		}
+
+		self::$post_access_level_cache[ $post_id ] = $post_access_level;
+
 		return $post_access_level;
 	}
 

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -117,7 +117,7 @@ class Jetpack_Memberships {
 	private static $post_access_level_cache = array();
 
 	/**
-	 * Cached results of get_post_access_level method.
+	 * Clear cached results of get_post_access_level method.
 	 */
 	public static function clear_post_access_level_cache() {
 		self::$post_access_level_cache = array();

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -546,8 +546,11 @@ class Jetpack_Memberships {
 			return Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY;
 		}
 
-		if ( isset( self::$post_access_level_cache[ $post_id ] ) ) {
-			return self::$post_access_level_cache[ $post_id ];
+		$blog_id   = get_current_blog_id();
+		$cache_key = $blog_id . '_' . $post_id;
+
+		if ( isset( self::$post_access_level_cache[ $cache_key ] ) ) {
+			return self::$post_access_level_cache[ $cache_key ];
 		}
 
 		$post_access_level = get_post_meta( $post_id, self::$post_access_level_meta_name, true );
@@ -555,7 +558,7 @@ class Jetpack_Memberships {
 			$post_access_level = Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_EVERYBODY;
 		}
 
-		self::$post_access_level_cache[ $post_id ] = $post_access_level;
+		self::$post_access_level_cache[ $cache_key ] = $post_access_level;
 
 		return $post_access_level;
 	}


### PR DESCRIPTION
Fixes p1712662633338699-slack-C052XEUUBL4


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add cache to get_post_access_level improving performance at least for post with lots of comments

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*