### PR TITLE
Launch the WP.com themes banner in wp-admin to all users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/release-wpcom-themes-banner
+++ b/projects/packages/jetpack-mu-wpcom/changelog/release-wpcom-themes-banner
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launch the WP.com themes banner in wp-admin to all users

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -52,7 +52,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.24.x-dev"
+			"dev-trunk": "5.25.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.24.1-alpha",
+	"version": "5.25.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.24.1-alpha';
+	const PACKAGE_VERSION = '5.25.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
@@ -13,10 +13,6 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
  * Displays a banner before the theme browser that links to the WP.com Theme Showcase.
  */
 function wpcom_themes_show_banner() {
-	if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
-		return;
-	}
-
 	$site_slug        = wp_parse_url( home_url(), PHP_URL_HOST );
 	$wpcom_logo       = plugins_url( 'images/wpcom-logo.svg', __FILE__ );
 	$background_image = plugins_url( 'images/banner-background.webp', __FILE__ );

--- a/projects/plugins/mu-wpcom-plugin/changelog/release-wpcom-themes-banner
+++ b/projects/plugins/mu-wpcom-plugin/changelog/release-wpcom-themes-banner
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -129,7 +129,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "6d08bd18e0d746a5c944ebe9c2312b37fceff752"
+                "reference": "363a5e59793e0ffbd391e6a01fe3a12f5cd57093"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -153,7 +153,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.24.x-dev"
+                    "dev-trunk": "5.25.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
## Proposed changes:

Makes the WP.com themes banner visible in `/wp-admin/theme-install.php` to all users.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to an Atomic sites following the instruction below
- Make sure your Atomic site uses either the default admin interface or the non-early classic admin interface (`wp option delete wpcom_classic_early_release`)
- Go to `/wp-admin/theme-install.php`
- Make sure the WP.com themes banner shows up
