### PR TITLE
Adds the ability to filter users in the WPCOM_JSON_API_List_Users_Endpoint endpoint by capability

### DIFF
--- a/projects/plugins/jetpack/changelog/add-list-users-endpoint-capabilities-filter
+++ b/projects/plugins/jetpack/changelog/add-list-users-endpoint-capabilities-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Adds the ability to filter users in the WPCOM_JSON_API_List_Users_Endpoint endpoint by capability

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -38,6 +38,7 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 			'search'          => '(string) Find matching users.',
 			'search_columns'  => "(array) Specify which columns to check for matching users. Can be any of 'ID', 'user_login', 'user_email', 'user_url', 'user_nicename', and 'display_name'. Only works when combined with `search` parameter.",
 			'role'            => '(string) Specify a specific user role to fetch.',
+			'capabilities'    => '(array) Specify a specific capability to fetch.',
 		),
 
 		'response_format'      => array(
@@ -157,6 +158,10 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		if ( ! empty( $args['role'] ) ) {
 			$query['role'] = $args['role'];
+		}
+
+		if ( ! empty( $args['capabilities'] ) ) {
+			$query['capability__in'] = $args['capabilities'];
 		}
 
 		$user_query = new WP_User_Query( $query );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -38,7 +38,7 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 			'search'          => '(string) Find matching users.',
 			'search_columns'  => "(array) Specify which columns to check for matching users. Can be any of 'ID', 'user_login', 'user_email', 'user_url', 'user_nicename', and 'display_name'. Only works when combined with `search` parameter.",
 			'role'            => '(string) Specify a specific user role to fetch.',
-			'capabilities'    => '(array) Specify one or more capabilities to fetch.',
+			'capability'      => '(string) Specify a specific capability to fetch. You can specify multiple by comma separating them, in which case the user needs to match all capabilities provided.',
 		),
 
 		'response_format'      => array(
@@ -160,8 +160,8 @@ class WPCOM_JSON_API_List_Users_Endpoint extends WPCOM_JSON_API_Endpoint {
 			$query['role'] = $args['role'];
 		}
 
-		if ( ! empty( $args['capabilities'] ) ) {
-			$query['capability__in'] = $args['capabilities'];
+		if ( ! empty( $args['capability'] ) ) {
+			$query['capability'] = $args['capability'];
 		}
 
 		$user_query = new WP_User_Query( $query );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-users-endpoint.php
@@ -38,7 +38,7 @@ new WPCOM_JSON_API_List_Users_Endpoint(
 			'search'          => '(string) Find matching users.',
 			'search_columns'  => "(array) Specify which columns to check for matching users. Can be any of 'ID', 'user_login', 'user_email', 'user_url', 'user_nicename', and 'display_name'. Only works when combined with `search` parameter.",
 			'role'            => '(string) Specify a specific user role to fetch.',
-			'capabilities'    => '(array) Specify a specific capability to fetch.',
+			'capabilities'    => '(array) Specify one or more capabilities to fetch.',
 		),
 
 		'response_format'      => array(


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/89443#pullrequestreview-1994133513

## Proposed changes:
- Adds a `capabilities` argument to the `/sites/:siteId/users` endpoint, allowing it to filter the user list by given capabilities.

### Discussion
This uses the `capability_in` filter of [WP_User_Query](https://developer.wordpress.org/reference/classes/wp_user_query/) meaning that when passing multiple capabilities (`capabilities[]=update_plugins&capabilities[]=manage_users`) it returns users having 1 or more of the given capabilities and not all capabilities. 

Do you think this is confusing? If so, we could filter the user list manually - or only allow the passing of 1 capability. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Apply this PR to your atomic site using Jetpack beta tester and the instructions below
- Apply this PR to your sandbox using the instructions below 
- Using the https://developer.wordpress.com/docs/api/console/ make a call to `/sites/:siteId/users?capabilities[]=update_plugins`. Try with some additional capabilities. 
- Make sure there are no regressions.