### PR TITLE
stub-generator: Set function stub return type when needed

### DIFF
--- a/projects/packages/stub-generator/changelog/add-stub-generator-function-return-type
+++ b/projects/packages/stub-generator/changelog/add-stub-generator-function-return-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Document function stub return type as "mixed" if it has a non-empty `return` but lacks any declaration or phpdoc, so Phan doesn't assume "void".

--- a/projects/packages/stub-generator/tests/php/PhpParser/StubNodeVisitorTest.php
+++ b/projects/packages/stub-generator/tests/php/PhpParser/StubNodeVisitorTest.php
@@ -85,6 +85,9 @@ class StubNodeVisitorTest extends TestCase {
 				'*',
 				<<<'PHP'
 				namespace {
+					/**
+					 * @phan-return mixed Dummy doc for stub.
+					 */
 					function foo()
 					{
 					}
@@ -107,6 +110,9 @@ class StubNodeVisitorTest extends TestCase {
 				array( 'function' => '*' ),
 				<<<'PHP'
 				namespace {
+					/**
+					 * @phan-return mixed Dummy doc for stub.
+					 */
 					function foo()
 					{
 					}
@@ -186,7 +192,9 @@ class StubNodeVisitorTest extends TestCase {
 				array( 'function' => array( 'foo', 'Some\NS\bar' ) ),
 				<<<'PHP'
 				namespace {
-					/** Non-namespaced */
+					/** Non-namespaced
+					 * @phan-return mixed Dummy doc for stub.
+					 */
 					function foo()
 					{
 					}
@@ -1498,6 +1506,90 @@ class StubNodeVisitorTest extends TestCase {
 				}
 				function uses_func_num_args(...$func_get_args)
 				{
+				}
+				PHP,
+			),
+
+			'Function return type inference'              => array(
+				<<<'PHP'
+				namespace X;
+
+				function no_return() {
+				}
+
+				function empty_return() {
+					return;
+				}
+
+				function has_return() {
+					if ( foo() ) {
+						return;
+					} else {
+						return 42;
+					}
+				}
+
+				function has_return_and_decl(): array {
+					return array();
+				}
+
+				/** @return array */
+				function has_return_and_phpdoc() {
+					return array();
+				}
+
+				/** @phan-return array */
+				function has_return_and_phan_phpdoc() {
+					return array();
+				}
+
+				/** @phan-real-return array */
+				function has_return_and_phan_phpdoc_real() {
+					return array();
+				}
+
+				class Foo {
+					function has_return() {
+						return 42;
+					}
+				}
+				PHP,
+				'*',
+				<<<'PHP'
+				namespace X;
+
+				function no_return()
+				{
+				}
+				function empty_return()
+				{
+				}
+				/**
+				 * @phan-return mixed Dummy doc for stub.
+				 */
+				function has_return()
+				{
+				}
+				function has_return_and_decl(): array
+				{
+				}
+				/** @return array */
+				function has_return_and_phpdoc()
+				{
+				}
+				/** @phan-return array */
+				function has_return_and_phan_phpdoc()
+				{
+				}
+				/** @phan-real-return array */
+				function has_return_and_phan_phpdoc_real()
+				{
+				}
+				class Foo
+				{
+					function has_return()
+					{
+					}
 				}
 				PHP,
 			),

--- a/projects/packages/stub-generator/tests/php/PhpParser/StubNodeVisitorTest.php
+++ b/projects/packages/stub-generator/tests/php/PhpParser/StubNodeVisitorTest.php
@@ -1529,6 +1529,25 @@ class StubNodeVisitorTest extends TestCase {
 					}
 				}
 
+				function return_only_in_subfunctions() {
+					function xxx() {
+						return 42;
+					}
+					class Huh {
+						public function xxx() {
+							return 42;
+						}
+					}
+					$x = function () {
+						return 42;
+					};
+					$x = new class() {
+						function xxx() {
+							return 42;
+						}
+					};
+				}
+
 				function has_return_and_decl(): array {
 					return array();
 				}
@@ -1568,6 +1587,9 @@ class StubNodeVisitorTest extends TestCase {
 				 * @phan-return mixed Dummy doc for stub.
 				 */
 				function has_return()
+				{
+				}
+				function return_only_in_subfunctions()
 				{
 				}
 				function has_return_and_decl(): array

--- a/projects/packages/stub-generator/tests/php/fixtures/files/functions.php
+++ b/projects/packages/stub-generator/tests/php/fixtures/files/functions.php
@@ -26,5 +26,5 @@ function another_function() {
 
 // This function has no docs.
 function undocumented_function( $args ) {
-	return $args;
+	var_dump( $args );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If a function stub lacks any declared return type or phpdoc `@return`, Phan will assume the return type is "void" and will therefore generate issues like PhanTypeVoidAssignment if the return value is used.

To avoid this situation, document the return type as "mixed" if the function has any non-empty `return` statement.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is CI happy?