### PR TITLE
AI Featured Image: fix panel transition after setting featured image

### DIFF
--- a/projects/plugins/jetpack/changelog/update-featured-images-fix-panel-transition
+++ b/projects/plugins/jetpack/changelog/update-featured-images-fix-panel-transition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Featured Image: fix bug on automatic transition to featured image panel

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -194,11 +194,16 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 			// Open the featured image panel for users to see the new image.
 			setTimeout( () => {
 				const isFeaturedImagePanelOpened = isEditorPanelOpened( 'featured-image' );
+				const isPostStatusPanelOpened = isEditorPanelOpened( 'post-status' );
 
 				// open the complementary area and then trigger the featured image panel.
 				triggerComplementaryArea().then( () => {
 					if ( ! isFeaturedImagePanelOpened ) {
 						toggleEditorPanelOpened( 'featured-image' );
+					}
+					// handle the case where the featured image panel is not present
+					if ( ! isPostStatusPanelOpened ) {
+						toggleEditorPanelOpened( 'post-status' );
 					}
 				} );
 			}, 500 );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -34,6 +34,7 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 		useDispatch( 'core/edit-post' );
 	const { editPost, toggleEditorPanelOpened: toggleEditorPanelOpenedFromEditor } =
 		useDispatch( 'core/editor' );
+	const { clearSelectedBlock } = useDispatch( 'core/block-editor' );
 
 	const [ isFeaturedImageModalVisible, setIsFeaturedImageModalVisible ] = useState( false );
 	const [ images, setImages ] = useState< CarrouselImages >( [ { generating: true } ] );
@@ -175,8 +176,10 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 	}, [ processImageGeneration, recordEvent ] );
 
 	const triggerComplementaryArea = useCallback( () => {
+		// clear any block selection, because selected blocks have precedence on settings sidebar
+		clearSelectedBlock();
 		enableComplementaryArea( 'core/edit-post', 'edit-post/document' );
-	}, [ enableComplementaryArea ] );
+	}, [ clearSelectedBlock, enableComplementaryArea ] );
 
 	const handleAccept = useCallback( () => {
 		// track the accept/use image event

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -178,7 +178,7 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 	const triggerComplementaryArea = useCallback( () => {
 		// clear any block selection, because selected blocks have precedence on settings sidebar
 		clearSelectedBlock();
-		enableComplementaryArea( 'core/edit-post', 'edit-post/document' );
+		return enableComplementaryArea( 'core/edit-post', 'edit-post/document' );
 	}, [ clearSelectedBlock, enableComplementaryArea ] );
 
 	const handleAccept = useCallback( () => {
@@ -193,14 +193,14 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 
 			// Open the featured image panel for users to see the new image.
 			setTimeout( () => {
-				// If the panel is not opened, open it and then trigger the complementary area.
-				if ( ! isEditorPanelOpened( 'featured-image' ) ) {
-					toggleEditorPanelOpened?.( 'featured-image' ).then( () => {
-						triggerComplementaryArea();
-					} );
-				} else {
-					triggerComplementaryArea();
-				}
+				const isFeaturedImagePanelOpened = isEditorPanelOpened( 'featured-image' );
+
+				// open the complementary area and then trigger the featured image panel.
+				triggerComplementaryArea().then( () => {
+					if ( ! isFeaturedImagePanelOpened ) {
+						toggleEditorPanelOpened( 'featured-image' );
+					}
+				} );
 			}, 500 );
 		};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36862.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

We recently added an automatic transition to show the featured image panel after the user set an image as featured on the featured image generator, but it was not working on some cases, so this PR:

* Fixes edge case where opening the panel would not work if some block was selected
* Adds support to opening both the `featured-image` panel and the `post-status` panel to handle newest versions of Gutenberg where the featured image was moved to the Post Status panel
* Small refactoring in the order of actions

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You are going to spend some requests by testing it, so may be worth spinning a new JN site and upgrading it to 100 or 200 requests
* Go to the block editor and add some content to it
* Let's test some scenarios, to make sure the transition to the featured image panel will work on all scenarios
* For every scenario, the testing process is the same:
   * Open the Jetpack sidebar and look for the featured image generator
   * Click the `Generate image`  button to generate an image
   * Click the `Set as featured image` button to set it as featured
   * Confirm the featured image panel will show up right after, with the new featured image on it
* The scenarios we are going to test are:
   * Using a previous version of Gutenberg (built-in on WordPress) vs. the new one (enabled by installing and activating the "Gutenberg" plugin)
   * Opening the Jetpack sidebar with a selected block on the editor vs. without any selected block
   * Opening the Jetpack sidebar with the featured image panel already open vs. still closed (on the post sidebar)
* All scenarios above should work correctly 

