### PR TITLE
phan: Add stubs for AMP and AMP for WP plugins

### DIFF
--- a/.phan/config.base.php
+++ b/.phan/config.base.php
@@ -23,6 +23,7 @@
  *   - parse_file_list: (array) Files to parse but not analyze. Equivalent to listing in both 'file_list' and 'exclude_analysis_directory_list'.
  *   - stubs: (array) Predefined stubs to load. Default is `array( 'wordpress', 'wp-cli' )`.
  *      - akismet: Stubs from .phan/stubs/akismet-stubs.php.
+ *      - amp: Stubs from .phan/stubs/amp-stubs.php.
  *      - full-site-editing: Stubs from .phan/stubs/full-site-editing-stubs.php.
  *      - photon-opencv: Stubs from .phan/stubs/photon-opencv-stubs.php.
  *      - woocommerce: Stubs from php-stubs/woocommerce.
@@ -58,6 +59,9 @@ function make_phan_config( $dir, $options = array() ) {
 		switch ( $stub ) {
 			case 'akismet':
 				$stubs[] = "$root/.phan/stubs/akismet-stubs.php";
+				break;
+			case 'amp':
+				$stubs[] = "$root/.phan/stubs/amp-stubs.php";
 				break;
 			case 'full-site-editing':
 				$stubs[] = "$root/.phan/stubs/full-site-editing-stubs.php";

--- a/.phan/stubs/amp-stubs.php
+++ b/.phan/stubs/amp-stubs.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Stubs automatically generated from AMP 2.5.3 and AMP for WP 1.0.94
+ * using the definition file `tools/stubs/amp-stub-defs.php` in the Jetpack monorepo.
+ *
+ * Do not edit this directly! Run tools/stubs/update-stubs.sh to regenerate it.
+ */
+
+/**
+ * Whether this is in 'canonical mode'.
+ *
+ * Themes can register support for this with `add_theme_support( AMP_Theme_Support::SLUG )`:
+ *
+ * ```php
+ * add_theme_support( AMP_Theme_Support::SLUG );
+ * ```
+ *
+ * This will serve templates in AMP-first, allowing you to use AMP components in your theme templates.
+ * If you want to make available in transitional mode, where templates are served in AMP or non-AMP documents, do:
+ *
+ * ```php
+ * add_theme_support( AMP_Theme_Support::SLUG, array(
+ *     'paired' => true,
+ * ) );
+ * ```
+ *
+ * Transitional mode is also implied if you define a `template_dir`:
+ *
+ * ```php
+ * add_theme_support( AMP_Theme_Support::SLUG, array(
+ *     'template_dir' => 'amp',
+ * ) );
+ * ```
+ *
+ * If you want to have AMP-specific templates in addition to serving AMP-first, do:
+ *
+ * ```php
+ * add_theme_support( AMP_Theme_Support::SLUG, array(
+ *     'paired'       => false,
+ *     'template_dir' => 'amp',
+ * ) );
+ * ```
+ *
+ * @see AMP_Theme_Support::read_theme_support()
+ * @return boolean Whether this is in AMP 'canonical' mode, that is whether it is AMP-first and there is not a separate (paired) AMP URL.
+ */
+function amp_is_canonical()
+{
+}
+/**
+ * Determines whether the legacy AMP post templates are being used.
+ *
+ * @since 2.0
+ * @return bool
+ */
+function amp_is_legacy()
+{
+}
+/**
+ * Determine whether AMP is available for the current URL.
+ *
+ * @since 2.0
+ *
+ * @return bool Whether there is an AMP version for the provided URL.
+ * @global string $pagenow
+ * @global WP_Query $wp_query
+ */
+function amp_is_available()
+{
+}
+/**
+ * Retrieves the full AMP-specific permalink for the given post ID.
+ *
+ * On a site in Standard mode, this is the same as `get_permalink()`.
+ *
+ * @since 0.1
+ *
+ * @param int $post_id Post ID.
+ * @return string AMP permalink.
+ */
+function amp_get_permalink($post_id)
+{
+}
+/**
+ * Determine whether the current request is for an AMP page.
+ *
+ * This function cannot be called before the parse_query action because it needs to be able
+ * to determine the queried object is able to be served as AMP. If 'amp' theme support is not
+ * present, this function returns true just if the query var is present. If theme support is
+ * present, then it returns true in transitional mode if an AMP template is available and the query
+ * var is present, or else in standard mode if just the template is available.
+ *
+ * @since 2.0 Formerly known as is_amp_endpoint().
+ *
+ * @return bool Whether it is the AMP endpoint.
+ * @global WP_Query $wp_query
+ */
+function amp_is_request()
+{
+}
+/**
+ * Determine whether the current response being served as AMP.
+ *
+ * This function cannot be called before the parse_query action because it needs to be able
+ * to determine the queried object is able to be served as AMP. If 'amp' theme support is not
+ * present, this function returns true just if the query var is present. If theme support is
+ * present, then it returns true in transitional mode if an AMP template is available and the query
+ * var is present, or else in standard mode if just the template is available.
+ *
+ * @since 0.1
+ * @since 2.0 Renamed to AMP-prefixed version, amp_is_request().
+ * @deprecated Use amp_is_request() instead.
+ *
+ * @return bool Whether it is the AMP endpoint.
+ */
+function is_amp_endpoint()
+{
+}
+/**
+ * Class AMP_Options_Manager
+ *
+ * @internal
+ */
+class AMP_Options_Manager
+{
+    /**
+     * Get plugin option.
+     *
+     * @param string $option  Plugin option name.
+     * @param bool   $default Default value.
+     *
+     * @return mixed Option value.
+     */
+    public static function get_option($option, $default = \false)
+    {
+    }
+}
+/**
+ * Registers a submenu page to access the AMP template editor panel in the Customizer.
+ *
+ * @internal
+ */
+function amp_add_customizer_link()
+{
+}
+// AMP endpoint Verifier
+/**
+ * @phan-return mixed Dummy doc for stub.
+ */
+function ampforwp_is_amp_endpoint()
+{
+}

--- a/projects/packages/blocks/.phan/baseline.php
+++ b/projects/packages/blocks/.phan/baseline.php
@@ -11,15 +11,15 @@ return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 2 occurrences
     // PhanUndeclaredClassMethod : 2 occurrences
+    // PhanDeprecatedFunction : 1 occurrence
     // PhanPluginDuplicateConditionalNullCoalescing : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanUndeclaredClassInCallable : 1 occurrence
     // PhanUndeclaredClassReference : 1 occurrence
-    // PhanUndeclaredFunction : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-blocks.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction'],
+        'src/class-blocks.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
         'tests/php/test-blocks.php' => ['PhanTypeMismatchArgument'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/blocks/.phan/config.php
+++ b/projects/packages/blocks/.phan/config.php
@@ -10,4 +10,4 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'amp' ) ) );

