### PR TITLE
Remove the “My Sites” copy for Simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove-my-sites
+++ b/projects/plugins/jetpack/changelog/update-remove-my-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Remove the “My Sites” copy for Simple sites

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -977,18 +977,11 @@ class Masterbar {
 			$blog_name = mb_substr( html_entity_decode( $blog_name, ENT_QUOTES ), 0, 20 ) . '&hellip;';
 		}
 
-		$my_site_url   = 'https://wordpress.com/sites/' . $this->primary_site_url;
-		$my_site_title = _n( 'My Site', 'My Sites', $this->user_site_count, 'jetpack' );
-		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
-			$my_site_url   = 'https://wordpress.com/sites';
-			$my_site_title = esc_html__( 'My Sites', 'jetpack' );
-		}
-
+		$my_site_url = 'https://wordpress.com/sites/' . $this->primary_site_url;
 		$wp_admin_bar->add_menu(
 			array(
 				'parent' => 'root-default',
 				'id'     => 'blog',
-				'title'  => $my_site_title,
 				'href'   => $my_site_url,
 				'meta'   => array(
 					'class' => 'my-sites mb-trackable',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/pull/89469#issuecomment-2051741265, p1712927690662239/1712871943.690009-slack-C06DN6QQVAQ

## Proposed changes:

This is a follow-up PR for https://github.com/Automattic/wp-calypso/pull/89469, which removes the “My Sites” copy from the top left of the masterbar for Simple sites when users have the classic view toggled on for that page via the "View" option in the top right corner. Please refer to https://github.com/Automattic/wp-calypso/pull/89469 for backgrounds. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*