### PR TITLE
Fix timeout issues in E2E tests

### DIFF
--- a/projects/plugins/social/changelog/fix-timeout-issues-in-e2e
+++ b/projects/plugins/social/changelog/fix-timeout-issues-in-e2e
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed timeouts in E2E tests

--- a/projects/plugins/social/tests/e2e/flows/connection.js
+++ b/projects/plugins/social/tests/e2e/flows/connection.js
@@ -7,7 +7,7 @@ export async function connect( page, premium = false ) {
 
 	let socialPage = await JetpackSocialPage.visit( page );
 	await socialPage.getStarted();
-	await ( await AuthorizePage.init( page ) ).approve();
+	await ( await AuthorizePage.init( page ) ).approve( { redirectUrl: socialPage.url } );
 	socialPage = await JetpackSocialPage.init( page );
 
 	if ( premium ) {

--- a/projects/plugins/social/tests/e2e/pages/wp-admin/jetpack-social.js
+++ b/projects/plugins/social/tests/e2e/pages/wp-admin/jetpack-social.js
@@ -5,7 +5,7 @@ import { resolveSiteUrl } from 'jetpack-e2e-commons/helpers/utils-helper.js';
 export default class JetpackSocialPage extends WpPage {
 	constructor( page ) {
 		const url = resolveSiteUrl() + '/wp-admin/admin.php?page=jetpack-social';
-		super( page, { expectedSelectors: [ '#jetpack-social-root' ], url } );
+		super( page, { expectedSelectors: [], url } );
 	}
 
 	async getStarted() {

--- a/tools/e2e-commons/flows/jetpack-connect.js
+++ b/tools/e2e-commons/flows/jetpack-connect.js
@@ -22,7 +22,9 @@ const cardCredentials = config.get( 'testCardCredentials' );
 export async function doClassicConnection( page, plan = 'free' ) {
 	const jetpackPage = await JetpackPage.init( page );
 	await jetpackPage.connect();
-	await ( await AuthorizePage.init( page ) ).approve();
+	await (
+		await AuthorizePage.init( page )
+	).approve( { redirectUrl: 'https://wordpress.com/jetpack/connect/plans/**' } );
 
 	if ( plan === 'free' ) {
 		await ( await PickAPlanPage.init( page ) ).select( 'free' );

--- a/tools/e2e-commons/pages/wp-admin/login.js
+++ b/tools/e2e-commons/pages/wp-admin/login.js
@@ -14,7 +14,7 @@ export default class WPLoginPage extends WpPage {
 
 		// If the SSO login button (a tag with the jetpack-sso class) is present,
 		// click on the link (a tag with the jetpack-sso-toggle class) to log in with the default core WP login form instead.
-		if ( await this.isElementVisible( '.jetpack-sso' ) ) {
+		if ( await this.isElementVisible( '.jetpack-sso', 10 ) ) {
 			await this.click( '.jetpack-sso-toggle' );
 		}
 

--- a/tools/e2e-commons/pages/wp-page.js
+++ b/tools/e2e-commons/pages/wp-page.js
@@ -11,7 +11,7 @@ export default class WpPage extends PageActions {
 	 *
 	 * @param {Object}  page           Playwright representation of the page.
 	 * @param {boolean} checkSelectors whether to also check for expected selectors
-	 * @return {WpPage} Instance of the Page Object class
+	 * @return {Promise<WpPage>} Instance of the Page Object class
 	 */
 	static async init( page, checkSelectors = true ) {
 		const it = new this( page );

--- a/tools/e2e-commons/pages/wpcom/authorize.js
+++ b/tools/e2e-commons/pages/wpcom/authorize.js
@@ -6,26 +6,20 @@ export default class AuthorizePage extends WpPage {
 		super( page, { expectedSelectors: [ '.jetpack-connect__logged-in-form' ] } );
 	}
 
-	async approve( repeat = true ) {
+	async approve( options ) {
+		const { redirectUrl, repeat = true } = options;
 		const authorizeButtonSelector = '.jetpack-connect__authorize-form button';
 		try {
-			return await Promise.all( [
-				this.click( authorizeButtonSelector ),
-				this.waitToDisappear(),
-				this.waitForDomContentLoaded( 50000 ),
-			] );
+			await this.click( authorizeButtonSelector );
+
+			await this.page.waitForURL( redirectUrl );
 		} catch ( error ) {
 			if ( repeat ) {
 				const message = 'Jetpack connection failed. Retrying once again.';
 				logger.error( message );
-				return await this.approve( false );
+				return await this.approve( { ...options, repeat: false } );
 			}
 			throw error;
 		}
-	}
-
-	async waitToDisappear() {
-		await this.waitForElementToBeHidden( '.jetpack-connect__logged-in-form-loading' );
-		await this.waitForElementToBeHidden( '.jetpack-connect__authorize-form button' );
 	}
 }


### PR DESCRIPTION
Our e2e tests have many timeout issues and many awaits for timeouts which are unnecessary and can be solved easily. This PR is a result of our hack session in @Automattic/jetpack-reach Kuala Lumpur meetup while working on #37046

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the timeout issues in some E2E tests 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdrWKz-1zy-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Just run the e2e tests