### PR TITLE
Remove sync option backward-compatibility temporary solution

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-remove-temp-backward-code
+++ b/projects/packages/scheduled-updates/changelog/fix-remove-temp-backward-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove sync option backward-compatibility temporary solution

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -93,12 +93,6 @@ class Scheduled_Updates {
 		// Active flag saving.
 		add_action( 'add_option_' . Scheduled_Updates_Active::OPTION_NAME, $callback );
 		add_action( 'update_option_' . Scheduled_Updates_Active::OPTION_NAME, $callback );
-
-		// This is a temporary solution for backward compatibility. It will be removed in the future.
-		// It's needed to ensure that preexisting schedules are loaded into the sync option.
-		if ( false === get_option( self::PLUGIN_CRON_HOOK ) ) {
-			call_user_func( $callback );
-		}
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -61,6 +61,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		Scheduled_Updates::init();
 
 		self::$sync_counter = 0;
+		add_action( 'add_option', array( __CLASS__, 'sync_callback' ) );
 		add_action( 'update_option', array( __CLASS__, 'sync_callback' ) );
 	}
 

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -80,6 +80,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		remove_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		self::$sync_counter = 0;
+		remove_action( 'add_option', array( __CLASS__, 'sync_callback' ) );
 		remove_action( 'update_option', array( __CLASS__, 'sync_callback' ) );
 	}
 

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -268,40 +268,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
-	 * Temporary test to ensure backward compatibility. It will be removed in the future.
-	 */
-	public function test_init_backward_compatibility() {
-		$plugins = array(
-			'custom-plugin/custom-plugin.php',
-			'gutenberg/gutenberg.php',
-		);
-		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
-		$request->set_body_params(
-			array(
-				'plugins'  => $plugins,
-				'schedule' => $this->get_schedule(),
-			)
-		);
-
-		wp_set_current_user( $this->admin_id );
-		$result = rest_do_request( $request );
-
-		$this->assertSame( 200, $result->get_status() );
-
-		$pre_sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		$this->assertIsArray( $pre_sync_option );
-
-		// Force deleting the option to test backward compatibility.
-		$this->assertTrue( delete_option( Scheduled_Updates::PLUGIN_CRON_HOOK ) );
-
-		// Simulate an init.
-		Scheduled_Updates::init();
-		$post_sync_option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		$this->assertEquals( $pre_sync_option, $post_sync_option );
-		$this->assertSame( 1, self::$sync_counter );
-	}
-
-	/**
 	 * Can't have multiple schedules for the same time.
 	 *
 	 * @covers ::validate_schedule


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/36913

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove temporary solution, not needed anymore

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Working unit tests are enough

