### PR TITLE
Fix SIG not shown in Jetpack sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sig-not-visible-in-jetpack-sidebar
+++ b/projects/plugins/jetpack/changelog/fix-sig-not-visible-in-jetpack-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed SIG not visible in Jetpack sidebar

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -45,9 +45,12 @@ const PublicizeSettings = () => {
 		);
 	} else {
 		children = (
-			<PublicizePanel>
-				<UpsellNotice />
-			</PublicizePanel>
+			<>
+				<PublicizePanel>
+					<UpsellNotice />
+				</PublicizePanel>
+				{ isSocialImageGeneratorAvailable && <SocialImageGeneratorPanel /> }
+			</>
 		);
 		panels = (
 			<>
@@ -59,10 +62,7 @@ const PublicizeSettings = () => {
 
 	return (
 		<PostTypeSupportCheck supportKeys="publicize">
-			<JetpackPluginSidebar>
-				{ children }
-				{ isSocialImageGeneratorAvailable && <SocialImageGeneratorPanel /> }
-			</JetpackPluginSidebar>
+			<JetpackPluginSidebar>{ children }</JetpackPluginSidebar>
 			{ panels }
 		</PostTypeSupportCheck>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -28,7 +28,7 @@ export const name = 'publicize';
 const PublicizeSettings = () => {
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( name );
-	const { isSocialImageGeneratorAvailable } = usePublicizeConfig();
+	const { isSocialImageGeneratorAvailable, isPublicizeEnabled } = usePublicizeConfig();
 
 	let children = null;
 	let panels = null;
@@ -49,7 +49,7 @@ const PublicizeSettings = () => {
 				<PublicizePanel>
 					<UpsellNotice />
 				</PublicizePanel>
-				{ isSocialImageGeneratorAvailable && <SocialImageGeneratorPanel /> }
+				{ isSocialImageGeneratorAvailable && isPublicizeEnabled && <SocialImageGeneratorPanel /> }
 			</>
 		);
 		panels = (

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -51,7 +51,6 @@ const PublicizeSettings = () => {
 		);
 		panels = (
 			<>
-				{ isSocialImageGeneratorAvailable && <SocialImageGeneratorPanel /> }
 				<PrePublishPanels isSocialImageGeneratorAvailable={ isSocialImageGeneratorAvailable } />
 				<PostPublishPanels />
 			</>
@@ -60,7 +59,10 @@ const PublicizeSettings = () => {
 
 	return (
 		<PostTypeSupportCheck supportKeys="publicize">
-			<JetpackPluginSidebar>{ children }</JetpackPluginSidebar>
+			<JetpackPluginSidebar>
+				{ children }
+				{ isSocialImageGeneratorAvailable && <SocialImageGeneratorPanel /> }
+			</JetpackPluginSidebar>
 			{ panels }
 		</PostTypeSupportCheck>
 	);


### PR DESCRIPTION
There was some regression in #36654 which made SIG to not show up in Jetpack sidebar, although it works fine in Social sidebar.

Fixes https://github.com/Automattic/jetpack-reach/issues/286

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that `<SocialImageGeneratorPanel />` is rendered inside  `<JetpackPluginSidebar>`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack sidebar on the post edit page
* Confirm that SIG shows up and works as expected

<img width="288" alt="image" src="https://github.com/Automattic/jetpack/assets/18226415/2bb745bc-cf1f-4574-824e-bcd5a11ee4cb">
