### PR TITLE
Remove unnecessary React imports

### DIFF
--- a/projects/packages/forms/changelog/refactor-blocks-wordpress-element-imports
+++ b/projects/packages/forms/changelog/refactor-blocks-wordpress-element-imports
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove unnecessary react imports
+
+

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.15",
+	"version": "0.30.16-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-manage-responses-settings.js
@@ -2,7 +2,6 @@ import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { get } from 'lodash';
-import React from 'react';
 import InspectorHint from '../components/inspector-hint';
 
 const RESPONSES_PATH = `${ get( getJetpackData(), 'adminUrl', false ) }edit.php?post_type=feedback`;

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.15';
+	const PACKAGE_VERSION = '0.30.16-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/plugins/jetpack/changelog/refactor-blocks-wordpress-element-imports
+++ b/projects/plugins/jetpack/changelog/refactor-blocks-wordpress-element-imports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove unnecessary react imports

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_3",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_4",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-controls/index.tsx
@@ -10,7 +10,6 @@ import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { post, postContent, postExcerpt, termDescription, blockTable } from '@wordpress/icons';
 import debugFactory from 'debug';
-import React from 'react';
 /**
  * Internal dependencies
  */
@@ -35,6 +34,7 @@ import './style.scss';
 import type { ExtendedBlockProp } from '../../extensions/ai-assistant';
 import type { PromptTypeProp } from '../../lib/prompt';
 import type { ToneProp } from '../tone-dropdown-control';
+import type { ReactElement } from 'react';
 
 const debug = debugFactory( 'jetpack-ai-assistant:dropdown' );
 
