### PR TITLE
Boost: Fix CSS gen library and it's sourcemap to boost.

### DIFF
--- a/projects/plugins/boost/changelog/fix-boost-webpack-css-gen
+++ b/projects/plugins/boost/changelog/fix-boost-webpack-css-gen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Changes to development assets
+
+

--- a/projects/plugins/boost/webpack.config.js
+++ b/projects/plugins/boost/webpack.config.js
@@ -10,18 +10,26 @@ const cssGenPath = path.dirname(
 	path.dirname( require.resolve( 'jetpack-boost-critical-css-gen' ) )
 );
 
-const cssGenCopyPatterns = [
-	{
-		from: path.join( cssGenPath, 'dist/bundle.js' ),
-		to: 'critical-css-gen.js',
-	},
-];
+let cssGenCopyPatterns;
 
-if ( ! isProduction ) {
-	cssGenCopyPatterns.push( {
-		from: path.join( cssGenPath, 'dist/bundle.js.map' ),
-		to: 'critical-css-gen.js.map',
-	} );
+if ( isProduction ) {
+	cssGenCopyPatterns = [
+		{
+			from: path.join( cssGenPath, 'dist/bundle.js' ),
+			to: 'critical-css-gen.js',
+		},
+	];
+} else {
+	cssGenCopyPatterns = [
+		{
+			from: path.join( cssGenPath, 'dist/bundle.full.js' ),
+			to: 'critical-css-gen.js',
+		},
+		{
+			from: path.join( cssGenPath, 'dist/bundle.full.js.map' ),
+			to: 'bundle.full.js.map',
+		},
+	];
 }
 
 const imageGuideCopyPatterns = [


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Copy the sourcemap with the correct name so the reference doesn't break.
* Copy the non-minified version in development

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Make sure critical CSS gen still works in production and development

