### PR TITLE
Add scheduled updates sync option

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-sync-2
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a sync option where for scheduled updated.

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -49,7 +49,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.7.x-dev"
+			"dev-trunk": "0.8.x-dev"
 		},
 		"textdomain": "jetpack-scheduled-updates",
 		"version-constants": {

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -53,6 +53,7 @@ class Scheduled_Updates {
 		add_filter( 'auto_update_plugin', array( __CLASS__, 'allowlist_scheduled_plugins' ), 10, 2 );
 		add_filter( 'plugin_auto_update_setting_html', array( __CLASS__, 'show_scheduled_updates' ), 10, 2 );
 		add_action( 'deleted_plugin', array( __CLASS__, 'deleted_plugin' ), 10, 2 );
+		add_filter( 'jetpack_sync_callable_whitelist', array( __CLASS__, 'add_scheduled_callable_whitelist' ) );
 	}
 
 	/**
@@ -132,33 +133,6 @@ class Scheduled_Updates {
 		self::clear_cron_cache();
 
 		return wp_unschedule_event( $timestamp, self::PLUGIN_CRON_HOOK, $plugins, true );
-	}
-
-	/**
-	 * Save the schedules for sync.
-	 *
-	 * @return bool
-	 */
-	public static function save_schedules_for_sync() {
-		$events = wp_get_scheduled_events( self::PLUGIN_CRON_HOOK );
-
-		foreach ( array_keys( $events ) as $schedule_id ) {
-			$events[ $schedule_id ]->schedule_id = $schedule_id;
-
-			$status = self::get_scheduled_update_status( $schedule_id );
-
-			if ( ! $status ) {
-				$status = array(
-					'last_run_timestamp' => null,
-					'last_run_status'    => null,
-				);
-			}
-
-			$events[ $schedule_id ]->last_run_timestamp = $status['last_run_timestamp'];
-			$events[ $schedule_id ]->last_run_status    = $status['last_run_status'];
-		}
-
-		return update_option( self::PLUGIN_CRON_HOOK, $events );
 	}
 
 	/**
@@ -484,6 +458,48 @@ class Scheduled_Updates {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Add Scheduled Updates to the sync callable whitelist.
+	 *
+	 * @param array $callables Existing callables whitelist.
+	 * @return array Updated callables whitelist.
+	 */
+	public static function add_scheduled_callable_whitelist( $callables ) {
+		return array_merge(
+			$callables,
+			array(
+				'jetpack_get_scheduled_plugins_update' => array( __CLASS__, 'get_scheduled_updates' ),
+			)
+		);
+	}
+
+	/**
+	 * Get the scheduled updates.
+	 *
+	 * @return array
+	 */
+	public static function get_scheduled_updates() {
+		$events = wp_get_scheduled_events( self::PLUGIN_CRON_HOOK );
+
+		foreach ( array_keys( $events ) as $schedule_id ) {
+			$events[ $schedule_id ]->schedule_id = $schedule_id;
+
+			$status = self::get_scheduled_update_status( $schedule_id );
+
+			if ( ! $status ) {
+				$status = array(
+					'last_run_timestamp' => null,
+					'last_run_status'    => null,
+				);
+			}
+
+			$events[ $schedule_id ]->last_run_timestamp = $status['last_run_timestamp'];
+			$events[ $schedule_id ]->last_run_status    = $status['last_run_status'];
+		}
+
+		return $events;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -135,6 +135,33 @@ class Scheduled_Updates {
 	}
 
 	/**
+	 * Save the schedules for sync.
+	 *
+	 * @return bool
+	 */
+	public static function save_schedules_for_sync() {
+		$events = wp_get_scheduled_events( self::PLUGIN_CRON_HOOK );
+
+		foreach ( array_keys( $events ) as $schedule_id ) {
+			$events[ $schedule_id ]->schedule_id = $schedule_id;
+
+			$status = self::get_scheduled_update_status( $schedule_id );
+
+			if ( ! $status ) {
+				$status = array(
+					'last_run_timestamp' => null,
+					'last_run_status'    => null,
+				);
+			}
+
+			$events[ $schedule_id ]->last_run_timestamp = $status['last_run_timestamp'];
+			$events[ $schedule_id ]->last_run_status    = $status['last_run_status'];
+		}
+
+		return update_option( self::PLUGIN_CRON_HOOK, $events );
+	}
+
+	/**
 	 * Clear the cron cache.
 	 */
 	public static function clear_cron_cache() {

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.7.2';
+	const PACKAGE_VERSION = '0.8.0-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -467,12 +467,9 @@ class Scheduled_Updates {
 	 * @return array Updated callables whitelist.
 	 */
 	public static function add_scheduled_callable_whitelist( $callables ) {
-		return array_merge(
-			$callables,
-			array(
-				'jetpack_get_scheduled_plugins_update' => array( __CLASS__, 'get_scheduled_updates' ),
-			)
-		);
+		$callables[ self::PLUGIN_CRON_HOOK ] = array( __CLASS__, 'get_scheduled_updates' );
+
+		return $callables;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -53,8 +53,17 @@ class Scheduled_Updates {
 		add_filter( 'auto_update_plugin', array( __CLASS__, 'allowlist_scheduled_plugins' ), 10, 2 );
 		add_filter( 'plugin_auto_update_setting_html', array( __CLASS__, 'show_scheduled_updates' ), 10, 2 );
 		add_action( 'deleted_plugin', array( __CLASS__, 'deleted_plugin' ), 10, 2 );
-		add_action( 'add_option_cron', array( __CLASS__, 'update_option_cron' ) );
-		add_action( 'update_option_cron', array( __CLASS__, 'update_option_cron' ) );
+
+		// Update cron sync option after options update.
+		$callback = array( __CLASS__, 'update_option_cron' );
+
+		// Main cron saving.
+		add_action( 'add_option_cron', $callback );
+		add_action( 'update_option_cron', $callback );
+
+		// Logs saving.
+		add_action( 'add_option_' . Scheduled_Updates_Logs::OPTION_NAME, $callback );
+		add_action( 'update_option_' . Scheduled_Updates_Logs::OPTION_NAME, $callback );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -64,6 +64,12 @@ class Scheduled_Updates {
 		// Logs saving.
 		add_action( 'add_option_' . Scheduled_Updates_Logs::OPTION_NAME, $callback );
 		add_action( 'update_option_' . Scheduled_Updates_Logs::OPTION_NAME, $callback );
+
+		// This is a temporary solution for backward compatibility. It will be removed in the future.
+		// It's needed to ensure that preexisting schedules are loaded into the sync option.
+		if ( false === get_option( self::PLUGIN_CRON_HOOK ) ) {
+			call_user_func( $callback );
+		}
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -278,9 +278,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		// Set an empty status of a schedule on creation/modify.
 		Scheduled_Updates::set_scheduled_update_status( $id, null, null );
 
-		// Sync option.
-		Scheduled_Updates::save_schedules_for_sync();
-
 		return rest_ensure_response( $id );
 	}
 
@@ -361,9 +358,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			Scheduled_Updates::set_scheduled_update_status( $item->data, $previous_schedule_status['last_run_timestamp'], $previous_schedule_status['last_run_status'] );
 		}
 
-		// Sync option.
-		Scheduled_Updates::save_schedules_for_sync();
-
 		return $item;
 	}
 
@@ -396,9 +390,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			$request['last_run_status']
 		);
 
-		// Sync option.
-		Scheduled_Updates::save_schedules_for_sync();
-
 		return rest_ensure_response( $option[ $request['schedule_id'] ] );
 	}
 
@@ -429,9 +420,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$context     = $request['context'];
 
 		Scheduled_Updates_Logs::log( $schedule_id, $action, $message, $context );
-
-		// Sync option.
-		Scheduled_Updates::save_schedules_for_sync();
 
 		return rest_ensure_response( true );
 	}
