### PR TITLE
AI Assistant: Add partial heading inline extension

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extensions
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extensions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: Export ExtensionAIControl

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.12.3",
+	"version": "0.12.4-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/components/index.ts
+++ b/projects/js-packages/ai-client/src/components/index.ts
@@ -1,4 +1,4 @@
-export { AIControl, BlockAIControl } from './ai-control/index.js';
+export { AIControl, BlockAIControl, ExtensionAIControl } from './ai-control/index.js';
 export { default as AiStatusIndicator } from './ai-status-indicator/index.js';
 export { default as AudioDurationDisplay } from './audio-duration-display/index.js';
 export {

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add partial heading inline extension

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
@@ -44,7 +44,15 @@ export const QUICK_EDIT_KEY_MAKE_LONGER = 'make-longer' as const;
 // Ask AI Assistant option
 export const KEY_ASK_AI_ASSISTANT = 'ask-ai-assistant' as const;
 
-const quickActionsList = {
+const quickActionsList: {
+	[ key: string ]: {
+		name: string;
+		key: string;
+		aiSuggestion: PromptTypeProp;
+		icon: ReactElement;
+		options?: AiAssistantDropdownOnChangeOptionsArgProps;
+	}[];
+} = {
 	default: [
 		{
 			name: __( 'Correct spelling and grammar', 'jetpack' ),
@@ -102,14 +110,16 @@ export type AiAssistantDropdownOnChangeOptionsArgProps = {
 	userPrompt?: string;
 };
 
+export type OnRequestSuggestion = (
+	promptType: PromptTypeProp,
+	options?: AiAssistantDropdownOnChangeOptionsArgProps
+) => void;
+
 type AiAssistantToolbarDropdownContentProps = {
 	blockType: ExtendedBlockProp;
 	disabled?: boolean;
 	onAskAiAssistant: () => void;
-	onRequestSuggestion: (
-		promptType: PromptTypeProp,
-		options?: AiAssistantDropdownOnChangeOptionsArgProps
-	) => void;
+	onRequestSuggestion: OnRequestSuggestion;
 };
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/editor.js
@@ -11,6 +11,7 @@ import './editor.scss';
 import './supports';
 import './extensions/ai-assistant';
 import './extensions/jetpack-contact-form';
+import './inline-extensions/with-ai-extension';
 
 registerJetpackBlockFromMetadata( metadata, {
 	edit,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/block-handler.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/block-handler.tsx
@@ -1,0 +1,37 @@
+/**
+ * Internal dependencies
+ */
+import { HeadingHandler } from './heading';
+/**
+ * Types
+ */
+import type { IBlockHandler } from './types';
+import type { ExtendedInlineBlockProp } from '../extensions/ai-assistant';
+
+const handlers = {
+	'core/heading': HeadingHandler,
+};
+
+/**
+ * Gets the block handler based on the block type.
+ * The block handler is used to handle the request suggestions.
+ * @param {ExtendedInlineBlockProp} blockType - The block type.
+ * @param {string} clientId                   - The block client ID.
+ * @returns {IBlockHandler}                     The block handler.
+ */
+export function blockHandler(
+	blockType: ExtendedInlineBlockProp,
+	clientId: string
+): IBlockHandler {
+	const HandlerClass = handlers[ blockType ];
+
+	if ( ! HandlerClass ) {
+		throw new Error( `No handler found for block type: ${ blockType }` );
+	}
+
+	const handler = new HandlerClass( clientId );
+
+	return {
+		onSuggestion: handler.onSuggestion.bind( handler ),
+	};
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -1,0 +1,68 @@
+/*
+ * External dependencies
+ */
+import { ExtensionAIControl } from '@automattic/jetpack-ai-client';
+import { useState } from '@wordpress/element';
+import React from 'react';
+/*
+ * Types
+ */
+import type { RequestingErrorProps, RequestingStateProp } from '@automattic/jetpack-ai-client';
+import type { ReactElement } from 'react';
+
+export default function AiAssistantInput( {
+	requestingState,
+	request,
+	stopSuggestion,
+	close,
+	undo,
+}: {
+	clientId?: string;
+	postId?: number;
+	requestingState: RequestingStateProp;
+	requestingError?: RequestingErrorProps;
+	suggestion?: string;
+	request: ( question: string ) => void;
+	stopSuggestion?: () => void;
+	close?: () => void;
+	undo?: () => void;
+} ): ReactElement {
+	const [ value, setValue ] = useState( '' );
+	const disabled = [ 'requesting', 'suggesting' ].includes( requestingState );
+
+	function handleSend(): void {
+		request?.( value );
+	}
+
+	function handleStopSuggestion(): void {
+		stopSuggestion?.();
+	}
+
+	function handleClose(): void {
+		close?.();
+	}
+
+	function handleUndo(): void {
+		undo?.();
+	}
+
+	function handleUpgrade(): void {
+		throw new Error( 'Function not implemented.' );
+	}
+
+	return (
+		<>
+			<ExtensionAIControl
+				disabled={ disabled }
+				value={ value }
+				state={ requestingState }
+				onChange={ setValue }
+				onSend={ handleSend }
+				onStop={ handleStopSuggestion }
+				onClose={ handleClose }
+				onUndo={ handleUndo }
+				onUpgrade={ handleUpgrade }
+			/>
+		</>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-toolbar-dropdown/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-toolbar-dropdown/index.tsx
@@ -1,0 +1,110 @@
+/*
+ * External dependencies
+ */
+import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { ToolbarButton, Dropdown } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+/*
+ * Internal dependencies
+ */
+import AiAssistantToolbarDropdownContent from '../../../components/ai-assistant-toolbar-dropdown/dropdown-content';
+/*
+ * Types
+ */
+import type { OnRequestSuggestion } from '../../../components/ai-assistant-toolbar-dropdown/dropdown-content';
+import type { ExtendedInlineBlockProp } from '../../../extensions/ai-assistant';
+import type { ReactElement } from 'react';
+
+type AiAssistantExtensionToolbarDropdownContentProps = {
+	blockType: ExtendedInlineBlockProp;
+	onClose: () => void;
+	onAskAiAssistant: () => void;
+	onRequestSuggestion: OnRequestSuggestion;
+};
+
+/**
+ * The dropdown component with logic for the AI Assistant block.
+ * @param {AiAssistantExtensionToolbarDropdownContentProps} props - The props.
+ * @returns {ReactElement} The React content of the dropdown.
+ */
+function AiAssistantExtensionToolbarDropdownContent( {
+	blockType,
+	onClose,
+	onAskAiAssistant,
+	onRequestSuggestion,
+}: AiAssistantExtensionToolbarDropdownContentProps ) {
+	const handleRequestSuggestion: OnRequestSuggestion = ( promptType, options ) => {
+		onRequestSuggestion?.( promptType, options );
+		onClose?.();
+	};
+
+	const handleAskAiAssistant = () => {
+		onAskAiAssistant?.();
+		onClose?.();
+	};
+
+	return (
+		<AiAssistantToolbarDropdownContent
+			blockType={ blockType }
+			onRequestSuggestion={ handleRequestSuggestion }
+			onAskAiAssistant={ handleAskAiAssistant }
+			disabled={ false }
+		/>
+	);
+}
+
+type AiAssistantExtensionToolbarDropdownProps = {
+	blockType: ExtendedInlineBlockProp;
+	label?: string;
+	onAskAiAssistant: () => void;
+	onRequestSuggestion: OnRequestSuggestion;
+};
+
+export default function AiAssistantExtensionToolbarDropdown( {
+	blockType,
+	label = __( 'AI Assistant', 'jetpack' ),
+	onAskAiAssistant,
+	onRequestSuggestion,
+}: AiAssistantExtensionToolbarDropdownProps ): ReactElement {
+	const { tracks } = useAnalytics();
+
+	const toggleHandler = ( isOpen: boolean ) => {
+		if ( isOpen ) {
+			tracks.recordEvent( 'jetpack_ai_assistant_extension_toolbar_menu_show', {
+				block_type: blockType,
+			} );
+		}
+	};
+
+	return (
+		<Dropdown
+			popoverProps={ {
+				variant: 'toolbar',
+			} }
+			renderToggle={ ( { isOpen, onToggle } ) => {
+				return (
+					<ToolbarButton
+						className="jetpack-ai-assistant__button"
+						showTooltip
+						onClick={ onToggle }
+						aria-haspopup="true"
+						aria-expanded={ isOpen }
+						label={ label }
+						icon={ aiAssistantIcon }
+					/>
+				);
+			} }
+			onToggle={ toggleHandler }
+			renderContent={ ( { onClose: onClose } ) => (
+				<AiAssistantExtensionToolbarDropdownContent
+					onClose={ onClose }
+					blockType={ blockType }
+					onAskAiAssistant={ onAskAiAssistant }
+					onRequestSuggestion={ onRequestSuggestion }
+				/>
+			) }
+		/>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/heading/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/heading/index.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { renderMarkdownFromHTML, renderHTMLFromMarkdown } from '@automattic/jetpack-ai-client';
+import { rawHandler } from '@wordpress/blocks';
+import { select, dispatch } from '@wordpress/data';
+/**
+ * Types
+ */
+import type { BlockEditorSelect, IBlockHandler } from '../types';
+import type { Block } from '@automattic/jetpack-ai-client';
+
+export function getContent( html ) {
+	return renderMarkdownFromHTML( { content: html } );
+}
+
+export function renderContent( markdown ) {
+	return renderHTMLFromMarkdown( { content: markdown, rules: [] } );
+}
+
+export class HeadingHandler implements IBlockHandler {
+	public block: Block;
+
+	constructor( clientId: string ) {
+		const { getBlock } = select( 'core/block-editor' ) as BlockEditorSelect;
+		this.block = getBlock( clientId );
+	}
+
+	public onSuggestion( suggestion: string ): void {
+		// Adjust suggestion if it does not start with a hash.
+		if ( ! suggestion.startsWith( '#' ) ) {
+			suggestion = `${ '#'.repeat(
+				( this.block?.attributes?.level as number ) || 1
+			) } ${ suggestion }`;
+		}
+
+		const HTML = renderContent( suggestion );
+		this.replaceBlockContent( HTML );
+	}
+
+	private replaceBlockContent( newContent: string ): void {
+		// Create a new block with the raw HTML content.
+		const [ newBlock ] = rawHandler( { HTML: newContent } );
+		if ( ! newBlock ) {
+			return;
+		}
+
+		// Replace the original block attributes with the new block attributes.
+		dispatch( 'core/block-editor' ).updateBlockAttributes(
+			this.block.clientId as string,
+			newBlock.attributes
+		);
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/lib/is-possible-to-extend-block.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/lib/is-possible-to-extend-block.ts
@@ -1,0 +1,71 @@
+/*
+ * External dependencies
+ */
+import { getBlockType } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
+/*
+ * Internal dependencies
+ */
+import {
+	EXTENDED_INLINE_BLOCKS,
+	isAiAssistantExtensionsSupportEnabled,
+} from '../../extensions/ai-assistant';
+
+export type isPossibleToExtendBlockProps = {
+	blockName?: string;
+	clientId: string;
+};
+
+/**
+ * Check if it is possible to extend the block as an inline extension.
+ *
+ * @param {isPossibleToExtendBlockProps} options - The options.
+ * @param {string} options.blockName             - The block name.
+ * @param {string} options.clientId              - The block client ID.
+ * @returns {boolean} Whether it is possible to extend the block.
+ */
+export function isPossibleToExtendBlock( {
+	blockName,
+	clientId,
+}: isPossibleToExtendBlockProps ): boolean {
+	// Check if the AI Assistant block is registered. If not, we understand that Jetpack AI is not active.
+	const isBlockRegistered = getBlockType( 'jetpack/ai-assistant' );
+
+	if ( ! isBlockRegistered ) {
+		return false;
+	}
+
+	// Check if there is a block name.
+	if ( typeof blockName !== 'string' ) {
+		return false;
+	}
+
+	// Check if Jetpack extensions support is enabled.
+	if ( ! isAiAssistantExtensionsSupportEnabled ) {
+		return false;
+	}
+
+	// clientId is required
+	if ( ! clientId?.length ) {
+		return false;
+	}
+
+	// Only extend the Heading block.
+	if ( ! EXTENDED_INLINE_BLOCKS.includes( blockName ) ) {
+		return false;
+	}
+
+	/*
+	 * Do not extend if the AI Assistant block is hidden
+	 * Todo: Do we want to make the extension depend on the block visibility?
+	 * ToDo: the `editPostStore` is undefined for P2 sites.
+	 * Let's find a way to check if the block is hidden.
+	 */
+	const { getHiddenBlockTypes } = select( 'core/edit-post' ) || {};
+	const hiddenBlocks = getHiddenBlockTypes?.() || []; // It will extend the block if the function is undefined.
+	if ( hiddenBlocks.includes( blockName ) ) {
+		return false;
+	}
+
+	return true;
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Types
+ */
+import type { Block } from '@automattic/jetpack-ai-client';
+
+export type OnSuggestion = ( suggestion: string ) => void;
+
+export interface IBlockHandler {
+	onSuggestion: OnSuggestion;
+}
+
+export type BlockEditorSelect = {
+	getBlock: ( clientId: string ) => Block;
+};

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -1,0 +1,170 @@
+/*
+ * External dependencies
+ */
+import {
+	ERROR_NETWORK,
+	ERROR_QUOTA_EXCEEDED,
+	useAiSuggestions,
+} from '@automattic/jetpack-ai-client';
+import { BlockControls } from '@wordpress/block-editor';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { select, useDispatch } from '@wordpress/data';
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+import debugFactory from 'debug';
+import React from 'react';
+/*
+ * Internal dependencies
+ */
+import { EXTENDED_INLINE_BLOCKS } from '../extensions/ai-assistant';
+import { blockHandler } from './block-handler';
+import AiAssistantInput from './components/ai-assistant-input';
+import AiAssistantExtensionToolbarDropdown from './components/ai-assistant-toolbar-dropdown';
+import { isPossibleToExtendBlock } from './lib/is-possible-to-extend-block';
+/*
+ * Types
+ */
+import type { OnRequestSuggestion } from '../components/ai-assistant-toolbar-dropdown/dropdown-content';
+import type { ExtendedInlineBlockProp } from '../extensions/ai-assistant';
+
+const debug = debugFactory( 'jetpack-ai-assistant:extensions:with-ai-extension' );
+
+// HOC to populate the block's edit component with the AI Assistant bar and button.
+const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
+	return props => {
+		const { clientId, isSelected, name: blockName } = props;
+
+		// Only extend the allowed block types.
+		const possibleToExtendBlock = isPossibleToExtendBlock( {
+			blockName,
+			clientId,
+		} );
+
+		const [ showAiControl, setShowAiControl ] = useState( false );
+
+		const { getCurrentPostId } = select( 'core/editor' );
+		const postId = getCurrentPostId();
+
+		const { increaseAiAssistantRequestsCount } = useDispatch( 'wordpress-com/plans' );
+
+		const onDone = useCallback( () => {
+			increaseAiAssistantRequestsCount();
+		}, [ increaseAiAssistantRequestsCount ] );
+
+		const onError = useCallback(
+			error => {
+				// Increase the AI Suggestion counter only for valid errors.
+				if ( error.code === ERROR_NETWORK || error.code === ERROR_QUOTA_EXCEEDED ) {
+					return;
+				}
+
+				increaseAiAssistantRequestsCount();
+			},
+			[ increaseAiAssistantRequestsCount ]
+		);
+
+		// Suggestions are handled by the block handler for specific implementations.
+		const { onSuggestion } = blockHandler( blockName, clientId );
+
+		const { request, stopSuggestion, requestingState, error, suggestion } = useAiSuggestions( {
+			onSuggestion,
+			onDone,
+			onError,
+			askQuestionOptions: {
+				postId,
+				feature: 'ai-assistant',
+			},
+		} );
+
+		// Close the AI Control if the block is deselected.
+		useEffect( () => {
+			if ( ! isSelected ) {
+				setShowAiControl( false );
+				// TODO: reset all extension data.
+			}
+		}, [ isSelected ] );
+
+		// Only extend the target block.
+		if ( ! possibleToExtendBlock ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const blockControlsProps = {
+			group: 'block' as const,
+		};
+
+		const onAskAiAssistant = () => {
+			setShowAiControl( true );
+		};
+
+		const onRequestSuggestion: OnRequestSuggestion = ( promptType, options ) => {
+			setShowAiControl( true );
+			// TODO: handle the promptType and options to request the suggestion.
+			debug( 'onRequestSuggestion', promptType, options );
+		};
+
+		const onClose = () => {
+			setShowAiControl( false );
+		};
+
+		const onUndo = () => {
+			// TODO: handle the undo action.
+			debug( 'onUndo' );
+		};
+
+		return (
+			<>
+				<div className="jetpack-ai-extension--wrapper">
+					<BlockEdit { ...props } />
+					{ showAiControl && (
+						<AiAssistantInput
+							clientId={ clientId }
+							postId={ postId }
+							requestingState={ requestingState }
+							requestingError={ error }
+							suggestion={ suggestion }
+							request={ request }
+							stopSuggestion={ stopSuggestion }
+							close={ onClose }
+							undo={ onUndo }
+						/>
+					) }
+				</div>
+
+				<BlockControls { ...blockControlsProps }>
+					<AiAssistantExtensionToolbarDropdown
+						blockType={ blockName }
+						onAskAiAssistant={ onAskAiAssistant }
+						onRequestSuggestion={ onRequestSuggestion }
+					/>
+				</BlockControls>
+			</>
+		);
+	};
+}, 'blockEditWithAiComponents' );
+
+/**
+ * Function used to extend the registerBlockType settings.
+ * Populates the block edit component with the AI Assistant bar and button.
+ * @param {object} settings - The block settings.
+ * @param {string} name     - The block name.
+ * @returns {object}          The extended block settings.
+ */
+function blockWithInlineExtension( settings, name: ExtendedInlineBlockProp ) {
+	// Only extend the allowed block types.
+	if ( ! EXTENDED_INLINE_BLOCKS.includes( name ) ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		edit: blockEditWithAiComponents( settings.edit ),
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'jetpack/ai-assistant-support/with-ai-extension',
+	blockWithInlineExtension,
+	100
+);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/get-feature-availability.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/get-feature-availability.ts
@@ -1,0 +1,3 @@
+export function getFeatureAvailability( feature: string ): boolean {
+	return window?.Jetpack_Editor_Initial_State?.available_blocks?.[ feature ]?.available === true;
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/transforms/index.tsx
@@ -7,7 +7,10 @@ import { createBlock, getSaveContent } from '@wordpress/blocks';
  * Internal dependencies
  */
 import metadata from '../block.json';
-import { EXTENDED_BLOCKS, isPossibleToExtendBlock } from '../extensions/ai-assistant';
+import {
+	EXTENDED_TRANSFORMATIVE_BLOCKS,
+	isPossibleToExtendBlock,
+} from '../extensions/ai-assistant';
 /**
  * Types
  */
@@ -59,14 +62,14 @@ export function transformToAIAssistantBlock( blockType: ExtendedBlockProp, attrs
 /*
  * Create individual transform handler for each block type.
  */
-for ( const blockType of EXTENDED_BLOCKS ) {
+for ( const blockType of EXTENDED_TRANSFORMATIVE_BLOCKS ) {
 	from.push( {
 		type: 'block',
 		blocks: [ blockType ],
 		isMatch: () => isPossibleToExtendBlock(),
 		transform: ( attrs, innerBlocks ) => {
 			const content = getSaveContent( blockType, attrs, innerBlocks );
-			return transformToAIAssistantBlock( blockType, { ...attrs, content } );
+			return transformToAIAssistantBlock( blockType as ExtendedBlockProp, { ...attrs, content } );
 		},
 	} );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #37015
Depends on/To be rebased after #37082

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `with-inline-extensions` folder/namespace
* Changes the `core/heading` extension behavior when the feature flag is enabled, leaving it as is if it is disabled
* Adds the AI toolbar and the ExtensionAIControl
* Adds block-specific architecture and heading code

Known issues, to be fixed later:
* Does not map the quick actions to actual requests
* Does not build the prompt with the current content, only generating new content
* The AIControl state is not mapped properly
* The editor's block inserter on hover gets confused with the addition of the `ExtensionAIControl`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the feature flag is disabled
* Go to the block editor and add a Heading block
* Check that the AI extension still works as normal, with a block transformation
* Enable the feature flag with `add_filter( 'jetpack_inline_extensions_enabled', '__return_true' );` (tip: use the Code Snippets plugin)
* Go back to the editor
* Check that the Heading block still has an AI icon, but it works differently
* The toolbar is the same, but quick actions/suggestions are not executed (check a debug message instead)
* Check that all actions makes the input visible
* Use the input to ask for some content (tip: "a one-line poem", you don't want a lot of content in a heading)
* Check that the Heading content is updated accordingly
* Deselect the Heading by selecting another block
* Check that the input is gone

This is a work in progress, the problems will be tackled in separate issues