### PR TITLE
Fix/php error in inspect plugin

### DIFF
--- a/projects/plugins/inspect/.phan/baseline.php
+++ b/projects/plugins/inspect/.phan/baseline.php
@@ -32,7 +32,6 @@ return [
         'packages/Async_Option/Async_Option.php' => ['PhanParamTooMany'],
         'packages/Async_Option/Endpoint.php' => ['PhanParamTooMany'],
         'packages/Async_Option/Registry.php' => ['PhanCommentParamWithoutRealParam'],
-        'packages/Async_Option/Storage/WP_Option.php' => ['PhanUndeclaredProperty'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/plugins/inspect/changelog/fix-php-error-in-inspect-plugin
+++ b/projects/plugins/inspect/changelog/fix-php-error-in-inspect-plugin
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: This PR fixes a minor PHP warning
+
+

--- a/projects/plugins/inspect/packages/Async_Option/Storage/WP_Option.php
+++ b/projects/plugins/inspect/packages/Async_Option/Storage/WP_Option.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack\Packages\Async_Option\Storage;
 
 class WP_Option implements Storage {
+	private $namespace;
 
 	public function __construct( $namepsace ) {
 		$this->namespace = $namepsace;


### PR DESCRIPTION
This PR fixes a minor PHP Deprecation Warning that I was seeing while running the Inspect plugin. 

```
 PHP Deprecated:  Creation of dynamic property Automattic\Jetpack\Packages\Async_Option\Storage\WP_Option::$namespace is deprecated in /usr/local/src/jetpack-monorepo/projects/plugins/inspect/packages/Async_Option/Storage/WP_Option.php on line 9
```


## Proposed changes:
* Adds the `private $namespace;` so that PHP stops complaining. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Run the inspect plugin notice that it still works as expected and that the php warning is not there any more. 