--- a/projects/packages/blocks/changelog/add-phan-amp-stubs
+++ b/projects/packages/blocks/changelog/add-phan-amp-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update Phan config to use AMP stubs. No change to functionality.
+
+

--- a/projects/packages/lazy-images/.phan/baseline.php
+++ b/projects/packages/lazy-images/.phan/baseline.php
@@ -10,13 +10,13 @@
 return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 2 occurrences
+    // PhanDeprecatedFunction : 1 occurrence
     // PhanParamTooMany : 1 occurrence
     // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
-    // PhanUndeclaredFunction : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/lazy-images.php' => ['PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredFunction'],
+        'src/lazy-images.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchPropertyProbablyReal'],
         'tests/php/test_class.lazy-images.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/lazy-images/.phan/config.php
+++ b/projects/packages/lazy-images/.phan/config.php
@@ -10,4 +10,4 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'amp' ) ) );

--- a/projects/packages/lazy-images/changelog/add-phan-amp-stubs
+++ b/projects/packages/lazy-images/changelog/add-phan-amp-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update Phan config to use AMP stubs. No change to functionality.
+
+

--- a/projects/packages/stats/.phan/baseline.php
+++ b/projects/packages/stats/.phan/baseline.php
@@ -14,7 +14,6 @@ return [
     // PhanUnextractableAnnotationSuffix : 5 occurrences
     // PhanTypeVoidAssignment : 4 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 2 occurrences
-    // PhanUndeclaredFunction : 2 occurrences
     // PhanDeprecatedFunction : 1 occurrence
     // PhanTypeMismatchProperty : 1 occurrence
     // PhanTypeMismatchReturn : 1 occurrence
@@ -23,7 +22,7 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-options.php' => ['PhanUnextractableAnnotationSuffix'],
-        'src/class-tracking-pixel.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredFunction', 'PhanUnextractableAnnotationSuffix'],
+        'src/class-tracking-pixel.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUnextractableAnnotationSuffix'],
         'src/class-wpcom-stats.php' => ['PhanTypeMismatchReturn', 'PhanUnextractableAnnotationSuffix'],
         'tests/php/test-main.php' => ['PhanParamTooMany', 'PhanTypeVoidAssignment'],
         'tests/php/test-options.php' => ['PhanTypeVoidAssignment'],

