### PR TITLE
AI Featured Image: Show Upgrade Prompt after generation

### DIFF
--- a/projects/plugins/jetpack/changelog/update-featured-image-upgrade-prompt-on-generating
+++ b/projects/plugins/jetpack/changelog/update-featured-image-upgrade-prompt-on-generating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Avoid showing featured image upgrade prompt on generating

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -253,7 +253,7 @@ export default function FeaturedImage( { busy, disabled }: { busy: boolean; disa
 				<AiAssistantModal handleClose={ toggleFeaturedImageModal } title={ modalTitle }>
 					<div className="ai-assistant-featured-image__content">
 						<div className="ai-assistant-featured-image__image-canvas">
-							{ ( requireUpgrade || notEnoughRequests ) && (
+							{ ( requireUpgrade || notEnoughRequests ) && ! currentPointer?.generating && (
 								<UpgradePrompt
 									description={
 										notEnoughRequests


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Avoid showing the `Upgrade Prompt` after finishing the image generation, since we have subsequent actions after the generation, we keep the loading more time, but the upgrade prompt was showing before all the actions finished.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only show `UpgradePrompt` if `currentPointer.generating` is false.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spawn a new JN site and activate beta blocks.
* Use `AI Assistant` to use 1/2 requests.
* Then ask to generate a featured image.
* It should show the upgrade prompt after the generation was finished.

