### PR TITLE
Google Fonts: Prevent the default fonts from overridden by the theme fonts

### DIFF
--- a/projects/plugins/jetpack/changelog/feat-dont-override-default-fonts
+++ b/projects/plugins/jetpack/changelog/feat-dont-override-default-fonts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Google Fonts: Avoid theme fonts overriding the default fonts so fonts with a specific font weight that are not supported by the provided theme can be rendered correctly

--- a/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/class-jetpack-google-font-face.php
@@ -72,7 +72,7 @@ class Jetpack_Google_Font_Face {
 		foreach ( $fonts as $font_faces ) {
 			$font_family = $font_faces[0]['font-family'] ?? '';
 			if ( in_array( $this->format_font( $font_family ), $fonts_in_use, true ) ) {
-				$fonts_to_print[ $font_family ] = $font_faces;
+				$fonts_to_print[] = $font_faces;
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -84,33 +84,6 @@ function jetpack_get_available_google_fonts_map( $google_fonts_data ) {
 }
 
 /**
- * Gets the font families of the active theme
- *
- * @return object[] The font families of the active theme.
- */
-function jetpack_get_theme_fonts_map() {
-	if ( ! class_exists( 'WP_Theme_JSON_Resolver' ) ) {
-		return array();
-	}
-
-	$theme_json = WP_Theme_JSON_Resolver::get_theme_data();
-	$raw_data   = $theme_json->get_data();
-	if ( empty( $raw_data['settings']['typography']['fontFamilies'] ) ) {
-		return array();
-	}
-
-	$theme_fonts_map = array();
-	foreach ( $raw_data['settings']['typography']['fontFamilies'] as $font_family ) {
-		$font_family_name = $font_family['name'] ?? Jetpack_Google_Font_Face::get_font_family_name( $font_family );
-		if ( $font_family_name ) {
-			$theme_fonts_map[ $font_family_name ] = true;
-		}
-	}
-
-	return $theme_fonts_map;
-}
-
-/**
  * Register google fonts to the theme json data
  *
  * @param WP_Theme_JSON_Data $theme_json The theme json data of core.
@@ -123,18 +96,11 @@ function jetpack_register_google_fonts_to_theme_json( $theme_json ) {
 	}
 
 	$available_google_fonts_map = jetpack_get_available_google_fonts_map( $google_fonts_data );
-	$theme_fonts_map            = jetpack_get_theme_fonts_map();
 	$google_fonts_families      = array_values(
 		array_filter(
 			$google_fonts_data['fontFamilies'],
-			function ( $google_fonts_family ) use ( $available_google_fonts_map, $theme_fonts_map ) {
+			function ( $google_fonts_family ) use ( $available_google_fonts_map ) {
 				$name = $google_fonts_family['name'];
-
-				// Filter out the fonts that are provided by the active theme.
-				if ( isset( $theme_fonts_map[ $name ] ) && $theme_fonts_map[ $name ] ) {
-					return false;
-				}
-
 				return $available_google_fonts_map[ $name ] ?? false;
 			}
 		)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/84590

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Currently, the fonts provided by both the theme and Jetpack Google Fonts might not render correctly if the theme only supports a specific set of font weights. The reason was the theme fonts have a higher priority.
* As a result, this PR proposes to prevent the theme fonts from overriding the default fonts. With this change, all font weights of the font supported by Jetpack Google Fonts can render correctly. The downside is the font family name will be duplicated in the dropdown list but I think it's fine as it's the same as the installed fonts.

**The screenshot of applying the “Extra Light” appearance**
| | Before | After |
| - | - | - |
| Editor | ![image](https://github.com/Automattic/jetpack/assets/13596067/64183b76-f811-4f93-ad61-ff9be27c3656) | ![image](https://github.com/Automattic/jetpack/assets/13596067/ac8aae40-7138-46a0-8bbd-75a654c5aedc) |
| Frontend | ![image](https://github.com/Automattic/jetpack/assets/13596067/6ba53eb8-0635-4031-acae-c83e9da3ad74) | ![image](https://github.com/Automattic/jetpack/assets/13596067/6c68bec5-68ee-4cb2-a45b-86e764bbe43e) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow https://github.com/Automattic/jetpack/pull/37050#issuecomment-2074666436 to apply changes to your site
* Activate Adventurer theme
* Go to the Site Editor
* Change the font weight of the heading
* Make sure it works as expected
* Save the changes and preview your site
* Make sure it works on the frontend page as well

