### PR TITLE
Add scheduled updates sync option

### DIFF
--- a/projects/packages/sync/changelog/add-scheduled-updates-sync
+++ b/projects/packages/sync/changelog/add-scheduled-updates-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Scheduled Update Plugins option to synched options

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -58,7 +58,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.11.x-dev"
+			"dev-trunk": "2.12.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -200,6 +200,7 @@ class Defaults {
 		'jetpack_blocks_disabled',
 		'jetpack_package_versions',
 		'jetpack_newsletters_publishing_default_frequency',
+		'jetpack_scheduled_update_plugins',
 	);
 
 	/**

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -200,7 +200,7 @@ class Defaults {
 		'jetpack_blocks_disabled',
 		'jetpack_package_versions',
 		'jetpack_newsletters_publishing_default_frequency',
-		'jetpack_scheduled_update_plugins',
+		'jetpack_scheduled_plugins_update',
 	);
 
 	/**

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.11.1';
+	const PACKAGE_VERSION = '2.12.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/automattic-for-agencies-client/changelog/add-scheduled-updates-sync
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-scheduled-updates-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -992,7 +992,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "6f1c78637e77424cfaa762850842d08d3f79b4d0"
+                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1024,7 +1024,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.11.x-dev"
+                    "dev-trunk": "2.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/backup/changelog/add-scheduled-updates-sync
+++ b/projects/plugins/backup/changelog/add-scheduled-updates-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1545,7 +1545,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "6f1c78637e77424cfaa762850842d08d3f79b4d0"
+                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1577,7 +1577,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.11.x-dev"
+                    "dev-trunk": "2.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/add-scheduled-updates-sync
+++ b/projects/plugins/boost/changelog/add-scheduled-updates-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1535,7 +1535,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "6f1c78637e77424cfaa762850842d08d3f79b4d0"
+                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1567,7 +1567,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.11.x-dev"
+                    "dev-trunk": "2.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/add-scheduled-updates-sync
+++ b/projects/plugins/jetpack/changelog/add-scheduled-updates-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2453,7 +2453,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "6f1c78637e77424cfaa762850842d08d3f79b4d0"
+				"reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2485,7 +2485,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.11.x-dev"
+					"dev-trunk": "2.12.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -254,7 +254,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_classic_early_release'                  => true,
 			'jetpack_package_versions'                     => array(),
 			'jetpack_newsletters_publishing_default_frequency' => 'weekly',
-			'jetpack_scheduled_update_plugins'             => array(),
+			'jetpack_scheduled_plugins_update'             => array(),
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -254,6 +254,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_classic_early_release'                  => true,
 			'jetpack_package_versions'                     => array(),
 			'jetpack_newsletters_publishing_default_frequency' => 'weekly',
+			'jetpack_scheduled_update_plugins'             => array(),
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/projects/plugins/migration/changelog/add-scheduled-updates-sync
+++ b/projects/plugins/migration/changelog/add-scheduled-updates-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1545,7 +1545,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "6f1c78637e77424cfaa762850842d08d3f79b4d0"
+                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1577,7 +1577,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.11.x-dev"
+                    "dev-trunk": "2.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/add-scheduled-updates-sync
+++ b/projects/plugins/protect/changelog/add-scheduled-updates-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1458,7 +1458,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "6f1c78637e77424cfaa762850842d08d3f79b4d0"
+                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1490,7 +1490,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.11.x-dev"
+                    "dev-trunk": "2.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/add-scheduled-updates-sync
+++ b/projects/plugins/search/changelog/add-scheduled-updates-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1549,7 +1549,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "6f1c78637e77424cfaa762850842d08d3f79b4d0"
+                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1581,7 +1581,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.11.x-dev"
+                    "dev-trunk": "2.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-scheduled-updates-sync
+++ b/projects/plugins/social/changelog/add-scheduled-updates-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -85,6 +85,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ4_2_0"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ4_2_1_alpha"
 	}
 }

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1540,7 +1540,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "6f1c78637e77424cfaa762850842d08d3f79b4d0"
+				"reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1572,7 +1572,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.11.x-dev"
+					"dev-trunk": "2.12.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Social
  * Plugin URI: https://wordpress.org/plugins/jetpack-social
  * Description: Share your site’s posts on several social media networks automatically when you publish a new post.
- * Version: 4.2.0
+ * Version: 4.2.1-alpha
  * Author: Automattic - Jetpack Social team
  * Author URI: https://jetpack.com/social/
  * License: GPLv2 or later

--- a/projects/plugins/starter-plugin/changelog/add-scheduled-updates-sync
+++ b/projects/plugins/starter-plugin/changelog/add-scheduled-updates-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1401,7 +1401,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "6f1c78637e77424cfaa762850842d08d3f79b4d0"
+                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1433,7 +1433,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.11.x-dev"
+                    "dev-trunk": "2.12.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/add-scheduled-updates-sync
+++ b/projects/plugins/videopress/changelog/add-scheduled-updates-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1401,7 +1401,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "6f1c78637e77424cfaa762850842d08d3f79b4d0"
+                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1433,7 +1433,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.11.x-dev"
+                    "dev-trunk": "2.12.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Context: p1712832877052689-slack-C01A60HCGUA
See D145046-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add new `jetpack_scheduled_update_plugins` option to synched options: https://github.com/Automattic/jetpack/pull/36849/files#diff-957c3706a0e06fc3d914399593bfcba36135bfa023b172ea5474a04d56f0cb4d

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There is nothing to test here for the moment.