### PR TITLE
Fix/nav upsell RTL padding

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-nav-upsell-rtl-padding
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-nav-upsell-rtl-padding
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Fix navigation upsell RTL padding
+Fix navigation upsell and notification RTL spacing.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-nav-upsell-rtl-padding
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-nav-upsell-rtl-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fix navigation upsell RTL padding

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -438,6 +438,10 @@ function wpcom_add_hosting_menu_intro_notice() {
 			height: 16px;
 			margin-left: auto;
 		}
+		.rtl .wpcom-site-menu-intro-notice a.close-button {
+			margin-left: 0;
+			margin-right: auto;
+		}
 	</style>
 	<div class="wpcom-site-menu-intro-notice notice notice-info" role="alert">
 		<div class="banner-icon">

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -436,11 +436,7 @@ function wpcom_add_hosting_menu_intro_notice() {
 
 		.wpcom-site-menu-intro-notice a.close-button {
 			height: 16px;
-			margin-left: auto;
-		}
-		.rtl .wpcom-site-menu-intro-notice a.close-button {
-			margin-left: 0;
-			margin-right: auto;
+			margin-inline-start: auto;
 		}
 	</style>
 	<div class="wpcom-site-menu-intro-notice notice notice-info" role="alert">

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
@@ -125,6 +125,11 @@
 		.wp-menu-name {
 			left: auto;
 			padding-left: 4px;
+
+			.rtl & {
+			 	right: auto;
+				padding-right: 4px;
+			}
 		}
 
 		.upsell_banner {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
@@ -59,8 +59,7 @@
 	}
 
 	.wp-menu-name {
-		padding-top: 0;
-		padding-left: 8px;
+		padding: 0 8px 8px 8px;
 	}
 
 	.upsell_banner {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
@@ -147,13 +147,9 @@
 	@include folded;
 }
 
-.rtl .folded {
-	@include folded {
-		#adminmenu li.toplevel_page_site-notices .wp-menu-name {
-			right: auto;
-			padding-right: 4px;
-		}
-	}
+.rtl .folded #adminmenu li.toplevel_page_site-notices .wp-menu-name {
+	right: auto;
+	padding-right: 4px;
 }
 
 @media only screen and (max-width: 960px) and (min-width: 783px) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
@@ -147,7 +147,7 @@
 	@include folded;
 }
 
-.rtl .folded #adminmenu li.toplevel_page_site-notices .wp-menu-name {
+.rtl.folded #adminmenu li.toplevel_page_site-notices .wp-menu-name {
 	right: auto;
 	padding-right: 4px;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
@@ -125,11 +125,6 @@
 		.wp-menu-name {
 			left: auto;
 			padding-left: 4px;
-
-			.rtl & {
-			 	right: auto;
-				padding-right: 4px;
-			}
 		}
 
 		.upsell_banner {
@@ -150,6 +145,15 @@
 
 .folded {
 	@include folded;
+}
+
+.rtl {
+	@include folded {
+		#adminmenu li.toplevel_page_site-notices .wp-menu-name {
+			right: auto;
+			padding-right: 4px;
+		}
+	}
 }
 
 @media only screen and (max-width: 960px) and (min-width: 783px) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
@@ -147,7 +147,7 @@
 	@include folded;
 }
 
-.rtl {
+.rtl .folded {
 	@include folded {
 		#adminmenu li.toplevel_page_site-notices .wp-menu-name {
 			right: auto;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6811

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes the RTL padding for the domain upsell both when the sidebar is open and "folded"
* It also fixes the RTL notification close button margin.


Open
Before | After
--|--
<img width="1723" alt="jetpack-before" src="https://github.com/Automattic/jetpack/assets/140841/38604fc7-d7d0-435b-8256-06b6cc8105c8">  | <img width="1721" alt="jetpack-after" src="https://github.com/Automattic/jetpack/assets/140841/9b69fd7e-07e3-4f87-b1f7-d4375307ba14">

Folded
Before | After
--|--
<img width="1727" alt="Screenshot 2024-04-29 at 6 23 16 PM" src="https://github.com/Automattic/jetpack/assets/140841/43ec86b1-155c-4f15-be7c-efcf3c724ec7">  | <img width="1725" alt="Screenshot 2024-04-29 at 6 34 46 PM" src="https://github.com/Automattic/jetpack/assets/140841/ee85c34d-4e8b-43bc-b385-d68dc9a2ba59">




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To test on Simple sites
* Apply a RTL language to your profile at wordpress.com/me
* Visit a Classic-early-release test site and observer the spacing concerns mentioned above. To create a Classic-early-release simple site, you need to apply the site options below to it using `wpsh` on your sandbox.
> switch_to_blog($blog_id);
> add_option('wpcom_classic_early_release', 1);
> add_option('wpcom_admin_interface', 'wp-admin');
* Apply this PR to your Sandbox with the command `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/nav-upsell-rtl-padding` https://github.com/Automattic/jetpack/pull/37125#issuecomment-2083804879
* Sandbox your Classic-early-release test site.
* Observe the spacing concerns mentioned above are corrected.
* Switch your language back to a LTR language like English and make sure there are no regressions.

To test on Atomic sites
* Apply a RTL language to your profile at /wp-admin/profile.php
* Visit an Atomic Classic-early-release test site and observer the spacing concerns mentioned above. To create a Classic-early-release Atomic site, you need to apply the site options below to it using /_cli
> wp option add wpcom_classic_early_release 1
* Set your site to the Classic admin interface in https://wordpress.com/hosting-config/
* Apply this PR to your test site using the Jetpack Beta plugin. Select this PR for `jetpack-mu-wpcom` and be sure you've added `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` to your wp-config.php file. https://github.com/Automattic/jetpack/pull/37125#issuecomment-2083804879
* Hard refresh
* Observe the spacing concerns mentioned above are corrected.
* Switch your language back to a LTR language like English and make sure there are no regressions.