### PR TITLE
Admin menu: Fix "Appearance > Themes" menu for WP.com classic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-theme-showcase-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-theme-showcase-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a WP.com only issue that forced the Themes menu to always point to Calypso even when the classic interface was set

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
@@ -60,11 +60,6 @@ function wpcom_themes_add_theme_showcase_menu() {
 		return;
 	}
 
-	// Bail on Simple sites, since "Appearance > Themes" already links to the Theme Showcase on those.
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		return;
-	}
-
 	$site_slug = wp_parse_url( home_url(), PHP_URL_HOST );
 	add_submenu_page( 'themes.php', esc_attr__( 'Theme Showcase', 'jetpack-mu-wpcom' ), __( 'Theme Showcase', 'jetpack-mu-wpcom' ), 'read', "https://wordpress.com/themes/$site_slug?ref=wpcom-themes-menu" );
 }

--- a/projects/plugins/jetpack/changelog/fix-theme-showcase-menu
+++ b/projects/plugins/jetpack/changelog/fix-theme-showcase-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fixed a WP.com only issue that forced the Themes menu to always point to Calypso even when the classic interface was set
+
+

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -290,7 +290,7 @@ class Admin_Menu extends Base_Admin_Menu {
 			$default_customize_background_slug_2 => add_query_arg( array( 'autofocus' => array( 'section' => 'colors_manager_tool' ) ), $customize_url ),
 		);
 
-		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'themes.php' ) || self::CLASSIC_VIEW === $this->get_preferred_view( 'themes.php' ) ) {
+		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'themes.php' ) ) {
 			$submenus_to_update['themes.php'] = 'https://wordpress.com/themes/' . $this->domain;
 		}
 


### PR DESCRIPTION
## Proposed changes:

Fixes a regression introduced in https://github.com/Automattic/jetpack/pull/36851 that caused the "Appearance > Themes" to incorrectly link to the Calypso Theme Showcase on Atomic sites with the (non-early) classic admin interface enabled.

It also adds the Theme Showcase menu to Simple sites with the classic admin interface since it was missing.

Site | Before | After
--- | --- | ---
Atomic - Classic Non-early | <img width="462" alt="Screenshot 2024-04-17 at 11 10 37" src="https://github.com/Automattic/jetpack/assets/1233880/8191ea1b-0f67-48c5-bdac-19cbbe959ece"> | <img width="456" alt="Screenshot 2024-04-17 at 11 20 07" src="https://github.com/Automattic/jetpack/assets/1233880/20b837e3-d47e-43b4-8f0e-b3c80f95d7b0">
Simple - Classic | <img width="483" alt="Screenshot 2024-04-17 at 11 10 19" src="https://github.com/Automattic/jetpack/assets/1233880/cdf64e7f-a7c7-44d8-a84f-5e3f79a7784d"> | <img width="644" alt="Screenshot 2024-04-17 at 11 15 47" src="https://github.com/Automattic/jetpack/assets/1233880/686223e9-f99a-489f-8672-2d52afd96635">




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

**Simple site – Default**
- Apply these changes to your sandbox using the instructions below: https://github.com/Automattic/jetpack/pull/36934#issuecomment-2060766293
- Sandbox a regular Simple site
- Make sure "Appearance > Themes" links to `/themes/:site`
- Make sure there is no "Appearance > Theme Showcase" menu

**Simple site – Classic**
- Apply these changes to your sandbox using the instructions below: https://github.com/Automattic/jetpack/pull/36934#issuecomment-2060766293
- Sandbox a Simple site using the classic admin interface
  - If you don't have one, run `update_blog_option( blog_id, 'wpcom_admin_interface', 'wp-admin' );` and `update_blog_option( blog_id, 'wpcom_classic_early_release', 1 );`
- Make sure "Appearance > Themes" links to `/wp-admin/themes.php`
- Make sure "Appearance > Theme Showcase" links to `/themes/:site`

**Atomic site - Default**
- Apply these changes to an Atomic site using the instructions below: https://github.com/Automattic/jetpack/pull/36934#issuecomment-2060766293
- Go to `/hosting-config/:site`
- Switch to the default admin interface
- Make sure "Appearance > Themes" links to `/themes/:site`
- Make sure there is no "Appearance > Theme Showcase" menu

**Atomic site - Classic**
- Apply these changes to an Atomic site using the instructions below: https://github.com/Automattic/jetpack/pull/36934#issuecomment-2060766293
- Go to `/hosting-config/:site`
- Switch to the admin classic interface
- Make sure "Appearance > Themes" links to `/wp-admin/themes.php`
- Make sure "Appearance > Theme Showcase" links to `/themes/:site`

**Atomic site - Classic Early**
- Apply these changes to an Atomic site using the instructions below: https://github.com/Automattic/jetpack/pull/36934#issuecomment-2060766293
- Go to `/hosting-config/:site`
- Switch to the default classic interface
- Enable the early classic release: `wp option update wpcom_classic_early_release 1`
- Make sure "Appearance > Themes" links to `/wp-admin/themes.php`
- Make sure "Appearance > Theme Showcase" links to `/themes/:site`