### PR TITLE
Schedules updates: log success when there are no plugins to update

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-no-plugins-to-update
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-no-plugins-to-update
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Small bugfix
+
+

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -81,6 +81,7 @@ class Scheduled_Updates {
 			// No updates available. Update the status to 'success' and return.
 			self::set_scheduled_update_status( $schedule_id, time(), 'success' );
 
+			// We won't log a start here, instead logging success immediately.
 			Scheduled_Updates_Logs::log(
 				$schedule_id,
 				Scheduled_Updates_Logs::PLUGIN_UPDATES_SUCCESS,

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -81,18 +81,13 @@ class Scheduled_Updates {
 			// No updates available. Update the status to 'success' and return.
 			self::set_scheduled_update_status( $schedule_id, time(), 'success' );
 
-			( new Connection\Client() )->wpcom_json_api_request_as_blog(
-				sprintf( '/sites/%d/update-schedules/logs', \Jetpack_Options::get_option( 'id' ) ),
-				'2',
-				array( 'method' => 'POST' ),
+			Scheduled_Updates_Logs::log(
+				$schedule_id,
+				Scheduled_Updates_Logs::PLUGIN_UPDATES_SUCCESS,
+				'no_plugins_to_update',
 				array(
-					'action'  => Scheduled_Updates_Logs::PLUGIN_UPDATE_SUCCESS,
-					'message' => 'no_plugins_to_update',
-					'context' => array(
-						'plugins' => array(),
-					),
-				),
-				'wpcom'
+					'plugins' => array(),
+				)
 			);
 
 			return;

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -81,6 +81,20 @@ class Scheduled_Updates {
 			// No updates available. Update the status to 'success' and return.
 			self::set_scheduled_update_status( $schedule_id, time(), 'success' );
 
+			( new Connection\Client() )->wpcom_json_api_request_as_blog(
+				sprintf( '/sites/%d/update-schedules/logs', \Jetpack_Options::get_option( 'id' ) ),
+				'2',
+				array( 'method' => 'POST' ),
+				array(
+					'action'  => Scheduled_Updates_Logs::PLUGIN_UPDATE_SUCCESS,
+					'message' => 'no_plugins_to_update',
+					'context' => array(
+						'plugins' => array(),
+					),
+				),
+				'wpcom'
+			);
+
 			return;
 		}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -81,7 +81,7 @@ class Scheduled_Updates {
 			// No updates available. Update the status to 'success' and return.
 			self::set_scheduled_update_status( $schedule_id, time(), 'success' );
 
-			// Schedule a start and success log.
+			// Log a start and success.
 			Scheduled_Updates_Logs::log(
 				$schedule_id,
 				Scheduled_Updates_Logs::PLUGIN_UPDATES_START,

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -81,14 +81,16 @@ class Scheduled_Updates {
 			// No updates available. Update the status to 'success' and return.
 			self::set_scheduled_update_status( $schedule_id, time(), 'success' );
 
-			// We won't log a start here, instead logging success immediately.
+			// Schedule a start and success log.
+			Scheduled_Updates_Logs::log(
+				$schedule_id,
+				Scheduled_Updates_Logs::PLUGIN_UPDATES_START,
+				'no_plugins_to_update'
+			);
 			Scheduled_Updates_Logs::log(
 				$schedule_id,
 				Scheduled_Updates_Logs::PLUGIN_UPDATES_SUCCESS,
-				'no_plugins_to_update',
-				array(
-					'plugins' => array(),
-				)
+				'no_plugins_to_update'
 			);
 
 			return;


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/89347 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Logs PLUGIN_UPDATES_SUCCESS when there's nothing to update (with `no_plugins_to_update` to differentiate in Calypso)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Create a schedule for which no update is needed
- Wait for it to run
- There should be a PLUGIN_UPDATES_SUCCESS message
