### PR TITLE
Fix/get option fatal error

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-get_option_fatal_error
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-get_option_fatal_error
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Simple function change
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -750,7 +750,7 @@ function wpcom_launchpad_is_site_launched( $task, $is_complete ) {
 		return true;
 	}
 
-	$launch_status = get_blog_option( get_current_blog_id(), 'launch-status' );
+	$launch_status = get_option( 'launch-status' );
 
 	if ( 'launched' === $launch_status ) {
 		wpcom_mark_launchpad_task_complete( 'site_launched' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Context: p1713353693380999/1713353250.586039-slack-C034JEXD1RD

```
PHP Fatal error:  Uncaught Error: Call to undefined function get_blog_option() in <...>features/launchpad/launchpad-task-definitions.php:753

```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the `get_blog_option` function by `get_option`


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


### Testing SImple:
- Enable sandbox and apply this PR
- Create a site through the /start flow.
- On the Goals step, select sell.
- Go through the flow until you reach the Customer Home page.
- Click on the Launch your site task.
- Click on Show site setup
- Check if the Launch your Site task is completed.

### Testing Atomic
- Create **another** site through the /start flow.
- On the Goals step, select sell.
- Go through the flow until you reach the Customer Home page.
- Follow the instructions from the comment below to install the Jetpack Beta plugin and apply this branch.
- Click on the Launch your site task.
- Click on Show site setup
- Check if the Launch your Site task is completed.
