### PR TITLE
Add scheduled updates pause feature

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-scheduled-update-pause
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-update-pause
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add scheduled updates active flag

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -49,7 +49,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.10.x-dev"
+			"dev-trunk": "0.11.x-dev"
 		},
 		"textdomain": "jetpack-scheduled-updates",
 		"version-constants": {

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-active.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-active.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Scheduled Updates Active class
+ *
+ * @package automattic/scheduled-updates
+ */
+
+namespace Automattic\Jetpack;
+
+/**
+ * Scheduled_Updates_Active class
+ *
+ * This class provides static methods to get/save actiev for scheduled updates.
+ */
+class Scheduled_Updates_Active {
+
+	/**
+	 * The name of the WordPress option where the active option is stored.
+	 */
+	const OPTION_NAME = 'jetpack_scheduled_update_active';
+
+	/**
+	 * Get the active value for a scheduled update.
+	 *
+	 * @param string $schedule_id Request ID.
+	 * @return bool Active value.
+	 */
+	public static function get( $schedule_id ) {
+		$option = get_option( self::OPTION_NAME, array() );
+
+		return $option[ $schedule_id ] ?? true;
+	}
+
+	/**
+	 * Update the active value for a scheduled update.
+	 *
+	 * @param string $schedule_id Request ID.
+	 * @param bool   $active      Active value.
+	 * @return bool
+	 */
+	public static function update( $schedule_id, $active ) {
+		$option = get_option( self::OPTION_NAME, array() );
+
+		if ( ! is_array( $option ) ) {
+			$option = array();
+		}
+
+		$option[ $schedule_id ] = $active;
+
+		return update_option( self::OPTION_NAME, $option );
+	}
+
+	/**
+	 * Clear the active value for a scheduled update.
+	 *
+	 * @param string|null $schedule_id Request ID.
+	 * @return bool
+	 */
+	public static function clear( $schedule_id ) {
+		$option = get_option( self::OPTION_NAME, array() );
+
+		if ( isset( $option[ $schedule_id ] ) ) {
+			unset( $option[ $schedule_id ] );
+		}
+
+		if ( count( $option ) ) {
+			return update_option( self::OPTION_NAME, $option );
+		} else {
+			return delete_option( self::OPTION_NAME );
+		}
+	}
+
+	/**
+	 * Update the active value for a scheduled update hook.
+	 *
+	 * @param string           $id      The ID of the schedule.
+	 * @param object           $event   The event object.
+	 * @param \WP_REST_Request $request The request object.
+	 * @return bool
+	 */
+	public static function updates_active( $id, $event, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$schedule = $request['schedule'];
+		$active   = $schedule['active'] ?? true;
+
+		return self::update( $id, $active );
+	}
+
+	/**
+	 * REST prepare_item_for_response filter.
+	 *
+	 * @param array            $item    WP Cron event.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return array Response array on success.
+	 */
+	public static function response_filter( $item, $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$item['active'] = self::get( $item['schedule_id'] );
+
+		return $item;
+	}
+}

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-active.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-active.php
@@ -10,7 +10,7 @@ namespace Automattic\Jetpack;
 /**
  * Scheduled_Updates_Active class
  *
- * This class provides static methods to get/save actiev for scheduled updates.
+ * This class provides static methods to get/save active for scheduled updates.
  */
 class Scheduled_Updates_Active {
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
@@ -144,9 +144,22 @@ class Scheduled_Updates_Health_Paths {
 	 * @param \WP_REST_Request $request The request object.
 	 * @return bool
 	 */
-	public static function updates_health_paths( $id, $event, $request ) {
+	public static function updates_health_paths( $id, $event, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$schedule = $request['schedule'];
 		$paths    = $schedule['health_check_paths'] ?? array();
 		return self::update( $id, $paths );
+	}
+
+	/**
+	 * REST prepare_item_for_response filter.
+	 *
+	 * @param array            $item    WP Cron event.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return array Response array on success.
+	 */
+	public static function response_filter( $item, $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$item['health_check_paths'] = self::get( $item['schedule_id'] );
+
+		return $item;
 	}
 }

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -58,11 +58,19 @@ class Scheduled_Updates {
 		add_filter( 'plugin_auto_update_setting_html', array( Scheduled_Updates_Admin::class, 'show_scheduled_updates' ), 10, 2 );
 
 		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'maybe_disable_autoupdates' ), 10, 3 );
-		add_action( 'jetpack_scheduled_update_deleted', array( __CLASS__, 'enable_autoupdates' ), 10, 2 );
-		add_action( 'jetpack_scheduled_update_updated', array( Scheduled_Updates_Logs::class, 'replace_logs_schedule_id' ), 10, 2 );
-		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'delete_logs_schedule_id' ), 10, 3 );
+		add_action( 'jetpack_scheduled_update_created', array( Scheduled_Updates_Active::class, 'updates_active' ), 10, 3 );
 		add_action( 'jetpack_scheduled_update_created', array( Scheduled_Updates_Health_Paths::class, 'updates_health_paths' ), 10, 3 );
