### PR TITLE
Subscriptions: Fix registering block hooks for REST API calls

### DIFF
--- a/projects/plugins/jetpack/changelog/update-block-hooks-init-fix
+++ b/projects/plugins/jetpack/changelog/update-block-hooks-init-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Fix registering block hooks for REST API calls

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -48,7 +48,7 @@ function register_block() {
 	);
 
 	// If called via REST API, we need to register later in the lifecycle
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! jetpack_is_frontend() ) {
+	if ( ( new Host() )->is_wpcom_platform() && ! jetpack_is_frontend() ) {
 		add_action(
 			'restapi_theme_init',
 			function () {

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -47,7 +47,17 @@ function register_block() {
 		}
 	);
 
-	Jetpack_Subscription_Site::init()->handle_subscriber_login_block_placements();
+	// If called via REST API, we need to register later in the lifecycle
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! jetpack_is_frontend() ) {
+		add_action(
+			'restapi_theme_init',
+			function () {
+				Jetpack_Subscription_Site::init()->handle_subscriber_login_block_placements();
+			}
+		);
+	} else {
+		Jetpack_Subscription_Site::init()->handle_subscriber_login_block_placements();
+	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -182,7 +182,17 @@ function register_block() {
 		}
 	);
 
-	Jetpack_Subscription_Site::init()->handle_subscribe_block_placements();
+	// If called via REST API, we need to register later in the lifecycle
+	if ( is_wpcom() && ! jetpack_is_frontend() ) {
+		add_action(
+			'restapi_theme_init',
+			function () {
+				Jetpack_Subscription_Site::init()->handle_subscribe_block_placements();
+			}
+		);
+	} else {
+		Jetpack_Subscription_Site::init()->handle_subscribe_block_placements();
+	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_block', 9 );
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -183,7 +183,7 @@ function register_block() {
 	);
 
 	// If called via REST API, we need to register later in the lifecycle
-	if ( is_wpcom() && ! jetpack_is_frontend() ) {
+	if ( ( new Host() )->is_wpcom_platform() && ! jetpack_is_frontend() ) {
 		add_action(
 			'restapi_theme_init',
 			function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Link to the discussion p1713993211503079-slack-C065QF2R1B6

## Proposed changes:

It fixes registering block hooks for REST API calls by subscribing it to the `restapi_theme_init` action.

Tested it on Jetpack, Simple, and Atomic sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

It's important to test it with Jetpack and Dotcom sites.

1. Go to the Newsletter settings
2. Enable the "Add the Subscribe Block at the end of each post" option
3. Open the post making sure the Subscribe block is hooked after the post content
4. Open the Single Posts template editor making sure you can edit the hooked Subscribe block