### PR TITLE
Untangling: fix wp-admin's sidebar upsell color for Default scheme

### DIFF
--- a/projects/plugins/jetpack/changelog/untangling-fix-default-color-scheme
+++ b/projects/plugins/jetpack/changelog/untangling-fix-default-color-scheme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Untangling: fix sidebar upsells on Default color scheme to follow Core's

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/fresh/_variables.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/fresh/_variables.scss
@@ -20,6 +20,6 @@ $color-neutral-100-rgb: $studio-gray-100-rgb; // Calypso --color-neutral-100-rgb
 // Sidebar Nudges
 $menu-nudge-background: $studio-white;
 $menu-nudge-text-color: $studio-black;
-$menu-nudge-cta-background: $studio-pink;
+$menu-nudge-cta-background: #2271b1;
 $menu-nudge-cta-color: $studio-white;
-$menu-nudge-cta-background-hover: $studio-pink-60;
+$menu-nudge-cta-background-hover: #135e96;


### PR DESCRIPTION
Part of:

- https://github.com/Automattic/dotcom-forge/issues/6665

## Proposed changes:

This PR fixes the color of the sidebar upsell in the Atomic classic sites using the Default admin color scheme, to follow Core's scheme.

This fix only applies for wp-admin screens. Calypso screens are handled via https://github.com/Automattic/wp-calypso/pull/89885.

|Before|After|
|-|-|
|<img width="160" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/9fce5f4e-f0a6-4cb9-a766-0767626620c4">|<img width="160" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/473c7fad-875b-4bd5-908e-b1e6420caa5b">|

> [!NOTE]  
> This should not break production because the Default color scheme (with slug = `fresh`) is only available on untangled sites. It is not offered via Calypso's `/me/account`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare an Atomic site.
2. Go to Settings -> Hosting Configuration and change the admin interface style to Classic.
3. Go to the site's `_cli` and run `wp option update wpcom_classic_early_relase 1`.
4. Go to Users -> Profile.
5. Update the admin color scheme to Default.
6. Refresh the page.
7. Verify that the upsell button in the sidebar has the correct blue color (also when hovered).
