### PR TITLE
Launchpad: Add completion handler for eCommerce plan tasks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ecommerce-launchpad-tasks-completion
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ecommerce-launchpad-tasks-completion
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Launchpad: Add completion handler to eCommerce plan tasks

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -56,7 +56,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.27.x-dev"
+			"dev-trunk": "5.28.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.27.1-alpha",
+	"version": "5.28.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.27.1-alpha';
+	const PACKAGE_VERSION = '5.28.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -736,12 +736,12 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 		),
 
-		// Entrepreneur plan tasks
+		// WooCommerce tasks
 		'woo_customize-store'             => array(
 			'get_title'            => function () {
 				return __( 'Customize your store', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_woocommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store' );
@@ -751,7 +751,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Add your products', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_woocommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=products' );
@@ -761,7 +761,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Get paid with WooPayments', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_woocommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments' );
@@ -771,7 +771,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Collect sales tax', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_woocommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=tax' );
@@ -781,7 +781,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Grow your business', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_woocommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=marketing' );
@@ -791,7 +791,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Add a domain', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_woocommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/domains/add/' . $data['site_slug_encoded'];
@@ -801,7 +801,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Launch your store', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_woocommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=launch_site' );
@@ -838,14 +838,14 @@ function wpcom_launchpad_is_site_launched( $task, $is_complete ) {
 }
 
 /**
- * Returns true if the current site's eCommerce plan task is complete.
+ * Returns true if one of the site's WooCommerce tasks is complete.
  *
  * @param Task $task The task object.
  * @param bool $is_complete The current task status.
  *
  * @return boolean
  */
