### PR TITLE
push-to-mirrors: Disable git automatic garbage collection

### DIFF
--- a/projects/github-actions/push-to-mirrors/changelog/fix-push-to-mirrors-no-gc
+++ b/projects/github-actions/push-to-mirrors/changelog/fix-push-to-mirrors-no-gc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Disable git automatic garbage collection. No point to it as the local repos will be immediately discarded.

--- a/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
+++ b/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
@@ -138,6 +138,7 @@ while read -r GIT_SLUG; do
 
 	# Initialize the directory as a git repo, and set the remote
 	git init -b "$BRANCH" .
+	git config --local gc.auto 0
 	git remote add origin "${GITHUB_SERVER_URL}/${GIT_SLUG}"
 	if [[ -n "$API_TOKEN_GITHUB" ]]; then
 		git config --local "http.${GITHUB_SERVER_URL}/.extraheader" "AUTHORIZATION: basic $(printf "x-access-token:%s" "$API_TOKEN_GITHUB" | base64 -w 0)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
No point to it as the local repos will be immediately discarded. This matches what GitHub's own actions/checkout does, BTW.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. Not sure whether the garbage collecting had anything to do with p1713208276685249/1713207237.529689-slack-C01U2KGS2PQ.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷 Seems to require actual pushes, so you'd have to have some actual mirroring going on to some target repos.