### PR TITLE
Blocks: upgrade to API version 3 - Part 5

### DIFF
--- a/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-5
+++ b/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update blocks to use API version 3

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/contact-info",
 	"title": "Contact Info",
 	"description": "Add an email address, phone number, and physical address with improved markup for better SEO results.",

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/edit.js
@@ -1,4 +1,4 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import classnames from 'classnames';
 
 const ALLOWED_BLOCKS = [
@@ -29,10 +29,12 @@ const TEMPLATE = [ [ 'jetpack/email' ], [ 'jetpack/phone' ], [ 'jetpack/address'
 
 const ContactInfoEdit = props => {
 	const { isSelected } = props;
+	const blockProps = useBlockProps();
 
 	return (
 		<div
-			className={ classnames( {
+			{ ...blockProps }
+			className={ classnames( blockProps.className, {
 				'jetpack-contact-info-block': true,
 				'is-selected': isSelected,
 			} ) }

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/save.js
@@ -1,7 +1,11 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-export default ( { className } ) => (
-	<div className={ className }>
-		<InnerBlocks.Content />
-	</div>
-);
+export default () => {
+	const blockProps = useBlockProps.save();
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks.Content />
+		</div>
+	);
+};

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/image-compare",
 	"title": "Image Compare",
 	"description": "Compare two images with a slider. Works best with images of the same size.",

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/edit.js
@@ -1,4 +1,4 @@
-import { InspectorControls, RichText } from '@wordpress/block-editor';
+import { InspectorControls, RichText, useBlockProps } from '@wordpress/block-editor';
 import { Placeholder } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { useLayoutEffect, useRef } from '@wordpress/element';
@@ -12,11 +12,13 @@ import './view.js';
 
 /* global juxtapose */
 
-const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) => {
+const Edit = ( { attributes, clientId, isSelected, setAttributes } ) => {
 	const { align, imageBefore, imageAfter, caption, orientation } = attributes;
 	// Check for useResizeObserver, not available in older Gutenberg.
 	let resizeListener = null;
 	let sizes = null;
+
+	const blockProps = useBlockProps();
 	const juxtaposeRef = useRef();
 	if ( useResizeObserver ) {
 		// Let's look for resize so we can trigger the thing.
@@ -54,7 +56,7 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 	}, [ align, imageBefore, imageAfter, orientation ] );
 
 	return (
-		<figure className={ className } id={ clientId }>
+		<figure { ...blockProps } id={ clientId }>
 			{ resizeListener }
 			<InspectorControls key="controls">
 				<ImageCompareControls { ...{ attributes, setAttributes } } />

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/save.js
@@ -1,10 +1,11 @@
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
-const save = ( { attributes, className } ) => {
+const save = ( { attributes } ) => {
+	const blockProps = useBlockProps.save();
 	const { imageBefore, imageAfter, caption, orientation } = attributes;
 
 	return (
-		<figure className={ className }>
+		<figure { ...blockProps }>
 			<div className="juxtapose" data-mode={ orientation || 'horizontal' }>
 				<img
 					id={ imageBefore.id }

--- a/projects/plugins/jetpack/extensions/blocks/image-compare/test/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/image-compare/test/edit.js
@@ -10,7 +10,7 @@ import ImageCompareEdit from '../edit';
 function renderImageCompare( props ) {
 	const { container } = render( <ImageCompareEdit { ...props } /> );
 	// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-	return container.querySelector( `.${ props.className } > div:not([aria-hidden="true"])` );
+	return container.querySelector( `div:not([aria-hidden="true"])` );
 }
 
 describe( 'ImageCompareEdit', () => {
@@ -33,16 +33,14 @@ describe( 'ImageCompareEdit', () => {
 	const defaultProps = {
 		attributes: defaultAttributes,
 		isSelected: true,
-		className: 'custom-image-compare-class',
 		clientId: '1',
 	};
 
 	test( 'applies correct attributes to block wrapper', () => {
-		render( <ImageCompareEdit { ...defaultProps } /> );
-		const wrapper = screen.getByRole( 'figure' );
+		const { container } = render( <ImageCompareEdit { ...defaultProps } /> );
 
-		expect( wrapper ).toHaveClass( defaultProps.className );
-		expect( wrapper ).toHaveAttribute( 'id', defaultProps.clientId );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+		expect( container.querySelector( 'figure' ) ).toHaveAttribute( 'id', defaultProps.clientId );
 	} );
 
 	test( 'applies juxtapose classes when images present', () => {

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/pinterest",
 	"title": "Pinterest",
 	"description": "Embed a Pinterest pin, board, or user.",

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/edit.js
@@ -1,3 +1,4 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { SandBox, withNotices } from '@wordpress/components';
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import EditUrlForm from './components/edit-url-form';
@@ -9,13 +10,14 @@ import { pinType } from './utils';
 export function PinterestEdit( {
 	attributes,
 	isSelected,
-	className,
 	noticeOperations,
 	noticeUI,
 	setAttributes,
 	onReplace,
 } ) {
 	const { url } = attributes;
+
+	const blockProps = useBlockProps();
 	const { isFetching, pinterestUrl, testUrl, hasTestUrlError } = useTestPinterestEmbedUrl();
 	const [ isInteractive, setIsInteractive ] = useState( false );
 	const [ editedUrl, setEditedUrl ] = useState( '' );
@@ -96,40 +98,42 @@ export function PinterestEdit( {
 
 	const pinterestEmbedType = pinType( url );
 
+	let content;
+
 	if ( isEditing || ! url || ( url && ! pinterestEmbedType ) ) {
-		return (
+		content = (
 			<EditUrlForm
-				className={ className }
 				onSubmit={ onSubmitForm }
 				noticeUI={ noticeUI }
 				url={ editedUrl }
 				setUrl={ setEditedUrl }
 			/>
 		);
-	}
-
-	const sandBoxHTML = `<a data-pin-do='${ pinterestEmbedType }' href='${ url }'></a>`;
-	/*
+	} else {
+		const sandBoxHTML = `<a data-pin-do='${ pinterestEmbedType }' href='${ url }'></a>`;
+		/*
 		Disabled because the overlay div doesn't actually have a role or functionality
 		as far as the user is concerned. We're just catching the first click so that
 		the block can be selected without interacting with the embed preview that the overlay covers.
 	 */
-	/* eslint-disable jsx-a11y/no-static-element-interactions */
-	return (
-		<div className={ className }>
-			<div>
-				<SandBox
-					html={ sandBoxHTML }
-					scripts={ [ 'https://assets.pinterest.com/js/pinit.js' ] }
-					onFocus={ hideOverlay }
-				/>
-				{ ! isInteractive && (
-					<div className="block-library-embed__interactive-overlay" onMouseUp={ hideOverlay } />
-				) }
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
+		content = (
+			<div { ...blockProps }>
+				<div>
+					<SandBox
+						html={ sandBoxHTML }
+						scripts={ [ 'https://assets.pinterest.com/js/pinit.js' ] }
+						onFocus={ hideOverlay }
+					/>
+					{ ! isInteractive && (
+						<div className="block-library-embed__interactive-overlay" onMouseUp={ hideOverlay } />
+					) }
+				</div>
 			</div>
-		</div>
-	);
-	/* eslint-enable jsx-a11y/no-static-element-interactions */
+		);
+	}
+
+	return <div { ...blockProps }>{ content }</div>;
 }
 
 export default withNotices( PinterestEdit );

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/save.js
@@ -1,4 +1,12 @@
+import { useBlockProps } from '@wordpress/block-editor';
+
 export default function Save( { attributes } ) {
+	const blockProps = useBlockProps.save();
 	const { url } = attributes;
-	return <a href={ url }>{ url }</a>;
+
+	return (
+		<a { ...blockProps } href={ url }>
+			{ url }
+		</a>
+	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/related-posts/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/related-posts/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/related-posts",
 	"title": "Related Posts",
 	"description": "Display a list of related posts.",

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/tiled-gallery",
 	"title": "Tiled Gallery",
 	"description": "Display multiple images in an elegantly organized tiled layout.",

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.js
@@ -186,6 +186,7 @@ const TiledGalleryEdit = ( {
 				{ noticeUI }
 
 				<Layout
+					className="tiled-gallery__wrapper"
 					align={ align }
 					columns={ columns }
 					imageFilter={ imageFilter }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.js
@@ -1,5 +1,5 @@
 import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
-import { MediaPlaceholder } from '@wordpress/block-editor';
+import { MediaPlaceholder, useBlockProps } from '@wordpress/block-editor';
 import { DropZone, FormFileUpload, withNotices } from '@wordpress/components';
 import { mediaUpload } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
@@ -31,7 +31,6 @@ export const pickRelevantMediaFiles = image => {
 const TiledGalleryEdit = ( {
 	attributes,
 	isSelected,
-	className,
 	noticeOperations,
 	noticeUI,
 	setAttributes,
@@ -47,6 +46,7 @@ const TiledGalleryEdit = ( {
 	} = attributes;
 	const layoutStyle = getActiveStyleName( LAYOUT_STYLES, attributes.className );
 
+	const blockProps = useBlockProps();
 	const [ selectedImage, setSelectedImage ] = useState( null );
 	const [ changed, setChanged ] = useState(
 		'undefined' === typeof columnWidths || columnWidths?.length === 0 ? true : false
@@ -157,7 +157,6 @@ const TiledGalleryEdit = ( {
 		content = (
 			<MediaPlaceholder
 				icon={ getBlockIconComponent( metadata ) }
-				className={ className }
 				labels={ {
 					title: __( 'Tiled Gallery', 'jetpack' ),
 					name: __( 'images', 'jetpack' ),
@@ -188,7 +187,6 @@ const TiledGalleryEdit = ( {
 
 				<Layout
 					align={ align }
-					className={ className }
 					columns={ columns }
 					imageFilter={ imageFilter }
 					images={ images }
@@ -223,7 +221,7 @@ const TiledGalleryEdit = ( {
 	}
 
 	return (
-		<>
+		<div { ...blockProps }>
 			<TiledGalleryBlockControls
 				images={ images }
 				onSelectImages={ onSelectImages }
@@ -234,7 +232,7 @@ const TiledGalleryEdit = ( {
 				} }
 			/>
 			{ content }
-		</>
+		</div>
 	);
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/editor.scss
@@ -16,10 +16,6 @@
 }
 
 .wp-block-jetpack-tiled-gallery {
-	// Ensure that selected image outlines are visibile
-	padding-left: 4px;
-	padding-right: 4px;
-
 	&.is-style-square,
 	&.is-style-circle {
 		.tiled-gallery__item.is-transient img {
@@ -28,6 +24,12 @@
 			// By setting the bottom margin, ensure they occupy the correct vertical space.
 			margin-bottom: 100%;
 		}
+	}
+
+	.tiled-gallery__wrapper {
+		// Ensure that selected image outlines are visibile
+		padding-left: 4px;
+		padding-right: 4px;
 	}
 
 	.tiled-gallery__item {

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/save.js
@@ -1,3 +1,4 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { getActiveStyleName } from '../../shared/block-styles';
 import { LAYOUT_STYLES } from './constants';
 import { defaultColumnsNumber } from './edit';
@@ -5,6 +6,7 @@ import Layout from './layout';
 
 export default function TiledGallerySave( { attributes } ) {
 	const { imageFilter, images } = attributes;
+	const blockProps = useBlockProps.save();
 
 	if ( ! images.length ) {
 		return null;
@@ -20,17 +22,19 @@ export default function TiledGallerySave( { attributes } ) {
 	} = attributes;
 
 	return (
-		<Layout
-			align={ align }
-			className={ className }
-			columns={ columns }
-			imageFilter={ imageFilter }
-			images={ images }
-			isSave
-			layoutStyle={ getActiveStyleName( LAYOUT_STYLES, className ) }
-			linkTo={ linkTo }
-			roundedCorners={ roundedCorners }
-			columnWidths={ columnWidths }
-		/>
+		<div { ...blockProps }>
+			<Layout
+				align={ align }
+				className={ className }
+				columns={ columns }
+				imageFilter={ imageFilter }
+				images={ images }
+				isSave
+				layoutStyle={ getActiveStyleName( LAYOUT_STYLES, className ) }
+				linkTo={ linkTo }
+				roundedCorners={ roundedCorners }
+				columnWidths={ columnWidths }
+			/>
+		</div>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
@@ -6,8 +6,6 @@ $tiled-gallery-max-column-count: 20;
 $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 
 .wp-block-jetpack-tiled-gallery {
-	margin: 0 auto $jetpack-block-margin-bottom;
-
 	&.is-style-circle .tiled-gallery__item img {
 		border-radius: 50%;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the following blocks to use version 3 of the block API: 
- Contact Info
- Image Compare
- Tiled Gallery
- Related Posts
- Pinterest

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/34120

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check that the blocks above work as expected with a self-hosted site and on WordPress.com.

