### PR TITLE
Jetpack Social | Remove the "Connect an account" link for non-admins

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-remove-the-connect-an-account-link-for-non-admins
+++ b/projects/js-packages/publicize-components/changelog/update-remove-the-connect-an-account-link-for-non-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Removed the "Connect an account" link for non-admins

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.49.2",
+	"version": "0.49.3-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
@@ -1,3 +1,5 @@
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import PublicizeConnection from '../connection';
 import PublicizeSettingsButton from '../settings-button';
@@ -8,6 +10,8 @@ export const ConnectionsList: React.FC = () => {
 	const { connections, toggleById } = useSocialMediaConnections();
 
 	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
+
+	const isAdmin = useSelect( select => select( coreStore ).canUser( 'update', 'settings' ), [] );
 
 	return (
 		<ul className={ styles[ 'connections-list' ] }>
@@ -28,9 +32,11 @@ export const ConnectionsList: React.FC = () => {
 					/>
 				);
 			} ) }
-			<li>
-				<PublicizeSettingsButton />
-			</li>
+			{ isAdmin ? (
+				<li>
+					<PublicizeSettingsButton />
+				</li>
+			) : null }
 		</ul>
 	);
 };

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -7,6 +7,7 @@
  */
 
 import { Disabled, ExternalLink, PanelRow } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { Fragment, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -51,6 +52,8 @@ export default function PublicizeForm() {
 			numberOfSharesRemaining: select( socialStore ).numberOfSharesRemaining(),
 		};
 	}, [] );
+
+	const isAdmin = useSelect( select => select( coreStore ).canUser( 'update', 'settings' ), [] );
 
 	const Wrapper = isPublicizeDisabledBySitePlan ? Disabled : Fragment;
 
@@ -113,13 +116,14 @@ export default function PublicizeForm() {
 							/>
 						) ) }
 				</>
-			) : (
+			) : null }
+			{ ! hasConnections && isAdmin ? (
 				<PanelRow>
 					<ExternalLink href={ connectionsAdminUrl }>
 						{ __( 'Connect an account', 'jetpack' ) }
 					</ExternalLink>
 				</PanelRow>
-			) }
+			) : null }
 			{ ! isPublicizeDisabledBySitePlan && (
 				<Fragment>
 					{ isPublicizeEnabled && hasEnabledConnections && <SharePostForm /> }

--- a/projects/js-packages/publicize-components/src/components/panel/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.jsx
@@ -59,7 +59,7 @@ const PublicizePanel = ( { prePublish, children } ) => {
 									  )
 							}
 							onChange={ togglePublicizeFeature }
-							checked={ isPublicizeEnabled }
+							checked={ isPublicizeEnabled && hasConnections }
 							disabled={ ! hasConnections }
 						/>
 					) }


### PR DESCRIPTION
Right now, we show the "Connect an account" link to both admins and authors even though, technically, authors cannot connect accounts.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hide "Connect an account" link for non-admin authors
* Turn OFF "Share when publishing" option when there are no connections

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a fresh site with no connections, create a non-admin author account
* Login via the author account
* Goto Jetpack/Social sidebar
* Under "Share this post", confirm that you don't see the "Connect an account" link
* Now login as admin to confirm that you see the "Connect an account" link
* Confirm that "Share when publishing" option is turned OFF when there are no connections
* Now add a connection and mark it as global
* Come back to Jetpack sidebar
* Confirm that you see the + icon (Connect an account) after the connections list
* Now for author, confirm that you don't see the + icon

| BEFORE | AFTER |
|--------|--------|
| <img width="287" alt="Screenshot 2024-04-17 at 5 52 55 PM" src="https://github.com/Automattic/jetpack/assets/18226415/3f06d1e6-3027-4db0-a5ba-a89c683ba7f7"> | <img width="287" alt="Screenshot 2024-04-17 at 5 55 15 PM" src="https://github.com/Automattic/jetpack/assets/18226415/e90e24cd-681d-4000-b095-1da8b242a006"> |
| <img width="284" alt="Screenshot 2024-04-17 at 5 53 22 PM" src="https://github.com/Automattic/jetpack/assets/18226415/9170d107-0e99-4aca-b961-682cef026fe3"> | <img width="284" alt="Screenshot 2024-04-17 at 5 56 29 PM" src="https://github.com/Automattic/jetpack/assets/18226415/8c43fe6b-506e-4cb7-81f6-89f9b2f4993c"> |