### PR TITLE
AI Assistant: Add inline extensions feature flag

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-flag
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add inline extensions feature flag

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -149,3 +149,15 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Register the `ai-assistant-extensions-support` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		if ( apply_filters( 'jetpack_ai_enabled', true ) && apply_filters( 'jetpack_inline_extensions_enabled', false ) ) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-extensions-support' );
+		}
+	}
+);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -76,7 +76,8 @@
 		"videopress/video-chapters",
 		"ai-assistant-backend-prompts",
 		"ai-logo-generator",
-		"ai-title-optimization"
+		"ai-title-optimization",
+		"ai-assistant-extensions-support"
 	],
 	"experimental": [ "ai-image", "ai-paragraph" ],
 	"no-post-editor": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37083

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the `ai-assistant-extensions-support` beta flag
* Make it available only if the `jetpack_inline_extensions_enabled` filter is true

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set blocks to `production`
* Go to the block editor and check `Jetpack_Editor_Initial_State.available_blocks['ai-assistant-extensions-support']`
* It should return `undefined`
* Install the Code Snippets plugin
* Create and activate a snippet with this: `add_filter( 'jetpack_inline_extensions_enabled', '__return_true' );`
* Back to the block editor, check the value again. It should remain `undefined`, as the blocks are set to `production`
* Change the blocks to `beta`
* Check the block editor value again. It should be `{ available: true }`
* Go to the snippet page and click on `Save changes and deactivate` (there seems to be a permission error if you try to disable it from the toggle)
* Check the value on the editor again, it should be `{ available: false, unavailable_reason: "missing_module", details: [] }`
