### PR TITLE
Monetize: Move menu item under the Jetpack menu for all Classic interface users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/monetize-move-under-jetpack-menu-to-all-classic-users
+++ b/projects/packages/jetpack-mu-wpcom/changelog/monetize-move-under-jetpack-menu-to-all-classic-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Monetize: Move menu item under Jetpack menu for all Classic interface users

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Check if the current user has a WordPress.com account connected.
@@ -217,7 +218,11 @@ add_action( 'admin_bar_menu', 'add_all_sites_menu_to_masterbar', 15 );
  * Add the WordPress.com submenu items related to Jetpack under the Jetpack menu on the wp-admin sidebar.
  */
 function wpcom_add_jetpack_menu_item() {
-	if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
+	/*
+	 * Do not display any menu on WoA and WordPress.com Simple sites (unless Classic wp-admin is enabled).
+	 * They already get a menu item under Users via nav-unification.
+	 */
+	if ( ( new Host() )->is_wpcom_platform() && get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
 		return;
 	}
 

--- a/projects/plugins/jetpack/changelog/update-monetize-to-all-classic-interface-users
+++ b/projects/plugins/jetpack/changelog/update-monetize-to-all-classic-interface-users
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Monetize: Move menu item under Jetpack menu for all Classic interface users

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -350,7 +350,9 @@ class Admin_Menu extends Base_Admin_Menu {
 		$this->hide_submenu_page( 'tools.php', 'delete-blog' );
 
 		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack' ), __( 'Marketing', 'jetpack' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain, null, 0 );
-		add_submenu_page( 'tools.php', esc_attr__( 'Monetize', 'jetpack' ), __( 'Monetize', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
+		if ( ! $this->use_wp_admin_interface() ) {
+			add_submenu_page( 'tools.php', esc_attr__( 'Monetize', 'jetpack' ), __( 'Monetize', 'jetpack' ), 'manage_options', 'https://wordpress.com/earn/' . $this->domain, null, 1 );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Slack p1713541818507469/1713463217.428849-slack-C03FE3T479R

## Proposed changes:
Move Monetize menu item under the Jetpack menu for all Classic interface users to make it consistent with Subscribers.

| Default interface | Classic Interface |
| --- | --- | 
| ![image](https://github.com/Automattic/jetpack/assets/402286/b37d74a1-6797-46e1-9117-3c2c47486442) | ![image](https://github.com/Automattic/jetpack/assets/402286/81a7529d-77b8-46cc-82f0-e09245bcb5fe)|

## Jetpack product discussion
Slack p1713541818507469/1713463217.428849-slack-C03FE3T479R

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Apply this PR to mu-wpcom-plugin & jetpack on Jetpack Beta as mentioned in the first comment.
* With a site with Classic Interface
* `Monetize` should show under `Jetpack` menu and not under `Tools`.
* With a non-classic interface site
* `Monetize` should show under `Tools` and not under `Jetpack`.
* Check everything under wp-admin and Calypso