### PR TITLE
tools: Handle wporg error response in stable-tag.sh

### DIFF
--- a/tools/stable-tag.sh
+++ b/tools/stable-tag.sh
@@ -84,6 +84,9 @@ JSON=$(curl -s "https://api.wordpress.org/plugins/info/1.0/$WPSLUG.json")
 if ! jq -e '.' <<<"$JSON" &>/dev/null; then
 	die "Failed to retrieve JSON data from https://api.wordpress.org/plugins/info/1.0/$WPSLUG.json"
 fi
+if jq -e '.error' <<<"$JSON" &>/dev/null; then
+	die "WordPress.org plugin API returned an error when querying $WPSLUG: $( jq -r '.error' <<<"$JSON" )"
+fi
 
 # Current stable version
 CURRENT_STABLE_VERSION=$(jq -r .version <<<"$JSON")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If the WordPress.org plugin API returns an error, we should report that and exit instead of trying to continue processing only to fail with something cryptic later on.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1714511067967399/1714502372.796139-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* For the moment you can try running `tools/stable-tag.sh plugins/automattic-for-agencies-client`, as since the plugin is still in review the API returns a "Plugin not found" error.