+
+		add_action( 'jetpack_scheduled_update_updated', array( Scheduled_Updates_Logs::class, 'replace_logs_schedule_id' ), 10, 2 );
+
+		add_action( 'jetpack_scheduled_update_deleted', array( __CLASS__, 'enable_autoupdates' ), 10, 2 );
+		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Active::class, 'clear' ) );
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Health_Paths::class, 'clear' ) );
+		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'delete_logs_schedule_id' ), 10, 3 );
+
+		add_filter( 'jetpack_scheduled_response_item', array( __CLASS__, 'response_filter' ), 10, 2 );
+		add_filter( 'jetpack_scheduled_response_item', array( Scheduled_Updates_Active::class, 'response_filter' ), 10, 2 );
+		add_filter( 'jetpack_scheduled_response_item', array( Scheduled_Updates_Health_Paths::class, 'response_filter' ), 10, 2 );
 
 		// Update cron sync option after options update.
 		$callback = array( __CLASS__, 'update_option_cron' );
@@ -99,7 +107,13 @@ class Scheduled_Updates {
 	 * @param string ...$plugins List of plugins to update.
 	 */
 	public static function run_scheduled_update( ...$plugins ) {
-		$schedule_id       = self::generate_schedule_id( $plugins );
+		$schedule_id = self::generate_schedule_id( $plugins );
+
+		if ( ! Scheduled_Updates_Active::get( $schedule_id ) ) {
+			// The schedule is not active, return.
+			return false;
+		}
+
 		$available_updates = get_site_transient( 'update_plugins' );
 		$plugins_to_update = $available_updates->response ?? array();
 		$plugins_to_update = array_intersect_key( $plugins_to_update, array_flip( $plugins ) );
@@ -118,10 +132,10 @@ class Scheduled_Updates {
 				'no_plugins_to_update'
 			);
 
-			return;
+			return false;
 		}
 
-		( new Connection\Client() )->wpcom_json_api_request_as_blog(
+		$response = ( new Connection\Client() )->wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/hosting/scheduled-update', \Jetpack_Options::get_option( 'id' ) ),
 			'2',
 			array( 'method' => 'POST' ),
@@ -132,6 +146,8 @@ class Scheduled_Updates {
 			),
 			'wpcom'
 		);
+
+		return is_array( $response );
 	}
 
 	/**
@@ -458,6 +474,28 @@ class Scheduled_Updates {
 				Scheduled_Updates_Logs::replace_logs_schedule_id( $id, $schedule_id );
 			}
 		}
+	}
+
+	/**
+	 * REST prepare_item_for_response filter.
+	 *
+	 * @param array            $item    WP Cron event.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return array Response array on success.
+	 */
+	public static function response_filter( $item, $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$status = self::get_scheduled_update_status( $item['schedule_id'] );
+
+		if ( ! $status ) {
+			$status = array(
+				'last_run_timestamp' => null,
+				'last_run_status'    => null,
+			);
+		}
+
+		$item = array_merge( $item, $status );
+
+		return $item;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.10.0';
+	const PACKAGE_VERSION = '0.11.0-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -541,18 +541,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$item = (array) $item;
-
-		$status = Scheduled_Updates::get_scheduled_update_status( $item['schedule_id'] );
-		if ( ! $status ) {
-			$status = array(
-				'last_run_timestamp' => null,
-				'last_run_status'    => null,
-			);
-		}
-
-		$item                       = array_merge( $item, $status );
-		$item['health_check_paths'] = Scheduled_Updates_Health_Paths::get( $item['schedule_id'] );
-
+		$item = apply_filters( 'jetpack_scheduled_response_item', $item, $request );
 		$item = $this->add_additional_fields_to_object( $item, $request );
 
 		// Remove schedule ID, not needed in the response.
@@ -771,6 +760,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'type'        => 'string',
 					'enum'        => array( 'success', 'failure-and-rollback', 'failure-and-rollback-fail' ),
 				),
