### PR TITLE
My Jetpack: add connection errors to Global Notice

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -15,7 +15,7 @@ import {
 } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { useContext, useLayoutEffect, useState } from 'react';
+import { useContext, useEffect, useLayoutEffect, useState } from 'react';
 /*
  * Internal dependencies
  */
@@ -43,6 +43,14 @@ import WelcomeBanner from '../welcome-banner';
 import styles from './styles.module.scss';
 
 const GlobalNotice = ( { message, title, options } ) => {
+	const { recordEvent } = useAnalytics();
+
+	useEffect( () => {
+		recordEvent( 'jetpack_myjetpack_global_notice_view', {
+			noticeId: options.id,
+		} );
+	}, [ options.id, recordEvent ] );
+
 	const [ isBiggerThanMedium ] = useBreakpointMatch( [ 'md' ], [ '>' ] );
 
 	const actionButtons = options.actions?.map( action => {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -13,7 +13,6 @@ import {
 	useBreakpointMatch,
 	ActionButton,
 } from '@automattic/jetpack-components';
-import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { useContext, useLayoutEffect, useState } from 'react';
@@ -81,7 +80,6 @@ export default function MyJetpackScreen() {
 		title: noticeTitle,
 		options: noticeOptions,
 	} = currentNotice || {};
-	const { hasConnectionError } = useConnectionErrorNotice();
 	const { data: availabilityData, isLoading: isChatAvailabilityLoading } = useSimpleQuery( {
 		name: QUERY_CHAT_AVAILABILITY_KEY,
 		query: { path: REST_API_CHAT_AVAILABILITY_ENDPOINT },
@@ -140,11 +138,6 @@ export default function MyJetpackScreen() {
 							{ __( 'Discover all Jetpack Products', 'jetpack-my-jetpack' ) }
 						</Text>
 					</Col>
-					{ hasConnectionError && ! isWelcomeBannerVisible && (
-						<Col>
-							<ConnectionError />
-						</Col>
-					) }
 					{ noticeMessage && ! isWelcomeBannerVisible && (
 						<Col>
 							{

--- a/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
+++ b/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useState } from 'react';
+import { createContext, useCallback, useState } from 'react';
 import { NoticeContextType, Notice } from './types';
 
 const defaultNotice: Notice = {
@@ -21,16 +21,19 @@ export const NoticeContext = createContext< NoticeContextType >( {
 const NoticeContextProvider = ( { children } ) => {
 	const [ currentNotice, setCurrentNotice ] = useState< Notice >( defaultNotice );
 
-	const setNotice = ( notice: Notice ) => {
-		// Only update notice if there is not already a notice or the new notice has a higher priority
-		if ( ! currentNotice.message || notice.options.priority > currentNotice.options.priority ) {
-			setCurrentNotice( notice );
-		}
-	};
+	const setNotice = useCallback(
+		( notice: Notice ) => {
+			// Only update notice if there is not already a notice or the new notice has a higher priority
+			if ( ! currentNotice.message || notice.options.priority > currentNotice.options.priority ) {
+				setCurrentNotice( notice );
+			}
+		},
+		[ currentNotice.message, currentNotice.options.priority ]
+	);
 
-	const resetNotice = () => {
+	const resetNotice = useCallback( () => {
 		setCurrentNotice( defaultNotice );
-	};
+	}, [] );
 
 	return (
 		<NoticeContext.Provider

--- a/projects/packages/my-jetpack/_inc/context/notices/types.ts
+++ b/projects/packages/my-jetpack/_inc/context/notices/types.ts
@@ -11,6 +11,7 @@ export type Notice = {
 	message: string | ReactNode;
 	title?: string;
 	options: {
+		id?: string;
 		level: string;
 		actions?: NoticeButtonAction[];
 		priority: number;

--- a/projects/packages/my-jetpack/_inc/data/notices/use-fetching-error-notice.ts
+++ b/projects/packages/my-jetpack/_inc/data/notices/use-fetching-error-notice.ts
@@ -39,6 +39,7 @@ export const useFetchingErrorNotice = ( { infoName, isError, overrideMessage }: 
 			setNotice( {
 				message,
 				options: {
+					id: 'fetching-error-notice',
 					level: 'error',
 					priority: NOTICE_PRIORITY_LOW,
 				},

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/index.ts
@@ -1,5 +1,6 @@
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useBadInstallNotice from './use-bad-install-notice';
+import useConnectionErrorsNotice from './use-connection-errors-notice';
 import useSiteConnectionNotice from './use-site-connection-notice';
 
 const useNotificationWatcher = () => {
@@ -7,6 +8,7 @@ const useNotificationWatcher = () => {
 
 	useBadInstallNotice( redBubbleAlerts );
 	useSiteConnectionNotice( redBubbleAlerts );
+	useConnectionErrorsNotice();
 };
 
 export default useNotificationWatcher;

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-bad-install-notice.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-bad-install-notice.ts
@@ -41,6 +41,7 @@ const useBadInstallNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 		};
 
 		const noticeOptions = {
+			id: 'bad-installation-notice',
 			level: 'error',
 			actions: [
 				{

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
@@ -39,7 +39,7 @@ const useConnectionErrorsNotice = () => {
 			recordEvent( 'jetpack_my_jetpack_connection_error_notice_cta_click' );
 		};
 
-		const loadingButtonLabel = __( 'Reconnecting Jetpack', 'jetpack-my-jetpack' );
+		const loadingButtonLabel = __( 'Reconnecting Jetpack…', 'jetpack-my-jetpack' );
 		const restoreButtonLabel = __( 'Restore Connection', 'jetpack-my-jetpack' );
 
 		const noticeOptions = {

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
@@ -41,19 +41,7 @@ const useConnectionErrorsNotice = () => {
 		}
 
 		const onCtaClick = () => {
-			restoreConnection().then( () => {
-				resetNotice();
-				setNotice( {
-					message: __( 'Your connection has been restored.', 'jetpack-my-jetpack' ),
-					options: {
-						level: 'success',
-						actions: [],
-						priority: NOTICE_PRIORITY_HIGH,
-						hideCloseButton: false,
-						onClose: resetNotice,
-					},
-				} );
-			} );
+			restoreConnection();
 			recordEvent( 'jetpack_my_jetpack_connection_error_notice_reconnect_cta_click' );
 		};
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
@@ -1,6 +1,6 @@
 import { Col, Text } from '@automattic/jetpack-components';
 import { useConnectionErrorNotice, useRestoreConnection } from '@automattic/jetpack-connection';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useContext, useEffect } from 'react';
 import { NOTICE_PRIORITY_HIGH } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
@@ -28,14 +28,32 @@ const useConnectionErrorsNotice = () => {
 		if ( restoreConnectionError ) {
 			errorMessage = (
 				<Col>
-					<Text mb={ 2 }>{ restoreConnectionError }</Text>
+					<Text mb={ 2 }>
+						{ sprintf(
+							/* translators: placeholder is the error. */
+							__( 'There was an error reconnecting Jetpack. Error: %s', 'jetpack-my-jetpack' ),
+							restoreConnectionError
+						) }
+					</Text>
 					<Text mb={ 2 }>{ connectionErrorMessage }</Text>
 				</Col>
 			);
 		}
 
 		const onCtaClick = () => {
-			restoreConnection();
+			restoreConnection().then( () => {
+				resetNotice();
+				setNotice( {
+					message: __( 'Your connection has been restored.', 'jetpack-my-jetpack' ),
+					options: {
+						level: 'success',
+						actions: [],
+						priority: NOTICE_PRIORITY_HIGH,
+						hideCloseButton: false,
+						onClose: resetNotice,
+					},
+				} );
+			} );
 			recordEvent( 'jetpack_my_jetpack_connection_error_notice_reconnect_cta_click' );
 		};
 
@@ -68,6 +86,7 @@ const useConnectionErrorsNotice = () => {
 		restoreConnection,
 		isRestoringConnection,
 		restoreConnectionError,
+		resetNotice,
 	] );
 };
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
@@ -14,9 +14,9 @@ const useConnectionErrorsNotice = () => {
 	const { recordEvent } = useAnalytics();
 
 	useEffect( () => {
-		// Reset notice when the status of reconnection changes
+		// Reset notice before showing the failed to restore connection notice
 		resetNotice();
-	}, [ resetNotice, connectionErrorMessage, isRestoringConnection ] );
+	}, [ resetNotice, restoreConnectionError ] );
 
 	useEffect( () => {
 		if ( ! hasConnectionError ) {
@@ -53,7 +53,7 @@ const useConnectionErrorsNotice = () => {
 					noDefaultClasses: true,
 				},
 			],
-			priority: NOTICE_PRIORITY_HIGH,
+			priority: NOTICE_PRIORITY_HIGH + isRestoringConnection ? 1 : 0,
 		};
 
 		setNotice( {

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
@@ -1,0 +1,74 @@
+import { Col, Text } from '@automattic/jetpack-components';
+import { useConnectionErrorNotice, useRestoreConnection } from '@automattic/jetpack-connection';
+import { __ } from '@wordpress/i18n';
+import { useContext, useEffect } from 'react';
+import { NOTICE_PRIORITY_HIGH } from '../../context/constants';
+import { NoticeContext } from '../../context/notices/noticeContext';
+import useAnalytics from '../use-analytics';
+
+const useConnectionErrorsNotice = () => {
+	const { setNotice, resetNotice } = useContext( NoticeContext );
+	const { hasConnectionError, connectionErrorMessage } = useConnectionErrorNotice();
+	const { restoreConnection, isRestoringConnection, restoreConnectionError } =
+		useRestoreConnection();
+	const { recordEvent } = useAnalytics();
+
+	useEffect( () => {
+		// Reset notice when the status of reconnection changes
+		resetNotice();
+	}, [ resetNotice, connectionErrorMessage, isRestoringConnection ] );
+
+	useEffect( () => {
+		if ( ! hasConnectionError ) {
+			return;
+		}
+
+		let errorMessage = connectionErrorMessage;
+
+		if ( restoreConnectionError ) {
+			errorMessage = (
+				<Col>
+					<Text mb={ 2 }>{ restoreConnectionError }</Text>
+					<Text mb={ 2 }>{ connectionErrorMessage }</Text>
+				</Col>
+			);
+		}
+
+		const onCtaClick = () => {
+			restoreConnection();
+			recordEvent( 'jetpack_my_jetpack_connection_error_notice_cta_click' );
+		};
+
+		const loadingButtonLabel = __( 'Reconnecting Jetpack', 'jetpack-my-jetpack' );
+		const restoreButtonLabel = __( 'Restore Connection', 'jetpack-my-jetpack' );
+
+		const noticeOptions = {
+			level: 'error',
+			actions: [
+				{
+					label: restoreButtonLabel,
+					onClick: onCtaClick,
+					isLoading: isRestoringConnection,
+					loadingText: loadingButtonLabel,
+					noDefaultClasses: true,
+				},
+			],
+			priority: NOTICE_PRIORITY_HIGH,
+		};
+
+		setNotice( {
+			message: errorMessage,
+			options: noticeOptions,
+		} );
+	}, [
+		setNotice,
+		recordEvent,
+		hasConnectionError,
+		connectionErrorMessage,
+		restoreConnection,
+		isRestoringConnection,
+		restoreConnectionError,
+	] );
+};
+
+export default useConnectionErrorsNotice;

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
@@ -36,7 +36,7 @@ const useConnectionErrorsNotice = () => {
 
 		const onCtaClick = () => {
 			restoreConnection();
-			recordEvent( 'jetpack_my_jetpack_connection_error_notice_cta_click' );
+			recordEvent( 'jetpack_my_jetpack_connection_error_notice_reconnect_cta_click' );
 		};
 
 		const loadingButtonLabel = __( 'Reconnecting Jetpack…', 'jetpack-my-jetpack' );
@@ -53,7 +53,7 @@ const useConnectionErrorsNotice = () => {
 					noDefaultClasses: true,
 				},
 			],
-			priority: NOTICE_PRIORITY_HIGH + isRestoringConnection ? 1 : 0,
+			priority: NOTICE_PRIORITY_HIGH + ( isRestoringConnection ? 1 : 0 ),
 		};
 
 		setNotice( {

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
@@ -49,6 +49,7 @@ const useConnectionErrorsNotice = () => {
 		const restoreButtonLabel = __( 'Restore Connection', 'jetpack-my-jetpack' );
 
 		const noticeOptions = {
+			id: 'connection-error-notice',
 			level: 'error',
 			actions: [
 				{

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -8,12 +8,14 @@ import { NoticeContext } from '../../context/notices/noticeContext';
 import { useAllProducts } from '../../data/products/use-product';
 import { getMyJetpackWindowRestState } from '../../data/utils/get-my-jetpack-window-state';
 import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
+import useAnalytics from '../use-analytics';
 import useMyJetpackConnection from '../use-my-jetpack-connection';
 import useMyJetpackNavigate from '../use-my-jetpack-navigate';
 
 type RedBubbleAlerts = Window[ 'myJetpackInitialState' ][ 'redBubbleAlerts' ];
 
 const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
+	const { recordEvent } = useAnalytics();
 	const { setNotice, resetNotice } = useContext( NoticeContext );
 	const { apiRoot, apiNonce } = getMyJetpackWindowRestState();
 	const { isRegistered, isUserConnected, hasConnectedOwner } = useMyJetpackConnection();
@@ -42,14 +44,17 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 
 		const onActionButtonClick = () => {
 			if ( requiresUserConnection ) {
+				recordEvent( 'jetpack_my_jetpack_user_connection_notice_cta_click' );
 				navToConnection();
 			}
 
+			recordEvent( 'jetpack_my_jetpack_site_connection_notice_cta_click' );
 			handleRegisterSite().then( () => {
 				resetNotice();
 				setNotice( {
 					message: __( 'Your site has been successfully connected.', 'jetpack-my-jetpack' ),
 					options: {
+						id: 'site-connection-success-notice',
 						level: 'success',
 						actions: [],
 						priority: NOTICE_PRIORITY_HIGH,
@@ -91,6 +96,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 		};
 
 		const noticeOptions = {
+			id: requiresUserConnection ? 'user-connection-notice' : 'site-connection-notice',
 			level: 'info',
 			actions: [
 				{
@@ -129,6 +135,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 		isUserConnected,
 		navToConnection,
 		products,
+		recordEvent,
 		redBubbleAlerts,
 		resetNotice,
 		setNotice,

--- a/projects/packages/my-jetpack/changelog/add-connection-errors-notice
+++ b/projects/packages/my-jetpack/changelog/add-connection-errors-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: add errors from the connection package to the new notice component

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -78,7 +78,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.22.x-dev"
+			"dev-trunk": "4.23.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.22.4-alpha",
+	"version": "4.23.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.22.4-alpha';
+	const PACKAGE_VERSION = '4.23.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/backup/changelog/add-connection-errors-notice
+++ b/projects/plugins/backup/changelog/add-connection-errors-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1124,7 +1124,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b75e18b95f6e0b9f0edeeded684589e49450c92d"
+                "reference": "4f104c5627363e92ba7e195bb36ad95c0a142a67"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1158,7 +1158,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.22.x-dev"
+                    "dev-trunk": "4.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/add-connection-errors-notice
+++ b/projects/plugins/boost/changelog/add-connection-errors-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1043,7 +1043,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b75e18b95f6e0b9f0edeeded684589e49450c92d"
+                "reference": "4f104c5627363e92ba7e195bb36ad95c0a142a67"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1077,7 +1077,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.22.x-dev"
+                    "dev-trunk": "4.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/add-connection-errors-notice
+++ b/projects/plugins/jetpack/changelog/add-connection-errors-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1669,7 +1669,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "b75e18b95f6e0b9f0edeeded684589e49450c92d"
+				"reference": "4f104c5627363e92ba7e195bb36ad95c0a142a67"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1703,7 +1703,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.22.x-dev"
+					"dev-trunk": "4.23.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/add-connection-errors-notice
+++ b/projects/plugins/migration/changelog/add-connection-errors-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1124,7 +1124,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b75e18b95f6e0b9f0edeeded684589e49450c92d"
+                "reference": "4f104c5627363e92ba7e195bb36ad95c0a142a67"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1158,7 +1158,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.22.x-dev"
+                    "dev-trunk": "4.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/add-connection-errors-notice
+++ b/projects/plugins/protect/changelog/add-connection-errors-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1037,7 +1037,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b75e18b95f6e0b9f0edeeded684589e49450c92d"
+                "reference": "4f104c5627363e92ba7e195bb36ad95c0a142a67"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1071,7 +1071,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.22.x-dev"
+                    "dev-trunk": "4.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/add-connection-errors-notice
+++ b/projects/plugins/search/changelog/add-connection-errors-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -980,7 +980,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b75e18b95f6e0b9f0edeeded684589e49450c92d"
+                "reference": "4f104c5627363e92ba7e195bb36ad95c0a142a67"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1014,7 +1014,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.22.x-dev"
+                    "dev-trunk": "4.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/add-connection-errors-notice
+++ b/projects/plugins/social/changelog/add-connection-errors-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -980,7 +980,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "b75e18b95f6e0b9f0edeeded684589e49450c92d"
+				"reference": "4f104c5627363e92ba7e195bb36ad95c0a142a67"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1014,7 +1014,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.22.x-dev"
+					"dev-trunk": "4.23.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/add-connection-errors-notice
+++ b/projects/plugins/starter-plugin/changelog/add-connection-errors-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -980,7 +980,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b75e18b95f6e0b9f0edeeded684589e49450c92d"
+                "reference": "4f104c5627363e92ba7e195bb36ad95c0a142a67"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1014,7 +1014,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.22.x-dev"
+                    "dev-trunk": "4.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/add-connection-errors-notice
+++ b/projects/plugins/videopress/changelog/add-connection-errors-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -980,7 +980,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "b75e18b95f6e0b9f0edeeded684589e49450c92d"
+                "reference": "4f104c5627363e92ba7e195bb36ad95c0a142a67"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1014,7 +1014,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.22.x-dev"
+                    "dev-trunk": "4.23.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See linked issue

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR removes the usage of `<ConnectionError>` (from `@automattic/jetpack-connection`) from My Jetpack. It adds a new hook to `use-notification-watcher` that consumes the data from the `jetpack-connection` library and displays it as a Global Notice.

<img width="1228" alt="image" src="https://github.com/Automattic/jetpack/assets/5714212/fe664bb3-5e25-4780-af09-ad73f707a7f3">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pbNhbs-ag3-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes, it adds a new event to the "Reconnect Jetpack" button.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch and with Jetpack Debug Tools
* Visit My Jetpack, connect your account and dismiss the welcome banner
* Confirm that you don't see any notice on My Jetpack
* Now, go to Jetpack Debug, enable  "Broken token Utilities" and save
* After refreshing the page, go to "Broken Token" under "Jetpack Debug" and click on "Set invalid blog token" and "Set invalid user tokens"
* Go back to My Jetpack and confirm that you see an error like the one in the screenshot above. Try reconnecting Jetpack and confirm the behavior makes sense