### PR TITLE
Update share setting

### DIFF
--- a/projects/plugins/jetpack/changelog/update-share-setting
+++ b/projects/plugins/jetpack/changelog/update-share-setting
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Minor fix to share settings where showing link that doesn't always exist in jeptack menu
+
+

--- a/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
@@ -458,7 +458,7 @@ body.settings_page_sharing .advanced input[type=submit] {
 	margin-right:1rem;
 }
 
-.sharing-block-message__buttons-wrapper .button:visited {
+.sharing-block-message__buttons-wrapper .button-primary:visited {
 	color: #fff;
 }
 

--- a/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/admin-sharing.css
@@ -458,6 +458,9 @@ body.settings_page_sharing .advanced input[type=submit] {
 	margin-right:1rem;
 }
 
+.sharing-block-message__buttons-wrapper .button:visited {
+	color: #fff;
+}
 
 .admin-sharing-settings__block-theme-description {
 	margin-top: 1rem;

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -724,9 +724,15 @@ class Sharing_Admin {
 			new Share_Reddit( 'reddit', array() ),
 		);
 
-		// Hide the link to Jetpack Sharing settings if no Jetpack Settings found in submenu list
 		global $submenu;
-		$show_jetpack_admin_settings_link = isset( $submenu['jetpack'][1][2] ) && $submenu['jetpack'][1][2] === 'jetpack#/settings';
+		// Hide the link to Jetpack Sharing settings if no Jetpack Settings found in submenu list
+		$show_jetpack_admin_settings_link = array_reduce(
+			$submenu['jetpack'],
+			function ( $carry, $item ) {
+				return $carry || ( isset( $item[2] ) && $item[2] === 'jetpack#/settings' );
+			},
+			false
+		);
 		?>
 
 		<div class="share_manage_options">

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -723,6 +723,10 @@ class Sharing_Admin {
 			new Share_Email( 'email', array() ),
 			new Share_Reddit( 'reddit', array() ),
 		);
+
+		// Check if admin page exists
+		global $submenu;
+		error_log( print_r( compact('submenu'), true ) );
 		?>
 
 		<div class="share_manage_options">

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -724,10 +724,9 @@ class Sharing_Admin {
 			new Share_Reddit( 'reddit', array() ),
 		);
 
-		// Check if admin page exists
+		// Hide the link to Jetpack Sharing settings if no Jetpack Settings found in submenu list
 		global $submenu;
-		$show_jetpack_admin_settings_link = isset( $submenu['jetpack'][0][2] ) && $submenu['jetpack'][0][2] === 'jetpack#/settings';
-		error_log( var_export( compact('submenu', 'show_jetpack_admin_settings_link'), true ) );
+		$show_jetpack_admin_settings_link = isset( $submenu['jetpack'][1][2] ) && $submenu['jetpack'][1][2] === 'jetpack#/settings';
 		?>
 
 		<div class="share_manage_options">

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -755,8 +755,8 @@ class Sharing_Admin {
 							</ul>
 						</div>
 					</div>
-				</div><?php
-				if ( $show_jetpack_admin_settings_link ) : ?>
+				</div>
+				<?php if ( $show_jetpack_admin_settings_link ) : ?>
 				<p class="settings-sharing__block-theme-description">
 					<?php
 					printf(

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -726,7 +726,8 @@ class Sharing_Admin {
 
 		// Check if admin page exists
 		global $submenu;
-		error_log( print_r( compact('submenu'), true ) );
+		$show_jetpack_admin_settings_link = isset( $submenu['jetpack'][0][2] ) && $submenu['jetpack'][0][2] === 'jetpack#/settings';
+		error_log( var_export( compact('submenu', 'show_jetpack_admin_settings_link'), true ) );
 		?>
 
 		<div class="share_manage_options">
@@ -755,7 +756,8 @@ class Sharing_Admin {
 							</ul>
 						</div>
 					</div>
-				</div>
+				</div><?php
+				if ( $show_jetpack_admin_settings_link ) : ?>
 				<p class="settings-sharing__block-theme-description">
 					<?php
 					printf(
@@ -770,6 +772,7 @@ class Sharing_Admin {
 					);
 					?>
 				</p>
+				<?php endif; ?>
 			</div>
 			<br class="clearing" />
 		</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # https://github.com/Automattic/dotcom-forge/issues/6233

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This adds a check to the sharing settings to only show the link to Jetpack settings if that submenu item is available.
* This also fixes the visited color for the `Go to the site editor` button.

If you look at a simple site in classic view, you will see sharing settings (with a block theme) like the image below. 
![Image](https://github.com/Automattic/dotcom-forge/assets/1689238/95286884-7dd1-434d-81f1-f799b2396afb)

This settings contains a link to Jetpack settings that doesn't exist on simple and when loaded you go to an empty page
<img width="1133" alt="Screenshot 2024-04-17 at 15 38 27" src="https://github.com/Automattic/jetpack/assets/5560595/e3714363-dae9-4c35-bfb1-271fcc83bdb0">

With this PR this link will not be rendered if there are no Jetpack settings found in submenu.
<img width="1247" alt="Screenshot 2024-04-17 at 15 32 28" src="https://github.com/Automattic/jetpack/assets/5560595/0cb9a485-01e1-4735-9137-f14cd29bfd19">

### Other information:

The share settings shows this Jetpack settings link on Atomic sites but this is ok as these settings are available on Atomic. We don't want to hide the link in this case;

<img width="1615" alt="Screenshot 2024-04-17 at 15 33 48" src="https://github.com/Automattic/jetpack/assets/5560595/39c2ee73-694f-4cca-be44-736b42bd99b5">



## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* If you do not have a simple site on Classic view you can do the following
* Prepare a Simple site.
* Retrieve its site/blog ID.
* SSH to your sandbox and run:
    - `wpsh`
    - `update_blog_option( blog_id, 'wpcom_admin_interface', 'wp-admin' );`
    - `update_blog_option( blog_id, 'wpcom_classic_early_release', 1 );`
* Make sure your simple site is using a block theme
* Go to `https://[your-simple-site].wordpress.com/wp-admin/options-general.php?page=sharing`
* Confirm you see the link to Jetpack settings
* Apply this PR on your sandbox (make sure your simple site is also sandboxed).
* Confirm the link to Jetpack settings no longer is shown
* Use Jetpack Beta tester on Atomic site to confirm link is not hidden if the Jetpack settings are available

