### PR TITLE
Theme tools: deprecated site-logo

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-deprecate-site-logo
+++ b/projects/plugins/jetpack/changelog/remove-deprecate-site-logo
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Theme tools: deprecated site-logo functionality in favour of core supported custom-logo.

--- a/projects/plugins/jetpack/modules/theme-tools/site-logo.php
+++ b/projects/plugins/jetpack/modules/theme-tools/site-logo.php
@@ -30,7 +30,7 @@
 function site_logo_init() {
 	// Only load our code if our theme declares support, and the standalone plugin is not activated.
 	if ( current_theme_supports( 'site-logo' ) && ! class_exists( 'Site_Logo', false ) ) {
-		_deprecated_hook( 'site_logo_init', '$$next-version$$', 'custom-logo', 'Jetpack no longer supports site-logo feature. Add custom-logo support to your theme instead: https://developer.wordpress.org/themes/functionality/custom-logo/' );
+		_deprecated_hook( 'site-logo', '$$next-version$$', 'custom-logo', 'Jetpack no longer supports site-logo feature. Add custom-logo support to your theme instead: https://developer.wordpress.org/themes/functionality/custom-logo/' );
 		// Load our class for namespacing.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			// wpcom handles the image sizes differently.

--- a/projects/plugins/jetpack/modules/theme-tools/site-logo.php
+++ b/projects/plugins/jetpack/modules/theme-tools/site-logo.php
@@ -30,6 +30,7 @@
 function site_logo_init() {
 	// Only load our code if our theme declares support, and the standalone plugin is not activated.
 	if ( current_theme_supports( 'site-logo' ) && ! class_exists( 'Site_Logo', false ) ) {
+		_deprecated_hook( 'site_logo_init', '$$next-version$$', 'custom-logo', 'Jetpack no longer supports site-logo feature. Add custom-logo support to your theme instead: https://developer.wordpress.org/themes/functionality/custom-logo/' );
 		// Load our class for namespacing.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			// wpcom handles the image sizes differently.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Deprecating site-logo feature in favor of custom-logo (WP core) or logo block (also WP core).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added deprecation notice to site-logo init action.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pfwV0U-49-p2


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* The feature is mostly still available only in legacy themes so you can test using any older theme on a JN site (Radcliffe for example).
* Replace  `add_theme_support('custom-logo')` with `add_theme_support('site-logo')` in functions file.
* Check debug log, the deprecation message should be there