### PR TITLE
Blocks: upgrade to API version 3 - Part 4

### DIFF
--- a/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-4
+++ b/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update blocks to use API version 3

--- a/projects/plugins/jetpack/extensions/blocks/map/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/map/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/map",
 	"title": "Map",
 	"description": "Add an interactive map showing one or more locations.",

--- a/projects/plugins/jetpack/extensions/blocks/map/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/edit.js
@@ -1,6 +1,6 @@
 import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
-import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import { BlockControls, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	Button,
 	ExternalLink,
@@ -45,7 +45,6 @@ const RESIZABLE_BOX_ENABLE_OPTION = {
 };
 
 const MapEdit = ( {
-	className,
 	setAttributes,
 	attributes,
 	noticeUI,
@@ -75,6 +74,8 @@ const MapEdit = ( {
 	const [ apiKeySource, setApiKeySource ] = useState( null );
 	const [ apiRequestOutstanding, setApiRequestOutstanding ] = useState( null );
 	const mapRef = useRef( null );
+	const blockProps = useBlockProps();
+	const { className } = blockProps;
 
 	const mapStyle = getActiveStyleName( styles, className );
 	const mapProvider = getMapProvider( { mapStyle } );
@@ -322,67 +323,65 @@ const MapEdit = ( {
 					/>
 				</InspectorControls>
 
-				<div className={ className }>
-					<ResizableBox
-						size={ {
-							height: mapHeight || 'auto',
-							width: '100%',
-						} }
-						grid={ [ 10, 10 ] }
-						showHandle={ isSelected }
-						minHeight={ MIN_HEIGHT }
-						enable={ RESIZABLE_BOX_ENABLE_OPTION }
-						onResizeStart={ onResizeStart }
-						onResizeStop={ onMapResize }
-					>
-						<div className="wp-block-jetpack-map__map_wrapper">
-							<Map
-								ref={ mapRef }
-								address={ address }
-								scrollToZoom={ allowScrollToZoom }
-								showFullscreenButton={ showFullscreenButton }
-								mapStyle={ mapStyle || 'default' }
-								mapDetails={ mapDetails }
-								mapHeight={ mapHeight }
-								points={ points }
-								zoom={ zoom }
-								mapCenter={ mapCenter }
-								markerColor={ markerColor }
-								onSetZoom={ value => {
-									setAttributes( { zoom: value } );
-								} }
-								admin={ true }
-								apiKey={ apiKey }
-								onSetPoints={ value => setAttributes( { points: value } ) }
-								onSetMapCenter={ value => setAttributes( { mapCenter: value } ) }
-								onMapLoaded={ () => setAddPointVisibility( ! points.length ) }
-								onMarkerClick={ () => setAddPointVisibility( false ) }
-								onError={ onError }
-								mapProvider={ mapProvider }
-							>
-								{ isSelected && addPointVisibility && (
-									<AddPoint
-										onAddPoint={ addPoint }
-										onClose={ () => setAddPointVisibility( false ) }
-										apiKey={ apiKey }
-										onError={ onError }
-										tagName="AddPoint"
-										mapProvider={ mapProvider }
-									/>
-								) }
-							</Map>
-						</div>
-					</ResizableBox>
-				</div>
+				<ResizableBox
+					size={ {
+						height: mapHeight || 'auto',
+						width: '100%',
+					} }
+					grid={ [ 10, 10 ] }
+					showHandle={ isSelected }
+					minHeight={ MIN_HEIGHT }
+					enable={ RESIZABLE_BOX_ENABLE_OPTION }
+					onResizeStart={ onResizeStart }
+					onResizeStop={ onMapResize }
+				>
+					<div className="wp-block-jetpack-map__map_wrapper">
+						<Map
+							ref={ mapRef }
+							address={ address }
+							scrollToZoom={ allowScrollToZoom }
+							showFullscreenButton={ showFullscreenButton }
+							mapStyle={ mapStyle || 'default' }
+							mapDetails={ mapDetails }
+							mapHeight={ mapHeight }
+							points={ points }
+							zoom={ zoom }
+							mapCenter={ mapCenter }
+							markerColor={ markerColor }
+							onSetZoom={ value => {
+								setAttributes( { zoom: value } );
+							} }
+							admin={ true }
+							apiKey={ apiKey }
+							onSetPoints={ value => setAttributes( { points: value } ) }
+							onSetMapCenter={ value => setAttributes( { mapCenter: value } ) }
+							onMapLoaded={ () => setAddPointVisibility( ! points.length ) }
+							onMarkerClick={ () => setAddPointVisibility( false ) }
+							onError={ onError }
+							mapProvider={ mapProvider }
+						>
+							{ isSelected && addPointVisibility && (
+								<AddPoint
+									onAddPoint={ addPoint }
+									onClose={ () => setAddPointVisibility( false ) }
+									apiKey={ apiKey }
+									onError={ onError }
+									tagName="AddPoint"
+									mapProvider={ mapProvider }
+								/>
+							) }
+						</Map>
+					</div>
+				</ResizableBox>
 			</>
 		);
 	}
 
 	return (
-		<>
+		<div { ...blockProps }>
 			{ noticeUI }
 			{ content }
-		</>
+		</div>
 	);
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/map/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/save.js
@@ -1,51 +1,52 @@
-import { Component } from '@wordpress/element';
+import { useBlockProps } from '@wordpress/block-editor';
+import classNames from 'classnames';
 import { getActiveStyleName } from '../../shared/block-styles';
 import styles from './styles';
 
-class MapSave extends Component {
-	render() {
-		const { attributes } = this.props;
-		const {
-			align,
-			className,
-			mapDetails,
-			points,
-			zoom,
-			mapCenter,
-			markerColor,
-			scrollToZoom,
-			mapHeight,
-			showFullscreenButton,
-		} = attributes;
-		const mapStyle = getActiveStyleName( styles, className );
-		const pointsList = points.map( ( point, index ) => {
-			const { longitude, latitude } = point.coordinates;
-			const url = 'https://www.google.com/maps/search/?api=1&query=' + latitude + ',' + longitude;
-			return (
-				<li key={ index }>
-					<a href={ url }>{ point.title }</a>
-				</li>
-			);
-		} );
-		const alignClassName = align ? `align${ align }` : null;
-		// All camelCase attribute names converted to snake_case data attributes
+const MapSave = ( { attributes } ) => {
+	const {
+		align,
+		mapDetails,
+		points,
+		zoom,
+		mapCenter,
+		markerColor,
+		scrollToZoom,
+		mapHeight,
+		showFullscreenButton,
+	} = attributes;
+	const blockProps = useBlockProps.save();
+	const { className } = blockProps;
+
+	const mapStyle = getActiveStyleName( styles, className );
+	const pointsList = points.map( ( point, index ) => {
+		const { longitude, latitude } = point.coordinates;
+		const url = 'https://www.google.com/maps/search/?api=1&query=' + latitude + ',' + longitude;
 		return (
-			<div
-				className={ alignClassName }
-				data-map-style={ mapStyle }
-				data-map-details={ mapDetails }
-				data-points={ JSON.stringify( points ) }
-				data-zoom={ zoom }
-				data-map-center={ JSON.stringify( mapCenter ) }
-				data-marker-color={ markerColor }
-				data-scroll-to-zoom={ scrollToZoom || null }
-				data-map-height={ mapHeight || null }
-				data-show-fullscreen-button={ showFullscreenButton || null }
-			>
-				{ points.length > 0 && <ul>{ pointsList }</ul> }
-			</div>
+			<li key={ index }>
+				<a href={ url }>{ point.title }</a>
+			</li>
 		);
-	}
-}
+	} );
+
+	// All camelCase attribute names converted to snake_case data attributes
+	return (
+		<div
+			{ ...blockProps }
+			className={ classNames( className, align ? `align${ align }` : null ) }
+			data-map-style={ mapStyle }
+			data-map-details={ mapDetails }
+			data-points={ JSON.stringify( points ) }
+			data-zoom={ zoom }
+			data-map-center={ JSON.stringify( mapCenter ) }
+			data-marker-color={ markerColor }
+			data-scroll-to-zoom={ scrollToZoom || null }
+			data-map-height={ mapHeight || null }
+			data-show-fullscreen-button={ showFullscreenButton || null }
+		>
+			{ points.length > 0 && <ul>{ pointsList }</ul> }
+		</div>
+	);
+};
 
 export default MapSave;

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/nextdoor",
 	"title": "Nextdoor",
 	"description": "Embed a Nextdoor post for your neighbors on your blog.",

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/edit.js
@@ -1,4 +1,5 @@
 import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
+import { useBlockProps } from '@wordpress/block-editor';
 import { getBlockDefaultClassName } from '@wordpress/blocks';
 import { SandBox, Button, Placeholder, withNotices } from '@wordpress/components';
 import { useState } from '@wordpress/element';
@@ -15,12 +16,12 @@ const icon = getBlockIconComponent( metadata );
 export function NextdoorEdit( {
 	attributes,
 	clientId,
-	className,
 	name,
 	noticeOperations,
 	noticeUI,
 	setAttributes,
 } ) {
+	const blockProps = useBlockProps();
 	const defaultClassName = getBlockDefaultClassName( name );
 	const validatedAttributes = getValidatedAttributes( metadata.attributes, attributes );
 
@@ -95,7 +96,7 @@ export function NextdoorEdit( {
 	);
 
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			<NextdoorControls
 				{ ...{ defaultClassName, nextdoorShareUrl, onFormSubmit, setNextdoorShareUrl } }
 			/>

--- a/projects/plugins/jetpack/extensions/blocks/nextdoor/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/nextdoor/save.js
@@ -1,9 +1,10 @@
-/* eslint-disable jsdoc/require-jsdoc */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 export default function save() {
+	const blockProps = useBlockProps.save();
+
 	return (
-		<div>
+		<div { ...blockProps }>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "premium-content/container",
 	"title": "Paid Content",
 	"description": "Restrict access to your content for paying subscribers.",

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -1,4 +1,4 @@
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as blockEditorStore, useBlockProps } from '@wordpress/block-editor';
 import { Disabled, Placeholder, Spinner } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { select, useSelect } from '@wordpress/data';
@@ -56,10 +56,11 @@ const BLOCK_NAME = 'premium-content';
  * @param { Props } props
  */
 
-function Edit( props ) {
+function Edit( { clientId, isSelected, attributes, setAttributes } ) {
+	const { isPreview, selectedPlanIds } = attributes;
+
 	const [ selectedTab, selectTab ] = useState( tabs[ WALL_TAB ] );
-	const { isPreview, selectedPlanIds } = props.attributes;
-	const { clientId, isSelected, className, setAttributes } = props;
+	const blockProps = useBlockProps();
 
 	const setSelectedProductIds = productIds => setAttributes( { selectedPlanIds: productIds } );
 
@@ -100,7 +101,7 @@ function Edit( props ) {
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			{ ! isPreview && (
 				<>
 					{ isApiLoading && (

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/save.js
@@ -1,8 +1,14 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import classNames from 'classnames';
 
 export default function Save() {
+	const blockProps = useBlockProps.save();
+
 	return (
-		<div className="wp-block-premium-content-container">
+		<div
+			{ ...blockProps }
+			className={ classNames( blockProps.className, 'wp-block-premium-content-container' ) }
+		>
 			<InnerBlocks.Content />
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/subscriber-login",
 	"title": "Subscriber Login",
 	"description": "Show links for subscribers to login, logout, or manage their subscription.",

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/edit.js
@@ -1,14 +1,15 @@
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl, BaseControl, TextControl } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import metadata from './block.json';
 
-function SubscriberLoginEdit( { attributes, setAttributes, className } ) {
+function SubscriberLoginEdit( { attributes, setAttributes } ) {
 	const logInInputId = useInstanceId( TextControl, 'inspector-text-control' );
 	const logOutInputId = useInstanceId( TextControl, 'inspector-text-control' );
 	const manageSubscriptionsInputId = useInstanceId( TextControl, 'inspector-text-control' );
+	const blockProps = useBlockProps();
 	const validatedAttributes = getValidatedAttributes( metadata.attributes, attributes );
 	const {
 		redirectToCurrent,
@@ -19,7 +20,7 @@ function SubscriberLoginEdit( { attributes, setAttributes, className } ) {
 	} = validatedAttributes;
 
 	return (
-		<>
+		<div { ...blockProps }>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 					<ToggleControl
@@ -65,10 +66,8 @@ function SubscriberLoginEdit( { attributes, setAttributes, className } ) {
 					) }
 				</PanelBody>
 			</InspectorControls>
-			<div className={ className }>
-				<a href="#logout-pseudo-link">{ logOutLabel || __( 'Log out', 'jetpack' ) }</a>
-			</div>
-		</>
+			<a href="#logout-pseudo-link">{ logOutLabel || __( 'Log out', 'jetpack' ) }</a>
+		</div>
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/top-posts",
 	"title": "Top Posts & Pages",
 	"description": "Display your most popular content.",

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/edit.js
@@ -1,6 +1,6 @@
 import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
-import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import { BlockControls, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { useState, useEffect } from '@wordpress/element';
 import classNames from 'classnames';
 import { LoadingPostsGrid } from '../../shared/components/loading-posts-grid';
@@ -46,9 +46,11 @@ function TopPostsPreviewItem( props ) {
 	);
 }
 
-function TopPostsEdit( { attributes, className, setAttributes } ) {
+function TopPostsEdit( { attributes, setAttributes } ) {
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'stats' );
+	const blockProps = useBlockProps();
+	const { className } = blockProps;
 
 	const [ postsData, setPostsData ] = useState();
 	const [ postsToDisplay, setPostsToDisplay ] = useState();
@@ -134,43 +136,46 @@ function TopPostsEdit( { attributes, className, setAttributes } ) {
 		setPostsToDisplay,
 	] );
 
+	let content;
+
 	if ( ! isModuleActive && ! isLoadingModules ) {
-		return (
+		content = (
 			<InactiveStatsPlaceholder
 				className={ className }
 				changeStatus={ changeStatus }
 				isLoading={ isChangingStatus }
 			/>
 		);
-	}
+	} else if ( ! postsToDisplay ) {
+		content = <LoadingPostsGrid />;
+	} else {
+		content = (
+			<>
+				<InspectorControls>
+					<TopPostsInspectorControls
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+						toggleAttributes={ toggleAttributes }
+						setToggleAttributes={ setToggleAttributes }
+						postTypesData={ postTypesData }
+					/>
+				</InspectorControls>
 
-	if ( ! postsToDisplay ) {
-		return <LoadingPostsGrid />;
+				<BlockControls>
+					<TopPostsBlockControls attributes={ attributes } setAttributes={ setAttributes } />
+				</BlockControls>
+
+				<div data-item-count={ postsToDisplay.length }>
+					<div className="jetpack-top-posts-wrapper">{ postsToDisplay }</div>
+				</div>
+			</>
+		);
 	}
 
 	return (
-		<>
-			<InspectorControls>
-				<TopPostsInspectorControls
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-					toggleAttributes={ toggleAttributes }
-					setToggleAttributes={ setToggleAttributes }
-					postTypesData={ postTypesData }
-				/>
-			</InspectorControls>
-
-			<BlockControls>
-				<TopPostsBlockControls attributes={ attributes } setAttributes={ setAttributes } />
-			</BlockControls>
-
-			<div
-				className={ classNames( className, `is-${ layout }-layout` ) }
-				data-item-count={ postsToDisplay.length }
-			>
-				<div className="jetpack-top-posts-wrapper">{ postsToDisplay }</div>
-			</div>
-		</>
+		<div { ...blockProps } className={ classNames( className, `is-${ layout }-layout` ) }>
+			{ content }
+		</div>
 	);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the following blocks to use version 3 of the block API: 
- Top Posts
- Subscriber Login
- Map
- Nextdoor
- Paid Content

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/34120

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check that the blocks above work as expected with a self-hosted site and on WordPress.com.
