### PR TITLE
Newsletter: Add track event for email settings under newletters.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -44,7 +44,7 @@ const EmailSettings = props => {
 				SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION,
 				value === 'excerpt'
 			);
-			analytics.tracks.recordEvent( 'jetpack_newsletter_set_featured_image_in_email', { value } );
+			analytics.tracks.recordEvent( 'jetpack_newsletter_set_emails_use_excerpt', { value } );
 		},
 		[ updateFormStateAndSaveOptionValue ]
 	);

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -18,10 +18,6 @@ const FEATURED_IMAGE_IN_EMAIL_OPTION = 'wpcom_featured_image_in_email';
 const SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION = 'wpcom_subscription_emails_use_excerpt';
 const REPLY_TO_OPTION = 'jetpack_subscriptions_reply_to';
 
-//Check for feature flag
-const urlParams = new URLSearchParams( window.location.search );
-const isNewsletterReplyToEnabled = urlParams.get( 'enable-newsletter-replyto' ) === 'true';
-
 const EmailSettings = props => {
 	const {
 		isSavingAnyOption,
@@ -126,45 +122,30 @@ const EmailSettings = props => {
 					onChange={ handleSubscriptionEmailsUseExcerptChange }
 				/>
 			</SettingsGroup>
-			{ isNewsletterReplyToEnabled && (
-				<SettingsGroup
-					hasChild
-					disableInOfflineMode
-					disableInSiteConnectionMode
-					module={ subscriptionsModule }
-					support={ {
-						link: getRedirectUrl( 'jetpack-support-subscriptions', {
-							anchor: 'reply-to-email-address',
-						} ),
-						text: __(
-							'Sets the reply to email address for your newsletter emails. This is the email address that your subscribers send email to when they reply to the newsletter.',
-							'jetpack'
-						),
-					} }
-				>
-					<FormLegend className="jp-form-label-wide">
-						{ __( 'Reply-to settings', 'jetpack' ) }
-					</FormLegend>
-					<p>
-						{ __(
-							'Choose who receives emails when subscribers reply to your newsletter.',
-							'jetpack'
-						) }
-					</p>
-					<RadioControl
-						selected={ subscriptionReplyTo || 'no-reply' }
-						disabled={ replyToInputDisabled }
-						options={ [
-							{ label: __( 'Replies are not allowed.', 'jetpack' ), value: 'no-reply' },
-							{
-								label: __( "Replies will be sent to the post author's email.", 'jetpack' ),
-								value: 'author',
-							},
-						] }
-						onChange={ handleSubscriptionReplyToChange }
-					/>
-				</SettingsGroup>
-			) }
+			<SettingsGroup
+				hasChild
+				disableInOfflineMode
+				disableInSiteConnectionMode
+				module={ subscriptionsModule }
+				support={ {
+					link: getRedirectUrl( 'jetpack-support-subscriptions', {
+						anchor: 'reply-to-email-address',
+					} ),
+					text: __(
+						'Sets the reply to email address for your newsletter emails. This is the email address that your subscribers send email to when they reply to the newsletter.',
+						'jetpack'
+					),
+				} }
+			>
+				<FormLegend className="jp-form-label-wide">
+					{ __( 'Reply-to settings', 'jetpack' ) }
+				</FormLegend>
+				<p>
+					{ __(
+						'Choose who receives emails when subscribers reply to your newsletter.',
+						'jetpack'
+					) }
+				</p>
 				<RadioControl
 					selected={ subscriptionReplyTo || 'no-reply' }
 					disabled={ replyToInputDisabled }

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -150,9 +150,9 @@ const EmailSettings = props => {
 					selected={ subscriptionReplyTo || 'no-reply' }
 					disabled={ replyToInputDisabled }
 					options={ [
-						{ label: __( 'Replies are not allowed.', 'jetpack' ), value: 'no-reply' },
+						{ label: __( 'Replies are not allowed', 'jetpack' ), value: 'no-reply' },
 						{
-							label: __( "Replies will be sent to the post author's email.", 'jetpack' ),
+							label: __( "Replies will be sent to the post author's email", 'jetpack' ),
 							value: 'author',
 						},
 					] }

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -128,6 +128,9 @@ const EmailSettings = props => {
 				disableInSiteConnectionMode
 				module={ subscriptionsModule }
 				support={ {
+					link: getRedirectUrl( 'jetpack-support-subscriptions', {
+						anchor: 'reply-to-email-address',
+					} ),
 					text: __(
 						"Sets the reply to email address for your newsletter emails. It's the email where subscribers send their replies.",
 						'jetpack'

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -4,6 +4,7 @@ import { FormLegend } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import analytics from 'lib/analytics';
 import { useCallback } from 'react';
 import { connect } from 'react-redux';
 import { isUnavailableInOfflineMode, isUnavailableInSiteConnectionMode } from 'state/connection';
@@ -34,10 +35,11 @@ const EmailSettings = props => {
 	} = props;
 
 	const handleEnableFeaturedImageInEmailToggleChange = useCallback( () => {
-		updateFormStateAndSaveOptionValue(
-			FEATURED_IMAGE_IN_EMAIL_OPTION,
-			! isFeaturedImageInEmailEnabled
-		);
+		const value = ! isFeaturedImageInEmailEnabled;
+		updateFormStateAndSaveOptionValue( FEATURED_IMAGE_IN_EMAIL_OPTION, value );
+		analytics.tracks.recordEvent( 'jetpack_newsletter_set_toggle_featured_image_in_email', {
+			value,
+		} );
 	}, [ isFeaturedImageInEmailEnabled, updateFormStateAndSaveOptionValue ] );
 
 	const handleSubscriptionEmailsUseExcerptChange = useCallback(
@@ -46,6 +48,7 @@ const EmailSettings = props => {
 				SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION,
 				value === 'excerpt'
 			);
+			analytics.tracks.recordEvent( 'jetpack_newsletter_set_featured_image_in_email', { value } );
 		},
 		[ updateFormStateAndSaveOptionValue ]
 	);
@@ -53,6 +56,7 @@ const EmailSettings = props => {
 	const handleSubscriptionReplyToChange = useCallback(
 		value => {
 			updateFormStateAndSaveOptionValue( REPLY_TO_OPTION, value );
+			analytics.tracks.recordEvent( 'jetpack_newsletter_set_reply_to', { value } );
 		},
 		[ updateFormStateAndSaveOptionValue ]
 	);
@@ -161,6 +165,19 @@ const EmailSettings = props => {
 					/>
 				</SettingsGroup>
 			) }
+				<RadioControl
+					selected={ subscriptionReplyTo || 'no-reply' }
+					disabled={ replyToInputDisabled }
+					options={ [
+						{ label: __( 'Replies are not allowed.', 'jetpack' ), value: 'no-reply' },
+						{
+							label: __( "Replies will be sent to the post author's email.", 'jetpack' ),
+							value: 'author',
+						},
+					] }
+					onChange={ handleSubscriptionReplyToChange }
+				/>
+			</SettingsGroup>
 		</SettingsCard>
 	);
 };

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -128,11 +128,8 @@ const EmailSettings = props => {
 				disableInSiteConnectionMode
 				module={ subscriptionsModule }
 				support={ {
-					link: getRedirectUrl( 'jetpack-support-subscriptions', {
-						anchor: 'reply-to-email-address',
-					} ),
 					text: __(
-						'Sets the reply to email address for your newsletter emails. This is the email address that your subscribers send email to when they reply to the newsletter.',
+						"Sets the reply to email address for your newsletter emails. It's the email where subscribers send their replies.",
 						'jetpack'
 					),
 				} }

--- a/projects/plugins/jetpack/changelog/add-reply-to-tracks-enable
+++ b/projects/plugins/jetpack/changelog/add-reply-to-tracks-enable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add: tracks for email settings


### PR DESCRIPTION

## Proposed changes:
This PR does the following. 
1. Adds 3 track events. `jetpack_newsletter_set_toggle_featured_image_in_email`, `jetpack_newsletter_set_emails_use_excerpt`  and `jetpack_newsletter_set_reply_to`. with value set to `value` custom prompt. 
2. Removes the feature flag so that we can ship this feature. 

<img width="1053" alt="Screenshot 2024-05-02 at 10 06 00" src="https://github.com/Automattic/jetpack/assets/4068554/4fa97166-e544-4c9e-a92f-99fb01fc1837">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Go to /wp-admin/admin.php?page=jetpack#/newsletter
* Notice that you are able to select the reply to option. 
* Does all the copy make sense?
* Does the copy in the bubble make sense? 
* Notice that you are able to toggle different things. 
* Navigate to live tracks and notice that you are seeing the new events show up under your username.

