### PR TITLE
a4a: do not ship scss folder and its contents with stable version

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/.gitattributes
+++ b/projects/plugins/automattic-for-agencies-client/.gitattributes
@@ -31,6 +31,7 @@ package.json                                    production-exclude
 phpunit.xml.dist                                production-exclude
 README.md                                       production-exclude
 src/js/**                                       production-exclude
+src/scss/**                                     production-exclude
 tests/**                                        production-exclude
 /vendor/automattic/jetpack-autoloader/**        production-exclude
 /vendor/automattic/jetpack-changelogger/**      production-exclude

--- a/projects/plugins/automattic-for-agencies-client/changelog/update-a4a-exclude-scss
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-a4a-exclude-scss
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Exclude SCSS from production build
+
+


### PR DESCRIPTION
## Proposed changes:

We do not need to ship this directory with the production version of the plugin, since the scss are not enqueued.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?
* No

## Testing instructions:

Not much to test on this one. You could look at the build artifact and ensure the directory is not in there.