-function wpcom_launchpad_is_ecommerce_task_completed( $task, $is_complete ) {
+function wpcom_launchpad_is_woocommerce_task_completed( $task, $is_complete ) {
 	if ( $is_complete ) {
 		return true;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -751,7 +751,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Add your products', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=products' );
@@ -831,6 +831,29 @@ function wpcom_launchpad_is_site_launched( $task, $is_complete ) {
 
 	if ( 'launched' === $launch_status ) {
 		wpcom_mark_launchpad_task_complete( 'site_launched' );
+		return true;
+	} else {
+		return false;
+	}
+}
+
+/**
+ * Returns true if the current site's eCommerce plan task is complete.
+ *
+ * @param Task $task The task object.
+ * @param bool $is_complete The current task status.
+ *
+ * @return boolean
+ */
+function wpcom_launchpad_is_ecommerce_task_completed( $task, $is_complete ) {
+	if ( $is_complete ) {
+		return true;
+	}
+
+	$completed_tasks = get_option( 'woocommerce_task_list_tracked_completed_tasks', array() );
+
+	if ( in_array( 'products', $completed_tasks, true ) ) {
+		wpcom_mark_launchpad_task_complete( 'add_your_products' );
 		return true;
 	} else {
 		return false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -737,7 +737,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// WooCommerce tasks
-		'woo_customize-store'             => array(
+		'woo_customize_store'             => array(
 			'get_title'            => function () {
 				return __( 'Customize your store', 'jetpack-mu-wpcom' );
 			},
@@ -757,7 +757,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=products' );
 			},
 		),
-		'woo_woocommerce-payments'        => array(
+		'woo_woocommerce_payments'        => array(
 			'get_title'            => function () {
 				return __( 'Get paid with WooPayments', 'jetpack-mu-wpcom' );
 			},
@@ -852,9 +852,9 @@ function wpcom_launchpad_is_woocommerce_task_completed( $task, $is_complete ) {
 
 	// Array mapping task 'id' from $task to keys used in 'woocommerce_task_list_tracked_completed_tasks' site option
 	$task_map = array(
-		'woo_customize-store'      => 'customize-store',
+		'woo_customize_store'      => 'customize-store',
 		'woo_products'             => 'products',
-		'woo_woocommerce-payments' => 'woocommerce-payments',
+		'woo_woocommerce_payments' => 'woocommerce-payments',
 		'woo_tax'                  => 'tax',
 		'woo_marketing'            => 'marketing',
 		'woo_add_domain'           => 'add_domain',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -737,7 +737,7 @@ function wpcom_launchpad_get_task_definitions() {
 		),
 
 		// Entrepreneur plan tasks
-		'customize_your_store'            => array(
+		'woo_customize-store'             => array(
 			'get_title'            => function () {
 				return __( 'Customize your store', 'jetpack-mu-wpcom' );
 			},
@@ -747,7 +747,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store' );
 			},
 		),
-		'add_your_products'               => array(
+		'woo_products'                    => array(
 			'get_title'            => function () {
 				return __( 'Add your products', 'jetpack-mu-wpcom' );
 			},
@@ -757,7 +757,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=products' );
 			},
 		),
-		'get_paid_with_woopayments'       => array(
+		'woo_woocommerce-payments'        => array(
 			'get_title'            => function () {
 				return __( 'Get paid with WooPayments', 'jetpack-mu-wpcom' );
 			},
@@ -767,7 +767,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments' );
 			},
 		),
-		'collect_sales_tax'               => array(
+		'woo_tax'                         => array(
 			'get_title'            => function () {
 				return __( 'Collect sales tax', 'jetpack-mu-wpcom' );
 			},
@@ -777,7 +777,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=tax' );
 			},
 		),
-		'grow_your_business'              => array(
+		'woo_marketing'                   => array(
 			'get_title'            => function () {
 				return __( 'Grow your business', 'jetpack-mu-wpcom' );
 			},
@@ -787,7 +787,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=marketing' );
 			},
 		),
-		'add_a_domain'                    => array(
+		'woo_add_domain'                  => array(
 			'get_title'            => function () {
 				return __( 'Add a domain', 'jetpack-mu-wpcom' );
 			},
@@ -797,7 +797,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return '/domains/add/' . $data['site_slug_encoded'];
 			},
 		),
-		'launch_your_store'               => array(
+		'woo_launch_site'                 => array(
 			'get_title'            => function () {
 				return __( 'Launch your store', 'jetpack-mu-wpcom' );
 			},
@@ -850,10 +850,21 @@ function wpcom_launchpad_is_ecommerce_task_completed( $task, $is_complete ) {
 		return true;
 	}
 
+	// Array mapping task 'id' from $task to keys used in 'woocommerce_task_list_tracked_completed_tasks' site option
+	$task_map = array(
+		'woo_customize-store'      => 'customize-store',
+		'woo_products'             => 'products',
+		'woo_woocommerce-payments' => 'woocommerce-payments',
+		'woo_tax'                  => 'tax',
+		'woo_marketing'            => 'marketing',
+		'woo_add_domain'           => 'add_domain',
+		'woo_launch_site'          => 'launch_site',
+	);
+
 	$completed_tasks = get_option( 'woocommerce_task_list_tracked_completed_tasks', array() );
 
-	if ( in_array( 'products', $completed_tasks, true ) ) {
-		wpcom_mark_launchpad_task_complete( 'add_your_products' );
+	if ( array_key_exists( $task['id'], $task_map ) && in_array( $task_map[ $task['id'] ], $completed_tasks, true ) ) {
+		wpcom_mark_launchpad_task_complete( $task['id'] );
 		return true;
 	} else {
 		return false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -741,7 +741,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Customize your store', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&path=%2Fcustomize-store' );
@@ -761,7 +761,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Get paid with WooPayments', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=woocommerce-payments' );
@@ -771,7 +771,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Collect sales tax', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=tax' );
@@ -781,7 +781,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Grow your business', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=marketing' );
@@ -791,7 +791,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Add a domain', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				return '/domains/add/' . $data['site_slug_encoded'];
@@ -801,7 +801,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Launch your store', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_ecommerce_task_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_is_woocommerce_setup_visible',
 			'get_calypso_path'     => function () {
 				return site_url( '/wp-admin/admin.php?page=wc-admin&task=launch_site' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -291,13 +291,13 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'entrepreneur-site-setup' => array(
 			'task_ids' => array(
-				'customize_your_store',
-				'add_your_products',
-				'get_paid_with_woopayments',
-				'collect_sales_tax',
-				'grow_your_business',
-				'add_a_domain',
-				'launch_your_store',
+				'woo_customize-store',
+				'woo_products',
+				'woo_woocommerce-payments',
+				'woo_tax',
+				'woo_marketing',
+				'woo_add_domain',
+				'woo_launch_site',
 			),
 		),
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -291,9 +291,9 @@ function wpcom_launchpad_get_task_list_definitions() {
 		),
 		'entrepreneur-site-setup' => array(
 			'task_ids' => array(
-				'woo_customize-store',
+				'woo_customize_store',
 				'woo_products',
-				'woo_woocommerce-payments',
+				'woo_woocommerce_payments',
 				'woo_tax',
 				'woo_marketing',
 				'woo_add_domain',

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-ecommerce-launchpad-tasks-completion
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-ecommerce-launchpad-tasks-completion
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -549,7 +549,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "ca92a3e2fa415ff5d216be5fa54b8afb62ba4077"
+                "reference": "a2b95ed2cade4352f52bffc659c1da7b5de1d759"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -577,7 +577,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.27.x-dev"
+                    "dev-trunk": "5.28.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/6766

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* introduce `wpcom_launchpad_is_ecommerce_task_completed` callback that handles eCommerce plan tasks' completion
* rename task ids to represent their relation to WooCommerce

![Markup on 2024-04-30 at 14:03:53](https://github.com/Automattic/jetpack/assets/25105483/0dd116bb-e1ba-462a-a6ea-cf027b055d29)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Related PT: pdDOJh-3iE-p2.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:

1. Create a WordPress.com site with the **Entrepreneur plan**. You can use SA to add the plan.

ℹ️ We are not testing with the Trial plan because we need access to plugins and SFTP (which the Trial plan doesn't have).

2. Install and activate the [Jetpack Tester plugin](https://jetpack.com/download-jetpack-beta/) and select this branch (`add/ecommerce-launchpad-tasks-completion`) in its settings:

| Step 1 | Step 2 |
|--------|--------|
| ![Markup on 2024-04-26 at 14:52:27](https://github.com/Automattic/jetpack/assets/25105483/c5aa4107-1ffc-4ee7-8083-09190453dc9c) | ![Markup on 2024-04-30 at 14:03:02](https://github.com/Automattic/jetpack/assets/25105483/80057784-2c49-4de4-b24f-e3e04bd76ba5) | 

As you can see in the screenshots above, the branch needs to be selected inside "WordPress.com Features" section - which represents the `jetpack-mu-wpcom` plugin we are modifying in this PR.

4. Connect to your site over SFTP and add the following line to the `wp-config.php`: `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );`.
5. Sync built branch changes to your sandbox by running `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/entrepreneur-site-launchpad-tasks-completion` (or use `rsync`); if needed, the details can be found here: PCYsg-Osp-p2.
6. Open Calypso locally and make the following edits:

```diff
diff --git a/client/my-sites/customer-home/cards/launchpad/index.tsx b/client/my-sites/customer-home/cards/launchpad/index.tsx
index eb159b650b..8007b29281 100644
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -105,6 +105,11 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 				launchpadContext={ launchpadContext }
 				onSiteLaunched={ onSiteLaunched }
 			/>
+			<Launchpad
+				siteSlug={ siteSlug }
+				checklistSlug={ 'entrepreneur-site-setup' }
+				launchpadContext={ launchpadContext }
+			/>
 		</div>
 	);
 };
```

7. Open the WooCommerce Home page at `/wp-admin/admin.php?page=wc-admin`. We will use it to compare the tasks here with the newly-created Launchpad tasks - so you can keep the tab open.
8. Open the Calypso Home at `http://calypso.localhost:3000/home/<site-slug>?flags=entrepreneur-my-home`.
9. Sandbox `public-api.wordpress.com`.
10. When you go back to the Calypso Home, the newly-created Launchpad tasks should be loaded right below the existing Calypso Home tasks.
11. Compare the new Launchpad tasks with the ones on the WooCommerce Home page. Try to click the tasks and complete them; e.g. if you create your first product, the task should get completed in both: WooCommerce Home in WP Admin and Launchpad in Calypso's My Home. Please note that you may need to reload the page to see the change.