### PR TITLE
Markdown Block: add support for task lists

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3428,6 +3428,9 @@ importers:
       markdown-it-footnote:
         specifier: 3.0.3
         version: 3.0.3
+      markdown-it-task-lists:
+        specifier: 2.1.1
+        version: 2.1.1
       photon:
         specifier: 4.0.0
         version: 4.0.0
@@ -17986,6 +17989,10 @@ packages:
 
   /markdown-it-footnote@3.0.3:
     resolution: {integrity: sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w==}
+    dev: false
+
+  /markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
     dev: false
 
   /markdown-it@14.0.0:

--- a/projects/plugins/jetpack/changelog/add-tasklists-markdown-block
+++ b/projects/plugins/jetpack/changelog/add-tasklists-markdown-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Markdown Block: add option to insert to-do lists.

--- a/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
@@ -3,13 +3,17 @@ import { RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import MarkdownIt from 'markdown-it';
 import footnote_plugin from 'markdown-it-footnote';
+import taskLists from 'markdown-it-task-lists';
 
 /**
  * Module variables
  */
 const markdownConverter = new MarkdownIt( {
 	typographer: true,
-} ).use( footnote_plugin );
+} )
+	.use( footnote_plugin )
+	.use( taskLists );
+
 const handleLinkClick = event => {
 	if ( event.target.nodeName === 'A' ) {
 		const hasConfirmed = window.confirm(
@@ -27,8 +31,24 @@ const getStyles = ( attributes = {} ) => {
 	return spacingProps?.style ? spacingProps.style : {};
 };
 
+const renderMarkdown = source => {
+	if ( ! source.length ) {
+		return '';
+	}
+
+	let html = markdownConverter.render( source );
+
+	// Add inline styles to any to-do lists, found in the html as unordered lists with the .contains-task-list class.
+	// This is done to allow for custom styling of the to-do list items.
+	html = html.replace(
+		/<ul class="contains-task-list">/g,
+		'<ul class="contains-task-list" style="list-style: none;">'
+	);
+
+	return html;
+};
 export default ( { className, source = '', attributes } ) => (
 	<RawHTML className={ className } onClick={ handleLinkClick } style={ getStyles( attributes ) }>
-		{ source.length ? markdownConverter.render( source ) : '' }
+		{ renderMarkdown( source ) }
 	</RawHTML>
 );

--- a/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
+++ b/projects/plugins/jetpack/extensions/blocks/markdown/renderer.js
@@ -38,8 +38,7 @@ const renderMarkdown = source => {
 
 	let html = markdownConverter.render( source );
 
-	// Add inline styles to any to-do lists, found in the html as unordered lists with the .contains-task-list class.
-	// This is done to allow for custom styling of the to-do list items.
+	// Add inline styles to all to-do lists.
 	html = html.replace(
 		/<ul class="contains-task-list">/g,
 		'<ul class="contains-task-list" style="list-style: none;">'

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -95,6 +95,7 @@
 		"mapbox-gl": "1.13.0",
 		"markdown-it": "14.0.0",
 		"markdown-it-footnote": "3.0.3",
+		"markdown-it-task-lists": "2.1.1",
 		"photon": "4.0.0",
 		"postcss-custom-properties": "12.1.7",
 		"prop-types": "15.7.2",


### PR DESCRIPTION
Fixes #36891

## Proposed changes:

This introduces a new Markdown-it plugin to render to-do lists in the Markdown block.

Since to-do lists typically do not include any list style (no dots before each item), I've opted to modify the rendered html to add inline styles to remove those dots. This saves us from enqueuing a CSS file just to render content.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* In a new post, insert a Markdown block.
* Add in some markdown content, as well as a to-do list like so:

```html
- [ ] Milk
- [ ] Eggs
- [x] Lettuce
- [x] Tomatoes
```

* Switch to the Markdown Preview tab in the block and ensure the list is rendered as you would expect.
* Publish your post.
* View the post on the frontend, it should be displayed nicely.
