### PR TITLE
Backport mu-wpcom-plugin 2.1.17, jetpack 13.4-a.7 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.3] - 2024-04-25
+### Changed
+- AI Client: Separate AIControl UI from block logic. [#36967]
+
 ## [0.12.2] - 2024-04-22
 ### Added
 - AI Client: Add Markdown and HTML conversions. [#36906]
@@ -290,6 +294,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.12.3]: https://github.com/Automattic/jetpack-ai-client/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/Automattic/jetpack-ai-client/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.11.0...v0.12.0

--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-input-ui
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-input-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-AI Client: Separate AIControl UI from block logic

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.12.3-alpha",
+	"version": "0.12.3",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.23] - 2024-04-25
+### Changed
+- Base Styles: Reduce specificity of the body selector. [#37043]
+
 ## [0.6.22] - 2024-04-11
 ### Removed
 - Removed automattic brand colors. [#36747]
@@ -273,6 +277,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.23]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.22...0.6.23
 [0.6.22]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.21...0.6.22
 [0.6.21]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.20...0.6.21
 [0.6.20]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.19...0.6.20

--- a/projects/js-packages/base-styles/changelog/feat-reduce-specificity-of-body-selector
+++ b/projects/js-packages/base-styles/changelog/feat-reduce-specificity-of-body-selector
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Base Styles: Reduce specificity of the body selector

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.23-alpha",
+	"version": "0.6.23",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/packages/abtest/CHANGELOG.md
+++ b/projects/packages/abtest/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2024-04-25
+### Changed
+- Internal updates.
+
 ## [2.0.2] - 2024-04-08
 ### Changed
 - Internal updates.
@@ -296,6 +300,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a simple A/B test package
 
+[2.0.3]: https://github.com/Automattic/jetpack-abtest/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/jetpack-abtest/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-abtest/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-abtest/compare/v1.10.14...v2.0.0

--- a/projects/packages/abtest/changelog/fix-connection-client-phan-issues
+++ b/projects/packages/abtest/changelog/fix-connection-client-phan-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baselines. No change to functionality.
-
-

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.9] - 2024-04-25
+### Changed
+- Internal updates.
+
 ## [3.3.8] - 2024-04-22
 ### Changed
 - Internal updates.
@@ -609,6 +613,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.3.9]: https://github.com/Automattic/jetpack-backup/compare/v3.3.8...v3.3.9
 [3.3.8]: https://github.com/Automattic/jetpack-backup/compare/v3.3.7...v3.3.8
 [3.3.7]: https://github.com/Automattic/jetpack-backup/compare/v3.3.6...v3.3.7
 [3.3.6]: https://github.com/Automattic/jetpack-backup/compare/v3.3.5...v3.3.6

--- a/projects/packages/backup/changelog/fix-connection-client-phan-issues
+++ b/projects/packages/backup/changelog/fix-connection-client-phan-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baselines. No change to functionality.
-
-

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.3.9-alpha';
+	const PACKAGE_VERSION = '3.3.9';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.1] - 2024-04-25
+### Changed
+- Internal updates.
+
 ## [0.21.0] - 2024-04-22
 ### Added
 - Add new filters for the Blaze module. [#36950]
@@ -350,6 +354,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.21.1]: https://github.com/automattic/jetpack-blaze/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/automattic/jetpack-blaze/compare/v0.20.3...v0.21.0
 [0.20.3]: https://github.com/automattic/jetpack-blaze/compare/v0.20.2...v0.20.3
 [0.20.2]: https://github.com/automattic/jetpack-blaze/compare/v0.20.1...v0.20.2

