### PR TITLE
Scheduled Updates: Move arbitrary actions to callbacks

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-endpoint-actions
+++ b/projects/packages/scheduled-updates/changelog/add-endpoint-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Scheduled Updates: Move arbitrary actions to callbacks

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
@@ -162,7 +162,7 @@ class Scheduled_Updates_Logs {
 	 */
 	public static function infer_status_from_logs( $schedule_id ) {
 		$logs = self::get( $schedule_id );
-		if ( is_wp_error( $logs ) || empty( $logs ) ) {
+		if ( empty( $logs ) ) {
 			return false;
 		}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
@@ -199,6 +199,41 @@ class Scheduled_Updates_Logs {
 	}
 
 	/**
+	 * Replaces the logs with the old schedule ID with new ones.
+	 *
+	 * @param string $old_schedule_id The old schedule ID.
+	 * @param string $new_schedule_id The new schedule ID.
+	 */
+	public static function replace_logs_schedule_id( $old_schedule_id, $new_schedule_id ) {
+		if ( $old_schedule_id === $new_schedule_id ) {
+			return;
+		}
+
+		$logs = get_option( self::OPTION_NAME, array() );
+
+		if ( isset( $logs[ $old_schedule_id ] ) ) {
+			// Replace the logs with the old schedule ID with new ones.
+			$logs[ $new_schedule_id ] = $logs[ $old_schedule_id ];
+			unset( $logs[ $old_schedule_id ] );
+
+			update_option( self::OPTION_NAME, $logs );
+		}
+	}
+
+	/**
+	 * Deletes the logs for a schedule ID when the current request is a DELETE request.
+	 *
+	 * @param string           $schedule_id The ID of the schedule to delete.
+	 * @param object           $event       The deleted event object.
+	 * @param \WP_REST_Request $request     The request object.
+	 */
+	public static function delete_logs_schedule_id( $schedule_id, $event, $request ) {
+		if ( $request->get_method() === \WP_REST_Server::DELETABLE ) {
+			self::clear( $schedule_id );
+		}
+	}
+
+	/**
 	 * Splits the logs into runs based on the PLUGIN_UPDATES_START action.
 	 *
 	 * @param array $logs The logs to split into runs.
@@ -224,34 +259,5 @@ class Scheduled_Updates_Logs {
 		}
 
 		return $runs;
-	}
-
-	/**
-	 * Replaces the logs with the old schedule ID with new ones.
-	 *
-	 * @param string $old_schedule_id The old schedule ID.
-	 * @param string $new_schedule_id The new schedule ID.
-	 *
-	 * @return bool True if the logs were successfully replaced, false otherwise.
-	 */
-	public static function replace_logs_schedule_id( $old_schedule_id, $new_schedule_id ) {
-
-		if ( $old_schedule_id === $new_schedule_id ) {
-			return false;
-		}
-
-		$logs = get_option( self::OPTION_NAME, array() );
-
-		if ( isset( $logs[ $old_schedule_id ] ) ) {
-			// Replace the logs with the old schedule ID with new ones
-			$logs[ $new_schedule_id ] = $logs[ $old_schedule_id ];
-			unset( $logs[ $old_schedule_id ] );
-
-			update_option( self::OPTION_NAME, $logs );
-
-			return true;
-		}
-
-		return false;
 	}
 }

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -59,9 +59,9 @@ class Scheduled_Updates {
 
 		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'maybe_disable_autoupdates' ), 10, 3 );
 		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'create_scheduled_update_status' ), 10, 3 );
-		add_action( 'jetpack_scheduled_update_updated', array( __CLASS__, 'migrate_schedule_status' ), 10, 2 );
 		add_action( 'jetpack_scheduled_update_deleted', array( __CLASS__, 'enable_autoupdates' ), 10, 2 );
-		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'clear' ) );
+		add_action( 'jetpack_scheduled_update_updated', array( Scheduled_Updates_Logs::class, 'replace_logs_schedule_id' ), 10, 2 );
+		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'delete_logs_schedule_id' ), 10, 3 );
 
 		// Update cron sync option after options update.
 		$callback = array( __CLASS__, 'update_option_cron' );
