### PR TITLE
WordAds: ensure that ads.txt works on subdirectory websites

### DIFF
--- a/projects/plugins/jetpack/changelog/feature-ads-txt-multisite
+++ b/projects/plugins/jetpack/changelog/feature-ads-txt-multisite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+WordAds: ensure that ads.txt works on subdirectory websites.

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -214,7 +214,8 @@ class WordAds {
 			WordAds_Consent_Management_Provider::init();
 		}
 
-		if ( isset( $_SERVER['REQUEST_URI'] ) && '/ads.txt' === $_SERVER['REQUEST_URI'] ) {
+		if ( ( isset( $_SERVER['REQUEST_URI'] ) && '/ads.txt' === $_SERVER['REQUEST_URI'] )
+			|| ( site_url( 'ads.txt', 'relative' ) === $_SERVER['REQUEST_URI'] ) ) {
 
 			$ads_txt_transient = get_transient( 'wordads_ads_txt' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Addressed  from https://github.com/Automattic/wordads-issues/issues/267

## Proposed changes:
Some users run WP on a subdirectory; when applied to WordAds, they must serve the `ads.txt`. This patch adds this feature.

**Note:** I'm aware that this is a non-standard, and the user would still need to set up a redirect from `domain.com/ads.txt` to `domain.com/blog/ads.txt,` but at least the user will have the chance to create this redirect, for instance, configuring manually on the `.htaccess` file.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Convert your blog to multsite: `jetpack docker multisite-convert`
* [Create the new site on a subdirectory in your network](http://localhost/wp-admin/network/site-new.php)
* In the store admin, add the Jetpack Security plan to your new site
* Enroll your new test Jetpack site to WordAds, if you have not enrolled already
* Try to access the `your-domain.com/your-subdirectory/ads.txt`
* Should show the content  starting with `#Rev - ...`
