### PR TITLE
Subscribe Block: Fix Paywall HTML in Reader

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-paywall
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-paywall
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscribe Block: fix paywall copy from showing HTML markup. 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1247,9 +1247,10 @@ function get_paywall_simple() {
 
 	return '
 <!-- wp:columns -->
-<div class="wp-block-columns" style="display: inline-block; width: 90%">
-                  font-family: \'SF Pro Text\', sans-serif;
-                  line-height: 28.8px;">
+<div 
+	class="wp-block-columns" 
+	style="display: inline-block; width: 90%; font-family: \'SF Pro Text\', sans-serif; line-height: 28.8px;"
+>
         ' . $access_heading . '
         </p>
         <!-- /wp:paragraph -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-calypso#89555

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevents the Subscribe block from displaying HTML markup in the WordPress.com Reader (presumably also affects emails too) 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
There's probably a better way to test this for the reader, but I added `return get_paywall_simple();` immediately after `render_block()` so that it could be tested on the front-end. 

| Before | After |
|--------|--------|
| <img width="830" alt="Screenshot 2024-04-16 at 08 37 31" src="https://github.com/Automattic/jetpack/assets/43215253/55206271-dd37-45ab-b2eb-eb666cfa98ea"> | <img width="740" alt="Screenshot 2024-04-16 at 08 40 15" src="https://github.com/Automattic/jetpack/assets/43215253/f7651f85-b217-4929-943e-0d979e1cc3c3"> |
