### PR TITLE
Google Docs Embed: fix non localized strings

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-google-embed-variations-translations
+++ b/projects/plugins/jetpack/changelog/fix-google-embed-variations-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Google Docs Embed: fix non localized strings

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/block.json
@@ -24,37 +24,5 @@
 		"variation": {
 			"type": "string"
 		}
-	},
-	"variations": [
-		{
-			"name": "jetpack/google-docs",
-			"isDefault": true,
-			"title": "Google Docs",
-			"description": "Embed a Google Document.",
-			"icon": "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z' /><path fill='#FDFFFF' d='M42,0l22,22H42V0z' /><path fill='#FDFFFF' d='M50,39H14v-5h36V39z M50,46H14v5h36V46z M40,58H14v5h26V58z' /></svg>",
-			"keywords": [ "document", "gsuite", "doc" ],
-			"attributes": { "variation": "jetpack/google-docs" },
-			"isActive": [ "variation" ]
-		},
-		{
-			"name": "jetpack/google-sheets",
-			"isDefault": true,
-			"title": "Google Sheets",
-			"description": "Embed a Google Sheet.",
-			"icon": "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z' /><path fill='#FDFFFF' d='M42,0l22,22H42V0z' /><path fill='#FDFFFF' d='M12,34.5v28h40v-28H12z M17,39.5h12.5V46H17V39.5z M17,51h12.5v6.5H17V51z M47,57.5H34.5V51H47V57.5z M47,46 H34.5v-6.5H47V46z' /></svg>",
-			"keywords": [ "sheet", "spreadsheet" ],
-			"attributes": { "variation": "jetpack/google-sheets" },
-			"isActive": [ "variation" ]
-		},
-		{
-			"name": "jetpack/google-slides",
-			"isDefault": true,
-			"title": "Google Slides",
-			"description": "Embed a Google Slides presentation.",
-			"icon": "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z' /><path fill='#FDFFFF' d='M42,0l22,22H42V0z' /><path fill='#FDFFFF' d='M12,34.5v28h40v-28H12z M47,57.5H17v-18h30V57.5z' /></svg>",
-			"keywords": [ "slide", "presentation", "deck" ],
-			"attributes": { "variation": "jetpack/google-slides" },
-			"isActive": [ "variation" ]
-		}
-	]
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/edit.js
@@ -1,12 +1,10 @@
-import { getBlockIconProp } from '@automattic/jetpack-shared-extension-utils';
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, SelectControl } from '@wordpress/components';
 import { Fragment, useEffect } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
-import metadata from './block.json';
 import Embed from './embed';
+import variations from './variations';
 
-const { variations } = metadata;
 const docsVariation = variations?.find( v => v.name === 'jetpack/google-docs' );
 const sheetsVariation = variations?.find( v => v.name === 'jetpack/google-sheets' );
 const slidesVariation = variations?.find( v => v.name === 'jetpack/google-slides' );
