### PR TITLE
Jetpack Social | Direct non-admin authors to user connection if needed

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-direct-authors-to-user-connection
+++ b/projects/js-packages/publicize-components/changelog/update-direct-authors-to-user-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update the Social sidebar share post panel to direct non-admin authors to user connection if there is no user connection.

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.49.2",
+	"version": "0.49.3-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
@@ -1,3 +1,4 @@
+import { useConnection } from '@automattic/jetpack-connection';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import PublicizeConnection from '../connection';
 import PublicizeSettingsButton from '../settings-button';
@@ -8,6 +9,8 @@ export const ConnectionsList: React.FC = () => {
 	const { connections, toggleById } = useSocialMediaConnections();
 
 	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
+
+	const { isUserConnected } = useConnection();
 
 	return (
 		<ul className={ styles[ 'connections-list' ] }>
@@ -28,9 +31,11 @@ export const ConnectionsList: React.FC = () => {
 					/>
 				);
 			} ) }
-			<li>
-				<PublicizeSettingsButton />
-			</li>
+			{ isUserConnected ? (
+				<li>
+					<PublicizeSettingsButton />
+				</li>
+			) : null }
 		</ul>
 	);
 };

--- a/projects/js-packages/publicize-components/src/components/panel/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.jsx
@@ -59,7 +59,7 @@ const PublicizePanel = ( { prePublish, children } ) => {
 									  )
 							}
 							onChange={ togglePublicizeFeature }
-							checked={ isPublicizeEnabled }
+							checked={ isPublicizeEnabled && hasConnections }
 							disabled={ ! hasConnections }
 						/>
 					) }

--- a/projects/js-packages/publicize-components/src/social-store/reducer/index.js
+++ b/projects/js-packages/publicize-components/src/social-store/reducer/index.js
@@ -14,6 +14,7 @@ const reducer = combineReducers( {
 	socialImageGeneratorSettings,
 	autoConversionSettings,
 	hasPaidPlan: ( state = false ) => state,
+	userConnectionUrl: ( state = '' ) => state,
 } );
 
 export default reducer;

--- a/projects/js-packages/publicize-components/src/social-store/selectors/index.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/index.js
@@ -12,6 +12,7 @@ const selectors = {
 	...sharesData,
 	...socialImageGeneratorSettingsSelectors,
 	...autoConversionSettingsSelectors,
+	userConnectionUrl: state => state.userConnectionUrl,
 };
 
 export default selectors;

--- a/projects/plugins/jetpack/changelog/update-direct-authors-to-user-connection
+++ b/projects/plugins/jetpack/changelog/update-direct-authors-to-user-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add the userConnectionUrl to initial state to use in Social sidebar

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -757,6 +757,7 @@ class Jetpack_Gutenberg {
 				'supportedAdditionalConnections'  => $publicize->get_supported_additional_connections(),
 				'autoConversionSettings'          => $settings['autoConversionSettings'],
 				'jetpackSharingSettingsUrl'       => esc_url_raw( admin_url( 'admin.php?page=jetpack#/sharing' ) ),
+				'userConnectionUrl'               => esc_url_raw( admin_url( 'admin.php?page=my-jetpack#/connection' ) ),
 			);
 		}
 

--- a/projects/plugins/social/changelog/update-direct-authors-to-user-connection
+++ b/projects/plugins/social/changelog/update-direct-authors-to-user-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update the Social sidebar share post panel to direct non-admin authors to user connection if there is no user connection.

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -350,6 +350,7 @@ class Jetpack_Social {
 					'autoConversionSettings'          => $settings['autoConversionSettings'],
 					'dismissedNotices'                => Dismissed_Notices::get_dismissed_notices(),
 					'supportedAdditionalConnections'  => $publicize->get_supported_additional_connections(),
+					'userConnectionUrl'               => esc_url_raw( admin_url( 'admin.php?page=my-jetpack#/connection' ) ),
 				),
 			)
 		);


### PR DESCRIPTION
In https://github.com/Automattic/jetpack/issues/35367#issuecomment-2061323904, it was suggested that the block editor sidebar UI should be updated to offer non-admin authors to connect their wordpress.com account before asking to add social media connections

Fixes #35367 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the sidebar links to direct non-admin authors to connect their WPCOM user account to be able to add social media accounts
* Disabled "Share this post" if there are no connections
* Removed "Connect an account" link if there is no user connection

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* On a fresh site with no connections, create a non-admin author account
* Login via the author account
* Goto Jetpack/Social sidebar
* Under "Share this post", confirm that you see `"You must connect your WordPress.com account to be able to add social media connections."` text and the `"Connect now"` link
* Click on "Connect now"
* Confirm that it leads to user connection page on My Jetpack
* Connect the user account and come back to the sidebar after reloading the page
* Confirm that the above notice is gone.
* Confirm that "Share when publishing" option is turned OFF when there are no connections.
* Confirm that you see the notice, `"Sharing is disabled because there are no social media accounts connected."`
* Confirm that you see the "Connect an account" link
* Click on "Connect an account" link and add a connection.
* Come back to Jetpack sidebar
* Confirm that the `"Sharing is disabled..."` notice is gone
* Confirm that you see the + icon (Connect an account) after the connections list
* Confirm that everything works as expected for the admin account

- When there is no user connection
    <img width="288" alt="Screenshot 2024-04-18 at 4 56 24 PM" src="https://github.com/Automattic/jetpack/assets/18226415/80309b53-fa59-456e-aac9-240a51fac588">
- When there is no user connection but there are some global social media connections
    <img width="285" alt="Screenshot 2024-04-18 at 5 10 52 PM" src="https://github.com/Automattic/jetpack/assets/18226415/87e4f19f-b716-4b5c-9002-5791e249ef5f">
- When there is user connection but no social media connections
    <img width="288" alt="image" src="https://github.com/Automattic/jetpack/assets/18226415/9881970d-1f68-41ca-8f75-181dd1646c52">

- When there is user connection as well as some social media connections
     <img width="284" alt="Screenshot 2024-04-18 at 5 13 43 PM" src="https://github.com/Automattic/jetpack/assets/18226415/e8fd446b-fda7-49df-bb38-a1cfaa5c8381">


