### PR TITLE
Woo Analytics: ensure the package is only initialized once

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/update-woo-analytics-init-once
+++ b/projects/packages/woocommerce-analytics/changelog/update-woo-analytics-init-once
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Ensure the package can only be initialized once

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -29,7 +29,7 @@ class Woocommerce_Analytics {
 	 * @return void
 	 */
 	public static function init() {
-		if ( ! self::should_track_store() ) {
+		if ( ! self::should_track_store() || did_action( 'woocommerce_analytics_init' ) ) {
 			return;
 		}
 
@@ -47,6 +47,13 @@ class Woocommerce_Analytics {
 		) {
 			add_action( 'init', array( new Checkout_Flow(), 'init_hooks' ) );
 		}
+
+		/**
+		 * Fires after the WooCommerce Analytics package is initialized
+		 *
+		 * @since $$next-version$$
+		 */
+		do_action( 'woocommerce_analytics_init' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

That should avoid any issues when multiple plugins run `Woocommerce_Analytics::init();`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* On a site running the WooCommerce plugin and Jetpack, while connected to WordPress.com,
* Go to Jetpack > Settings > Modules and enable the WooCommerce Analytics feature
* Then when on the frontend and looking at WooCommerce specific pages like the Cart page, you should see the `https://stats.wp.com/s-%d.js` script being enqueued.
