### PR TITLE
ci: Use matticbot token for update-phan-stubs workflow

### DIFF
--- a/.github/workflows/update-phan-stubs.yml
+++ b/.github/workflows/update-phan-stubs.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Use the matticbot token so CI runs on the created PR.
+          token: ${{ secrets.API_TOKEN_GITHUB }}
 
       - name: Update stubs
         run: tools/stubs/update-stubs.sh
@@ -50,7 +53,7 @@ jobs:
       - name: Create commit and PR
         if: steps.changes.outputs.needed == 'true' && steps.changes.outputs.has-branch == 'false'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
         run: |
           git checkout -b update/phan-custom-stubs
           git commit -am 'phan: Update custom stubs'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Using the default Actions token results in a PR that doesn't have any actions run.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/37018#issuecomment-2072559501

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [x] Ran it from this branch in https://github.com/Automattic/jetpack/actions/runs/8802640690, which created https://github.com/Automattic/jetpack/pull/37029.
