### PR TITLE
Tiled Gallery: fix round corners style

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-rounded-corners
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-rounded-corners
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tiled Gallery: fix round corners style

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
@@ -34,7 +34,7 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 	}
 
 	@for $i from 1 through $tiled-gallery-max-rounded-corners {
-		&.has-rounded-corners-#{$i} .tiled-gallery__item img {
+		.has-rounded-corners-#{$i} .tiled-gallery__item img {
 			border-radius: #{$i}px;
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/36938

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The PR fixes rounded corners not being applied on the Tiled Gallery block.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Connect Jetpack
- Create a new post/page
- Add a _Tiled Gallery_ block
- With the block selected, update the _Round Corners_ settings in the sidebar
<img width="500" alt="Screenshot 2024-04-17 at 9 56 39 AM" src="https://github.com/Automattic/jetpack/assets/1620183/3d529153-da78-41fb-ab42-0dad52553fb6">

- Notice the changes are reflected on the gallery items
- Open the preview
- Check that the round corners are applied too
<img width="500" alt="Screenshot 2024-04-17 at 9 56 46 AM" src="https://github.com/Automattic/jetpack/assets/1620183/db159be7-b73a-4587-bd51-547edc88fcb6">

