### PR TITLE
Subscriptions Block: Only check newsletter plans if on the wp-admin side

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscription
+++ b/projects/plugins/jetpack/changelog/update-subscription
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions Block: Only check newsletter plans if on the wp-admin side

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -163,7 +163,7 @@ function register_block() {
 
 	// Add a 'Newsletter' column to the Edit posts page
 	// We only display the "Newsletter" column if we have configured the paid newsletter plan
-	if ( Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' ) ) {
+	if ( defined( 'WP_ADMIN' ) && WP_ADMIN && Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' ) ) {
 		add_action( 'manage_post_posts_columns', __NAMESPACE__ . '\register_newsletter_access_column' );
 		add_action( 'manage_post_posts_custom_column', __NAMESPACE__ . '\render_newsletter_access_rows', 10, 2 );
 		add_action( 'admin_head', __NAMESPACE__ . '\newsletter_access_column_styles' );


### PR DESCRIPTION
On wpcom, when I was looking at SQL queries issued by suspended sites I found this.

The `init` action runs `Automattic\Jetpack\Extensions\Subscriptions\register_block()`, which calls `Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments()`, which can call `get_posts()` ([here](https://github.com/Automattic/jetpack/blob/8a350e717ca9342e777c4ed06e58882db87bba29/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php#L750)).

However, it's used to decide if we should add three actions which are only useful on the admin side:
```php
function register_block() {
        ...
	// Add a 'Newsletter' column to the Edit posts page
	// We only display the "Newsletter" column if we have configured the paid newsletter plan
	if ( Jetpack_Memberships::has_configured_plans_jetpack_recurring_payments( 'newsletter' ) ) {
		add_action( 'manage_post_posts_columns', __NAMESPACE__ . '\register_newsletter_access_column' );
		add_action( 'manage_post_posts_custom_column', __NAMESPACE__ . '\render_newsletter_access_rows', 10, 2 );
		add_action( 'admin_head', __NAMESPACE__ . '\newsletter_access_column_styles' );
	}
```

Therefore, there's no reason to run these checks on the front-end and API side.  See #35101 where the check was moved from the `manage_poss_*` actions to the `init` action instead.

## Proposed changes:

* Only run the check on the wp-admin side.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

