### PR TITLE
Jetpack Connection: Prevent unnecessary jetpack_connection_active_plugins option updates

### DIFF
--- a/projects/packages/connection/changelog/update-connection-jetpack_connection_active_plugins
+++ b/projects/packages/connection/changelog/update-connection-jetpack_connection_active_plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Connection: Prevent unnecessary jetpack_connection_active_plugins option updates

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.7.1';
+	const PACKAGE_VERSION = '2.7.2-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-plugin-storage.php
+++ b/projects/packages/connection/src/class-plugin-storage.php
@@ -167,6 +167,8 @@ class Plugin_Storage {
 			return;
 		}
 
+		self::$configured = true;
+
 		if ( is_multisite() ) {
 			self::$current_blog_id = get_current_blog_id();
 		}
@@ -178,8 +180,6 @@ class Plugin_Storage {
 		if ( $number_of_plugins_differ || true === self::$refresh_connected_plugins ) {
 			self::update_active_plugins_option();
 		}
-
-		self::$configured = true;
 	}
 
 	/**

--- a/projects/packages/connection/src/class-plugin-storage.php
+++ b/projects/packages/connection/src/class-plugin-storage.php
@@ -25,18 +25,16 @@ class Plugin_Storage {
 	const PLUGINS_DISABLED_OPTION_NAME = 'jetpack_connection_disabled_plugins';
 
 	/**
+	 * Transient name used as flag to indicate that the active connected plugins list needs refreshing.
+	 */
+	const ACTIVE_PLUGINS_REFRESH_FLAG = 'jetpack_connection_active_plugins_refresh';
+
+	/**
 	 * Whether this class was configured for the first time or not.
 	 *
 	 * @var boolean
 	 */
 	private static $configured = false;
-
-	/**
-	 * Refresh list of connected plugins upon intialization.
-	 *
-	 * @var boolean
-	 */
-	private static $refresh_connected_plugins = false;
 
 	/**
 	 * Connected plugins.
@@ -64,11 +62,6 @@ class Plugin_Storage {
 	 */
 	public static function upsert( $slug, array $args = array() ) {
 		self::$plugins[ $slug ] = $args;
-
-		// if plugin is not in the list of active plugins, refresh the list.
-		if ( ! array_key_exists( $slug, (array) get_option( self::ACTIVE_PLUGINS_OPTION_NAME, array() ) ) ) {
-			self::$refresh_connected_plugins = true;
-		}
 
 		return true;
 	}
@@ -169,6 +162,42 @@ class Plugin_Storage {
 
 		self::$configured = true;
 
+		add_action( 'update_option_active_plugins', array( __CLASS__, 'set_flag_to_refresh_active_connected_plugins' ) );
+
+		self::maybe_update_active_connected_plugins();
+	}
+
+	/**
+	 * Set a flag to indicate that the active connected plugins list needs to be updated.
+	 * This will happen when the `active_plugins` option is updated.
+	 *
+	 * @see configure
+	 */
+	public static function set_flag_to_refresh_active_connected_plugins() {
+		set_transient( self::ACTIVE_PLUGINS_REFRESH_FLAG, time() );
+	}
+
+	/**
+	 * Determine if we need to update the active connected plugins list.
+	 */
+	public static function maybe_update_active_connected_plugins() {
+		$maybe_error = self::ensure_configured();
+
+		if ( $maybe_error instanceof WP_Error ) {
+			return;
+		}
+		// Only attempt to update the option if the corresponding flag is set.
+		if ( ! get_transient( self::ACTIVE_PLUGINS_REFRESH_FLAG ) ) {
+			return;
+		}
+		// Only attempt to update the option on POST requests.
+		// This will prevent the option from being updated multiple times due to concurrent requests.
+		if ( ! ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) ) {
+			return;
+		}
+
+		delete_transient( self::ACTIVE_PLUGINS_REFRESH_FLAG );
+
 		if ( is_multisite() ) {
 			self::$current_blog_id = get_current_blog_id();
 		}
