### PR TITLE
Scheduled Updates: Use Cron API directly

### DIFF
--- a/projects/packages/scheduled-updates/changelog/replace-oneline-functions
+++ b/projects/packages/scheduled-updates/changelog/replace-oneline-functions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Scheduled Updates: Reused endpoint hooks for cache purge and move deleted plugins callback to using endpoint callbacks

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -159,20 +159,6 @@ class Scheduled_Updates {
 	}
 
 	/**
-	 * Create a scheduled update status.
-	 *
-	 * @param string           $schedule_id Request ID.
-	 * @param object           $event       The event object.
-	 * @param \WP_REST_Request $request     The request object.
-	 */
-	public static function create_scheduled_update_status( $schedule_id, $event, $request ) {
-		// Only create the status if this is a CREATE request.
-		if ( empty( $request['schedule_id'] ) ) {
-			self::set_scheduled_update_status( $schedule_id, null, null );
-		}
-	}
-
-	/**
 	 * Updates last status of a scheduled update.
 	 *
 	 * @param string      $schedule_id Request ID.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -408,12 +408,12 @@ class Scheduled_Updates {
 
 			if ( empty( $plugins ) ) {
 				// Delete the schedule if there are no more plugins.
-				$request = new \WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $id );
+				$request = new \WP_REST_Request( 'DELETE', '/wpcom/v2/update-schedules/' . $id );
 				$request->set_query_params( array( 'schedule_id' => $id ) );
 
 				$endpoint->delete_item( $request );
 			} else {
-				$request = new \WP_REST_Request( 'DELETE', '/wpcom/v2/update-schedules/' . $id );
+				$request = new \WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $id );
 				$request->set_body_params(
 					array(
 						'schedule_id' => $id,

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -193,7 +193,7 @@ class Scheduled_Updates {
 	public static function create_scheduled_update_status( $schedule_id, $event, $request ) {
 		// Only create the status if this is a CREATE request.
 		if ( empty( $request['schedule_id'] ) ) {
-			self::set_scheduled_update_status( $schedule_id );
+			self::set_scheduled_update_status( $schedule_id, null, null );
 		}
 	}
 
@@ -201,11 +201,11 @@ class Scheduled_Updates {
 	 * Updates last status of a scheduled update.
 	 *
 	 * @param string      $schedule_id Request ID.
-	 * @param int|null    $timestamp   Optional. Timestamp of the last run. Default is null.
-	 * @param string|null $status      Optional. Status of the last run. Default is null.
+	 * @param int|null    $timestamp   Timestamp of the last run.
+	 * @param string|null $status      Status of the last run.
 	 * @return false|array Updated statuses or false if not found.
 	 */
