### PR TITLE
Add feature flag for new social admin UI

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-social-admin-ui-feature-flag
+++ b/projects/js-packages/publicize-components/changelog/add-social-admin-ui-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added feature flag for new social admin ui

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.49.3",
+	"version": "0.49.4-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/social-store/reducer/index.js
+++ b/projects/js-packages/publicize-components/src/social-store/reducer/index.js
@@ -15,6 +15,7 @@ const reducer = combineReducers( {
 	autoConversionSettings,
 	hasPaidPlan: ( state = false ) => state,
 	userConnectionUrl: ( state = '' ) => state,
+	useAdminUiV1: ( state = false ) => state,
 } );
 
 export default reducer;

--- a/projects/js-packages/publicize-components/src/social-store/selectors/index.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/index.js
@@ -13,6 +13,7 @@ const selectors = {
 	...socialImageGeneratorSettingsSelectors,
 	...autoConversionSettingsSelectors,
 	userConnectionUrl: state => state.userConnectionUrl,
+	useAdminUiV1: state => state.useAdminUiV1,
 };
 
 export default selectors;

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -36,10 +36,11 @@ export type SocialStoreState = {
 	hasPaidPlan?: boolean;
 	// on Jetack Social admin page
 	jetpackSettings?: JetpackSettings;
+	useAdminUiV1?: boolean;
 };
 
 declare global {
 	interface Window {
-		jetpackSocialInitialState?: SocialStoreState & { useAdminUiV1?: boolean };
+		jetpackSocialInitialState?: SocialStoreState;
 	}
 }

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -36,11 +36,10 @@ export type SocialStoreState = {
 	hasPaidPlan?: boolean;
 	// on Jetack Social admin page
 	jetpackSettings?: JetpackSettings;
-	useAdminUiV1?: boolean;
 };
 
 declare global {
 	interface Window {
-		jetpackSocialInitialState?: SocialStoreState;
+		jetpackSocialInitialState?: SocialStoreState & { useAdminUiV1?: boolean };
 	}
 }

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -36,6 +36,7 @@ export type SocialStoreState = {
 	hasPaidPlan?: boolean;
 	// on Jetack Social admin page
 	jetpackSettings?: JetpackSettings;
+	useAdminUiV1?: boolean;
 };
 
 declare global {

--- a/projects/packages/publicize/changelog/add-social-admin-ui-feature-flag
+++ b/projects/packages/publicize/changelog/add-social-admin-ui-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added feature flag for new social admin ui

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -253,7 +253,18 @@ class Publicize extends Publicize_Base {
 					$user_id = (int) $connection['connection_data']['user_id'];
 					// phpcs:ignore WordPress.PHP.YodaConditions.NotYoda
 					if ( $user_id === 0 || $this->user_id() === $user_id ) {
-						$connections_to_return[ $service_name ][ $id ] = $connection;
+						if ( is_callable( array( self::class, 'use_amin_ui_v1' ) ) && self::use_admin_ui_v1() ) {
+							$connections_to_return[] = array_merge(
+								$connection,
+								array(
+									'service_name'   => $service_name,
+									'connection_id'  => $connection['connection_data']['id'],
+									'can_disconnect' => current_user_can( 'manage_options' ) || get_current_user_id() === $user_id,
+								)
+							);
+						} else {
+							$connections_to_return[ $service_name ][ $id ] = $connection;
+						}
 					}
 				}
 			}

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -74,6 +74,20 @@ class Publicize extends Publicize_Base {
 	}
 
 	/**
+	 * Whether to use the v1 admin UI.
+	 */
+	public static function use_admin_ui_v1(): bool {
+
+		// If the option is set, use it.
+		if ( get_option( 'jetpack_social_use_admin_ui_v1', false ) ) {
+			return true;
+		}
+
+		// Otherwise, use the constant.
+		return defined( 'JETPACK_SOCIAL_USE_ADMIN_UI_V1' ) && JETPACK_SOCIAL_USE_ADMIN_UI_V1;
+	}
+
+	/**
 	 * Force user connection before showing the Publicize UI.
 	 */
 	public function force_user_connection() {

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -253,7 +253,7 @@ class Publicize extends Publicize_Base {
 					$user_id = (int) $connection['connection_data']['user_id'];
 					// phpcs:ignore WordPress.PHP.YodaConditions.NotYoda
 					if ( $user_id === 0 || $this->user_id() === $user_id ) {
-						if ( is_callable( array( self::class, 'use_amin_ui_v1' ) ) && self::use_admin_ui_v1() ) {
+						if ( self::use_admin_ui_v1() ) {
 							$connections_to_return[] = array_merge(
 								$connection,
 								array(

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Publicize\Jetpack_Social_Settings;
 
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Publicize\Publicize;
 use Automattic\Jetpack\Publicize\Social_Image_Generator\Templates;
 
 /**
@@ -168,6 +169,8 @@ class Settings {
 			$settings['autoConversionSettings']['available']       = $this->is_auto_conversion_available();
 			$settings['socialImageGeneratorSettings']['available'] = $this->is_sig_available();
 		}
+
+		$settings['useAdminUiV1'] = Publicize::use_admin_ui_v1();
 
 		return $settings;
 	}

--- a/projects/packages/publicize/tests/php/jetpack-social-settings/test-jetpack-social-settings.php
+++ b/projects/packages/publicize/tests/php/jetpack-social-settings/test-jetpack-social-settings.php
@@ -120,6 +120,7 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 				'enabled'  => true,
 				'template' => 'example_template',
 			),
+			'useAdminUiV1'                 => false,
 		);
 
 		$this->settings = new SocialSettings();
@@ -139,6 +140,7 @@ class Jetpack_Social_Settings_Test extends BaseTestCase {
 				'enabled'  => false,
 				'template' => Templates::DEFAULT_TEMPLATE,
 			),
+			'useAdminUiV1'                 => false,
 		);
 
 		$this->settings = new SocialSettings();

--- a/projects/plugins/jetpack/_inc/client/sharing/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/index.jsx
@@ -47,6 +47,7 @@ class Sharing extends Component {
 			isAtomicSite: this.props.isAtomicSite,
 			hasSharingBlock: this.props.hasSharingBlock,
 			isBlockTheme: this.props.isBlockTheme,
+			useAdminUiV1: this.props.useAdminUiV1,
 		};
 
 		const foundPublicize = this.props.isModuleFound( 'publicize' ),
@@ -103,5 +104,6 @@ export default connect( state => {
 		isAtomicSite: isAtomicSite( state ),
 		hasSharingBlock: isSharingBlockAvailable( state ),
 		isBlockTheme: currentThemeIsBlockTheme( state ),
+		useAdminUiV1: state.jetpack.initialState.socialInitialState.useAdminUiV1,
 	};
 } )( Sharing );

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -179,6 +179,9 @@ export const Publicize = withModuleSettingsFormHelpers(
 					) }
 
 					{ isActive && configCard() }
+					{ window.Initial_State.socialInitialState.useAdminUiV1 ? (
+						<span>New connections UI goes here</span>
+					) : null }
 				</SettingsCard>
 			);
 		}

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -37,7 +37,8 @@ export const Publicize = withModuleSettingsFormHelpers(
 				hasAutoConversion = this.props.hasAutoConversion,
 				isAtomicSite = this.props.isAtomicSite,
 				activeFeatures = this.props.activeFeatures,
-				userCanManageModules = this.props.userCanManageModules;
+				userCanManageModules = this.props.userCanManageModules,
+				useAdminUiV1 = this.props.useAdminUiV1;
 
 			const showUpgradeLink =
 				! isAtomicSite &&
@@ -179,9 +180,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 					) }
 
 					{ isActive && configCard() }
-					{ window.Initial_State.socialInitialState.useAdminUiV1 ? (
-						<span>New connections UI goes here</span>
-					) : null }
+					{ useAdminUiV1 ? <span>New connections UI goes here</span> : null }
 				</SettingsCard>
 			);
 		}

--- a/projects/plugins/jetpack/changelog/add-social-admin-ui-feature-flag
+++ b/projects/plugins/jetpack/changelog/add-social-admin-ui-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Added feature flag for social admin ui

--- a/projects/plugins/social/changelog/add-social-admin-ui-feature-flag
+++ b/projects/plugins/social/changelog/add-social-admin-ui-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added feature flag for new social admin ui

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -348,6 +348,7 @@ class Jetpack_Social {
 					'isSocialImageGeneratorAvailable' => $settings['socialImageGeneratorSettings']['available'],
 					'isSocialImageGeneratorEnabled'   => $settings['socialImageGeneratorSettings']['enabled'],
 					'autoConversionSettings'          => $settings['autoConversionSettings'],
+					'useAdminUiV1'                    => $settings['useAdminUiV1'],
 					'dismissedNotices'                => Dismissed_Notices::get_dismissed_notices(),
 					'supportedAdditionalConnections'  => $publicize->get_supported_additional_connections(),
 					'userConnectionUrl'               => esc_url_raw( admin_url( 'admin.php?page=my-jetpack#/connection' ) ),

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -6,7 +6,7 @@ import {
 	Col,
 } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
-import { SOCIAL_STORE_ID } from '@automattic/jetpack-publicize-components';
+import { store as socialStore } from '@automattic/jetpack-publicize-components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
 import React from 'react';
@@ -29,10 +29,11 @@ const Admin = () => {
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
 	const [ forceDisplayPricingPage, setForceDisplayPricingPage ] = useState( false );
 
-	const refreshJetpackSocialSettings = useDispatch( SOCIAL_STORE_ID ).refreshJetpackSocialSettings;
+	const refreshJetpackSocialSettings = useDispatch( socialStore ).refreshJetpackSocialSettings;
 
 	const onUpgradeToggle = useCallback( () => setForceDisplayPricingPage( true ), [] );
 	const onPricingPageDismiss = useCallback( () => setForceDisplayPricingPage( false ), [] );
+	const useAdminUiV1 = useSelect( select => select( socialStore ).useAdminUiV1(), [] );
 
 	const {
 		isModuleEnabled,
@@ -45,7 +46,7 @@ const Admin = () => {
 		shouldShowAdvancedPlanNudge,
 		isUpdatingJetpackSettings,
 	} = useSelect( select => {
-		const store = select( SOCIAL_STORE_ID );
+		const store = select( socialStore );
 		return {
 			isModuleEnabled: store.isModuleEnabled(),
 			showPricingPage: store.showPricingPage(),
@@ -109,9 +110,7 @@ const Admin = () => {
 					<AdminSection>
 						{ shouldShowAdvancedPlanNudge && <AdvancedUpsellNotice /> }
 						<InstagramNotice onUpgrade={ onUpgradeToggle } />
-						{ window.jetpackSocialInitialState.useAdminUiV1 ? (
-							<span>New connections UI goes here</span>
-						) : null }
+						{ useAdminUiV1 ? <span>New connections UI goes here</span> : null }
 						<SocialModuleToggle />
 						{ isModuleEnabled && <SocialNotesToggle disabled={ isUpdatingJetpackSettings } /> }
 						{ isModuleEnabled && isAutoConversionAvailable && (

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -109,6 +109,9 @@ const Admin = () => {
 					<AdminSection>
 						{ shouldShowAdvancedPlanNudge && <AdvancedUpsellNotice /> }
 						<InstagramNotice onUpgrade={ onUpgradeToggle } />
+						{ window.jetpackSocialInitialState.useAdminUiV1 ? (
+							<span>New connections UI goes here</span>
+						) : null }
 						<SocialModuleToggle />
 						{ isModuleEnabled && <SocialNotesToggle disabled={ isUpdatingJetpackSettings } /> }
 						{ isModuleEnabled && isAutoConversionAvailable && (


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a static method `use_admin_ui_v1` to `Publicize` class to use as feature flag
* Use the feature flag to control logic on the backend changes
* Pass the feature flag to the frontend
* Render the new UI conditionally depending upon the feature flag value

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Use these instructions with both Jetpack and Social separately and together

* Checkout the PR
* Goto Jetpack Social admin page
* Confirm that the new UI is not visible
* Goto Jetpack Settings > Sharing
* Confirm that the new UI is not visible
* Now either add an option named `jetpack_social_use_admin_ui_v1` or define a constant (e.g. in `wp-config.php`) named `JETPACK_SOCIAL_USE_ADMIN_UI_V1` with the value as `true`
* Confirm that you see the above UIs

<img width="723" alt="Screenshot 2024-04-30 at 6 34 34 PM" src="https://github.com/Automattic/jetpack/assets/18226415/55955852-d228-4119-a45f-316b32d624e6">
<img width="761" alt="Screenshot 2024-04-30 at 6 34 56 PM" src="https://github.com/Automattic/jetpack/assets/18226415/16b4bb13-1f16-46ae-928e-fbbea6e015f4">