@@ -177,7 +206,7 @@ class Plugin_Storage {
 		// self::$plugins is populated in Config::ensure_options_connection().
 		$number_of_plugins_differ = count( self::$plugins ) !== count( (array) get_option( self::ACTIVE_PLUGINS_OPTION_NAME, array() ) );
 
-		if ( $number_of_plugins_differ || true === self::$refresh_connected_plugins ) {
+		if ( $number_of_plugins_differ ) {
 			self::update_active_plugins_option();
 		}
 	}
@@ -188,7 +217,7 @@ class Plugin_Storage {
 	 * @return void
 	 */
 	public static function update_active_plugins_option() {
-		// Note: Since this options is synced to wpcom, if you change its structure, you have to update the sanitizer at wpcom side.
+		// Note: Since this option is synced to wpcom, if you change its structure, you have to update the sanitizer at wpcom side.
 		update_option( self::ACTIVE_PLUGINS_OPTION_NAME, self::$plugins );
 
 		if ( ! class_exists( 'Automattic\Jetpack\Sync\Settings' ) || ! \Automattic\Jetpack\Sync\Settings::is_sync_enabled() ) {

--- a/projects/packages/connection/tests/php/test_plugin_storage.php
+++ b/projects/packages/connection/tests/php/test_plugin_storage.php
@@ -41,9 +41,14 @@ class Test_Plugin_Storage extends TestCase {
 	 * @after
 	 */
 	public function tear_down() {
+		unset( $_SERVER['REQUEST_METHOD'] );
 		$this->http_request_attempted = false;
 		Constants::clear_constants();
 		WorDBless_Options::init()->clear_options();
+
+		$reflection_class = new \ReflectionClass( '\Automattic\Jetpack\Connection\Plugin_Storage' );
+		$reflection_class->setStaticPropertyValue( 'configured', false );
+		$reflection_class->setStaticPropertyValue( 'plugins', array() );
 	}
 
 	/**
@@ -71,6 +76,98 @@ class Test_Plugin_Storage extends TestCase {
 		Plugin_Storage::update_active_plugins_option();
 		remove_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10 );
 		$this->assertFalse( $this->http_request_attempted );
+	}
+
+	/**
+	 * Unit test for the `Plugin_Storage::configure()` method.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Plugin_Storage::set_flag_to_refresh_active_connected_plugins
+	 */
+	public function test_setting_flag_on_active_plugins_option_update() {
+		Plugin_Storage::configure();
+		do_action( 'update_option_active_plugins' );
+		$this->assertNotFalse( get_transient( Plugin_Storage::ACTIVE_PLUGINS_REFRESH_FLAG ) );
+	}
+
+	/**
+	 * Unit test for the `Plugin_Storage::maybe_update_active_connected_plugins()` method.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Plugin_Storage::maybe_update_active_connected_plugins
+	 */
+	public function test_maybe_update_active_connected_plugins_not_configured() {
+		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		\Jetpack_Options::update_option( 'id', 1234 );
+
+		Plugin_Storage::upsert( 'dummy-slug' );
+		set_transient( Plugin_Storage::ACTIVE_PLUGINS_REFRESH_FLAG, microtime() );
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10, 3 );
+		Plugin_Storage::maybe_update_active_connected_plugins();
+		remove_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10 );
+
+		$this->assertFalse( $this->http_request_attempted );
+	}
+
+	/**
+	 * Unit test for the `Plugin_Storage::maybe_update_active_connected_plugins()` method.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Plugin_Storage::maybe_update_active_connected_plugins
+	 */
+	public function test_maybe_update_active_connected_plugins_flag_not_set() {
+		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		\Jetpack_Options::update_option( 'id', 1234 );
+
+		Plugin_Storage::upsert( 'dummy-slug' );
+		Plugin_Storage::configure();
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10, 3 );
+		Plugin_Storage::maybe_update_active_connected_plugins();
+		remove_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10 );
+
+		$this->assertFalse( $this->http_request_attempted );
+	}
+
+	/**
+	 * Unit test for the `Plugin_Storage::maybe_update_active_connected_plugins()` method.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Plugin_Storage::maybe_update_active_connected_plugins
+	 */
+	public function test_maybe_update_active_connected_plugins_non_post_request() {
+		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		\Jetpack_Options::update_option( 'id', 1234 );
+
+		Plugin_Storage::upsert( 'dummy-slug' );
+		Plugin_Storage::configure();
+		set_transient( Plugin_Storage::ACTIVE_PLUGINS_REFRESH_FLAG, microtime() );
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10, 3 );
+		Plugin_Storage::maybe_update_active_connected_plugins();
+		remove_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10 );
+
+		$this->assertFalse( $this->http_request_attempted );
+	}
+
+	/**
+	 * Unit test for the `Plugin_Storage::maybe_update_active_connected_plugins()` method.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Plugin_Storage::maybe_update_active_connected_plugins
+	 */
+	public function test_maybe_update_active_connected_plugins_success() {
+		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		\Jetpack_Options::update_option( 'id', 1234 );
+
+		Plugin_Storage::upsert( 'dummy-slug' );
+		Plugin_Storage::configure();
+		set_transient( Plugin_Storage::ACTIVE_PLUGINS_REFRESH_FLAG, microtime() );
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10, 3 );
+		Plugin_Storage::maybe_update_active_connected_plugins();
+		remove_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10 );
+
+		$this->assertTrue( $this->http_request_attempted );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test_plugin_storage.php
+++ b/projects/packages/connection/tests/php/test_plugin_storage.php
@@ -45,10 +45,20 @@ class Test_Plugin_Storage extends TestCase {
 		$this->http_request_attempted = false;
 		Constants::clear_constants();
 		WorDBless_Options::init()->clear_options();
-
+		// Reset private static properties after each test.
 		$reflection_class = new \ReflectionClass( '\Automattic\Jetpack\Connection\Plugin_Storage' );
-		$reflection_class->setStaticPropertyValue( 'configured', false );
-		$reflection_class->setStaticPropertyValue( 'plugins', array() );
+		try {
+			$reflection_class->setStaticPropertyValue( 'configured', false );
+			$reflection_class->setStaticPropertyValue( 'plugins', array() );
+		} catch ( ReflectionException $e ) { // PHP 7 compat
+			$configured = $reflection_class->getProperty( 'configured' );
+			$configured->setAccessible( true );
+			$configured = $configured->setValue( false );
+
+			$plugins = $reflection_class->getProperty( 'plugins' );
+			$plugins->setAccessible( true );
+			$plugins = $plugins->setValue( array() );
+		}
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test_plugin_storage.php
+++ b/projects/packages/connection/tests/php/test_plugin_storage.php
@@ -50,14 +50,14 @@ class Test_Plugin_Storage extends TestCase {
 		try {
 			$reflection_class->setStaticPropertyValue( 'configured', false );
 			$reflection_class->setStaticPropertyValue( 'plugins', array() );
-		} catch ( ReflectionException $e ) { // PHP 7 compat
+		} catch ( \ReflectionException $e ) { // PHP 7 compat
 			$configured = $reflection_class->getProperty( 'configured' );
 			$configured->setAccessible( true );
-			$configured = $configured->setValue( false );
+			$configured->setValue( false );
 
 			$plugins = $reflection_class->getProperty( 'plugins' );
 			$plugins->setAccessible( true );
-			$plugins = $plugins->setValue( array() );
+			$plugins->setValue( array() );
 		}
 	}
 


### PR DESCRIPTION
We've observed a behaviour where in some cases (still not reproducible) the `jetpack_connection_active_plugins` option is constantly flip-flopping on certain sites (see linked discussion).

This PR updates how we handle `jetpack_connection_active_plugins` updates, by triggering those only when the `active_plugins` option is changed.
The idea is to set a flag (transient) when the `active_plugins` option is changed. 
On the next `POST` request, the flag will be checked and if set we will attempt to update the `jetpack_connection_active_plugins`.
The added restriction to only attempt updates on `POST` requests is to limit concurrent updates on high traffic sites.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Connection\Plugin_Storage::ACTIVE_PLUGINS_REFRESH_FLAG`: Transient name used as flag to indicate that the active connected plugins list needs refreshing.
* `Automattic\Jetpack\Connection\Plugin_Storage::configure`: Stop checking for option updates on every request. Instead listen for `active_plugins` changes and set a flag to indicate that the active connected plugins list needs refreshing.
* `Automattic\Jetpack\Connection\Plugin_Storage::maybe_update_active_connected_plugins`: Only attempt to refresh the list of active connected plugins if the corresponding flag is set and the current request is a `POST` request

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9o2xV-46w-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a JP connected site, try activating/deactivating Jetpack standalone plugins and ensure the change is reflected in `jetpack_connection_active_plugins`