+				'active'             => array(
+					'description' => 'Whether the schedule is active.',
+					'type'        => 'boolean',
+				),
 				'health_check_paths' => array(
 					'description' => 'Paths to check for site health.',
 					'type'        => 'array',
@@ -807,12 +800,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 				'type'        => 'object',
 				'required'    => true,
 				'properties'  => array(
-					'active'             => array(
-						'description' => 'Whether the schedule is active.',
-						'type'        => 'boolean',
-						'required'    => false,
-						'default'     => true,
-					),
 					'interval'           => array(
 						'description' => 'Interval for the schedule.',
 						'type'        => 'string',
@@ -823,6 +810,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 						'description' => 'Unix timestamp (UTC) for when to first run the schedule.',
 						'type'        => 'integer',
 						'required'    => true,
+					),
+					'active'             => array(
+						'description' => 'Whether the schedule is active.',
+						'type'        => 'boolean',
+						'required'    => false,
+						'default'     => true,
 					),
 					'health_check_paths' => array(
 						'description'       => 'List of paths to check for site health after the update.',

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -807,6 +807,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 				'type'        => 'object',
 				'required'    => true,
 				'properties'  => array(
+					'active'             => array(
+						'description' => 'Whether the schedule is active.',
+						'type'        => 'boolean',
+						'required'    => false,
+						'default'     => true,
+					),
 					'interval'           => array(
 						'description' => 'Interval for the schedule.',
 						'type'        => 'string',

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-active-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-active-test.php
@@ -6,11 +6,11 @@
  */
 
 use Automattic\Jetpack\Scheduled_Updates;
+use Automattic\Jetpack\Scheduled_Updates_Active;
+use Automattic\Jetpack\Scheduled_Updates_Logs;
 
 /**
  * Test class for WPCOM_REST_API_V2_Endpoint_Update_Schedules, active feature.
- *
- * @coversDefaultClass WPCOM_REST_API_V2_Endpoint_Update_Schedules
  */
 class Scheduled_Updates_Active_Test extends \WorDBless\BaseTestCase {
 
@@ -77,21 +77,163 @@ class Scheduled_Updates_Active_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function tear_down() {
 		wp_delete_user( $this->admin_id );
-		delete_option( 'jetpack_scheduled_update_health_check_active' );
+		delete_option( Scheduled_Updates_Active::OPTION_NAME );
 
 		parent::tear_down_wordbless();
 	}
 
 	/**
-	 * Test get_items.
+	 * Test create_item.
 	 *
-	 * @covers ::get_items
+	 * @covers WPCOM_REST_API_V2_Endpoint_Update_Schedules::create_item
 	 */
-	public function test_get_items() {
+	public function test_create_scheduled_update_with_active_true() {
+		$plugins   = array(
+			'custom-plugin/custom-plugin.php',
+			'gutenberg/gutenberg.php',
+		);
+		$request   = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$post_data = array(
+			'plugins'  => $plugins,
+			'schedule' => array(
+				'timestamp'          => strtotime( 'next Monday 8:00' ),
+				'interval'           => 'weekly',
+				'health_check_paths' => array(),
+				'active'             => true,
+			),
+		);
+
+		$request->set_body_params( $post_data );
+
+		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
+		$result      = rest_do_request( $request );
+		$id          = $result->get_data();
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( $schedule_id, $id );
+		$this->assertTrue( Scheduled_Updates_Active::get( $schedule_id ) );
+
 		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules' );
 		$result  = rest_do_request( $request );
-
-		// No schedules.
 		$this->assertSame( 200, $result->get_status() );
+
+		// Set active to false.
+		$post_data['schedule']['active'] = false;
+
+		$request->set_method( 'PUT' );
+		$request->set_route( '/wpcom/v2/update-schedules/' . $id );
+		$request->set_body_params( $post_data );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+
+		$request->set_method( 'GET' );
+		$result = rest_do_request( $request );
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertFalse( $result->get_data()['active'] );
+
+		$request->set_method( 'DELETE' );
+		$result = rest_do_request( $request );
+		$this->assertSame( 200, $result->get_status() );
+
+		// The option should be removed.
+		$this->assertSame( 'test', get_option( Scheduled_Updates_Active::OPTION_NAME, 'test' ) );
+	}
+
+	/**
+	 * Test create_item.
+	 *
+	 * @covers WPCOM_REST_API_V2_Endpoint_Update_Schedules::create_item
+	 */
+	public function test_create_scheduled_update_is_active() {
+		$plugins   = array( 'gutenberg/gutenberg.php' );
+		$request   = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$post_data = array(
+			'plugins'  => $plugins,
+			'schedule' => array(
+				'timestamp'          => strtotime( 'next Monday 8:00' ),
+				'interval'           => 'weekly',
+				'health_check_paths' => array(),
+			),
+		);
+
+		$request->set_body_params( $post_data );
+
+		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
+		$result      = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		delete_option( Scheduled_Updates_Active::OPTION_NAME );
+
+		$request->set_method( 'GET' );
+		$result = rest_do_request( $request );
+		$this->assertSame( 200, $result->get_status() );
+
+		// Still active (for backwards compatibility)
+		$this->assertTrue( $result->get_data()[ $schedule_id ]['active'] );
+	}
+
+	/**
+	 * Test run_scheduled_update.
+	 *
+	 * @covers Scheduled_Updates::run_scheduled_update
+	 */
+	public function test_run_inactive_schedule() {
+		$plugins   = array(
+			'custom-plugin/custom-plugin.php',
+			'gutenberg/gutenberg.php',
+		);
+		$request   = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$post_data = array(
+			'plugins'  => $plugins,
+			'schedule' => array(
+				'timestamp'          => strtotime( 'next Monday 8:00' ),
+				'interval'           => 'weekly',
+				'health_check_paths' => array(),
+				'active'             => false,
+			),
+		);
+
+		$request->set_body_params( $post_data );
+		$result = rest_do_request( $request );
+		$this->assertSame( 200, $result->get_status() );
+
+		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
+		$this->assertSame( $schedule_id, $result->get_data() );
+		$this->assertFalse( call_user_func_array( array( Scheduled_Updates::class, 'run_scheduled_update' ), $plugins ) );
+	}
+
+	/**
+	 * Test run_scheduled_update.
+	 *
+	 * @covers Scheduled_Updates::run_scheduled_update
+	 */
+	public function test_run_active_schedule() {
+		$plugins   = array( 'gutenberg/gutenberg.php' );
+		$request   = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$post_data = array(
+			'plugins'  => $plugins,
+			'schedule' => array(
+				'timestamp'          => strtotime( 'next Monday 8:00' ),
+				'interval'           => 'weekly',
+				'health_check_paths' => array(),
+			),
+		);
+
+		$request->set_body_params( $post_data );
+		$result = rest_do_request( $request );
+		$this->assertSame( 200, $result->get_status() );
+
+		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
+		$this->assertSame( $schedule_id, $result->get_data() );
+		$this->assertFalse( call_user_func_array( array( Scheduled_Updates::class, 'run_scheduled_update' ), $plugins ) );
+
+		$logs = Scheduled_Updates_Logs::get( $schedule_id );
+		$this->assertCount( 1, $logs );
+		$this->assertCount( 2, $logs[0] );
+
+		// The schduled update started and succeeded.
+		$this->assertSame( Scheduled_Updates_Logs::PLUGIN_UPDATES_START, $logs[0][0]['action'] );
+		$this->assertSame( Scheduled_Updates_Logs::PLUGIN_UPDATES_SUCCESS, $logs[0][1]['action'] );
 	}
 }

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-active-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-active-test.php
@@ -232,7 +232,7 @@ class Scheduled_Updates_Active_Test extends \WorDBless\BaseTestCase {
 		$this->assertCount( 1, $logs );
 		$this->assertCount( 2, $logs[0] );
 
-		// The schduled update started and succeeded.
+		// The scheduled update started and succeeded.
 		$this->assertSame( Scheduled_Updates_Logs::PLUGIN_UPDATES_START, $logs[0][0]['action'] );
 		$this->assertSame( Scheduled_Updates_Logs::PLUGIN_UPDATES_SUCCESS, $logs[0][1]['action'] );
 	}

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-active-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-active-test.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Test class for WPCOM_REST_API_V2_Endpoint_Update_Schedules, active feature.
+ *
+ * @package automattic/scheduled-updates
+ */
+
+use Automattic\Jetpack\Scheduled_Updates;
+
+/**
+ * Test class for WPCOM_REST_API_V2_Endpoint_Update_Schedules, active feature.
+ *
+ * @coversDefaultClass WPCOM_REST_API_V2_Endpoint_Update_Schedules
+ */
+class Scheduled_Updates_Active_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Used to mock global functions inside a namespace.
+	 *
+	 * @see https://github.com/php-mock/php-mock-phpunit
+	 */
+	use \phpmock\phpunit\PHPMock;
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	public $admin_id;
+
+	/**
+	 * The endpoint object.
+	 *
+	 * @var WPCOM_REST_API_V2_Endpoint_Update_Schedules
+	 */
+	public static $endpoint;
+
+	/**
+	 * Set up before class.
+	 *
+	 * @see Restrictions here: https://github.com/php-mock/php-mock-phpunit?tab=readme-ov-file#restrictions
+	 * @beforeClass
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$endpoint = new WPCOM_REST_API_V2_Endpoint_Update_Schedules();
+	}
+
+	/**
+	 * Set up.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		parent::set_up_wordbless();
+		\WorDBless\Users::init()->clear_all_users();
+
+		$this->admin_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_path_user',
+				'user_pass'  => 'dummy_path_pass',
+				'role'       => 'administrator',
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+
+		Scheduled_Updates::init();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Clean up after test
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+		wp_delete_user( $this->admin_id );
+		delete_option( 'jetpack_scheduled_update_health_check_active' );
+
+		parent::tear_down_wordbless();
+	}
+
+	/**
+	 * Test get_items.
+	 *
+	 * @covers ::get_items
+	 */
+	public function test_get_items() {
+		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules' );
+		$result  = rest_do_request( $request );
+
+		// No schedules.
+		$this->assertSame( 200, $result->get_status() );
+	}
+}

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -135,6 +135,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 					'last_run_timestamp' => null,
 					'last_run_status'    => null,
 					'health_check_paths' => array(),
+					'active'             => true,
 				),
 				Scheduled_Updates::generate_schedule_id( $plugins ) => array(
 					'hook'               => Scheduled_Updates::PLUGIN_CRON_HOOK,
@@ -145,6 +146,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 					'last_run_timestamp' => null,
 					'last_run_status'    => null,
 					'health_check_paths' => array(),
+					'active'             => true,
 				),
 			),
 			$result->get_data()
@@ -422,6 +424,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 					'last_run_timestamp' => null,
 					'last_run_status'    => null,
 					'health_check_paths' => array(),
+					'active'             => true,
 				),
 			),
 			$result->get_data()
@@ -505,6 +508,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 				'last_run_timestamp' => null,
 				'last_run_status'    => null,
 				'health_check_paths' => array(),
+				'active'             => true,
 			),
 			$result->get_data()
 		);

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-update-pause
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-update-pause
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_19"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_20_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -978,7 +978,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "f54ff98d9b5b3ba08e1684e06d722f2ac9f899be"
+                "reference": "83cc27751c6f1c887d3c04fd4d3c367da7b98745"
             },
             "require": {
                 "php": ">=7.0"
@@ -1001,7 +1001,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.10.x-dev"
+                    "dev-trunk": "0.11.x-dev"
                 },
                 "textdomain": "jetpack-scheduled-updates",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.19
