### PR TITLE
Jetpack Sync: Update/send post for jetpack published post

### DIFF
--- a/projects/packages/sync/changelog/update-send-post-for-jetpack-published-post
+++ b/projects/packages/sync/changelog/update-send-post-for-jetpack-published-post
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Sync: When publishing post, sending the actual post in the jetpack_published_post action to avoid sending unnecessary extra action.

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -58,7 +58,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.13.x-dev"
+			"dev-trunk": "2.14.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.13.0';
+	const PACKAGE_VERSION = '2.14.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -151,7 +151,7 @@ class Posts extends Module {
 		add_action( 'jetpack_sync_save_post', $callable, 10, 4 );
 
 		add_action( 'deleted_post', $callable, 10 );
-		add_action( 'jetpack_published_post', $callable, 10, 2 );
+		add_action( 'jetpack_published_post', $callable, 10, 3 );
 		add_filter( 'jetpack_sync_before_enqueue_deleted_post', array( $this, 'filter_blacklisted_post_types_deleted' ) );
 
 		add_action( 'transition_post_status', array( $this, 'save_published' ), 10, 3 );
@@ -732,10 +732,6 @@ class Posts extends Module {
 		// Only Send Pulished Post event if post_type is not blacklisted.
 		if ( ! in_array( $post->post_type, Settings::get_setting( 'post_types_blacklist' ), true ) ) {
 
-			// Refreshing the post in the cache site before triggering the publish event.
-			// The true parameter means that it's an update action, not create action.
-			$this->wp_insert_post( $post_ID, $post, true );
-
 			/**
 			 * Action that gets synced when a post type gets published.
 			 *
@@ -744,8 +740,9 @@ class Posts extends Module {
 			 *
 			 * @param int $post_ID
 			 * @param mixed array $flags post flags that are added to the post
+			 * @param WP_Post $post The post object
 			 */
-			do_action( 'jetpack_published_post', $post_ID, $flags );
+			do_action( 'jetpack_published_post', $post_ID, $flags, $post );
 		}
 		unset( $this->just_published[ $post_ID ] );
 

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -161,6 +161,7 @@ class Posts extends Module {
 		$this->init_meta_whitelist_handler( 'post', array( $this, 'filter_meta' ) );
 
 		add_filter( 'jetpack_sync_before_enqueue_jetpack_sync_save_post', array( $this, 'filter_jetpack_sync_before_enqueue_jetpack_sync_save_post' ) );
+		add_filter( 'jetpack_sync_before_enqueue_jetpack_published_post', array( $this, 'filter_jetpack_sync_before_enqueue_jetpack_published_post' ) );
 
 		add_action( 'jetpack_daily_akismet_meta_cleanup_before', array( $this, 'daily_akismet_meta_cleanup_before' ) );
 		add_action( 'jetpack_daily_akismet_meta_cleanup_after', array( $this, 'daily_akismet_meta_cleanup_after' ) );
@@ -349,6 +350,18 @@ class Posts extends Module {
 		}
 
 		return array( $post_id, $this->filter_post_content_and_add_links( $post ), $update, $previous_state );
+	}
+
+	/**
+	 * Add filtered post content.
+	 *
+	 * @param array $args Hook arguments.
+	 * @return array Hook arguments.
+	 */
+	public function filter_jetpack_sync_before_enqueue_jetpack_published_post( $args ) {
+		list( $post_id, $flags, $post ) = $args;
+
+		return array( $post_id, $flags, $this->filter_post_content_and_add_links( $post ) );
 	}
 
 	/**

--- a/projects/plugins/automattic-for-agencies-client/changelog/update-send-post-for-jetpack-published-post
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-send-post-for-jetpack-published-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -993,7 +993,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
+                "reference": "5f1e574ac98b4cfa494ee2585d7adb9efe89189b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1025,7 +1025,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/backup/changelog/update-send-post-for-jetpack-published-post
+++ b/projects/plugins/backup/changelog/update-send-post-for-jetpack-published-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1546,7 +1546,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
+                "reference": "5f1e574ac98b4cfa494ee2585d7adb9efe89189b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1578,7 +1578,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/update-send-post-for-jetpack-published-post
+++ b/projects/plugins/boost/changelog/update-send-post-for-jetpack-published-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1536,7 +1536,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
+                "reference": "5f1e574ac98b4cfa494ee2585d7adb9efe89189b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1568,7 +1568,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/update-send-post-for-jetpack-published-post
+++ b/projects/plugins/jetpack/changelog/update-send-post-for-jetpack-published-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2454,7 +2454,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
+				"reference": "5f1e574ac98b4cfa494ee2585d7adb9efe89189b"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2486,7 +2486,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.13.x-dev"
+					"dev-trunk": "2.14.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1366,15 +1366,15 @@ That was a cool video.';
 
 		$events = $this->server_event_storage->get_all_events();
 
-		$events = array_slice( $events, -6 );
+		$events = array_slice( $events, -4 );
 
-		$this->assertEquals( $events[0]->args[0], $events[2]->args[0] );
+		$this->assertEquals( $events[0]->args[0], $events[1]->args[0] );
 		$this->assertEquals( 'jetpack_sync_save_post', $events[0]->action );
-		$this->assertEquals( 'jetpack_published_post', $events[2]->action );
+		$this->assertEquals( 'jetpack_published_post', $events[1]->action );
 
-		$this->assertEquals( $events[3]->args[0], $events[5]->args[0] );
-		$this->assertEquals( 'jetpack_sync_save_post', $events[3]->action );
-		$this->assertEquals( 'jetpack_published_post', $events[5]->action );
+		$this->assertEquals( $events[2]->args[0], $events[3]->args[0] );
+		$this->assertEquals( 'jetpack_sync_save_post', $events[2]->action );
+		$this->assertEquals( 'jetpack_published_post', $events[3]->action );
 	}
 
 	/**

--- a/projects/plugins/migration/changelog/update-send-post-for-jetpack-published-post
+++ b/projects/plugins/migration/changelog/update-send-post-for-jetpack-published-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1546,7 +1546,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
+                "reference": "5f1e574ac98b4cfa494ee2585d7adb9efe89189b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1578,7 +1578,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/update-send-post-for-jetpack-published-post
+++ b/projects/plugins/protect/changelog/update-send-post-for-jetpack-published-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1459,7 +1459,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
+                "reference": "5f1e574ac98b4cfa494ee2585d7adb9efe89189b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1491,7 +1491,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/update-send-post-for-jetpack-published-post
+++ b/projects/plugins/search/changelog/update-send-post-for-jetpack-published-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1550,7 +1550,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
+                "reference": "5f1e574ac98b4cfa494ee2585d7adb9efe89189b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1582,7 +1582,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/update-send-post-for-jetpack-published-post
+++ b/projects/plugins/social/changelog/update-send-post-for-jetpack-published-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1541,7 +1541,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
+				"reference": "5f1e574ac98b4cfa494ee2585d7adb9efe89189b"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1573,7 +1573,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.13.x-dev"
+					"dev-trunk": "2.14.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/starter-plugin/changelog/update-send-post-for-jetpack-published-post
+++ b/projects/plugins/starter-plugin/changelog/update-send-post-for-jetpack-published-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1402,7 +1402,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
+                "reference": "5f1e574ac98b4cfa494ee2585d7adb9efe89189b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1434,7 +1434,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/update-send-post-for-jetpack-published-post
+++ b/projects/plugins/videopress/changelog/update-send-post-for-jetpack-published-post
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1402,7 +1402,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "b1bbaa41c0511633ee32d04d3ce37e4953a3c322"
+                "reference": "5f1e574ac98b4cfa494ee2585d7adb9efe89189b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1434,7 +1434,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.13.x-dev"
+                    "dev-trunk": "2.14.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is a different approach to https://github.com/Automattic/jetpack/pull/24827

DO NOT MERGE without D146543-code first.
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Instead of triggering again `wp_insert_post` when publishing a post, the idea is to send the actual post in the `jetpack_published_post` action so that it is saved if needed. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jpop-issues/issues/7411

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
The ones in the relevant diff, above.