### PR TITLE
stub-generator: Skip setting `'kind'` on `Namespace_` nodes

### DIFF
--- a/projects/packages/stub-generator/changelog/fix-stub-generator-namespace-kind
+++ b/projects/packages/stub-generator/changelog/fix-stub-generator-namespace-kind
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Skip setting `'kind'` on `Namespace_` nodes. The printer doesn't care.
+
+

--- a/projects/packages/stub-generator/src/Application.php
+++ b/projects/packages/stub-generator/src/Application.php
@@ -253,12 +253,8 @@ class Application extends SingleCommandApplication {
 
 		ksort( $visitor->namespaces );
 		$stmts = array_values( $visitor->namespaces );
-		if ( count( $stmts ) === 1 ) {
-			if ( $stmts[0]->name ) {
-				$stmts[0]->setAttribute( 'kind', \PhpParser\Node\Stmt\Namespace_::KIND_SEMICOLON );
-			} else {
-				$stmts = $stmts[0]->stmts;
-			}
+		if ( count( $stmts ) === 1 && ! $stmts[0]->name ) {
+			$stmts = $stmts[0]->stmts;
 		}
 		return $stmts;
 	}

--- a/projects/packages/stub-generator/src/PhpParser/StubNodeVisitor.php
+++ b/projects/packages/stub-generator/src/PhpParser/StubNodeVisitor.php
@@ -370,9 +370,7 @@ class StubNodeVisitor extends NodeVisitorAbstract {
 		) {
 			$nsName = $this->getNamespaceName( $node );
 			if ( ! isset( $this->namespaces[ $nsName ] ) ) {
-				$ns = new Namespace_( $nsName === '' ? null : new Name( $nsName ) );
-				$ns->setAttribute( 'kind', Namespace_::KIND_BRACED );
-				$this->namespaces[ $nsName ] = $ns;
+				$this->namespaces[ $nsName ] = new Namespace_( $nsName === '' ? null : new Name( $nsName ) );
 			}
 			$this->namespaces[ $nsName ]->stmts[] = $node;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We had been setting the `'kind'` to try to use braced namespaces unless there's only one. But it turns out the printer has its own logic, it ignores the kind and figures out on its own whether it needs to used braced namespaces or not. So there's no point in us bothering to set the `'kind'`, and it may even be confusing when we set it to braced but the printer uses semicolons anyway.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?