### PR TITLE
Subscribers: link to Jetpack Cloud to manage subscribers instead of WP.com

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
@@ -11,7 +11,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { isCurrentUserLinked, isUnavailableInOfflineMode, isOfflineMode } from 'state/connection';
 import { getModule } from 'state/modules';
-import { siteUsesWpAdminInterface } from 'state/site';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
 const trackViewSubsClick = () => {
@@ -32,7 +31,6 @@ function Newsletter( props ) {
 		isSavingAnyOption,
 		isLinked,
 		isOffline,
-		isWpAdminInterface,
 		isSubscriptionsActive,
 		unavailableInOfflineMode,
 		subscriptions,
@@ -43,16 +41,12 @@ function Newsletter( props ) {
 			return '';
 		}
 
-		const source = isWpAdminInterface
-			? 'jetpack-settings-jetpack-manage-subscribers'
-			: 'calypso-subscribers';
-
 		return (
 			<Card
 				compact
 				className="jp-settings-card__configure-link"
 				onClick={ trackViewSubsClick }
-				href={ getRedirectUrl( source, {
+				href={ getRedirectUrl( 'jetpack-settings-jetpack-manage-subscribers', {
 					site: blogID ?? siteRawUrl,
 				} ) }
 				target="_blank"
@@ -114,7 +108,6 @@ export default withModuleSettingsFormHelpers(
 		return {
 			isLinked: isCurrentUserLinked( state ),
 			isOffline: isOfflineMode( state ),
-			isWpAdminInterface: siteUsesWpAdminInterface( state ),
 			isSubscriptionsActive: ownProps.getOptionValue( SUBSCRIPTIONS_MODULE_NAME ),
 			unavailableInOfflineMode: isUnavailableInOfflineMode( state, SUBSCRIPTIONS_MODULE_NAME ),
 			subscriptions: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),

--- a/projects/plugins/jetpack/changelog/update-subscriptions-link-to-cloud
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-link-to-cloud
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscriptions: manage subscribers in Jetpack cloud instead of WP.com.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1026,13 +1026,8 @@ class Jetpack_Subscriptions {
 
 		$blog_id = Connection_Manager::get_site_id( true );
 
-		$source = 'jetpack-menu-calypso-subscribers';
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
-			$source = 'jetpack-menu-jetpack-manage-subscribers';
-		}
-
 		$link = Redirect::get_url(
-			$source,
+			'jetpack-menu-jetpack-manage-subscribers',
 			array( 'site' => $blog_id ? $blog_id : $status->get_site_suffix() )
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Now that Jetpack Cloud is open to everyone, let's also link Jetpack sites to Jetpack Cloud, not just WP.com Atomic sites.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove link to WP.com subscriber management also for Jetpack sites


**Before**

<img width="1702" alt="Screenshot 2024-05-01 at 14 54 19" src="https://github.com/Automattic/jetpack/assets/87168/6e47cbc3-6804-4775-a3ed-a6faa253c155">

**After**

<img width="1696" alt="Screenshot 2024-05-01 at 14 53 07" src="https://github.com/Automattic/jetpack/assets/87168/0c9a5145-ed81-4a3d-9dff-b178160d2485">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable subscriptions for the Jetpack site
* Check the link in the sidebar, and the link in the settings:

    <img width="1705" alt="Screenshot 2024-05-01 at 14 57 16" src="https://github.com/Automattic/jetpack/assets/87168/b0111d68-e499-497e-8cce-3051322a776c">

* Test also WP.com sites
