### PR TITLE
Add configs for simple classic to load blaze

### DIFF
--- a/projects/packages/blaze/changelog/update-blaze-default-config-data
+++ b/projects/packages/blaze/changelog/update-blaze-default-config-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update configs to accomodate for Simple Classic for Blaze

--- a/projects/packages/blaze/src/class-dashboard-config-data.php
+++ b/projects/packages/blaze/src/class-dashboard-config-data.php
@@ -53,7 +53,9 @@ class Dashboard_Config_Data {
 			'site_name'                => \get_bloginfo( 'name' ),
 			'sections'                 => array(),
 			// Features are inlined in Calypso Blaze app (wp-calypso/apps/blaze-dashboard)
-			'features'                 => array(),
+			'features'                 => array(
+				'is_running_in_jetpack_site' => ! $host->is_wpcom_simple(),
+			),
 			'initial_state'            => array(
 				'currentUser' => array(
 					'id'           => $user['ID'],
@@ -67,7 +69,7 @@ class Dashboard_Config_Data {
 						"$blog_id" => array(
 							'ID'           => $blog_id,
 							'URL'          => site_url(),
-							'jetpack'      => true,
+							'jetpack'      => ! $host->is_wpcom_simple(),
 							'visible'      => true,
 							'capabilities' => $empty_object,
 							'products'     => array(),
@@ -76,6 +78,7 @@ class Dashboard_Config_Data {
 								'admin_url'       => admin_url(),
 								'gmt_offset'      => $this->get_gmt_offset(),
 								'is_wpcom_atomic' => $host->is_woa_site(),
+								'is_wpcom_simple' => $host->is_wpcom_simple(),
 								'jetpack_version' => Constants::get_constant( 'JETPACK__VERSION' ),
 							),
 						),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6234

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR only makes sure the front page for Blaze in Simple Classic Loads, in short don't click on anything yet, because it probably won't work.
* Will make issues for everything and fix them in followup PRs 

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/jetpack/assets/6586048/5d34623e-84e6-4f49-93cd-bfda1216eed1">  | <img src="https://github.com/Automattic/jetpack/assets/6586048/dbd4bbcd-4599-4e7a-a351-7c49284747b0">|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pfsHM7-EF-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the instructions https://github.com/Automattic/jetpack/pull/36842#issuecomment-2049115600 to test.

To enable Simple Classic, create a Simple Site and in your sandbox wpsh run:
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
update_blog_option( blogID ,'wpcom_classic_early_release', 1 );
```

- Sandbox `yoursite.wordpress.com`
- Go to `/wp-admin/tools.php?page=advertising`
- Check the Network Tab and make sure there are no more API CORS errors

Make sure Atomic/Jetpack sites aren't affected by this change.