### PR TITLE
Scheduled Updates: Move health check functions into hooks

### DIFF
--- a/projects/packages/scheduled-updates/changelog/update-health-check-to-callbacks
+++ b/projects/packages/scheduled-updates/changelog/update-health-check-to-callbacks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Scheduled Updates: move health check functions into hooks

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -49,7 +49,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.9.x-dev"
+			"dev-trunk": "0.10.x-dev"
 		},
 		"textdomain": "jetpack-scheduled-updates",
 		"version-constants": {

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
@@ -135,4 +135,18 @@ class Scheduled_Updates_Health_Paths {
 
 		return $ret;
 	}
+
+	/**
+	 * Update the health check paths for a scheduled update hook.
+	 *
+	 * @param string           $id      The ID of the schedule.
+	 * @param object           $event   The event object.
+	 * @param \WP_REST_Request $request The request object.
+	 * @return bool
+	 */
+	public static function updates_health_paths( $id, $event, $request ) {
+		$schedule = $request['schedule'];
+		$paths    = $schedule['health_check_paths'] ?? array();
+		return self::update( $id, $paths );
+	}
 }

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
@@ -36,11 +36,14 @@ class Scheduled_Updates_Health_Paths {
 	/**
 	 * Update the health check paths for a scheduled update.
 	 *
-	 * @param string $schedule_id Request ID.
-	 * @param array  $paths       List of paths to save.
+	 * @param string           $schedule_id The ID of the schedule.
+	 * @param object           $event       The event object.
+	 * @param \WP_REST_Request $request     The request object.
 	 * @return bool
 	 */
-	public static function update( $schedule_id, $paths ) {
+	public static function update( $schedule_id, $event, $request ) {
+		$schedule     = $request['schedule'];
+		$paths        = $schedule['health_check_paths'] ?? array();
 		$option       = get_option( self::OPTION_NAME, array() );
 		$parsed_paths = array();
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
@@ -36,14 +36,11 @@ class Scheduled_Updates_Health_Paths {
 	/**
 	 * Update the health check paths for a scheduled update.
 	 *
-	 * @param string           $schedule_id The ID of the schedule.
-	 * @param object           $event       The event object.
-	 * @param \WP_REST_Request $request     The request object.
+	 * @param string $schedule_id Request ID.
+	 * @param array  $paths       List of paths to save.
 	 * @return bool
 	 */
-	public static function update( $schedule_id, $event, $request ) {
-		$schedule     = $request['schedule'];
-		$paths        = $schedule['health_check_paths'] ?? array();
+	public static function update( $schedule_id, $paths ) {
 		$option       = get_option( self::OPTION_NAME, array() );
 		$parsed_paths = array();
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -61,7 +61,7 @@ class Scheduled_Updates {
 		add_action( 'jetpack_scheduled_update_deleted', array( __CLASS__, 'enable_autoupdates' ), 10, 2 );
 		add_action( 'jetpack_scheduled_update_updated', array( Scheduled_Updates_Logs::class, 'replace_logs_schedule_id' ), 10, 2 );
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'delete_logs_schedule_id' ), 10, 3 );
-		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'updates_health_paths' ), 10, 3 );
+		add_action( 'jetpack_scheduled_update_created', array( Scheduled_Updates_Health_Paths::class, 'updates_health_paths' ), 10, 3 );
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Health_Paths::class, 'clear' ) );
 
 		// Update cron sync option after options update.
@@ -484,19 +484,5 @@ class Scheduled_Updates {
 		}
 
 		return \Automattic\Jetpack\Sync\Functions::file_system_write_access();
-	}
-
-	/**
-	 * Update the health check paths for a scheduled update.
-	 *
-	 * @param string           $id      The ID of the schedule.
-	 * @param object           $event   The event object.
-	 * @param \WP_REST_Request $request The request object.
-	 * @return bool
-	 */
-	public static function updates_health_paths( $id, $event, $request ) {
-		$schedule = $request['schedule'];
-		$paths    = $schedule['health_check_paths'] ?? array();
-		return Scheduled_Updates_Health_Paths::update( $id, $paths );
 	}
 }

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -61,8 +61,8 @@ class Scheduled_Updates {
 		add_action( 'jetpack_scheduled_update_deleted', array( __CLASS__, 'enable_autoupdates' ), 10, 2 );
 		add_action( 'jetpack_scheduled_update_updated', array( Scheduled_Updates_Logs::class, 'replace_logs_schedule_id' ), 10, 2 );
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'delete_logs_schedule_id' ), 10, 3 );
-		add_action( 'jetpack_scheduled_update_created', array( Scheduled_Updates_Health_Paths::class, 'update' ), 10, 3 );
-		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Health_Paths::class, 'clear' ), 10, 1 );
+		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'updates_health_paths' ), 10, 3 );
+		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Health_Paths::class, 'clear' ) );
 
 		// Update cron sync option after options update.
 		$callback = array( __CLASS__, 'update_option_cron' );
