### PR TITLE
Scheduled Updates: Introduce Views Link

### DIFF
--- a/projects/packages/scheduled-updates/.phan/baseline.php
+++ b/projects/packages/scheduled-updates/.phan/baseline.php
@@ -17,11 +17,10 @@ return [
     // PhanUndeclaredClassMethod : 2 occurrences
     // PhanNoopNew : 1 occurrence
     // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
-    // PhanTypeMismatchDimFetch : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-scheduled-updates.php' => ['PhanRedundantCondition', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimFetch', 'PhanUndeclaredClassMethod'],
+        'src/class-scheduled-updates.php' => ['PhanRedundantCondition', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod'],
         'src/pluggable.php' => ['PhanTypeArraySuspiciousNullable'],
         'src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php' => ['PhanPluginMixedKeyNoKey'],
         'tests/php/class-scheduled-updates-logs-test.php' => ['PhanCompatibleAccessMethodOnTraitDefinition', 'PhanUndeclaredProperty'],

--- a/projects/packages/scheduled-updates/changelog/add-plugin-list-filter
+++ b/projects/packages/scheduled-updates/changelog/add-plugin-list-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Scheduled Updates: Added a views link to filter plugins that are part of a scheduled update.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-admin.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-admin.php
@@ -53,7 +53,6 @@ class Scheduled_Updates_Admin {
 				'<a href="%1$s" class="%2$s">%3$s <span class="count">(%4$s)</span></a>',
 				esc_url( add_query_arg( array( 'plugin_status' => 'scheduled-updates' ), 'plugins.php' ) ),
 				isset( $_REQUEST['plugin_status'] ) && 'scheduled-updates' === $_REQUEST['plugin_status'] ? 'current' : '', // phpcs:ignore WordPress.Security.NonceVerification
-				/* translators: %s is the number of scheduled updates. */
 				__( 'Scheduled Updates', 'jetpack-scheduled-updates' ),
 				number_format_i18n( $totals['scheduled-updates'] )
 			);

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-admin.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-admin.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Scheduled Updates Admin.
+ *
+ * @package automattic/scheduled-updates
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Class Scheduled_Updates_Admin.
+ *
+ * Contains all the wp-admin-related functionality for scheduled updates.
+ */
+class Scheduled_Updates_Admin {
+
+	/**
+	 * Add context for scheduled updates in the Plugins list table.
+	 *
+	 * @param array $plugins An array of plugins.
+	 * @return array
+	 */
+	public static function add_scheduled_updates_context( $plugins ) {
+		if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
+			require_once __DIR__ . '/pluggable.php';
+		}
+
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
+
+		if ( ! empty( $events ) ) {
+			if ( ! empty( $_REQUEST['plugin_status'] ) && 'scheduled-updates' === $_REQUEST['plugin_status'] ) { // phpcs:ignore WordPress.Security.NonceVerification
+				$GLOBALS['status'] = 'scheduled-updates'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			}
+
+			$scheduled                    = array_unique( array_merge( ...array_values( wp_list_pluck( $events, 'args' ) ) ) );
+			$plugins['scheduled-updates'] = array_intersect_key( (array) $plugins['all'], array_flip( $scheduled ) );
+		}
+
+		return $plugins;
+	}
+
+	/**
+	 * Add a view for scheduled updates in the Plugins list table.
+	 *
+	 * @param array $views An array of available views.
+	 * @return array
+	 */
+	public static function add_scheduled_updates_view( $views ) {
+		global $totals;
+
+		if ( ! empty( $totals['scheduled-updates'] ) ) {
+			$views['scheduled-updates'] = sprintf(
+				'<a href="%1$s" class="%2$s">%3$s <span class="count">(%4$s)</span></a>',
+				esc_url( add_query_arg( array( 'plugin_status' => 'scheduled-updates' ), 'plugins.php' ) ),
+				isset( $_REQUEST['plugin_status'] ) && 'scheduled-updates' === $_REQUEST['plugin_status'] ? 'current' : '', // phpcs:ignore WordPress.Security.NonceVerification
+				/* translators: %s is the number of scheduled updates. */
+				__( 'Scheduled Updates', 'jetpack-scheduled-updates' ),
+				number_format_i18n( $totals['scheduled-updates'] )
+			);
+		}
+
+		return $views;
+	}
+
+	/**
+	 * Filters the HTML of the auto-updates setting for each plugin in the Plugins list table.
+	 *
+	 * @param string $html        The HTML of the plugin's auto-update column content,
+	 *                            including toggle auto-update action links and
+	 *                            time to next update.
+	 * @param string $plugin_file Path to the plugin file relative to the plugin directory.
+	 */
+	public static function show_scheduled_updates( $html, $plugin_file ) {
+		if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
+			require_once __DIR__ . '/pluggable.php';
+		}
+
+		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
+
+		$schedules = array();
+		foreach ( $events as $event ) {
+			if ( in_array( $plugin_file, $event->args, true ) ) {
+				$schedules[] = $event;
+			}
+		}
+
+		// Plugin is not part of an update schedule.
+		if ( empty( $schedules ) ) {
+			return $html;
+		}
+
+		$text = array_map( array( __CLASS__, 'get_scheduled_update_text' ), $schedules );
+
+		$html  = '<p style="margin: 0 0 8px">' . implode( '<br>', $text ) . '</p>';
+		$html .= sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( 'https://wordpress.com/plugins/scheduled-updates/' . ( new Status() )->get_site_suffix() ),
+			esc_html__( 'Edit', 'jetpack-scheduled-updates' )
+		);
+
+		return $html;
+	}
+
+	/**
+	 * Get the text for a scheduled update.
+	 *
+	 * @param object $schedule The scheduled update.
+	 * @return string
+	 */
+	public static function get_scheduled_update_text( $schedule ) {
+		if ( DAY_IN_SECONDS === $schedule->interval ) {
+			$html = sprintf(
+			/* translators: %s is the time of day. Daily at 10 am. */
+				esc_html__( 'Daily at %s.', 'jetpack-scheduled-updates' ),
+				wp_date( get_option( 'time_format' ), $schedule->timestamp )
+			);
+		} else {
+			// Not getting smart about passing in weekdays makes it easier to translate.
+			$weekdays = array(
+				/* translators: %s is the time of day. Mondays at 10 am. */
+				1 => __( 'Mondays at %s.', 'jetpack-scheduled-updates' ),
+				/* translators: %s is the time of day. Tuesdays at 10 am. */
+				2 => __( 'Tuesdays at %s.', 'jetpack-scheduled-updates' ),
+				/* translators: %s is the time of day. Wednesdays at 10 am. */
+				3 => __( 'Wednesdays at %s.', 'jetpack-scheduled-updates' ),
+				/* translators: %s is the time of day. Thursdays at 10 am. */
+				4 => __( 'Thursdays at %s.', 'jetpack-scheduled-updates' ),
+				/* translators: %s is the time of day. Fridays at 10 am. */
+				5 => __( 'Fridays at %s.', 'jetpack-scheduled-updates' ),
+				/* translators: %s is the time of day. Saturdays at 10 am. */
+				6 => __( 'Saturdays at %s.', 'jetpack-scheduled-updates' ),
+				/* translators: %s is the time of day. Sundays at 10 am. */
+				7 => __( 'Sundays at %s.', 'jetpack-scheduled-updates' ),
+			);
+
+			$html = sprintf(
+				$weekdays[ wp_date( 'N', $schedule->timestamp ) ],
+				wp_date( get_option( 'time_format' ), $schedule->timestamp )
+			);
+		}
+
+		return $html;
+	}
+}

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-admin.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-admin.php
@@ -133,7 +133,7 @@ class Scheduled_Updates_Admin {
 			);
 
 			$html = sprintf(
-				$weekdays[ wp_date( 'N', $schedule->timestamp ) ],
+				$weekdays[ (int) wp_date( 'N', $schedule->timestamp ) ],
 				wp_date( get_option( 'time_format' ), $schedule->timestamp )
 			);
 		}

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-admin.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-admin.php
@@ -32,8 +32,29 @@ class Scheduled_Updates_Admin {
 				$GLOBALS['status'] = 'scheduled-updates'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			}
 
