### PR TITLE
General: update WP version requirements to WordPress 6.4

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -40,7 +40,7 @@ case "$WP_BRANCH" in
 	previous)
 		# We hard-code the version here because there's a time near WP releases where
 		# we've dropped the old 'previous' but WP hasn't actually released the new 'latest'
-		TAG=6.3
+		TAG=6.4
 		;;
 	*)
 		echo "Unrecognized value for WP_BRANCH: $WP_BRANCH" >&2

--- a/.phpcs.config.xml
+++ b/.phpcs.config.xml
@@ -2,7 +2,7 @@
 <!-- This file configures everything except the list of rules. -->
 <!-- The separation is so .github/files/phpcompatibility-dev-phpcs.xml can use the same config with a different rule set. -->
 <ruleset>
-	<config name="minimum_supported_wp_version" value="6.3" />
+	<config name="minimum_supported_wp_version" value="6.4" />
 	<config name="testVersion" value="7.0-"/>
 
 	<!-- Use our custom filter for `.phpcsignore` and `.phpcs.dir.xml` support. -->

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
 		"phan/phan": "^5.4",
 		"php-parallel-lint/php-parallel-lint": "1.3.2",
 		"php-stubs/woocommerce-stubs": ">=8.7",
-		"php-stubs/wordpress-stubs": ">=6.3",
-		"php-stubs/wordpress-tests-stubs": ">=6.3",
+		"php-stubs/wordpress-stubs": ">=6.4",
+		"php-stubs/wordpress-tests-stubs": ">=6.4",
 		"php-stubs/wp-cli-stubs": "^2.10",
 		"sirbrillig/phpcs-changed": "2.11.4",
 		"squizlabs/php_codesniffer": "^3.6.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "02f92def2ba7aea3f906f91528261cf5",
+    "content-hash": "ea0720f27be9bac14e63538bec9535f0",
     "packages": [],
     "packages-dev": [
         {
@@ -1025,27 +1025,25 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.4.3",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "6105bdab2f26c0204fe90ecc53d5684754550e8f"
+                "reference": "286d42eeb44c6808633cc59b8dbb9aa75fe41264"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/6105bdab2f26c0204fe90ecc53d5684754550e8f",
-                "reference": "6105bdab2f26c0204fe90ecc53d5684754550e8f",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/286d42eeb44c6808633cc59b8dbb9aa75fe41264",
+                "reference": "286d42eeb44c6808633cc59b8dbb9aa75fe41264",
                 "shasum": ""
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "nikic/php-parser": "^4.13",
                 "php": "^7.4 || ~8.0.0",
                 "php-stubs/generator": "^0.8.3",
                 "phpdocumentor/reflection-docblock": "^5.3",
-                "phpstan/phpstan": "^1.10.49",
-                "phpunit/phpunit": "^9.5",
-                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.11"
+                "phpstan/phpstan": "^1.10.12",
+                "phpunit/phpunit": "^9.5"
             },
             "suggest": {
                 "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
@@ -1066,22 +1064,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.4.3"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.4.0"
             },
-            "time": "2024-02-11T18:56:19+00:00"
+            "time": "2023-11-08T07:02:08+00:00"
         },
         {
             "name": "php-stubs/wordpress-tests-stubs",
-            "version": "v6.5.0",
+            "version": "v6.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-tests-stubs.git",
-                "reference": "7d6649a7e91d92aea7a191d2c1f621605d310f4e"
+                "reference": "e7d6d1653f2347cd016f66fb9cd74d7cf7360b49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-tests-stubs/zipball/7d6649a7e91d92aea7a191d2c1f621605d310f4e",
-                "reference": "7d6649a7e91d92aea7a191d2c1f621605d310f4e",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-tests-stubs/zipball/e7d6d1653f2347cd016f66fb9cd74d7cf7360b49",
+                "reference": "e7d6d1653f2347cd016f66fb9cd74d7cf7360b49",
                 "shasum": ""
             },
             "require-dev": {
@@ -1106,9 +1104,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-tests-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-tests-stubs/tree/v6.5.0"
+                "source": "https://github.com/php-stubs/wordpress-tests-stubs/tree/v6.4.0"
             },
-            "time": "2024-04-02T18:38:25+00:00"
+            "time": "2024-02-26T13:52:25+00:00"
         },
         {
             "name": "php-stubs/wp-cli-stubs",
@@ -2921,7 +2919,7 @@
         "automattic/jetpack-phpcs-filter": 20
     },
     "prefer-stable": true,
-    "prefer-lowest": false,
+    "prefer-lowest": true,
     "platform": {
         "ext-json": "*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -981,16 +981,16 @@
         },
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v8.7.0",
+            "version": "v8.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "1bab3a764a91ed037f420dc38124e2516b29e6b8"
+                "reference": "320ad596d47d4a8687bbeac0924d8167a6689da6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/1bab3a764a91ed037f420dc38124e2516b29e6b8",
-                "reference": "1bab3a764a91ed037f420dc38124e2516b29e6b8",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/320ad596d47d4a8687bbeac0924d8167a6689da6",
+                "reference": "320ad596d47d4a8687bbeac0924d8167a6689da6",
                 "shasum": ""
             },
             "require": {
@@ -1019,31 +1019,33 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v8.7.0"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v8.8.2"
             },
