### PR TITLE
phan: Add stubs for the WordPress.com Editing Toolkit plugin

### DIFF
--- a/.phan/config.base.php
+++ b/.phan/config.base.php
@@ -23,6 +23,7 @@
  *   - parse_file_list: (array) Files to parse but not analyze. Equivalent to listing in both 'file_list' and 'exclude_analysis_directory_list'.
  *   - stubs: (array) Predefined stubs to load. Default is `array( 'wordpress', 'wp-cli', 'wpcom' )`.
  *      - akismet: Stubs from .phan/stubs/akismet-stubs.php.
+ *      - full-site-editing: Stubs from .phan/stubs/full-site-editing-stubs.php.
  *      - woocommerce: Stubs from php-stubs/woocommerce.
  *      - woocommerce-internal: Stubs from .phan/stubs/woocommerce-internal-stubs.php.
  *      - woocommerce-packages: Stubs from php-stubs/woocommerce.
@@ -56,6 +57,9 @@ function make_phan_config( $dir, $options = array() ) {
 		switch ( $stub ) {
 			case 'akismet':
 				$stubs[] = "$root/.phan/stubs/akismet-stubs.php";
+				break;
+			case 'full-site-editing':
+				$stubs[] = "$root/.phan/stubs/full-site-editing-stubs.php";
 				break;
 			case 'woocommerce':
 				$stubs[] = "$root/vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php";

--- a/.phan/stubs/full-site-editing-stubs.php
+++ b/.phan/stubs/full-site-editing-stubs.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Stubs automatically generated from WordPress.com Editing Toolkit 4.19624
+ * using the definition file `tools/stubs/full-site-editing-stub-defs.php` in the Jetpack monorepo.
+ *
+ * Do not edit this directly! Run tools/stubs/update-stubs.sh to regenerate it.
+ */
+
+namespace {
+    /**
+     * Limit Global Styles on WP.com to paid plans.
+     *
+     * @package full-site-editing-plugin
+     */
+    /**
+     * Checks if Global Styles should be limited on the given site.
+     *
+     * @param  int $blog_id Blog ID.
+     * @return bool Whether Global Styles are limited.
+     */
+    function wpcom_should_limit_global_styles($blog_id = 0)
+    {
+    }
+    /**
+     * Checks if the current blog has custom styles in use.
+     *
+     * @return bool Returns true if custom styles are in use.
+     */
+    function wpcom_global_styles_in_use()
+    {
+    }
+}
+namespace A8C\FSE {
+    /**
+     * Whether or not FSE is active.
+     * If false, FSE functionality should be disabled.
+     *
+     * @returns bool True if FSE is active, false otherwise.
+     * @phan-return mixed Dummy doc for stub.
+     */
+    function is_full_site_editing_active()
+    {
+    }
+    /**
+     * Whether or not the site is eligible for FSE. This is essentially a feature
+     * gate to disable FSE on some sites which could theoretically otherwise use it.
+     *
+     * By default, sites should not be eligible.
+     *
+     * @return bool True if current site is eligible for FSE, false otherwise.
+     */
+    function is_site_eligible_for_full_site_editing()
+    {
+    }
+}

--- a/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
@@ -9,7 +9,7 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredFunction : 65+ occurrences
+    // PhanUndeclaredFunction : 60+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 50+ occurrences
     // PhanTypeMismatchArgument : 30+ occurrences
     // PhanTypeArraySuspicious : 25+ occurrences

--- a/projects/packages/jetpack-mu-wpcom/.phan/config.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/config.php
@@ -15,6 +15,7 @@ $root = dirname( __DIR__, 4 );
 return make_phan_config(
 	dirname( __DIR__ ),
 	array(
+		'+stubs'          => array( 'full-site-editing' ),
 		'parse_file_list' => array(
 			"$root/projects/packages/stats-admin/src/class-dashboard.php",
 			"$root/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php",

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-phan-full-site-editing-stubs
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-phan-full-site-editing-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Update Phan config to use new WordPress.com Editing Toolkit stubs. No change to functionality.
+
+

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -59,7 +59,6 @@ return [
     // PhanTypeInvalidLeftOperandOfNumericOp : 10+ occurrences
     // PhanTypeMismatchReturnNullable : 10+ occurrences
     // PhanUndeclaredClassProperty : 10+ occurrences
-    // PhanUndeclaredClassReference : 10+ occurrences
     // PhanUndeclaredConstant : 10+ occurrences
     // PhanUndeclaredTypeReturnType : 10+ occurrences
     // PhanCommentParamWithoutRealParam : 9 occurrences
@@ -72,6 +71,7 @@ return [
     // PhanTypeMismatchArgumentInternalReal : 7 occurrences
     // PhanUndeclaredTypeParameter : 7 occurrences
     // PhanCommentAbstractOnInheritedMethod : 6 occurrences
+    // PhanUndeclaredClassReference : 6 occurrences
     // PhanUndeclaredTypeProperty : 6 occurrences
     // PhanUndeclaredVariableDim : 6 occurrences
     // PhanUnextractableAnnotationElementName : 6 occurrences
@@ -89,7 +89,6 @@ return [
     // PhanTypeInvalidRightOperandOfBitwiseOp : 4 occurrences
     // PhanTypeInvalidRightOperandOfNumericOp : 4 occurrences
     // PhanUndeclaredClassInCallable : 4 occurrences
-    // PhanUndeclaredClassReference : 4 occurrences
     // PhanDeprecatedFunctionInternal : 3 occurrences
     // PhanDeprecatedTrait : 3 occurrences
     // PhanTypeConversionFromArray : 3 occurrences
@@ -588,7 +587,7 @@ return [
         'sal/class.json-api-post-base.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredFunction'],
         'sal/class.json-api-site-base.php' => ['PhanParamTooMany', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
         'sal/class.json-api-site-jetpack-base.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal'],
-        'sal/class.json-api-site-jetpack.php' => ['PhanParamSignatureMismatch', 'PhanUndeclaredFunction'],
+        'sal/class.json-api-site-jetpack.php' => ['PhanParamSignatureMismatch'],
         'sal/class.json-api-token.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanSuspiciousValueComparison', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanUndeclaredVariable'],
         'src/class-jetpack-crm-data.php' => ['PhanUndeclaredFunction'],
         'src/class-jetpack-modules-overrides.php' => ['PhanRedundantCondition'],

--- a/projects/plugins/jetpack/.phan/config.php
+++ b/projects/plugins/jetpack/.phan/config.php
@@ -13,7 +13,7 @@ require __DIR__ . '/../../../../.phan/config.base.php';
 return make_phan_config(
 	dirname( __DIR__ ),
 	array(
-		'+stubs'                          => array( 'akismet', 'woocommerce', 'woocommerce-internal', 'woocommerce-packages' ),
+		'+stubs'                          => array( 'akismet', 'full-site-editing', 'woocommerce', 'woocommerce-internal', 'woocommerce-packages' ),
 		'exclude_file_list'               => array(
 			// Mocks of core classes.
 			'tests/php/_inc/lib/mocks/class-simplepie-file.php',

--- a/projects/plugins/jetpack/changelog/add-phan-full-site-editing-stubs
+++ b/projects/plugins/jetpack/changelog/add-phan-full-site-editing-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update Phan config to use new WordPress.com Editing Toolkit stubs. No change to functionality.
+
+

--- a/tools/stubs/full-site-editing-stub-defs.php
+++ b/tools/stubs/full-site-editing-stub-defs.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Stub config for WordPress.com Editing Toolkit classes and such needed in the Jetpack monorepo.
+ *
+ * @package automattic/jetpack-monorepo
+ */
+
+// phpcs:disable PHPCompatibility.Syntax.NewFlexibleHeredocNowdoc.ClosingMarkerNoNewLine -- https://github.com/PHPCompatibility/PHPCompatibility/issues/1696
+
+$work_dir = getenv( 'WORK_DIR' );
+if ( ! is_dir( $work_dir ) ) {
+	throw new RuntimeException( 'WORK_DIR is not set or does not refer to a directory' );
+}
+
+$data = file_get_contents( "$work_dir/full-site-editing/full-site-editing-plugin.php" );
+if ( ! preg_match( '/^ \* Version: (\d+\.\d+.*)/m', (string) $data, $m ) ) {
+	throw new RuntimeException( "Failed to extract version from $work_dir/full-site-editing/full-site-editing-plugin.php" );
+}
+$version = $m[1];
+
+return array(
+	'header'  => <<<HEAD
+	/**
+	 * Stubs automatically generated from WordPress.com Editing Toolkit $version
+	 * using the definition file `tools/stubs/full-site-editing-stub-defs.php` in the Jetpack monorepo.
+	 *
+	 * Do not edit this directly! Run tools/stubs/update-stubs.sh to regenerate it.
+	 */
+	HEAD,
+	'basedir' => "$work_dir/full-site-editing/",
+	'files'   => array(
+		'wpcom-global-styles/index.php' => array(
+			'function' => array( 'wpcom_global_styles_in_use', 'wpcom_should_limit_global_styles' ),
+		),
+		'dotcom-fse/helpers.php'        => array(
+			'function' => array( 'A8C\FSE\is_full_site_editing_active', 'A8C\FSE\is_site_eligible_for_full_site_editing' ),
+		),
+	),
+);

--- a/tools/stubs/update-stubs.sh
+++ b/tools/stubs/update-stubs.sh
@@ -82,6 +82,14 @@ info 'Extracting Akismet stubs'
 "$BASE/projects/packages/stub-generator/bin/jetpack-stub-generator" --output "$BASE/.phan/stubs/akismet-stubs.php" "$BASE/tools/stubs/akismet-stub-defs.php"
 
 echo
+info 'Downloading WordPress.com Editing Toolkit'
+fetch_plugin full-site-editing
+
+echo
+info 'Extracting WordPress.com Editing Toolkit stubs'
+"$BASE/projects/packages/stub-generator/bin/jetpack-stub-generator" --output "$BASE/.phan/stubs/full-site-editing-stubs.php" "$BASE/tools/stubs/full-site-editing-stub-defs.php"
+
+echo
 info 'Downloading WooCommerce'
 fetch_repo woocommerce/woocommerce
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
A few functions from this plugin are called from Jetpack and the jetpack-mu-wpcom package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?