--- a/projects/packages/stats/.phan/config.php
+++ b/projects/packages/stats/.phan/config.php
@@ -10,4 +10,4 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'amp' ) ) );

--- a/projects/packages/stats/changelog/add-phan-amp-stubs
+++ b/projects/packages/stats/changelog/add-phan-amp-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update Phan config to use AMP stubs. No change to functionality.
+
+

--- a/projects/packages/stats/src/class-package-version.php
+++ b/projects/packages/stats/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Stats;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '0.12.1';
+	const PACKAGE_VERSION = '0.12.2-alpha';
 
 	const PACKAGE_SLUG = 'stats';
 

--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -38,7 +38,6 @@ return [
     // PhanTypeMismatchReturnNullable : 2 occurrences
     // PhanTypePossiblyInvalidDimOffset : 2 occurrences
     // PhanTypeSuspiciousStringExpression : 2 occurrences
-    // PhanUndeclaredFunction : 2 occurrences
     // PhanDeprecatedFunction : 1 occurrence
     // PhanNoopNew : 1 occurrence
     // PhanParamTooManyCallable : 1 occurrence
@@ -50,6 +49,7 @@ return [
     // PhanTypeMismatchDefault : 1 occurrence
     // PhanTypeMismatchProperty : 1 occurrence
     // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
+    // PhanUndeclaredFunction : 1 occurrence
     // PhanUndeclaredMethodInCallable : 1 occurrence
     // PhanUndeclaredStaticMethod : 1 occurrence
     // PhanUndeclaredTypeParameter : 1 occurrence
@@ -83,7 +83,7 @@ return [
         'src/modules/class-network-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
         'src/modules/class-plugins.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredMethod'],
-        'src/modules/class-posts.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginUseReturnValueInternalKnown', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
+        'src/modules/class-posts.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginUseReturnValueInternalKnown', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-protect.php' => ['PhanUndeclaredClassMethod'],
         'src/modules/class-term-relationships.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument'],
         'src/modules/class-terms.php' => ['PhanAccessMethodInternal', 'PhanParamSignatureMismatch'],

--- a/projects/packages/sync/.phan/config.php
+++ b/projects/packages/sync/.phan/config.php
@@ -10,4 +10,4 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'woocommerce', 'woocommerce-internal' ) ) );
+return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'amp', 'woocommerce', 'woocommerce-internal' ) ) );

--- a/projects/packages/sync/changelog/add-phan-amp-stubs
+++ b/projects/packages/sync/changelog/add-phan-amp-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update Phan config to use AMP stubs. No change to functionality.
+
+