@@ -138,12 +138,12 @@ type AiAssistantDropdownContentProps = {
 /**
  * The React content of the dropdown.
  * @param {AiAssistantDropdownContentProps} props - The props.
- * @returns {React.ReactNode} The React content of the dropdown.
+ * @returns {ReactElement} The React content of the dropdown.
  */
 function AiAssistantDropdownContent( {
 	onClose,
 	blockType,
-}: AiAssistantDropdownContentProps ): React.JSX.Element {
+}: AiAssistantDropdownContentProps ): ReactElement {
 	// Set the state for the no content info.
 	const [ noContent, setNoContent ] = useState( false );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-panel/index.tsx
@@ -5,7 +5,7 @@ import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
 import { BlockIcon } from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import React from 'react';
+import type { ReactElement } from 'react';
 /**
  * Internal dependencies
  */
@@ -14,9 +14,9 @@ import './style.scss';
 /**
  * Block sidebar Pannel
  *
- * @returns {React.ReactElement} The component's elements.
+ * @returns {ReactElement} The component's elements.
  */
-export default function AiAssistantPanel(): React.ReactElement {
+export default function AiAssistantPanel(): ReactElement {
 	return (
 		<PanelBody
 			title={ __( 'AI Assistant', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
@@ -13,7 +13,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronRight } from '@wordpress/icons';
 import { globe } from '@wordpress/icons';
-import React from 'react';
 /*
  * Internal dependencies
  */

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/improve-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/improve-dropdown-control/index.tsx
@@ -12,7 +12,6 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
-import React from 'react';
 
 export const IMPROVE_KEY_MAKE_LONGER = 'make-longer' as const;
 const IMPROVE_SUGGESTION_MAKE_LONGER = 'makeLonger' as const;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/prompt-templates-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/prompt-templates-control/index.tsx
@@ -5,7 +5,6 @@ import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { MenuItem, MenuGroup, ToolbarDropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { title, postContent, postExcerpt, termDescription, post, pencil } from '@wordpress/icons';
-import React from 'react';
 
 type PromptTemplatesControlProps = {
 	hasContentBefore: boolean;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -14,7 +14,6 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronRight } from '@wordpress/icons';
-import React from 'react';
 /**
  * Internal dependencies
  */

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -3,10 +3,9 @@
  */
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import debugFactory from 'debug';
-import React, { useCallback } from 'react';
 /*
  * Internal dependencies
  */
@@ -15,6 +14,7 @@ import { PLAN_TYPE_TIERED, usePlanType } from '../../../../shared/use-plan-type'
 import useAICheckout from '../../hooks/use-ai-checkout';
 import useAiFeature from '../../hooks/use-ai-feature';
 import { canUserPurchasePlan } from '../../lib/connection';
+import type { ReactElement } from 'react';
 import './style.scss';
 
 type UpgradePromptProps = {
@@ -28,12 +28,12 @@ const debug = debugFactory( 'jetpack-ai-assistant:upgrade-prompt' );
  * to the checkout page or the Jetpack AI interstitial page.
  *
  * @param {UpgradePromptProps} props - Component props.
- * @returns {React.ReactNode} the Nudge component with the prompt.
+ * @returns {ReactElement} the Nudge component with the prompt.
  */
 const DefaultUpgradePrompt = ( {
 	placement = null,
 	description = null,
-}: UpgradePromptProps ): React.JSX.Element => {
+}: UpgradePromptProps ): ReactElement => {
 	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
 	const canUpgrade = canUserPurchasePlan();
 	const {
@@ -181,13 +181,9 @@ const DefaultUpgradePrompt = ( {
  *
  * @param {object} props - Component props.
  * @param {string} props.description - The description to display in the prompt.
- * @returns {React.ReactNode} the Nudge component with the prompt.
+ * @returns {ReactElement} the Nudge component with the prompt.
  */
-const VIPUpgradePrompt = ( {
-	description = null,
-}: {
-	description?: string;
-} ): React.JSX.Element => {
+const VIPUpgradePrompt = ( { description = null }: { description?: string } ): ReactElement => {
 	const vipDescription = createInterpolateElement(
 		__(
 			"You've reached the Jetpack AI rate limit. <strong>Please reach out to your VIP account team.</strong>",

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -8,11 +8,10 @@ import { rawHandler } from '@wordpress/blocks';
 import { Notice, PanelBody, PanelRow, KeyboardShortcuts } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { RawHTML, useState, useCallback } from '@wordpress/element';
+import { RawHTML, useState, useCallback, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import MarkdownIt from 'markdown-it';
-import { useEffect, useRef } from 'react';
 /**
  * Internal dependencies
  */

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/with-ai-assistant.tsx
@@ -3,7 +3,6 @@
  */
 import { BlockControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import React from 'react';
 /**
  * Internal dependencies
  */

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-bar/index.tsx
@@ -19,7 +19,6 @@ import {
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import classNames from 'classnames';
-import React from 'react';
 /**
  * Internal dependencies
  */

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/components/ai-assistant-toolbar-button/index.tsx
@@ -4,14 +4,14 @@
 import { aiAssistantIcon, useAiContext } from '@automattic/jetpack-ai-client';
 import { KeyboardShortcuts, ToolbarButton } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { useContext, useRef, useCallback } from '@wordpress/element';
+import { useEffect, useContext, useRef, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import React, { useEffect } from 'react';
 /*
  * Internal dependencies
  */
 import { AiAssistantUiContext } from '../../ui-handler/context';
 import { selectFormBlock } from '../../ui-handler/with-ui-handler-data-provider';
+import type { ReactElement } from 'react';
 
 const AI_ASSISTANT_BAR_SLOT_CLASS = 'jetpack-ai-assistant-bar__slot';
 
@@ -22,13 +22,13 @@ const AI_ASSISTANT_BAR_SLOT_CLASS = 'jetpack-ai-assistant-bar__slot';
  *
  * @param {object} props - The component props.
  * @param {string} props.jetpackFormClientId - The Jetpack Form block client ID.
- * @returns {React.ReactElement}               The toolbar button.
+ * @returns {ReactElement}               The toolbar button.
  */
 export default function AiAssistantToolbarButton( {
 	jetpackFormClientId,
 }: {
 	jetpackFormClientId?: string;
-} ): React.ReactElement {
+} ): ReactElement {
 	const { isVisible, toggle, setAnchor, assistantAnchor } = useContext( AiAssistantUiContext );
 	const { requestingState } = useAiContext();
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/ui-handler/with-ui-handler-data-provider.tsx
@@ -10,7 +10,6 @@ import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import { useState, useMemo, useCallback, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import React from 'react';
 /**
  * Internal dependencies
  */

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-auto-scroll/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-auto-scroll/index.ts
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import { useCallback, useRef } from '@wordpress/element';
+import { useCallback, useRef, useEffect } from '@wordpress/element';
 import debugFactory from 'debug';
-import { useEffect } from 'react';
 
 const debug = debugFactory( 'jetpack-ai-assistant:use-auto-scroll' );
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/components/feedback/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/components/feedback/index.js
@@ -4,8 +4,8 @@
  * WordPress dependencies
  */
 import { Button, TextControl, Icon } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from 'react';
 /**
  * Internal dependencies
  */

--- a/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/eventbrite/edit.js
@@ -1,7 +1,7 @@
 import { BlockControls, InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { Button, withNotices } from '@wordpress/components';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import { useCallback, useEffect, useState } from 'react';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import testEmbedUrl from '../../shared/test-embed-url';
 import metadata from './block.json';

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/controls.js
@@ -1,7 +1,7 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { ExternalLink, PanelBody, TextControl } from '@wordpress/components';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useRef } from 'react';
 import {
 	NOTIFICATION_PROCESSING,
 	NOTIFICATION_SUCCESS,

--- a/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/mailchimp/edit.js
@@ -4,8 +4,8 @@ import {
 } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import { withNotices } from '@wordpress/components';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
-import { useCallback, useEffect, useState } from 'react';
 import metadata from './block.json';
 import Body from './body';
 import { API_STATE_CONNECTED, API_STATE_NOTCONNECTED, API_STATE_LOADING } from './constants';

--- a/projects/plugins/jetpack/extensions/blocks/markdown/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/edit.js
@@ -1,8 +1,8 @@
 import { BlockControls, PlainText, useBlockProps } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useRef, useState } from 'react';
 import ToolbarButton from './controls';
 import MarkdownRenderer from './renderer';
 

--- a/projects/plugins/jetpack/extensions/blocks/markdown/test/markdown-renderer.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/test/markdown-renderer.js
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/react';
-import React from 'react';
 import MarkdownRenderer from '../renderer';
 import { source } from './fixtures/source';
 

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/edit.jsx
@@ -1,9 +1,8 @@
 import { InspectorControls, useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useCallback } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
-import { useCallback } from 'react';
 import ProductManagementControls from '../../shared/components/product-management-controls';
 import { StripeNudge } from '../../shared/components/stripe-nudge';
 import { getEditorType, POST_EDITOR } from '../../shared/get-editor-type';

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/index.js
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/react';
 import { range } from 'lodash';
-import React from 'react';
 import Mosaic from '..';
 import * as imageSets from '../../test/fixtures/image-sets';
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.js
@@ -28,13 +28,18 @@ import {
 	withInstanceId,
 } from '@wordpress/compose';
 import { useSelect, withDispatch, withSelect } from '@wordpress/data';
-import { Component, createInterpolateElement, createRef, Fragment } from '@wordpress/element';
+import {
+	Component,
+	createInterpolateElement,
+	createRef,
+	Fragment,
+	useEffect,
+} from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
 import classnames from 'classnames';
 import { get, indexOf } from 'lodash';
-import { useEffect } from 'react';
 import { VideoPressIcon } from '../../shared/icons';
 import { VideoPressBlockProvider } from './components';
 import { VIDEO_PRIVACY } from './constants';

--- a/projects/plugins/jetpack/extensions/blocks/videopress/seekbar-color-settings.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/seekbar-color-settings.js
@@ -2,7 +2,6 @@ import { PanelColorSettings } from '@wordpress/block-editor';
 import { Button, PanelBody, ToggleControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import React from 'react';
 
 class SeekbarColorSettings extends Component {
 	constructor() {

--- a/projects/plugins/jetpack/extensions/blocks/videopress/v6-transform/components/transform-control/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/v6-transform/components/transform-control/index.js
@@ -7,11 +7,8 @@ import { createBlock } from '@wordpress/blocks';
 import { Button, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
+import { ReactElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-/**
- * External dependencies
- */
-import { ReactElement } from 'react';
 /**
  * Internal dependencies
  */

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.4-a.3
+ * Version: 13.4-a.4
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.4-a.3' );
+define( 'JETPACK__VERSION', '13.4-a.4' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.4.0-a.3",
+	"version": "13.4.0-a.4",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/36764

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR refactors the import statements of some blocks to:
- remove unnecessary React imports
- import functions from `@wordpress/element` instead of `react`, when possible

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You might want to add some of the changed blocks (e.g., VideoPress, MailChimp, Eventbrite, Markdown, Contact Form) to a new post/page and check there's no error in the editor/site.
