### PR TITLE
ci: Only do version-number-only phan stub updates monthly

### DIFF
--- a/.github/workflows/update-phan-stubs.yml
+++ b/.github/workflows/update-phan-stubs.yml
@@ -33,19 +33,24 @@ jobs:
         id: changes
         run: |
           if git diff --exit-code; then
-            echo "No changes"
+            echo "::notice::No changes"
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+          elif ! [[ "$(date +%e)" -le 7 && "$(date +%A)" == Thursday ]] && git diff --exit-code --ignore-matching-lines='^ \* Stubs automatically generated from' >/dev/null; then
+            echo "::notice::No changes (other than version bumps) and it's not the first Thursday"
             echo "needed=false" >> "$GITHUB_OUTPUT"
           elif git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin update/phan-custom-stubs >/dev/null; then
             TMP=$( git -c core.quotepath=off diff --name-only )
             mapfile -t FILES <<<"$TMP"
             if git diff --quiet --exit-code origin/update/phan-custom-stubs "${FILES[@]}"; then
-              echo "Branch already exists and is up to date with these changes"
+              echo "::notice::Branch already exists and is up to date with these changes"
               echo "needed=false" >> "$GITHUB_OUTPUT"
             else
+              echo "::notice::Branch needs updating"
               echo "has-branch=true" >> "$GITHUB_OUTPUT"
               echo "needed=true" >> "$GITHUB_OUTPUT"
             fi
           else
+            echo "::notice::Branch needs creating"
             echo "has-branch=false" >> "$GITHUB_OUTPUT"
             echo "needed=true" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We only really need to update when there are actual changes to the stubs. So let's only do version-number-only bumps on the first Thursday of the month.

Any real change in any of the stubs will also update the version numbers in any other stub files that need it, the Thursday thing is just so they don't get excessively out of date if none of the stubs ever get updated.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You'd have to apply this on a fork, then revert one of the recent updates like #37126 there, then run this. Then repeat it on a first Thursday.
