### PR TITLE
Base Styles: Reduce specificity of body selector

### DIFF
--- a/projects/js-packages/base-styles/changelog/feat-reduce-specificity-of-body-selector
+++ b/projects/js-packages/base-styles/changelog/feat-reduce-specificity-of-body-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Base Styles: Reduce specificity of the body selector

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.22",
+	"version": "0.6.23-alpha",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/style.scss
+++ b/projects/js-packages/base-styles/style.scss
@@ -26,7 +26,7 @@
 /********* Generic styles *********/
 $wp-gray-dark: #23282d;
 
-body {
+:where(body) {
 	min-height: 100%;
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/89631
Related to https://github.com/WordPress/gutenberg/pull/60106, p1713865028094699-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Referring to https://github.com/WordPress/gutenberg/pull/60106, it would be better to reduce the specificity of the body selector on Jetpack to avoid the styles of the font family being overridden. I'm unsure of the purpose of the body styles but I guess we can consider removing them later

Here is the result of Bedrock theme:

![Screenshot 2024-04-24 at 12 50 26 PM](https://github.com/Automattic/jetpack/assets/13596067/e8bff668-01d9-4bea-abfc-1be12214ecc6)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow https://github.com/Automattic/jetpack/pull/37043#issuecomment-2073950385 to apply the changes on your site
  * You have to apply this branch to Jetpack & Jetpack VideoPress on atomic sites
* Remember to disable the cache before getting started
* Go through pages under the Jetpack
* Make sure the styles look good
* Activate any of these themes: Kingsley, Arbutus, and Geologist (or probably any theme).
* Create a new post
* Add a paragraph with sample text.
* Make sure the fonts are rendered correctly
* Go to the Site Editor
* Add jetpack blocks
* Make sure the styles of jetpack blocks look good