### PR TITLE
Donations Form block: show Stripe notice when not connected

### DIFF
--- a/projects/plugins/jetpack/changelog/dontations-form-show-stripe-notice-when-not-connected
+++ b/projects/plugins/jetpack/changelog/dontations-form-show-stripe-notice-when-not-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dontains Form block: show Stripe nudge if not connected.

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { StripeNudge } from '../../shared/components/stripe-nudge';
 import { SUPPORTED_CURRENCIES } from '../../shared/currencies';
 import getConnectUrl from '../../shared/get-connect-url';
+import { store as membershipProductsStore } from '../../store/membership-products';
 import { STORE_NAME as MEMBERSHIPS_PRODUCTS_STORE } from '../../store/membership-products/constants';
 import fetchDefaultProducts from './fetch-default-products';
 import fetchStatus from './fetch-status';
@@ -20,6 +21,11 @@ const Edit = props => {
 
 	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' );
 	const post = useSelect( select => select( 'core/editor' ).getCurrentPost(), [] );
+
+	const isStripeConnected = useSelect(
+		select => select( membershipProductsStore ).isApiStateConnected(),
+		false
+	);
 
 	const { setConnectUrl, setConnectedAccountDefaultCurrency } = useDispatch(
 		MEMBERSHIPS_PRODUCTS_STORE
@@ -127,13 +133,12 @@ const Edit = props => {
 	}
 
 	if ( ! currency ) {
+		if ( ! isStripeConnected ) {
+			<StripeNudge blockName="donations" />;
+		}
+
 		// Memberships settings are still loading
-		return (
-			<>
-				<StripeNudge blockName="donations" />
-				<Spinner color="black" />
-			</>
-		);
+		return <Spinner color="black" />;
 	}
 
 	return <Tabs { ...props } products={ products } />;

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -22,9 +22,9 @@ const Edit = props => {
 	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' );
 	const post = useSelect( select => select( 'core/editor' ).getCurrentPost(), [] );
 
-	const isStripeConnected = useSelect(
-		select => select( membershipProductsStore ).isApiStateConnected(),
-		false
+	const stripeConnectUrl = useSelect(
+		select => select( membershipProductsStore ).getConnectUrl(),
+		''
 	);
 
 	const { setConnectUrl, setConnectedAccountDefaultCurrency } = useDispatch(
@@ -133,7 +133,7 @@ const Edit = props => {
 	}
 
 	if ( ! currency ) {
-		if ( ! isStripeConnected ) {
+		if ( stripeConnectUrl ) {
 			<StripeNudge blockName="donations" />;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -132,11 +132,12 @@ const Edit = props => {
 		return <LoadingError className={ className } error={ loadingError } />;
 	}
 
-	if ( ! currency ) {
-		if ( stripeConnectUrl ) {
-			return <StripeNudge blockName="donations" />;
-		}
+	if ( stripeConnectUrl ) {
+		// Need to connect Stripe first
+		return <StripeNudge blockName="donations" />;
+	}
 
+	if ( ! currency ) {
 		// Memberships settings are still loading
 		return <Spinner color="black" />;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -134,7 +134,7 @@ const Edit = props => {
 
 	if ( ! currency ) {
 		if ( stripeConnectUrl ) {
-			<StripeNudge blockName="donations" />;
+			return <StripeNudge blockName="donations" />;
 		}
 
 		// Memberships settings are still loading

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -2,6 +2,7 @@ import { Spinner } from '@automattic/jetpack-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { StripeNudge } from '../../shared/components/stripe-nudge';
 import { SUPPORTED_CURRENCIES } from '../../shared/currencies';
 import getConnectUrl from '../../shared/get-connect-url';
 import { STORE_NAME as MEMBERSHIPS_PRODUCTS_STORE } from '../../store/membership-products/constants';
@@ -127,7 +128,12 @@ const Edit = props => {
 
 	if ( ! currency ) {
 		// Memberships settings are still loading
-		return <Spinner />;
+		return (
+			<>
+				<StripeNudge blockName="donations" />
+				<Spinner color="black" />
+			</>
+		);
 	}
 
 	return <Tabs { ...props } products={ products } />;

--- a/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
-import { StripeNudge } from '../../shared/components/stripe-nudge';
 import Controls from './controls';
 import Tab from './tab';
 
@@ -54,7 +53,6 @@ const Tabs = props => {
 
 	return (
 		<div className={ className }>
-			<StripeNudge blockName="donations" />
 			<div className="donations__container">
 				{ Object.keys( tabs ).length > 1 && (
 					<div className="donations__nav">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/89123

<img width="718" alt="Screenshot 2567-04-11 at 14 36 42" src="https://github.com/Automattic/jetpack/assets/6851384/79584ecf-e1ce-4c08-8e0f-701f69029435">

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* If Stripe is not connected, make sure the connect nudge is displayed. 
* Changes the colour of the loading spinner, which wasn't visible on a white background

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site without Stripe connected, add a new post and type `/donation` and insert the Payments wrapper bock then choose Dontains, or choose the Donations Form block directly
* It should appear empty with no visual feedback as reported in https://github.com/Automattic/wp-calypso/issues/89123
* Using the comment below, apply this branch to your site and try again
* You should now see the Stripe nudge appear
* Connect a Stripe account and confirm the nudge is not shown and you see the Donations Form block
* Disconnect your Stripe account and confirm the nudge is shown again

