### PR TITLE
Subscriptions block: add back missing paywall html styles for email and reader

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-paywall-email-html
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-paywall-email-html
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: add back missing HTML for paywall in emails

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1267,12 +1267,19 @@ function get_paywall_simple() {
 	return '
 <!-- wp:columns -->
 <div class="wp-block-columns" style="display: inline-block; width: 90%">
+    <!-- wp:column -->
+    <div class="wp-block-column" style="background-color: #F6F7F7; padding: 32px; 24px;">
+        <!-- wp:paragraph -->
+        <p class="has-text-align-center"
+           style="text-align: center;
+                  color: #50575E;
+                  font-weight: 400;
+                  font-size: 16px;
                   font-family: \'SF Pro Text\', sans-serif;
                   line-height: 28.8px;">
         ' . $access_heading . '
         </p>
         <!-- /wp:paragraph -->
-
         <!-- wp:buttons -->
         <div class="wp-block-buttons" style="text-align: center;">
             <!-- wp:button -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Alternative to https://github.com/Automattic/jetpack/pull/36912 
Fixes https://github.com/Automattic/wp-calypso/issues/89555

Copied the original HTML from https://github.com/Automattic/jetpack/commit/ffe3a522e8225bc6a7278c58dd766954b6119158#diff-9164d71f603706b3c6cc58c71ba3f2fbb12b1dba772adca76793f60c24ddbca7R859

Somehow along the way a piece of HTML has gone missing; it still works but causes visual issues especially in the Reader.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds back missing HTML for the paywall


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Have a paywalled post e.g. https://cicerosletters.wordpress.com/2024/03/01/paid-post-with-paywall/
- Send yourself a test, here's my test blog with test post `php bin/subscriptions/send.php 217848045 post 123099285 EMAIL`
- Open the post in the reader — paid posts are fetched directly from the page for subscribers I think so no cache issues

<img width="796" alt="Screenshot 2024-04-29 at 17 17 52" src="https://github.com/Automattic/jetpack/assets/87168/06c32795-88cd-4737-bc0c-c35eef19f355">
