### PR TITLE
AI Featured Image: Update UX on generating and navigating on carrousel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-featured-image-ux
+++ b/projects/plugins/jetpack/changelog/update-featured-image-ux
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update UX on Featured Image

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/carrousel.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/carrousel.scss
@@ -115,6 +115,7 @@
 		}
 
 		&-image-container {
+			display: flex;
 			width: 100%;
 			height: auto;
 			position: absolute;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -42,7 +42,7 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 
 	const { enableComplementaryArea } = useDispatch( 'core/interface' );
 	const { generateImage } = useImageGenerator();
-	const { isLoading: isSavingToMediaLibrary, saveToMediaLibrary } = useSaveToMediaLibrary();
+	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 	const { tracks } = useAnalytics();
 	const { recordEvent } = tracks;
 
@@ -124,14 +124,15 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 			.then( result => {
 				if ( result.data.length > 0 ) {
 					const image = 'data:image/png;base64,' + result.data[ 0 ].b64_json;
-					updateImages( { image, generating: false }, pointer.current );
+					updateImages( { image }, pointer.current );
 					updateRequestsCount();
 					saveToMediaLibrary( image )
 						.then( savedImage => {
-							updateImages( { libraryId: savedImage.id }, pointer.current );
+							updateImages( { libraryId: savedImage.id, generating: false }, pointer.current );
 							pointer.current += 1;
 						} )
 						.catch( () => {
+							updateImages( { generating: false }, pointer.current );
 							pointer.current += 1;
 						} );
 				}
@@ -282,10 +283,8 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 										<Button
 											onClick={ handleRegenerate }
 											variant="secondary"
-											isBusy={ isSavingToMediaLibrary || currentPointer?.generating }
-											disabled={
-												isSavingToMediaLibrary || notEnoughRequests || currentPointer?.generating
-											}
+											isBusy={ currentPointer?.generating }
+											disabled={ notEnoughRequests || currentPointer?.generating }
 										>
 											{ __( 'Generate new image', 'jetpack' ) }
 										</Button>
@@ -293,8 +292,8 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 									<Button
 										onClick={ handleAccept }
 										variant="primary"
-										isBusy={ isSavingToMediaLibrary || currentImage?.generating }
-										disabled={ isSavingToMediaLibrary || ! currentImage?.image }
+										isBusy={ currentImage?.generating }
+										disabled={ ! currentImage?.image }
 									>
 										{ __( 'Set as featured image', 'jetpack' ) }
 									</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Update the user experience inside the featured image, to keep the loading state while saving to library and avoid flicking the images counter.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Upgrade the Carrousel styling to use `display: flex`.
* Upgrade the state to flag `generating` as false only when finished to save to library.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion.  
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post.
* Generate an image, you should see the loading until the end (image saved to library).
* Generate a new one, you should see the loading and switching between the image and the new loading one, won't flick the counter.

