### PR TITLE
Scheduled Updates: Check if load function exists before using it.

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-function-exists-check
+++ b/projects/packages/scheduled-updates/changelog/add-function-exists-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Adds an exists check before using wpcom_rest_api_v2_load_plugin() in the API endpoint.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.9.0';
+	const PACKAGE_VERSION = '0.9.1-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -218,9 +218,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			$event->schedule_id = $schedule_id;
 
 			// Run through the prepare_item_for_response method to add the last run status.
-			$response[ $schedule_id ] = $this->prepare_response_for_collection(
-				$this->prepare_item_for_response( $event, $request )
-			);
+			$response[ $schedule_id ] = $this->prepare_item_for_response( $event, $request );
 		}
 
 		return rest_ensure_response( $response );
@@ -507,28 +505,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		Scheduled_Updates_Health_Paths::clear( $request['schedule_id'] );
 
 		return rest_ensure_response( true );
-	}
-
-	/**
-	 * Prepares a response for insertion into a collection.
-	 *
-	 * @param WP_REST_Response $response Response object.
-	 * @return array|mixed Response data, ready for insertion into collection data.
-	 */
-	public function prepare_response_for_collection( $response ) {
-		if ( ! ( $response instanceof WP_REST_Response ) ) {
-			return $response;
-		}
-
-		$data   = (array) $response->get_data();
-		$server = rest_get_server();
-		$links  = $server::get_compact_response_links( $response );
-
-		if ( ! empty( $links ) ) {
-			$data['_links'] = $links;
-		}
-
-		return $data;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -218,7 +218,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			$event->schedule_id = $schedule_id;
 
 			// Run through the prepare_item_for_response method to add the last run status.
-			$response[ $schedule_id ] = $this->prepare_item_for_response( $event, $request );
+			$response[ $schedule_id ] = $this->prepare_response_for_collection(
+				$this->prepare_item_for_response( $event, $request )
+			);
 		}
 
 		return rest_ensure_response( $response );
@@ -505,6 +507,32 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		Scheduled_Updates_Health_Paths::clear( $request['schedule_id'] );
 
 		return rest_ensure_response( true );
+	}
+
+	/**
+	 * Prepares a response for insertion into a collection.
+	 *
+	 * @param WP_REST_Response $response Response object.
+	 * @return array|mixed Response data, ready for insertion into collection data.
+	 */
+	public function prepare_response_for_collection( $response ) {
+		if ( ! ( $response instanceof WP_REST_Response ) ) {
+			return $response;
+		}
+
+		$data = (array) $response->get_data();
+
+		// Only call rest_get_server() if we're in a REST API request.
+		if ( did_action( 'rest_api_init' ) ) {
+			$server = rest_get_server();
+			$links  = $server::get_compact_response_links( $response );
+
+			if ( ! empty( $links ) ) {
+				$data['_links'] = $links;
+			}
+		}
+
+		return $data;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -834,4 +834,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	}
 }
 
-wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Update_Schedules' );
+if ( function_exists( 'wpcom_rest_api_v2_load_plugin' ) ) {
+	wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Update_Schedules' );
+}


### PR DESCRIPTION
In #36915 we introduced an alternative load path for the endpoint file, which can lead to undefined function errors when loaded outside of the context of Jetpack.

See p1714057439665549/1714037739.152019-slack-C05Q5HSS013

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds function exists check before using wpcom_rest_api_v2_load_plugin().
* Now only calls `rest_get_server()` if `rest_api_init` has run before, to avoid loading all endpoints on an internal API request.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

See p1714057439665549/1714037739.152019-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I needs some manual work to test this properly:
* Check out the branch and sync the package to a WoA test site.
* Comment out [this line](https://github.com/Automattic/jetpack/blob/add/function-exists-check/projects/packages/scheduled-updates/src/class-scheduled-updates.php#L40), to avoid the endpoint being loaded at the right time.
* Add `delete_option( self::PLUGIN_CRON_HOOK );` ahead of the get_option check to trigger the callback.
* Load any page and make sure it doesn't fatal.