### PR TITLE
Site Migration: New setting for tracking the migration flow

### DIFF
--- a/projects/plugins/jetpack/changelog/89401-update-in-site-migration-setting
+++ b/projects/plugins/jetpack/changelog/89401-update-in-site-migration-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add in_site_migration_flow to the list of available site options to update and retrieve. This will be used as part of the Site Migration on-boarding flow.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1138,13 +1138,14 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 
 				case 'in_site_migration_flow':
+					$canonical_value = (int) (bool) $value;
 					if ( ! (bool) $value ) {
 						delete_option( 'in_site_migration_flow' );
 					} else {
-						update_option( 'in_site_migration_flow', (int) (bool) $value );
+						update_option( 'in_site_migration_flow', $canonical_value );
 					}
 
-					$updated[ $key ] = (int) (bool) $value;
+					$updated[ $key ] = $canonical_value;
 					break;
 
 				default:

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -45,6 +45,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 		),
 
 		'request_format'      => array(
+			'in_site_migration_flow'                  => '(bool) Whether the site is currently in the Site Migration signup flow.',
 			'blogname'                                => '(string) Blog name',
 			'blogdescription'                         => '(string) Blog description',
 			'default_pingback_flag'                   => '(bool) Notify blogs linked from article?',
@@ -468,6 +469,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'enable_blocks_comments'           => (bool) get_option( 'enable_blocks_comments', true ),
 						'highlander_comment_form_prompt'   => $this->get_highlander_comment_form_prompt_option(),
 						'jetpack_comment_form_color_scheme' => (string) get_option( 'jetpack_comment_form_color_scheme' ),
+						'in_site_migration_flow'           => (bool) get_option( 'in_site_migration_flow', 0 ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -1133,6 +1135,16 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						$updated[ $key ] = $value;
 					}
 
+					break;
+
+				case 'in_site_migration_flow':
+					if ( ! (bool) $value ) {
+						delete_option( 'in_site_migration_flow' );
+					} else {
+						update_option( 'in_site_migration_flow', (int) (bool) $value );
+					}
+
+					$updated[ $key ] = (int) (bool) $value;
 					break;
 
 				default:

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1139,7 +1139,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'in_site_migration_flow':
 					$canonical_value = (int) (bool) $value;
-					if ( ! (bool) $value ) {
+					if ( 0 === $canonical_value ) {
 						delete_option( 'in_site_migration_flow' );
 					} else {
 						update_option( 'in_site_migration_flow', $canonical_value );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -35,6 +35,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 		),
 
 		'request_format'  => array(
+			'in_site_migration_flow'                  => '(bool) Whether the site is currently in the Site Migration signup flow.',
 			'blogname'                                => '(string) Blog name',
 			'blogdescription'                         => '(string) Blog description',
 			'default_pingback_flag'                   => '(bool) Notify blogs linked from article?',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/89401

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

As part of the new Site Migration onboarding flow, we need to know if a new site is in the middle of the Site Migration Stepper flow.

This adds `in_site_migration_flow` to the list of site settings that can be set and retrieved from the `/rest/v1.2/sites/:siteId/settings` endpoint. We'll be updating Calypso to set this setting to `true` when the migration flow starts and `false` when it's done.

Then we'll use the presence of this setting to redirect the user appropriately when they click on the verification email for their account.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on your sandbox and sandbox the public-api.
* Pick any newly created Simple site and get the site id.
* In the https://developer.wordpress.com/docs/api/console/, do a `GET` query to `/rest/v1.4/site/:siteId/settings`.
* Scroll through the `settings` property of the response until you find `in_site_migration_flow` (you may have to expand some of the collapsed sections.
* Verify that the value of `in_site_migration_flow` is false.
![CleanShot 2024-04-18 at 07 51 14@2x](https://github.com/Automattic/jetpack/assets/917632/47986a37-7f05-4df1-99a0-7010e70df9e3)
* At this point, you may want to comment out line 36 of `class.wpcom-json-api-site-settings-endpoint.php` (which is `'group'               => '__do_not_document',`) so you can see the endpoint in the API console.
* Refresh the API console and select a `POST` request.
* Find the `/rest/v1.4/site/:siteId/settings` endpoint and set `in_site_migration_flow` to `1` in the body.
<img width="721" alt="CleanShot 2024-04-18 at 07 54 14@2x" src="https://github.com/Automattic/jetpack/assets/917632/e2dd3f16-a43f-4db7-b5b0-cc26ecf491e2">
* Make the `POST` request and verify there are no errors.
* Then make another `GET` request and verify that `in_site_migration_flow` is now true.