### PR TITLE
Subscription: Add Filter to Allow Capability to be changed

### DIFF
--- a/projects/plugins/jetpack/changelog/Subscriber-Cap-Filter
+++ b/projects/plugins/jetpack/changelog/Subscriber-Cap-Filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscription: Add Filter to Allow Newsletter Block Meta to Capability to be Changed. 

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_3",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_4",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.4-a.3
+ * Version: 13.4-a.4
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.4-a.3' );
+define( 'JETPACK__VERSION', '13.4-a.4' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -960,7 +960,9 @@ class Jetpack_Subscriptions {
 	 * @return bool
 	 */
 	public function first_published_status_meta_auth_callback() {
-		if ( current_user_can( 'publish_posts' ) ) {
+		$capability = apply_filters( 'jetpack_subscriber_was_published_capability', 'publish_posts' );
+
+		if ( current_user_can( $capability ) ) {
 			return true;
 		}
 		return false;

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -960,8 +960,16 @@ class Jetpack_Subscriptions {
 	 * @return bool
 	 */
 	public function first_published_status_meta_auth_callback() {
-		$capability = apply_filters( 'jetpack_subscriber_was_published_capability', 'publish_posts' );
-
+		/**
+		 * Filter the capability to view if a post was ever published in the Subscription Module.
+		 *
+		 * @module subscriptions
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $capability User capability needed to view if a post was ever published. Default to publish_posts.
+		 */
+		$capability = apply_filters( 'jetpack_subscriptions_post_was_ever_published_capability', 'publish_posts' );
 		if ( current_user_can( $capability ) ) {
 			return true;
 		}

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.4.0-a.3",
+	"version": "13.4.0-a.4",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #36908

## Proposed changes:
* The `first_published_status_meta_auth_callback` defaults to `publish_post` this PR adds the new `jetpack_subscriber_was_published_capability` filter to allow this to be changed. This was requested by a VIP customer who would like to change the filter to `edit_post`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

* Have an admin user who can `edit_posts` but not `publish_posts` 
* Visit a post in the admin
* Try to edit post-meta and see "Updating failed. Sorry, you are not allowed to edit the jetpack_post_was_ever_published custom field."
* Add the `jetpack_subscriber_was_published_capability` filter to a cap your user has (ie `edit_post`)
* The error will go away and the content will load.

## Does this pull request change what data or activity we track or use?

This PR does not update any tracking data