--- a/projects/packages/blaze/changelog/fix-connection-client-phan-issues
+++ b/projects/packages/blaze/changelog/fix-connection-client-phan-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baselines. No change to functionality.
-
-

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.21.1-alpha",
+	"version": "0.21.1",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.21.1-alpha';
+	const PACKAGE_VERSION = '0.21.1';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/compat/CHANGELOG.md
+++ b/projects/packages/compat/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2024-04-25
+### Changed
+- Internal updates.
+
 ## [3.0.1] - 2024-04-08
 ### Changed
 - Update GlotPress locales. [#36748]
@@ -147,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Jetpack 7.5: Back compatibility package
 
+[3.0.2]: https://github.com/Automattic/jetpack-compat/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/Automattic/jetpack-compat/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/Automattic/jetpack-compat/compare/v2.0.1...v3.0.0
 [2.0.1]: https://github.com/Automattic/jetpack-compat/compare/v2.0.0...v2.0.1

--- a/projects/packages/compat/changelog/update-wp-requirements-64
+++ b/projects/packages/compat/changelog/update-wp-requirements-64
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Phan: update configuration
-
-

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.3] - 2024-04-25
+### Changed
+- General: Remove code that was added to remain compatible with versions of WordPress lower than 6.4. [#37049]
+
+### Fixed
+- Disconnect connection owner on removal. [#36888]
+- Improve phpdoc comments in Client class, and remove some unnecessary boolean checks. [#37056]
+
 ## [2.7.2] - 2024-04-22
 ### Added
 - SSO: Add SSO feature to the package. [#36587]
@@ -1023,6 +1031,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.7.3]: https://github.com/Automattic/jetpack-connection/compare/v2.7.2...v2.7.3
 [2.7.2]: https://github.com/Automattic/jetpack-connection/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/Automattic/jetpack-connection/compare/v2.7.0...v2.7.1
 [2.7.0]: https://github.com/Automattic/jetpack-connection/compare/v2.6.2...v2.7.0

--- a/projects/packages/connection/changelog/fix-connection-client-phan-issues
+++ b/projects/packages/connection/changelog/fix-connection-client-phan-issues
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Improve phpdoc comments in Client class, and remove some unnecessary boolean checks.

--- a/projects/packages/connection/changelog/fix-disconnect-connection-owner-upon-removal
+++ b/projects/packages/connection/changelog/fix-disconnect-connection-owner-upon-removal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Disconnect connection owner on removal.

--- a/projects/packages/connection/changelog/update-jetpack-mu-wpcom-dependencies
+++ b/projects/packages/connection/changelog/update-jetpack-mu-wpcom-dependencies
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Updated docblock type definition to match the code.
-
-

--- a/projects/packages/connection/changelog/update-rm-63-code
+++ b/projects/packages/connection/changelog/update-rm-63-code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: remove code that was added to remain compatible with versions of WordPress lower than 6.4.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.7.3-alpha';
+	const PACKAGE_VERSION = '2.7.3';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.7.3';
+	const PACKAGE_VERSION = '2.7.4-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.17] - 2024-04-25
+### Fixed
+- Set correct `textdomain` in `block.json`. [#37057]
+
 ## [0.30.16] - 2024-04-22
 ### Changed
 - Internal updates.
@@ -543,6 +547,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.30.17]: https://github.com/automattic/jetpack-forms/compare/v0.30.16...v0.30.17
 [0.30.16]: https://github.com/automattic/jetpack-forms/compare/v0.30.15...v0.30.16
 [0.30.15]: https://github.com/automattic/jetpack-forms/compare/v0.30.14...v0.30.15
 [0.30.14]: https://github.com/automattic/jetpack-forms/compare/v0.30.13...v0.30.14

--- a/projects/packages/forms/changelog/add-lint-block-json-textdomains
+++ b/projects/packages/forms/changelog/add-lint-block-json-textdomains
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Set correct `textdomain` in `block.json`.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.17-alpha",
+	"version": "0.30.17",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.30.17",
+	"version": "0.30.18-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.17-alpha';
+	const PACKAGE_VERSION = '0.30.17';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.30.17';
+	const PACKAGE_VERSION = '0.30.18-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.4] - 2024-04-25
+### Changed
+- Update dependencies.
+
 ## [0.18.3] - 2024-04-08
 ### Changed
 - Updated package dependencies. [#36760]
@@ -532,6 +536,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.18.4]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.3...v0.18.4
 [0.18.3]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.2...v0.18.3
 [0.18.2]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.1...v0.18.2
 [0.18.1]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.0...v0.18.1

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.18.3",
+	"version": "0.18.4",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -26,7 +26,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.18.3';
+	const PACKAGE_VERSION = '0.18.4';
 
 	/**
 	 * Package Slug

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2024-04-25
+### Changed
+- Update dependencies. [#33960]
+
 ## [0.3.5] - 2024-04-22
 ### Fixed
 - WP.com: Don't Photonize images on private WordPress.com sites. [#36876]
@@ -77,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add image CDN package. [#29561]
 
+[0.3.6]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.3.2...v0.3.3

--- a/projects/packages/image-cdn/package.json
+++ b/projects/packages/image-cdn/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-image-cdn",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"description": "Serve images through Jetpack's powerful CDN",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/image-cdn/#readme",
 	"bugs": {

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Assets;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.3.5';
+	const PACKAGE_VERSION = '0.3.6';
 
 	/**
 	 * Singleton.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.26.0] - 2024-04-25
+### Added
+- Admin menu: Show sidebar notices on classic interface. [#36797]
+
+### Changed
+- Admin menu: Sidebar notices can be dismissed now. [#37031]
+
+### Fixed
+- Update project dependencies to explicitly reflect the current state. [#37035]
+
 ## [5.25.0] - 2024-04-22
 ### Added
 - Add missing dependency on `automattic/jetpack-status`. [#36881]
@@ -743,6 +753,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.26.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.25.0...v5.26.0
 [5.25.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.24.0...v5.25.0
 [5.24.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.23.2...v5.24.0
 [5.23.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.23.1...v5.23.2

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-untangled-atomic-sidebar-notices
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-untangled-atomic-sidebar-notices
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Admin menu: Show sidebar notices on classic interface

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-untanglined-sidebar-notice-border
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-untanglined-sidebar-notice-border
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fixed a WP.com only issue on the sidebar notices
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-dependencies
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-dependencies
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Update automattic/jetpack-mu-wpcom's dependencies to explicitly reflect the current state.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-untangling-sidebar-notice-dismiss
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-untangling-sidebar-notice-dismiss
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Admin menu: Sidebar notices can be dismissed now

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.26.0-alpha",
+	"version": "5.26.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.26.0",
+	"version": "5.26.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.26.0-alpha';
+	const PACKAGE_VERSION = '5.26.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.26.0';
+	const PACKAGE_VERSION = '5.26.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.8] - 2024-04-25
+### Changed
+- Internal updates.
+
 ## [3.1.7] - 2024-04-22
 ### Changed
 - Internal updates.
@@ -707,6 +711,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.1.8]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.7...v3.1.8
 [3.1.7]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.6...v3.1.7
 [3.1.6]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.5...v3.1.6
 [3.1.5]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.4...v3.1.5

--- a/projects/packages/jitm/changelog/fix-connection-client-phan-issues
+++ b/projects/packages/jitm/changelog/fix-connection-client-phan-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baselines. No change to functionality.
-
-

--- a/projects/packages/jitm/changelog/update-jetpack-mu-wpcom-dependencies
+++ b/projects/packages/jitm/changelog/update-jetpack-mu-wpcom-dependencies
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Updated phan baseline.
-
-

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.1.8-alpha';
+	const PACKAGE_VERSION = '3.1.8';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.1.8';
+	const PACKAGE_VERSION = '3.1.9-alpha';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.22.2] - 2024-04-25
+### Fixed
+- My Jetpack: Fix issue where the TOS component was being called inside of a <p>, throwing a warning that <p> can't be a descendant of <p>. This also fixes the font size of the TOS text. [#37034]
+
 ## [4.22.1] - 2024-04-22
 ### Changed
 - Internal updates.
@@ -1437,6 +1441,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.22.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.22.1...4.22.2
 [4.22.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.22.0...4.22.1
 [4.22.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.21.0...4.22.0
 [4.21.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.20.2...4.21.0

--- a/projects/packages/my-jetpack/changelog/fix-connection-client-phan-issues
+++ b/projects/packages/my-jetpack/changelog/fix-connection-client-phan-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baselines. No change to functionality.
-
-

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-tos-text-component
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-tos-text-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-My Jetpack: fix minor issue where the TOS component was being called inside of a <p>, throwing a warning that <p> can't be a descendant of <p>. This also fixes the font size of the TOS text.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.22.2-alpha",
+	"version": "4.22.2",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.22.2-alpha';
+	const PACKAGE_VERSION = '4.22.2';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/plans/CHANGELOG.md
+++ b/projects/packages/plans/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.6] - 2024-04-25
+### Changed
+- Update dependencies.
+
 ## [0.4.5] - 2024-04-22
 ### Changed
 - Internal updates.
@@ -130,6 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 - Moved the options class into Connection. [#24095]
 
+[0.4.6]: https://github.com/Automattic/jetpack-plans/compare/v0.4.5...v0.4.6
 [0.4.5]: https://github.com/Automattic/jetpack-plans/compare/v0.4.4...v0.4.5
 [0.4.4]: https://github.com/Automattic/jetpack-plans/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/Automattic/jetpack-plans/compare/v0.4.2...v0.4.3

--- a/projects/packages/plans/package.json
+++ b/projects/packages/plans/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-plans",
-	"version": "0.4.5",
+	"version": "0.4.6",
 	"description": "Fetch information about Jetpack Plans from wpcom",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/plans/#readme",
 	"bugs": {

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.42.12] - 2024-04-25
+### Changed
+- Internal updates.
+
 ## [0.42.11] - 2024-04-22
 ### Changed
 - Internal updates.
@@ -525,6 +529,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.42.12]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.11...v0.42.12
 [0.42.11]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.10...v0.42.11
 [0.42.10]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.9...v0.42.10
 [0.42.9]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.8...v0.42.9

--- a/projects/packages/publicize/changelog/fix-connection-client-phan-issues
+++ b/projects/packages/publicize/changelog/fix-connection-client-phan-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baselines. No change to functionality.
-
-

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.12-alpha",
+	"version": "0.42.12",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/redirect/CHANGELOG.md
+++ b/projects/packages/redirect/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2024-04-25
+### Changed
+- Update dependencies.
+
 ## [2.0.1] - 2024-03-12
 ### Changed
 - Internal updates.
@@ -197,6 +201,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Create Jetpack Redirect package
 
+[2.0.2]: https://github.com/Automattic/jetpack-redirect/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-redirect/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.27...v2.0.0
 [1.7.27]: https://github.com/Automattic/jetpack-redirect/compare/v1.7.26...v1.7.27

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2024-04-25
+### Added
+- Add health paths to scheduled updates. [#36990]
+
+### Changed
+- Move arbitrary actions to callbacks. [#36835]
+
+### Removed
+- Remove checks for valid schedules when retreiving and clearing logs. [#36961]
+
 ## [0.8.0] - 2024-04-22
 ### Added
 - Add a sync option where for scheduled updated. [#36877]
@@ -124,6 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.9.0]: https://github.com/Automattic/scheduled-updates/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Automattic/scheduled-updates/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/Automattic/scheduled-updates/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/Automattic/scheduled-updates/compare/v0.7.0...v0.7.1

--- a/projects/packages/scheduled-updates/changelog/add-endpoint-actions
+++ b/projects/packages/scheduled-updates/changelog/add-endpoint-actions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Scheduled Updates: Move arbitrary actions to callbacks

--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-health-checks
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-health-checks
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add health paths to scheduled updates.

--- a/projects/packages/scheduled-updates/changelog/fix-connection-client-phan-issues
+++ b/projects/packages/scheduled-updates/changelog/fix-connection-client-phan-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baselines. No change to functionality.
-
-

--- a/projects/packages/scheduled-updates/changelog/remove-schedule-check
+++ b/projects/packages/scheduled-updates/changelog/remove-schedule-check
@@ -1,4 +1,0 @@
-Significance: major
-Type: removed
-
-Scheduled Updates: Removed checks for valid schedules when retreiving and clearing logs

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.9.0-alpha';
+	const PACKAGE_VERSION = '0.9.0';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.3] - 2024-04-25
+### Changed
+- Internal updates.
+
 ## [0.44.2] - 2024-04-22
 ### Changed
 - Internal updates.
@@ -941,6 +945,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.44.3]: https://github.com/Automattic/jetpack-search/compare/v0.44.2...v0.44.3
 [0.44.2]: https://github.com/Automattic/jetpack-search/compare/v0.44.1...v0.44.2
 [0.44.1]: https://github.com/Automattic/jetpack-search/compare/v0.44.0...v0.44.1
 [0.44.0]: https://github.com/Automattic/jetpack-search/compare/v0.43.8...v0.44.0

--- a/projects/packages/search/changelog/fix-connection-client-phan-issues
+++ b/projects/packages/search/changelog/fix-connection-client-phan-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baselines. No change to functionality.
-
-

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.3-alpha",
+	"version": "0.44.3",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.3-alpha';
+	const VERSION = '0.44.3';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.18.3 - 2024-04-25
+### Changed
+- Update dependencies.
+
 ## 0.18.2 - 2024-04-22
 ### Changed
 - Internal updates.

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.18.2",
+	"version": "0.18.3",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.18.2';
+	const VERSION = '0.18.3';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.3] - 2024-04-25
+### Changed
+- Update dependencies.
+
 ## [0.12.2] - 2024-04-22
 ### Changed
 - Internal updates.
@@ -158,6 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.12.3]: https://github.com/Automattic/jetpack-stats/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/Automattic/jetpack-stats/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/Automattic/jetpack-stats/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Automattic/jetpack-stats/compare/v0.11.2...v0.12.0

--- a/projects/packages/stats/src/class-package-version.php
+++ b/projects/packages/stats/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Stats;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '0.12.2';
+	const PACKAGE_VERSION = '0.12.3';
 
 	const PACKAGE_SLUG = 'stats';
 

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2024-04-25
+### Added
+- Add is_automattician_feature_flags_only on Jetpack sites as an alternative to is_automattician present on simple sites. [#34798]
+
+### Removed
+- Remove methods deprecated long ago. [#36985]
+
 ## [2.2.2] - 2024-04-22
 ### Changed
 - Internal updates.
@@ -330,6 +337,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[3.0.0]: https://github.com/Automattic/jetpack-status/compare/v2.2.2...v3.0.0
 [2.2.2]: https://github.com/Automattic/jetpack-status/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/Automattic/jetpack-status/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Automattic/jetpack-status/compare/v2.1.3...v2.2.0

--- a/projects/packages/status/changelog/add-is_automattician-check-for-Atomic-sites
+++ b/projects/packages/status/changelog/add-is_automattician-check-for-Atomic-sites
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added is_automattician_feature_flags_only on Jetpack sites as an alternative to is_automattician present on simple sites.

--- a/projects/packages/status/changelog/remove-deprecated_offline_omed_methods
+++ b/projects/packages/status/changelog/remove-deprecated_offline_omed_methods
@@ -1,4 +1,0 @@
-Significance: major
-Type: removed
-
-Removed methods deprecated long ago

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.13.1] - 2024-04-25
+### Changed
+- Update dependencies.
+
 ## [2.13.0] - 2024-04-22
 ### Changed
 - Added scheduled updates sync option. [#36877]
@@ -1108,6 +1112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.13.1]: https://github.com/Automattic/jetpack-sync/compare/v2.13.0...v2.13.1
 [2.13.0]: https://github.com/Automattic/jetpack-sync/compare/v2.12.0...v2.13.0
 [2.12.0]: https://github.com/Automattic/jetpack-sync/compare/v2.11.1...v2.12.0
 [2.11.1]: https://github.com/Automattic/jetpack-sync/compare/v2.11.0...v2.11.1

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.13.0';
+	const PACKAGE_VERSION = '2.13.1';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.17] - 2024-04-25
+### Fixed
+- Set correct `textdomain` in `block.json`. [#37057]
+
 ## [0.23.16] - 2024-04-22
 ### Changed
 - Bump VideoPress block API version. [#36864]
@@ -1318,6 +1322,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.17]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.16...v0.23.17
 [0.23.16]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.15...v0.23.16
 [0.23.15]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.14...v0.23.15
 [0.23.14]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.13...v0.23.14

--- a/projects/packages/videopress/changelog/add-lint-block-json-textdomains
+++ b/projects/packages/videopress/changelog/add-lint-block-json-textdomains
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Set correct `textdomain` in `block.json`.

--- a/projects/packages/videopress/changelog/fix-connection-client-phan-issues
+++ b/projects/packages/videopress/changelog/fix-connection-client-phan-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baselines. No change to functionality.
-
-

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.17-alpha",
+	"version": "0.23.17",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.17-alpha';
+	const PACKAGE_VERSION = '0.23.17';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.5] - 2024-04-25
+### Changed
+- Internal updates.
+
 ## [0.16.4] - 2024-04-22
 ### Changed
 - Internal updates.
@@ -305,6 +309,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.16.5]: https://github.com/Automattic/jetpack-waf/compare/v0.16.4...v0.16.5
 [0.16.4]: https://github.com/Automattic/jetpack-waf/compare/v0.16.3...v0.16.4
 [0.16.3]: https://github.com/Automattic/jetpack-waf/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/Automattic/jetpack-waf/compare/v0.16.1...v0.16.2

--- a/projects/packages/waf/changelog/fix-connection-client-phan-issues
+++ b/projects/packages/waf/changelog/fix-connection-client-phan-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Phan baselines. No change to functionality.
-
-

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.16] - 2024-04-25
+### Changed
+- Update dependencies. [#36903]
+
 ## [0.3.15] - 2024-04-15
 ### Changed
 - Update dependencies. [#36848]
@@ -339,6 +343,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.16]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.15...v0.3.16
 [0.3.15]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.14...v0.3.15
 [0.3.14]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.13...v0.3.14
 [0.3.13]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.12...v0.3.13

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.15",
+	"version": "0.3.16",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.15';
+	const VERSION = '0.3.16';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.4-a.7 - 2024-04-25
+### Improved compatibility
+- General: Update WordPress version requirements to WordPress 6.4 and remove compatibility code for lower versions. [#37047] [#37049]
+
+### Bug fixes
+- Google Fonts: Avoid theme fonts overriding the default fonts so fonts with a specific font weight that are not supported by the provided theme can be rendered correctly. [#37050]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add migration_source_site_domain to the list of available site options to update and retrieve. This will be used as part of the Site Migration on-boarding flow. [#37060]
+- Add title optimization as beta [#37001]
+- Add title optimization jetpack sidebar entry [#37002]
+- Add title optimization modal content [#37003]
+- Add update_plugins capability to the /sites/%s endpoint. [#36280]
+- AI Assistant: Separate toolbar dropdown logic and UI [#37016]
+- AI Assistant: Update AIControl imports [#36967]
+- Cookie Consent: localize default text [#37012]
+- Enhanced Distribution: remove deprecated module file. [#37032]
+- Masterbar: Specific styles for sidebar upsells are now maintained in separate files for each color scheme [#37022]
+- Subscriptions: Add "Paid newsletter" section to the Newsletter settings [#36975]
+- Subscriptions: Link "Subscribed" button to individual subscription page [#37021]
+
 ## 13.4-a.5 - 2024-04-22
 ### Enhancements
 - Subscription: Add a filter to Allow Newsletter Block Meta Capability to be Changed. [#36909]

--- a/projects/plugins/jetpack/changelog/add-is_automattician-check-for-Atomic-sites
+++ b/projects/plugins/jetpack/changelog/add-is_automattician-check-for-Atomic-sites
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-is_automattician-check-for-Atomic-sites#2
+++ b/projects/plugins/jetpack/changelog/add-is_automattician-check-for-Atomic-sites#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-title-optimization-content
+++ b/projects/plugins/jetpack/changelog/add-title-optimization-content
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add title optimization modal content

--- a/projects/plugins/jetpack/changelog/add-title-optimization-feature-extension
+++ b/projects/plugins/jetpack/changelog/add-title-optimization-feature-extension
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add title optimization as beta

--- a/projects/plugins/jetpack/changelog/add-title-optimization-sidebar-entry
+++ b/projects/plugins/jetpack/changelog/add-title-optimization-sidebar-entry
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add title optimization jetpack sidebar entry

--- a/projects/plugins/jetpack/changelog/add-update-plugins-cap
+++ b/projects/plugins/jetpack/changelog/add-update-plugins-cap
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add update_plugins capability to the /sites/%s endpoint.

--- a/projects/plugins/jetpack/changelog/feat-dont-override-default-fonts
+++ b/projects/plugins/jetpack/changelog/feat-dont-override-default-fonts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Google Fonts: Avoid theme fonts overriding the default fonts so fonts with a specific font weight that are not supported by the provided theme can be rendered correctly

--- a/projects/plugins/jetpack/changelog/fix-connection-client-phan-issues
+++ b/projects/plugins/jetpack/changelog/fix-connection-client-phan-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update Phan baselines. No change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/fix-cookie-consent-localizatoin
+++ b/projects/plugins/jetpack/changelog/fix-cookie-consent-localizatoin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Cookie Consent: localize default text

--- a/projects/plugins/jetpack/changelog/fix-disconnect-connection-owner-upon-removal
+++ b/projects/plugins/jetpack/changelog/fix-disconnect-connection-owner-upon-removal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Move user disconnect on removal into the Connection package.
-
-

--- a/projects/plugins/jetpack/changelog/remove-deprecated_offline_omed_methods
+++ b/projects/plugins/jetpack/changelog/remove-deprecated_offline_omed_methods
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/rm-enhanced-distribution-module
+++ b/projects/plugins/jetpack/changelog/rm-enhanced-distribution-module
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Enhanced Distribution: remove deprecated module file.

--- a/projects/plugins/jetpack/changelog/update-color-schemes-decouple-sidebar-notice-styles
+++ b/projects/plugins/jetpack/changelog/update-color-schemes-decouple-sidebar-notice-styles
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Masterbar: Specific styles for sidebar upsells are now maintained in separate files for each color scheme

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-input-ui
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-input-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Update AIControl imports

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-separate-toolbar-dropdown-ui-from-logic
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-separate-toolbar-dropdown-ui-from-logic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Separate toolbar dropdown logic and UI

--- a/projects/plugins/jetpack/changelog/update-migration-source-setting
+++ b/projects/plugins/jetpack/changelog/update-migration-source-setting
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add migration_source_site_domain to the list of available site options to update and retrieve. This will be used as part of the Site Migration on-boarding flow.

--- a/projects/plugins/jetpack/changelog/update-paid-newsletter-link
+++ b/projects/plugins/jetpack/changelog/update-paid-newsletter-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriptions: Add "Paid newsletter" section to the Newsletter settings

--- a/projects/plugins/jetpack/changelog/update-rm-63-code
+++ b/projects/plugins/jetpack/changelog/update-rm-63-code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-General: remove code that was added to remain compatible with versions of WordPress lower than 6.4.

--- a/projects/plugins/jetpack/changelog/update-subscribe-individual-subscription-link
+++ b/projects/plugins/jetpack/changelog/update-subscribe-individual-subscription-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriptions: Link "Subscribed" button to individual subscription page

--- a/projects/plugins/jetpack/changelog/update-wp-requirements-64
+++ b/projects/plugins/jetpack/changelog/update-wp-requirements-64
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-General: update WordPress version requirements to WordPress 6.4.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3005,7 +3005,7 @@ p {
 	/**
 	 * Disconnects the user.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.4
 	 * @see \Automattic\Jetpack\Connection\Manager::disconnect_user()
 	 *
 	 * @param int $user_id The user ID to disconnect.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_6",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_7",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_7",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_4_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.4-a.6
+ * Version: 13.4-a.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.4-a.6' );
+define( 'JETPACK__VERSION', '13.4-a.7' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.4-a.7
+ * Version: 13.4-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.4-a.7' );
+define( 'JETPACK__VERSION', '13.4-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.4.0-a.6",
+	"version": "13.4.0-a.7",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.4.0-a.7",
+	"version": "13.4.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,9 +326,12 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.4-a.5 - 2024-04-22
-#### Enhancements
-- Subscription: Add a filter to Allow Newsletter Block Meta Capability to be Changed.
+### 13.4-a.7 - 2024-04-25
+#### Improved compatibility
+- General: Update WordPress version requirements to WordPress 6.4 and remove compatibility code for lower versions. [#37047]
+
+#### Bug fixes
+- Google Fonts: Avoid theme fonts overriding the default fonts so fonts with a specific font weight that are not supported by the provided theme can be rendered correctly.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.17 - 2024-04-25
+### Changed
+- Internal updates.
+
 ## 2.1.16 - 2024-04-22
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-endpoint-actions
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-endpoint-actions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-untangled-atomic-sidebar-notices
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-untangled-atomic-sidebar-notices
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/remove-deprecated_offline_omed_methods
+++ b/projects/plugins/mu-wpcom-plugin/changelog/remove-deprecated_offline_omed_methods
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-dependencies
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-mu-wpcom-dependencies
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Internal dependency updates.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_17_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_17"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.17-alpha
+ * Version: 2.1.17
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.17-alpha",
+	"version": "2.1.17",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.17, jetpack 13.4-a.7

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.