-			$scheduled                    = array_unique( array_merge( ...array_values( wp_list_pluck( $events, 'args' ) ) ) );
-			$plugins['scheduled-updates'] = array_intersect_key( (array) $plugins['all'], array_flip( $scheduled ) );
+			/*
+			 * Get the unique list of plugins that are part of scheduled updates.
+			 *
+			 * Example:
+			 *  $scheduled = array(
+			 *      'rest-api-console/rest-api-console.php'     => 0,
+			 *      'wordpress-importer/wordpress-importer.php' => 1,
+			 *      'wp-last-login/wp-last-login.php'           => 2,
+			 *  );
+			 */
+			$scheduled = array_flip(
+				array_unique(
+					array_merge(
+						...array_values(
+							wp_list_pluck( $events, 'args' )
+						)
+					)
+				)
+			);
+
+			// Removing from the auto-update-disabled list since they are scheduled.
+			$plugins['auto-update-disabled'] = array_diff_key( (array) $plugins['auto-update-disabled'], $scheduled );
+			$plugins['scheduled-updates']    = array_intersect_key( (array) $plugins['all'], $scheduled );
 		}
 
 		return $plugins;

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -51,8 +51,11 @@ class Scheduled_Updates {
 		add_action( self::PLUGIN_CRON_HOOK, array( __CLASS__, 'run_scheduled_update' ), 10, 10 );
 		add_action( 'rest_api_init', array( __CLASS__, 'add_is_managed_extension_field' ) );
 		add_filter( 'auto_update_plugin', array( __CLASS__, 'allowlist_scheduled_plugins' ), 10, 2 );
-		add_filter( 'plugin_auto_update_setting_html', array( __CLASS__, 'show_scheduled_updates' ), 10, 2 );
 		add_action( 'deleted_plugin', array( __CLASS__, 'deleted_plugin' ), 10, 2 );
+
+		add_filter( 'plugins_list', array( Scheduled_Updates_Admin::class, 'add_scheduled_updates_context' ) );
+		add_filter( 'views_plugins', array( Scheduled_Updates_Admin::class, 'add_scheduled_updates_view' ) );
+		add_filter( 'plugin_auto_update_setting_html', array( Scheduled_Updates_Admin::class, 'show_scheduled_updates' ), 10, 2 );
 
 		// Update cron sync option after options update.
 		$callback = array( __CLASS__, 'update_option_cron' );
@@ -261,86 +264,6 @@ class Scheduled_Updates {
 		}
 
 		return $update;
-	}
-
-	/**
-	 * Filters the HTML of the auto-updates setting for each plugin in the Plugins list table.
-	 *
-	 * @param string $html        The HTML of the plugin's auto-update column content,
-	 *                            including toggle auto-update action links and
-	 *                            time to next update.
-	 * @param string $plugin_file Path to the plugin file relative to the plugin directory.
-	 */
-	public static function show_scheduled_updates( $html, $plugin_file ) {
-		if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
-			require_once __DIR__ . '/pluggable.php';
-		}
-
-		$events = wp_get_scheduled_events( self::PLUGIN_CRON_HOOK );
-
-		$schedules = array();
-		foreach ( $events as $event ) {
-			if ( in_array( $plugin_file, $event->args, true ) ) {
-				$schedules[] = $event;
-			}
-		}
-
-		// Plugin is not part of an update schedule.
-		if ( empty( $schedules ) ) {
-			return $html;
-		}
-
-		$text = array_map( array( __CLASS__, 'get_scheduled_update_text' ), $schedules );
-
-		$html  = '<p style="margin: 0 0 8px">' . implode( '<br>', $text ) . '</p>';
-		$html .= sprintf(
-			'<a href="%1$s">%2$s</a>',
-			esc_url( 'https://wordpress.com/plugins/scheduled-updates/' . ( new Status() )->get_site_suffix() ),
-			esc_html__( 'Edit', 'jetpack-scheduled-updates' )
-		);
-
-		return $html;
-	}
-
-	/**
-	 * Get the text for a scheduled update.
-	 *
-	 * @param object $schedule The scheduled update.
-	 * @return string
-	 */
-	public static function get_scheduled_update_text( $schedule ) {
-		if ( DAY_IN_SECONDS === $schedule->interval ) {
-			$html = sprintf(
-				/* translators: %s is the time of day. Daily at 10 am. */
-				esc_html__( 'Daily at %s.', 'jetpack-scheduled-updates' ),
-				wp_date( get_option( 'time_format' ), $schedule->timestamp )
-			);
-		} else {
-			// Not getting smart about passing in weekdays makes it easier to translate.
-			$weekdays = array(
-				/* translators: %s is the time of day. Mondays at 10 am. */
-				1 => __( 'Mondays at %s.', 'jetpack-scheduled-updates' ),
-				/* translators: %s is the time of day. Tuesdays at 10 am. */
-				2 => __( 'Tuesdays at %s.', 'jetpack-scheduled-updates' ),
-				/* translators: %s is the time of day. Wednesdays at 10 am. */
-				3 => __( 'Wednesdays at %s.', 'jetpack-scheduled-updates' ),
-				/* translators: %s is the time of day. Thursdays at 10 am. */
-				4 => __( 'Thursdays at %s.', 'jetpack-scheduled-updates' ),
-				/* translators: %s is the time of day. Fridays at 10 am. */
-				5 => __( 'Fridays at %s.', 'jetpack-scheduled-updates' ),
-				/* translators: %s is the time of day. Saturdays at 10 am. */
-				6 => __( 'Saturdays at %s.', 'jetpack-scheduled-updates' ),
-				/* translators: %s is the time of day. Sundays at 10 am. */
-				7 => __( 'Sundays at %s.', 'jetpack-scheduled-updates' ),
-			);
-
-			$html = sprintf(
-				$weekdays[ wp_date( 'N', $schedule->timestamp ) ],
-				wp_date( get_option( 'time_format' ), $schedule->timestamp )
-			);
-		}
-
-		return $html;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-admin-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-admin-test.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Test class for Scheduled_Updates.
+ *
+ * @package automattic/scheduled-updates
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Test class for Scheduled_Updates_Admin.
+ *
+ * @coversDefaultClass Scheduled_Updates_Admin
+ */
+class Scheduled_Updates_Admin_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Test get_scheduled_update_text.
+	 *
+	 * @dataProvider update_text_provider
+	 * @covers ::get_scheduled_update_text
+	 *
+	 * @param object $schedule The schedule object.
+	 * @param string $expected The expected text.
+	 */
+	public function test_get_scheduled_update_text( $schedule, $expected ) {
+		$this->assertSame( $expected, Scheduled_Updates_Admin::get_scheduled_update_text( $schedule ) );
+	}
+
+	/**
+	 * Data provider for test_get_scheduled_update_text.
+	 *
+	 * @return array[]
+	 */
+	public function update_text_provider() {
+		return array(
+			array(
+				(object) array(
+					'timestamp' => strtotime( 'next Monday 00:00' ),
+					'interval'  => WEEK_IN_SECONDS,
+				),
+				sprintf( 'Mondays at %s.', gmdate( get_option( 'time_format' ), strtotime( 'next Monday 8:00' ) ) ),
+			),
+			array(
+				(object) array(
+					'timestamp' => strtotime( 'next Tuesday 00:00' ),
+					'interval'  => DAY_IN_SECONDS,
+				),
+				sprintf( 'Daily at %s.', gmdate( get_option( 'time_format' ), strtotime( 'next Tuesday 8:00' ) ) ),
+			),
+			array(
+				(object) array(
+					'timestamp' => strtotime( 'next Sunday 00:00' ),
+					'interval'  => WEEK_IN_SECONDS,
+				),
+				sprintf( 'Sundays at %s.', gmdate( get_option( 'time_format' ), strtotime( 'next Sunday 8:00' ) ) ),
+			),
+		);
+	}
+}

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -557,19 +557,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test get_scheduled_update_text.
-	 *
-	 * @dataProvider update_text_provider
-	 * @covers ::get_scheduled_update_text
-	 *
-	 * @param object $schedule The schedule object.
-	 * @param string $expected The expected text.
-	 */
-	public function test_get_scheduled_update_text( $schedule, $expected ) {
-		$this->assertSame( $expected, Scheduled_Updates::get_scheduled_update_text( $schedule ) );
-	}
-
-	/**
 	 * Test clear CRON cache.
 	 *
 	 * @covers ::clear_cron_cache
@@ -643,37 +630,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( 200, $result->get_status() );
 		$this->assertArrayNotHasKey( $id_1, $data );
 		$this->assertArrayHasKey( $id_2, $data );
-	}
-
-	/**
-	 * Data provider for test_get_scheduled_update_text.
-	 *
-	 * @return array[]
-	 */
-	public function update_text_provider() {
-		return array(
-			array(
-				(object) array(
-					'timestamp' => strtotime( 'next Monday 00:00' ),
-					'interval'  => WEEK_IN_SECONDS,
-				),
-				sprintf( 'Mondays at %s.', gmdate( get_option( 'time_format' ), strtotime( 'next Monday 8:00' ) ) ),
-			),
-			array(
-				(object) array(
-					'timestamp' => strtotime( 'next Tuesday 00:00' ),
-					'interval'  => DAY_IN_SECONDS,
-				),
-				sprintf( 'Daily at %s.', gmdate( get_option( 'time_format' ), strtotime( 'next Tuesday 8:00' ) ) ),
-			),
-			array(
-				(object) array(
-					'timestamp' => strtotime( 'next Sunday 00:00' ),
-					'interval'  => WEEK_IN_SECONDS,
-				),
-				sprintf( 'Sundays at %s.', gmdate( get_option( 'time_format' ), strtotime( 'next Sunday 8:00' ) ) ),
-			),
-		);
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -59,6 +59,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		);
 		wp_set_current_user( 0 );
 
