### PR TITLE
Subscriptions: Disable Paid Newsletter settings section when user is not connected to wp.com

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/paid-newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/paid-newsletter.jsx
@@ -6,7 +6,9 @@ import SettingsGroup from 'components/settings-group';
 import analytics from 'lib/analytics';
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
+import { isUnavailableInOfflineMode, isOfflineMode } from 'state/connection';
 import { getJetpackCloudUrl } from 'state/initial-state';
+import { getModule } from 'state/modules';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
 /**
@@ -16,17 +18,26 @@ import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
  * @returns {React.Component} Subscription settings component.
  */
 function PaidNewsletter( props ) {
-	const { isSubscriptionsActive, setupPaymentPlansUrl } = props;
+	const {
+		isSubscriptionsActive,
+		setupPaymentPlansUrl,
+		subscriptionsModule,
+		unavailableInOfflineMode,
+	} = props;
 
-	const setupPaymentPlansButtonDisabled = ! isSubscriptionsActive;
+	const setupPaymentPlansButtonDisabled = ! isSubscriptionsActive || unavailableInOfflineMode;
 
 	const trackSetupPaymentPlansButtonClick = useCallback( () => {
 		analytics.tracks.recordJetpackClick( 'newsletter_settings_setup_payment_plans_button_click' );
 	}, [] );
 
 	return (
-		<SettingsCard header={ __( 'Paid Newsletter', 'jetpack' ) } hideButton>
-			<SettingsGroup>
+		<SettingsCard { ...props } header={ __( 'Paid Newsletter', 'jetpack' ) } hideButton>
+			<SettingsGroup
+				disableInOfflineMode
+				disableInSiteConnectionMode
+				module={ subscriptionsModule }
+			>
 				<p className="jp-settings-card__email-settings">
 					{ __(
 						'Earn money through your Newsletter. Reward your most loyal subscribers with exclusive content or add a paywall to monetize content.',
@@ -53,6 +64,9 @@ export default withModuleSettingsFormHelpers(
 		return {
 			isSubscriptionsActive: ownProps.getOptionValue( SUBSCRIPTIONS_MODULE_NAME ),
 			setupPaymentPlansUrl: getJetpackCloudUrl( state, 'monetize/payments' ),
+			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
+			isOffline: isOfflineMode( state ),
+			unavailableInOfflineMode: isUnavailableInOfflineMode( state, SUBSCRIPTIONS_MODULE_NAME ),
 		};
 	} )( PaidNewsletter )
 );

--- a/projects/plugins/jetpack/_inc/client/newsletter/paid-newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/paid-newsletter.jsx
@@ -6,7 +6,7 @@ import SettingsGroup from 'components/settings-group';
 import analytics from 'lib/analytics';
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
-import { isUnavailableInOfflineMode, isOfflineMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 import { getJetpackCloudUrl } from 'state/initial-state';
 import { getModule } from 'state/modules';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
@@ -18,14 +18,9 @@ import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
  * @returns {React.Component} Subscription settings component.
  */
 function PaidNewsletter( props ) {
-	const {
-		isSubscriptionsActive,
-		setupPaymentPlansUrl,
-		subscriptionsModule,
-		unavailableInOfflineMode,
-	} = props;
+	const { isSubscriptionsActive, setupPaymentPlansUrl, subscriptionsModule } = props;
 
-	const setupPaymentPlansButtonDisabled = ! isSubscriptionsActive || unavailableInOfflineMode;
+	const setupPaymentPlansButtonDisabled = ! isSubscriptionsActive;
 
 	const trackSetupPaymentPlansButtonClick = useCallback( () => {
 		analytics.tracks.recordJetpackClick( 'newsletter_settings_setup_payment_plans_button_click' );
@@ -66,7 +61,6 @@ export default withModuleSettingsFormHelpers(
 			setupPaymentPlansUrl: getJetpackCloudUrl( state, 'monetize/payments' ),
 			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
 			isOffline: isOfflineMode( state ),
-			unavailableInOfflineMode: isUnavailableInOfflineMode( state, SUBSCRIPTIONS_MODULE_NAME ),
 		};
 	} )( PaidNewsletter )
 );

--- a/projects/plugins/jetpack/changelog/update-paid-newsletter-disable-offline
+++ b/projects/plugins/jetpack/changelog/update-paid-newsletter-disable-offline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Disable Paid Newsletter settings section when user is not connected to wp.com


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

It disables the Paid Newsletter settings section when user is not connected to wp.com.

### Before

<img width="1053" alt="Screenshot 2024-05-01 at 08 52 22" src="https://github.com/Automattic/jetpack/assets/4068554/cc489e4e-2fd5-41d4-82db-6a2176cd9da5">

### After

<img width="1053" alt="Screenshot 2024-05-01 at 08 52 07" src="https://github.com/Automattic/jetpack/assets/4068554/bc7e5bbb-d20e-49d3-a360-534b122fb1c5">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have the Site connected to the wp.com but not the user
* Go to Newsletter settings making sure the Paid Newsletter section is disabled
* Connect the user
* Make sure the Paid Newsletter section is enabled

