### PR TITLE
Jetpack Google Fonts: Add filter to conditionally skip loading

### DIFF
--- a/projects/plugins/jetpack/changelog/update-google-fonts-skip
+++ b/projects/plugins/jetpack/changelog/update-google-fonts-skip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack Google Fonts: Add filter to conditionally skip loading

--- a/projects/plugins/jetpack/modules/google-fonts/load.php
+++ b/projects/plugins/jetpack/modules/google-fonts/load.php
@@ -8,6 +8,21 @@
 add_action(
 	'plugins_loaded',
 	function () {
+		/**
+		* Filters whether to skip loading the Jetpack Google Fonts module.
+		*
+		* This filter allows skipping the loading of the Jetpack Google Fonts module
+		* based on specific conditions or requirements. By default, the module will
+		* load normally. If the filter returns true, the module will be skipped.
+		*
+		* @since $$next-version$$
+		*
+		* @param bool $skip Whether to skip loading the Jetpack Google Fonts module. Default false.
+		*/
+		if ( apply_filters( 'jetpack_google_fonts_skip_load', false ) ) {
+			return;
+		}
+
 		if ( class_exists( 'WP_Font_Face' ) ) {
 			// WordPress 6.5 or above with the new Font Library.
 			require_once __DIR__ . '/current/load-google-fonts.php';

--- a/projects/plugins/jetpack/modules/google-fonts/load.php
+++ b/projects/plugins/jetpack/modules/google-fonts/load.php
@@ -15,6 +15,8 @@ add_action(
 		* based on specific conditions or requirements. By default, the module will
 		* load normally. If the filter returns true, the module will be skipped.
 		*
+		* @module google-fonts
+		*
 		* @since $$next-version$$
 		*
 		* @param bool $skip Whether to skip loading the Jetpack Google Fonts module. Default false.


### PR DESCRIPTION


## Proposed changes:

* Add an optional filter to skip loading JP google fonts. Crucially, it happens at [plugins_loaded, 999] time, so we can decide to not load this after jetpack is loaded.

**Context**: For WPCOM, I am looking at ways to reduce the work done by suspended sites. We'd like a way to turn off this module after we've decided a site is suspended. For more info, see: D145929-code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

