### PR TITLE
A4A Client: Remove Jetpack Header/Footer, Fix Dark Blue Background Color

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/remove-a4a-jetpack-admin-page-wrapper
+++ b/projects/plugins/automattic-for-agencies-client/changelog/remove-a4a-jetpack-admin-page-wrapper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed the Jetpack-branded header and footer from the plugin.

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/admin-page/index.jsx
@@ -1,13 +1,6 @@
-import {
-	AdminPage,
-	AdminSectionHero,
-	Container,
-	Col,
-	ThemeProvider,
-} from '@automattic/jetpack-components';
+import { Container, Col, ThemeProvider } from '@automattic/jetpack-components';
 import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
 import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 import React from 'react';
 import ConnectedCard from '../connected-card';
 import ConnectionCard from '../connection-card';
@@ -21,17 +14,11 @@ const Admin = () => {
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
 	return (
 		<ThemeProvider targetDom={ document.body }>
-			<AdminPage
-				moduleName={ __( 'Automattic For Agencies Client', 'automattic-for-agencies-client' ) }
-			>
-				<AdminSectionHero>
-					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
-						<Col sm={ 4 } md={ 8 } lg={ 12 }>
-							{ showConnectionCard ? <ConnectionCard /> : <ConnectedCard /> }
-						</Col>
-					</Container>
-				</AdminSectionHero>
-			</AdminPage>
+			<Container horizontalSpacing={ 10 } horizontalGap={ 3 }>
+				<Col sm={ 4 } md={ 8 } lg={ 12 }>
+					{ showConnectionCard ? <ConnectionCard /> : <ConnectedCard /> }
+				</Col>
+			</Container>
 		</ThemeProvider>
 	);
 };

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/branded-card/styles.module.scss
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/branded-card/styles.module.scss
@@ -1,7 +1,7 @@
 @import '~@automattic/color-studio/dist/color-variables';
 
 .card {
-	background-color: $studio-automattic-blue-90;
+	background-color: $studio-automattic-blue-100;
 	border-radius: 14px;
 	display: flex;
 	padding: 8px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/automattic-for-agencies-dev/issues/247

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the `AdminPage` and `AdminSectionHero` components that were wrapping the plugin screen with a Jetpack-branded header and footer.
* Adjusted the dark blue color variable used to closer match the designs (the colors scheme changed slightly when we introduced color studio).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/automattic-for-agencies-dev/issues/247

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* View the plugin page, verify the connection process still works without issue.

<img width="1728" alt="Screenshot 2024-04-16 at 4 25 50 PM" src="https://github.com/Automattic/jetpack/assets/10933065/07c557f2-9bde-40cf-9252-f5a9d3a1b138">
