### PR TITLE
repo-gardening: Fix ignoring of update/phan-custom-stubs PRs

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-stubs-PRs
+++ b/projects/github-actions/repo-gardening/changelog/fix-repo-gardening-stubs-PRs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Follow-up to #36830, no need for a separate changelog entry.
+
+

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -470,7 +470,7 @@ async function checkDescription( payload, octokit ) {
 
 	if (
 		( ref === 'update/phan-wpcom-stubs' || ref === 'update/phan-custom-stubs' ) &&
-		author === 'matticbot'
+		( author === 'matticbot' || author === 'github-actions[bot]' )
 	) {
 		debug( `check-description: Automated stub update, skipping` );
 		return;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
These come in with author as "github-actions[bot]", not "matticbot".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Merge this in a fork where the gardening workflow will run, then trigger the action to create a PR like https://github.com/Automattic/jetpack/pull/36907.