### PR TITLE
Point 'Add New User' menu to Calypso when in Default view

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-default-add-new-user-menu
+++ b/projects/plugins/jetpack/changelog/fix-default-add-new-user-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Point 'Add New User' menu item to Calypso when Default interface

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -125,7 +125,8 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$slug = current_user_can( 'list_users' ) ? 'users.php' : 'profile.php';
 		if ( self::DEFAULT_VIEW === $this->get_preferred_view( 'users.php' ) ) {
 			$submenus_to_update = array(
-				'users.php' => 'https://wordpress.com/people/team/' . $this->domain,
+				'users.php'    => 'https://wordpress.com/people/team/' . $this->domain,
+				'user-new.php' => 'https://wordpress.com/people/new/' . $this->domain,
 			);
 			$this->update_submenus( $slug, $submenus_to_update );
 		}

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -312,7 +312,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_users_menu();
 		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, $submenu['users.php'][0][2] );
-		$this->assertSame( 'https://wordpress.com/people/new/', $submenu['users.php'][2][2] );
+		$this->assertSame( 'https://wordpress.com/people/new/' . static::$domain, $submenu['users.php'][2][2] );
 		$this->assertSame( 'https://wordpress.com/subscribers/' . static::$domain, $submenu['users.php'][4][2] );
 		$this->assertSame( 'https://wordpress.com/me', $submenu['users.php'][5][2] );
 		$this->assertSame( 'https://wordpress.com/me/account', $submenu['users.php'][6][2] );

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -312,7 +312,7 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 
 		static::$admin_menu->add_users_menu();
 		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, $submenu['users.php'][0][2] );
-		$this->assertSame( 'user-new.php', $submenu['users.php'][2][2] );
+		$this->assertSame( 'https://wordpress.com/people/new/', $submenu['users.php'][2][2] );
 		$this->assertSame( 'https://wordpress.com/subscribers/' . static::$domain, $submenu['users.php'][4][2] );
 		$this->assertSame( 'https://wordpress.com/me', $submenu['users.php'][5][2] );
 		$this->assertSame( 'https://wordpress.com/me/account', $submenu['users.php'][6][2] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


> [!CAUTION]
> In retrospect, we may want to leave this link as is. See p1713910504645919/1713891137.161859-slack-C06DN6QQVAQ

Fixes https://github.com/Automattic/wp-calypso/issues/89646

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR ensures 'Add New Users' goes to the Calypso page for sites with the Default admin interface.

Before | After
--|--
<img width="1002" alt="Screenshot 2024-04-23 at 3 25 18 PM" src="https://github.com/Automattic/jetpack/assets/140841/f206b1fa-1ac9-4747-8111-70c5fa60e898">  | <img width="1378" alt="Screenshot 2024-04-23 at 3 29 23 PM" src="https://github.com/Automattic/jetpack/assets/140841/2ac1aee3-c38f-4ede-80c7-628c10b1ae75">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On an Atomic site with the Default [admin interface view](https://wordpress.com/support/dashboard/#set-the-admin-interface-style) enabled view that the 'Add New Users' menu item links to /wp-admin/user-new.php
* Use the Jetpack Beta plugin to apply this PR
* On the same Atomic site, now view that the 'Add New Users' point to Calypso /people/new/[site].wpcomstaging.com
* Set your Atomic site to the Classic admin interface view and observe the  'Add New Users' menu item links to /wp-admin/user-new.php