### PR TITLE
A4A: remove 0.1.0 alpha refs

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-a4a-remove_0.1.0_alpha_refs
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-a4a-remove_0.1.0_alpha_refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove errant alpha refs.
+
+

--- a/projects/plugins/automattic-for-agencies-client/readme.txt
+++ b/projects/plugins/automattic-for-agencies-client/readme.txt
@@ -4,7 +4,7 @@ Tags: agency, dashboard, management, sites, monitoring
 Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
-Stable tag: 0.1.0-alpha
+Stable tag: 0.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,7 +39,7 @@ If you would like to disconnect a site or check if the site is connected correct
 1. Manage your connection to the agency dashboard from the Settings screen in your WordPress dashboard.
 
 == Changelog ==
-### 0.1.0-alpha - 2024-04-30
+### 0.1.0 - 2024-04-30
 #### Added
 - Added connected state content and site disconnection flow.
 - Added connection card

--- a/projects/plugins/automattic-for-agencies-client/src/class-automattic-for-agencies-client.php
+++ b/projects/plugins/automattic-for-agencies-client/src/class-automattic-for-agencies-client.php
@@ -43,7 +43,7 @@ class Automattic_For_Agencies_Client {
 	/**
 	 * Configure what Jetpack packages should get automatically initialized.
 	 *
-	 * @since 0.1.0-alpha
+	 * @since 0.1.0
 	 *
 	 * @return void
 	 */
@@ -75,7 +75,7 @@ class Automattic_For_Agencies_Client {
 	/**
 	 * Add submenu.
 	 *
-	 * @since 0.1.0-alpha
+	 * @since 0.1.0
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

A4A: remove 0.1.0 alpha refs

## Proposed changes:

Fixes alpha refs as done in the `automattic-for-agencies-client/branch-0.1.0` branch: d4f53cd7b2d82424a82751bdf6bde2a251942a20

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

