### PR TITLE
WP Super Cache: fix the CDN function when caching is disabled by logged-in check

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-cdn-while-caching-disabled
+++ b/projects/plugins/super-cache/changelog/fix-cdn-while-caching-disabled
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Super-cache: Fix the CDN functionality when cache is disabled

--- a/projects/plugins/super-cache/ossdl-cdn.php
+++ b/projects/plugins/super-cache/ossdl-cdn.php
@@ -1,6 +1,6 @@
 <?php
 
-/* Taken from OSSDL CDN off-linker, a plugin by W-Mark Kubacki (http://mark.ossdl.de/) and used with permission */
+/* Taken from OSSDL CDN off-linker, a plugin by W-Mark Kubacki and used with permission */
 
 if ( ! isset( $ossdlcdn ) ) {
 	$ossdlcdn = 1; // have to default to on for existing users.
@@ -374,7 +374,15 @@ function scossdl_off_options() {
 		<input type="hidden" name="action" value="update_ossdl_off" />
 		<p class="submit"><input type="submit" class="button-primary" value="<?php esc_attr_e( 'Save Changes', 'wp-super-cache' ); ?>" /></p>
 		</form></p>
-		<p><?php _e( 'CDN functionality provided by <a href="https://wordpress.org/plugins/ossdl-cdn-off-linker/">OSSDL CDN Off Linker</a> by <a href="http://mark.ossdl.de/">Mark Kubacki</a>', 'wp-super-cache' ); ?></p>
+		<p>
+		<?php
+			printf(
+				/* Translators: placeholder is a link to OSSDL CDN Off Linker plugin on WordPress.org */
+				esc_html__( 'CDN functionality provided by %s by Mark Kubacki', 'wp-super-cache' ),
+				'<a href="https://wordpress.org/plugins/ossdl-cdn-off-linker/">OSSDL CDN Off Linker</a>'
+			);
+		?>
+		</p>
 		</div> <!-- Close .wpsc-card -->
 	<?php
 }

--- a/projects/plugins/super-cache/wp-cache-phase1.php
+++ b/projects/plugins/super-cache/wp-cache-phase1.php
@@ -56,7 +56,6 @@ if ( ! isset( $wp_cache_plugins_dir ) ) {
 
 // from the secret shown on the Advanced settings page.
 if ( isset( $_GET['donotcachepage'] ) && isset( $cache_page_secret ) && $_GET['donotcachepage'] == $cache_page_secret ) {
-	$cache_enabled = false;
 	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 		define( 'DONOTCACHEPAGE', 1 );
 	}
@@ -124,7 +123,6 @@ if ( wpsc_is_rejected_cookie() ) {
 	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
 		define( 'DONOTCACHEPAGE', 1 );
 	}
-	$cache_enabled = false;
 	wp_cache_debug( 'Caching disabled because rejected cookie found.' );
 	return true;
 }
@@ -145,7 +143,7 @@ if ( isset( $wp_cache_make_known_anon ) && $wp_cache_make_known_anon ) {
 // an init action wpsc plugins can hook on to.
 do_cacheaction( 'cache_init' );
 
-if ( ! $cache_enabled ) {
+if ( ! $cache_enabled ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- set by configuration or cache_init action
 	return true;
 }
 

--- a/projects/plugins/super-cache/wp-cache-phase1.php
+++ b/projects/plugins/super-cache/wp-cache-phase1.php
@@ -144,9 +144,7 @@ if ( isset( $wp_cache_make_known_anon ) && $wp_cache_make_known_anon ) {
 do_cacheaction( 'cache_init' );
 
 if ( ! $cache_enabled ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- set by configuration or cache_init action
-	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
-		define( 'DONOTCACHEPAGE', 1 );
-	}
+	return true;
 }
 
 // don't cache or serve cached files for various URLs, including the Customizer.

--- a/projects/plugins/super-cache/wp-cache-phase1.php
+++ b/projects/plugins/super-cache/wp-cache-phase1.php
@@ -144,7 +144,9 @@ if ( isset( $wp_cache_make_known_anon ) && $wp_cache_make_known_anon ) {
 do_cacheaction( 'cache_init' );
 
 if ( ! $cache_enabled ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- set by configuration or cache_init action
-	return true;
+	if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+		define( 'DONOTCACHEPAGE', 1 );
+	}
 }
 
 // don't cache or serve cached files for various URLs, including the Customizer.

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -388,11 +388,6 @@ function wp_cache_postload() {
 	global $cache_enabled, $wp_super_cache_late_init;
 	global $wp_cache_request_uri;
 
-	if ( defined( 'DONOTCACHEPAGE' ) && DONOTCACHEPAGE ) {
-		wp_cache_debug( 'wp_cache_postload: DONOTCACHEPAGE defined. Not running.' );
-		return false;
-	}
-
 	if ( empty( $wp_cache_request_uri ) ) {
 		wp_cache_debug( 'wp_cache_postload: no request uri configured. Not running.' );
 		return false;


### PR DESCRIPTION
In the last version of the plugin, a check for DONOTCACHEPAGE was added to the postload function which caused caching to be disabled very early in the process, before the output buffer was created. The CDN functionality relies on the output buffer and was broken as a result.
This PR fixes that by removing the DONOTCACHEPAGE check and doing some other cleanups. The removal of setting $cache_enabled means those won't short circuit the CDN either for these checks, although a $cache_enabled check still exists in the postload function but that may be set by other methods.

ref: https://wordpress.org/support/topic/cdn-support-is-not-working-if-user-logged-in/


## Proposed changes:
* Don't check for DONOTCACHEPAGE in the postload function, as that stops the output buffer being created. This function is called by wp-setting.php after advanced-cache.php is loaded.
* Don't set $cache_enabled to false for rejected cookie and when donotcachepage is found, as that would disable the CDN too.
* Removed the link to the OSSDL CDN author's website as it has disappeared.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Disable caching for logged in users on the advanced settings page.
* Testing the CDN functionality might be awkward with secure certs required for new hostnames, but instead, hook on to the `wp_cache_ob_callback_filter` filter and confirm that it is loaded with the text of the website when you load a page.
* Also, enable debugging and confirm that you see the following in the log file when you load a page, while logged in:
```
Created output buffer
DONOTCACHEPAGE defined. Caching disabled.
wp_cache_maybe_dynamic: returned $buffer
```