### PR TITLE
Search: fix connection flow for new sites

### DIFF
--- a/projects/packages/search/changelog/fix-search-new-site-flow
+++ b/projects/packages/search/changelog/fix-search-new-site-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix connection flow for new sites.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -40,7 +40,7 @@ export default function DashboardPage( { isLoading = false } ) {
 	const sendPaidPlanToCart = () => {
 		const checkoutProductUrl = getProductCheckoutUrl(
 			'jetpack_search',
-			blogID ?? domain,
+			blogID || domain,
 			`admin.php?page=jetpack-search&just_upgraded=1`,
 			true
 		);

--- a/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
+++ b/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
@@ -58,7 +58,7 @@ export default function useProductCheckoutWorkflow( {
 	// Build the checkout URL.
 	const checkoutProductUrl = getProductCheckoutUrl(
 		productSlug,
-		blogID ?? siteSuffix,
+		blogID || siteSuffix,
 		redirectUri,
 		isUserConnected || isWpcom
 	);


### PR DESCRIPTION
## Proposed changes:
* Fix broken connection/purchase flow for first-time connection.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1714040909590009-slack-C02ME06LF

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Create new site with Jetpack Search. If reusing a site, it should not have any search plan (even free one), and should not have blog ID stored in the options.
2. Go to "Jetpack -> Search" and click either "Get Search" or "Start for free".
3. Connect the user, go through the checkout. Confirm it goes well.