### PR TITLE
Donations block: fix non lolcalized strings

### DIFF
--- a/projects/packages/jitm/.phan/baseline.php
+++ b/projects/packages/jitm/.phan/baseline.php
@@ -12,10 +12,10 @@ return [
     // PhanTypeExpectedObjectPropAccess : 3 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
     // PhanTypeMismatchReturn : 2 occurrences
+    // PhanUndeclaredMethod : 2 occurrences
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanTypeInvalidDimOffset : 1 occurrence
     // PhanTypeMismatchArgument : 1 occurrence
-    // PhanUndeclaredMethod : 1 occurrence
     // PhanUnreferencedUseNormal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions

--- a/projects/packages/jitm/changelog/fix-donation-block-translations
+++ b/projects/packages/jitm/changelog/fix-donation-block-translations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: PHAN: update baseline
+
+

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -119,7 +119,6 @@ return [
     // PhanTypeComparisonFromArray : 1 occurrence
     // PhanTypeInstantiateAbstract : 1 occurrence
     // PhanTypeInvalidCallableArraySize : 1 occurrence
-    // PhanTypeMismatchForeach : 1 occurrence
     // PhanTypeMismatchReturnSuperType : 1 occurrence
     // PhanTypeSuspiciousEcho : 1 occurrence
     // PhanTypeVoidArgument : 1 occurrence
@@ -226,7 +225,7 @@ return [
         'extensions/blocks/calendly/calendly.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/contact-info/class-jetpack-contact-info-block.php' => ['PhanTypeMismatchReturn'],
         'extensions/blocks/cookie-consent/cookie-consent.php' => ['PhanParamTooMany', 'PhanUndeclaredFunction'],
-        'extensions/blocks/donations/donations.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchForeach', 'PhanUndeclaredFunction'],
+        'extensions/blocks/donations/donations.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredFunction'],
         'extensions/blocks/gif/gif.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/google-calendar/google-calendar.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/google-docs-embed/google-docs-embed.php' => ['PhanRedundantCondition', 'PhanUndeclaredFunction'],

--- a/projects/plugins/jetpack/changelog/fix-donation-block-translations
+++ b/projects/plugins/jetpack/changelog/fix-donation-block-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Donations Block: fix non localized strings

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -45,10 +45,7 @@
 			"default": {
 				"show": true,
 				"planId": null,
-				"amounts": [ 5, 15, 100 ],
-				"heading": "Make a one-time donation",
-				"extraText": "Your contribution is appreciated.",
-				"buttonText": "Donate"
+				"amounts": [ 5, 15, 100 ]
 			}
 		},
 		"monthlyDonation": {
@@ -56,10 +53,7 @@
 			"default": {
 				"show": true,
 				"planId": null,
-				"amounts": [ 5, 15, 100 ],
-				"heading": "Make a monthly donation",
-				"extraText": "Your contribution is appreciated.",
-				"buttonText": "Donate monthly"
+				"amounts": [ 5, 15, 100 ]
 			}
 		},
 		"annualDonation": {
@@ -67,10 +61,7 @@
 			"default": {
 				"show": true,
 				"planId": null,
-				"amounts": [ 5, 15, 100 ],
-				"heading": "Make a yearly donation",
-				"extraText": "Your contribution is appreciated.",
-				"buttonText": "Donate yearly"
+				"amounts": [ 5, 15, 100 ]
 			}
 		},
 		"showCustomAmount": {

--- a/projects/plugins/jetpack/extensions/blocks/donations/constants.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/constants.js
@@ -1,4 +1,0 @@
-import { __ } from '@wordpress/i18n';
-
-export const DEFAULT_CHOOSE_AMOUNT_TEXT = __( 'Choose an amount', 'jetpack' );
-export const DEFAULT_CUSTOM_AMOUNT_TEXT = __( 'Or enter a custom amount', 'jetpack' );

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -53,11 +53,15 @@ function render_block( $attr, $content ) {
 
 	require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-jetpack-currencies.php';
 
+	$default_texts = get_default_texts();
+
 	$donations = array(
 		'one-time' => array_merge(
 			array(
-				'title' => __( 'One-Time', 'jetpack' ),
-				'class' => 'donations__one-time-item',
+				'title'      => __( 'One-Time', 'jetpack' ),
+				'class'      => 'donations__one-time-item',
+				'heading'    => $default_texts['oneTimeDonation']['heading'],
+				'buttonText' => $default_texts['oneTimeDonation']['buttonText'],
 			),
 			$attr['oneTimeDonation']
 		),
@@ -65,8 +69,10 @@ function render_block( $attr, $content ) {
 	if ( $attr['monthlyDonation']['show'] ) {
 		$donations['1 month'] = array_merge(
 			array(
-				'title' => __( 'Monthly', 'jetpack' ),
-				'class' => 'donations__monthly-item',
+				'title'      => __( 'Monthly', 'jetpack' ),
+				'class'      => 'donations__monthly-item',
+				'heading'    => $default_texts['monthlyDonation']['heading'],
+				'buttonText' => $default_texts['monthlyDonation']['buttonText'],
 			),
 			$attr['monthlyDonation']
 		);
@@ -74,22 +80,23 @@ function render_block( $attr, $content ) {
 	if ( $attr['annualDonation']['show'] ) {
 		$donations['1 year'] = array_merge(
 			array(
-				'title' => __( 'Yearly', 'jetpack' ),
-				'class' => 'donations__annual-item',
+				'title'      => __( 'Yearly', 'jetpack' ),
+				'class'      => 'donations__annual-item',
+				'heading'    => $default_texts['annualDonation']['heading'],
+				'buttonText' => $default_texts['annualDonation']['buttonText'],
 			),
 			$attr['annualDonation']
 		);
 	}
 
-	$choose_amount_text = isset( $attr['chooseAmountText'] ) && ! empty( $attr['chooseAmountText'] ) ? $attr['chooseAmountText'] : __( 'Choose an amount', 'jetpack' );
-	$custom_amount_text = isset( $attr['customAmountText'] ) && ! empty( $attr['customAmountText'] ) ? $attr['customAmountText'] : __( 'Or enter a custom amount', 'jetpack' );
-
-	$currency   = $attr['currency'];
-	$nav        = '';
-	$headings   = '';
-	$amounts    = '';
-	$extra_text = '';
-	$buttons    = '';
+	$choose_amount_text = isset( $attr['chooseAmountText'] ) && ! empty( $attr['chooseAmountText'] ) ? $attr['chooseAmountText'] : $default_texts['chooseAmountText'];
+	$custom_amount_text = isset( $attr['customAmountText'] ) && ! empty( $attr['customAmountText'] ) ? $attr['customAmountText'] : $default_texts['customAmountText'];
+	$currency           = $attr['currency'];
+	$nav                = '';
+	$headings           = '';
+	$amounts            = '';
+	$extra_text         = '';
+	$buttons            = '';
 	foreach ( $donations as $interval => $donation ) {
 		$plan_id = (int) $donation['planId'];
 		$plan    = get_post( $plan_id );
@@ -127,7 +134,7 @@ function render_block( $attr, $content ) {
 		$extra_text .= sprintf(
 			'<p class="%1$s">%2$s</p>',
 			esc_attr( $donation['class'] ),
-			wp_kses_post( $donation['extraText'] )
+			wp_kses_post( isset( $donation['extraText'] ) ? $donation['extraText'] : $default_texts['extraText'] )
 		);
 		$buttons    .= sprintf(
 			'<a class="wp-block-button__link donations__donate-button %1$s" href="%2$s">%3$s</a>',
@@ -187,6 +194,52 @@ function render_block( $attr, $content ) {
 		$buttons
 	);
 }
+
+/**
+ * Get the default texts for the block.
+ *
+ * @return array
+ */
+function get_default_texts() {
+	return array(
+		'chooseAmountText' => __( 'Choose an amount', 'jetpack' ),
+		'customAmountText' => __( 'Or enter a custom amount', 'jetpack' ),
+		'extraText'        => __( 'Your contribution is appreciated.', 'jetpack' ),
+		'oneTimeDonation'  => array(
+			'heading'    => __( 'Make a one-time donation', 'jetpack' ),
+			'buttonText' => __( 'Donate', 'jetpack' ),
+		),
+		'monthlyDonation'  => array(
+			'heading'    => __( 'Make a monthly donation', 'jetpack' ),
+			'buttonText' => __( 'Donate monthly', 'jetpack' ),
+		),
+		'annualDonation'   => array(
+			'heading'    => __( 'Make a yearly donation', 'jetpack' ),
+			'buttonText' => __( 'Donate yearly', 'jetpack' ),
+		),
+	);
+}
+
+/**
+ * Make default texts available to the editor.
+ */
+function load_editor_scripts() {
+	// Only relevant to the editor right now.
+	if ( ! is_admin() ) {
+		return;
+	}
+
+	$data = array(
+		'defaultTexts' => get_default_texts(),
+	);
+
+	wp_add_inline_script(
+		'jetpack-blocks-editor',
+		'var Jetpack_DonationsBlock = ' . wp_json_encode( $data, JSON_HEX_TAG | JSON_HEX_AMP ) . ';',
+		'before'
+	);
+}
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\load_editor_scripts' );
 
 /**
  * Determine if AMP should be disabled on posts having Donations blocks.

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -134,7 +134,7 @@ function render_block( $attr, $content ) {
 		$extra_text .= sprintf(
 			'<p class="%1$s">%2$s</p>',
 			esc_attr( $donation['class'] ),
-			wp_kses_post( isset( $donation['extraText'] ) ? $donation['extraText'] : $default_texts['extraText'] )
+			wp_kses_post( $donation['extraText'] ?? $default_texts['extraText'] )
 		);
 		$buttons    .= sprintf(
 			'<a class="wp-block-button__link donations__donate-button %1$s" href="%2$s">%3$s</a>',

--- a/projects/plugins/jetpack/extensions/blocks/donations/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/save.js
@@ -1,4 +1,7 @@
 import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { getDefaultTexts } from './utils';
+
+const DEFAULT_TEXTS = getDefaultTexts();
 
 const Save = ( { attributes } ) => {
 	const blockProps = useBlockProps.save();
@@ -15,43 +18,52 @@ const Save = ( { attributes } ) => {
 
 	return (
 		<div { ...blockProps }>
-			<RichText.Content tagName="h4" value={ oneTimeDonation.heading } />
-			<RichText.Content tagName="p" value={ oneTimeDonation.extraText } />
+			<RichText.Content tagName="h4" value={ DEFAULT_TEXTS.oneTimeDonation?.heading } />
+			<RichText.Content
+				tagName="p"
+				value={ oneTimeDonation.extraText ?? DEFAULT_TEXTS.extraText }
+			/>
 			<RichText.Content
 				tagName="a"
 				className="jetpack-donations-fallback-link"
 				href={ fallbackLinkUrl }
 				rel="noopener noreferrer noamphtml"
 				target="_blank"
-				value={ oneTimeDonation.buttonText }
+				value={ DEFAULT_TEXTS.oneTimeDonation?.buttonText }
 			/>
 			{ monthlyDonation.show && (
 				<>
 					<hr className="donations__separator" />
-					<RichText.Content tagName="h4" value={ monthlyDonation.heading } />
-					<RichText.Content tagName="p" value={ monthlyDonation.extraText } />
+					<RichText.Content tagName="h4" value={ DEFAULT_TEXTS.monthlyDonation?.heading } />
+					<RichText.Content
+						tagName="p"
+						value={ monthlyDonation.extraText ?? DEFAULT_TEXTS.extraText }
+					/>
 					<RichText.Content
 						tagName="a"
 						className="jetpack-donations-fallback-link"
 						href={ fallbackLinkUrl }
 						rel="noopener noreferrer noamphtml"
 						target="_blank"
-						value={ monthlyDonation.buttonText }
+						value={ DEFAULT_TEXTS.monthlyDonation?.buttonText }
 					/>
 				</>
 			) }
 			{ annualDonation.show && (
 				<>
 					<hr className="donations__separator" />
-					<RichText.Content tagName="h4" value={ annualDonation.heading } />
-					<RichText.Content tagName="p" value={ annualDonation.extraText } />
+					<RichText.Content tagName="h4" value={ DEFAULT_TEXTS.annualDonation?.heading } />
+					<RichText.Content
+						tagName="p"
+						value={ annualDonation.extraText ?? DEFAULT_TEXTS.extraText }
+					/>
 					<RichText.Content
 						tagName="a"
 						className="jetpack-donations-fallback-link"
 						href={ fallbackLinkUrl }
 						rel="noopener noreferrer noamphtml"
 						target="_blank"
-						value={ annualDonation.buttonText }
+						value={ DEFAULT_TEXTS.annualDonation?.buttonText }
 					/>
 				</>
 			) }

--- a/projects/plugins/jetpack/extensions/blocks/donations/tab.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tab.js
@@ -6,7 +6,9 @@ import {
 	minimumTransactionAmountForCurrency,
 } from '../../shared/currencies';
 import Amount from './amount';
-import { DEFAULT_CHOOSE_AMOUNT_TEXT, DEFAULT_CUSTOM_AMOUNT_TEXT } from './constants';
+import { getDefaultTexts } from './utils';
+
+const DEFAULT_TEXTS = getDefaultTexts();
 
 const Tab = ( { activeTab, attributes, setAttributes } ) => {
 	const {
@@ -15,8 +17,8 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 		monthlyDonation,
 		annualDonation,
 		showCustomAmount,
-		chooseAmountText = DEFAULT_CHOOSE_AMOUNT_TEXT,
-		customAmountText = DEFAULT_CUSTOM_AMOUNT_TEXT,
+		chooseAmountText = DEFAULT_TEXTS.chooseAmountText,
+		customAmountText = DEFAULT_TEXTS.customAmountText,
 	} = attributes;
 
 	const donationAttributes = {
@@ -25,9 +27,9 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 		'1 year': 'annualDonation',
 	};
 
-	const getDonationValue = key => attributes[ donationAttributes[ activeTab ] ][ key ];
+	const donationAttribute = donationAttributes[ activeTab ];
+	const getDonationValue = key => attributes[ donationAttribute ][ key ];
 	const setDonationValue = ( key, value ) => {
-		const donationAttribute = donationAttributes[ activeTab ];
 		const donation = attributes[ donationAttribute ];
 		setAttributes( {
 			[ donationAttribute ]: {
@@ -66,7 +68,7 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 			<RichText
 				tagName="h4"
 				placeholder={ __( 'Write a message…', 'jetpack' ) }
-				value={ getDonationValue( 'heading' ) }
+				value={ getDonationValue( 'heading' ) || DEFAULT_TEXTS[ donationAttribute ]?.heading }
 				onChange={ value => setDonationValue( 'heading', value ) }
 			/>
 			<RichText
@@ -112,14 +114,16 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 			<RichText
 				tagName="p"
 				placeholder={ __( 'Write a message…', 'jetpack' ) }
-				value={ getDonationValue( 'extraText' ) }
+				value={ getDonationValue( 'extraText' ) ?? DEFAULT_TEXTS.extraText }
 				onChange={ value => setDonationValue( 'extraText', value ) }
 			/>
 			<div className="wp-block-button donations__donate-button-wrapper">
 				<RichText
 					className="wp-block-button__link donations__donate-button"
 					placeholder={ __( 'Write a message…', 'jetpack' ) }
-					value={ getDonationValue( 'buttonText' ) }
+					value={
+						getDonationValue( 'buttonText' ) || DEFAULT_TEXTS[ donationAttribute ]?.buttonText
+					}
 					onChange={ value => setButtonText( value ) }
 					allowedFormats={ allowedFormatsForButton }
 				/>

--- a/projects/plugins/jetpack/extensions/blocks/donations/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/utils.js
@@ -1,0 +1,19 @@
+/**
+ * Return the default texts defined in `donations.php` and injected client side by assigning them
+ * to the `Jetpack_DonationsBlock` attribute of the window object.
+ *
+ * @returns {object} Defaut texts for the block.
+ */
+export function getDefaultTexts() {
+	if ( 'undefined' === typeof window ) {
+		return {};
+	}
+
+	const texts = window.Jetpack_DonationsBlock?.defaultTexts;
+
+	if ( 'object' !== typeof texts ) {
+		return {};
+	}
+
+	return texts;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The Donations block contains several unlocalized strings. This PR fixes them. That issue was originally tackled in https://github.com/Automattic/jetpack/pull/36724, but some strings were forgotten.

In more details, the PR:
- Move the localized strings defined in the `block.json` `attributes` field out of that file since [attributes are not localized](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#attributes)
- Redefine these strings server side in `donations.php` since they'll be used to render the block view in the site
- Inject these strings client side as well as we'll need them on the editor side

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pf5801-Aw-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

_Warning: don't checkout this branch just yet._

All translations may not be picked up yet as you test this PR so let's just do some regression testing.

- Spin up a test site running on the `trunk` branch
- Connect Jetpack
- Create a new post or page
- Add a _Donations_ block
<img width="500" alt="Screenshot 2024-04-16 at 7 26 36 PM" src="https://github.com/Automattic/jetpack/assets/1620183/b04d1816-2b44-4030-b6fb-948f47e3fff9">

- Save the post/page
- Duplicate the browser tab
- Switch to this branch and build the blocks with `cd projects/plugins/jetpack && pnpm run build-extensions`
- Refresh the page in the duplicated tab
- Check that the block works as it does on trunk
- Verify the the block works as expected in the preview too

