### PR TITLE
Launchpad: Add Entrepreneur plan tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-entrepreneur-site-launchpad-tasks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-entrepreneur-site-launchpad-tasks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: Add Entrepreneur plan launchpad tasks

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -56,7 +56,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.26.x-dev"
+			"dev-trunk": "5.27.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.26.1",
+	"version": "5.27.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.26.1';
+	const PACKAGE_VERSION = '5.27.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -735,6 +735,26 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/domains/manage/' . $data['site_slug_encoded'];
 			},
 		),
+		'customize_your_store'            => array(
+			'get_title'            => function () {
+				return __( 'Customize your store', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
+			'get_calypso_path'     => function () {
+				return site_url( '/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store' );
+			},
+		),
+		'add_your_products'               => array(
+			'get_title'            => function () {
+				return __( 'Add your products', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
+			'get_calypso_path'     => function () {
+				return site_url( '/wp-admin/admin.php?page=wc-admin&task=products' );
+			},
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -735,6 +735,8 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/domains/manage/' . $data['site_slug_encoded'];
 			},
 		),
+
+		// Entrepreneur plan tasks
 		'customize_your_store'            => array(
 			'get_title'            => function () {
 				return __( 'Customize your store', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -755,6 +755,56 @@ function wpcom_launchpad_get_task_definitions() {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=products' );
 			},
 		),
+		'get_paid_with_woopayments'       => array(
+			'get_title'            => function () {
+				return __( 'Get paid with WooPayments', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
+			'get_calypso_path'     => function () {
+				return site_url( '/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments' );
+			},
+		),
+		'collect_sales_tax'               => array(
+			'get_title'            => function () {
+				return __( 'Collect sales tax', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
+			'get_calypso_path'     => function () {
+				return site_url( '/wp-admin/admin.php?page=wc-admin&task=tax' );
+			},
+		),
+		'grow_your_business'              => array(
+			'get_title'            => function () {
+				return __( 'Grow your business', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
+			'get_calypso_path'     => function () {
+				return site_url( '/wp-admin/admin.php?page=wc-admin&task=marketing' );
+			},
+		),
+		'add_a_domain'                    => array(
+			'get_title'            => function () {
+				return __( 'Add a domain', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
+			'get_calypso_path'     => function ( $task, $default, $data ) {
+				return '/domains/add/' . $data['site_slug_encoded'];
+			},
+		),
+		'launch_your_store'               => array(
+			'get_title'            => function () {
+				return __( 'Launch your store', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
+			'get_calypso_path'     => function () {
+				return site_url( '/wp-admin/admin.php?page=wc-admin&task=launch_site' );
+			},
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -31,7 +31,7 @@ require_once __DIR__ . '/launchpad-task-definitions.php';
  */
 function wpcom_launchpad_get_task_list_definitions() {
 	$core_task_list_definitions = array(
-		'build'                  => array(
+		'build'                   => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -45,7 +45,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'free'                   => array(
+		'free'                    => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -60,7 +60,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'link-in-bio'            => array(
+		'link-in-bio'             => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -73,7 +73,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'link-in-bio-tld'        => array(
+		'link-in-bio-tld'         => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -86,7 +86,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'newsletter'             => array(
+		'newsletter'              => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -102,7 +102,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'videopress'             => array(
+		'videopress'              => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -114,7 +114,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'write'                  => array(
+		'write'                   => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -127,7 +127,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'start-writing'          => array(
+		'start-writing'           => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -140,7 +140,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'design-first'           => array(
+		'design-first'            => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -154,7 +154,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'intent-build'           => array(
+		'intent-build'            => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -171,7 +171,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_keep_building_enabled',
 		),
-		'intent-write'           => array(
+		'intent-write'            => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -185,7 +185,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_intent_write_enabled',
 		),
-		'intent-free-newsletter' => array(
+		'intent-free-newsletter'  => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -199,7 +199,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_free_newsletter_enabled',
 		),
-		'intent-paid-newsletter' => array(
+		'intent-paid-newsletter'  => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -215,14 +215,14 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_paid_newsletter_enabled',
 		),
-		'earn'                   => array(
+		'earn'                    => array(
 			'task_ids'            => array(
 				'stripe_connected',
 				'paid_offer_created',
 			),
 			'is_enabled_callback' => '__return_true',
 		),
-		'host-site'              => array(
+		'host-site'               => array(
 			'task_ids'            => array(
 				'site_theme_selected',
 				'install_custom_plugin',
@@ -233,14 +233,14 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_is_hosting_flow_enabled',
 		),
-		'subscribers'            => array(
+		'subscribers'             => array(
 			'task_ids' => array(
 				'import_subscribers',
 				'add_subscribe_block',
 				'share_site',
 			),
 		),
-		'assembler-first'        => array(
+		'assembler-first'         => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -256,7 +256,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'ai-assembler'           => array(
+		'ai-assembler'            => array(
 			'get_title'           => function () {
 				return __( 'Next steps for your site', 'jetpack-mu-wpcom' );
 			},
@@ -272,7 +272,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			),
 			'is_enabled_callback' => 'wpcom_launchpad_get_fullscreen_enabled',
 		),
-		'legacy-site-setup'      => array(
+		'legacy-site-setup'       => array(
 			'get_title'      => function () {
 				return __( 'Site setup', 'jetpack-mu-wpcom' );
 			},
@@ -287,6 +287,12 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'mobile_app_installed',
 				'post_sharing_enabled',
 				'site_launched',
+			),
+		),
+		'entrepreneur-site-setup' => array(
+			'task_ids' => array(
+				'customize_your_store',
+				'add_your_products',
 			),
 		),
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -293,6 +293,11 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'task_ids' => array(
 				'customize_your_store',
 				'add_your_products',
+				'get_paid_with_woopayments',
+				'collect_sales_tax',
+				'grow_your_business',
+				'add_a_domain',
+				'launch_your_store',
 			),
 		),
 	);

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-entrepreneur-site-launchpad-tasks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-entrepreneur-site-launchpad-tasks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -549,7 +549,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "78393b07da58b027c22850823a56326c3d5cd9bf"
+                "reference": "ca92a3e2fa415ff5d216be5fa54b8afb62ba4077"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -577,7 +577,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.26.x-dev"
+                    "dev-trunk": "5.27.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/6763

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* create new Launchpad tasks that match existing WooCommerce Home tasks:

| WooCommerce Home tasks | → | Calypso Home tasks (Launchpad) |
|--------|--------|--------|
| ![Markup on 2024-04-26 at 15:17:25](https://github.com/Automattic/jetpack/assets/25105483/2276c270-6711-4204-99d9-90bd54320e17) | → | ![Markup on 2024-04-26 at 15:11:36](https://github.com/Automattic/jetpack/assets/25105483/515730a1-cec6-4862-b96e-78c23faf7975) | 

The new Launchpad tasks will be then used for the new Calypso Home page dedicated to the WordPress.com Entrepreneur plan.

ℹ️ This PR does not address task completion. This will be addressed by a separate task: https://github.com/Automattic/dotcom-forge/issues/6766.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Related PT: pdDOJh-3iE-p2.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:

1. Create a WordPress.com site with the **Entrepreneur plan**. You can use SA to add the plan.

ℹ️ We are not testing with the Trial plan because we need access to plugins and SFTP (which the Trial plan doesn't have).

2. Install and activate the [Jetpack Tester plugin](https://jetpack.com/download-jetpack-beta/) and select this branch (`add/entrepreneur-site-launchpad-tasks`) in its settings:

| Step 1 | Step 2 |
|--------|--------|
| ![Markup on 2024-04-26 at 14:52:27](https://github.com/Automattic/jetpack/assets/25105483/c5aa4107-1ffc-4ee7-8083-09190453dc9c) | ![Markup on 2024-04-26 at 14:51:32](https://github.com/Automattic/jetpack/assets/25105483/2a8b7885-ebb6-4886-bca5-8e450afccb7d) | 

As you can see in the screenshots above, the branch needs to be selected inside "WordPress.com Features" section - which represents the `jetpack-mu-wpcom` plugin we are modifying in this PR.

4. Connect to your site over SFTP and add the following line to the `config.php`: `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );`.
5. Sync built branch changes to your sandbox by running `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/entrepreneur-site-launchpad-tasks` (or use `rsync`); if needed, the details can be found here: PCYsg-Osp-p2.
6. Open Calypso locally and make the following edits:

```diff
diff --git a/client/my-sites/customer-home/cards/launchpad/index.tsx b/client/my-sites/customer-home/cards/launchpad/index.tsx
index eb159b650b..8007b29281 100644
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -105,6 +105,11 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 				launchpadContext={ launchpadContext }
 				onSiteLaunched={ onSiteLaunched }
 			/>
+			<Launchpad
+				siteSlug={ siteSlug }
+				checklistSlug={ 'entrepreneur-site-setup' }
+				launchpadContext={ 'entrepreneur-site-setup' }
+			/>
 		</div>
 	);
 };
diff --git a/client/my-sites/customer-home/index.js b/client/my-sites/customer-home/index.js
index 62cf0fbd8a..495a62b149 100644
--- a/client/my-sites/customer-home/index.js
+++ b/client/my-sites/customer-home/index.js
@@ -6,5 +6,5 @@ import home, { maybeRedirect } from './controller';
 export default function () {
 	page( '/home', siteSelection, sites, makeLayout, clientRender );
 
-	page( '/home/:siteId', siteSelection, maybeRedirect, navigation, home, makeLayout, clientRender );
+	page( '/home/:siteId', siteSelection, navigation, home, makeLayout, clientRender );
 }

```

ℹ️ The change in `client/my-sites/customer-home/cards/launchpad/index.tsx ` is required because at the moment, `http://calypso.localhost:300/home/<site-slug>` is redirected to the WooCommerce Home in WP Admin and without the change we wouldn't be able to see the new Launchpad tasks in Calypso Home.

7. Open the WooCommerce Home page at `/wp-admin/admin.php?page=wc-admin`. We will use it to compare the tasks here with the newly-created Launchpad tasks - so you can keep the tab open.
8. Open the Calypso Home at `http://calypso.localhost:3000/home/<site-slug>`.
9. Sandbox `public-api.wordpress.com`.
10. When you go back to the Calypso Home, the newly-created Launchpad tasks should be loaded right below the existing Calypso Home tasks.
11. Compare the new Launchpad tasks with the ones on the WooCommerce Home page. Try to click each task - you should be directed to the same page as with the equivalent WooCommerce Home task.