### PR TITLE
Add action 'woocommerce_remove_order_item_ids' to send sync event whe…

### DIFF
--- a/projects/packages/sync/changelog/add-sync-woo-remove-order-items
+++ b/projects/packages/sync/changelog/add-sync-woo-remove-order-items
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Woocommerce event remove_order_items to Jetpack Sync

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -58,7 +58,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.13.x-dev"
+			"dev-trunk": "2.14.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.13.0';
+	const PACKAGE_VERSION = '2.14.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -93,6 +93,9 @@ class WooCommerce extends Module {
 
 		// Blacklist Action Scheduler comment types.
 		add_filter( 'jetpack_sync_prevent_sending_comment_data', array( $this, 'filter_action_scheduler_comments' ), 10, 2 );
+
+		// Preprocess action to be sent by Jetpack sync.
+		add_action( 'woocommerce_remove_order_items', array( $this, 'action_woocommerce_remove_order_items' ), 10, 2 );
 	}
 
 	/**
@@ -128,6 +131,7 @@ class WooCommerce extends Module {
 		add_action( 'woocommerce_new_order_item', $callable, 10, 4 );
 		add_action( 'woocommerce_update_order_item', $callable, 10, 4 );
 		add_action( 'woocommerce_delete_order_item', $callable, 10, 1 );
+		add_action( 'woocommerce_remove_order_item_ids', $callable, 10, 1 );
 		$this->init_listeners_for_meta_type( 'order_item', $callable );
 
 		// Payment tokens.
@@ -195,6 +199,25 @@ class WooCommerce extends Module {
 		// Make sure we always have all the data - prior to WooCommerce 3.0 we only have the user supplied data in the second argument and not the full details.
 		$args[1] = $this->build_order_item( $args[0] );
 		return $args;
+	}
+
+	/**
+	 * Retrieve the order item ids to be removed and send them as one action
+	 *
+	 * @param Order  $order The order argument.
+	 * @param string $type Order item type.
+	 */
+	public function action_woocommerce_remove_order_items( $order, $type ) {
+		if ( $type ) {
+			$order_items = $order->get_items( $type );
+		} else {
+			$order_items = $order->get_items();
+		}
+		$order_item_ids = array_keys( $order_items );
+
+		if ( $order_item_ids ) {
+			do_action( 'woocommerce_remove_order_item_ids', $order_item_ids );
+		}
 	}
 
 	/**


### PR DESCRIPTION
…n order items are removed

Temporal test 

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

