### PR TITLE
Fix/launch task completion

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launch-task-completion
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launch-task-completion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Added completed callback for site_launched task

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.24.0",
+	"version": "5.24.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.24.0';
+	const PACKAGE_VERSION = '5.24.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -739,12 +739,25 @@ function wpcom_launchpad_get_task_definitions() {
 
 /**
  * Returns true if the current site is launched.
+ * 
+ * @param array $task The task object.
+ * @param bool  $is_complete The current task status.
  *
  * @return boolean
  */
-function wpcom_launchpad_is_site_launched() {
+function wpcom_launchpad_is_site_launched( $task, $is_complete ) {
+	if ( $is_complete ) {
+		return true;
+	}
+	
 	$launch_status = get_blog_option( get_current_blog_id(), 'launch-status' );
-	return 'launched' === $launch_status;
+
+	if( 'launched' === $launch_status ) {
+		wpcom_mark_launchpad_task_complete( 'site_launched' );	
+		return true;
+	} else {
+		return false;
+	}
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -154,6 +154,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Launch your site', 'jetpack-mu-wpcom' );
 			},
 			'isLaunchTask'          => true,
+			'is_complete_callback'  => 'wpcom_launchpad_is_site_launched',
 			'add_listener_callback' => 'wpcom_launchpad_add_site_launch_listener',
 		),
 		'verify_email'                    => array(
@@ -734,6 +735,17 @@ function wpcom_launchpad_get_task_definitions() {
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );
 
 	return array_merge( $extended_task_definitions, $task_definitions );
+}
+
+/**
+ * Returns true if the current site is launched.
+ *
+ * @return boolean
+ */
+
+function wpcom_launchpad_is_site_launched( $task ) {
+	$launch_status = get_blog_option( null, 'launch-status' );
+	return 'launched' === $launch_status;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -739,7 +739,7 @@ function wpcom_launchpad_get_task_definitions() {
 
 /**
  * Returns true if the current site is launched.
- * 
+ *
  * @param array $task The task object.
  * @param bool  $is_complete The current task status.
  *
@@ -749,11 +749,11 @@ function wpcom_launchpad_is_site_launched( $task, $is_complete ) {
 	if ( $is_complete ) {
 		return true;
 	}
-	
+
 	$launch_status = get_blog_option( get_current_blog_id(), 'launch-status' );
 
-	if( 'launched' === $launch_status ) {
-		wpcom_mark_launchpad_task_complete( 'site_launched' );	
+	if ( 'launched' === $launch_status ) {
+		wpcom_mark_launchpad_task_complete( 'site_launched' );
 		return true;
 	} else {
 		return false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -742,8 +742,7 @@ function wpcom_launchpad_get_task_definitions() {
  *
  * @return boolean
  */
-
-function wpcom_launchpad_is_site_launched( $task ) {
+function wpcom_launchpad_is_site_launched() {
 	$launch_status = get_blog_option( null, 'launch-status' );
 	return 'launched' === $launch_status;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -743,7 +743,7 @@ function wpcom_launchpad_get_task_definitions() {
  * @return boolean
  */
 function wpcom_launchpad_is_site_launched() {
-	$launch_status = get_blog_option( null, 'launch-status' );
+	$launch_status = get_blog_option( get_current_blog_id(), 'launch-status' );
 	return 'launched' === $launch_status;
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/88007

## Proposed changes:
The "Launch site" task remains incomplete even when the site is launched. 

This PR adds logic to the task to check the launch_status and be "completed" if the site is launched.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Enable sandbox and apply this PR
- Create a site through the /start flow.
- On the Goals step, select sell.
- Go through the flow until you reach the Customer Home page.
- Click on the Launch your site task.
- Click on Show site setup
- Check if the Launch your Site task is completed.

![image](https://github.com/Automattic/jetpack/assets/3801502/15717282-ed1e-4ec7-a939-42b31e221a19)