@@ -484,5 +484,19 @@ class Scheduled_Updates {
 		}
 
 		return \Automattic\Jetpack\Sync\Functions::file_system_write_access();
+	}
+
+	/**
+	 * Update the health check paths for a scheduled update.
+	 *
+	 * @param string           $id      The ID of the schedule.
+	 * @param object           $event   The event object.
+	 * @param \WP_REST_Request $request The request object.
+	 * @return bool
+	 */
+	public static function updates_health_paths( $id, $event, $request ) {
+		$schedule = $request['schedule'];
+		$paths    = $schedule['health_check_paths'] ?? array();
+		return Scheduled_Updates_Health_Paths::update( $id, $paths );
 	}
 }

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -61,6 +61,8 @@ class Scheduled_Updates {
 		add_action( 'jetpack_scheduled_update_deleted', array( __CLASS__, 'enable_autoupdates' ), 10, 2 );
 		add_action( 'jetpack_scheduled_update_updated', array( Scheduled_Updates_Logs::class, 'replace_logs_schedule_id' ), 10, 2 );
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'delete_logs_schedule_id' ), 10, 3 );
+		add_action( 'jetpack_scheduled_update_created', array( Scheduled_Updates_Health_Paths::class, 'update' ), 10, 3 );
+		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Health_Paths::class, 'clear' ), 10, 1 );
 
 		// Update cron sync option after options update.
 		$callback = array( __CLASS__, 'update_option_cron' );

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.9.1';
+	const PACKAGE_VERSION = '0.10.0-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -267,7 +267,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		}
 
 		$id = Scheduled_Updates::generate_schedule_id( $plugins );
-		Scheduled_Updates_Health_Paths::update( $id, $schedule['health_check_paths'] ?? array() );
 
 		/**
 		 * Fires when a scheduled update is created.
@@ -503,8 +502,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		 * @param WP_REST_Request $request The request object.
 		 */
 		do_action( 'jetpack_scheduled_update_deleted', $request['schedule_id'], $event, $request );
-
-		Scheduled_Updates_Health_Paths::clear( $request['schedule_id'] );
 
 		return rest_ensure_response( true );
 	}

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-health-check-to-callbacks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-health-check-to-callbacks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_18"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_19_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "ce33d9393f024efd66071ea0eae3758f000748cc"
+                "reference": "f54ff98d9b5b3ba08e1684e06d722f2ac9f899be"
             },
             "require": {
                 "php": ">=7.0"
@@ -1001,7 +1001,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "textdomain": "jetpack-scheduled-updates",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.18
+ * Version: 2.1.19-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.18",
+	"version": "2.1.19-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6700

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This is a follow-up from #36990
* Add Scheduled_Updates_Health_Paths::update to jetpack_scheduled_update_created action.
* Add Scheduled_Updates_Health_Paths::clear to jetpack_scheduled_update_deleted action.
* Remove original functions from `WPCOM_REST_API_V2_Endpoint_Update_Schedules`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow #36990 and create schedules using REST API Console with health check paths and everything should work as before. 