### PR TITLE
Untangling: prevent admin color scheme CSS concat instead of reenqueuing

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/untangling-fix-css-concat
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangling-fix-css-concat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Untangling: prevent CSS concat on colors handle instead of reenqueuing colors from CDN


### PR DESCRIPTION
Part of:

- https://github.com/Automattic/dotcom-forge/issues/6665


## Proposed changes:

The Default admin color scheme does not enqueue any CSS file. Before, we always reenqueue the current admin color CSS from our CDN (ref: https://github.com/Automattic/jetpack/pull/36341). As a result, when we switch to the Default color, the color scheme cannot be previewed.

This PR aims to fix the behavior by just preventing the color from being concatenated (which solves the original issue). I just found out that there's a filter that can do that 🤦

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

First, verify that you can reproduce the issue. DON'T apply this patch yet.

1. Prepare an Atomic site.
2. Go to Settings -> Hosting Configuration and change the admin interface style to Classic.
3. Go to the site's `_cli` and run `wp option update wpcom_classic_early_relase 1`.
4. Go to Users -> Profile.
5. Update the admin color scheme to Sunrise.
6. REFRESH the page.
7. Now, click the Coffee scheme. Verify that the color is updated immediately (expected).
8. Then, click the Default scheme. Verify that the color is NOT updated to the Default's scheme (not expected), but somehow it is back to Sunrise's scheme.

Now, apply this patch to Jetpack Beta Tester (on WordPress.com Features). Then: 

- Repeat steps 4-8, and verify that when we click the Default scheme, the color is updated immediately as well.

> [!NOTE]  
> Ignore the colors on the sidebar upsells (if you see any); it is out of the scope of this PR!