+ * Version: 2.1.20-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.19",
+	"version": "2.1.20-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6797

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added `active` boolean flag to `wpcom/v2/update-schedules`.
* Added check on `run_scheduled_update` that returns when a scheduled update is not active.
* Added new `jetpack_scheduled_response_item` filter run by `::prepare_item_for_response`.
* Added `active`, `health_check_paths`, and `last_run_timestamp`/`last_run_status` to the new filter.
* `active` is not required and defaults to `true` for retro compatibility

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test 1
1. On Jetpack Beta > WordPress.com Features install `add/scheduled-update-pause`.
2. Install REST API console or similar.
3. Force a plugin version to an old one.
4. Create a scheduled update one minute in the future, such as:

`/wpcom/v2/update-schedules?plugins[]=rest-api-console/rest-api-console.php&schedule[interval]=daily&schedule[timestamp]=NNNNN`

You can obtain 60 seconds in the future in the dev tools by writing `a = new Date(); a = Math.floor( a.getTime() / 1000 ) + 60; console.log('/wpcom/v2/update-schedules?plugins[]=rest-api-console/rest-api-console.php&schedule[interval]=daily&schedule[timestamp]=' + a);`

1. Refresh the plugins page and wait a minute.
2. Meanwhile, access `_cli` and option get `jetpack_scheduled_update_active` and ensure the `active: true` flag is there.
3. Check if the plugin is updated.

### Test 2
Do the same steps as test 1, but add `&schedule[active]=0` to the URL. Wait one minute and be sure the plugin is not updated (skipped). Like:

`a = new Date(); a = Math.floor( a.getTime() / 1000 ) + 60; console.log('/wpcom/v2/update-schedules?plugins[]=rest-api-console/rest-api-console.php&schedule[interval]=daily&schedule[active]=0&schedule[timestamp]=' + a);`

Check on Calypso that the field is there.