### PR TITLE
Site Migration: Add handler for the migration_source_site_domain option

### DIFF
--- a/projects/plugins/jetpack/changelog/update-migration_source_site_domain
+++ b/projects/plugins/jetpack/changelog/update-migration_source_site_domain
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add handler for the migration_source_site_domain option

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1165,6 +1165,22 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$updated[ $key ] = $value;
 					break;
 
+				case 'migration_source_site_domain':
+					// If we get an empty value, delete the option
+					if ( empty( $value ) ) {
+						delete_option( 'migration_source_site_domain' );
+						break;
+					}
+
+					// If we get a non-url value, don't update the option.
+					if ( wp_http_validate_url( $value ) === false ) {
+						break;
+					}
+
+					update_option( 'migration_source_site_domain', $value );
+					$updated[ $key ] = $value;
+					break;
+
 				default:
 					// allow future versions of this endpoint to support additional settings keys.
 					if ( has_filter( 'site_settings_endpoint_update_' . $key ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/89401

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

In #37060, we added a new setting called `migration_source_site_domain` but didn't add the handler to actually set/delete the option. This PR adds functionality to save or remove the option

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR on your sandbox and sandbox the public-api.
* Pick any newly created Simple site and get the site id.
* In the https://developer.wordpress.com/docs/api/console/, do a `GET` query to `/rest/v1.4/site/:siteId/settings`.
* Scroll through the `settings` property of the response until you find `migration_source_site_domain` (you may have to expand some of the collapsed sections.
* Verify that the value of `in_site_migration_flow` is null.
* At this point, you may want to comment out line 36 of `class.wpcom-json-api-site-settings-endpoint.php` (which is `'group'               => '__do_not_document',`) so you can see the endpoint in the API console.
* Refresh the API console and select a `POST` request.
* Find the `/rest/v1.4/site/:siteId/settings` endpoint and set `migration_source_site_domain` to `https://example.wordpress.com` in the body.
* Make the `POST` request and verify there are no errors.
* Then make another `GET` request and verify that `migration_source_site_domain` is now `https://example.wordpress.com`.