### PR TITLE
Sitemaps: Consider lastmod date from jetpack_page_sitemap_other_urls filter

### DIFF
--- a/projects/plugins/jetpack/changelog/sitemap-consider-other-urls-lastmod
+++ b/projects/plugins/jetpack/changelog/sitemap-consider-other-urls-lastmod
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sitemaps: Ensured that the last modification date from the jetpack_page_sitemap_other_urls filter is considered for the last modification date of the generated sitemap.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -686,6 +686,9 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 
 					if ( true === $buffer->append( $item['xml'] ) ) {
 						$last_post_id = -$index;
+						if ( isset( $url['lastmod'] ) ) {
+							$buffer->view_time( jp_sitemap_datetime( $url['lastmod'] ) );
+						}
 					} else {
 						break;
 					}

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/test-class.sitemap-builder.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/test-class.sitemap-builder.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Tests for the Jetpack_Sitemap_Builder class.
+ *
+ * @package automattic/jetpack
+ * @since $$next-version$$
+ */
+
+/**
+ * Test class for Jetpack_Sitemap_Builder.
+ *
+ * @since $$next-version$$
+ */
+class WP_Test_Jetpack_Sitemap_Builder extends WP_UnitTestCase {
+
+	/**
+	 * "lastmod" date from other URLs filter is considered when building a sitemap.
+	 *
+	 * @covers Jetpack_Sitemap_Builder::build_one_page_sitemap
+	 * @group jetpack-sitemap
+	 * @since $$next-version$$
+	 */
+	public function test_build_one_page_sitemap_considers_lastmod_from_other_urls() {
+		$other_urls = array(
+			array(
+				'loc'     => 'https://example.com/1',
+				'lastmod' => '2019-01-01T00:00:00Z',
+			),
+			array(
+				'loc'     => 'https://example.com/2',
+				'lastmod' => '2024-03-08T01:02:03Z',
+			),
+			array(
+				'loc'     => 'https://example.com/3',
+				'lastmod' => '2022-02-02T00:00:00Z',
+			),
+		);
+
+		$callback = function () use ( $other_urls ) {
+			return $other_urls;
+		};
+
+		add_filter( 'jetpack_page_sitemap_other_urls', $callback );
+
+		$builder = new Jetpack_Sitemap_Builder();
+		$result  = $builder->build_one_page_sitemap( 1, 1 );
+
+		remove_filter( 'jetpack_page_sitemap_other_urls', $callback );
+
+		$this->assertSame( '2024-03-08T01:02:03Z', $result['last_modified'], 'Last modified date is not the one from the other_urls filter.' );
+	}
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensured that the last modification date from the jetpack_page_sitemap_other_urls filter is considered for the last modification date of the generated sitemap.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add a test plugin like so (just a single PHP file into `wp-content/plugins` (make sure to use a more recent date/time for `lastmod` than all other changes in your sitemap, like just now):
```
<?php
/*
 * Plugin Name: Sitemap test
 */

add_filter( 'jetpack_page_sitemap_other_urls', function ( $urls ) {
        return [['loc' => 'https://example.com', 'lastmod' => '2024-04-19T00:00:00Z']];
});
```
2. Activate the plugin
3. Enable sitemaps in the jetpack settings
4. Enable search engine indexing on `/wp-admin/options-reading.php` (sitemap will refuse to build otherwise)
5. Run `jetpack docker wp jetpack sitemap rebuild` to rebuild the sitemap
6. Access your sitemap index (`/sitemap.xml`) and verify that the `lastmod` for (likely) the `sitemap-1.xml` lines up with the date and time that you have added in your custom filter plugin

Without this patch, it would just have been ignored and the lastmod date therefore not be accurate.