### PR TITLE
Cookie Consent: localize default text

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-cookie-consent-localizatoin
+++ b/projects/plugins/jetpack/changelog/fix-cookie-consent-localizatoin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Cookie Consent: localize default text

--- a/projects/plugins/jetpack/extensions/blocks/cookie-consent/constants.js
+++ b/projects/plugins/jetpack/extensions/blocks/cookie-consent/constants.js
@@ -1,6 +1,12 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
-export const DEFAULT_TEXT = __(
-	'Privacy &amp; Cookies: This site uses cookies. By continuing to use this website, you agree to their use. To find out more, including how to control cookies, see here: <a href="https://automattic.com/cookies/">Cookie Policy</a>.',
-	'jetpack'
+export const COOKIE_POLICY_URL = 'https://automattic.com/cookies/';
+
+export const DEFAULT_TEXT = sprintf(
+	// translators: %s is a link to the cookie policy.
+	__(
+		'Privacy & Cookies: This site uses cookies. By continuing to use this website, you agree to their use. To find out more, including how to control cookies, see here: %s.',
+		'jetpack'
+	),
+	`<a href="${ COOKIE_POLICY_URL }">${ __( 'Cookie Policy', 'jetpack' ) }</a>`
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The default text of the _Cookie Consent_ block doesn't seem to be localized. This PR is an attempt at fixing this by ensuring the translatable texts don't contain markup.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf5801-Aw-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Since translations are not created yet, let's just do some regression testing.

- Spin up a test site with this site
- Connect Jetpack
- Visit the site editor at `/wp-admin/site-editor.php`
- On a page, add the _Cookie Consent_ block
- Check it behaves as it did before