### PR TITLE
Backport mu-wpcom-plugin 2.1.15, jetpack 13.4-a.3 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2024-04-15
+### Added
+- AI Client: Add callbacks, initial requesting state and change error handling. [#36869]
+
 ## [0.12.0] - 2024-04-08
 ### Added
 - Add error rejection in image generation. [#36709]
@@ -282,6 +286,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.12.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.10.0...v0.10.1

--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-merge-hooks
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-merge-hooks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-AI Client: Add callbacks, initial requesting state and change error handling

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.12.1-alpha",
+	"version": "0.12.1",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.75 - 2024-04-15
+### Changed
+- Update dependencies. [#36848]
+
 ## 0.2.74 - 2024-04-08
 ### Changed
 - Updated package dependencies. [#36760]

--- a/projects/js-packages/partner-coupon/changelog/force-a-release
+++ b/projects/js-packages/partner-coupon/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.75-alpha",
+	"version": "0.2.75",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.2] - 2024-04-15
+### Changed
+- Updated social previews package. [#36874]
+
+### Fixed
+- Fixed social previews crashing for non-admin authors. [#36875]
+
 ## [0.49.1] - 2024-04-11
 ### Changed
 - Update dependencies. [#36156]
@@ -644,6 +651,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.49.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.49.1...v0.49.2
 [0.49.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.49.0...v0.49.1
 [0.49.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.48.5...v0.49.0
 [0.48.5]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.48.4...v0.48.5

--- a/projects/js-packages/publicize-components/changelog/fix-social-previews-for-non-admin-authors
+++ b/projects/js-packages/publicize-components/changelog/fix-social-previews-for-non-admin-authors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed social previews crashing for non admin authors

--- a/projects/js-packages/publicize-components/changelog/update-social-previews-package
+++ b/projects/js-packages/publicize-components/changelog/update-social-previews-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated social previews package

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.49.2-alpha",
+	"version": "0.49.2",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.7] - 2024-04-15
+### Changed
+- Internal updates.
+
 ## [3.3.6] - 2024-04-08
 ### Changed
 - Updated package dependencies. [#36760]
@@ -601,6 +605,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.3.7]: https://github.com/Automattic/jetpack-backup/compare/v3.3.6...v3.3.7
 [3.3.6]: https://github.com/Automattic/jetpack-backup/compare/v3.3.5...v3.3.6
 [3.3.5]: https://github.com/Automattic/jetpack-backup/compare/v3.3.4...v3.3.5
 [3.3.4]: https://github.com/Automattic/jetpack-backup/compare/v3.3.3...v3.3.4

--- a/projects/packages/backup/changelog/add-woocommerce-internal-stubs
+++ b/projects/packages/backup/changelog/add-woocommerce-internal-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Use "woocommerce-internal" Phan stubs. No change to functionality.
-
-

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.3.7-alpha';
+	const PACKAGE_VERSION = '3.3.7';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.3] - 2024-04-15
+### Fixed
+- Update configs to accomodate for Simple Classic for Blaze. [#36842]
+
 ## [0.20.2] - 2024-04-08
 ### Changed
 - Updated package dependencies. [#36760]
@@ -342,6 +346,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.20.3]: https://github.com/automattic/jetpack-blaze/compare/v0.20.2...v0.20.3
 [0.20.2]: https://github.com/automattic/jetpack-blaze/compare/v0.20.1...v0.20.2
 [0.20.1]: https://github.com/automattic/jetpack-blaze/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/automattic/jetpack-blaze/compare/v0.19.3...v0.20.0

--- a/projects/packages/blaze/changelog/add-phan-woocommerce-stubs
+++ b/projects/packages/blaze/changelog/add-phan-woocommerce-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add WooCommerce stubs to the Phan config. No change to functionality.
-
-

--- a/projects/packages/blaze/changelog/update-blaze-default-config-data
+++ b/projects/packages/blaze/changelog/update-blaze-default-config-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Update configs to accomodate for Simple Classic for Blaze

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.20.3-alpha",
+	"version": "0.20.3",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.20.3-alpha';
+	const PACKAGE_VERSION = '0.20.3';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/changelogger/CHANGELOG.md
+++ b/projects/packages/changelogger/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.1] - 2024-04-15
+### Changed
+- Support symfony/console 7.0. [#36861]
+
 ## [4.2.0] - 2024-04-11
 ### Deprecated
 - Deprecated the `$subheading` parameter to `ChangelogEntry::getChangesBySubheading()` to make the return value clearer. [#36755]
@@ -220,6 +224,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Initial version.
 
+[4.2.1]: https://github.com/Automattic/jetpack-changelogger/compare/4.2.0...4.2.1
 [4.2.0]: https://github.com/Automattic/jetpack-changelogger/compare/4.1.2...4.2.0
 [4.1.2]: https://github.com/Automattic/jetpack-changelogger/compare/4.1.1...4.1.2
 [4.1.1]: https://github.com/Automattic/jetpack-changelogger/compare/4.1.0...4.1.1

--- a/projects/packages/changelogger/changelog/add-phan-allow-removing-baselines
+++ b/projects/packages/changelogger/changelog/add-phan-allow-removing-baselines
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove empty Phan baseline. No change to functionality.
-
-

--- a/projects/packages/changelogger/changelog/update-symfony-console
+++ b/projects/packages/changelogger/changelog/update-symfony-console
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Support symfony/console 7.0.

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.2.1-alpha';
+	const VERSION = '4.2.1';
 
 	/**
 	 * Constructor.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.15] - 2024-04-15
+### Changed
+- Update dependencies. [#36848]
+
 ## [0.30.14] - 2024-04-08
 ### Changed
 - Updated package dependencies. [#36760]
@@ -535,6 +539,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.30.15]: https://github.com/automattic/jetpack-forms/compare/v0.30.14...v0.30.15
 [0.30.14]: https://github.com/automattic/jetpack-forms/compare/v0.30.13...v0.30.14
 [0.30.13]: https://github.com/automattic/jetpack-forms/compare/v0.30.12...v0.30.13
 [0.30.12]: https://github.com/automattic/jetpack-forms/compare/v0.30.11...v0.30.12

--- a/projects/packages/forms/changelog/force-a-release
+++ b/projects/packages/forms/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.15-alpha",
+	"version": "0.30.15",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.15-alpha';
+	const PACKAGE_VERSION = '0.30.15';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.24.0] - 2024-04-15
+### Added
+- WP.com Patterns: Hide WP.com categories that start with underscore. [#36763]
+- Calypso: Add Theme Showcase menu. [#36851]
+- Display a banner before the theme browser that links to the WP.com Theme Showcase. [#36801]
+
+### Changed
+- Conditionally enable link manager on Simple and Atomic sites. [#36770]
+- Hide Customize on block themes on Simple Classic sites. [#36856]
+- Monetize: Move into Jetpack menu and open the page on Jetpack Cloud. [#36799]
+- Update Monetize Launchpad links to Jetpack Cloud. [#36728]
+
+### Removed
+- Removed All Sites menu option from sidebar. [#36632]
+
+### Fixed
+- Add translation support for the Launchpad API endpoint. [#36802]
+
 ## [5.23.2] - 2024-04-08
 ### Changed
 - Updated package dependencies. [#36760] [#36761] [#36788]
@@ -711,6 +729,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.24.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.23.2...v5.24.0
 [5.23.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.23.1...v5.23.2
 [5.23.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.23.0...v5.23.1
 [5.23.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.22.0...v5.23.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-hidden-categories-with-underscore-prefix
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-hidden-categories-with-underscore-prefix
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Dotcom patterns: Hide Dotcom categories that start with underscore

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-links-manager-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-links-manager-check
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Conditionally enable link manager on Simple and Atomic sites

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-translation-support-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-translation-support-launchpad
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Add translation support for the Launchpad API endpoint

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-untangling-theme-showcase-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-untangling-theme-showcase-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Untangling: Add Theme Showcase menu

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-themes-banner
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-themes-banner
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-We now display a banner before the theme browser that links to the WP.com Theme Showcase.

--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-move-monetize-to-jetpack-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-move-monetize-to-jetpack-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Monetize: Move into Jetpack menu and open the page on Jetpack Cloud

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-all-sites-nav
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-all-sites-nav
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Removed All Sites menu option from sidebar

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-hide-customize-on-simple
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-hide-customize-on-simple
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Hide Customize on block themes on Simple Classic sites

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-monetize-jpcloud-launchpad-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-monetize-jpcloud-launchpad-links
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update Monetize Launchpad links to Jetpack Cloud

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-themes-banner-background
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-themes-banner-background
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Minor update of the new WP.com themes banner image
-
-

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.24.0-alpha",
+	"version": "5.24.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.24.0-alpha';
+	const PACKAGE_VERSION = '5.24.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.6] - 2024-04-15
+### Changed
+- Internal updates.
+
 ## [3.1.5] - 2024-04-11
 ### Changed
 - Internal updates.
@@ -699,6 +703,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.1.6]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.5...v3.1.6
 [3.1.5]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.4...v3.1.5
 [3.1.4]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.3...v3.1.4
 [3.1.3]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.2...v3.1.3

--- a/projects/packages/jitm/changelog/add-untangling-theme-showcase-menu
+++ b/projects/packages/jitm/changelog/add-untangling-theme-showcase-menu
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baseline
-
-

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.1.6-alpha';
+	const PACKAGE_VERSION = '3.1.6';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.10] - 2024-04-15
+### Fixed
+- Fixed 403 error for SIG for non-admin authors. [#36894]
+
 ## [0.42.9] - 2024-04-08
 ### Changed
 - Updated package dependencies. [#36760]
@@ -517,6 +521,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.42.10]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.9...v0.42.10
 [0.42.9]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.8...v0.42.9
 [0.42.8]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.7...v0.42.8
 [0.42.7]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.6...v0.42.7

--- a/projects/packages/publicize/changelog/fix-sig-for-non-admin-authors
+++ b/projects/packages/publicize/changelog/fix-sig-for-non-admin-authors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed 403 error for SIG for non-admin authors

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.10-alpha",
+	"version": "0.42.10",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2024-04-15
+### Changed
+- Internal updates.
+
 ## [0.7.1] - 2024-04-08
 ### Fixed
 - Delete logs after scheduled update deletion. [#36778]
@@ -111,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.7.2]: https://github.com/Automattic/scheduled-updates/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/Automattic/scheduled-updates/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Automattic/scheduled-updates/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Automattic/scheduled-updates/compare/v0.5.3...v0.6.0

--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-no-plugins-to-update
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-no-plugins-to-update
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Small bugfix
-
-

--- a/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-logs-endpoint-enums
+++ b/projects/packages/scheduled-updates/changelog/fix-scheduled-updates-logs-endpoint-enums
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: No change to end user
-
-

--- a/projects/packages/scheduled-updates/changelog/move-status-fields
+++ b/projects/packages/scheduled-updates/changelog/move-status-fields
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: No functional changes, just moved some code around
-
-

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.7.2-alpha';
+	const PACKAGE_VERSION = '0.7.2';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.1] - 2024-04-15
+### Changed
+- Update dependencies. [#36848]
+
 ## [0.44.0] - 2024-04-08
 ### Changed
 - Updated package dependencies. [#36760]
@@ -933,6 +937,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.44.1]: https://github.com/Automattic/jetpack-search/compare/v0.44.0...v0.44.1
 [0.44.0]: https://github.com/Automattic/jetpack-search/compare/v0.43.8...v0.44.0
 [0.43.8]: https://github.com/Automattic/jetpack-search/compare/v0.43.7...v0.43.8
 [0.43.7]: https://github.com/Automattic/jetpack-search/compare/v0.43.6...v0.43.7

--- a/projects/packages/search/changelog/force-a-release
+++ b/projects/packages/search/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.1-alpha",
+	"version": "0.44.1",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.1-alpha';
+	const VERSION = '0.44.1';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0] - 2024-04-15
+### Added
+- Add Scheduled Update Plugins option to synched options. [#36849]
+
 ## [2.11.1] - 2024-04-11
 ### Changed
 - Internal updates.
@@ -1100,6 +1104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.12.0]: https://github.com/Automattic/jetpack-sync/compare/v2.11.1...v2.12.0
 [2.11.1]: https://github.com/Automattic/jetpack-sync/compare/v2.11.0...v2.11.1
 [2.11.0]: https://github.com/Automattic/jetpack-sync/compare/v2.10.5...v2.11.0
 [2.10.5]: https://github.com/Automattic/jetpack-sync/compare/v2.10.4...v2.10.5

--- a/projects/packages/sync/changelog/add-scheduled-updates-sync
+++ b/projects/packages/sync/changelog/add-scheduled-updates-sync
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add Scheduled Update Plugins option to synched options

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.12.0-alpha';
+	const PACKAGE_VERSION = '2.12.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.3] - 2024-04-15
+### Security
+- Improves handling of REQUEST_URI. [#36833]
+
 ## [0.16.2] - 2024-04-08
 ### Changed
 - Internal updates.
@@ -297,6 +301,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.16.3]: https://github.com/Automattic/jetpack-waf/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/Automattic/jetpack-waf/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/Automattic/jetpack-waf/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/Automattic/jetpack-waf/compare/v0.15.1...v0.16.0

--- a/projects/packages/waf/changelog/fix-request-uri-handling
+++ b/projects/packages/waf/changelog/fix-request-uri-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Improves handling of REQUEST_URI

--- a/projects/packages/woocommerce-analytics/CHANGELOG.md
+++ b/projects/packages/woocommerce-analytics/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2024-04-15
+### Changed
+- Internal updates.
+
 ## [0.1.3] - 2024-04-08
 ### Fixed
 - Fixed a JavaScript error when accessing the Shortcode checkout with WooCommerce Analytics enable. [#36560]
@@ -27,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix namespace issue with WooCommerce class reference. [#35857]
 - General: bail early when WooCommerce is not active. [#36278]
 
+[0.1.4]: https://github.com/Automattic/woocommerce-analytics/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/Automattic/woocommerce-analytics/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Automattic/woocommerce-analytics/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Automattic/woocommerce-analytics/compare/v0.1.0...v0.1.1

--- a/projects/packages/woocommerce-analytics/changelog/add-phan-woocommerce-stubs
+++ b/projects/packages/woocommerce-analytics/changelog/add-phan-woocommerce-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add WooCommerce stubs to the Phan config. No change to functionality.
-
-

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -20,7 +20,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.1.4-alpha';
+	const PACKAGE_VERSION = '0.1.4';
 
 	/**
 	 * Initializer.

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.15] - 2024-04-15
+### Changed
+- Update dependencies. [#36848]
+
 ## [0.3.14] - 2024-04-08
 ### Changed
 - Updated package dependencies. [#36760]
@@ -335,6 +339,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.15]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.14...v0.3.15
 [0.3.14]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.13...v0.3.14
 [0.3.13]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.12...v0.3.13
 [0.3.12]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.11...v0.3.12

--- a/projects/packages/wordads/changelog/force-a-release
+++ b/projects/packages/wordads/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.15-alpha",
+	"version": "0.3.15",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.15-alpha';
+	const VERSION = '0.3.15';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.4-a.3 - 2024-04-15
+### Improved compatibility
+- WordPress.com Toolbar: Avoid fatal errors when using other menu management plugins and the WordPress.com Toolbar feature. [#36783]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add the 'All Sites' menu. [#36632]
+- Add 'Carrousel' in 'Featured Image'. [#36834]
+- Add upgrade prompt in 'Featured Image'. [#36806]
+- Admin Menu: Moved "Theme Showcase" menu registration to jetpack-mu-wpcom package. [#36851]
+- AI Assistant: Remove AI Playground. [#36808]
+- AI Assistant: Rename useSuggestionsFromOpenAI to useAIAssistant and deduplicate suggestion logic. [#36869]
+- AI Featured Image: Fix bug on automatic transition to featured image panel. [#36863]
+- AI Featured Image: Include link to provide feedback on the footer of the modal. [#36831]
+- AI Featured Image: Incorporate i3  updates on style and UI. [#36868]
+- AI Featured Image: Update copy and UI alignments. [#36812]
+- A minor performance improvement on memberships. [#36821]
+- Auto-save image from featured image feature. [#36822]
+- Avoid showing featured image upgrade prompt on generating. [#36899]
+- Business Hours: Fix time formatting in preview mode. [#36786]
+- Business Hours Block: Refactor Edit component to a function. [#36785]
+- Dontains Form block: Show Stripe nudge if not connected. [#36841]
+- Fix auto scroll on iframe editor. [#36726]
+- Fixed SIG not visible in Jetpack sidebar. [#36895]
+- Improve performance of memberships checks. [#36798]
+- Make the representation of the end date consistent in membership subscription abbreviation. [#36838]
+- Map Block: Refactor Edit component to function. [#36795]
+- Post endpoint: Return a 404 if a post is being trashed but does not exist. [#36768]
+- Simple Payments Block: Refactor Edit component to a function. [#36809]
+- Slideshow Block: Refactor Edit component to a function. [#36805]
+- Tiled Gallery Block: Refactor Edit component to a function. [#36804]
+- Update blocks to use API version 3. [#36827] [#36852] [#36854]
+- Updated social previews package. [#36874]
+- Update Testimonials CPT priority so it always appears below Portfolio Projects. [#36866]
+- Update UX on Featured Image. [#36865]
+
 ## 13.4-a.1 - 2024-04-08
 ### Enhancements
 - Newsletters: Add a filter that enables the user to control the timing at which the Subscribe Modal loads. [#36374]
@@ -33,6 +68,7 @@
 - Updated package dependencies. [#36760] [#36761] [#36775] [#36788]
 
 ## 13.3.1 - 2024-04-10
+
 - Protect: Improved handling of request URLs. [#36833]
 
 ## [13.3] - 2024-04-03

--- a/projects/plugins/jetpack/changelog/add-phan-woocommerce-stubs
+++ b/projects/plugins/jetpack/changelog/add-phan-woocommerce-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Add WooCommerce stubs to the Phan config. No change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/add-scheduled-updates-sync
+++ b/projects/plugins/jetpack/changelog/add-scheduled-updates-sync
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-site-connection-notice
+++ b/projects/plugins/jetpack/changelog/add-site-connection-notice
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-untangling-theme-showcase-menu
+++ b/projects/plugins/jetpack/changelog/add-untangling-theme-showcase-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Admin menu: Moved "Theme showcase" menu registration to jetpack-mu-wpcom package

--- a/projects/plugins/jetpack/changelog/add-upgrade-featured-image
+++ b/projects/plugins/jetpack/changelog/add-upgrade-featured-image
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add upgrade prompt in featured image

--- a/projects/plugins/jetpack/changelog/add-woocommerce-internal-stubs
+++ b/projects/plugins/jetpack/changelog/add-woocommerce-internal-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Use "woocommerce-internal" Phan stubs. No change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/dontations-form-show-stripe-notice-when-not-connected
+++ b/projects/plugins/jetpack/changelog/dontations-form-show-stripe-notice-when-not-connected
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Dontains Form block: show Stripe nudge if not connected.

--- a/projects/plugins/jetpack/changelog/fix-auto-scroll-on-iframe
+++ b/projects/plugins/jetpack/changelog/fix-auto-scroll-on-iframe
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix auto scroll on iframe editor

--- a/projects/plugins/jetpack/changelog/fix-business-hours-format
+++ b/projects/plugins/jetpack/changelog/fix-business-hours-format
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Business Hours: fix time formatting in preview mode

--- a/projects/plugins/jetpack/changelog/fix-duplicate-package-json-names
+++ b/projects/plugins/jetpack/changelog/fix-duplicate-package-json-names
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Remove unnecessary `name` in `tests/e2e/package.json`. No change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/fix-masterbar-fatal-menu
+++ b/projects/plugins/jetpack/changelog/fix-masterbar-fatal-menu
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-WordPress.com Toolbar: avoid Fatal errors when using other menu management plugins and the WordPress.com Toolbar feature.

--- a/projects/plugins/jetpack/changelog/fix-membership-performance
+++ b/projects/plugins/jetpack/changelog/fix-membership-performance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Improve performance of memberships checks

--- a/projects/plugins/jetpack/changelog/fix-memberships-subscription-end-date-format
+++ b/projects/plugins/jetpack/changelog/fix-memberships-subscription-end-date-format
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Make the representation of the end date consistent in membership subscription abbreviation.

--- a/projects/plugins/jetpack/changelog/fix-phan-in-changelogger
+++ b/projects/plugins/jetpack/changelog/fix-phan-in-changelogger
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-phan-undeclared-in-autoloader
+++ b/projects/plugins/jetpack/changelog/fix-phan-undeclared-in-autoloader
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-post-endpoint-return-404-on-trash-not-found
+++ b/projects/plugins/jetpack/changelog/fix-post-endpoint-return-404-on-trash-not-found
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Post endpoint: return a 404 if a post is being trashed but does not exist

--- a/projects/plugins/jetpack/changelog/fix-sig-not-visible-in-jetpack-sidebar
+++ b/projects/plugins/jetpack/changelog/fix-sig-not-visible-in-jetpack-sidebar
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixed SIG not visible in Jetpack sidebar

--- a/projects/plugins/jetpack/changelog/update-ai-featured-image-update-designs-to-i3
+++ b/projects/plugins/jetpack/changelog/update-ai-featured-image-update-designs-to-i3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Featured Image: incorporate i3  updates on style and UI

--- a/projects/plugins/jetpack/changelog/update-all-sites-nav
+++ b/projects/plugins/jetpack/changelog/update-all-sites-nav
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add All Sites menu

--- a/projects/plugins/jetpack/changelog/update-auto-save-featured-image
+++ b/projects/plugins/jetpack/changelog/update-auto-save-featured-image
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Auto-save image from featured image feature

--- a/projects/plugins/jetpack/changelog/update-featured-image-add-provide-feedback-link-on-footer
+++ b/projects/plugins/jetpack/changelog/update-featured-image-add-provide-feedback-link-on-footer
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-AI Featured Image: include link to provide feedback on the footer of the modal.

--- a/projects/plugins/jetpack/changelog/update-featured-image-carrousel
+++ b/projects/plugins/jetpack/changelog/update-featured-image-carrousel
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add Carrousel in Featured Image

--- a/projects/plugins/jetpack/changelog/update-featured-image-copy-update
+++ b/projects/plugins/jetpack/changelog/update-featured-image-copy-update
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Featured Image: update copy and UI alignments

--- a/projects/plugins/jetpack/changelog/update-featured-image-upgrade-prompt-on-generating
+++ b/projects/plugins/jetpack/changelog/update-featured-image-upgrade-prompt-on-generating
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Avoid showing featured image upgrade prompt on generating

--- a/projects/plugins/jetpack/changelog/update-featured-image-ux
+++ b/projects/plugins/jetpack/changelog/update-featured-image-ux
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Update UX on Featured Image

--- a/projects/plugins/jetpack/changelog/update-featured-images-fix-panel-transition
+++ b/projects/plugins/jetpack/changelog/update-featured-images-fix-panel-transition
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Featured Image: fix bug on automatic transition to featured image panel

--- a/projects/plugins/jetpack/changelog/update-improve-memberships-performance
+++ b/projects/plugins/jetpack/changelog/update-improve-memberships-performance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-a minor performance improvement on memberships

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-merge-hooks
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-merge-hooks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Rename useSuggestionsFromOpenAI to useAIAssistant and deduplicate suggestion logic

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-remove-playground
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-remove-playground
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Remove AI Playground

--- a/projects/plugins/jetpack/changelog/update-refactor-business-hours
+++ b/projects/plugins/jetpack/changelog/update-refactor-business-hours
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Business Hours Block: refactor Edit component to function 

--- a/projects/plugins/jetpack/changelog/update-refactor-map-block
+++ b/projects/plugins/jetpack/changelog/update-refactor-map-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Map Block: refactor Edit component to function

--- a/projects/plugins/jetpack/changelog/update-refactor-simple-payments
+++ b/projects/plugins/jetpack/changelog/update-refactor-simple-payments
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Simple Payments Block: refactor Edit component to function

--- a/projects/plugins/jetpack/changelog/update-refactor-slide-show-edit
+++ b/projects/plugins/jetpack/changelog/update-refactor-slide-show-edit
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Slideshow Block: refactor Edit component to function

--- a/projects/plugins/jetpack/changelog/update-refactor-tiled-gallery-edit
+++ b/projects/plugins/jetpack/changelog/update-refactor-tiled-gallery-edit
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Tiled Gallery Block: refactor Edit component to function

--- a/projects/plugins/jetpack/changelog/update-social-previews-package
+++ b/projects/plugins/jetpack/changelog/update-social-previews-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated social previews package

--- a/projects/plugins/jetpack/changelog/update-symfony-console
+++ b/projects/plugins/jetpack/changelog/update-symfony-console
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-testimonial-cpt-priority
+++ b/projects/plugins/jetpack/changelog/update-testimonial-cpt-priority
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update Testimonials CPT priority so it always appears below Portfolio Projects

--- a/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-3
+++ b/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-3
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update blocks to use API version 3

--- a/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-4
+++ b/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-4
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update blocks to use API version 3

--- a/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-5
+++ b/projects/plugins/jetpack/changelog/update-upgrade-block-api-part-5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update blocks to use API version 3

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_2",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_3",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.4-a.2
+ * Version: 13.4-a.3
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.4-a.2' );
+define( 'JETPACK__VERSION', '13.4-a.3' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.4.0-a.2",
+	"version": "13.4.0-a.3",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,13 +326,9 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.4-a.1 - 2024-04-08
-#### Enhancements
-- Newsletters: Add a filter that enables the user to control the timing at which the Subscribe Modal loads.
-
-#### Bug fixes
-- Secure Sign-On: Disable the WordPress.com invitation setup on Multisite.
-- Theme Tools: Fix deprecation notices in the color management library.
+### 13.4-a.3 - 2024-04-15
+#### Improved compatibility
+- WordPress.com Toolbar: Avoid fatal errors when using other menu management plugins and the WordPress.com Toolbar feature.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.15 - 2024-04-15
+### Changed
+- Internal updates.
+
 ## 2.1.14 - 2024-04-08
 ### Changed
 - Updated package dependencies. [#36775]

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-hidden-categories-with-underscore-prefix
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-hidden-categories-with-underscore-prefix
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-links-manager-check
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-links-manager-check
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-translation-support-launchpad
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-translation-support-launchpad
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-wpcom-themes-banner
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-wpcom-themes-banner
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-phan-in-changelogger
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-phan-in-changelogger
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-all-sites-nav
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-all-sites-nav
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-symfony-console
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-symfony-console
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_15_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_15"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.15-alpha
+ * Version: 2.1.15
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.15-alpha",
+	"version": "2.1.15",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.15, jetpack 13.4-a.3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.