-            "time": "2024-03-19T16:55:16+00:00"
+            "time": "2024-04-17T12:41:04+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.4.0",
+            "version": "v6.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "286d42eeb44c6808633cc59b8dbb9aa75fe41264"
+                "reference": "379f17a90c01498d4c99a0d15aab6e7aa6a2c840"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/286d42eeb44c6808633cc59b8dbb9aa75fe41264",
-                "reference": "286d42eeb44c6808633cc59b8dbb9aa75fe41264",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/379f17a90c01498d4c99a0d15aab6e7aa6a2c840",
+                "reference": "379f17a90c01498d4c99a0d15aab6e7aa6a2c840",
                 "shasum": ""
             },
             "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "nikic/php-parser": "^4.13",
                 "php": "^7.4 || ~8.0.0",
                 "php-stubs/generator": "^0.8.3",
-                "phpdocumentor/reflection-docblock": "^5.3",
-                "phpstan/phpstan": "^1.10.12",
-                "phpunit/phpunit": "^9.5"
+                "phpdocumentor/reflection-docblock": "5.3",
+                "phpstan/phpstan": "^1.10.49",
+                "phpunit/phpunit": "^9.5",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.11"
             },
             "suggest": {
                 "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
@@ -1064,22 +1066,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.4.0"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.5.2"
             },
-            "time": "2023-11-08T07:02:08+00:00"
+            "time": "2024-04-14T17:30:14+00:00"
         },
         {
             "name": "php-stubs/wordpress-tests-stubs",
-            "version": "v6.4.0",
+            "version": "v6.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-tests-stubs.git",
-                "reference": "e7d6d1653f2347cd016f66fb9cd74d7cf7360b49"
+                "reference": "7d6649a7e91d92aea7a191d2c1f621605d310f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-tests-stubs/zipball/e7d6d1653f2347cd016f66fb9cd74d7cf7360b49",
-                "reference": "e7d6d1653f2347cd016f66fb9cd74d7cf7360b49",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-tests-stubs/zipball/7d6649a7e91d92aea7a191d2c1f621605d310f4e",
+                "reference": "7d6649a7e91d92aea7a191d2c1f621605d310f4e",
                 "shasum": ""
             },
             "require-dev": {
@@ -1104,9 +1106,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-tests-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-tests-stubs/tree/v6.4.0"
+                "source": "https://github.com/php-stubs/wordpress-tests-stubs/tree/v6.5.0"
             },
-            "time": "2024-02-26T13:52:25+00:00"
+            "time": "2024-04-02T18:38:25+00:00"
         },
         {
             "name": "php-stubs/wp-cli-stubs",
@@ -2919,7 +2921,7 @@
         "automattic/jetpack-phpcs-filter": 20
     },
     "prefer-stable": true,
-    "prefer-lowest": true,
+    "prefer-lowest": false,
     "platform": {
         "ext-json": "*"
     },