@@ -521,9 +509,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 
 		// Delete logs
 		Scheduled_Updates_Logs::clear( $request['schedule_id'], true );
-
-		// Sync option.
-		Scheduled_Updates::save_schedules_for_sync();
 
 		return rest_ensure_response( true );
 	}

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -278,6 +278,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		// Set an empty status of a schedule on creation/modify.
 		Scheduled_Updates::set_scheduled_update_status( $id, null, null );
 
+		// Sync option.
+		Scheduled_Updates::save_schedules_for_sync();
+
 		return rest_ensure_response( $id );
 	}
 
@@ -358,6 +361,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			Scheduled_Updates::set_scheduled_update_status( $item->data, $previous_schedule_status['last_run_timestamp'], $previous_schedule_status['last_run_status'] );
 		}
 
+		// Sync option.
+		Scheduled_Updates::save_schedules_for_sync();
+
 		return $item;
 	}
 
@@ -390,6 +396,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			$request['last_run_status']
 		);
 
+		// Sync option.
+		Scheduled_Updates::save_schedules_for_sync();
+
 		return rest_ensure_response( $option[ $request['schedule_id'] ] );
 	}
 
@@ -420,6 +429,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$context     = $request['context'];
 
 		Scheduled_Updates_Logs::log( $schedule_id, $action, $message, $context );
