### PR TITLE
Subscriptions: Hide subscriber count for already subscribed users

### DIFF
--- a/projects/plugins/jetpack/changelog/update-hide-subscribers-number-subscribed
+++ b/projects/plugins/jetpack/changelog/update-hide-subscribers-number-subscribed
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Subscriptions: Hide subscribers count for subscribed users
+Subscriptions: Hide subscriber count for already subscribed users

--- a/projects/plugins/jetpack/changelog/update-hide-subscribers-number-subscribed
+++ b/projects/plugins/jetpack/changelog/update-hide-subscribers-number-subscribed
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscriptions: Hide subscribers count for subscribed users

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -704,11 +704,11 @@ function render_for_website( $data, $classes, $styles ) {
 		$post_id = get_option( 'page_on_front' );
 	}
 
-	$subscribe_field_id     = apply_filters( 'subscribe_field_id', 'subscribe-field' . $widget_id_suffix, $data['widget_id'] );
-	$tier_id                = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
-	$is_subscribed          = Jetpack_Memberships::is_current_user_subscribed();
-	$button_text            = get_submit_button_text( $data );
-	$show_subscribers_count = $data['show_subscribers_total'] && $data['subscribers_total'] && ! $is_subscribed;
+	$subscribe_field_id    = apply_filters( 'subscribe_field_id', 'subscribe-field' . $widget_id_suffix, $data['widget_id'] );
+	$tier_id               = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
+	$is_subscribed         = Jetpack_Memberships::is_current_user_subscribed();
+	$button_text           = get_submit_button_text( $data );
+	$show_subscriber_count = $data['show_subscribers_total'] && $data['subscribers_total'] && ! $is_subscribed;
 
 	ob_start();
 
@@ -828,7 +828,7 @@ function render_for_website( $data, $classes, $styles ) {
 					</div>
 				</form>
 			<?php endif; ?>
-			<?php if ( $show_subscribers_count ) : ?>
+			<?php if ( $show_subscriber_count ) : ?>
 				<div class="wp-block-jetpack-subscriptions__subscount">
 					<?php echo esc_html( Jetpack_Memberships::get_join_others_text( $data['subscribers_total'] ) ); ?>
 				</div>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -704,10 +704,11 @@ function render_for_website( $data, $classes, $styles ) {
 		$post_id = get_option( 'page_on_front' );
 	}
 
-	$subscribe_field_id = apply_filters( 'subscribe_field_id', 'subscribe-field' . $widget_id_suffix, $data['widget_id'] );
-	$tier_id            = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
-	$is_subscribed      = Jetpack_Memberships::is_current_user_subscribed();
-	$button_text        = get_submit_button_text( $data );
+	$subscribe_field_id     = apply_filters( 'subscribe_field_id', 'subscribe-field' . $widget_id_suffix, $data['widget_id'] );
+	$tier_id                = get_post_meta( $post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, true );
+	$is_subscribed          = Jetpack_Memberships::is_current_user_subscribed();
+	$button_text            = get_submit_button_text( $data );
+	$show_subscribers_count = $data['show_subscribers_total'] && $data['subscribers_total'] && ! $is_subscribed;
 
 	ob_start();
 
@@ -827,11 +828,9 @@ function render_for_website( $data, $classes, $styles ) {
 					</div>
 				</form>
 			<?php endif; ?>
-			<?php if ( $data['show_subscribers_total'] && $data['subscribers_total'] ) : ?>
+			<?php if ( $show_subscribers_count ) : ?>
 				<div class="wp-block-jetpack-subscriptions__subscount">
-					<?php
-					echo esc_html( Jetpack_Memberships::get_join_others_text( $data['subscribers_total'] ) );
-					?>
+					<?php echo esc_html( Jetpack_Memberships::get_join_others_text( $data['subscribers_total'] ) ); ?>
 				</div>
 			<?php endif; ?>
 		</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:

It hides the subscriber count for already subscribed users.

### Before

<img width="666" alt="Screenshot 2024-04-25 at 14 49 21" src="https://github.com/Automattic/jetpack/assets/4068554/2a585d9f-37c1-44f2-b17f-09efdf91432f">

### After

<img width="666" alt="Screenshot 2024-04-25 at 14 49 33" src="https://github.com/Automattic/jetpack/assets/4068554/786c1b5b-cacf-4b60-8ddd-3e33373ab7a9">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add the Subscribe block with the "Show subscriber count" option enabled
* Open the post making sure the subscriber count is visible
* Subscribe to the blog and make sure the subscriber count is no longer visible

