### PR TITLE
A4A Client: Add "Reconnect" Flow and Connection Error Handling

### DIFF
--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -995,7 +995,7 @@ class REST_Connector {
 	 *
 	 * @return mixed|null
 	 */
-	public static function connection_check() {
+	public function connection_check() {
 		/**
 		 * Filters the successful response of the REST API test_connection method
 		 *

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -995,7 +995,7 @@ class REST_Connector {
 	 *
 	 * @return mixed|null
 	 */
-	public function connection_check() {
+	public static function connection_check() {
 		/**
 		 * Filters the successful response of the REST API test_connection method
 		 *

--- a/projects/plugins/automattic-for-agencies-client/changelog/add-a4a-reconnect
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-a4a-reconnect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added reconnection flow to the A4A client plugin.

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/admin-page/index.jsx
@@ -1,22 +1,61 @@
 import { Container, Col, ThemeProvider } from '@automattic/jetpack-components';
 import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
 import { useSelect } from '@wordpress/data';
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import ConnectedCard from '../connected-card';
 import ConnectionCard from '../connection-card';
+import DisconnectSiteLink from '../disconnect-site-link';
+import DisconnectedCard from '../disconnected-card';
 
 const Admin = () => {
-	const connectionStatus = useSelect(
+	/** True if the user has just disconnected their site in the ongoing session. */
+	const [ wasManuallyDisconnected, setWasManuallyDisconnected ] = useState( false );
+
+	/** Callback that runs after the site is disconnected. */
+	const onDisconnect = useCallback(
+		() => setWasManuallyDisconnected( true ),
+		[ setWasManuallyDisconnected ]
+	);
+
+	const { isUserConnected, isRegistered } = useSelect(
 		select => select( CONNECTION_STORE_ID ).getConnectionStatus(),
 		[]
 	);
-	const { isUserConnected, isRegistered } = connectionStatus;
-	const showConnectionCard = ! isRegistered || ! isUserConnected;
+
+	const connectionErrors = useSelect(
+		select => select( CONNECTION_STORE_ID ).getConnectionErrors(),
+		[]
+	);
+
+	/** Render the relevant card based on the connection status. */
+	const connectionCard = useMemo( () => {
+		// Show the disconnection card if there are connection errors, or if the user has manually disconnected the site.
+		if ( Object.keys( connectionErrors ).length || wasManuallyDisconnected ) {
+			return <DisconnectedCard />;
+		}
+		// Show the connection card if we don't have a site and user connection.
+		if ( ! isRegistered || ! isUserConnected ) {
+			return <ConnectionCard />;
+		}
+		// Default to showing the card for a successfully connected site.
+		return <ConnectedCard />;
+	}, [ isRegistered, isUserConnected, connectionErrors, wasManuallyDisconnected ] );
+
+	const showDisconnectSiteLink = useMemo(
+		() =>
+			isRegistered &&
+			isUserConnected &&
+			! Object.keys( connectionErrors ).length &&
+			! wasManuallyDisconnected,
+		[ isRegistered, isUserConnected, connectionErrors, wasManuallyDisconnected ]
+	);
+
 	return (
 		<ThemeProvider targetDom={ document.body }>
 			<Container horizontalSpacing={ 10 } horizontalGap={ 3 }>
 				<Col sm={ 4 } md={ 8 } lg={ 12 }>
-					{ showConnectionCard ? <ConnectionCard /> : <ConnectedCard /> }
+					{ connectionCard }
+					{ showDisconnectSiteLink && <DisconnectSiteLink onDisconnect={ onDisconnect } /> }
 				</Col>
 			</Container>
 		</ThemeProvider>

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/connected-card/index.jsx
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/connected-card/index.jsx
@@ -1,198 +1,10 @@
-import restApi from '@automattic/jetpack-api';
-import { Button, Spinner } from '@automattic/jetpack-components';
-import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
-import { Modal } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { Button } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import BrandedCard from '../branded-card';
 import CheckCircleIcon from '../check-circle-icon';
-import CloseCircleIcon from '../close-circle-icon';
 import styles from './styles.module.scss';
-
-/**
- * Site Connected Content component.
- *
- * @returns {React.Component} The `SiteConnectedContent` component.
- */
-function SiteConnectedContent() {
-	const navigateToDashboard = useCallback( () => {
-		const currentUrl = encodeURIComponent( window.location.href );
-		window.location.href = `https://agencies.automattic.com?source=client-plugin&wp-admin-url=${ currentUrl }`;
-	}, [] );
-
-	return (
-		<div className={ styles.card }>
-			<h1>
-				{ __(
-					'Your site is connected to Automattic for Agencies',
-					'automattic-for-agencies-client'
-				) }
-			</h1>
-			<p
-				className={ classNames(
-					styles.connection_status,
-					styles[ 'connection_status--connected' ]
-				) }
-			>
-				<CheckCircleIcon />
-				{ __( 'Site is connected and syncing', 'automattic-for-agencies-client' ) }
-			</p>
-			<div>
-				<Button onClick={ navigateToDashboard } isExternalLink>
-					{ __( 'Visit the dashboard', 'automattic-for-agencies-client' ) }
-				</Button>
-			</div>
-		</div>
-	);
-}
-
-/**
- * Site Disconnected Content component.
- *
- * @returns {React.Component} The `SiteDisconnectedContent` component.
- */
-function SiteDisconnectedContent() {
-	const { setConnectionStatus } = useDispatch( CONNECTION_STORE_ID );
-
-	const refreshConnectionState = useCallback( () => {
-		setConnectionStatus( { isActive: false, isRegistered: false, isUserConnected: false } );
-	}, [ setConnectionStatus ] );
-
-	return (
-		<div className={ styles.card }>
-			<h1>
-				{ __(
-					'Your site was disconnected from Automattic for Agencies',
-					'automattic-for-agencies-client'
-				) }
-			</h1>
-			<p
-				className={ classNames(
-					styles.connection_status,
-					styles[ 'connection_status--disconnected' ]
-				) }
-			>
-				<CloseCircleIcon />
-				{ __( 'Site is disconnected', 'automattic-for-agencies-client' ) }
-			</p>
-			<div>
-				<Button onClick={ refreshConnectionState }>
-					{ __( 'Reconnect this site now', 'automattic-for-agencies-client' ) }
-				</Button>
-			</div>
-		</div>
-	);
-}
-
-/**
- * Disconnect Site Link component.
- *
- * @param {object}   props              - Component props.
- * @param {Function} props.onDisconnect - Callback to run when the site is disconnected.
- * @returns {React.Component} The `DisconnectSiteLink` component.
- */
-function DisconnectSiteLink( { onDisconnect } ) {
-	const { apiNonce, apiRoot } = window.automatticForAgenciesClientInitialState;
-
-	const [ showDisconnectSiteDialog, setShowDisconnectSiteDialog ] = useState( false );
-	const [ isDisconnecting, setIsDisconnecting ] = useState( false );
-	const [ disconnectError, setDisconnectError ] = useState( false );
-
-	const onDisconnectSiteClick = useCallback( () => setShowDisconnectSiteDialog( true ), [] );
-	const onCloseDisconnectSiteDialog = useCallback( () => setShowDisconnectSiteDialog( false ), [] );
-
-	/**
-	 * Disconnect the site.
-	 * Uses the rest API to remove the Jetpack connection.
-	 */
-	const disconnect = useCallback( () => {
-		setIsDisconnecting( true );
-		restApi
-			.disconnectSite()
-			.then( () => {
-				setIsDisconnecting( false );
-				setShowDisconnectSiteDialog( false );
-				onDisconnect();
-			} )
-			.catch( error => {
-				setIsDisconnecting( false );
-				setDisconnectError( error );
-			} );
-	}, [ onDisconnect ] );
-
-	/**
-	 * Initialize the REST API.
-	 */
-	useEffect( () => {
-		restApi.setApiRoot( apiRoot );
-		restApi.setApiNonce( apiNonce );
-	}, [ apiRoot, apiNonce ] );
-
-	return (
-		<>
-			<div className={ styles.disconnect_site_trigger }>
-				<Button variant="link" size="small" onClick={ onDisconnectSiteClick }>
-					{ __( 'Disconnect site', 'automattic-for-agencies-client' ) }
-				</Button>
-			</div>
-			{ showDisconnectSiteDialog && (
-				<Modal
-					title={ __(
-						'Are you sure you want to disconnect this site?',
-						'automattic-for-agencies-client'
-					) }
-					onRequestClose={ onCloseDisconnectSiteDialog }
-					shouldCloseOnClickOutside={ false }
-					shouldCloseOnEsc={ false }
-					isDismissible={ false }
-					className={ styles.disconnect_modal }
-				>
-					<p>
-						{ __(
-							'It will no longer show up in the Automattic for Agencies dashboard and you won’t be able to update plugins with one click or be notified of any downtime.',
-							'automattic-for-agencies-client'
-						) }
-					</p>
-					<div className={ styles.disconnect_modal__actions }>
-						<Button
-							variant="secondary"
-							size="small"
-							disabled={ isDisconnecting }
-							onClick={ onCloseDisconnectSiteDialog }
-						>
-							{ __( 'Keep the site connected', 'automattic-for-agencies-client' ) }
-						</Button>
-						<Button
-							variant="primary"
-							isDestructive
-							size="small"
-							isLoading={ isDisconnecting }
-							disabled={ isDisconnecting }
-							onClick={ disconnect }
-							className={ styles.disconnect_button }
-						>
-							{ isDisconnecting ? (
-								<Spinner />
-							) : (
-								__( 'Yes, disconnect site', 'automattic-for-agencies-client' )
-							) }
-						</Button>
-					</div>
-					{ disconnectError && (
-						<p className={ styles.disconnect_modal__error }>
-							{ __(
-								'An error occurred disconnecting the site.',
-								'automattic-for-agencies-client'
-							) }
-						</p>
-					) }
-				</Modal>
-			) }
-		</>
-	);
-}
 
 /**
  * Connected Card component.
@@ -200,16 +12,35 @@ function DisconnectSiteLink( { onDisconnect } ) {
  * @returns {React.Component} The `ConnectionCard` component.
  */
 export default function ConnectedCard() {
-	const [ isDisconnected, setIsDisconnected ] = useState( false );
-
-	const onDisconnect = useCallback( () => setIsDisconnected( true ), [ setIsDisconnected ] );
+	const navigateToDashboard = useCallback( () => {
+		const currentUrl = encodeURIComponent( window.location.href );
+		window.location.href = `https://agencies.automattic.com?source=client-plugin&wp-admin-url=${ currentUrl }`;
+	}, [] );
 
 	return (
-		<>
-			<BrandedCard>
-				{ ! isDisconnected ? <SiteConnectedContent /> : <SiteDisconnectedContent /> }
-			</BrandedCard>
-			{ ! isDisconnected && <DisconnectSiteLink onDisconnect={ onDisconnect } /> }
-		</>
+		<BrandedCard>
+			<div className={ styles.card }>
+				<h1>
+					{ __(
+						'Your site is connected to Automattic for Agencies',
+						'automattic-for-agencies-client'
+					) }
+				</h1>
+				<p
+					className={ classNames(
+						styles.connection_status,
+						styles[ 'connection_status--connected' ]
+					) }
+				>
+					<CheckCircleIcon />
+					{ __( 'Site is connected and syncing', 'automattic-for-agencies-client' ) }
+				</p>
+				<div>
+					<Button onClick={ navigateToDashboard } isExternalLink>
+						{ __( 'Visit the dashboard', 'automattic-for-agencies-client' ) }
+					</Button>
+				</div>
+			</div>
+		</BrandedCard>
 	);
 }

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/connected-card/styles.module.scss
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/connected-card/styles.module.scss
@@ -25,36 +25,3 @@
 .connection_status--disconnected {
     color: var( --jp-red-50 );
 }
-
-.disconnect_site_trigger {
-    display: flex;
-    justify-content: center;
-    padding: 32px;
-}
-
-.disconnect_modal {
-    max-width: 512px;
-}
-
-.disconnect_modal__error {
-    color: var( --jp-red-50 );
-    text-align: end;
-    margin-bottom: 0;
-}
-
-.disconnect_modal__actions {
-    display: flex;
-    gap: 8px;
-    justify-content: flex-end;
-
-    :global {
-        .components-button {
-            --spacing-base: 16px;
-            --font-body-extra-small: 14px;
-        }
-    }
-}
-
-.disconnect_button {
-    min-width: 167px;
-}

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/disconnect-site-link/index.jsx
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/disconnect-site-link/index.jsx
@@ -1,0 +1,114 @@
+import restApi from '@automattic/jetpack-api';
+import { Button, Spinner } from '@automattic/jetpack-components';
+import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import React, { useCallback, useEffect, useState } from 'react';
+import styles from './styles.module.scss';
+
+/**
+ * Disconnect Site Link component.
+ *
+ * @param {object}   props              - Component props.
+ * @param {Function} props.onDisconnect - Callback to run when the site is disconnected.
+ * @returns {React.Component} The `DisconnectSiteLink` component.
+ */
+export default function DisconnectSiteLink( { onDisconnect } ) {
+	const { apiNonce, apiRoot } = window.automatticForAgenciesClientInitialState;
+
+	const [ showDisconnectSiteDialog, setShowDisconnectSiteDialog ] = useState( false );
+	const [ isDisconnecting, setIsDisconnecting ] = useState( false );
+	const [ disconnectError, setDisconnectError ] = useState( false );
+
+	const onDisconnectSiteClick = useCallback( () => setShowDisconnectSiteDialog( true ), [] );
+	const onCloseDisconnectSiteDialog = useCallback( () => setShowDisconnectSiteDialog( false ), [] );
+
+	/**
+	 * Disconnect the site.
+	 * Uses the rest API to remove the Jetpack connection.
+	 */
+	const disconnect = useCallback( () => {
+		setIsDisconnecting( true );
+		restApi
+			.disconnectSite()
+			.then( () => {
+				setIsDisconnecting( false );
+				setShowDisconnectSiteDialog( false );
+				onDisconnect();
+			} )
+			.catch( error => {
+				setIsDisconnecting( false );
+				setDisconnectError( error );
+			} );
+	}, [ onDisconnect ] );
+
+	/**
+	 * Initialize the REST API.
+	 */
+	useEffect( () => {
+		restApi.setApiRoot( apiRoot );
+		restApi.setApiNonce( apiNonce );
+	}, [ apiRoot, apiNonce ] );
+
+	return (
+		<>
+			<div className={ styles.disconnect_site_trigger }>
+				<Button variant="link" size="small" onClick={ onDisconnectSiteClick }>
+					{ __( 'Disconnect site', 'automattic-for-agencies-client' ) }
+				</Button>
+			</div>
+			{ showDisconnectSiteDialog && (
+				<Modal
+					title={ __(
+						'Are you sure you want to disconnect this site?',
+						'automattic-for-agencies-client'
+					) }
+					onRequestClose={ onCloseDisconnectSiteDialog }
+					shouldCloseOnClickOutside={ false }
+					shouldCloseOnEsc={ false }
+					isDismissible={ false }
+					className={ styles.disconnect_modal }
+				>
+					<p>
+						{ __(
+							'It will no longer show up in the Automattic for Agencies dashboard and you won’t be able to update plugins with one click or be notified of any downtime.',
+							'automattic-for-agencies-client'
+						) }
+					</p>
+					<div className={ styles.disconnect_modal__actions }>
+						<Button
+							variant="secondary"
+							size="small"
+							disabled={ isDisconnecting }
+							onClick={ onCloseDisconnectSiteDialog }
+						>
+							{ __( 'Keep the site connected', 'automattic-for-agencies-client' ) }
+						</Button>
+						<Button
+							variant="primary"
+							isDestructive
+							size="small"
+							isLoading={ isDisconnecting }
+							disabled={ isDisconnecting }
+							onClick={ disconnect }
+							className={ styles.disconnect_button }
+						>
+							{ isDisconnecting ? (
+								<Spinner />
+							) : (
+								__( 'Yes, disconnect site', 'automattic-for-agencies-client' )
+							) }
+						</Button>
+					</div>
+					{ disconnectError && (
+						<p className={ styles.disconnect_modal__error }>
+							{ __(
+								'An error occurred disconnecting the site.',
+								'automattic-for-agencies-client'
+							) }
+						</p>
+					) }
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/disconnect-site-link/styles.module.scss
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/disconnect-site-link/styles.module.scss
@@ -1,0 +1,32 @@
+.disconnect_site_trigger {
+    display: flex;
+    justify-content: center;
+    padding: 32px;
+}
+
+.disconnect_modal {
+    max-width: 512px;
+}
+
+.disconnect_modal__error {
+    color: var( --jp-red-50 );
+    text-align: end;
+    margin-bottom: 0;
+}
+
+.disconnect_modal__actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+
+    :global {
+        .components-button {
+            --spacing-base: 16px;
+            --font-body-extra-small: 14px;
+        }
+    }
+}
+
+.disconnect_button {
+    min-width: 167px;
+}

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/disconnected-card/index.jsx
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/disconnected-card/index.jsx
@@ -1,0 +1,61 @@
+import { CONNECTION_STORE_ID, ConnectButton } from '@automattic/jetpack-connection';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
+import React, { useMemo } from 'react';
+import BrandedCard from '../branded-card';
+import CloseCircleIcon from '../close-circle-icon';
+import styles from './styles.module.scss';
+
+/**
+ * Disconnected Card component.
+ *
+ * @returns {React.Component} The `ConnectionCard` component.
+ */
+export default function DisconnectedCard() {
+	const { apiNonce, apiRoot, registrationNonce } = window.automatticForAgenciesClientInitialState;
+
+	const connectionErrors = useSelect(
+		select => select( CONNECTION_STORE_ID ).getConnectionErrors(),
+		[]
+	);
+
+	// Use the highest-level error message.
+	const errorMessage = useMemo( () => {
+		return Object.values( connectionErrors )?.shift()?.shift()?.error_message;
+	}, [ connectionErrors ] );
+
+	return (
+		<BrandedCard>
+			<div className={ styles.card }>
+				<h1>
+					{ __(
+						'Your site was disconnected from Automattic for Agencies',
+						'automattic-for-agencies-client'
+					) }
+				</h1>
+				<p
+					className={ classNames(
+						styles.connection_status,
+						styles[ 'connection_status--disconnected' ]
+					) }
+				>
+					<CloseCircleIcon />
+					{ errorMessage || __( 'Site is disconnected', 'automattic-for-agencies-client' ) }
+				</p>
+				<div className={ styles[ 'site-connection' ] }>
+					<div className={ styles[ 'connect-button-wrapper' ] }>
+						<ConnectButton
+							connectLabel={ __( 'Reconnect this site now', 'automattic-for-agencies-client' ) }
+							apiRoot={ apiRoot }
+							apiNonce={ apiNonce }
+							registrationNonce={ registrationNonce }
+							from="automattic-for-agencies-client"
+							redirectUri="options-general.php?page=automattic-for-agencies-client"
+						/>
+					</div>
+				</div>
+			</div>
+		</BrandedCard>
+	);
+}

--- a/projects/plugins/automattic-for-agencies-client/src/js/components/disconnected-card/styles.module.scss
+++ b/projects/plugins/automattic-for-agencies-client/src/js/components/disconnected-card/styles.module.scss
@@ -1,0 +1,74 @@
+@import '~@automattic/color-studio/dist/color-variables';
+
+.card {
+    padding: 160px 48px 48px;
+    display: flex;
+	flex-direction: column;
+	gap: 24px;
+
+    @media (max-width: 959px) {
+		padding: 16px;
+	}
+}
+
+.connection_status {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    font-size: 16px;
+    line-height: 22px;
+    padding-bottom: 24px;
+}
+
+.connection_status--connected {
+    color: var( --jp-green-50 );
+}
+
+.connection_status--disconnected {
+    color: var( --jp-red-50 );
+}
+
+.disconnect_site_trigger {
+    display: flex;
+    justify-content: center;
+    padding: 32px;
+}
+
+.disconnect_modal {
+    max-width: 512px;
+}
+
+.disconnect_modal__error {
+    color: var( --jp-red-50 );
+    text-align: end;
+    margin-bottom: 0;
+}
+
+.disconnect_modal__actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+
+    :global {
+        .components-button {
+            --spacing-base: 16px;
+            --font-body-extra-small: 14px;
+        }
+    }
+}
+
+.disconnect_button {
+    min-width: 167px;
+}
+
+.connect-button-wrapper {
+	:global {
+		.components-button.is-primary {
+			min-width: 228px;
+		}
+	}
+
+    display: inline-flex;
+    flex-direction: column;
+    gap: 8px;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves https://github.com/Automattic/automattic-for-agencies-dev/issues/130

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check for connection errors on load, and display the "disconnected" state when there are connection errors present.
* Minor refactor of how the card components are displayed, to support the above change.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/automattic-for-agencies-dev/issues/130

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install the Jetpack Debug plugin.
* Enable "Broken token Utilities".
* Navigate to the "Connection Errors" screen now available under the Jetpack Debug sidebar menu item.
* Add a fake connection error.
* Visit the A4A client plugin admin page, and validate the error is displayed to you alongside a reconnect button. The error message for a fake error from the debug plugin is "An error was triggered".

## Screenshots

<img width="1020" alt="Screenshot 2024-04-22 at 5 37 25 PM" src="https://github.com/Automattic/jetpack/assets/10933065/aac1eac3-31d8-40de-8bb9-bbb1a804d617">

