### PR TITLE
Repo Gardening: check if PR owner is a member of the org to determine if they're an OSS Citizen

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/try-check-for-org-membership-for-oss-citizen
+++ b/projects/github-actions/repo-gardening/changelog/try-check-for-org-membership-for-oss-citizen
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Check if PR owner is a member of the organization to determine if they're a OSS Citizen
+Repo Gardening: Check if PR owner is a member of the organization to determine if they're an OSS Citizen

--- a/projects/github-actions/repo-gardening/changelog/try-check-for-org-membership-for-oss-citizen
+++ b/projects/github-actions/repo-gardening/changelog/try-check-for-org-membership-for-oss-citizen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Check if PR owner is a member of the organization to determine if they're a OSS Citizen

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "repo-gardening",
-	"version": "5.0.1-alpha",
+	"version": "5.1.0-alpha",
 	"description": "Manage Pull Requests and issues in your Open Source project (automate labelling, milestones, feedback to PR authors, ...)",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/github-actions/repo-gardening/src/tasks/flag-oss/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/flag-oss/index.js
@@ -15,7 +15,14 @@ async function flagOss( payload, octokit ) {
 	const { head, base } = pull_request;
 	const { owner, name } = repository;
 
-	if ( head.repo.full_name === base.repo.full_name ) {
+	// Check if PR author is org member
+	// https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
+	const orgMembershipRequest = await octokit.rest.orgs.checkMembershipForUser( {
+		org: owner.login,
+		username: head.user.login,
+	} );
+
+	if ( head.repo.full_name === base.repo.full_name || 204 === orgMembershipRequest.status ) {
 		return;
 	}
 

--- a/projects/github-actions/repo-gardening/src/tasks/flag-oss/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/flag-oss/index.js
@@ -15,6 +15,10 @@ async function flagOss( payload, octokit ) {
 	const { head, base } = pull_request;
 	const { owner, name } = repository;
 
+	if ( head.repo.full_name === base.repo.full_name ) {
+		return;
+	}
+
 	// Check if PR author is org member
 	// https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
 	const orgMembershipRequest = await octokit.rest.orgs.checkMembershipForUser( {
@@ -22,7 +26,7 @@ async function flagOss( payload, octokit ) {
 		username: head.user.login,
 	} );
 
-	if ( head.repo.full_name === base.repo.full_name || 204 === orgMembershipRequest.status ) {
+	if ( 204 === orgMembershipRequest.status ) {
 		return;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In some cases, PR authors within an organization might create a PR from a fork, in which case they will be mislabeled as an OSS Citizen. Here I propose an additional check for the PR Author's membership to the repo's organization.

Example of this occurring: https://github.com/Automattic/themes/pull/7734 — The PR Author is a member of Automattic, but created a PR from a fork.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

- Create a repo within the organization, to avoid spamming existing repositories.
- Add the repo gardening workflow to the new repo.
- Create a PR from a fork, pointing to that repo.
- You should not be flagged as an OSS Citizen.

## Does this pull request change what data or activity we track or use?

No.