+		Scheduled_Updates::init();
 		do_action( 'rest_api_init' );
 	}
 
@@ -73,6 +74,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		wp_clear_scheduled_hook( Scheduled_Updates::PLUGIN_CRON_HOOK );
 		delete_option( 'jetpack_scheduled_update_statuses' );
+		delete_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
 	}
 
 	/**
@@ -865,11 +867,11 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
-	 * Test adding a log entry.
+	 * Test adding a log entry for a non-existent schedule.
 	 *
 	 * @covers ::add_log
 	 */
-	public function test_add_log() {
+	public function test_add_log_invalid_schedule() {
 		wp_set_current_user( $this->admin_id );
 
 		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . Scheduled_Updates::generate_schedule_id( array() ) . '/logs' );
@@ -882,7 +884,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$result = rest_do_request( $request );
 
 		$this->assertSame( 404, $result->get_status() );
-		$this->assertSame( false, get_option( Scheduled_Updates::PLUGIN_CRON_HOOK ) );
+		$this->assertEmpty( get_option( Scheduled_Updates::PLUGIN_CRON_HOOK ) );
 	}
 
 	/**

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-plugin-list-filter
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-plugin-list-filter
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+


### PR DESCRIPTION
This came up in a recent user test as something they'd look for.
See pcmemI-2YC-p2#comment-2229

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves existing wp-admin functionality in new class (incl. tests)
* Adds callbacks to add a view link and filter the list of plugins based on whether they're part of a schedule.

<img width="1122" alt="image" src="https://github.com/Automattic/jetpack/assets/1398304/0a6d4d93-32ed-40fc-92a6-6e67e6dc2b48">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply diff and sync to a test site.
* Visit `/wp-admin/plugins.php` and make sure no additional views link is present.
* Create a new schedule with some plugins.
* Visit `/wp-admin/plugins.php` and make sure the views link for Scheduled Updates shows up and filters the correct plugins.
* Create another schedule, maybe with overlap of plugins. 
* Visit `/wp-admin/plugins.php` and make sure the views link for Scheduled Updates shows up and still filters the correct plugins.

