### PR TITLE
Untangling: Fix border colors in sidebar notices

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-untanglined-sidebar-notice-border
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-untanglined-sidebar-notice-border
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed a WP.com only issue on the sidebar notices
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.js
@@ -22,9 +22,7 @@ const wpcomShowSidebarNotice = () => {
 						<div class="upsell_banner">
 							<div class="upsell_banner__icon dashicons" aria-hidden="true"></div>
 							<div class="upsell_banner__text">${ wpcomSidebarNotice.text }</div>
-							<button type="button" class="upsell_banner__action button button-primary">${
-								wpcomSidebarNotice.action
-							}</button>
+							<button type="button" class="upsell_banner__action button">${ wpcomSidebarNotice.action }</button>
 							${
 								wpcomSidebarNotice.dismissible === '1'
 									? '<button type="button" class="upsell_banner__dismiss button button-link">' +

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
@@ -95,6 +95,7 @@
 		cursor: pointer;
 		min-height: 32px;
 		margin-bottom: 0;
+		border: 0;
 	}
 
 	.upsell_banner__dismiss {


### PR DESCRIPTION
Follow-up of https://github.com/Automattic/jetpack/pull/36797

## Proposed changes:

Fixes an issue that showing an incorrect border color on the CTA button of the new sidebar notices displayed for untangled sites

Color scheme | Before | After
--- | --- | ---
Default | <img width="267" alt="Screenshot 2024-04-24 at 12 46 44" src="https://github.com/Automattic/jetpack/assets/1233880/ff2fe212-6d2a-4784-98db-f74dba051129"> | <img width="367" alt="Screenshot 2024-04-24 at 12 50 43" src="https://github.com/Automattic/jetpack/assets/1233880/47f9acef-6313-4e5c-bd43-89726f509f56">
Blue | <img width="382" alt="Screenshot 2024-04-24 at 12 46 17" src="https://github.com/Automattic/jetpack/assets/1233880/67ff42c8-c920-4f47-8084-a2ff0ea4e8d6"> | <img width="303" alt="Screenshot 2024-04-24 at 12 50 55" src="https://github.com/Automattic/jetpack/assets/1233880/f2c4e125-e4e0-4b32-96e8-35f4f08107a0">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com untangled site using the instructions from the auto-generated comment below
- Go to `/wp-admin/profile.php`
- Select either Default or Blue
- Save the settings
- Upon reloading, make sure the button in the sidebar notice does not have a wrong colored border.
