### PR TITLE
phan: Improve phpunit stub munging

### DIFF
--- a/.phan/stubs/phpunit-stubs.php
+++ b/.phan/stubs/phpunit-stubs.php
@@ -825,7 +825,7 @@ abstract class Assert
      *
      * @phan-param ExpectedType $expected
      *
-     * @phan-assert =ExpectedType $actual
+     * @phan-assert ExpectedType $actual
      */
     public static function assertSame($expected, $actual, string $message = ''): void
     {
@@ -852,7 +852,7 @@ abstract class Assert
      *
      * @phan-param class-string<ExpectedType> $expected
      *
-     * @phan-assert =ExpectedType $actual
+     * @phan-assert ExpectedType $actual
      */
     public static function assertInstanceOf(string $expected, $actual, string $message = ''): void
     {
@@ -2773,7 +2773,7 @@ function assertObjectNotHasProperty(string $attributeName, object $object, strin
  *
  * @phan-param ExpectedType $expected
  *
- * @phan-assert =ExpectedType $actual
+ * @phan-assert ExpectedType $actual
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *
@@ -2808,7 +2808,7 @@ function assertNotSame($expected, $actual, string $message = '', ...$func_get_ar
  *
  * @phan-param class-string<ExpectedType> $expected
  *
- * @phan-assert =ExpectedType $actual
+ * @phan-assert ExpectedType $actual
  *
  * @no-named-arguments Parameter names are not covered by the backward compatibility promise for PHPUnit
  *

--- a/projects/packages/changelogger/changelog/fix-phan-phpunit-stubs
+++ b/projects/packages/changelogger/changelog/fix-phan-phpunit-stubs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Suppress a Phan issue in a test now that Phan infers classes from assertInstanceOf(). No change to functionality.
+
+

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.2.2';
+	const VERSION = '4.2.3-alpha';
 
 	/**
 	 * Constructor.

--- a/projects/packages/changelogger/tests/php/tests/src/ConfigTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ConfigTest.php
@@ -356,6 +356,7 @@ class ConfigTest extends TestCase {
 				'filename' => 'dummy.php',
 				'option'   => 'value',
 			),
+			// @phan-suppress-next-line PhanUndeclaredClassProperty -- Same.
 			$ret->c
 		);
 

--- a/tools/stubs/munge-phpunit-stubs.php
+++ b/tools/stubs/munge-phpunit-stubs.php
@@ -18,6 +18,9 @@ $stubs = strtr(
 		'@psalm-template'  => '@phan-template',
 		'@psalm-var'       => '@phan-var',
 		'@psalm-immutable' => '@phan-side-effect-free', // https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-immutable vs https://github.com/phan/phan/wiki/Annotating-Your-Source-Code#phan-side-effect-free-on-classes
+
+		// Psalm allows asserting "=Foo" versus "Foo", with the difference being that with "=Foo" does not imply "!Foo" when the call throws. Phan doesn't make that assumption in any case.
+		'@psalm-assert ='  => '@phan-assert ',
 	)
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In Psalm, `@psalm-assert Foo $arg` asserts both that if the function doesn't throw then the argument is an instance of Foo _and_ that if the function does throw then the argument is not an instance of Foo. If you want only the first without the second, you do `@psalm-assert =Foo $arg` instead.

Phan, on the other hand, never makes the inverse assumption. So effectively `@phan-assert Foo $arg` is equivalent to `@psalm-assert =Foo $arg`, and trying to `@phan-assert =Foo` is a syntax error.

Thus, when we're munging the phpunit annotations, the `=` needs to be stripped when converting `@psalm-assert` to `@phan-assert`. This will allow Phan to infer correct types for `assertInstanceOf()` and `assertSame()`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?