### PR TITLE
Site Restore: Add `is_deleted` attribute to sites api response to flag deleted sites

### DIFF
--- a/projects/plugins/jetpack/changelog/add-site-is-deleted-field
+++ b/projects/plugins/jetpack/changelog/add-site-is-deleted-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+WordPress.com REST API: exposed is_deleted attribute with sites API response

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -83,6 +83,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'was_migration_trial'         => '(bool) If the site ever used a migration trial.',
 		'was_hosting_trial'           => '(bool) If the site ever used a hosting trial.',
 		'wpcom_site_setup'            => '(string) The WP.com site setup identifier.',
+		'is_deleted'                  => '(bool) If the site flagged as deleted.',
 	);
 
 	/**
@@ -116,6 +117,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_core_site_editor_enabled',
 		'is_wpcom_atomic',
 		'is_wpcom_staging_site',
+		'is_deleted',
 	);
 
 	/**
@@ -614,6 +616,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'was_upgraded_from_trial':
 				$response[ $key ] = $this->site->was_upgraded_from_trial();
+				break;
+			case 'is_deleted':
+				$response[ $key ] = $this->site->is_deleted();
 				break;
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -77,6 +77,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'was_upgraded_from_trial'     => '(bool) If the site ever upgraded to a paid plan from a trial.',
 		'was_migration_trial'         => '(bool) If the site ever used a migration trial.',
 		'was_hosting_trial'           => '(bool) If the site ever used a hosting trial.',
+		'is_deleted'                  => '(bool) If the site flagged as deleted.',
 	);
 
 	/**

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -410,6 +410,13 @@ abstract class SAL_Site {
 	abstract public function get_user_interactions();
 
 	/**
+	 * Flag a site as deleted. Not used in Jetpack.
+	 *
+	 * @see class.json-api-site-jetpack.php for implementation.
+	 */
+	abstract public function is_deleted();
+
+	/**
 	 * Return the user interactions with a site. Not used in Jetpack.
 	 *
 	 * @param string $role The capability to check.

--- a/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
@@ -645,6 +645,17 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	/**
+	 * Get site deleted status. Not used in Jetpack.
+	 *
+	 * @see /wpcom/public.api/rest/sal/trait.json-api-site-wpcom.php.
+	 *
+	 * @return bool
+	 */
+	public function is_deleted() {
+		return false;
+	}
+
+	/**
 	 * Detect whether a site is WordPress.com Staging Site. Not used in Jetpack.
 	 *
 	 * @see /wpcom/public.api/rest/sal/trait.json-api-site-wpcom.php.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Relates to https://github.com/Automattic/wp-calypso/issues/89825

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* add `is_deleted` attribute to site api response

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your sandbox
* Apply D147075-code
* Go to `/settings/delete-site/` and delete a site
* Use developer console to fetch the deleted site `WP.COM API GET v1.2/me/sites?site_visibility=deleted`
* Verify `is_deleted` field is present and is `true`
![image](https://github.com/Automattic/jetpack/assets/47489215/cf2848ec-618a-443a-860d-a00f82877f09)
