### PR TITLE
Debug Helper: restrict REST API access to site admins.

### DIFF
--- a/projects/plugins/debug-helper/changelog/update-debug-helper-rest-route-permissions
+++ b/projects/plugins/debug-helper/changelog/update-debug-helper-rest-route-permissions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+REST API: restrict access to authenticated site admins

--- a/projects/plugins/debug-helper/modules/class-cookie-state.php
+++ b/projects/plugins/debug-helper/modules/class-cookie-state.php
@@ -49,7 +49,9 @@ class Cookie_State {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'save' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => function () {
+						return current_user_can( 'manage_options' );
+				},
 				'args'                => array(
 					'key'   => array(
 						'description' => 'The state key.',

--- a/projects/plugins/debug-helper/modules/class-mocker.php
+++ b/projects/plugins/debug-helper/modules/class-mocker.php
@@ -51,7 +51,9 @@ class Mocker {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'run' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => function () {
+						return current_user_can( 'manage_options' );
+				},
 			)
 		);
 	}


### PR DESCRIPTION
## Proposed changes:

Restrict API access to authenticated site admins for those Debug tools.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* Internal reference: 2472977-h1

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* In your development environment, activate the Jetpack Debug tools plugin
* Go to the Jetpack Debug menu
* Enable the Mocker feature
* Go to Jetpack Debug > Mocker
* Test the Mocker
* You should not get any errors.
