### PR TITLE
Carousel / Lightbox: take wpcom simple shortcircuit into account

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-lightbox-disable-wpcom-simple
+++ b/projects/plugins/jetpack/changelog/fix-carousel-lightbox-disable-wpcom-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: ensure that disabling the feature on WordPress.com Simple brings back Core's Lightbox back.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -83,9 +83,6 @@ class Jetpack_Carousel {
 		$this->single_image_gallery_enabled            = ! $this->maybe_disable_jp_carousel_single_images();
 		$this->single_image_gallery_enabled_media_file = $this->maybe_enable_jp_carousel_single_images_media_file();
 
-		// Disable core lightbox when Carousel is enabled.
-		add_action( 'wp_theme_json_data_theme', array( $this, 'disable_core_lightbox' ) );
-
 		if ( is_admin() ) {
 			// Register the Carousel-related related settings.
 			add_action( 'admin_init', array( $this, 'register_settings' ), 5 );
@@ -99,6 +96,9 @@ class Jetpack_Carousel {
 			add_action( 'wp_ajax_nopriv_get_attachment_comments', array( $this, 'get_attachment_comments' ) );
 			add_action( 'wp_ajax_post_attachment_comment', array( $this, 'post_attachment_comment' ) );
 			add_action( 'wp_ajax_nopriv_post_attachment_comment', array( $this, 'post_attachment_comment' ) );
+
+			// Disable core lightbox when Carousel is enabled.
+			add_action( 'wp_theme_json_data_theme', array( $this, 'disable_core_lightbox' ) );
 		} else {
 			if ( ! $this->in_jetpack ) {
 				if ( 0 === $this->test_1or0_option( get_option( 'carousel_enable_it' ), true ) ) {
@@ -128,6 +128,9 @@ class Jetpack_Carousel {
 
 			// `is_amp_request()` can't be called until the 'wp' filter.
 			add_action( 'wp', array( $this, 'check_amp_support' ) );
+
+			// Disable core lightbox when Carousel is enabled.
+			add_action( 'wp_theme_json_data_theme', array( $this, 'disable_core_lightbox' ) );
 		}
 
 		if ( $this->in_jetpack ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/89564

## Proposed changes:

Follow-up to #36565

This is a second take on #36565; we need to ensure that when one disables the Carousel feature on their wpcom simple site, we do not remove Core's Lightbox feature.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> Test this on WordPress.com Simple, on a site using a block-based theme.

* Go to Settings > Media
* Disable the Carousel feature.
* Go to Posts > Add New
* Insert an Image block, and add an image.
* Click on the "Link" icon in the block toolbar.
* You should see an "Expand on Click" option.
* Go back to Settings > Media
* Enable the Carousel feature back.
* Go to Posts > Add New
* Insert an Image block, and add an image.
* Click on the "Link" icon in the block toolbar.
* You should not see the "Expand on click" option anymore.
