### PR TITLE
CRM: Modifying invoice quick filter status logic to fix an issue breaking those filters

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-invoice-status-filters
+++ b/projects/plugins/crm/changelog/fix-crm-invoice-status-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Listviews: Invoice quick filter status fix to prevent filters not working

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
@@ -196,11 +196,11 @@ class zbsDAL_invoices extends zbsDAL_ObjectLayer {
 			// Add statuses if enabled.
 			if ( $zbs->settings->get( 'filtersfromstatus' ) === 1 ) {
 				$statuses = array(
-					'draft'   => __( 'Draft', 'zero-bs-crm' ),
-					'unpaid'  => __( 'Unpaid', 'zero-bs-crm' ),
-					'paid'    => __( 'Paid', 'zero-bs-crm' ),
-					'overdue' => __( 'Overdue', 'zero-bs-crm' ),
-					'deleted' => __( 'Deleted', 'zero-bs-crm' ),
+					'Draft'   => __( 'Draft', 'zero-bs-crm' ),
+					'Unpaid'  => __( 'Unpaid', 'zero-bs-crm' ),
+					'Paid'    => __( 'Paid', 'zero-bs-crm' ),
+					'Overdue' => __( 'Overdue', 'zero-bs-crm' ),
+					'Deleted' => __( 'Deleted', 'zero-bs-crm' ),
 				);
 				foreach ( $statuses as $status_slug => $status_label ) {
 					$listview_filters[ ZBS_TYPE_INVOICE ]['status'][ 'status_' . $status_slug ] = $status_label;
@@ -811,8 +811,7 @@ class zbsDAL_invoices extends zbsDAL_ObjectLayer {
 					if ( str_starts_with( $qFilter, 'status_' ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 						$quick_filter_status         = substr( $qFilter, 7 ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-						$quick_filter_status         = str_replace( '_', ' ', $quick_filter_status );
-						$wheres['quickfilterstatus'] = array( 'zbsi_status', 'LIKE', '%s', ucwords( $quick_filter_status ) );
+						$wheres['quickfilterstatus'] = array( 'zbsi_status', '=', 'convert(%s using utf8mb4) collate utf8mb4_bin', $quick_filter_status );
 
 					} else {
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Invoices.php
@@ -811,7 +811,8 @@ class zbsDAL_invoices extends zbsDAL_ObjectLayer {
 					if ( str_starts_with( $qFilter, 'status_' ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 						$quick_filter_status         = substr( $qFilter, 7 ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-						$wheres['quickfilterstatus'] = array( 'zbsi_status', '=', 'convert(%s using utf8mb4) collate utf8mb4_bin', $quick_filter_status );
+						$quick_filter_status         = str_replace( '_', ' ', $quick_filter_status );
+						$wheres['quickfilterstatus'] = array( 'zbsi_status', 'LIKE', '%s', ucwords( $quick_filter_status ) );
 
 					} else {
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3461

## Proposed changes:

* This PR fixes an issue that meant that it wasn't possible to filter by invoice status on the invoice list view page.
* Specifically, this PR reverts changes introduced in CRM 6.4.2, but specific to invoice quick filter statuses. Changes were added in https://github.com/Automattic/jetpack/pull/36232 to allow list view status filters to be case sensitive, but as noted here https://github.com/Automattic/zero-bs-crm/issues/3439  the original edge case bug would likely only be an issue for contacts and transactions - invoice statuses are hard-coded and translated. So for now, reverting seems a good option for invoices.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/zero-bs-crm/issues/3461
p1713883670179739-slack-CL5UJ9ASE

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Apply this PR, and make sure you have a few invoices with differing statuses.
* On the invoice listview page at `/wp-admin/admin.php?page=manage-invoices`, select any invoice filter and you should see the list view correctly reflect invoices with that selected status.
* In trunk, nothing will be found for any status.
