### PR TITLE
Untangling: Dismiss sidebar notices

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-untangling-sidebar-notice-dismiss
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-untangling-sidebar-notice-dismiss
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin menu: Sidebar notices can be dismissed now

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.js
@@ -1,4 +1,4 @@
-/* global wpcomSidebarNotice */
+/* global wp, wpcomSidebarNotice */
 
 const wpcomShowSidebarNotice = () => {
 	const adminMenu = document.querySelector( '#adminmenu' );
@@ -9,19 +9,52 @@ const wpcomShowSidebarNotice = () => {
 	adminMenu.insertAdjacentHTML(
 		'afterbegin',
 		`
-			<li class="wp-not-current-submenu menu-top menu-icon-generic toplevel_page_site-notices" id="toplevel_page_site-notices">
-				<a href="${ wpcomSidebarNotice.url }" class="wp-not-current-submenu menu-top menu-icon-generic toplevel_page_site-notices">
+			<li
+				id="toplevel_page_site-notices"
+				class="wp-not-current-submenu menu-top menu-icon-generic toplevel_page_site-notices"
+				data-id="${ wpcomSidebarNotice.id }"
+				data-feature-class="${ wpcomSidebarNotice.featureClass }"
+			>
+				<a href="${
+					wpcomSidebarNotice.url
+				}" class="wp-not-current-submenu menu-top menu-icon-generic toplevel_page_site-notices">
 					<div class="wp-menu-name">
 						<div class="upsell_banner">
 							<div class="upsell_banner__icon dashicons" aria-hidden="true"></div>
 							<div class="upsell_banner__text">${ wpcomSidebarNotice.text }</div>
-							<button type="button" class="upsell_banner__action button button-primary">${ wpcomSidebarNotice.action }</button>
+							<button type="button" class="upsell_banner__action button button-primary">${
+								wpcomSidebarNotice.action
+							}</button>
+							${
+								wpcomSidebarNotice.dismissible === '1'
+									? '<button type="button" class="upsell_banner__dismiss button button-link">' +
+									  wpcomSidebarNotice.dismissLabel +
+									  '</button>'
+									: ''
+							}
 						</div>
 					</div>
 				</a>
 			</li>
 		`
 	);
+
+	const sidebarNotice = adminMenu.firstElementChild;
+
+	sidebarNotice.addEventListener( 'click', event => {
+		if (
+			event.target.classList.contains( 'upsell_banner__dismiss' ) ||
+			event.target.closest( '.upsell_banner__dismiss' )
+		) {
+			event.preventDefault();
+			wp.ajax.post( 'wpcom_dismiss_sidebar_notice', {
+				id: sidebarNotice.dataset.id,
+				feature_class: sidebarNotice.dataset.featureClass,
+				_ajax_nonce: wpcomSidebarNotice.dismissNonce,
+			} );
+			sidebarNotice.remove();
+		}
+	} );
 };
 
 document.addEventListener( 'DOMContentLoaded', wpcomShowSidebarNotice );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
@@ -96,6 +96,24 @@
 		min-height: 32px;
 		margin-bottom: 0;
 	}
+
+	.upsell_banner__dismiss {
+		background-color: transparent;
+		color: inherit;
+		min-height: 0;
+		font-size: 12px;
+		line-height: 16px;
+		text-align: center;
+		margin-top: -2px;
+
+		&:hover {
+			background-color: transparent;
+		}
+
+		&:focus {
+			box-shadow: none;
+		}
+	}
 }
 
 @mixin folded {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
@@ -136,7 +136,8 @@
 		}
 
 		.upsell_banner__text,
-		.upsell_banner__action {
+		.upsell_banner__action,
+		.upsell_banner__dismiss {
 			display: none;
 		}
 	}


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/6403
Follow-up of https://github.com/Automattic/jetpack/pull/36797

## Proposed changes:
Adds the ability to dismiss sidebar notices on untangled sites.

<img width="397" alt="Screenshot 2024-04-23 at 18 05 57" src="https://github.com/Automattic/jetpack/assets/1233880/b63a5ddb-8144-476f-b48f-e95b6b302aad">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- In your sandbox, modify the rules of any of the dismissible `:sidebar_notice` messages in the `jitm-engine.php` file to make visible one of them. I typically do this:
```
diff --git a/wp-content/lib/jetpack-jitm/jitm-engine.php b/wp-content/lib/jetpack-jitm/jitm-engine.php
index 3da7b5e1f1..426eb0bab1 100644
--- a/wp-content/lib/jetpack-jitm/jitm-engine.php
+++ b/wp-content/lib/jetpack-jitm/jitm-engine.php
@@ -2416,7 +2416,7 @@ class Engine {
                                                $site_slug = $cache->get_site_slug();
                                                return '/plans/' . $site_slug;
                                        }
-                               )->user_has_marketing_tag( 'jitm_ml_upsell_promo_' . $tag_type_index, 'show' )
+                               )/*->user_has_marketing_tag( 'jitm_ml_upsell_promo_' . $tag_type_index, 'show' )*/
                                ->show( $message )
                                ->is_dismissible( true )
                                ->max_dismissals( 1 )
```

- Add this to your `mu-plugins/0-sandbox.php` file:
```
add_filter( 'jetpack_just_in_time_msg_cache', '__return_false', 1000 );
```
- Set up a test site:
  - Apply these changes to your site using the instructions from the auto-generated comment below.
  - Simple sites
    - Sandbox the API and a simple site
    - Open `wp shell` and run these commands: `update_blog_option( blog_id, 'wpcom_admin_interface', 'wp-admin' ); update_blog_option( blog_id, 'wpcom_classic_early_release', 1 );`
  - Atomic sites:
    - Go to wordpress.com/hosting-config
    - Select your site
    - Change the admin interface style to Classic
    - Go to <SITE_DOMAIN>/_cli and run this command: `wp option update wpcom_classic_early_release 1`
- Go to `/wp-admin`
- Make sure the dismissible sidebar notice shows up correctly
- Make sure you can dismiss it