### PR TITLE
Jetpack Sync: Prevent enqueueing invalid Woo HPOS order data

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-hpos-woo-warning
+++ b/projects/packages/sync/changelog/fix-sync-hpos-woo-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Sync: Prevent enqueueing invalid Woo HPOS order data

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -201,7 +201,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	 * @return array
 	 */
 	public function expand_order_object( $args ) {
-		if ( false === is_array( $args ) || false === isset( $args[0] ) ) {
+		if ( ! is_array( $args ) || ! isset( $args[0] ) ) {
 			return false;
 		}
 		$order_object = $args[0];

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -201,6 +201,9 @@ class WooCommerce_HPOS_Orders extends Module {
 	 * @return array
 	 */
 	public function expand_order_object( $args ) {
+		if ( false === is_array( $args ) || false === isset( $args[0] ) ) {
+			return false;
+		}
 		$order_object = $args[0];
 
 		if ( is_int( $order_object ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes the following Warning: `PHP Warning:  Undefined array key 0 in [REDACTED]/jetpack_vendor/automattic/jetpack-sync/src/modules/class-woocommerce-hpos-orders.php on line 204`

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders`: Adds a check in `expand_order_object` so that if the `$args` input is not an array or `$args[0]` is not set, we return `false` to prevent the corresponding action from being added to the Sync queue

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1712679936228689-slack-C011BCGRMBR

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* So far I was able to reproduce this Warning while testing https://github.com/Automattic/jetpack/pull/33748 by attempting to complete an order with an invalid card 
* Test instructions are similar to the ones provided in https://github.com/Automattic/jetpack/pull/33748
* With the branch applied no Warning should occur

Noting that the args we were receiving in `expand_order_object` that were causing the Warning were: `[{"refunds":null,"customer_id":null}]`