### PR TITLE
WordPress.com Block Editor: avoid relying on the Jetpack class

### DIFF
--- a/projects/plugins/jetpack/changelog/update-wpcom-block-editor-jetpack-class
+++ b/projects/plugins/jetpack/changelog/update-wpcom-block-editor-jetpack-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordPress.com Block Editor: avoid relying on the Jetpack class.

--- a/projects/plugins/jetpack/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/projects/plugins/jetpack/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -7,7 +7,9 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status\Host;
 
 /**
@@ -152,7 +154,7 @@ class Jetpack_WPCOM_Block_Editor {
 		if ( ! empty( $args['frame-nonce'] ) && $this->framing_allowed( $args['frame-nonce'] ) ) {
 
 			// If SSO is active, we'll let WordPress.com handle authentication...
-			if ( Jetpack::is_module_active( 'sso' ) ) {
+			if ( ( new Modules() )->is_active( 'sso' ) ) {
 				// ...but only if it's not an Atomic site. They already do that.
 				if ( ! ( new Host() )->is_woa_site() ) {
 					add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
@@ -216,7 +218,12 @@ class Jetpack_WPCOM_Block_Editor {
 	 * @return bool
 	 */
 	public function framing_allowed( $nonce ) {
-		$verified = $this->verify_frame_nonce( $nonce, 'frame-' . Jetpack_Options::get_option( 'id' ) );
+		$blog_id = Connection_Manager::get_site_id();
+		if ( is_wp_error( $blog_id ) ) {
+			return false;
+		}
+
+		$verified = $this->verify_frame_nonce( $nonce, 'frame-' . $blog_id );
 
 		if ( is_wp_error( $verified ) ) {
 			wp_die( $verified ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
## Proposed changes:

This should offer no functionality change. It only ensures the feature doesn't rely on the Jetpack class, just in case we want this feature to live outside of the Jetpack plugin in the future.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start from a site where Jetpack is connected to WordPress.com
* Go to Posts > Add New
* Add a Paragraph block
    * You should continue to see "Underline" and "Justify" options when selecting some text and checking the advanced formatting options.
 
<img width="299" alt="Screenshot 2024-04-25 at 15 44 57" src="https://github.com/Automattic/jetpack/assets/426388/325ac9ec-3524-4eee-9895-f8bace392dd0">

