### PR TITLE
Add/migrate src domain option

### DIFF
--- a/projects/plugins/jetpack/changelog/update-migration-source-setting
+++ b/projects/plugins/jetpack/changelog/update-migration-source-setting
@@ -1,4 +1,3 @@
-
 Significance: minor
 Type: other
 

--- a/projects/plugins/jetpack/changelog/update-migration-source-setting
+++ b/projects/plugins/jetpack/changelog/update-migration-source-setting
@@ -1,0 +1,5 @@
+
+Significance: minor
+Type: other
+
+Add migration_source_site_domain to the list of available site options to update and retrieve. This will be used as part of the Site Migration on-boarding flow.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -45,6 +45,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 		),
 
 		'request_format'      => array(
+			'migration_source_site_domain'            => '(string) The source site URL, from the migration flow',
 			'in_site_migration_flow'                  => '(bool) Whether the site is currently in the Site Migration signup flow.',
 			'blogname'                                => '(string) Blog name',
 			'blogdescription'                         => '(string) Blog description',
@@ -470,6 +471,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'highlander_comment_form_prompt'   => $this->get_highlander_comment_form_prompt_option(),
 						'jetpack_comment_form_color_scheme' => (string) get_option( 'jetpack_comment_form_color_scheme' ),
 						'in_site_migration_flow'           => (bool) get_option( 'in_site_migration_flow', 0 ),
+						'migration_source_site_domain'     => (string) get_option( 'migration_source_site_domain' ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -35,6 +35,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 		),
 
 		'request_format'  => array(
+			'migration_source_site_domain'            => '(string) The source site URL, from the migration flow',
 			'in_site_migration_flow'                  => '(bool) Whether the site is currently in the Site Migration signup flow.',
 			'blogname'                                => '(string) Blog name',
 			'blogdescription'                         => '(string) Blog description',


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/89649
Related to https://github.com/Automattic/wp-calypso/issues/89897


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We need to store the URL of the site we are migrating from.
* This PR adds a new setting, `migration_source_site_domain`, to track that.
* It will the used in the new migration flow

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
 No 

## Testing instructions:

- Apply this PR on your sandbox and sandbox the public-api.
- Using calypso from https://github.com/Automattic/wp-calypso/pull/89866:
- Go to the import site flow (`/start`, pick the import option)
- Follow the instructions until the `site-migration-identify` step
- Enter a valid URL and click continue
- In the https://developer.wordpress.com/docs/api/console/, do a GET query to /rest/v1.4/site/:siteId/settings.
- Scroll through the settings property of the response until you find `migration_source_site_domain` 
- It should be the same URL you entered

