### PR TITLE
Blocks: Cookie Consent: Hide the consent banner client-side when the user has dismissed it.

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/view.js
@@ -10,6 +10,13 @@ domReady( function () {
 	const expireTimeDate = new Date( Date.now() + expireDays * millisInDay );
 	const cookieName = 'eucookielaw';
 
+	/**
+	 * Hide the consent block if it's already dismissed.
+	 */
+	if ( container && document.cookie.includes( cookieName ) ) {
+		container.style.display = 'none';
+	}
+
 	const button = container.querySelector( '.wp-block-button a' );
 	button.setAttribute( 'role', 'button' );
 	button.setAttribute( 'href', 'javascript:void(0)' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36814 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hide the cookie consent block at render time, if the cookie is set.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