-	public static function set_scheduled_update_status( $schedule_id, $timestamp = null, $status = null ) {
+	public static function set_scheduled_update_status( $schedule_id, $timestamp, $status ) {
 		$events = wp_get_scheduled_events( self::PLUGIN_CRON_HOOK );
 
 		if ( empty( $events[ $schedule_id ] ) ) {
@@ -250,7 +250,7 @@ class Scheduled_Updates {
 	 * Migrate the status of a scheduled update.
 	 *
 	 * @param string $old_schedule_id Old schedule ID.
-	 * @param object $new_schedule_id New schedule ID.
+	 * @param string $new_schedule_id New schedule ID.
 	 */
 	public static function migrate_schedule_status( $old_schedule_id, $new_schedule_id ) {
 		$old_status = static::get_scheduled_update_status( $old_schedule_id );

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -247,21 +247,6 @@ class Scheduled_Updates {
 	}
 
 	/**
-	 * Migrate the status of a scheduled update.
-	 *
-	 * @param string $old_schedule_id Old schedule ID.
-	 * @param string $new_schedule_id New schedule ID.
-	 */
-	public static function migrate_schedule_status( $old_schedule_id, $new_schedule_id ) {
-		$old_status = static::get_scheduled_update_status( $old_schedule_id );
-
-		// Sets the previous status.
-		if ( $old_status ) {
-			static::set_scheduled_update_status( $new_schedule_id, $old_status['last_run_timestamp'], $old_status['last_run_status'] );
-		}
-	}
-
-	/**
 	 * Allow plugins that are part of scheduled updates to be updated automatically.
 	 *
 	 * @param bool|null $update Whether to update. The value of null is internally used

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -184,14 +184,28 @@ class Scheduled_Updates {
 	}
 
 	/**
+	 * Create a scheduled update status.
+	 *
+	 * @param string           $schedule_id Request ID.
+	 * @param object           $event       The event object.
+	 * @param \WP_REST_Request $request     The request object.
+	 */
+	public static function create_scheduled_update_status( $schedule_id, $event, $request ) {
+		// Only create the status if this is a CREATE request.
+		if ( empty( $request['schedule_id'] ) ) {
+			self::set_scheduled_update_status( $schedule_id );
+		}
+	}
+
+	/**
 	 * Updates last status of a scheduled update.
 	 *
 	 * @param string      $schedule_id Request ID.
-	 * @param int|null    $timestamp   Timestamp of the last run.
-	 * @param string|null $status      Status of the last run.
+	 * @param int|null    $timestamp   Optional. Timestamp of the last run. Default is null.
+	 * @param string|null $status      Optional. Status of the last run. Default is null.
 	 * @return false|array Updated statuses or false if not found.
 	 */
-	public static function set_scheduled_update_status( $schedule_id, $timestamp, $status ) {
+	public static function set_scheduled_update_status( $schedule_id, $timestamp = null, $status = null ) {
 		$events = wp_get_scheduled_events( self::PLUGIN_CRON_HOOK );
 
 		if ( empty( $events[ $schedule_id ] ) ) {
@@ -230,6 +244,21 @@ class Scheduled_Updates {
 	 */
 	public static function get_scheduled_update_status( $schedule_id ) {
 		return Scheduled_Updates_Logs::infer_status_from_logs( $schedule_id );
+	}
+
+	/**
+	 * Migrate the status of a scheduled update.
+	 *
+	 * @param string $old_schedule_id Old schedule ID.
+	 * @param object $new_schedule_id New schedule ID.
+	 */
+	public static function migrate_schedule_status( $old_schedule_id, $new_schedule_id ) {
+		$old_status = static::get_scheduled_update_status( $old_schedule_id );
+
+		// Sets the previous status.
+		if ( $old_status ) {
+			static::set_scheduled_update_status( $new_schedule_id, $old_status['last_run_timestamp'], $old_status['last_run_status'] );
+		}
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -260,8 +260,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$plugins  = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );
 
-		$event = Scheduled_Updates::create_scheduled_update( $schedule['timestamp'], $schedule['interval'], $plugins );
-
+		$event = wp_schedule_event( $schedule['timestamp'], $schedule['interval'], Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins, true );
 		if ( is_wp_error( $event ) ) {
 			return $event;
 		}
@@ -486,13 +485,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 
 		$event = $events[ $request['schedule_id'] ];
 
-		$result = Scheduled_Updates::delete_scheduled_update( $event->timestamp, $event->args );
+		$result = wp_unschedule_event( $event->timestamp, Scheduled_Updates::PLUGIN_CRON_HOOK, $event->args, true );
 		if ( is_wp_error( $result ) ) {
 			return $result;
-		}
-
-		if ( false === $result ) {
-			return new WP_Error( 'unschedule_event_error', __( 'Error during unschedule of the event.', 'jetpack-scheduled-updates' ), array( 'status' => 500 ) );
 		}
 
 		/**


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Will need to be rebased to trunk, once https://github.com/Automattic/jetpack/pull/36835 made it in.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reuses endpoint hooks to clear cache
* Replaces wrapper functions with Cron API calls
* Reuses endpoint methods when updating schedules after a plugin was deleted.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a schedule with a few plugins.
* Delete one of the plugins in the schedule.
* Make sure the schedule was updated to remove the plugin.
* Make sure the event logs etc were maintained.

