### PR TITLE
AI Featured Image: Add upgrade prompt inside modal

### DIFF
--- a/projects/plugins/jetpack/changelog/add-upgrade-featured-image
+++ b/projects/plugins/jetpack/changelog/add-upgrade-featured-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add upgrade prompt in featured image

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -19,6 +19,7 @@ import './style.scss';
 
 type UpgradePromptProps = {
 	placement?: string;
+	description?: string;
 };
 
 const debug = debugFactory( 'jetpack-ai-assistant:upgrade-prompt' );
@@ -29,7 +30,10 @@ const debug = debugFactory( 'jetpack-ai-assistant:upgrade-prompt' );
  * @param {UpgradePromptProps} props - Component props.
  * @returns {React.ReactNode} the Nudge component with the prompt.
  */
-const DefaultUpgradePrompt = ( { placement = null }: UpgradePromptProps ): React.JSX.Element => {
+const DefaultUpgradePrompt = ( {
+	placement = null,
+	description = null,
+}: UpgradePromptProps ): React.JSX.Element => {
 	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
 	const canUpgrade = canUserPurchasePlan();
 	const {
@@ -67,19 +71,21 @@ const DefaultUpgradePrompt = ( { placement = null }: UpgradePromptProps ): React
 	}, [ tracks, placement ] );
 
 	if ( ! canUpgrade ) {
+		const cantUpgradeDescription = createInterpolateElement(
+			__(
+				'Congratulations on exploring Jetpack AI and reaching the free requests limit! <strong>Reach out to the site administrator to upgrade and keep using Jetpack AI.</strong>',
+				'jetpack'
+			),
+			{
+				strong: <strong />,
+			}
+		);
+
 		return (
 			<Nudge
 				showButton={ false }
 				className={ 'jetpack-ai-upgrade-banner' }
-				description={ createInterpolateElement(
-					__(
-						'Congratulations on exploring Jetpack AI and reaching the free requests limit! <strong>Reach out to the site administrator to upgrade and keep using Jetpack AI.</strong>',
-						'jetpack'
-					),
-					{
-						strong: <strong />,
-					}
-				) }
+				description={ description || cantUpgradeDescription }
 				visible={ true }
 				align={ null }
 				title={ null }
@@ -91,13 +97,15 @@ const DefaultUpgradePrompt = ( { placement = null }: UpgradePromptProps ): React
 	if ( tierPlansEnabled ) {
 		if ( ! nextTier ) {
 			const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
+			const contactUsDescription = __(
+				'You have reached the request limit for your current plan.',
+				'jetpack'
+			);
+
 			return (
 				<Nudge
 					buttonText={ __( 'Contact Us', 'jetpack' ) }
-					description={ __(
-						'You have reached the request limit for your current plan.',
-						'jetpack'
-					) }
+					description={ description || contactUsDescription }
 					className={ 'jetpack-ai-upgrade-banner' }
 					checkoutUrl={ contactHref }
 					visible={ true }
@@ -108,6 +116,21 @@ const DefaultUpgradePrompt = ( { placement = null }: UpgradePromptProps ): React
 				/>
 			);
 		}
+
+		const upgradeDescription = createInterpolateElement(
+			sprintf(
+				/* Translators: number of requests */
+				__(
+					'You have reached the requests limit for your current plan. <strong>Upgrade now to increase your requests limit to %d.</strong>',
+					'jetpack'
+				),
+				nextTier.limit
+			),
+			{
+				strong: <strong />,
+			}
+		);
+
 		return (
 			<Nudge
 				buttonText={ sprintf(
@@ -117,19 +140,7 @@ const DefaultUpgradePrompt = ( { placement = null }: UpgradePromptProps ): React
 				) }
 				checkoutUrl={ checkoutUrl }
 				className={ 'jetpack-ai-upgrade-banner' }
-				description={ createInterpolateElement(
-					sprintf(
-						/* Translators: number of requests */
-						__(
-							'You have reached the requests limit for your current plan. <strong>Upgrade now to increase your requests limit to %d.</strong>',
-							'jetpack'
-						),
-						nextTier.limit
-					),
-					{
-						strong: <strong />,
-					}
-				) }
+				description={ description || upgradeDescription }
 				goToCheckoutPage={ handleUpgradeClick }
 				isRedirecting={ isRedirecting }
 				visible={ true }
@@ -168,23 +179,31 @@ const DefaultUpgradePrompt = ( { placement = null }: UpgradePromptProps ): React
  * The VIP upgrade prompt, with a single text message recommending that the user reach
  * out to their VIP account team.
  *
+ * @param {object} props - Component props.
+ * @param {string} props.description - The description to display in the prompt.
  * @returns {React.ReactNode} the Nudge component with the prompt.
  */
-const VIPUpgradePrompt = (): React.JSX.Element => {
+const VIPUpgradePrompt = ( {
+	description = null,
+}: {
+	description?: string;
+} ): React.JSX.Element => {
+	const vipDescription = createInterpolateElement(
+		__(
+			"You've reached the Jetpack AI rate limit. <strong>Please reach out to your VIP account team.</strong>",
+			'jetpack'
+		),
+		{
+			strong: <strong />,
+		}
+	);
+
 	return (
 		<Nudge
 			buttonText={ null }
 			checkoutUrl={ null }
 			className={ 'jetpack-ai-upgrade-banner' }
-			description={ createInterpolateElement(
-				__(
-					"You've reached the Jetpack AI rate limit. <strong>Please reach out to your VIP account team.</strong>",
-					'jetpack'
-				),
-				{
-					strong: <strong />,
-				}
-			) }
+			description={ description || vipDescription }
 			goToCheckoutPage={ null }
 			isRedirecting={ null }
 			visible={ true }
@@ -200,7 +219,7 @@ const UpgradePrompt = props => {
 
 	// If the user is on a VIP site, show the VIP upgrade prompt.
 	if ( upgradeType === 'vip' ) {
-		return VIPUpgradePrompt();
+		return VIPUpgradePrompt( { description: props.description } );
 	}
 
 	return DefaultUpgradePrompt( props );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -204,16 +204,14 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 					title={ generating ? modalTitleWhenGenerating : modalTitleWhenDone }
 				>
 					{ generating ? (
-						<>
-							<div className="ai-assistant-featured-image__loading">
-								<Spinner
-									style={ {
-										width: '50px',
-										height: '50px',
-									} }
-								/>
-							</div>
-						</>
+						<div className="ai-assistant-featured-image__loading">
+							<Spinner
+								style={ {
+									width: '50px',
+									height: '50px',
+								} }
+							/>
+						</div>
 					) : (
 						<div className="ai-assistant-featured-image__content">
 							<div className="ai-assistant-featured-image__image-canvas">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -6,11 +6,12 @@ import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, Spinner } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
 import './style.scss';
+import UpgradePrompt from '../../../../blocks/ai-assistant/components/upgrade-prompt';
 import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import {
 	PLAN_TYPE_FREE,
@@ -44,6 +45,7 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 
 	// Get feature data
 	const {
+		requireUpgrade,
 		requestsCount: allTimeRequestsCount,
 		requestsLimit: freeRequestsLimit,
 		usagePeriod,
@@ -202,17 +204,35 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 					title={ generating ? modalTitleWhenGenerating : modalTitleWhenDone }
 				>
 					{ generating ? (
-						<div className="ai-assistant-featured-image__loading">
-							<Spinner
-								style={ {
-									width: '50px',
-									height: '50px',
-								} }
-							/>
-						</div>
+						<>
+							<div className="ai-assistant-featured-image__loading">
+								<Spinner
+									style={ {
+										width: '50px',
+										height: '50px',
+									} }
+								/>
+							</div>
+						</>
 					) : (
 						<div className="ai-assistant-featured-image__content">
 							<div className="ai-assistant-featured-image__image-canvas">
+								{ ( requireUpgrade || notEnoughRequests ) && (
+									<UpgradePrompt
+										description={
+											notEnoughRequests
+												? sprintf(
+														// Translators: %d is the cost of generating a featured image.
+														__(
+															"Featured image generation costs %d requests per image. You don't have enough requests to generate another image.",
+															'jetpack'
+														),
+														featuredImageCost
+												  )
+												: null
+										}
+									/>
+								) }
 								{ error ? (
 									<div className="ai-assistant-featured-image__error">
 										{ __(

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/style.scss
@@ -39,4 +39,10 @@
 			color: red;
 		}
 	}
+
+	&__image-canvas {
+		& > .jetpack-ai-upgrade-banner {
+			margin-bottom: 8px;
+		}
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Add an upgrade prompt inside modal, to push users for upgrade as soon the user achieves the maximum usage of `featured image`.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `description` prop in `UpgradePrompt`.
* Use `UpgradePrompt` inside `Featured Image` component.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spawn a new JN site with beta blocks active.
* Use the free version, and generate 2 images without using Jetpack AI, it will achieve the limit and show the prompt.
* Or use one/two time the Jetpack AI and generates an image, it will show the prompt saying you don't have enough requests for one more image.