--- a/projects/plugins/boost/.phan/baseline.php
+++ b/projects/plugins/boost/.phan/baseline.php
@@ -16,10 +16,10 @@ return [
     // PhanTypeMissingReturn : 10+ occurrences
     // PhanTypeArraySuspicious : 9 occurrences
     // PhanTypeMismatchArgument : 9 occurrences
-    // PhanUndeclaredFunction : 8 occurrences
     // PhanParamTooMany : 7 occurrences
     // PhanPossiblyUndeclaredVariable : 6 occurrences
     // PhanUndeclaredClassMethod : 6 occurrences
+    // PhanUndeclaredFunction : 6 occurrences
     // PhanUndeclaredConstant : 5 occurrences
     // PhanCommentParamOnEmptyParamList : 3 occurrences
     // PhanPluginUseReturnValueInternalKnown : 3 occurrences
@@ -101,10 +101,10 @@ return [
         'app/modules/optimizations/page-cache/pre-wordpress/Logger.php' => ['PhanCoalescingNeverNull', 'PhanPluginDuplicateConditionalNullCoalescing'],
         'app/modules/optimizations/page-cache/pre-wordpress/Request.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchPropertyDefault'],
         'app/modules/optimizations/page-cache/pre-wordpress/storage/File_Storage.php' => ['PhanTypeMismatchArgument'],
-        'app/modules/optimizations/render-blocking-js/class-render-blocking-js.php' => ['PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMissingReturn', 'PhanUndeclaredFunction'],
+        'app/modules/optimizations/render-blocking-js/class-render-blocking-js.php' => ['PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMissingReturn'],
         'app/modules/performance-history/Performance_History.php' => ['PhanTypeMissingReturn'],
         'app/rest-api/permissions/Nonce.php' => ['PhanParamTooMany'],
-        'compatibility/amp.php' => ['PhanUndeclaredClassInCallable', 'PhanUndeclaredFunction', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
+        'compatibility/amp.php' => ['PhanUndeclaredClassInCallable', 'PhanUndeclaredTypeParameter', 'PhanUndeclaredTypeProperty'],
         'compatibility/elementor.php' => ['PhanUndeclaredClassConstant'],
         'compatibility/jetpack.php' => ['PhanUndeclaredClassMethod'],
         'compatibility/lib/class-sync-jetpack-module-status.php' => ['PhanParamTooMany', 'PhanUndeclaredClassMethod'],

--- a/projects/plugins/boost/.phan/config.php
+++ b/projects/plugins/boost/.phan/config.php
@@ -10,4 +10,4 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'woocommerce' ) ) );
+return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'amp', 'woocommerce' ) ) );

