### PR TITLE
Monetize: Update cache key to prevent false hits

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-paid-subscriber-cache
+++ b/projects/plugins/jetpack/changelog/fix-paid-subscriber-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Ensure that the paid subscriber cache is unique to the parameters it consumes.

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -635,16 +635,19 @@ class Jetpack_Memberships {
 		if ( empty( $user_id ) ) {
 			$user_id = get_current_user_id();
 		}
-		if ( ! isset( self::$user_is_paid_subscriber_cache[ $user_id ] ) ) {
+		// sort and stringify sorted valid plan ids to use as a cache key
+		sort( $valid_plan_ids );
+		$cache_key = $user_id . '_' . implode( ',', $valid_plan_ids );
+		if ( ! isset( self::$user_is_paid_subscriber_cache[ $cache_key ] ) ) {
 			require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 			if ( empty( $valid_plan_ids ) ) {
 				$valid_plan_ids = self::get_all_newsletter_plan_ids();
 			}
 			$paywall            = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service( $user_id );
 			$is_paid_subscriber = $paywall->visitor_can_view_content( $valid_plan_ids, Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS );
-			self::$user_is_paid_subscriber_cache[ $user_id ] = $is_paid_subscriber;
+			self::$user_is_paid_subscriber_cache[ $cache_key ] = $is_paid_subscriber;
 		}
-		return self::$user_is_paid_subscriber_cache[ $user_id ];
+		return self::$user_is_paid_subscriber_cache[ $cache_key ];
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -634,6 +634,9 @@ class Jetpack_Memberships {
 	public static function user_is_paid_subscriber( $valid_plan_ids = array(), $user_id = null ) {
 		if ( empty( $user_id ) ) {
 			$user_id = get_current_user_id();
+			if ( empty( $user_id ) ) {
+				return false;
+			}
 		}
 		// sort and stringify sorted valid plan ids to use as a cache key
 		sort( $valid_plan_ids );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Revises the changes made in #35587 
* Adds additional context to the cache key used in `user_is_paid_subscriber`

### Other information:

- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this Jetpack branch on a site with monetize products
* Visit a tiered newsletter post
* Purchase this tier as a subscriber
* Open a new private window and return to the post
* Enter the subscriber's email address and click "upgrade"
* You should be prompted for a login code and you should be able to login after entering that code and access the content.