@@ -244,21 +244,6 @@ class Scheduled_Updates {
 	 */
 	public static function get_scheduled_update_status( $schedule_id ) {
 		return Scheduled_Updates_Logs::infer_status_from_logs( $schedule_id );
-	}
-
-	/**
-	 * Migrate the status of a scheduled update.
-	 *
-	 * @param string $old_schedule_id Old schedule ID.
-	 * @param string $new_schedule_id New schedule ID.
-	 */
-	public static function migrate_schedule_status( $old_schedule_id, $new_schedule_id ) {
-		$old_status = static::get_scheduled_update_status( $old_schedule_id );
-
-		// Sets the previous status.
-		if ( $old_status ) {
-			static::set_scheduled_update_status( $new_schedule_id, $old_status['last_run_timestamp'], $old_status['last_run_status'] );
-		}
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -58,7 +58,6 @@ class Scheduled_Updates {
 		add_filter( 'plugin_auto_update_setting_html', array( Scheduled_Updates_Admin::class, 'show_scheduled_updates' ), 10, 2 );
 
 		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'maybe_disable_autoupdates' ), 10, 3 );
-		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'create_scheduled_update_status' ), 10, 3 );
 		add_action( 'jetpack_scheduled_update_deleted', array( __CLASS__, 'enable_autoupdates' ), 10, 2 );
 		add_action( 'jetpack_scheduled_update_updated', array( Scheduled_Updates_Logs::class, 'replace_logs_schedule_id' ), 10, 2 );
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'delete_logs_schedule_id' ), 10, 3 );
@@ -181,20 +180,6 @@ class Scheduled_Updates {
 	 */
 	public static function clear_cron_cache() {
 		wp_cache_delete( 'alloptions', 'options' );
-	}
-
-	/**
-	 * Create a scheduled update status.
-	 *
-	 * @param string           $schedule_id Request ID.
-	 * @param object           $event       The event object.
-	 * @param \WP_REST_Request $request     The request object.
-	 */
-	public static function create_scheduled_update_status( $schedule_id, $event, $request ) {
-		// Only create the status if this is a CREATE request.
-		if ( empty( $request['schedule_id'] ) ) {
-			self::set_scheduled_update_status( $schedule_id, null, null );
-		}
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -193,7 +193,7 @@ class Scheduled_Updates {
 	public static function create_scheduled_update_status( $schedule_id, $event, $request ) {
 		// Only create the status if this is a CREATE request.
 		if ( empty( $request['schedule_id'] ) ) {
-			self::set_scheduled_update_status( $schedule_id );
+			self::set_scheduled_update_status( $schedule_id, null, null );
 		}
 	}
 
@@ -201,11 +201,11 @@ class Scheduled_Updates {
 	 * Updates last status of a scheduled update.
 	 *
 	 * @param string      $schedule_id Request ID.
-	 * @param int|null    $timestamp   Optional. Timestamp of the last run. Default is null.
-	 * @param string|null $status      Optional. Status of the last run. Default is null.
+	 * @param int|null    $timestamp   Timestamp of the last run.
+	 * @param string|null $status      Status of the last run.
 	 * @return false|array Updated statuses or false if not found.
 	 */
-	public static function set_scheduled_update_status( $schedule_id, $timestamp = null, $status = null ) {
+	public static function set_scheduled_update_status( $schedule_id, $timestamp, $status ) {
 		$events = wp_get_scheduled_events( self::PLUGIN_CRON_HOOK );
 
 		if ( empty( $events[ $schedule_id ] ) ) {
@@ -250,7 +250,7 @@ class Scheduled_Updates {
 	 * Migrate the status of a scheduled update.
 	 *
 	 * @param string $old_schedule_id Old schedule ID.
-	 * @param object $new_schedule_id New schedule ID.
+	 * @param string $new_schedule_id New schedule ID.
 	 */
 	public static function migrate_schedule_status( $old_schedule_id, $new_schedule_id ) {
 		$old_status = static::get_scheduled_update_status( $old_schedule_id );

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -265,16 +265,16 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return $event;
 		}
 
-		require_once ABSPATH . 'wp-admin/includes/update.php';
-
-		if ( wp_is_auto_update_enabled_for_type( 'plugin' ) ) {
-			// Remove the plugins that are now updated on a schedule from the auto-update list.
-			$auto_update_plugins = get_option( 'auto_update_plugins', array() );
-			$auto_update_plugins = array_diff( $auto_update_plugins, $plugins );
-			update_option( 'auto_update_plugins', $auto_update_plugins );
-		}
-
 		$id = Scheduled_Updates::generate_schedule_id( $plugins );
+
+		/**
+		 * Fires when a scheduled update is created.
+		 *
+		 * @param string          $id      The ID of the schedule.
+		 * @param object          $event   The event object.
+		 * @param WP_REST_Request $request The request object.
+		 */
+		do_action( 'jetpack_scheduled_update_created', $id, $event, $request );
 
 		return rest_ensure_response( $id );
 	}
@@ -346,16 +346,27 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 
 		$clear_logs = false;
 		$deleted    = $this->delete_item( $request, $clear_logs );
+
 		if ( is_wp_error( $deleted ) ) {
 			return $deleted;
 		}
 
 		$item = $this->create_item( $request );
 
+
 		// Sets the previous status.
 		if ( $previous_schedule_status ) {
 			Scheduled_Updates_Logs::replace_logs_schedule_id( $request['schedule_id'], $item->data );
 		}
+
+		/**
+		 * Fires when a scheduled update is updated.
+		 *
+		 * @param string          $old_id  The ID of the schedule to update.
+		 * @param string          $new_id  The ID of the updated event.
+		 * @param WP_REST_Request $request The request object.
+		 */
+		do_action( 'jetpack_scheduled_update_updated', $request['schedule_id'], $item->data, $request );
 
 		return $item;
 	}
@@ -493,28 +504,19 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return new WP_Error( 'unschedule_event_error', __( 'Error during unschedule of the event.', 'jetpack-scheduled-updates' ), array( 'status' => 500 ) );
 		}
 
-		require_once ABSPATH . 'wp-admin/includes/update.php';
-
-		if ( wp_is_auto_update_enabled_for_type( 'plugin' ) ) {
-			unset( $events[ $request['schedule_id'] ] );
-
-			// Find the plugins that are not part of any other schedule.
-			$plugins = $event->args;
-			foreach ( wp_list_pluck( $events, 'args' ) as $args ) {
-				$plugins = array_diff( $plugins, $args );
-			}
-
-			// Add the plugins that are no longer updated on a schedule to the auto-update list.
-			$auto_update_plugins = get_option( 'auto_update_plugins', array() );
-			$auto_update_plugins = array_unique( array_merge( $auto_update_plugins, $plugins ) );
-			usort( $auto_update_plugins, 'strnatcasecmp' );
-			update_option( 'auto_update_plugins', $auto_update_plugins );
-		}
-
 		// Delete logs
 		if ( $clear_logs ) {
 			Scheduled_Updates_Logs::clear( $request['schedule_id'] );
 		}
+
+		/**
+		 * Fires when a scheduled update is deleted.
+		 *
+		 * @param string          $id      The ID of the schedule to delete.
+		 * @param object          $event   The deleted event object.
+		 * @param WP_REST_Request $request The request object.
+		 */
+		do_action( 'jetpack_scheduled_update_deleted', $request['schedule_id'], $event, $request );
 
 		return rest_ensure_response( true );
 	}

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -641,13 +641,14 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$schedule_id = $result->get_data();
 
-		// Get the updated status
+		// Get the updated status.
 		$updated_status = Scheduled_Updates::get_scheduled_update_status( $schedule_id );
+
 		if ( $updated_status === false ) {
 			$this->fail( 'Scheduled_Updates::get_scheduled_update_status() returned false.' );
 		} else {
 			$this->assertIsArray( $updated_status, 'Scheduled_Updates::get_scheduled_update_status() should return an array.' );
-			// doing these null checks for the static analyzer
+			// doing these null checks for the static analyzer.
 			$this->assertSame( $timestamp, $updated_status['last_run_timestamp'] ?? null );
 			$this->assertSame( $status, $updated_status['last_run_status'] ?? null );
 
@@ -888,7 +889,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$schedule_id = $this->create_test_schedule();
 
-		// Simulate 5 runs
+		// Simulate 5 runs.
 		for ( $i = 0;$i < 5;$i++ ) {
 			$request = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $schedule_id . '/logs' );
 			$request->set_body_params(

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-endpoint-actions
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-endpoint-actions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+


### PR DESCRIPTION
This is somewhat of a first step for https://github.com/Automattic/dotcom-forge/issues/6337, to make it easier to manage notification settings as part of schedule management, assuming we want to manage that on a per-schedule basis.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduces `do_action` calls for create, update, delete endpoints in `update-schedule`.
* Creates callbacks to these new actions to maintain the current functionality.
* Removes schedule validations from logs API as it's probably not needed.
* Updates unit tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using Jetpack beta or rsync, enable this branch on a test site.
* Create a new schedule and make sure the plugins selected have autoupdates disabled after.
* Downgrade a plugin or two and run a scheduled update.
* Make sure logs are added as expected.
* Update the schedule with a new time or a new plugin.
* Make sure the logs have migrated to the updated schedule.
* Delete that schedule and make sure the plugins have autoupdates enabled after.
* Make sure the logs have been deleted.
