### PR TITLE
launchpad: return home after changing site name.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-return-home
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-launchpad-return-home
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support returning to launchpad after updating site name

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -144,7 +144,12 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_disabled_callback' => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
-					return admin_url( 'options-general.php' );
+					$query = http_build_query(
+						array(
+							'return-url' => esc_url( 'https://wordpress.com/home/' . $data['site_slug_encoded'] ),
+						)
+					);
+					return admin_url( 'options-general.php?' . $query );
 				}
 				return '/settings/general/' . $data['site_slug_encoded'];
 			},
@@ -369,7 +374,12 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_visible_callback'  => 'wpcom_launchpad_is_site_title_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				if ( wpcom_launchpad_should_use_wp_admin_link() ) {
-					return admin_url( 'options-general.php' );
+					$query = http_build_query(
+						array(
+							'return-url' => esc_url( 'https://wordpress.com/home/' . $data['site_slug_encoded'] ),
+						)
+					);
+					return admin_url( 'options-general.php?' . $query );
 				}
 				return '/settings/general/' . $data['site_slug_encoded'];
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -1124,3 +1124,19 @@ function wpcom_set_launchpad_config_option( $option, $value ) {
 
 	return update_option( 'wpcom_launchpad_config', $wpcom_launchpad_config );
 }
+
+/**
+ * Takes the user back to launchpad once they have changed the name of their site.
+ */
+function launchpad_redirect_on_change_site_name() {
+	if ( ! isset( $_GET['settings-updated'] ) || ! isset( $_GET['return-url'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return;
+	}
+	// todo: apply same check as the name change.
+	$site_slug = wpcom_get_site_slug();
+	$redirect  = wp_sanitize_redirect( wp_unslash( $_GET['return-url'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$redirect  = wp_validate_redirect( $redirect, "https://wordpress.com/home/$site_slug" );
+
+	wp_safe_redirect( $redirect );
+}
+add_action( 'load-options-general.php', 'launchpad_redirect_on_change_site_name' );


### PR DESCRIPTION
6313-gh-Automattic/dotcom-forge#issue-2210567423

The "Launchpad" gives a checklist of tasks to set up your wpcom site.

<img width="500" alt="Screenshot 2024-04-23 at 11 02 35 am" src="https://github.com/Automattic/jetpack/assets/22446385/3ad4a2ba-e024-44cb-993b-ad94fa230a04">

Previously you would have to click back to "My Home" after completing each task.

But with the recent nav redesign of wpcom, we are using wp-admin as much as possible and have removed the link back to "My Home" for **"classic navigation"** sites
<img width="300" alt="Screenshot 2024-04-23 at 11 37 26 am" src="https://github.com/Automattic/jetpack/assets/22446385/48949afa-519b-44b5-b5e9-b8b1ab938f56">

This means that the user would get "stuck" on the settings page and not be able to continue the checklist.
<img width="500" alt="Screenshot 2024-04-23 at 11 04 01 am" src="https://github.com/Automattic/jetpack/assets/22446385/194e8c00-61e1-4d44-a8b9-c46f909d497d">

This draft PR demonstrates how we could return the user back to my-home after changing the site name.

There are other tasks where the user will now be "stuck" and where it might be good to take them back to my-home. We may have to check through the tasks in https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php#L35
There are about 40 tasks total across the different site_intent's 
e.g.
* Select a design
* Claim one year free domain
* Choose a domain
* Choose a plan
* Write your first post
* Edit site design
* Launch your site
* Verify email address
* Start Writing
* Set up payment method
* Add subscribers
... etc

I'm just putting this implementation up so we can decide if this is worth doing and if it's what we want to go with.

### Testing instructions

Create an atomic site with "classic nav" enabled (not strictly neccessary for testing)
Get the atomic site set up with jetpack beta tester and apply this PR . fieldguide: (PCYsg-Osp-p2)
The task list you'll see is based on `site_intent` on the shadow site. Look up site in network-admin to find shadow site id then use wpsh on the sandbox (at least that's how I did it)
```bash
#wpsh
update_blog_option(197699678, 'site_intent', 'intent-build') # intent-build includes a task to set site name
```
Then navigate to my-home for the site, you should see the checklist.
Click on the "Give your site a name" task
You'll be taken to the wp-admin settings page with a "return-url" param. 
Change the name and save.
You should be taken back to wordpress.com/home/$slug with the checklist item checked off.
Reset the checklist by going to the atomic sites `/_cli` and running 
`wp option update launchpad_checklist_tasks_statuses []`