--- a/projects/plugins/boost/changelog/add-phan-amp-stubs
+++ b/projects/plugins/boost/changelog/add-phan-amp-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update Phan config to use AMP stubs. No change to functionality.
+
+

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -31,10 +31,10 @@ return [
     // PhanPluginDuplicateAdjacentStatement : 40+ occurrences
     // PhanUndeclaredStaticProperty : 40+ occurrences
     // PhanTypeInvalidDimOffset : 35+ occurrences
-    // PhanUndeclaredFunction : 35+ occurrences
     // PhanUndeclaredProperty : 35+ occurrences
     // PhanParamSignatureMismatch : 30+ occurrences
     // PhanTypeMismatchPropertyProbablyReal : 30+ occurrences
+    // PhanUndeclaredFunction : 30+ occurrences
     // PhanDeprecatedProperty : 25+ occurrences
     // PhanPluginSimplifyExpressionBool : 25+ occurrences
     // PhanTypeMismatchDefault : 25+ occurrences
@@ -104,7 +104,6 @@ return [
     // PhanStaticCallToNonStatic : 2 occurrences
     // PhanTypeMismatchArgumentInternalProbablyReal : 2 occurrences
     // PhanUndeclaredClassInCallable : 2 occurrences
-    // PhanUndeclaredClassReference : 2 occurrences
     // PhanUndeclaredStaticMethod : 2 occurrences
     // PhanAccessPropertyPrivate : 1 occurrence
     // PhanDeprecatedPartiallySupportedCallable : 1 occurrence
@@ -120,6 +119,7 @@ return [
     // PhanTypeMismatchReturnSuperType : 1 occurrence
     // PhanTypeSuspiciousEcho : 1 occurrence
     // PhanTypeVoidArgument : 1 occurrence
+    // PhanUndeclaredClassReference : 1 occurrence
     // PhanUndeclaredExtendedClass : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
@@ -127,7 +127,7 @@ return [
         '3rd-party/bbpress.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],
         '3rd-party/class-domain-mapping.php' => ['PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunctionInCallable', 'PhanUndeclaredTypeReturnType'],
         '3rd-party/class-jetpack-bbpress-rest-api.php' => ['PhanUndeclaredFunction', 'PhanUnextractableAnnotationSuffix'],
-        '3rd-party/class.jetpack-amp-support.php' => ['PhanParamTooMany', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable'],
+        '3rd-party/class.jetpack-amp-support.php' => ['PhanDeprecatedFunction', 'PhanParamTooMany', 'PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable'],
         '3rd-party/debug-bar/class-jetpack-search-debug-bar.php' => ['PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod'],
         '3rd-party/qtranslate-x.php' => ['PhanTypeMismatchReturn'],
         '3rd-party/woocommerce.php' => ['PhanParamTooMany'],
@@ -218,10 +218,10 @@ return [
         'extensions/blocks/calendly/calendly.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/contact-info/class-jetpack-contact-info-block.php' => ['PhanTypeMismatchReturn'],
         'extensions/blocks/cookie-consent/cookie-consent.php' => ['PhanParamTooMany'],
-        'extensions/blocks/donations/donations.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredFunction'],
+        'extensions/blocks/donations/donations.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/gif/gif.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/google-calendar/google-calendar.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'extensions/blocks/google-docs-embed/google-docs-embed.php' => ['PhanRedundantCondition', 'PhanUndeclaredFunction'],
+        'extensions/blocks/google-docs-embed/google-docs-embed.php' => ['PhanRedundantCondition'],
         'extensions/blocks/image-compare/image-compare.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/like/like.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredStaticMethod'],
         'extensions/blocks/mailchimp/mailchimp.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
@@ -244,7 +244,7 @@ return [
         'extensions/blocks/repeat-visitor/repeat-visitor.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/sharing-button/class-sharing-source-block.php' => ['PhanCommentParamWithoutRealParam', 'PhanImpossibleTypeComparison', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/sharing-button/sharing-button.php' => ['PhanRedundantCondition'],
-        'extensions/blocks/simple-payments/simple-payments.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredFunction'],
+        'extensions/blocks/simple-payments/simple-payments.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/slideshow/slideshow.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/story/story.php' => ['PhanImpossibleCondition', 'PhanMisspelledAnnotation', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable'],
         'extensions/blocks/subscriptions/subscriptions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUnextractableAnnotationSuffix'],
@@ -391,7 +391,7 @@ return [
         'modules/google-fonts/wordpress-6.3/load-google-fonts.php' => ['PhanUndeclaredFunction'],
         'modules/gravatar-hovercards.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUnextractableAnnotationSuffix'],
         'modules/infinite-scroll.php' => ['PhanUndeclaredClassMethod'],
-        'modules/infinite-scroll/infinity.php' => ['PhanNoopNew', 'PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunction'],
+        'modules/infinite-scroll/infinity.php' => ['PhanNoopNew', 'PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredFunction'],
         'modules/latex.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'modules/likes.php' => ['PhanPluginRedundantAssignment', 'PhanUndeclaredFunction'],
         'modules/likes/jetpack-likes-master-iframe.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
@@ -403,7 +403,7 @@ return [
         'modules/masterbar/admin-menu/class-base-admin-menu.php' => ['PhanEmptyFQSENInCallable', 'PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInstantiateAbstract', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypePossiblyInvalidDimOffset'],
         'modules/masterbar/admin-menu/class-domain-only-admin-menu.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'modules/masterbar/admin-menu/class-jetpack-admin-menu.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgumentProbablyReal'],
-        'modules/masterbar/admin-menu/class-p2-admin-menu.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunctionInCallable'],
+        'modules/masterbar/admin-menu/class-p2-admin-menu.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'modules/masterbar/admin-menu/class-wpcom-admin-menu.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn'],
         'modules/masterbar/admin-menu/load.php' => ['PhanUndeclaredFunction'],
         'modules/masterbar/inline-help/class-inline-help.php' => ['PhanTypeSuspiciousEcho'],

--- a/projects/plugins/jetpack/.phan/config.php
+++ b/projects/plugins/jetpack/.phan/config.php
@@ -13,7 +13,7 @@ require __DIR__ . '/../../../../.phan/config.base.php';
 return make_phan_config(
 	dirname( __DIR__ ),
 	array(
-		'+stubs'                          => array( 'akismet', 'full-site-editing', 'woocommerce', 'woocommerce-internal', 'woocommerce-packages', 'wpcom' ),
+		'+stubs'                          => array( 'akismet', 'amp', 'full-site-editing', 'woocommerce', 'woocommerce-internal', 'woocommerce-packages', 'wpcom' ),
 		'exclude_file_list'               => array(
 			// Mocks of core classes.
 			'tests/php/_inc/lib/mocks/class-simplepie-file.php',

--- a/projects/plugins/jetpack/changelog/add-phan-amp-stubs
+++ b/projects/plugins/jetpack/changelog/add-phan-amp-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update Phan config to use AMP stubs. No change to functionality.
+
+

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -567,6 +567,10 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertObjectNotHasProperty( 'amp_permalink', $post );
 
+		/**
+		 * @phan-suppress PhanRedefineFunction
+		 * @todo Defining this function mid-test here seems risky. Is there a better way we can test this?
+		 */
 		function amp_get_permalink( $post_id ) { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
 			return "http://example.com/?p=$post_id&amp";
 		}

--- a/projects/plugins/super-cache/.phan/baseline.php
+++ b/projects/plugins/super-cache/.phan/baseline.php
@@ -21,8 +21,8 @@ return [
     // PhanTypeSuspiciousStringExpression : 10+ occurrences
     // PhanUndeclaredFunctionInCallable : 10+ occurrences
     // PhanTypeMismatchArgument : 9 occurrences
-    // PhanUndeclaredFunction : 9 occurrences
     // PhanTypeInvalidDimOffset : 8 occurrences
+    // PhanUndeclaredFunction : 8 occurrences
     // PhanTypeArraySuspiciousNull : 7 occurrences
     // PhanTypeArraySuspiciousNullable : 7 occurrences
     // PhanUndeclaredVariableDim : 7 occurrences
@@ -60,7 +60,7 @@ return [
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'advanced-cache.php' => ['PhanPluginSimplifyExpressionBool'],
-        'inc/delete-cache-button.php' => ['PhanPluginNeverReturnFunction', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanUndeclaredFunction'],
+        'inc/delete-cache-button.php' => ['PhanPluginNeverReturnFunction', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal'],
         'ossdl-cdn.php' => ['PhanUndeclaredClassMethod'],
         'partials/advanced.php' => ['PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredGlobalVariable', 'PhanRedundantConditionInGlobalScope', 'PhanTypeMismatchArgument', 'PhanTypeNonVarPassByRef', 'PhanUndeclaredGlobalVariable'],
         'partials/debug.php' => ['PhanTypeNonVarPassByRef', 'PhanUndeclaredGlobalVariable'],

--- a/projects/plugins/super-cache/.phan/config.php
+++ b/projects/plugins/super-cache/.phan/config.php
@@ -10,4 +10,4 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'amp' ) ) );

--- a/projects/plugins/super-cache/changelog/add-phan-amp-stubs
+++ b/projects/plugins/super-cache/changelog/add-phan-amp-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update Phan config to use AMP stubs. No change to functionality.
+
+

--- a/tools/stubs/amp-stub-defs.php
+++ b/tools/stubs/amp-stub-defs.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Stub config for AMP and AMP for WP functions and such needed in the Jetpack monorepo.
+ *
+ * @package automattic/jetpack-monorepo
+ */
+
+// phpcs:disable PHPCompatibility.Syntax.NewFlexibleHeredocNowdoc.ClosingMarkerNoNewLine -- https://github.com/PHPCompatibility/PHPCompatibility/issues/1696
+
+$work_dir = getenv( 'WORK_DIR' );
+if ( ! is_dir( $work_dir ) ) {
+	throw new RuntimeException( 'WORK_DIR is not set or does not refer to a directory' );
+}
+
+$data = file_get_contents( "$work_dir/amp/amp.php" );
+if ( ! preg_match( '/^ \* Version: (\d+\.\d+.*)/m', (string) $data, $m ) ) {
+	throw new RuntimeException( "Failed to extract version from $work_dir/amp/amp.php" );
+}
+$amp_version = trim( $m[1] );
+
+$data = file_get_contents( "$work_dir/accelerated-mobile-pages/accelerated-moblie-pages.php" );
+if ( ! preg_match( '/^Version: (\d+\.\d+.*)/m', (string) $data, $m ) ) {
+	throw new RuntimeException( "Failed to extract version from $work_dir/accelerated-mobile-pages/accelerated-moblie-pages.php" );
+}
+$ampforwp_version = trim( $m[1] );
+
+return array(
+	'header'  => <<<HEAD
+	/**
+	 * Stubs automatically generated from AMP $amp_version and AMP for WP $ampforwp_version
+	 * using the definition file `tools/stubs/amp-stub-defs.php` in the Jetpack monorepo.
+	 *
+	 * Do not edit this directly! Run tools/stubs/update-stubs.sh to regenerate it.
+	 */
+	HEAD,
+	'basedir' => "$work_dir/",
+	'files'   => array(
+		'amp/includes/amp-helper-functions.php' => array(
+			'function' => array( 'amp_get_permalink', 'amp_is_available', 'amp_is_canonical', 'amp_is_legacy', 'amp_is_request', 'is_amp_endpoint' ),
+		),
+		'amp/includes/options/class-amp-options-manager.php' => array(
+			'class' => array(
+				'AMP_Options_Manager' => array(
+					'method' => array( 'get_option' ),
+				),
+			),
+		),
+		'amp/includes/admin/functions.php'      => array(
+			'function' => array( 'amp_add_customizer_link' ),
+		),
+		'accelerated-mobile-pages/accelerated-moblie-pages.php' => array(
+			'function' => array( 'ampforwp_is_amp_endpoint' ),
+		),
+	),
+);

--- a/tools/stubs/update-stubs.sh
+++ b/tools/stubs/update-stubs.sh
@@ -85,6 +85,19 @@ echo
 info 'Extracting Akismet stubs'
 "$BASE/projects/packages/stub-generator/bin/jetpack-stub-generator" --output "$BASE/.phan/stubs/akismet-stubs.php" "$BASE/tools/stubs/akismet-stub-defs.php"
 
+# Apparently there are two different AMP plugins we have to deal with.
+echo
+info 'Downloading AMP plugin'
+fetch_plugin amp
+
+echo
+info 'Downloading AMP for WP plugin'
+fetch_plugin accelerated-mobile-pages
+
+echo
+info 'Extracting AMP stubs'
+"$BASE/projects/packages/stub-generator/bin/jetpack-stub-generator" --output "$BASE/.phan/stubs/amp-stubs.php" "$BASE/tools/stubs/amp-stub-defs.php"
+
 echo
 info 'Downloading WordPress.com Editing Toolkit'
 fetch_plugin full-site-editing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
There's only one function specific to AMP for WP that we need, and it seems unlikely anyone will want only that one stub and not any AMP stubs, so let's combine them into one file.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?