### PR TITLE
Blocks: upgrade to API version 3 - Part 8

### DIFF
--- a/projects/packages/videopress/changelog/update-upgrade-block-api-part-8
+++ b/projects/packages/videopress/changelog/update-upgrade-block-api-part-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Bump VideoPress block API version

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.15",
+	"version": "0.23.16-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.15';
+	const PACKAGE_VERSION = '0.23.16-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "videopress/video",
 	"version": "0.1.0",
 	"title": "VideoPress",

--- a/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-8
+++ b/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update blocks to use API version 3

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_3",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_4",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/simple-payments",
 	"title": "Pay with PayPal",
 	"description": "Add credit and debit card payment buttons with minimal setup. Good for collecting donations or payments for products and services.",

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/edit.js
@@ -1,5 +1,5 @@
 import { getCurrencyDefaults } from '@automattic/format-currency';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	Disabled,
 	ExternalLink,
@@ -53,6 +53,8 @@ export const SimplePaymentsEdit = ( {
 	 * local state.
 	 */
 	const isDisabled = productId && isEmpty( simplePayment );
+
+	const blockProps = useBlockProps();
 
 	const [ fieldEmailError, setFieldEmailError ] = useState( null );
 	const [ fieldPriceError, setFieldPriceError ] = useState( null );
@@ -426,7 +428,7 @@ export const SimplePaymentsEdit = ( {
 		const Wrapper = isDisabled ? Disabled : 'div';
 
 		elt = (
-			<Wrapper className="wp-block-jetpack-simple-payments">
+			<Wrapper className="simple-payments__wrapper">
 				<InspectorControls>
 					<PanelControls postLinkText={ attributes.postLinkText } setAttributes={ setAttributes } />
 				</InspectorControls>
@@ -523,7 +525,7 @@ export const SimplePaymentsEdit = ( {
 		);
 	}
 
-	return elt;
+	return <div { ...blockProps }>{ elt }</div>;
 };
 
 const mapSelectToProps = withSelect( ( select, props ) => {

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/editor.scss
@@ -3,9 +3,12 @@
 .wp-block-jetpack-simple-payments {
 	font-family: $default-font;
 	font-size: $default-font-size;
-	display: grid;
-	grid-template-columns: 200px auto;
-	grid-column-gap: 10px;
+
+	.simple-payments__wrapper {
+		display: grid;
+		grid-template-columns: 200px auto;
+		grid-column-gap: 10px;
+	}
 
 	.simple-payments__field {
 		.components-base-control__field {

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/editor.scss
@@ -1,13 +1,13 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
 .wp-block-jetpack-simple-payments {
-	font-family: $default-font;
-	font-size: $default-font-size;
-
 	.simple-payments__wrapper {
 		display: grid;
 		grid-template-columns: 200px auto;
 		grid-column-gap: 10px;
+
+		font-family: $default-font;
+		font-size: $default-font-size;
 	}
 
 	.simple-payments__field {

--- a/projects/plugins/jetpack/extensions/blocks/simple-payments/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/simple-payments/save.js
@@ -1,6 +1,9 @@
+import { useBlockProps } from '@wordpress/block-editor';
+import classNames from 'classnames';
 import { formatPrice } from './utils';
 
 export default function Save( { attributes } ) {
+	const blockProps = useBlockProps.save();
 	const {
 		content,
 		currency,
@@ -12,12 +15,19 @@ export default function Save( { attributes } ) {
 		productId,
 		title,
 	} = attributes;
+
 	if ( ! productId ) {
 		return null;
 	}
 
 	return (
-		<div className={ `jetpack-simple-payments-wrapper jetpack-simple-payments-${ productId }` }>
+		<div
+			{ ...blockProps }
+			className={ classNames(
+				blockProps.className,
+				`jetpack-simple-payments-wrapper jetpack-simple-payments-${ productId }`
+			) }
+		>
 			<div className="jetpack-simple-payments-product">
 				{ featuredMediaUrl && (
 					<div className="jetpack-simple-payments-product-image">

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.4-a.3
+ * Version: 13.4-a.4
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.4-a.3' );
+define( 'JETPACK__VERSION', '13.4-a.4' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.4.0-a.3",
+	"version": "13.4.0-a.4",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the following blocks to use version 3 of the block API:
- Pay with Paypal
- VideoPress

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/34120


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check that the blocks above work as expected with a self-hosted site and on WordPress.com.