### PR TITLE
Slideshow Block: refactor Edit component to function

### DIFF
--- a/projects/plugins/jetpack/changelog/update-refactor-slide-show-edit
+++ b/projects/plugins/jetpack/changelog/update-refactor-slide-show-edit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Slideshow Block: refactor Edit component to function

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/edit.js
@@ -5,9 +5,9 @@ import { DropZone, FormFileUpload, withNotices } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { mediaUpload } from '@wordpress/editor';
-import { Component, Fragment } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { filter, get, map, pick } from 'lodash';
+import { get, map, pick } from 'lodash';
 import metadata from './block.json';
 import { PanelControls, ToolbarControls } from './controls';
 import Slideshow from './slideshow';
@@ -15,7 +15,6 @@ import Slideshow from './slideshow';
 import './editor.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
-const icon = getBlockIconComponent( metadata );
 
 export const pickRelevantMediaFiles = ( image, sizeSlug ) => {
 	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption' ] );
@@ -26,67 +25,42 @@ export const pickRelevantMediaFiles = ( image, sizeSlug ) => {
 	return imageProps;
 };
 
-export class SlideshowEdit extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			selectedImage: null,
-		};
-	}
-	componentDidMount() {
-		const { ids, sizeSlug } = this.props.attributes;
-		if ( ! sizeSlug ) {
-			// To improve the performance, we use large size images by default except for blocks inserted before the
-			// image size attribute was added, since they were loading full size images. The presence or lack of images
-			// in a block determines when it has been inserted (before or after we added the image size attribute),
-			// given that now it is not possible to have a block with images and no size.
-			this.setAttributes( { sizeSlug: ids.length ? 'full' : 'large' } );
-		}
-	}
-	setAttributes( attributes ) {
-		if ( attributes.ids ) {
-			throw new Error(
-				'The "ids" attribute should not be changed directly. It is managed automatically when "images" attribute changes'
-			);
-		}
+export const SlideshowEdit = ( {
+	attributes,
+	setAttributes,
+	className,
+	isSelected,
+	noticeOperations,
+	noticeUI,
+	lockPostSaving,
+	unlockPostSaving,
+	imageSizes,
+	resizedImages,
+} ) => {
+	const { align, autoplay, delay, effect, images, sizeSlug, ids } = attributes;
 
-		if ( attributes.images ) {
-			attributes = {
-				...attributes,
-				ids: attributes.images.map( ( { id } ) => parseInt( id, 10 ) ),
-			};
-		}
-
-		this.props.setAttributes( attributes );
-	}
-	onSelectImages = images => {
-		const { sizeSlug } = this.props.attributes;
-		const mapped = images.map( image => pickRelevantMediaFiles( image, sizeSlug ) );
-		this.setAttributes( {
-			images: mapped,
+	const setImages = imgs => {
+		setAttributes( {
+			images: imgs,
+			ids: imgs.map( ( { id } ) => parseInt( id, 10 ) ),
 		} );
 	};
-	onRemoveImage = index => {
-		return () => {
-			const images = filter( this.props.attributes.images, ( img, i ) => index !== i );
-			this.setState( { selectedImage: null } );
-			this.setAttributes( { images } );
-		};
-	};
-	addFiles = files => {
-		const currentImages = this.props.attributes.images || [];
-		const sizeSlug = this.props.attributes.sizeSlug;
-		const { lockPostSaving, unlockPostSaving, noticeOperations } = this.props;
+
+	const onSelectImages = imgs =>
+		setImages( imgs.map( image => pickRelevantMediaFiles( image, sizeSlug ) ) );
+
+	const addFiles = files => {
 		const lockName = 'slideshowBlockLock';
+
 		lockPostSaving( lockName );
 		mediaUpload( {
 			allowedTypes: ALLOWED_MEDIA_TYPES,
 			filesList: files,
-			onFileChange: images => {
-				const imagesNormalized = images.map( image => pickRelevantMediaFiles( image, sizeSlug ) );
-				this.setAttributes( {
-					images: [ ...currentImages, ...imagesNormalized ],
-				} );
+			onFileChange: imgs => {
+				const imagesNormalized = imgs.map( image => pickRelevantMediaFiles( image, sizeSlug ) );
+
+				setImages( [ ...( images || [] ), ...imagesNormalized ] );
+
 				if ( ! imagesNormalized.every( image => isBlobURL( image.url ) ) ) {
 					unlockPostSaving( lockName );
 				}
@@ -94,80 +68,64 @@ export class SlideshowEdit extends Component {
 			onError: noticeOperations.createErrorNotice,
 		} );
 	};
-	uploadFromFiles = event => this.addFiles( event.target.files );
-	getImageSizeOptions() {
-		const { imageSizes } = this.props;
-		return map( imageSizes, ( { name, slug } ) => ( { value: slug, label: name } ) );
-	}
-	updateImagesSize = sizeSlug => {
-		const { images } = this.props.attributes;
-		const { resizedImages } = this.props;
 
+	const uploadFromFiles = event => addFiles( event.target.files );
+
+	const getImageSizeOptions = () =>
+		map( imageSizes, ( { name, slug } ) => ( { value: slug, label: name } ) );
+
+	const updateImagesSize = slug => {
 		const updatedImages = images.map( image => {
 			const resizedImage = resizedImages.find(
 				( { id } ) => parseInt( id, 10 ) === parseInt( image.id, 10 )
 			);
-			const url = get( resizedImage, [ 'sizes', sizeSlug, 'source_url' ] );
+			const url = get( resizedImage, [ 'sizes', slug, 'source_url' ] );
 			return {
 				...image,
 				...( url && { url } ),
 			};
 		} );
 
-		this.setAttributes( { images: updatedImages, sizeSlug } );
+		setImages( updatedImages );
+		setAttributes( { sizeSlug: slug } );
 	};
-	render() {
-		const { attributes, className, isSelected, noticeOperations, noticeUI } = this.props;
-		const { align, autoplay, delay, effect, images } = attributes;
 
-		const imageSizeOptions = this.getImageSizeOptions();
-		const controls = (
-			<>
-				<InspectorControls>
-					<PanelControls
-						attributes={ attributes }
-						imageSizeOptions={ imageSizeOptions }
-						onChangeImageSize={ this.updateImagesSize }
-						setAttributes={ attrs => this.setAttributes( attrs ) }
-					/>
-				</InspectorControls>
-				<BlockControls>
-					<ToolbarControls
-						allowedMediaTypes={ ALLOWED_MEDIA_TYPES }
-						attributes={ attributes }
-						onSelectImages={ this.onSelectImages }
-					/>
-				</BlockControls>
-			</>
-		);
-
-		if ( images.length === 0 ) {
-			return (
-				<Fragment>
-					{ controls }
-					<MediaPlaceholder
-						icon={ icon }
-						className={ className }
-						labels={ {
-							title: __( 'Slideshow', 'jetpack' ),
-							instructions: __(
-								'Drag images, upload new ones or select files from your library.',
-								'jetpack'
-							),
-						} }
-						onSelect={ this.onSelectImages }
-						accept="image/*"
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						multiple
-						notices={ noticeUI }
-						onError={ noticeOperations.createErrorNotice }
-					/>
-				</Fragment>
-			);
+	useEffect( () => {
+		if ( ! sizeSlug ) {
+			// To improve the performance, we use large size images by default except for blocks inserted before the
+			// image size attribute was added, since they were loading full size images. The presence or lack of images
+			// in a block determines when it has been inserted (before or after we added the image size attribute),
+			// given that now it is not possible to have a block with images and no size.
+			setAttributes( { sizeSlug: ids.length ? 'full' : 'large' } );
 		}
-		return (
-			<Fragment>
-				{ controls }
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	let content;
+
+	if ( images.length === 0 ) {
+		content = (
+			<MediaPlaceholder
+				icon={ getBlockIconComponent( metadata ) }
+				className={ className }
+				labels={ {
+					title: __( 'Slideshow', 'jetpack' ),
+					instructions: __(
+						'Drag images, upload new ones or select files from your library.',
+						'jetpack'
+					),
+				} }
+				onSelect={ onSelectImages }
+				accept="image/*"
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				multiple
+				notices={ noticeUI }
+				onError={ noticeOperations.createErrorNotice }
+			/>
+		);
+	} else {
+		content = (
+			<>
 				{ noticeUI }
 				<Slideshow
 					align={ align }
@@ -178,13 +136,13 @@ export class SlideshowEdit extends Component {
 					images={ images }
 					onError={ noticeOperations.createErrorNotice }
 				/>
-				<DropZone onFilesDrop={ this.addFiles } />
+				<DropZone onFilesDrop={ addFiles } />
 				{ isSelected && (
 					<div className="wp-block-jetpack-slideshow__add-item">
 						<FormFileUpload
 							multiple
 							className="wp-block-jetpack-slideshow__add-item-button"
-							onChange={ this.uploadFromFiles }
+							onChange={ uploadFromFiles }
 							accept="image/*"
 							icon="insert"
 						>
@@ -192,10 +150,32 @@ export class SlideshowEdit extends Component {
 						</FormFileUpload>
 					</div>
 				) }
-			</Fragment>
+			</>
 		);
 	}
-}
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelControls
+					attributes={ attributes }
+					imageSizeOptions={ getImageSizeOptions() }
+					onChangeImageSize={ updateImagesSize }
+					setAttributes={ setAttributes }
+				/>
+			</InspectorControls>
+			<BlockControls>
+				<ToolbarControls
+					allowedMediaTypes={ ALLOWED_MEDIA_TYPES }
+					attributes={ attributes }
+					onSelectImages={ onSelectImages }
+				/>
+			</BlockControls>
+			{ content }
+		</>
+	);
+};
+
 export default compose(
 	withSelect( ( select, props ) => {
 		const imageSizes = select( 'core/editor' ).getEditorSettings().imageSizes;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR refactors the Slideshow block's Edit component to be a functional component. It's preparatory work for upgrading to block API to version 3.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/36765

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- If you run it locally, make sure to run `cd projects/plugins/jetpack && pnpm run build-extensions`
- Create a post
- Add the _Slideshow_ block
- Make sure it behaves as it does in production


