### PR TITLE
Blogging Prompt: localize wordpress.com link

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -262,7 +262,7 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 	public function prepare_items_for_response( $items ) {
 		$locale = get_locale();
 
-		if ( ! isset( $locale ) || empty( $locale ) ) {
+		if ( empty( $locale ) ) {
 			return $items;
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-blogging-prompts.php
@@ -99,6 +99,7 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 	 */
 	public function get_items( $request ) {
 		if ( ! $this->is_wpcom ) {
+			// @phan-suppress-next-line PhanTypeMismatchReturn
 			return $this->prepare_items_for_response( $this->proxy_request_to_wpcom( $request ) );
 		}
 
@@ -114,6 +115,7 @@ class WPCOM_REST_API_V3_Endpoint_Blogging_Prompts extends WP_REST_Posts_Controll
 		remove_action( 'pre_get_posts', array( $this, 'modify_query' ) );
 		restore_current_blog();
 
+		// @phan-suppress-next-line PhanTypeMismatchArgument,PhanTypeMismatchReturn
 		return $this->prepare_items_for_response( $items );
 	}
 

--- a/projects/plugins/jetpack/changelog/update-localize-blogging-prompt-link
+++ b/projects/plugins/jetpack/changelog/update-localize-blogging-prompt-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blog Prompt: localize wordpress.com link


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/36648

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR localizes the link to wordpress.com in the _Blogging Prompt_ block to be consistent with the site language.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf5801-Aw-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Prerequisites
- Spin a test site with this branch
- Connect Jetpack
- Create a new post/page
- Add a _Blogging Prompt_ block

### Regression testing
- Open the preview
- Check that the link in the block leads to wordpress.com and doesn't contain any `lang` parameter

### Feature testing
- From WPadmin, change the site language in `/wp-admin/options-general.php`
- Go back to the post/page edition page
- Remove the _Blogging Prompt_ block and add a new one
- Open the preview
- Check that the link in the block leads to wordpress.com and **does** contain a `lang` parameter with the site language for value
<img width="400" alt="Screenshot 2024-04-22 at 4 59 40 PM" src="https://github.com/Automattic/jetpack/assets/1620183/1ace88d0-721a-439f-a78a-0eb27f0b272a">


- Verify the page on wordpress.com isn't broken