### PR TITLE
Ensure gutenberg assets are enqueued only when needed

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-style-enqueue
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-style-enqueue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix enqueuing editor styles

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-gutenberg-editor.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-gutenberg-editor.php
@@ -51,6 +51,8 @@ class Verbum_Gutenberg_Editor {
 
 	/**
 	 * Enqueue the assets for the Gutenberg editor
+	 *
+	 * In case the page is singular and has comment closed or front page with comments closed we avoid the enqueueing
 	 */
 	public function enqueue_assets() {
 		if (

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-gutenberg-editor.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-gutenberg-editor.php
@@ -53,6 +53,13 @@ class Verbum_Gutenberg_Editor {
 	 * Enqueue the assets for the Gutenberg editor
 	 */
 	public function enqueue_assets() {
+		if (
+			! ( is_singular() && comments_open() )
+			&& ! ( is_front_page() && is_page() && comments_open() )
+		) {
+			return;
+		}
+
 		$vbe_cache_buster = filemtime( ABSPATH . '/widgets.wp.com/verbum-block-editor/build_meta.json' );
 
 		wp_enqueue_style(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
This PR fixes the enqueuing of the verbum editor styles. 
This should happen only when needed since it can affect lighthouse scores.


Fixes #
p1713466488341179-slack-C02ECE3ML


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Shortcircuit enqueuing with checks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this PR to your sandbox
* Sandbox 3cekY-p2
* Check when visiting the site - the verbum editor styles should not be enqueued
* Open a simple site, and visit the home page - the verbum editor styles should not be enqueued
* Check if the block editor is working properly - small regression test
*