### PR TITLE
push-to-mirrors: Fix slowdown due to `git fetch --filter=tree:0`

### DIFF
--- a/projects/github-actions/push-to-mirrors/changelog/fix-push-to-mirrors-slow
+++ b/projects/github-actions/push-to-mirrors/changelog/fix-push-to-mirrors-slow
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix slowdown when using the new update-ref functionality. No need for a separate changelog entry since that hasn't been in a release yet.
+
+

--- a/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
+++ b/projects/github-actions/push-to-mirrors/push-to-mirrors.sh
@@ -113,20 +113,34 @@ if [[ "$NO_UPSTREAM_REFS" != 'true' ]]; then
 fi
 
 function get_upstream_sha {
-	if [[ "$NO_UPSTREAM_REFS" != 'true' ]] &&
-		git -c protocol.version=2 fetch --filter=tree:0 --tags --progress --no-recurse-submodules origin >&2
+	if [[ "$NO_UPSTREAM_REFS" == 'true' ]]; then
+		return 1
+	fi
+
+	# `git fetch --filter=tree:0` works well here to save downloading a lot of unnecessary data.
+	# However, when pushing, git seems to decide it needs to fetch some portion of that data anyway, and does so in an inefficient manner.
+	# We can avoid that by making a temporary second `.git` directory and doing the `git fetch --filter=tree:0` into that instead of into the real one,
+	# so the real one doesn't wind up with whatever weirdness makes git do the slow data fetch on push.
+	local tmpgit
+	tmpgit=$( mktemp -d -p . .git-tmp-XXXXXXXX ) || return 1
+	if
+		cp -a .git/. "$tmpgit/." &&
+		GIT_DIR=$tmpgit git -c protocol.version=2 fetch --filter=tree:0 --tags --progress --no-recurse-submodules origin >&2
 	then
 		local regex
 		for regex in "${UPSTREAM_REGEXES[@]}"; do
 			local dstsha
-			if dstsha=$( git rev-parse --verify --quiet ":/$regex" ) &&
+			if dstsha=$( GIT_DIR=$tmpgit git rev-parse --verify --quiet ":/$regex" ) &&
+				# Fetch the sha into the real .git, not $tmpgit
 				git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin "$dstsha" >&2
 			then
+				rm -rf "$tmpgit"
 				echo "$dstsha"
 				return 0
 			fi
 		done
 	fi
+	rm -rf "$tmpgit"
 	return 1
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`git fetch --filter=tree:0` works well when checking the commit messages for Update-Ref to save downloading a lot of unnecessary data. However, when pushing, git seems to decide it needs to fetch some portion of that data anyway, and does so in an inefficient manner.

We can avoid that by making a temporary second `.git` directory and doing the `git fetch --filter=tree:0` into that instead of into the real one, so the real one doesn't wind up with whatever weirdness makes git do the slow data fetch on push.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You'd have to arrange for the action to run to update a mirror somewhere.
  * Comparing [this run using trunk](https://github.com/anomiex/testing/actions/runs/8790707453/job/24123312593#step:4:806) with [this run using this PR](https://github.com/anomiex/testing/actions/runs/8790718130/job/24123368168#step:4:802) maybe? The highlighted line on the trunk run shows the push took 1.124321817 s, while with the PR it took 0.520909061 s.