### PR TITLE
Social: Added proxy endpoints for social connection CRUD operations 

### DIFF
--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -30,7 +30,6 @@ return [
     // PhanTypeMismatchDefault : 1 occurrence
     // PhanTypeMismatchDimFetch : 1 occurrence
     // PhanTypeMismatchReturn : 1 occurrence
-    // PhanUndeclaredMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
@@ -41,7 +40,7 @@ return [
         'src/class-publicize-setup.php' => ['PhanTypeMismatchArgument'],
         'src/class-publicize-ui.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
         'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredStaticMethod'],
-        'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod'],
+        'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'src/social-image-generator/class-post-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/social-image-generator/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/social-image-generator/class-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],

--- a/projects/packages/publicize/changelog/add-proxy-endpoints-publicize
+++ b/projects/packages/publicize/changelog/add-proxy-endpoints-publicize
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added new endpoint to delete publicize connection

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -67,7 +67,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.42.x-dev"
+			"dev-trunk": "0.43.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.42.14-alpha",
+	"version": "0.43.0-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -169,16 +169,7 @@ class REST_Controller {
 	 * @return bool|WP_Error True if a blog token was used to sign the request, WP_Error otherwise.
 	 */
 	public function require_admin_privilege_callback() {
-		if ( current_user_can( 'manage_options' ) ) {
-			return true;
-		}
-
-		$error_msg = esc_html__(
-			'You are not allowed to perform this action.',
-			'jetpack-publicize-pkg'
-		);
-
-		return new WP_Error( 'rest_forbidden', $error_msg, array( 'status' => rest_authorization_required_code() ) );
+		return current_user_can( 'manage_options' );
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -203,7 +203,7 @@ class REST_Controller {
 					'type'        => 'string',
 				),
 				'shared'                => array(
-					'description' => __( 'Whethe the connection is shared with other users', 'jetpack-publicize-pkg' ),
+					'description' => __( 'Whether the connection is shared with other users', 'jetpack-publicize-pkg' ),
 					'type'        => 'boolean',
 				),
 			),
@@ -228,7 +228,7 @@ class REST_Controller {
 					'type'        => 'string',
 				),
 				'shared'           => array(
-					'description' => __( 'Whethe the connection is shared with other users', 'jetpack-publicize-pkg' ),
+					'description' => __( 'Whether the connection is shared with other users', 'jetpack-publicize-pkg' ),
 					'type'        => 'boolean',
 				),
 			),

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -145,7 +145,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'create_publicize_connection' ),
-				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+				'permission_callback' => array( $this, 'require_author_privilege_callback' ),
 				'schema'              => array( $this, 'get_jetpack_social_connections_schema' ),
 			)
 		);
@@ -157,7 +157,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'update_publicize_connection' ),
-				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+				'permission_callback' => array( $this, 'require_author_privilege_callback' ),
 			)
 		);
 
@@ -168,7 +168,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::DELETABLE,
 				'callback'            => array( $this, 'delete_publicize_connection' ),
-				'permission_callback' => array( $this, 'require_admin_privilege_callback' ),
+				'permission_callback' => array( $this, 'require_author_privilege_callback' ),
 			)
 		);
 	}
@@ -180,6 +180,24 @@ class REST_Controller {
 	 */
 	public function require_admin_privilege_callback() {
 		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		$error_msg = esc_html__(
+			'You are not allowed to perform this action.',
+			'jetpack-publicize-pkg'
+		);
+
+		return new WP_Error( 'rest_forbidden', $error_msg, array( 'status' => rest_authorization_required_code() ) );
+	}
+
+	/**
+	 * Only administrators can access the API.
+	 *
+	 * @return bool|WP_Error True if a blog token was used to sign the request, WP_Error otherwise.
+	 */
+	public function require_author_privilege_callback() {
+		if ( current_user_can( 'publish_posts' ) ) {
 			return true;
 		}
 

--- a/projects/packages/publicize/tests/php/test-publicize-rest-controller.php
+++ b/projects/packages/publicize/tests/php/test-publicize-rest-controller.php
@@ -89,7 +89,7 @@ class Test_REST_Controller extends TestCase {
 		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/publicize/connections' );
 		$response = $this->dispatch_request_signed_with_blog_token( $request );
 		$this->assertEquals( 401, $response->get_status() );
-		$this->assertEquals( 'You are not allowed to perform this action.', $response->get_data()['message'] );
+		$this->assertEquals( 'Sorry, you are not allowed to do that.', $response->get_data()['message'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-proxy-endpoints-publicize
+++ b/projects/plugins/jetpack/changelog/add-proxy-endpoints-publicize
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2049,7 +2049,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/publicize",
-				"reference": "cdf843add1fb7328d3b3c5f265d1a6b6ce9cd792"
+				"reference": "81b0b1f69ea4cf23a5a0dce2312b89487a029120"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -2077,7 +2077,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.42.x-dev"
+					"dev-trunk": "0.43.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/social/changelog/add-proxy-endpoints-publicize
+++ b/projects/plugins/social/changelog/add-proxy-endpoints-publicize
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1356,7 +1356,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/publicize",
-				"reference": "cdf843add1fb7328d3b3c5f265d1a6b6ce9cd792"
+				"reference": "81b0b1f69ea4cf23a5a0dce2312b89487a029120"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1384,7 +1384,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.42.x-dev"
+					"dev-trunk": "0.43.x-dev"
 				}
 			},
 			"autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added proxy endpoints for Social connection CRUD operations
* Update the `require_admin_privilege_callback` to `require_author_privilege_callback` where necessary for existing endpoints
* Deleted the obsolete endpoint `publicize/shares-count` which is not used anywhere, it was also using a publicize method that doesn't exist anymore leading to a 500. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox D146900-code

* We are going to test the endpoint using POSTMAN, but before we test, we need to grab some auth information

- Go to wp-admin and click on copy as curl for any admin request as shown below. 

<img width="1056" alt="Screenshot 2024-04-29 at 7 22 09 PM" src="https://github.com/Automattic/jetpack/assets/6594561/c1f4c746-0abb-4595-889f-99dde27fd2a4">

- Open POSTMAN or any other such tool and import your CURL request. 

<img width="1060" alt="Screenshot 2024-04-29 at 7 22 18 PM" src="https://github.com/Automattic/jetpack/assets/6594561/b941f4a7-37c5-4cff-b072-ba2fdf2d9766">

-  Remove the post body from the request, if any. 

Now, your authentication should be setup correctly. 

Testing deleting a connection:

-  Change the method to DELETE and make sure your request URL looks like this `https://your-site/wp-json/jetpack/v4/social/connections/25207170`, replace 25207170 with a valid connection id. 

- Ensure that you're able to delete your connection. 

Testing creating a connection:

-  Change the method to POST and make sure your request URL looks like this `https://your-site/wp-json/jetpack/v4/social/connections` and add the following json body to your request. To grab a keyring_connection_ID, go to calypso and create a connection. From the request that creates a connection, grab the keyring_connection_ID. Delete the connection, so you don't create duplicate connections. 

```
{"keyring_connection_ID":122344,"shared":false}
```

- Ensure that you're able to create your connection. 

Testing globalizing a connection:

- Make a PUT request to `https://your-site/wp-json/jetpack/v4/social/connections/25267022`, replace 25267022 with a valid connection id with the post body shown below to globalize a connection. Go to Calypso and ensure that the connection is globalized correctly. Send `shared` as `false` to unglobalize the connection. 
```
{"shared":true}
```