### PR TITLE
jitm: Fix most Phan issues

### DIFF
--- a/projects/packages/jitm/.phan/baseline.php
+++ b/projects/packages/jitm/.phan/baseline.php
@@ -9,21 +9,11 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeExpectedObjectPropAccess : 3 occurrences
-    // PhanTypeMismatchReturn : 2 occurrences
-    // PhanUndeclaredMethod : 2 occurrences
-    // PhanPluginSimplifyExpressionBool : 1 occurrence
-    // PhanTypeInvalidDimOffset : 1 occurrence
     // PhanTypeMismatchArgument : 1 occurrence
-    // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
-    // PhanUnreferencedUseNormal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-post-connection-jitm.php' => ['PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturn'],
-        'src/class-rest-api-endpoints.php' => ['PhanPluginSimplifyExpressionBool'],
-        'tests/php/test_JITM.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUnreferencedUseNormal'],
-        'tests/php/test_pre_connection_jitm.php' => ['PhanTypeInvalidDimOffset', 'PhanUndeclaredMethod'],
+        'src/class-post-connection-jitm.php' => ['PhanTypeMismatchArgument'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/jitm/changelog/fix-most-phan-in-packages-jitm
+++ b/projects/packages/jitm/changelog/fix-most-phan-in-packages-jitm
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix most Phan issues. One remains, I couldn't figure out what should be correct there.
+
+

--- a/projects/packages/jitm/src/class-post-connection-jitm.php
+++ b/projects/packages/jitm/src/class-post-connection-jitm.php
@@ -43,9 +43,9 @@ class Post_Connection_JITM extends JITM {
 	/**
 	 * A special filter for WooCommerce, to set a message based on local state.
 	 *
-	 * @param string $content The current message.
+	 * @param object $content The current message.
 	 *
-	 * @return array The new message.
+	 * @return object The new message.
 	 */
 	public static function jitm_woocommerce_services_msg( $content ) {
 		if ( ! function_exists( 'wc_get_base_location' ) ) {

--- a/projects/packages/jitm/src/class-rest-api-endpoints.php
+++ b/projects/packages/jitm/src/class-rest-api-endpoints.php
@@ -63,7 +63,7 @@ class Rest_Api_Endpoints {
 			$query['s'] = $request['s'];
 		}
 
-		return $jitm->get_messages( $request['message_path'], urldecode_deep( $query ), 'true' === $request['full_jp_logo_exists'] ? true : false );
+		return $jitm->get_messages( $request['message_path'], urldecode_deep( $query ), 'true' === $request['full_jp_logo_exists'] );
 	}
 
 	/**

--- a/projects/packages/jitm/tests/php/test_JITM.php
+++ b/projects/packages/jitm/tests/php/test_JITM.php
@@ -3,7 +3,6 @@
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\JITMS\JITM;
-use Automattic\Jetpack\JITMS\Pre_Connection_JITM;
 use Brain\Monkey;
 use Brain\Monkey\Actions;
 use Brain\Monkey\Filters;
@@ -80,6 +79,7 @@ class Test_Jetpack_JITM extends TestCase {
 
 		$jitm = new JITM();
 		$screen = (object) array( 'id' => $screen_id ); // fake screen object
+		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Fake object, don't care.
 		$jitm->prepare_jitms( $screen );
 
 		// Set up mocks for a bunch of methods called by the hook.

--- a/projects/packages/jitm/tests/php/test_pre_connection_jitm.php
+++ b/projects/packages/jitm/tests/php/test_pre_connection_jitm.php
@@ -177,6 +177,7 @@ class Test_Pre_Connection_JITM extends TestCase {
 			->andReturn( $this->test_jitms );
 
 		$messages = $this->jitm_instance->get_messages( '/wp:plugins:admin_notices/', '', false );
+		// @phan-suppress-next-line PhanTypeInvalidDimOffset -- It's confused by the assignment above.
 		$this->assertSame( $this->test_jitms[0]['id'], $messages[0]->id );
 	}
 
@@ -201,6 +202,7 @@ class Test_Pre_Connection_JITM extends TestCase {
 			->andReturn( $this->test_jitms );
 
 		$jitm = \Mockery::mock( Pre_Connection_JITM::class )->makePartial();
+		'@phan-var \Mockery\LegacyMockInterface&\Mockery\MockInterface&Pre_Connection_JITM $jitm'; // Bad phpdoc in Mockery plus probably https://github.com/phan/phan/issues/4849 makes Phan get the type wrong.
 		$jitm
 			->expects( 'generate_icon' )
 			->once()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The main motivation here is to handle a bit in
`tests/php/test_pre_connection_jitm.php` that's giving different issues depending on the version of Mockery in use, but I figured I may as well fix the rest too.

One issue remains. As far as I can tell it's technically a `mixed` from `$_GET` that's being assumed to be an array in a few places but is actually a string, but when it's a string it probably should be turned into a single-element array (as implicitly happens inside the call Phan flags). I'll leave that for someone who actually knows about this code to deal with.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1713989530241239-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?