### PR TITLE
Hide the Customize menu item on Simple Classic wp-admin

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-hide-customize-on-simple
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-hide-customize-on-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Hide Customize on block themes on Simple Classic sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -379,7 +379,7 @@ function wpcom_site_menu_handle_dismiss_notice() {
 add_action( 'wp_ajax_dismiss_wpcom_site_menu_intro_notice', 'wpcom_site_menu_handle_dismiss_notice' );
 
 /**
- * Ensures customizer menu and adminbar items are not visible on a block theme .
+ * Ensures customizer menu and adminbar items are not visible on a block theme.
  */
 function hide_customizer_menu_on_block_theme() {
 	if ( wp_is_block_theme() && ! is_customize_preview() ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -382,8 +382,7 @@ add_action( 'wp_ajax_dismiss_wpcom_site_menu_intro_notice', 'wpcom_site_menu_han
  * Ensures customizer menu and adminbar items are not visible on a block theme for atomic sites.
  */
 function hide_customizer_menu_on_block_theme() {
-	$is_wpcom = ( defined( 'IS_WPCOM' ) && IS_WPCOM );
-	if ( ! $is_wpcom && wp_is_block_theme() && ! is_customize_preview() ) {
+	if ( wp_is_block_theme() && ! is_customize_preview() ) {
 		remove_action( 'customize_register', 'add_logotool_button', 20 );
 		remove_action( 'customize_register', 'footercredits_register', 99 );
 		remove_action( 'customize_register', 'wpcom_disable_customizer_site_icon', 20 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -379,7 +379,7 @@ function wpcom_site_menu_handle_dismiss_notice() {
 add_action( 'wp_ajax_dismiss_wpcom_site_menu_intro_notice', 'wpcom_site_menu_handle_dismiss_notice' );
 
 /**
- * Ensures customizer menu and adminbar items are not visible on a block theme for atomic sites.
+ * Ensures customizer menu and adminbar items are not visible on a block theme .
  */
 function hide_customizer_menu_on_block_theme() {
 	if ( wp_is_block_theme() && ! is_customize_preview() ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Issue: https://github.com/Automattic/dotcom-forge/issues/6280

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- This diff removes the wpcom gate check on `hide_customizer_menu_on_block_theme` so it hides the Customize menu item on wpcom as well as Atomic sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
- Using a Simple Classic-early site
- Apply this PR to your Sandbox
- Go to any Calypso page
- Ensure the Customizer menu is hidden
- Go to any wp-admin page
- Ensure the Customizer menu is hidden
- Ensure you can reach the Customizer via deep link at /wp-admin/customize.php
- Switch to a Classic theme (e.g., Twenty Eleven)
- Ensure the Customizer menu is shown


