### PR TITLE
stub-generator: Handle functions calling `func_get_args()`

### DIFF
--- a/projects/packages/stub-generator/changelog/add-stub-generator-func_get_args
+++ b/projects/packages/stub-generator/changelog/add-stub-generator-func_get_args
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a fake `...$func_get_args` parameter to functions/methods that call `func_get_args()`.

--- a/projects/packages/stub-generator/src/PhpParser/StubNodeVisitor.php
+++ b/projects/packages/stub-generator/src/PhpParser/StubNodeVisitor.php
@@ -12,6 +12,7 @@ namespace Automattic\Jetpack\StubGenerator\PhpParser;
 @phan-type Definitions = array{constant:'*'|string[],function:'*'|string[],class:ClassDefs,interface:ClassDefs,trait:ClassDefs}
 PHAN;
 
+use PhpParser\BuilderFactory;
 use PhpParser\Node;
 use PhpParser\Node\Expr\BinaryOp\Concat as BinaryOp_Concat;
 use PhpParser\Node\Expr\FuncCall;
@@ -28,6 +29,7 @@ use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Trait_;
+use PhpParser\NodeFinder;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter_Standard;
 use RuntimeException;
@@ -221,6 +223,7 @@ class StubNodeVisitor extends NodeVisitorAbstract {
 			if ( $this->defs['function'] === '*' || in_array( $node->namespacedName->toString(), $this->defs['function'], true ) ) {
 				// Ignore anything inside the function.
 				if ( $node->stmts ) {
+					$this->mutateForFuncGetArgs( $node );
 					$node->stmts = array();
 				}
 				$this->debug( "Keeping function {$node->namespacedName}" );
@@ -287,6 +290,7 @@ class StubNodeVisitor extends NodeVisitorAbstract {
 			} elseif ( $defs === '*' || in_array( $node->name->toString(), $defs, true ) ) {
 				// Ignore anything inside the method.
 				if ( $node->stmts ) {
+					$this->mutateForFuncGetArgs( $node );
 					$node->stmts = array();
 				}
 				$this->debug( "Keeping method {$node->name}" );
@@ -376,6 +380,32 @@ class StubNodeVisitor extends NodeVisitorAbstract {
 			}
 			$this->namespaces[ $nsName ]->stmts[] = $node;
 
+		}
+	}
+
+	/**
+	 * Mutate a function/method's signature if it uses `func_get_args()`.
+	 *
+	 * @param Function_|ClassMethod $node Node.
+	 */
+	private function mutateForFuncGetArgs( Node $node ): void {
+		// First, see if the function already uses varargs.
+		foreach ( $node->getParams() as $param ) {
+			if ( $param->variadic ) {
+				return;
+			}
+		}
+
+		// See if the function contains a call to `func_get_args()`.
+		$call = ( new NodeFinder() )->findFirst(
+			$node->stmts,
+			function ( Node $n ) {
+				return $n instanceof FuncCall && $n->name instanceof Name && in_array( $n->name->toString(), array( 'func_get_args', 'func_get_arg', 'func_num_args' ), true );
+			}
+		);
+
+		if ( $call !== null ) {
+			$node->params[] = ( new BuilderFactory() )->param( 'func_get_args' )->makeVariadic()->getNode();
 		}
 	}
 }

--- a/projects/packages/stub-generator/tests/php/PhpParser/StubNodeVisitorTest.php
+++ b/projects/packages/stub-generator/tests/php/PhpParser/StubNodeVisitorTest.php
@@ -1429,6 +1429,78 @@ class StubNodeVisitorTest extends TestCase {
 				}
 				PHP,
 			),
+
+			'Handling of func_get_args()'                 => array(
+				<<<'PHP'
+				namespace Some\NS;
+
+				function no_params() {
+					func_get_args();
+				}
+
+				function no_varargs( $x, $y ) {
+					func_get_args();
+				}
+
+				function has_varargs( $x, ...$args ) {
+					func_get_args();
+				}
+
+				class Foo {
+					public function no_params() {
+						func_get_args();
+					}
+
+					public function no_varargs( $x, $y ) {
+						func_get_args();
+					}
+
+					public function has_varargs( $x, ...$args ) {
+						func_get_args();
+					}
+				}
+
+				function uses_func_get_arg() {
+					func_get_arg();
+				}
+
+				function uses_func_num_args() {
+					func_num_args();
+				}
+				PHP,
+				'*',
+				<<<'PHP'
+				namespace Some\NS;
+
+				function no_params(...$func_get_args)
+				{
+				}
+				function no_varargs($x, $y, ...$func_get_args)
+				{
+				}
+				function has_varargs($x, ...$args)
+				{
+				}
+				class Foo
+				{
+					public function no_params(...$func_get_args)
+					{
+					}
+					public function no_varargs($x, $y, ...$func_get_args)
+					{
+					}
+					public function has_varargs($x, ...$args)
+					{
+					}
+				}
+				function uses_func_get_arg(...$func_get_args)
+				{
+				}
+				function uses_func_num_args(...$func_get_args)
+				{
+				}
+				PHP,
+			),
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If a function or method calls `func_get_args()`, Phan treats it as if it has an implicit varargs argument at the end of its parameter list. But when we stub the function it can no longer see the `func_get_args()` call so it tries to incorrect force the declared parameter list.

So let's do the same thing when generating the stubs, if there's a `func_get_args()` call (and no varargs param already) let's add one.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?