+
+		// Sync option.
+		Scheduled_Updates::save_schedules_for_sync();
 
 		return rest_ensure_response( true );
 	}
@@ -509,6 +521,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 
 		// Delete logs
 		Scheduled_Updates_Logs::clear( $request['schedule_id'], true );
+
+		// Sync option.
+		Scheduled_Updates::save_schedules_for_sync();
 
 		return rest_ensure_response( true );
 	}

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -260,6 +260,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		usort( $plugins, 'strnatcasecmp' );
 
 		$event = Scheduled_Updates::create_scheduled_update( $schedule['timestamp'], $schedule['interval'], $plugins );
+
 		if ( is_wp_error( $event ) ) {
 			return $event;
 		}

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -420,7 +420,11 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$message     = $request['message'];
 		$context     = $request['context'];
 
-		Scheduled_Updates_Logs::log( $schedule_id, $action, $message, $context );
+		$log = Scheduled_Updates_Logs::log( $schedule_id, $action, $message, $context );
+
+		if ( is_wp_error( $log ) ) {
+			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be found.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
+		}
 
 		return rest_ensure_response( true );
 	}

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -182,12 +182,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( $schedule_id, $result->get_data() );
 
-		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		$this->assertIsArray( $sync_option );
-		$this->assertIsObject( $sync_option[ $schedule_id ] );
-		$this->assertSame( $plugins, $sync_option[ $schedule_id ]->args );
-		$this->assertNull( $sync_option[ $schedule_id ]->last_run_timestamp );
-		$this->assertNull( $sync_option[ $schedule_id ]->last_run_status );
+		$callable_result = Scheduled_Updates::get_scheduled_updates();
+		$this->assertIsArray( $callable_result );
+		$this->assertIsObject( $callable_result[ $schedule_id ] );
+		$this->assertSame( $plugins, $callable_result[ $schedule_id ]->args );
+		$this->assertNull( $callable_result[ $schedule_id ]->last_run_timestamp );
+		$this->assertNull( $callable_result[ $schedule_id ]->last_run_status );
 
 		// Can't create a schedule for the same time again.
 		$request->set_body_params(
@@ -235,12 +235,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( $schedule_id, $result->get_data() );
 
-		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		$this->assertIsArray( $sync_option );
-		$this->assertIsObject( $sync_option[ $schedule_id ] );
-		$this->assertSame( $plugins, $sync_option[ $schedule_id ]->args );
-		$this->assertNull( $sync_option[ $schedule_id ]->last_run_timestamp );
-		$this->assertNull( $sync_option[ $schedule_id ]->last_run_status );
+		$callable_result = Scheduled_Updates::get_scheduled_updates();
+		$this->assertIsArray( $callable_result );
+		$this->assertIsObject( $callable_result[ $schedule_id ] );
+		$this->assertSame( $plugins, $callable_result[ $schedule_id ]->args );
+		$this->assertNull( $callable_result[ $schedule_id ]->last_run_timestamp );
+		$this->assertNull( $callable_result[ $schedule_id ]->last_run_status );
 
 		$plugins[] = 'wp-test-plugin/wp-test-plugin.php';
 		$request->set_body_params(
@@ -259,10 +259,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( $schedule_id_2, $result->get_data() );
 
-		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		$this->assertIsArray( $sync_option );
-		$this->assertIsObject( $sync_option[ $schedule_id ] );
-		$this->assertIsObject( $sync_option[ $schedule_id_2 ] );
+		$callable_result = Scheduled_Updates::get_scheduled_updates();
+		$this->assertIsArray( $callable_result );
+		$this->assertIsObject( $callable_result[ $schedule_id ] );
+		$this->assertIsObject( $callable_result[ $schedule_id_2 ] );
 	}
 
 	/**
@@ -627,10 +627,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( $schedule_id, $result->get_data() );
 
-		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		$this->assertIsArray( $sync_option );
-		$this->assertIsObject( $sync_option[ $schedule_id ] );
-		$this->assertSame( $plugins, $sync_option[ $schedule_id ]->args );
+		$callable_result = Scheduled_Updates::get_scheduled_updates();
+		$this->assertIsArray( $callable_result );
+		$this->assertIsObject( $callable_result[ $schedule_id ] );
+		$this->assertSame( $plugins, $callable_result[ $schedule_id ]->args );
 	}
 
 	/**
@@ -680,12 +680,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			$this->assertSame( $timestamp, $updated_status['last_run_timestamp'] ?? null );
 			$this->assertSame( $status, $updated_status['last_run_status'] ?? null );
 
-			$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-			$this->assertIsArray( $sync_option );
-			$this->assertIsObject( $sync_option[ $schedule_id ] );
-			$this->assertSame( $plugins, $sync_option[ $schedule_id ]->args );
-			$this->assertSame( $timestamp, $sync_option[ $schedule_id ]->last_run_timestamp );
-			$this->assertSame( $status, $sync_option[ $schedule_id ]->last_run_status );
+			$callable_result = Scheduled_Updates::get_scheduled_updates();
+			$this->assertIsArray( $callable_result );
+			$this->assertIsObject( $callable_result[ $schedule_id ] );
+			$this->assertSame( $plugins, $callable_result[ $schedule_id ]->args );
+			$this->assertSame( $timestamp, $callable_result[ $schedule_id ]->last_run_timestamp );
+			$this->assertSame( $status, $callable_result[ $schedule_id ]->last_run_status );
 		}
 	}
 
@@ -751,8 +751,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$this->assertFalse( wp_get_scheduled_event( Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins ) );
 
-		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		$this->assertSame( array(), $sync_option );
+		$callable_result = Scheduled_Updates::get_scheduled_updates();
+		$this->assertSame( array(), $callable_result );
 	}
 
 	/**
@@ -846,7 +846,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$result = rest_do_request( $request );
 
 		$this->assertSame( 200, $result->get_status() );
-		$this->assertSame( array(), get_option( Scheduled_Updates::PLUGIN_CRON_HOOK ) );
+		$this->assertSame( array(), Scheduled_Updates::get_scheduled_updates() );
 	}
 
 	/**
@@ -865,10 +865,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( array(), $result->get_data() );
 
-		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		$this->assertIsArray( $sync_option );
-		$this->assertNull( $sync_option[ $schedule_id ]->last_run_timestamp );
-		$this->assertNull( $sync_option[ $schedule_id ]->last_run_status );
+		$callable_result = Scheduled_Updates::get_scheduled_updates();
+		$this->assertIsArray( $callable_result );
+		$this->assertNull( $callable_result[ $schedule_id ]->last_run_timestamp );
+		$this->assertNull( $callable_result[ $schedule_id ]->last_run_status );
 	}
 
 	/**
@@ -900,10 +900,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertCount( 1, $result->get_data() );
 		$this->assertSame( Scheduled_Updates_Logs::PLUGIN_UPDATES_START, $result->get_data()[0][0]['action'] );
 
-		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		$this->assertIsArray( $sync_option );
-		$this->assertNull( $sync_option[ $schedule_id ]->last_run_timestamp );
-		$this->assertSame( 'in-progress', $sync_option[ $schedule_id ]->last_run_status );
+		$callable_result = Scheduled_Updates::get_scheduled_updates();
+		$this->assertIsArray( $callable_result );
+		$this->assertNull( $callable_result[ $schedule_id ]->last_run_timestamp );
+		$this->assertSame( 'in-progress', $callable_result[ $schedule_id ]->last_run_status );
 	}
 
 	/**
@@ -947,9 +947,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertCount( Scheduled_Updates_Logs::MAX_RUNS_PER_SCHEDULE, $result->get_data() );
 		$this->assertSame( Scheduled_Updates_Logs::PLUGIN_UPDATES_START, $result->get_data()[0][0]['action'] );
 
-		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		$this->assertNotNull( $sync_option[ $schedule_id ]->last_run_timestamp );
-		$this->assertSame( 'success', $sync_option[ $schedule_id ]->last_run_status );
+		$callable_result = Scheduled_Updates::get_scheduled_updates();
+		$this->assertNotNull( $callable_result[ $schedule_id ]->last_run_timestamp );
+		$this->assertSame( 'success', $callable_result[ $schedule_id ]->last_run_status );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -846,8 +846,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		);
 		$result = rest_do_request( $request );
 
-		$this->assertSame( 200, $result->get_status() );
-		$this->assertSame( array(), get_option( Scheduled_Updates::PLUGIN_CRON_HOOK ) );
+		$this->assertSame( 404, $result->get_status() );
+		$this->assertSame( false, get_option( Scheduled_Updates::PLUGIN_CRON_HOOK ) );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -34,6 +34,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
+		Scheduled_Updates::init();
 		new WPCOM_REST_API_V2_Endpoint_Update_Schedules();
 	}
 
@@ -182,12 +183,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( $schedule_id, $result->get_data() );
 
-		$callable_result = Scheduled_Updates::get_scheduled_updates();
-		$this->assertIsArray( $callable_result );
-		$this->assertIsObject( $callable_result[ $schedule_id ] );
-		$this->assertSame( $plugins, $callable_result[ $schedule_id ]->args );
-		$this->assertNull( $callable_result[ $schedule_id ]->last_run_timestamp );
-		$this->assertNull( $callable_result[ $schedule_id ]->last_run_status );
+		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertIsArray( $sync_option );
+		$this->assertIsObject( $sync_option[ $schedule_id ] );
+		$this->assertSame( $plugins, $sync_option[ $schedule_id ]->args );
+		$this->assertNull( $sync_option[ $schedule_id ]->last_run_timestamp );
+		$this->assertNull( $sync_option[ $schedule_id ]->last_run_status );
 
 		// Can't create a schedule for the same time again.
 		$request->set_body_params(
@@ -235,12 +236,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( $schedule_id, $result->get_data() );
 
-		$callable_result = Scheduled_Updates::get_scheduled_updates();
-		$this->assertIsArray( $callable_result );
-		$this->assertIsObject( $callable_result[ $schedule_id ] );
-		$this->assertSame( $plugins, $callable_result[ $schedule_id ]->args );
-		$this->assertNull( $callable_result[ $schedule_id ]->last_run_timestamp );
-		$this->assertNull( $callable_result[ $schedule_id ]->last_run_status );
+		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertIsArray( $sync_option );
+		$this->assertIsObject( $sync_option[ $schedule_id ] );
+		$this->assertSame( $plugins, $sync_option[ $schedule_id ]->args );
+		$this->assertNull( $sync_option[ $schedule_id ]->last_run_timestamp );
+		$this->assertNull( $sync_option[ $schedule_id ]->last_run_status );
 
 		$plugins[] = 'wp-test-plugin/wp-test-plugin.php';
 		$request->set_body_params(
@@ -259,10 +260,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( $schedule_id_2, $result->get_data() );
 
-		$callable_result = Scheduled_Updates::get_scheduled_updates();
-		$this->assertIsArray( $callable_result );
-		$this->assertIsObject( $callable_result[ $schedule_id ] );
-		$this->assertIsObject( $callable_result[ $schedule_id_2 ] );
+		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertIsArray( $sync_option );
+		$this->assertIsObject( $sync_option[ $schedule_id ] );
+		$this->assertIsObject( $sync_option[ $schedule_id_2 ] );
 	}
 
 	/**
@@ -627,10 +628,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( $schedule_id, $result->get_data() );
 
-		$callable_result = Scheduled_Updates::get_scheduled_updates();
-		$this->assertIsArray( $callable_result );
-		$this->assertIsObject( $callable_result[ $schedule_id ] );
-		$this->assertSame( $plugins, $callable_result[ $schedule_id ]->args );
+		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertIsArray( $sync_option );
+		$this->assertIsObject( $sync_option[ $schedule_id ] );
+		$this->assertSame( $plugins, $sync_option[ $schedule_id ]->args );
 	}
 
 	/**
@@ -680,12 +681,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			$this->assertSame( $timestamp, $updated_status['last_run_timestamp'] ?? null );
 			$this->assertSame( $status, $updated_status['last_run_status'] ?? null );
 
-			$callable_result = Scheduled_Updates::get_scheduled_updates();
-			$this->assertIsArray( $callable_result );
-			$this->assertIsObject( $callable_result[ $schedule_id ] );
-			$this->assertSame( $plugins, $callable_result[ $schedule_id ]->args );
-			$this->assertSame( $timestamp, $callable_result[ $schedule_id ]->last_run_timestamp );
-			$this->assertSame( $status, $callable_result[ $schedule_id ]->last_run_status );
+			$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+			$this->assertIsArray( $sync_option );
+			$this->assertIsObject( $sync_option[ $schedule_id ] );
+			$this->assertSame( $plugins, $sync_option[ $schedule_id ]->args );
+			$this->assertSame( $timestamp, $sync_option[ $schedule_id ]->last_run_timestamp );
+			$this->assertSame( $status, $sync_option[ $schedule_id ]->last_run_status );
 		}
 	}
 
@@ -751,8 +752,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$this->assertFalse( wp_get_scheduled_event( Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins ) );
 
-		$callable_result = Scheduled_Updates::get_scheduled_updates();
-		$this->assertSame( array(), $callable_result );
+		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertSame( array(), $sync_option );
 	}
 
 	/**
@@ -846,7 +847,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$result = rest_do_request( $request );
 
 		$this->assertSame( 200, $result->get_status() );
-		$this->assertSame( array(), Scheduled_Updates::get_scheduled_updates() );
+		$this->assertSame( array(), get_option( Scheduled_Updates::PLUGIN_CRON_HOOK ) );
 	}
 
 	/**
@@ -865,10 +866,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertSame( array(), $result->get_data() );
 
-		$callable_result = Scheduled_Updates::get_scheduled_updates();
-		$this->assertIsArray( $callable_result );
-		$this->assertNull( $callable_result[ $schedule_id ]->last_run_timestamp );
-		$this->assertNull( $callable_result[ $schedule_id ]->last_run_status );
+		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertIsArray( $sync_option );
+		$this->assertNull( $sync_option[ $schedule_id ]->last_run_timestamp );
+		$this->assertNull( $sync_option[ $schedule_id ]->last_run_status );
 	}
 
 	/**
@@ -900,10 +901,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertCount( 1, $result->get_data() );
 		$this->assertSame( Scheduled_Updates_Logs::PLUGIN_UPDATES_START, $result->get_data()[0][0]['action'] );
 
-		$callable_result = Scheduled_Updates::get_scheduled_updates();
-		$this->assertIsArray( $callable_result );
-		$this->assertNull( $callable_result[ $schedule_id ]->last_run_timestamp );
-		$this->assertSame( 'in-progress', $callable_result[ $schedule_id ]->last_run_status );
+		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertIsArray( $sync_option );
+		$this->assertNull( $sync_option[ $schedule_id ]->last_run_timestamp );
+		$this->assertSame( 'in-progress', $sync_option[ $schedule_id ]->last_run_status );
 	}
 
 	/**
@@ -947,9 +948,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$this->assertCount( Scheduled_Updates_Logs::MAX_RUNS_PER_SCHEDULE, $result->get_data() );
 		$this->assertSame( Scheduled_Updates_Logs::PLUGIN_UPDATES_START, $result->get_data()[0][0]['action'] );
 
-		$callable_result = Scheduled_Updates::get_scheduled_updates();
-		$this->assertNotNull( $callable_result[ $schedule_id ]->last_run_timestamp );
-		$this->assertSame( 'success', $callable_result[ $schedule_id ]->last_run_status );
+		$sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertNotNull( $sync_option[ $schedule_id ]->last_run_timestamp );
+		$this->assertSame( 'success', $sync_option[ $schedule_id ]->last_run_status );
 	}
 
 	/**

--- a/projects/packages/sync/changelog/add-scheduled-updates-callable
+++ b/projects/packages/sync/changelog/add-scheduled-updates-callable
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Moved scheduled updates option to callable.

--- a/projects/packages/sync/changelog/add-scheduled-updates-callable
+++ b/projects/packages/sync/changelog/add-scheduled-updates-callable
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Moved scheduled updates option to callable.

--- a/projects/packages/sync/changelog/add-scheduled-updates-sync
+++ b/projects/packages/sync/changelog/add-scheduled-updates-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added scheduled updates sync option.

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -58,7 +58,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.12.x-dev"
+			"dev-trunk": "2.13.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -200,6 +200,7 @@ class Defaults {
 		'jetpack_blocks_disabled',
 		'jetpack_package_versions',
 		'jetpack_newsletters_publishing_default_frequency',
+		'jetpack_scheduled_plugins_update',
 	);
 
 	/**

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -200,7 +200,6 @@ class Defaults {
 		'jetpack_blocks_disabled',
 		'jetpack_package_versions',
 		'jetpack_newsletters_publishing_default_frequency',
-		'jetpack_scheduled_plugins_update',
 	);
 
 	/**

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.12.0';
+	const PACKAGE_VERSION = '2.13.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/automattic-for-agencies-client/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -992,7 +992,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
+                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1024,7 +1024,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.12.x-dev"
+                    "dev-trunk": "2.13.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/backup/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/backup/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1545,7 +1545,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
+                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1577,7 +1577,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.12.x-dev"
+                    "dev-trunk": "2.13.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/boost/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1535,7 +1535,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
+                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1567,7 +1567,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.12.x-dev"
+                    "dev-trunk": "2.13.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/jetpack/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Moved scheduled updates option to callable.

--- a/projects/plugins/jetpack/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/jetpack/changelog/add-scheduled-updates-sync-2
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Moved scheduled updates option to callable.
+Added scheduled updates sync option.

--- a/projects/plugins/jetpack/changelog/add-scheduled-updates-sync-2#2
+++ b/projects/plugins/jetpack/changelog/add-scheduled-updates-sync-2#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2453,7 +2453,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
+				"reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2485,7 +2485,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.12.x-dev"
+					"dev-trunk": "2.13.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -254,6 +254,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_classic_early_release'                  => true,
 			'jetpack_package_versions'                     => array(),
 			'jetpack_newsletters_publishing_default_frequency' => 'weekly',
+			'jetpack_scheduled_plugins_update'             => array(),
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -254,7 +254,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'wpcom_classic_early_release'                  => true,
 			'jetpack_package_versions'                     => array(),
 			'jetpack_newsletters_publishing_default_frequency' => 'weekly',
-			'jetpack_scheduled_plugins_update'             => array(),
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/projects/plugins/migration/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/migration/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1545,7 +1545,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
+                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1577,7 +1577,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.12.x-dev"
+                    "dev-trunk": "2.13.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_15"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_16_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -198,7 +198,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "4dbf0c9b0bf8384ef49f5cbd8ab76713a2f41222"
+                "reference": "a829494dc67c0e478c7f1b500986dff319081f23"
             },
             "require": {
                 "php": ">=7.0"
@@ -221,7 +221,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.7.x-dev"
+                    "dev-trunk": "0.8.x-dev"
                 },
                 "textdomain": "jetpack-scheduled-updates",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.15
+ * Version: 2.1.16-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.15",
+	"version": "2.1.16-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/protect/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/protect/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1458,7 +1458,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
+                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1490,7 +1490,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.12.x-dev"
+                    "dev-trunk": "2.13.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/search/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1549,7 +1549,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
+                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1581,7 +1581,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.12.x-dev"
+                    "dev-trunk": "2.13.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/social/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1540,7 +1540,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
+				"reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1572,7 +1572,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.12.x-dev"
+					"dev-trunk": "2.13.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/starter-plugin/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/starter-plugin/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1401,7 +1401,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
+                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1433,7 +1433,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.12.x-dev"
+                    "dev-trunk": "2.13.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/add-scheduled-updates-sync-2
+++ b/projects/plugins/videopress/changelog/add-scheduled-updates-sync-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1401,7 +1401,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
+                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1433,7 +1433,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.12.x-dev"
+                    "dev-trunk": "2.13.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
Context: p1712832877052689-slack-C01A60HCGUA
See also: https://github.com/Automattic/jetpack/pull/36849

Now, a sync option is saved every time the cron is updated, or a log is added.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Save the scheduled updates in an option that is automatically synched so that can be retrieved on WPCOM
* Fix: `PUT /logs` endpoint now return 404 if it can't find the scheduled update

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Jetpack:
* On Jetpack Beta > WordPress.com Features install `add/scheduled-updates-sync-2`
* From Calypso create or update scheduled updates.
* In your site `_cli` run `wp option get jetpack_scheduled_plugins_update`. Ensure your scheduled update is there.

WPCOM
* Open `wpsh`
* `switch_to_blog( _BLOG_ID_ )`
* `print_r( get_option( 'jetpack_scheduled_plugins_update' ) );`
* Ensure the option is synched

WPCOM 2
* Make sure you are running the watcher
* `wp run-scheduled-update --require=bin/scheduled-updates/run-scheduled-updates.php --blog-id=__ID__`
* Make sure the CLI reports `Scheduled update found on sync option.`
* `wp run-scheduled-update --require=bin/scheduled-updates/run-scheduled-updates.php --blog-id=__ID__ --no-dry-run` to run it (now the script is on dry-run by default)