### PR TITLE
Social Notes: Remove featured image block from template

### DIFF
--- a/projects/plugins/social/changelog/changee-social-notes-remove-featured-image-block
+++ b/projects/plugins/social/changelog/changee-social-notes-remove-featured-image-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Removed the featured image block from the template

--- a/projects/plugins/social/src/class-note.php
+++ b/projects/plugins/social/src/class-note.php
@@ -122,9 +122,10 @@ class Note {
 						'placeholder' => __( "What's on your mind?", 'jetpack-social' ),
 					),
 				),
-				array(
-					'core/post-featured-image',
-				),
+				// We should add this back when the double featured image issue is fixed.
+				// array(
+				// 'core/post-featured-image',
+				// ),
 			),
 		);
 		register_post_type( self::JETPACK_SOCIAL_NOTE_CPT, $args );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/280

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed the block from the template while we fix the double featured image issuee

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/280
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new note and check that the featured image block is not in the template
* You should still be able to add id as a new block