@@ -14,21 +12,21 @@ const slidesVariation = variations?.find( v => v.name === 'jetpack/google-slides
 const GOOGLE_DOCUMENT = {
 	type: 'document',
 	title: docsVariation?.title,
-	icon: getBlockIconProp( docsVariation ),
+	icon: docsVariation.icon,
 	patterns: [ /^(http|https):\/\/(docs\.google.com)\/document\/d\/([A-Za-z0-9_-]+).*?$/i ],
 };
 
 const GOOGLE_SPREADSHEET = {
 	type: 'spreadsheets',
 	title: sheetsVariation?.title,
-	icon: getBlockIconProp( sheetsVariation ),
+	icon: sheetsVariation.icon,
 	patterns: [ /^(http|https):\/\/(docs\.google.com)\/spreadsheets\/d\/([A-Za-z0-9_-]+).*?$/i ],
 };
 
 const GOOGLE_SLIDE = {
 	type: 'presentation',
 	title: slidesVariation?.title,
-	icon: getBlockIconProp( slidesVariation ),
+	icon: slidesVariation.icon,
 	patterns: [ /^(http|https):\/\/(docs\.google.com)\/presentation\/d\/([A-Za-z0-9_-]+).*?$/i ],
 };
 

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/editor.js
@@ -3,6 +3,7 @@ import metadata from './block.json';
 import edit from './edit';
 import save from './save'; // TODO: Replace
 import transforms from './transforms';
+import variations from './variations';
 
 import './editor.scss';
 
@@ -10,4 +11,5 @@ registerJetpackBlockFromMetadata( metadata, {
 	edit,
 	save,
 	transforms: transforms( metadata.name ),
+	variations,
 } );

--- a/projects/plugins/jetpack/extensions/blocks/google-docs-embed/variations.js
+++ b/projects/plugins/jetpack/extensions/blocks/google-docs-embed/variations.js
@@ -1,0 +1,42 @@
+import { getBlockIconProp } from '@automattic/jetpack-shared-extension-utils';
+import { __ } from '@wordpress/i18n';
+
+const variations = [
+	{
+		name: 'jetpack/google-docs',
+		isDefault: true,
+		title: __( 'Google Docs', 'jetpack' ),
+		description: __( 'Embed a Google Document.', 'jetpack' ),
+		icon: "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z' /><path fill='#FDFFFF' d='M42,0l22,22H42V0z' /><path fill='#FDFFFF' d='M50,39H14v-5h36V39z M50,46H14v5h36V46z M40,58H14v5h26V58z' /></svg>",
+		keywords: [ __( 'document', 'jetpack' ), __( 'gsuite', 'jetpack' ), __( 'doc', 'jetpack' ) ],
+		attributes: { variation: 'jetpack/google-docs' },
+		isActive: [ 'variation' ],
+	},
+	{
+		name: 'jetpack/google-sheets',
+		isDefault: true,
+		title: __( 'Google Sheets', 'jetpack' ),
+		description: __( 'Embed a Google Sheet.', 'jetpack' ),
+		icon: "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z' /><path fill='#FDFFFF' d='M42,0l22,22H42V0z' /><path fill='#FDFFFF' d='M12,34.5v28h40v-28H12z M17,39.5h12.5V46H17V39.5z M17,51h12.5v6.5H17V51z M47,57.5H34.5V51H47V57.5z M47,46 H34.5v-6.5H47V46z' /></svg>",
+		keywords: [ __( 'sheet', 'jetpack' ), __( 'spreadsheet', 'jetpack' ) ],
+		attributes: { variation: 'jetpack/google-sheets' },
+		isActive: [ 'variation' ],
+	},
+	{
+		name: 'jetpack/google-slides',
+		isDefault: true,
+		title: __( 'Google Slides', 'jetpack' ),
+		description: __( 'Embed a Google Slides presentation.', 'jetpack' ),
+		icon: "<svg viewBox='0 0 64 88' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M58,88H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h36l22,22v60C64,85.3,61.3,88,58,88z' /><path fill='#FDFFFF' d='M42,0l22,22H42V0z' /><path fill='#FDFFFF' d='M12,34.5v28h40v-28H12z M47,57.5H17v-18h30V57.5z' /></svg>",
+
+		keywords: [
+			__( 'slide', 'jetpack' ),
+			__( 'presentation', 'jetpack' ),
+			__( 'deck', 'jetpack' ),
+		],
+		attributes: { variation: 'jetpack/google-slides' },
+		isActive: [ 'variation' ],
+	},
+].map( variation => ( { ...variation, icon: getBlockIconProp( variation ) } ) );
+
+export default variations;

--- a/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
+++ b/projects/plugins/jetpack/extensions/shared/register-jetpack-block.js
@@ -83,16 +83,6 @@ export function registerJetpackBlockFromMetadata( metadata, settings, childBlock
 		icon: getBlockIconProp( metadata ),
 		attributes: metadata.attributes || {},
 	};
-	const { variations } = metadata;
-
-	if ( Array.isArray( variations ) && variations.length > 0 ) {
-		mergedSettings.variations = variations.map( variation => {
-			return {
-				...variation,
-				icon: getBlockIconProp( variation ),
-			};
-		} );
-	}
 
 	return registerJetpackBlock( metadata, mergedSettings, childBlocks, prefix );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The Google Docs Embed block has several variations whose title, description, and keywords were not localized. This issue is caused by a workaround implemented in `registerJetpackBlockFromMetadata` to allow custom icons. This PR solves the issue by:
- Removing the lines of code causing the issue in `registerJetpackBlockFromMetadata`
- Defining the variations in a separate `variations.js` file instead of the `block.json` metadata file. This is necessary to ensure we can use icons other than dashicons.

Since the Google Docs Embed block is the only block declaring its variations in its metadata `block.json` file, the changes in `registerJetpackBlockFromMetadata` shouldn't impact other blocks.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pxLjZ-8t1-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

At the time of testing, translations might not have been picked up yet. Let's just do some regression testing.

- Spin up a test site with this branch
- Connect Jetpack
- Create a new post/page
- Add a _Google Docs_, _Google Sheets_, and _Google Slides_ blocks
- Notice everything works as in production