### PR TITLE
Scheduled Updates: Fix phan errors

### DIFF
--- a/projects/packages/abtest/.phan/baseline.php
+++ b/projects/packages/abtest/.phan/baseline.php
@@ -11,11 +11,9 @@ return [
     // # Issue statistics:
     // PhanUndeclaredProperty : 10+ occurrences
     // PhanDeprecatedFunction : 1 occurrence
-    // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-abtest.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/test-abtest.php' => ['PhanDeprecatedFunction', 'PhanUndeclaredProperty'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/abtest/changelog/fix-phan-errors
+++ b/projects/packages/abtest/changelog/fix-phan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Phan baseline updates.
+
+

--- a/projects/packages/backup/.phan/baseline.php
+++ b/projects/packages/backup/.phan/baseline.php
@@ -10,8 +10,8 @@
 return [
     // # Issue statistics:
     // PhanTypeMismatchReturnProbablyReal : 15+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 8 occurrences
     // PhanTypeMismatchReturn : 6 occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 5 occurrences
     // PhanUndeclaredStaticMethod : 2 occurrences
     // PhanPossiblyUndeclaredVariable : 1 occurrence
     // PhanUndeclaredClassMethod : 1 occurrence

--- a/projects/packages/backup/changelog/fix-phan-errors
+++ b/projects/packages/backup/changelog/fix-phan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Phan baseline updates.
+
+

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.3.7';
+	const PACKAGE_VERSION = '3.3.8-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/.phan/baseline.php
+++ b/projects/packages/blaze/.phan/baseline.php
@@ -10,9 +10,9 @@
 return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 2 occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
     // PhanTypeMismatchReturn : 2 occurrences
     // PhanParamTooMany : 1 occurrence
+    // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
     // PhanTypeNoAccessiblePropertiesForeach : 1 occurrence
     // PhanUndeclaredFunction : 1 occurrence

--- a/projects/packages/blaze/changelog/fix-phan-errors
+++ b/projects/packages/blaze/changelog/fix-phan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Phan baseline updates.
+
+

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.20.3",
+	"version": "0.20.4-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.20.3';
+	const PACKAGE_VERSION = '0.20.4-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/connection/changelog/fix-phan-errors
+++ b/projects/packages/connection/changelog/fix-phan-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connection: Update phpdocs to better reflect accepted parameter types for wpcom_json_api_request_as_blog().

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -440,12 +440,12 @@ class Client {
 	/**
 	 * Query the WordPress.com REST API using the blog token
 	 *
-	 * @param string       $path          The API endpoint relative path.
-	 * @param string       $version       The API version.
-	 * @param array        $args          Request arguments.
-	 * @param array|string $body          Request body.
-	 * @param string       $base_api_path (optional) the API base path override, defaults to 'rest'.
-	 * @return array|WP_Error $response Data.
+	 * @param string            $path          The API endpoint relative path.
+	 * @param string            $version       Optional. The API version. Default is '1.1'.
+	 * @param array             $args          Optional. Request arguments. Default empty array.
+	 * @param array|string|null $body          Optional. Request body. Default null.
+	 * @param string            $base_api_path Optional. The API base path override. Defaults to 'rest'.
+	 * @return array|WP_Error The response array or a WP_Error on failure.
 	 */
 	public static function wpcom_json_api_request_as_blog(
 		$path,

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -440,11 +440,11 @@ class Client {
 	/**
 	 * Query the WordPress.com REST API using the blog token
 	 *
-	 * @param String $path The API endpoint relative path.
-	 * @param String $version The API version.
-	 * @param array  $args Request arguments.
-	 * @param String $body Request body.
-	 * @param String $base_api_path (optional) the API base path override, defaults to 'rest'.
+	 * @param string       $path          The API endpoint relative path.
+	 * @param string       $version       The API version.
+	 * @param array        $args          Request arguments.
+	 * @param array|string $body          Request body.
+	 * @param string       $base_api_path (optional) the API base path override, defaults to 'rest'.
 	 * @return array|WP_Error $response Data.
 	 */
 	public static function wpcom_json_api_request_as_blog(

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.7.1';
+	const PACKAGE_VERSION = '2.7.2-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/jitm/.phan/baseline.php
+++ b/projects/packages/jitm/.phan/baseline.php
@@ -10,17 +10,17 @@
 return [
     // # Issue statistics:
     // PhanTypeExpectedObjectPropAccess : 3 occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
     // PhanTypeMismatchReturn : 2 occurrences
     // PhanUndeclaredMethod : 2 occurrences
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanTypeInvalidDimOffset : 1 occurrence
     // PhanTypeMismatchArgument : 1 occurrence
+    // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
     // PhanUnreferencedUseNormal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-post-connection-jitm.php' => ['PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
+        'src/class-post-connection-jitm.php' => ['PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
         'src/class-rest-api-endpoints.php' => ['PhanPluginSimplifyExpressionBool'],
         'tests/php/test_JITM.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUnreferencedUseNormal'],
         'tests/php/test_pre_connection_jitm.php' => ['PhanTypeInvalidDimOffset', 'PhanUndeclaredMethod'],

--- a/projects/packages/jitm/changelog/fix-phan-errors
+++ b/projects/packages/jitm/changelog/fix-phan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Phan baseline updates.
+
+

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.1.6';
+	const PACKAGE_VERSION = '3.1.7-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/my-jetpack/.phan/baseline.php
+++ b/projects/packages/my-jetpack/.phan/baseline.php
@@ -12,7 +12,6 @@ return [
     // PhanTypeMismatchArgumentNullable : 60+ occurrences
     // PhanTypeMismatchPropertyDefault : 15+ occurrences
     // PhanParamTooMany : 10+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 10+ occurrences
     // PhanAbstractStaticMethodCallInStatic : 8 occurrences
     // PhanUndeclaredClassMethod : 8 occurrences
@@ -20,6 +19,7 @@ return [
     // PhanTypeMismatchReturn : 6 occurrences
     // PhanUndeclaredStaticProperty : 6 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 5 occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 4 occurrences
     // PhanUnextractableAnnotation : 4 occurrences
     // PhanTypeArraySuspicious : 3 occurrences
     // PhanTypeMismatchReturnNullable : 3 occurrences
@@ -49,7 +49,7 @@ return [
         'src/class-rest-zendesk-chat.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction', 'PhanUnextractableAnnotationSuffix'],
         'src/class-wpcom-products.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUnextractableAnnotation'],
         'src/products/class-anti-spam.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
-        'src/products/class-backup.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyDefault'],
+        'src/products/class-backup.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
         'src/products/class-boost.php' => ['PhanTypeMismatchPropertyDefault'],
         'src/products/class-creator.php' => ['PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturnProbablyReal'],
         'src/products/class-crm.php' => ['PhanTypeMismatchPropertyDefault'],
@@ -58,10 +58,9 @@ return [
         'src/products/class-jetpack-ai.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
         'src/products/class-module-product.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
         'src/products/class-product.php' => ['PhanAbstractStaticMethodCallInStatic', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
-        'src/products/class-protect.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyDefault'],
-        'src/products/class-scan.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal'],
-        'src/products/class-search-stats.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'src/products/class-search.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClassMethod'],
+        'src/products/class-protect.php' => ['PhanTypeMismatchPropertyDefault'],
+        'src/products/class-scan.php' => ['PhanTypeMismatchArgumentNullable'],
+        'src/products/class-search.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClassMethod'],
         'src/products/class-security.php' => ['PhanTypeMismatchArgumentNullable'],
         'src/products/class-social.php' => ['PhanTypeMismatchPropertyDefault'],
         'src/products/class-starter.php' => ['PhanTypeMismatchArgumentNullable'],

--- a/projects/packages/my-jetpack/changelog/fix-phan-errors
+++ b/projects/packages/my-jetpack/changelog/fix-phan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Phan baseline updates.
+
+

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.22.0",
+	"version": "4.22.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.22.0';
+	const PACKAGE_VERSION = '4.22.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -11,7 +11,7 @@ return [
     // # Issue statistics:
     // PhanUndeclaredClassMethod : 20+ occurrences
     // PhanTypeMismatchArgument : 15+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 15+ occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
     // PhanDeprecatedFunction : 9 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 7 occurrences
     // PhanTypeMismatchProperty : 7 occurrences
@@ -41,7 +41,7 @@ return [
         'src/auto-conversion-settings/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/class-connections-post-field.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanUndeclaredTypeReturnType'],
         'src/class-keyring-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanUndeclaredTypeReturnType'],
-        'src/class-publicize-base.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
+        'src/class-publicize-base.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
         'src/class-publicize-setup.php' => ['PhanTypeMismatchArgument', 'PhanUnextractableAnnotationSuffix'],
         'src/class-publicize-ui.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
         'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredStaticMethod'],

--- a/projects/packages/publicize/changelog/fix-phan-errors
+++ b/projects/packages/publicize/changelog/fix-phan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Phan baseline updates.
+
+

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.10",
+	"version": "0.42.11-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/scheduled-updates/.phan/baseline.php
+++ b/projects/packages/scheduled-updates/.phan/baseline.php
@@ -9,24 +9,11 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredProperty : 40+ occurrences
-    // PhanCompatibleAccessMethodOnTraitDefinition : 2 occurrences
-    // PhanPluginMixedKeyNoKey : 2 occurrences
-    // PhanRedundantCondition : 2 occurrences
-    // PhanTypeArraySuspiciousNullable : 2 occurrences
-    // PhanUndeclaredClassMethod : 2 occurrences
-    // PhanNoopNew : 1 occurrence
-    // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
     // PhanTypeMismatchDimFetch : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-scheduled-updates.php' => ['PhanRedundantCondition', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimFetch', 'PhanUndeclaredClassMethod'],
-        'src/pluggable.php' => ['PhanTypeArraySuspiciousNullable'],
-        'src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php' => ['PhanPluginMixedKeyNoKey'],
-        'tests/php/class-scheduled-updates-logs-test.php' => ['PhanCompatibleAccessMethodOnTraitDefinition', 'PhanUndeclaredProperty'],
-        'tests/php/class-scheduled-updates-test.php' => ['PhanCompatibleAccessMethodOnTraitDefinition', 'PhanUndeclaredProperty'],
-        'tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php' => ['PhanNoopNew'],
+        'src/class-scheduled-updates.php' => ['PhanTypeMismatchDimFetch'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/scheduled-updates/changelog/fix-phan-errors
+++ b/projects/packages/scheduled-updates/changelog/fix-phan-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Scheduled Updates: Fixed phan errors and removed exemptions.

--- a/projects/packages/scheduled-updates/changelog/fix-phan-errors#2
+++ b/projects/packages/scheduled-updates/changelog/fix-phan-errors#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Updated package dependencies.

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -4,7 +4,11 @@
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=7.0"
+		"php": ">=7.0",
+		"automattic/jetpack-status": "^2.2@dev",
+		"automattic/jetpack-sync": "^2.12@dev",
+		"automattic/jetpack-constants": "^2.0@dev",
+		"automattic/jetpack-connection": "^2.7@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.1.0",

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -5,10 +5,10 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.0",
-		"automattic/jetpack-status": "^2.2@dev",
-		"automattic/jetpack-sync": "^2.12@dev",
-		"automattic/jetpack-constants": "^2.0@dev",
-		"automattic/jetpack-connection": "^2.7@dev"
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-sync": "@dev",
+		"automattic/jetpack-constants": "@dev",
+		"automattic/jetpack-connection": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.1.0",

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -343,24 +343,23 @@ class Scheduled_Updates {
 		$reasons_can_not_autoupdate   = array();
 		$reasons_can_not_modify_files = array();
 
-		$has_file_system_write_access = self::file_system_write_access();
+		$has_file_system_write_access = Sync\Functions::file_system_write_access();
 		if ( ! $has_file_system_write_access ) {
 			$reasons_can_not_modify_files['has_no_file_system_write_access'] = __( 'The file permissions on this host prevent editing files.', 'jetpack-scheduled-updates' );
 		}
 
-		$disallow_file_mods = \Automattic\Jetpack\Constants::get_constant( 'DISALLOW_FILE_MODS' );
+		$disallow_file_mods = Constants::get_constant( 'DISALLOW_FILE_MODS' );
 		if ( $disallow_file_mods ) {
 			$reasons_can_not_modify_files['disallow_file_mods'] = __( 'File modifications are explicitly disabled by a site administrator.', 'jetpack-scheduled-updates' );
 		}
 
-		$automatic_updater_disabled = \Automattic\Jetpack\Constants::get_constant( 'AUTOMATIC_UPDATER_DISABLED' );
+		$automatic_updater_disabled = Constants::get_constant( 'AUTOMATIC_UPDATER_DISABLED' );
 		if ( $automatic_updater_disabled ) {
 			$reasons_can_not_autoupdate['automatic_updater_disabled'] = __( 'Any autoupdates are explicitly disabled by a site administrator.', 'jetpack-scheduled-updates' );
 		}
 
 		if ( is_multisite() ) {
-			// @phan-suppress-next-line PhanUndeclaredClassMethod
-			if ( class_exists( 'Jetpack' ) && \Jetpack::is_multi_network() ) {
+			if ( ( new Status() )->is_multi_network() ) {
 				$reasons_can_not_modify_files['is_multi_network'] = __( 'Multi network install are not supported.', 'jetpack-scheduled-updates' );
 			}
 			// Is the site the main site here.
@@ -469,20 +468,5 @@ class Scheduled_Updates {
 	 */
 	public static function generate_schedule_id( $args ) {
 		return md5( serialize( $args ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
-	}
-
-	/**
-	 * Returns if the file system is writeable.
-	 * Used mostly for mocking during tests.
-	 *
-	 * @see Automattic\Jetpack\Sync\Functions::file_system_write_access
-	 */
-	private static function file_system_write_access() {
-		if ( class_exists( 'Automattic\Jetpack\Sync\Functions' ) ) {
-			// @phan-suppress-next-line PhanUndeclaredClassMethod
-			return Automattic\Jetpack\Sync\Functions::file_system_write_access();
-		}
-
-		return false;
 	}
 }

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -359,8 +359,8 @@ class Scheduled_Updates {
 		}
 
 		if ( is_multisite() ) {
-			// is it the main network ? is really is multi network
-			if ( Jetpack::is_multi_network() ) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod
+			if ( class_exists( 'Jetpack' ) && \Jetpack::is_multi_network() ) {
 				$reasons_can_not_modify_files['is_multi_network'] = __( 'Multi network install are not supported.', 'jetpack-scheduled-updates' );
 			}
 			// Is the site the main site here.
@@ -370,8 +370,8 @@ class Scheduled_Updates {
 		}
 
 		$file_mod_capabilities = array(
-			'modify_files'     => (bool) empty( $reasons_can_not_modify_files ), // install, remove, update
-			'autoupdate_files' => (bool) empty( $reasons_can_not_modify_files ) && empty( $reasons_can_not_autoupdate ), // enable autoupdates
+			'modify_files'     => empty( $reasons_can_not_modify_files ), // install, remove, update.
+			'autoupdate_files' => empty( $reasons_can_not_modify_files ) && empty( $reasons_can_not_autoupdate ), // enable autoupdates.
 		);
 
 		$errors = array();
@@ -478,10 +478,11 @@ class Scheduled_Updates {
 	 * @see Automattic\Jetpack\Sync\Functions::file_system_write_access
 	 */
 	private static function file_system_write_access() {
-		if ( ! class_exists( 'Automattic\Jetpack\Sync\Functions' ) ) {
-			return false;
+		if ( class_exists( 'Automattic\Jetpack\Sync\Functions' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod
+			return Automattic\Jetpack\Sync\Functions::file_system_write_access();
 		}
 
-		return \Automattic\Jetpack\Sync\Functions::file_system_write_access();
+		return false;
 	}
 }

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.7.2';
+	const PACKAGE_VERSION = '0.7.3-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/scheduled-updates/src/pluggable.php
+++ b/projects/packages/scheduled-updates/src/pluggable.php
@@ -10,8 +10,9 @@ if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
 	 * Retrieves scheduled events.
 	 *
 	 * Retrieves all the events that have been scheduled for the hook provided.
-	 *
 	 * This should really be in Core, and until it is, we'll define it here in a forward-compatible way.
+	 *
+	 * @suppress PhanTypeArraySuspiciousNullable
 	 *
 	 * @param string $hook Action hook of the event.
 	 * @return object[]|array {

--- a/projects/packages/scheduled-updates/src/pluggable.php
+++ b/projects/packages/scheduled-updates/src/pluggable.php
@@ -12,8 +12,6 @@ if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
 	 * Retrieves all the events that have been scheduled for the hook provided.
 	 * This should really be in Core, and until it is, we'll define it here in a forward-compatible way.
 	 *
-	 * @suppress PhanTypeArraySuspiciousNullable
-	 *
 	 * @param string $hook Action hook of the event.
 	 * @return object[]|array {
 	 *     Array of event objects. Empty array if no events exist for the hook.
@@ -54,6 +52,9 @@ if ( ! function_exists( 'wp_get_scheduled_events' ) ) {
 			if ( isset( $cron[ $hook ] ) ) {
 				$key             = key( $cron[ $hook ] );
 				$scheduled_event = array_pop( $cron[ $hook ] );
+				if ( null === $scheduled_event ) {
+					continue;
+				}
 
 				$event = (object) array(
 					'hook'      => $hook,

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -51,6 +51,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			'/' . $this->rest_base,
 			array(
 				array(
+					// @phan-suppress-next-line PhanPluginMixedKeyNoKey
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
@@ -152,6 +153,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			'/' . $this->rest_base . '/(?P<schedule_id>[\w]+)',
 			array(
 				array(
+					// @phan-suppress-next-line PhanPluginMixedKeyNoKey
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -51,7 +51,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			'/' . $this->rest_base,
 			array(
 				array(
-					// @phan-suppress-next-line PhanPluginMixedKeyNoKey
+					// @phan-suppress-next-line PhanPluginMixedKeyNoKey -- `register_rest_route()` requires mixed key/no-key for `$args`, and then https://github.com/phan/phan/issues/4852 puts the error on the wrong line.
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
@@ -153,7 +153,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			'/' . $this->rest_base . '/(?P<schedule_id>[\w]+)',
 			array(
 				array(
-					// @phan-suppress-next-line PhanPluginMixedKeyNoKey
+					// @phan-suppress-next-line PhanPluginMixedKeyNoKey -- `register_rest_route()` requires mixed key/no-key for `$args`, and then https://github.com/phan/phan/issues/4852 puts the error on the wrong line.
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
@@ -24,6 +24,13 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 	use \phpmock\phpunit\PHPMock;
 
 	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	protected $admin_id;
+
+	/**
 	 * Set up before class.
 	 *
 	 * @see Restrictions here: https://github.com/php-mock/php-mock-phpunit?tab=readme-ov-file#restrictions
@@ -31,7 +38,7 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 	 */
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
-		\phpmock\phpunit\PHPMock::defineFunctionMock( 'Automattic\Jetpack', 'realpath' );
+		static::defineFunctionMock( 'Automattic\Jetpack', 'realpath' );
 		Scheduled_Updates::init();
 		Scheduled_Updates::load_rest_api_endpoints();
 	}

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -22,6 +22,27 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	use \phpmock\phpunit\PHPMock;
 
 	/**
+	 * WordPress filesystem.
+	 *
+	 * @var \WP_Filesystem_Base
+	 */
+	protected $wp_filesystem;
+
+	/**
+	 * Plugin directory.
+	 *
+	 * @var string
+	 */
+	protected $plugin_dir;
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	protected $admin_id;
+
+	/**
 	 * Set up before class.
 	 *
 	 * @see Restrictions here: https://github.com/php-mock/php-mock-phpunit?tab=readme-ov-file#restrictions
@@ -29,7 +50,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 */
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
-		\phpmock\phpunit\PHPMock::defineFunctionMock( 'Automattic\Jetpack', 'realpath' );
+		static::defineFunctionMock( 'Automattic\Jetpack', 'realpath' );
 
 		Scheduled_Updates::init();
 		Scheduled_Updates::load_rest_api_endpoints();

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -34,6 +34,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
+		// @phan-suppress-next-line PhanNoopNew
 		new WPCOM_REST_API_V2_Endpoint_Update_Schedules();
 	}
 

--- a/projects/packages/search/.phan/baseline.php
+++ b/projects/packages/search/.phan/baseline.php
@@ -12,9 +12,9 @@ return [
     // PhanUnextractableAnnotation : 45+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 10+ occurrences
     // PhanTypeMismatchArgument : 10+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 9 occurrences
     // PhanUndeclaredClassMethod : 8 occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 7 occurrences
     // PhanUndeclaredTypeProperty : 7 occurrences
     // PhanRedundantCondition : 6 occurrences
     // PhanTypeMismatchProperty : 6 occurrences
@@ -47,9 +47,8 @@ return [
         'src/class-cli.php' => ['PhanTypeMismatchArgument'],
         'src/class-helper.php' => ['PhanDeprecatedPartiallySupportedCallable', 'PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter'],
         'src/class-options.php' => ['PhanPluginSimplifyExpressionBool'],
-        'src/class-plan.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUnextractableAnnotation'],
-        'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
-        'src/class-stats.php' => ['PhanTypeMismatchArgumentProbablyReal'],
+        'src/class-plan.php' => ['PhanDeprecatedFunction', 'PhanUnextractableAnnotation'],
+        'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-template-tags.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/classic-search/class-classic-search.php' => ['PhanImpossibleCondition', 'PhanPluginRedundantAssignment', 'PhanRedundantCondition', 'PhanTypeComparisonToArray', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty'],
         'src/customizer/customize-controls/class-excluded-post-types-control.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/search/changelog/fix-phan-errors
+++ b/projects/packages/search/changelog/fix-phan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Phan baseline updates.
+
+

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.1",
+	"version": "0.44.2-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.1';
+	const VERSION = '0.44.2-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/videopress/.phan/baseline.php
+++ b/projects/packages/videopress/.phan/baseline.php
@@ -10,11 +10,11 @@
 return [
     // # Issue statistics:
     // PhanPluginDuplicateConditionalNullCoalescing : 20+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
     // PhanUndeclaredClassMethod : 10+ occurrences
     // PhanUndeclaredFunction : 10+ occurrences
     // PhanTypeMismatchReturn : 8 occurrences
     // PhanUndeclaredProperty : 8 occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 7 occurrences
     // PhanTypeArraySuspicious : 6 occurrences
     // PhanTypeMismatchReturnProbablyReal : 6 occurrences
     // PhanUnextractableAnnotation : 5 occurrences
@@ -49,7 +49,7 @@ return [
     'file_suppressions' => [
         'src/class-access-control.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction'],
         'src/class-admin-ui.php' => ['PhanUndeclaredClassMethod'],
-        'src/class-ajax.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],
+        'src/class-ajax.php' => ['PhanUndeclaredFunction'],
         'src/class-attachment-handler.php' => ['PhanNonClassMethodCall', 'PhanTypeArraySuspicious'],
         'src/class-block-editor-content.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-block-editor-extensions.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal'],
@@ -58,13 +58,12 @@ return [
         'src/class-initializer.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredMethod'],
         'src/class-jwt-token-bridge.php' => ['PhanTypeMismatchReturn'],
         'src/class-plan.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUnextractableAnnotation'],
-        'src/class-site.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'src/class-stats.php' => ['PhanTypeArraySuspiciousNullable'],
         'src/class-status.php' => ['PhanUndeclaredClassMethod'],
         'src/class-uploader-rest-endpoints.php' => ['PhanParamTooMany'],
         'src/class-uploader.php' => ['PhanTypeMismatchArgument'],
         'src/class-utils.php' => ['PhanUnextractableAnnotation'],
-        'src/class-videopresstoken.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
+        'src/class-videopresstoken.php' => ['PhanTypeMismatchReturn'],
         'src/class-wpcom-rest-api-v2-attachment-field-videopress.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
         'src/class-wpcom-rest-api-v2-attachment-videopress-data.php' => ['PhanUndeclaredFunction'],
         'src/class-wpcom-rest-api-v2-endpoint-videopress.php' => ['PhanAccessMethodInternal', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],

--- a/projects/packages/videopress/changelog/fix-phan-errors
+++ b/projects/packages/videopress/changelog/fix-phan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Phan baseline updates.
+
+

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.15",
+	"version": "0.23.16-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.15';
+	const PACKAGE_VERSION = '0.23.16-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/.phan/baseline.php
+++ b/projects/packages/waf/.phan/baseline.php
@@ -11,9 +11,9 @@ return [
     // # Issue statistics:
     // PhanUndeclaredMethod : 25+ occurrences
     // PhanTypeMismatchArgument : 10+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
     // PhanUnextractableAnnotationSuffix : 10+ occurrences
     // PhanDeprecatedFunction : 9 occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 9 occurrences
     // PhanTypeMismatchReturn : 7 occurrences
     // PhanNoopNew : 6 occurrences
     // PhanTypeMismatchDefault : 5 occurrences
@@ -52,7 +52,7 @@ return [
         'src/class-waf-constants.php' => ['PhanCoalescingNeverNull', 'PhanUndeclaredConstant'],
         'src/class-waf-operators.php' => ['PhanTypeMismatchReturn'],
         'src/class-waf-request.php' => ['PhanGenericConstructorTypes', 'PhanUnextractableAnnotationSuffix'],
-        'src/class-waf-rules-manager.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
+        'src/class-waf-rules-manager.php' => ['PhanUndeclaredMethod'],
         'src/class-waf-runner.php' => ['PhanUndeclaredMethod'],
         'src/class-waf-runtime.php' => ['PhanGenericConstructorTypes', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable', 'PhanUndeclaredConstant', 'PhanUnextractableAnnotationElementName', 'PhanUnextractableAnnotationSuffix'],
         'src/class-waf-standalone-bootstrap.php' => ['PhanUndeclaredMethod'],

--- a/projects/packages/waf/changelog/fix-phan-errors
+++ b/projects/packages/waf/changelog/fix-phan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Phan baseline updates.
+
+

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -11,7 +11,7 @@ return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 560+ occurrences
     // PhanUndeclaredMethod : 370+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 360+ occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 350+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 290+ occurrences
     // PhanUndeclaredClassMethod : 240+ occurrences
     // PhanNoopNew : 210+ occurrences
@@ -147,7 +147,7 @@ return [
         '_inc/lib/class-jetpack-ai-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchPropertyDefault', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
         '_inc/lib/class-jetpack-currencies.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal'],
         '_inc/lib/class-jetpack-google-drive-helper.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
-        '_inc/lib/class-jetpack-instagram-gallery-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
+        '_inc/lib/class-jetpack-instagram-gallery-helper.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
         '_inc/lib/class-jetpack-mapbox-helper.php' => ['PhanTypeMismatchArgumentNullable', 'PhanUndeclaredFunction'],
         '_inc/lib/class-jetpack-podcast-feed-locator.php' => ['PhanDeprecatedFunctionInternal'],
         '_inc/lib/class-jetpack-podcast-helper.php' => ['PhanMisspelledAnnotation', 'PhanStaticCallToNonStatic', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousStringExpression'],
@@ -540,7 +540,7 @@ return [
         'modules/widgets/authors.php' => ['PhanTypeMismatchArgument', 'PhanTypeMissingReturn'],
         'modules/widgets/blog-stats.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument'],
         'modules/widgets/class-jetpack-eu-cookie-law-widget.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMissingReturn'],
-        'modules/widgets/class-jetpack-instagram-widget.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
+        'modules/widgets/class-jetpack-instagram-widget.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
         'modules/widgets/contact-info.php' => ['PhanParamSignatureMismatch', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'modules/widgets/eu-cookie-law/form.php' => ['PhanUndeclaredGlobalVariable', 'PhanUndeclaredThis'],
         'modules/widgets/eu-cookie-law/widget-amp.php' => ['PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeArraySuspiciousNullable', 'PhanUndeclaredGlobalVariable'],

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -167,7 +167,7 @@ return [
         '_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/core-api/load-wpcom-endpoints.php' => ['PhanUndeclaredVariableDim'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php' => ['PhanPluginMixedKeyNoKey', 'PhanPluginSimplifyExpressionBool', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunctionInCallable'],
-        '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
+        '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-blog-stats.php' => ['PhanTypeMismatchReturnProbablyReal'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-following.php' => ['PhanUndeclaredFunction'],

--- a/projects/plugins/jetpack/changelog/fix-phan-errors
+++ b/projects/plugins/jetpack/changelog/fix-phan-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed a phan error and updated baseline

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_3",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_4",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.4-a.3
+ * Version: 13.4-a.4
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.4-a.3' );
+define( 'JETPACK__VERSION', '13.4-a.4' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.4.0-a.3",
+	"version": "13.4.0-a.4",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-phan-errors
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-phan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_15"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_16_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -7,6 +7,118 @@
     "content-hash": "eec12a75b7ddd8f85b30cc58ffb814c6",
     "packages": [
         {
+            "name": "automattic/jetpack-a8c-mc-stats",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/a8c-mc-stats",
+                "reference": "29e2de602fcb803984eed4229ffa60a2f96a53f9"
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-a8c-mc-stats",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-admin-ui",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/admin-ui",
+                "reference": "b191c34a0e21f625069eab0c054d8827b9542dfa"
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-logo": "@dev",
+                "automattic/wordbless": "dev-master",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-admin-ui",
+                "textdomain": "jetpack-admin-ui",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.4.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-admin-menu.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "post-update-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Generic Jetpack wp-admin UI elements",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-assets",
             "version": "dev-trunk",
             "dist": {
@@ -73,6 +185,82 @@
             }
         },
         {
+            "name": "automattic/jetpack-connection",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/connection",
+                "reference": "c8993518f67538ea9d7f898077aa597e4cdc0970"
+            },
+            "require": {
+                "automattic/jetpack-a8c-mc-stats": "@dev",
+                "automattic/jetpack-admin-ui": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-roles": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/wordbless": "@dev",
+                "brain/monkey": "2.6.1",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-connection",
+                "textdomain": "jetpack-connection",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "legacy",
+                    "src/",
+                    "src/webhooks"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "post-install-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "post-update-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to connect to the Jetpack infrastructure",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-constants",
             "version": "dev-trunk",
             "dist": {
@@ -119,6 +307,187 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for defining constants in a more testable way.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-identity-crisis",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/identity-crisis",
+                "reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-logo": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/wordbless": "@dev",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-identity-crisis",
+                "textdomain": "jetpack-idc",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-identity-crisis.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.18.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "NODE_ENV='production' pnpm run build"
+                ],
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "post-update-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Identity Crisis.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-ip",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/ip",
+                "reference": "b696350993b7f42257788add260e0efa7c9934f4"
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "brain/monkey": "2.6.1",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-ip",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-ip/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.2.x-dev"
+                },
+                "textdomain": "jetpack-ip",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-utils.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities for working with IP addresses.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-logo",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/logo",
+                "reference": "e152a4c83d1f952442d40260c559c4880757b298"
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-logo",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-logo/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A logo for Jetpack",
             "transport-options": {
                 "relative": true
             }
@@ -193,14 +562,300 @@
             }
         },
         {
+            "name": "automattic/jetpack-password-checker",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/password-checker",
+                "reference": "16182898ae3faae3eb6ca9e5d2c490fd0b844243"
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/wordbless": "@dev",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-password-checker",
+                "textdomain": "jetpack-password-checker",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-password-checker/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "post-update-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Password Checker.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-redirect",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/redirect",
+                "reference": "effd6fdea78e9c3cb1bebf479474b4a9262444a1"
+            },
+            "require": {
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "brain/monkey": "2.6.1",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-redirect",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-redirect/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-roles",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/roles",
+                "reference": "0ac6d02e8ef2adb058f8f52e80a4924a33fa9b86"
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "brain/monkey": "2.6.1",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-roles",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-roles/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities, related with user roles and capabilities.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-status",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/status",
+                "reference": "90b8d62a2a976c5a39114c1e6f295faaa5ebb2d0"
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-ip": "@dev",
+                "brain/monkey": "2.6.1",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-status",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-sync",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/sync",
+                "reference": "9e12c71d3a061cdf252f6279e730247700ecfab9"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-identity-crisis": "@dev",
+                "automattic/jetpack-ip": "@dev",
+                "automattic/jetpack-password-checker": "@dev",
+                "automattic/jetpack-roles": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/wordbless": "@dev",
+                "yoast/phpunit-polyfills": "1.1.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-sync",
+                "textdomain": "jetpack-sync",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "2.12.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ],
+                "post-update-cmd": [
+                    "WorDBless\\Composer\\InstallDropin::copy"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to allow syncing to the WP.com infrastructure.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/scheduled-updates",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "4dbf0c9b0bf8384ef49f5cbd8ab76713a2f41222"
+                "reference": "2835be9a7a144d63bb6f7f2b26d176001860588a"
             },
             "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-sync": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.15
+ * Version: 2.1.16-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.15",
+	"version": "2.1.16-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/protect/.phan/baseline.php
+++ b/projects/plugins/protect/.phan/baseline.php
@@ -12,21 +12,21 @@ return [
     // PhanPluginDuplicateConditionalNullCoalescing : 45+ occurrences
     // PhanParamTooMany : 6 occurrences
     // PhanTypeMismatchArgument : 5 occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 5 occurrences
     // PhanTypeMismatchProperty : 2 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
     // PhanNoopNew : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanRedundantCondition : 1 occurrence
+    // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'jetpack-protect.php' => ['PhanNoopNew'],
-        'src/class-credentials.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
+        'src/class-credentials.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-plan.php' => ['PhanTypeMismatchReturnProbablyReal'],
-        'src/class-protect-status.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
+        'src/class-protect-status.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-rest-controller.php' => ['PhanParamTooMany'],
-        'src/class-scan-status.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchProperty'],
+        'src/class-scan-status.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchProperty'],
         'src/class-status.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument'],
         'src/class-threats.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgumentProbablyReal'],
         'tests/php/test-scan-status.php' => ['PhanTypeMismatchArgument'],

--- a/projects/plugins/protect/changelog/fix-phan-errors
+++ b/projects/plugins/protect/changelog/fix-phan-errors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Phan baseline updates.
+
+


### PR DESCRIPTION
Fixes most errors and adds suppression where we can't change it.

The remaining error gets fixed in #36880.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates phpdocs to better reflect accepted parameter types for wpcom_json_api_request_as_blog().
* Adds phan suppression calls in cases where we can't fix it.
* Defines properties in unit test classes.
* Removes redundant type casting.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

No functional changes, unit tests should cover it.
