### PR TITLE
docker: Support `docker compose` for Docker compose v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ jetpack_vendor/
 .DS_Store
 *.code-workspace
 *.swp
-# Custom environment for docker-compose (used by docker-compose.yml)
+# Custom environment for Docker compose (used by docker-compose.yml)
 /.env
 /tools/docker/compose-extras.yml
 /tools/docker/compose-volumes.yml
@@ -34,7 +34,7 @@ npm-debug.log
 phpcs.xml
 .phpunit.result.cache
 
-## Things for docker-composer
+## Things for Docker compose
 /tools/docker/data/*
 !/tools/docker/data/.gitkeep
 !/tools/docker/data/ssh.keys/

--- a/tools/check-development-environment.sh
+++ b/tools/check-development-environment.sh
@@ -358,19 +358,23 @@ if [[ -z "$BIN" ]]; then
 else
 	success "yes"
 
-	checking '[optional] Docker-compose is available'
-	BIN="$(command -v docker-compose)"
-	if [[ -z "$BIN" ]]; then
+	checking '[optional] Docker compose is available'
+	AS=
+	if docker compose version &>/dev/null; then
+		VER="$(docker compose version 2>/dev/null | sed -n -E 's/^(docker-compose|Docker Compose) version v?([0-9]+\.[0-9]+\.[0-9a-zA-Z.-]+)(, .*|\+.*)?$/\2/p')"
+		AS='docker compose'
+	elif BIN="$(command -v docker-compose)"; then
+		VER="$(docker-compose --version 2>/dev/null | sed -n -E 's/^(docker-compose|Docker Compose) version v?([0-9]+\.[0-9]+\.[0-9a-zA-Z.-]+)(, .*|\+.*)?$/\2/p')"
+		AS='docker-compose'
+	fi
+	if [[ -z "$AS" ]]; then
 		warning "no" 'docker-supported-recommended'
+	elif [[ -z "$VER" ]]; then
+		warning "yes (as '$AS', version unknown)"
+	elif version_compare "$VER" "1.28"; then
+		success "yes (as '$AS', version $VER)"
 	else
-		VER="$(docker-compose --version 2>/dev/null | sed -n -E 's/^(docker-compose|Docker Compose) version v?([0-9]+\.[0-9]+\.[0-9a-zA-Z.-]+)(, .*)?$/\2/p')"
-		if [[ -z "$VER" ]]; then
-			warning "yes (version unknown)"
-		elif version_compare "$VER" "1.28"; then
-			success "yes (version $VER)"
-		else
-			warning "yes (version $VER)" '' "Docker-compose at $BIN is version $VER. Version 1.28 or later is recommended."
-		fi
+		warning "yes (as '$AS', version $VER)" '' "Docker compose at $BIN is version $VER. Version 1.28 or later is recommended."
 	fi
 
 	checking '[optional] Docker is running'

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -29,7 +29,7 @@ cp tools/docker/default.env tools/docker/.env
 
 Anything you put in `.env` overrides values in `default.env`. You should modify all the password fields for security, for example.
 
-**Note**: in older versions of docker-compose (earlier than 1.28), you'll need to place that file at the root of the monorepo.
+**Note**: in older versions of Docker compose (earlier than 1.28), you'll need to place that file at the root of the monorepo.
 
 ## Quick start
 
@@ -59,7 +59,7 @@ WordPress’ `WP_SITEURL` and `WP_HOME` constants are configured to be dynamic i
 ## Custom mounts, environment Variables, `.env` Files, and Ports
 
 You can control some of the behavior of Jetpack's Docker configuration with environment variables. Note, though, that there are two types of environments:
-1. The host environment in which the `jetpack docker *` (`docker-compose`) commands run when creating/managing the containers.
+1. The host environment in which the `jetpack docker *` (Docker compose) commands run when creating/managing the containers.
 2. The containers' environments.
 
 ### Host Environment
@@ -90,7 +90,7 @@ Users can extended these configurations further via override config file `tools/
 The default config file `tools/docker/jetpack-docker-config-default.yml` includes inline comments explaining the structure of config, but here's quick overview. The configuration is grouped per environment type: `default`, `dev`, `e2e`. Each type may define `volumeMappings` and `extras`:
 
 * `volumeMappings` - list of key value pairs which defines local directory mappings with following structure: local_path: wordpress_container_path
-* `extras` - basically any other configuration that is supported by `docker-compose`
+* `extras` - basically any other configuration that is supported by Docker compose.
 
 ## Working with containers
 
@@ -144,7 +144,7 @@ Stops all containers.
 jetpack docker down
 ```
 
-Will stop all of the containers created by this docker-compose configuration and remove them, too. It won’t remove the images. Just the containers that have just been stopped.
+Will stop all of the containers created by this Docker compose configuration and remove them, too. It won’t remove the images. Just the containers that have just been stopped.
 
 ### Running unit tests
 

--- a/tools/docker/compose-volumes.yml.sample
+++ b/tools/docker/compose-volumes.yml.sample
@@ -5,7 +5,7 @@
 ########
 
 ## List volumes for plugins, themes, and so on here. Format is a sequence as appropriate for
-## docker-compose's service.volumes. In brief,
+## Docker compose's service.volumes. In brief,
 ##  - Begin each line with a "-" followed by a space.
 ##  - Line consists of two fields, local path and docker path, separated by a colon.
 ##  - Local path may be absolute, or relative to this file by beginning with "./" or "../".

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   ## - The container wordpress is a very basic but custom container with WordPress and all of the tools we need
   ##   for development.
-  ## - The container will be named jetpack_wordpress for easy reference when running docker/docker-compose commands
+  ## - The container will be named jetpack_dev_wordpress_1 or jetpack_dev-wordpress-1 (depending on your Docker compose version) for easy reference when running Docker commands
   ##
   ## Here we map the following:
   ##  - The docker/wordpress-develop directory where we'll get WordPress source code with unit tests

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -9,7 +9,7 @@ default:
     tools/docker/mu-plugins: /var/www/html/wp-content/mu-plugins
 
   # Extra configuration (none by default). Anything set under this key will be written out as
-  # an extra docker-compose configuration file.
+  # an extra Docker compose configuration file.
   extras:
 
 # Dev environment overrides. None by default.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
GitHub [has recently announced][1] that they're going to be dropping support for `docker-compose` soon, so at least for our E2E tests we'll need to start running it as `docker compose` instead.

Fortunately for the most part we already have that abstracted behind `jetpack docker`, so mostly all we need to do is update that to detect whether `docker compose` is valid and use that in preference to `docker-compose` (but we still need to support the latter for Debian and older Ubuntu).

The `check-development-environment.sh` script then also needs to check for `docker compose` rather than just `docker-compose`.

Beyond that, it's mainly updating docs to reference the tool by name ("Docker compose") rather than by command.

Note this may result in some environments starting to use v2 rather than v1, if they had `docker-compose` as v1 but `docker compose` also works. In such environments people may notice that the container names change from being like "jetpack_dev_wordpress_1" to "jetpack_dev-wordpress-1". Again, we've apparently mostly avoided depending on that in our tooling, but you may need to run `COMPOSE_COMPATIBILITY=1 jetpack docker down` to stop the old-named containers (or just reboot).

I note `projects/plugins/super-cache/tests/e2e/package.json` still has some direct references to `docker-compose`, which I didn't update here as that doesn't seem to be used in our CI.

[1]: https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI E2E tests still work as well as they did before?
* Try `tools/check-development-environment.sh`.
* Try other Jetpack Docker Dev Env stuff, it should all still work too. Particularly if you have `docker compose` working on your system.