### PR TITLE
Scheduled updates: add enum in API definition

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-logs-endpoint-enums
+++ b/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-logs-endpoint-enums
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: No change to end user
+
+

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.7.1';
+	const PACKAGE_VERSION = '0.7.2-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -116,6 +116,17 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 							'description' => 'The action to be logged',
 							'type'        => 'string',
 							'required'    => true,
+							'enum'        => array(
+								Scheduled_Updates_Logs::PLUGIN_UPDATES_START,
+								Scheduled_Updates_Logs::PLUGIN_UPDATES_SUCCESS,
+								Scheduled_Updates_Logs::PLUGIN_UPDATES_FAILURE,
+								Scheduled_Updates_Logs::PLUGIN_UPDATE_SUCCESS,
+								Scheduled_Updates_Logs::PLUGIN_UPDATE_FAILURE,
+								Scheduled_Updates_Logs::PLUGIN_SITE_HEALTH_CHECK_SUCCESS,
+								Scheduled_Updates_Logs::PLUGIN_SITE_HEALTH_CHECK_FAILURE,
+								Scheduled_Updates_Logs::PLUGIN_UPDATE_FAILURE_AND_ROLLBACK,
+								Scheduled_Updates_Logs::PLUGIN_UPDATE_FAILURE_AND_ROLLBACK_FAIL,
+							),
 						),
 						'message' => array(
 							'description' => 'The message to be logged',


### PR DESCRIPTION
Context: https://github.com/Automattic/jetpack/pull/36687#discussion_r1556137048

## Proposed changes:
- Add the possible action types as enum values

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Apply this PR using Jetpack Beta tester
2. Do a test run using the CLI tool: `wp run-scheduled-update --require=bin/scheduled-updates/run-scheduled-updates.php --blog-id=`
3. Confirm that every step is logged

Or:

1. Manually test the endpoint using https://developer.wordpress.com/docs/api/console/