### PR TITLE
Populate sync option with results from endpoint

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-sync-3
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-sync-3
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Populated sync option with results from endpoint.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -155,25 +155,18 @@ class Scheduled_Updates {
 	 * Save the schedules for sync after cron option saving.
 	 */
 	public static function update_option_cron() {
-		$events = wp_get_scheduled_events( self::PLUGIN_CRON_HOOK );
+		$endpoint = new \WPCOM_REST_API_V2_Endpoint_Update_Schedules();
+		$events   = $endpoint->get_items( new \WP_REST_Request() );
 
-		foreach ( array_keys( $events ) as $schedule_id ) {
-			$events[ $schedule_id ]->schedule_id = $schedule_id;
-
-			$status = self::get_scheduled_update_status( $schedule_id );
-
-			if ( ! $status ) {
-				$status = array(
-					'last_run_timestamp' => null,
-					'last_run_status'    => null,
-				);
-			}
-
-			$events[ $schedule_id ]->last_run_timestamp = $status['last_run_timestamp'];
-			$events[ $schedule_id ]->last_run_status    = $status['last_run_status'];
+		if ( ! is_wp_error( $events ) ) {
+			$option = array_map(
+				function ( $event ) {
+					return (object) $event;
+				},
+				$events->get_data()
+			);
+			update_option( self::PLUGIN_CRON_HOOK, $option );
 		}
-
-		update_option( self::PLUGIN_CRON_HOOK, $events );
 	}
 
 	/**


### PR DESCRIPTION
See https://github.com/Automattic/jetpack/pull/36877/files#r1562650507

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Populate sync option with the results from the REST endpoint.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Enable `add/scheduled-updates-sync-3` on Jetpack beta
2. See https://github.com/Automattic/jetpack/pull/36877 for a list of tests to be made.