### PR TITLE
SSO: automatically label SSO changes in connection package

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-gardening-sso-label
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-sso-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Auto-labeling: label changes to the SSO feature in the Connection package.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -137,6 +137,12 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			}
 		}
 
+		// The SSO feature nows lives in both a package and a Jetpack module.
+		const sso = file.match( /^projects\/packages\/connection\/src\/sso\// );
+		if ( sso !== null ) {
+			keywords.add( '[Feature] SSO' );
+		}
+
 		// The WooCommerce Analytics feature now lives in both a package and a Jetpack module.
 		const wooCommerceAnalytics = file.match( /^projects\/packages\/woocommerce-analytics\// );
 		if ( wooCommerceAnalytics !== null ) {


### PR DESCRIPTION
## Proposed changes:

The SSO feature now lives in the Connection package, in its own directory. Let's handle that in our action.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> This can only be tested in a fork.

* In your fork, merge this branch to `trunk`.
* Open a new PR in your fork, for a new branch to `trunk`, making a change to one of the files in `projects/packages/connection/src/sso/`.
    * The SSO label should be automatically added to the PR.
