### PR TITLE
Launchpad: Add translation support

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-translation-support-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-translation-support-launchpad
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Add translation support for the Launchpad API endpoint

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -51,7 +51,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.23.x-dev"
+			"dev-trunk": "5.24.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.23.2",
+	"version": "5.24.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.23.2';
+	const PACKAGE_VERSION = '5.24.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -148,13 +148,19 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	 *               and `checklist`.
 	 */
 	public function get_data( $request ) {
+		// Handle translations for Atomic sites.
+		$locale = $request['_locale'] ? get_user_locale() : null;
+		if ( $locale ) {
+			$switched_locale = switch_to_locale( $locale );
+		}
+
 		$checklist_slug = isset( $request['checklist_slug'] ) ? $request['checklist_slug'] : get_option( 'site_intent' );
 
 		$launchpad_context = isset( $request['launchpad_context'] )
 			? $request['launchpad_context']
 			: null;
 
-		return array(
+		$response = array(
 			'site_intent'        => get_option( 'site_intent' ),
 			'launchpad_screen'   => get_option( 'launchpad_screen' ),
 			'checklist_statuses' => get_option( 'launchpad_checklist_tasks_statuses', array() ),
@@ -164,6 +170,12 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 			'is_dismissible'     => wpcom_launchpad_is_task_list_dismissible( $checklist_slug ),
 			'title'              => wpcom_get_launchpad_checklist_title_by_checklist_slug( $checklist_slug ),
 		);
+
+		if ( $switched_locale ) {
+			restore_previous_locale();
+		}
+
+		return $response;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php
@@ -149,7 +149,9 @@ class WPCOM_REST_API_V2_Endpoint_Launchpad extends WP_REST_Controller {
 	 */
 	public function get_data( $request ) {
 		// Handle translations for Atomic sites.
-		$locale = $request['_locale'] ? get_user_locale() : null;
+		$switched_locale = false;
+		$locale          = $request['_locale'] ? get_user_locale() : null;
+
 		if ( $locale ) {
 			$switched_locale = switch_to_locale( $locale );
 		}

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-translation-support-launchpad
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-translation-support-launchpad
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_14"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_15_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -129,7 +129,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "6afd8e193ad433131247e6cba33ba6d3d926c055"
+                "reference": "6f45a0b01e673600031623777197022c2cc3aef6"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -152,7 +152,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.23.x-dev"
+                    "dev-trunk": "5.24.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.14
+ * Version: 2.1.15-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.14",
+	"version": "2.1.15-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wpcomsh/issues/1727 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check for the `_locale` parameter in the request and switch to the user locale when it's present so Atomic sites get localized/translated strings for Launchpad tasks.
* This is part 1 of fixing Launchpad translations for Atomic sites. We also need to ensure we're looking for the translations at the right text domain (`wpcomsh` instead of `jetpack-mu-wpcom`) which is handled here: https://github.com/Automattic/wpcomsh/pull/1770 
* We can safely ship the two PRs separately without any negative repercussions.

<img width="652" alt="Screenshot 2024-04-09 at 12 31 21 PM" src="https://github.com/Automattic/jetpack/assets/2124984/161a9192-50b7-4b0b-aee0-0a502b35a4c3">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure you have a WoA developer site that has a visible task list on My Home
* Apply this patch to your WoA developer site -- you can either use Jetpack Beta or apply it manually over SSH
* Apply this wpcomsh patch to your WoA developer site -- https://github.com/Automattic/wpcomsh/pull/1770
* Switch your user language to something other than English via `/me/account`
* Visit `/home/yourwoadevsite.wpcomstaging.com` and `/earn/yourwoadevsite.wpcomstaging.com`
* You should see the task list strings are translated to the language you chose in step 2.
* Test the PR on your sandbox with a non-Atomic site to ensure you get the expected results there, too.
