### PR TITLE
codesniffer: Fix Phan issues

### DIFF
--- a/projects/packages/codesniffer/.phan/baseline.php
+++ b/projects/packages/codesniffer/.phan/baseline.php
@@ -8,20 +8,9 @@
  * (can be combined with --load-baseline)
  */
 return [
-    // # Issue statistics:
-    // PhanPluginDuplicateConditionalNullCoalescing : 2 occurrences
-    // PhanUnextractableAnnotationSuffix : 2 occurrences
-    // PhanPluginSimplifyExpressionBool : 1 occurrence
-    // PhanTypeMismatchReturn : 1 occurrence
-    // UnusedPluginSuppression : 1 occurrence
-
+    // This baseline has no suppressions
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'Jetpack/Sniffs/Constants/MasterUserConstantSniff.php' => ['PhanUnextractableAnnotationSuffix'],
-        'Jetpack/Sniffs/Functions/I18nSniff.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUnextractableAnnotationSuffix'],
-        'Jetpack/Sniffs/Functions/SetCookieSniff.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool'],
-        'hacks/PHPUnitTestTrait.php' => ['UnusedPluginSuppression'],
-        'tests/php/tests/test-jetpack-compat.php' => ['PhanTypeMismatchReturn'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/codesniffer/Jetpack/Sniffs/Constants/MasterUserConstantSniff.php
+++ b/projects/packages/codesniffer/Jetpack/Sniffs/Constants/MasterUserConstantSniff.php
@@ -17,7 +17,7 @@ class MasterUserConstantSniff implements Sniff {
 	/**
 	 * Returns the token types that this sniff is interested in.
 	 *
-	 * @return array(int)
+	 * @return int[]
 	 */
 	public function register() {
 		return array( T_STRING );

--- a/projects/packages/codesniffer/Jetpack/Sniffs/Functions/I18nSniff.php
+++ b/projects/packages/codesniffer/Jetpack/Sniffs/Functions/I18nSniff.php
@@ -32,7 +32,7 @@ class I18nSniff implements Sniff {
 	/**
 	 * Returns the token types that this sniff is interested in.
 	 *
-	 * @return array(int)
+	 * @return int[]
 	 */
 	public function register() {
 		return array( T_STRING );
@@ -131,7 +131,7 @@ class I18nSniff implements Sniff {
 			}
 
 			// Go through the values in the array looking for 'textdomain'.
-			$idx   = isset( $tokens[ $args[3][0] ]['parenthesis_opener'] ) ? $tokens[ $args[3][0] ]['parenthesis_opener'] : $args[3][0];
+			$idx   = $tokens[ $args[3][0] ]['parenthesis_opener'] ?? $args[3][0];
 			$end   = $args[3][1];
 			$start = $phpcsFile->findNext( Tokens::$emptyTokens, $idx + 1, $end, true );
 			$toks  = array( T_OPEN_CURLY_BRACKET, T_OPEN_SQUARE_BRACKET, T_OPEN_PARENTHESIS, T_OPEN_SHORT_ARRAY, T_COMMA );

--- a/projects/packages/codesniffer/Jetpack/Sniffs/Functions/SetCookieSniff.php
+++ b/projects/packages/codesniffer/Jetpack/Sniffs/Functions/SetCookieSniff.php
@@ -64,7 +64,7 @@ class SetCookieSniff extends AbstractFunctionParameterSniff {
 
 		// We're only interested in the third parameter.
 		$param = $this->target_functions[ $matched_content ]['param'];
-		if ( false === isset( $parameters[ $param ] ) || 'true' !== strtolower( $parameters[ $param ]['raw'] ) ) {
+		if ( ! isset( $parameters[ $param ] ) || 'true' !== strtolower( $parameters[ $param ]['raw'] ) ) {
 			$errorcode = 'MissingTrueHTTPOnly';
 
 			/*
@@ -77,7 +77,7 @@ class SetCookieSniff extends AbstractFunctionParameterSniff {
 
 			$this->phpcsFile->addWarning(
 				'The %s function requires the httponly parameter to be set to true, unless intentionally disabled.',
-				( isset( $parameters[ $param ]['start'] ) ? $parameters[ $param ]['start'] : $parameters[1]['start'] ),
+				$parameters[ $param ]['start'] ?? $parameters[1]['start'],
 				$errorcode,
 				array( $matched_content )
 			);

--- a/projects/packages/codesniffer/changelog/fix-phan-in-codesniffer
+++ b/projects/packages/codesniffer/changelog/fix-phan-in-codesniffer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix Phan issues. No change to functionality.
+
+

--- a/projects/packages/codesniffer/hacks/PHPUnitTestTrait.php
+++ b/projects/packages/codesniffer/hacks/PHPUnitTestTrait.php
@@ -25,7 +25,6 @@ trait PHPUnitTestTrait {
 	 * @var string[]
 	 */
 	private static $PHPUNIT_CLASSES = [
-		// @phan-suppress-previous-line PhanReadOnlyPrivateProperty Traits cannot have constants
 		'MediaWikiTestCase' => 'MediaWikiTestCase',
 		'MediaWikiUnitTestCase' => 'MediaWikiUnitTestCase',
 		'MediaWikiIntegrationTestCase' => 'MediaWikiIntegrationTestCase',

--- a/projects/packages/codesniffer/tests/php/tests/test-jetpack-compat.php
+++ b/projects/packages/codesniffer/tests/php/tests/test-jetpack-compat.php
@@ -99,7 +99,7 @@ EOF;
 	/**
 	 * Provide arguments for `test_phpcs()`.
 	 *
-	 * @return array
+	 * @return \Generator<array>
 	 */
 	public function provide_standards() {
 		$lines1 = array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Correct phpdoc types.
* Use `??` where appropriate.
* Simplify `false === isset()` to `! isset()`.
* Remove a phan suppression copied from upstream now that we use phan too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?