### PR TITLE
Block Scaffolding: update API version in template

### DIFF
--- a/projects/plugins/jetpack/changelog/update-block-template-api-version
+++ b/projects/plugins/jetpack/changelog/update-block-template-api-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Block Scaffolding: update API version in template

--- a/projects/plugins/jetpack/wp-cli-templates/block-block-json.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-block-json.mustache
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 1,
+	"apiVersion": 3,
 	"name": "jetpack/{{ slug }}",
 	"title": {{ title }},
 	"description": {{ description }},

--- a/projects/plugins/jetpack/wp-cli-templates/block-edit-js.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-edit-js.mustache
@@ -1,5 +1,5 @@
 import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
-import { BlockIcon } from '@wordpress/block-editor';
+import { BlockIcon, useBlockProps } from '@wordpress/block-editor';
 import { Placeholder, withNotices } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -8,7 +8,7 @@ import './editor.scss';
 
 const icon = getBlockIconComponent( metadata );
 
-function {{ className }}Edit( { attributes, className, noticeOperations, noticeUI, setAttributes } ) {
+function {{ className }}Edit( { attributes, noticeOperations, noticeUI, setAttributes } ) {
 	/**
 	 * Write the block editor UI.
 	 *
@@ -22,8 +22,10 @@ function {{ className }}Edit( { attributes, className, noticeOperations, noticeU
 		noticeOperations.createErrorNotice( __( 'Put error message here.', 'jetpack' ) );
 	};
 
+	const blockProps = useBlockProps();
+
 	return (
-		<div className={ className }>
+		<div { ...blockProps }>
 			<Placeholder
 				label={ __( '{{ title }}', 'jetpack' ) }
 				instructions={ __( 'Instructions go here.', 'jetpack' ) }

--- a/projects/plugins/jetpack/wp-cli-templates/block-editor-js.mustache
+++ b/projects/plugins/jetpack/wp-cli-templates/block-editor-js.mustache
@@ -5,5 +5,9 @@ import './editor.scss';
 
 registerJetpackBlockFromMetadata( metadata, {
 	edit,
-	save: () => null, // TODO: Implement save.
+	// TODO: implement the `save` function for static blocks. If you do, make sure to add the block
+	// props returned by `useBlockProps.save()`.
+	// https://developer.wordpress.org/news/2023/02/27/static-vs-dynamic-blocks-whats-the-difference/
+	// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#save
+	save: () => null,
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Update the template used by the command to create a new block, to use the latest Block API version.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/34120

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Nothing to test here.

