### PR TITLE
A4A: Add "wp-admin-url" query parameter to dashboard link.

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/add-a4a-wp-admin-url-query-param
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-a4a-wp-admin-url-query-param
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added additional query parameter when redirecting to A4A dashboard.
+
+

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/connected-card/index.jsx
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/connected-card/index.jsx
@@ -18,7 +18,8 @@ import styles from './styles.module.scss';
  */
 function SiteConnectedContent() {
 	const navigateToDashboard = useCallback( () => {
-		window.location.href = 'https://agencies.automattic.com?source=client-plugin';
+		const currentUrl = encodeURIComponent( window.location.href );
+		window.location.href = `https://agencies.automattic.com?source=client-plugin&wp-admin-url=${ currentUrl }`;
 	}, [] );
 
 	return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/automattic-for-agencies-dev/issues/48

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the current URL as a query argument to the A4A dashboard URL, which the dashboard will eventually use for "return to wp-admin" links in plugin flows.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/automattic-for-agencies-dev/issues/48

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a connected site, go to the A4A plugin page.
* Click the dashboard button/link.
* Validate the URL to your wp-admin A4A plugin page is included in the query string.

