### PR TITLE
Backport mu-wpcom-plugin 2.1.18 Changes

### DIFF
--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.4] - 2024-04-26
+### Changed
+- General: use wp_admin_notice function introduced in WP 6.4 to display notices. [#37051]
+
 ## [2.7.3] - 2024-04-25
 ### Changed
 - General: Remove code that was added to remain compatible with versions of WordPress lower than 6.4. [#37049]
@@ -1031,6 +1035,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.7.4]: https://github.com/Automattic/jetpack-connection/compare/v2.7.3...v2.7.4
 [2.7.3]: https://github.com/Automattic/jetpack-connection/compare/v2.7.2...v2.7.3
 [2.7.2]: https://github.com/Automattic/jetpack-connection/compare/v2.7.1...v2.7.2
 [2.7.1]: https://github.com/Automattic/jetpack-connection/compare/v2.7.0...v2.7.1

--- a/projects/packages/connection/changelog/fix-more-phan-undefined-because-of-phpdoc
+++ b/projects/packages/connection/changelog/fix-more-phan-undefined-because-of-phpdoc
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix a bunch of phpdocs to make Phan happier. No change to functionality.
-
-

--- a/projects/packages/connection/changelog/update-use-wp-admin-notice
+++ b/projects/packages/connection/changelog/update-use-wp-admin-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: use wp_admin_notice function introduced in WP 6.4 to display notices.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.7.4-alpha';
+	const PACKAGE_VERSION = '2.7.4';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.26.1] - 2024-04-26
+### Added
+- CloudFlare Analytics: add tracking code management (originally in the Jetpack plugin). [#37061]
+
+### Changed
+- General: use wp_admin_notice function introduced in WP 6.4 to display notices. [#37051]
+
+### Fixed
+- Calypso: Prevent CSS concat on colors handle instead of reenqueuing colors from CDN. [#37063]
+
 ## [5.26.0] - 2024-04-25
 ### Added
 - Admin menu: Show sidebar notices on classic interface. [#36797]
@@ -753,6 +763,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.26.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.26.0...v5.26.1
 [5.26.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.25.0...v5.26.0
 [5.25.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.24.0...v5.25.0
 [5.24.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.23.2...v5.24.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-more-phan-undefined-because-of-phpdoc
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-more-phan-undefined-because-of-phpdoc
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix a bunch of phpdocs to make Phan happier. No change to functionality.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/untangling-fix-css-concat
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangling-fix-css-concat
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Untangling: prevent CSS concat on colors handle instead of reenqueuing colors from CDN

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-cloudflare-analytics-move
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-cloudflare-analytics-move
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-CloudFlare Analytics: add tracking code management (originally in the Jetpack plugin).

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-use-wp-admin-notice
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-use-wp-admin-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-General: use wp_admin_notice function introduced in WP 6.4 to display notices.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.26.1-alpha",
+	"version": "5.26.1",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.26.1-alpha';
+	const PACKAGE_VERSION = '5.26.1';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/cloudflare-analytics/cloudflare-analytics.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/cloudflare-analytics/cloudflare-analytics.php
@@ -3,7 +3,7 @@
  * Cloudflare Analytics
  * Let WPCOM users automatically insert a Cloudflare analytics JS snippet into their site footer.
  *
- * @since $$next-version$$ -- Ported from Jetpack.
+ * @since 5.26.1 -- Ported from Jetpack.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Cloudflare_Analytics;
 /**
  * Add Cloudflare Analytics tracking code to the head.
  *
- * @since $$next-version$$ -- Ported from Jetpack.
+ * @since 5.26.1 -- Ported from Jetpack.
  */
 function insert_tracking_id() {
 	$option = get_option( 'jetpack_cloudflare_analytics' );

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.9] - 2024-04-26
+### Changed
+- Internal updates.
+
 ## [3.1.8] - 2024-04-25
 ### Changed
 - Internal updates.
@@ -711,6 +715,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.1.9]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.8...v3.1.9
 [3.1.8]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.7...v3.1.8
 [3.1.7]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.6...v3.1.7
 [3.1.6]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.5...v3.1.6

--- a/projects/packages/jitm/changelog/fix-most-phan-in-packages-jitm
+++ b/projects/packages/jitm/changelog/fix-most-phan-in-packages-jitm
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix most Phan issues. One remains, I couldn't figure out what should be correct there.
-
-

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.1.9-alpha';
+	const PACKAGE_VERSION = '3.1.9';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2024-04-26
+### Added
+- Adds an exists check before using wpcom_rest_api_v2_load_plugin() in the API endpoint. [#37081]
+
 ## [0.9.0] - 2024-04-25
 ### Added
 - Add health paths to scheduled updates. [#36990]
@@ -134,6 +138,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.9.1]: https://github.com/Automattic/scheduled-updates/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Automattic/scheduled-updates/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Automattic/scheduled-updates/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/Automattic/scheduled-updates/compare/v0.7.1...v0.7.2

--- a/projects/packages/scheduled-updates/changelog/add-function-exists-check
+++ b/projects/packages/scheduled-updates/changelog/add-function-exists-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Adds an exists check before using wpcom_rest_api_v2_load_plugin() in the API endpoint.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.9.1-alpha';
+	const PACKAGE_VERSION = '0.9.1';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.4] - 2024-04-26
+### Changed
+- Internal updates.
+
 ## [0.12.3] - 2024-04-25
 ### Changed
 - Update dependencies.
@@ -162,6 +166,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.12.4]: https://github.com/Automattic/jetpack-stats/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/Automattic/jetpack-stats/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/Automattic/jetpack-stats/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/Automattic/jetpack-stats/compare/v0.12.0...v0.12.1

--- a/projects/packages/stats/changelog/fix-more-phan-undefined-because-of-phpdoc
+++ b/projects/packages/stats/changelog/fix-more-phan-undefined-because-of-phpdoc
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix a bunch of phpdocs to make Phan happier. No change to functionality.
-
-

--- a/projects/packages/stats/src/class-package-version.php
+++ b/projects/packages/stats/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Stats;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '0.12.4-alpha';
+	const PACKAGE_VERSION = '0.12.4';
 
 	const PACKAGE_SLUG = 'stats';
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.18 - 2024-04-26
+### Changed
+- Internal updates.
+
 ## 2.1.17 - 2024-04-25
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_17"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_18"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.17
+ * Version: 2.1.18
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.17",
+	"version": "2.1.18",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.18

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.