### PR TITLE
Social Notes: Add CTA to admin page

### DIFF
--- a/projects/plugins/social/changelog/add-social-notes-cta-button
+++ b/projects/plugins/social/changelog/add-social-notes-cta-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a CTA button to create a social note

--- a/projects/plugins/social/src/js/components/social-notes-toggle/styles.module.scss
+++ b/projects/plugins/social/src/js/components/social-notes-toggle/styles.module.scss
@@ -10,6 +10,16 @@
 	}
 }
 
+.button {
+	margin-top: calc( var( --spacing-base ) * 2 );
+	grid-column: span 2;
+	justify-self: flex-start;
+
+	@media ( min-width: 600px ) {
+		grid-column: 2;
+	}
+}
+
 .notes-options-wrapper {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/250

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added the button to the admin page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Social admin page
* Turning off Social Notes should still reload the page to remove the items from the sidebar
* Turning it on should not Reload the page, as we have the CTA available now
* The button should be disabled until the call finishes
* Clicking the button should direct you to the editor with the Social Note post type selected


![CleanShot 2024-04-18 at 12 17 51 png](https://github.com/Automattic/jetpack/assets/36671565/3c1df5a2-6c90-4aab-b45c-8b6b4dfa0be4)