--- a/projects/packages/compat/.phan/baseline.php
+++ b/projects/packages/compat/.phan/baseline.php
@@ -9,11 +9,13 @@
  */
 return [
     // # Issue statistics:
+    // PhanDeprecatedFunction : 1 occurrence
     // PhanPluginDuplicateConditionalNullCoalescing : 1 occurrence
+    // PhanTypeMismatchProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'lib/locales.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
+        'lib/locales.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchProperty'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/compat/changelog/update-wp-requirements-64
+++ b/projects/packages/compat/changelog/update-wp-requirements-64
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Phan: update configuration
+
+

--- a/projects/plugins/automattic-for-agencies-client/changelog/update-wp-requirements-64
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-wp-requirements-64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/automattic-for-agencies-client/readme.txt
+++ b/projects/plugins/automattic-for-agencies-client/readme.txt
@@ -1,7 +1,7 @@
 === Automattic For Agencies Client ===
 Contributors: automattic
 Tags: agency, dashboard, management, sites, monitoring
-Requires at least: 6.3
+Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
 Stable tag: 0.1.0-alpha

--- a/projects/plugins/backup/changelog/update-wp-requirements-64
+++ b/projects/plugins/backup/changelog/update-wp-requirements-64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack VaultPress Backup ===
 Contributors: automattic, bjorsch, fgiannar, initsogar, jeherve, jwebbdev, kraftbj, macbre, pypt, samiff, sermitr, williamvianas
 Tags: jetpack, backup, restore
-Requires at least: 6.3
+Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
 Stable tag: 2.2

--- a/projects/plugins/inspect/changelog/update-wp-requirements-64
+++ b/projects/plugins/inspect/changelog/update-wp-requirements-64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/inspect/readme.txt
+++ b/projects/plugins/inspect/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack inspect ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.3
+Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
 Stable tag: 1.0.0-alpha

--- a/projects/plugins/jetpack/changelog/update-wp-requirements-64
+++ b/projects/plugins/jetpack/changelog/update-wp-requirements-64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -8,7 +8,7 @@
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP: 7.0
  *
  * @package automattic/jetpack
@@ -32,7 +32,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '6.3' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
 define( 'JETPACK__VERSION', '13.4-a.6' );
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, azaozz, barry, batmoo, beaulebens, bindlegirl, biskobe, bjorsch, blobaugh, brbrr, cainm, cena, cfinke, cgastrell, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, daniloercoli, davoraltman, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, joen, jblz, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lhkowalski, lschuyler, macmanx, martinremy, matt, mattwiebe, matveb, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, nunyvega, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, renatoagds, retrofox, richardmtl, richardmuscat, robertbpugh, roccotripaldi, ryancowles, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, thehenridev, tmoorewp, tyxla, Viper007Bond, westi, williamvianas, wpkaren, yoavf, zinigor
 Tags: Security, backup, malware, scan, performance
 Stable tag: 13.3.1
-Requires at least: 6.3
+Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
 License: GPLv2 or later

--- a/projects/plugins/migration/changelog/update-wp-requirements-64
+++ b/projects/plugins/migration/changelog/update-wp-requirements-64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/migration/readme.txt
+++ b/projects/plugins/migration/readme.txt
@@ -1,7 +1,7 @@
 === Move to WordPress.com ===
 Contributors: automattic
 Tags: migrate, migration, backup, restore, transfer, move, copy, wordpress.com, automattic, import, importer, hosting
-Requires at least: 6.3
+Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
 Stable tag: 2.0.0

--- a/projects/plugins/protect/changelog/update-wp-requirements-64
+++ b/projects/plugins/protect/changelog/update-wp-requirements-64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/protect/readme.txt
+++ b/projects/plugins/protect/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Protect ===
 Contributors: automattic, retrofox, leogermani, renatoagds, bjorsch, ebinnion, fgiannar, zinigor, miguelxavierpenha, dsmart, jeherve, manzoorwanijk, njweller, oskosk, samiff, siddarthan, wpkaren, arsihasi, kraftbj, kev, sermitr, kangzj, pabline, dkmyta
 Tags: jetpack, protect, security, malware, scan
-Requires at least: 6.3
+Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
 Stable tag: 1.4.1

--- a/projects/plugins/search/changelog/update-wp-requirements-64
+++ b/projects/plugins/search/changelog/update-wp-requirements-64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Search ===
 Contributors: automattic, annamcphee, bluefuton, kangzj, jsnmoon, robfelty, gibrown, trakos, dognose24, a8ck3n
 Tags: search, filter, woocommerce search, ajax search, product search, free cloud-based search
-Requires at least: 6.3
+Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
 Stable tag: 1.4.0

--- a/projects/plugins/social/changelog/update-wp-requirements-64
+++ b/projects/plugins/social/changelog/update-wp-requirements-64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Social  ===
 Contributors: automattic, pabline, siddarthan, gmjuhasz, manzoorwanijk, danielpost
 Tags: social-media, publicize, social-media-manager, social-networking, social marketing, social, social share,  social media scheduling, social media automation, auto post, auto- publish, social share
-Requires at least: 6.3
+Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
 Stable tag: 2.3.0

--- a/projects/plugins/starter-plugin/changelog/update-wp-requirements-64
+++ b/projects/plugins/starter-plugin/changelog/update-wp-requirements-64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/starter-plugin/readme.txt
+++ b/projects/plugins/starter-plugin/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Starter Plugin ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.3
+Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
 Stable tag: 0.1.0-alpha

--- a/projects/plugins/super-cache/changelog/update-wp-requirements-64
+++ b/projects/plugins/super-cache/changelog/update-wp-requirements-64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -1,7 +1,7 @@
 === WP Super Cache ===
 Contributors: donncha, automattic, adnan007, dilirity, mikemayhem3030, pyronaur, thingalon
 Tags: performance, caching, wp-cache, wp-super-cache, cache
-Requires at least: 6.3
+Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
 Stable tag: 1.12.0

--- a/projects/plugins/videopress/changelog/update-wp-requirements-64
+++ b/projects/plugins/videopress/changelog/update-wp-requirements-64
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, retrofox, oskosk, thehenridev, renatoagds, lhkowalski, nunyvega, leogermani, cgastrell
 Tags: video, video-hosting, video-player, cdn, video-streaming
 
-Requires at least: 6.3
+Requires at least: 6.4
 Tested up to: 6.5
 Stable tag: 1.5
 Requires PHP: 7.0

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -949,7 +949,7 @@ function createReadMeTxt( answers ) {
 		`=== Jetpack ${ answers.name } ===\n` +
 		'Contributors: automattic,\n' +
 		'Tags: jetpack, stuff\n' +
-		'Requires at least: 6.3\n' +
+		'Requires at least: 6.4\n' +
 		'Requires PHP: 7.0\n' +
 		'Tested up to: 6.5\n' +
 		`Stable tag: ${ answers.version }\n` +


### PR DESCRIPTION
## Proposed changes:

Now that WP 6.5 is out, we can start requiring a more recent version of WordPress, 6.4.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Epic: #33615

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here, this is just an update to the required version of WordPress. Ensure all plugins have been updated.
