### PR TITLE
Add `jp_memberships_is_sandboxed` to synced meta

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jp-memberships-sandbox-sync
+++ b/projects/plugins/jetpack/changelog/add-jp-memberships-sandbox-sync
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Adds a jp_memberships_is_sandboxed item for sync.

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -198,6 +198,9 @@ class Jetpack_Memberships {
 			'is_deleted'      => array(
 				'meta' => $meta_prefix . 'is_deleted',
 			),
+			'is_sandboxed'    => array(
+				'meta' => $meta_prefix . 'is_sandboxed',
+			),
 		);
 		return $properties;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/gold/issues/390

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This should allow `jp_memberships_is_sandboxed` to be synced.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See D146639-code for testing instructions.