### PR TITLE
AI Assistant: Link toolbar actions to requests on inline extensions

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-input-state
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-input-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Link toolbar actions to requests on inline extensions

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/ai-assistant-toolbar-dropdown/dropdown-content.tsx
@@ -18,8 +18,9 @@ import {
 	PROMPT_TYPE_CHANGE_LANGUAGE,
 	PROMPT_TYPE_USER_PROMPT,
 } from '../../lib/prompt';
-import { I18nMenuDropdown } from '../i18n-dropdown-control';
-import { ToneDropdownMenu } from '../tone-dropdown-control';
+import { capitalize } from '../../lib/utils/capitalize';
+import { I18nMenuDropdown, TRANSLATE_LABEL } from '../i18n-dropdown-control';
+import { TONE_LABEL, ToneDropdownMenu } from '../tone-dropdown-control';
 import './style.scss';
 /**
  * Types and constants
@@ -112,7 +113,8 @@ export type AiAssistantDropdownOnChangeOptionsArgProps = {
 
 export type OnRequestSuggestion = (
 	promptType: PromptTypeProp,
-	options?: AiAssistantDropdownOnChangeOptionsArgProps
+	options?: AiAssistantDropdownOnChangeOptionsArgProps,
+	humanText?: string
 ) => void;
 
 type AiAssistantToolbarDropdownContentProps = {
@@ -162,7 +164,11 @@ export default function AiAssistantToolbarDropdownContent( {
 						iconPosition="left"
 						key={ `key-${ quickAction.key }` }
 						onClick={ () => {
-							onRequestSuggestion( quickAction.aiSuggestion, { ...( quickAction.options ?? {} ) } );
+							onRequestSuggestion(
+								quickAction.aiSuggestion,
+								{ ...( quickAction.options ?? {} ) },
+								quickAction.name
+							);
 						} }
 						disabled={ disabled }
 					>
@@ -172,14 +178,22 @@ export default function AiAssistantToolbarDropdownContent( {
 
 				<ToneDropdownMenu
 					onChange={ tone => {
-						onRequestSuggestion( PROMPT_TYPE_CHANGE_TONE, { tone } );
+						onRequestSuggestion(
+							PROMPT_TYPE_CHANGE_TONE,
+							{ tone },
+							`${ TONE_LABEL }: ${ capitalize( tone ) }`
+						);
 					} }
 					disabled={ disabled }
 				/>
 
 				<I18nMenuDropdown
-					onChange={ language => {
-						onRequestSuggestion( PROMPT_TYPE_CHANGE_LANGUAGE, { language } );
+					onChange={ ( language, name ) => {
+						onRequestSuggestion(
+							PROMPT_TYPE_CHANGE_LANGUAGE,
+							{ language },
+							`${ TRANSLATE_LABEL }: ${ name }`
+						);
 					} }
 					disabled={ disabled }
 				/>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/i18n-dropdown-control/index.tsx
@@ -13,6 +13,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronRight } from '@wordpress/icons';
 import { globe } from '@wordpress/icons';
+import React from 'react';
 /*
  * Internal dependencies
  */
@@ -38,7 +39,7 @@ export type LanguageProp = ( typeof LANGUAGE_LIST )[ number ];
 
 type LanguageDropdownControlProps = {
 	value?: LanguageProp;
-	onChange: ( value: string ) => void;
+	onChange: ( value: string, name?: string ) => void;
 	label?: string;
 	disabled?: boolean;
 };
@@ -46,7 +47,7 @@ type LanguageDropdownControlProps = {
 const defaultLanguageLocale =
 	window?.Jetpack_Editor_Initial_State?.siteLocale || navigator?.language;
 
-const defaultLabel = __( 'Translate', 'jetpack' );
+export const TRANSLATE_LABEL = __( 'Translate', 'jetpack' );
 
 export const defaultLanguage = ( defaultLanguageLocale?.split( '-' )[ 0 ] || 'en' ) as LanguageProp;
 
@@ -89,16 +90,6 @@ export const LANGUAGE_MAP = {
 	ko: {
 		label: __( 'Korean', 'jetpack' ),
 	},
-
-	id: {
-		label: __( 'Indonesian', 'jetpack' ),
-	},
-	tl: {
-		label: __( 'Filipino', 'jetpack' ),
-	},
-	vi: {
-		label: __( 'Vietnamese', 'jetpack' ),
-	},
 };
 
 export const I18nMenuGroup = ( {
@@ -117,7 +108,12 @@ export const I18nMenuGroup = ( {
 				return (
 					<MenuItem
 						key={ `key-${ language }` }
-						onClick={ () => onChange( language + ' (' + LANGUAGE_MAP[ language ].label + ')' ) }
+						onClick={ () =>
+							onChange(
+								language + ' (' + LANGUAGE_MAP[ language ].label + ')',
+								LANGUAGE_MAP[ language ].label
+							)
+						}
 						isSelected={ value === language }
 					>
 						{ LANGUAGE_MAP[ language ].label }
@@ -130,7 +126,7 @@ export const I18nMenuGroup = ( {
 
 export default function I18nDropdownControl( {
 	value = defaultLanguage,
-	label = defaultLabel,
+	label = TRANSLATE_LABEL,
 	onChange,
 	disabled = false,
 }: LanguageDropdownControlProps ) {
@@ -164,7 +160,7 @@ export default function I18nDropdownControl( {
 
 export function I18nMenuDropdown( {
 	value = defaultLanguage,
-	label = defaultLabel,
+	label = TRANSLATE_LABEL,
 	onChange,
 	disabled = false,
 }: Pick< LanguageDropdownControlProps, 'label' | 'onChange' | 'value' | 'disabled' > & {
@@ -187,8 +183,8 @@ export function I18nMenuDropdown( {
 		>
 			{ ( { onClose } ) => (
 				<I18nMenuGroup
-					onChange={ newLanguage => {
-						onChange( newLanguage );
+					onChange={ ( ...args ) => {
+						onChange( ...args );
 						onClose();
 					} }
 					value={ value }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/tone-dropdown-control/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronRight } from '@wordpress/icons';
+import React from 'react';
 /**
  * Internal dependencies
  */
@@ -23,26 +24,18 @@ const PROMPT_TONES_LIST = [
 	'formal',
 	'informal',
 	'optimistic',
-	// 'pessimistic',
 	'humorous',
 	'serious',
 	'skeptical',
 	'empathetic',
-	// 'enthusiastic',
-	// 'neutral',
 	'confident',
-	// 'curious',
-	// 'respectful',
 	'passionate',
-	// 'cautious',
 	'provocative',
-	// 'inspirational',
-	// 'satirical',
-	// 'dramatic',
-	// 'mysterious',
 ] as const;
 
 export const DEFAULT_PROMPT_TONE = 'formal';
+
+export const TONE_LABEL = __( 'Change tone', 'jetpack' );
 
 export const PROMPT_TONES_MAP = {
 	formal: {
@@ -57,10 +50,6 @@ export const PROMPT_TONES_MAP = {
 		label: __( 'Optimistic', 'jetpack' ),
 		emoji: '😃',
 	},
-	// pessimistic: {
-	// 	label: __( 'Pessimistic', 'jetpack' ),
-	// 	emoji: '☹️',
-	// },
 	humorous: {
 		label: __( 'Humorous', 'jetpack' ),
 		emoji: '😂',
@@ -77,54 +66,18 @@ export const PROMPT_TONES_MAP = {
 		label: __( 'Empathetic', 'jetpack' ),
 		emoji: '💗',
 	},
-	// enthusiastic: {
-	// 	label: __( 'Enthusiastic', 'jetpack' ),
-	// 	emoji: '🤩',
-	// },
-	// neutral: {
-	// 	label: __( 'Neutral', 'jetpack' ),
-	// 	emoji: '😶',
-	// },
 	confident: {
 		label: __( 'Confident', 'jetpack' ),
 		emoji: '😎',
 	},
-	// curious: {
-	// 	label: __( 'Curious', 'jetpack' ),
-	// 	emoji: '🧐',
-	// },
-	// respectful: {
-	// 	label: __( 'Respectful', 'jetpack' ),
-	// 	emoji: '🙏',
-	// },
 	passionate: {
 		label: __( 'Passionate', 'jetpack' ),
 		emoji: '❤️',
 	},
-	// cautious: {
-	// 	label: __( 'Cautious', 'jetpack' ),
-	// 	emoji: '🚧',
-	// },
 	provocative: {
 		label: __( 'Provocative', 'jetpack' ),
 		emoji: '🔥',
 	},
-	// inspirational: {
-	// 	label: __( 'Inspirational', 'jetpack' ),
-	// 	emoji: '✨',
-	// },
-	// satirical: {
-	// 	label: __( 'Satirical', 'jetpack' ),
-	// 	emoji: '🃏',
-	// },
-	// dramatic: {
-	// 	label: __( 'Dramatic', 'jetpack' ),
-	// 	emoji: '🎭',
-	// },
-	// mysterious: {
-	// 	label: __( 'Mysterious', 'jetpack' ),
-	// 	emoji: '🔮',
-	// },
 };
 
 export type ToneProp = ( typeof PROMPT_TONES_LIST )[ number ];
@@ -153,7 +106,7 @@ const ToneMenuGroup = ( { value, onChange }: ToneToolbarDropdownMenuProps ) => (
 );
 
 export function ToneDropdownMenu( {
-	label = __( 'Change tone', 'jetpack' ),
+	label = TONE_LABEL,
 	value = DEFAULT_PROMPT_TONE,
 	onChange,
 	disabled = false,
@@ -194,7 +147,6 @@ export default function ToneToolbarDropdownMenu( {
 	onChange,
 	disabled = false,
 }: ToneToolbarDropdownMenuProps ) {
-	const label = __( 'Change tone', 'jetpack' );
 	const { tracks } = useAnalytics();
 
 	const toggleHandler = isOpen => {
@@ -204,7 +156,7 @@ export default function ToneToolbarDropdownMenu( {
 	};
 
 	return disabled ? (
-		<Tooltip text={ label }>
+		<Tooltip text={ TONE_LABEL }>
 			<Button disabled>
 				<Icon icon={ speakToneIcon } />
 			</Button>
@@ -212,7 +164,7 @@ export default function ToneToolbarDropdownMenu( {
 	) : (
 		<ToolbarDropdownMenu
 			icon={ speakToneIcon }
-			label={ label }
+			label={ TONE_LABEL }
 			popoverProps={ {
 				variant: 'toolbar',
 			} }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/block-handler.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/block-handler.tsx
@@ -33,5 +33,6 @@ export function blockHandler(
 
 	return {
 		onSuggestion: handler.onSuggestion.bind( handler ),
+		getContent: handler.getContent.bind( handler ),
 	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { ExtensionAIControl } from '@automattic/jetpack-ai-client';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import React from 'react';
 /*
  * Types
@@ -52,8 +53,16 @@ export default function AiAssistantInput( {
 		throw new Error( 'Function not implemented.' );
 	}
 
+	// Clear the input value on reset and when the request is done.
+	useEffect( () => {
+		if ( [ 'init', 'done' ].includes( requestingState ) ) {
+			setValue( '' );
+		}
+	}, [ requestingState ] );
+
 	return (
 		<ExtensionAIControl
+			placeholder={ __( 'Ask Jetpack AI to edit…', 'jetpack' ) }
 			disabled={ disabled }
 			value={ value }
 			state={ requestingState }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -14,6 +14,7 @@ import type { ReactElement } from 'react';
 export default function AiAssistantInput( {
 	requestingState,
 	wrapperRef,
+	action,
 	request,
 	stopSuggestion,
 	close,
@@ -25,6 +26,7 @@ export default function AiAssistantInput( {
 	requestingError?: RequestingErrorProps;
 	suggestion?: string;
 	wrapperRef?: React.MutableRefObject< HTMLDivElement | null >;
+	action?: string;
 	request: ( question: string ) => void;
 	stopSuggestion?: () => void;
 	close?: () => void;
@@ -59,6 +61,11 @@ export default function AiAssistantInput( {
 			setValue( '' );
 		}
 	}, [ requestingState ] );
+
+	// Set the value to the quick action text once it changes.
+	useEffect( () => {
+		setValue( action || '' );
+	}, [ action ] );
 
 	return (
 		<ExtensionAIControl

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-toolbar-dropdown/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-toolbar-dropdown/index.tsx
@@ -35,8 +35,8 @@ function AiAssistantExtensionToolbarDropdownContent( {
 	onAskAiAssistant,
 	onRequestSuggestion,
 }: AiAssistantExtensionToolbarDropdownContentProps ) {
-	const handleRequestSuggestion: OnRequestSuggestion = ( promptType, options ) => {
-		onRequestSuggestion?.( promptType, options );
+	const handleRequestSuggestion: OnRequestSuggestion = ( ...args ) => {
+		onRequestSuggestion?.( ...args );
 		onClose?.();
 	};
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/heading/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/heading/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { renderMarkdownFromHTML, renderHTMLFromMarkdown } from '@automattic/jetpack-ai-client';
-import { rawHandler } from '@wordpress/blocks';
+import { rawHandler, getBlockContent } from '@wordpress/blocks';
 import { select, dispatch } from '@wordpress/data';
 /**
  * Types
@@ -10,7 +10,7 @@ import { select, dispatch } from '@wordpress/data';
 import type { BlockEditorSelect, IBlockHandler } from '../types';
 import type { Block } from '@automattic/jetpack-ai-client';
 
-export function getContent( html ) {
+export function getMarkdown( html ) {
 	return renderMarkdownFromHTML( { content: html } );
 }
 
@@ -24,6 +24,10 @@ export class HeadingHandler implements IBlockHandler {
 	constructor( clientId: string ) {
 		const { getBlock } = select( 'core/block-editor' ) as BlockEditorSelect;
 		this.block = getBlock( clientId );
+	}
+
+	public getContent() {
+		return getMarkdown( getBlockContent( this.block ) );
 	}
 
 	public onSuggestion( suggestion: string ): void {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/types.ts
@@ -7,6 +7,7 @@ export type OnSuggestion = ( suggestion: string ) => void;
 
 export interface IBlockHandler {
 	onSuggestion: OnSuggestion;
+	getContent: () => string;
 }
 
 export type BlockEditorSelect = {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -69,7 +69,14 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		// Data and functions with block-specific implementations.
 		const { onSuggestion } = blockHandler( blockName, clientId );
 
-		const { request, stopSuggestion, requestingState, error, suggestion } = useAiSuggestions( {
+		const {
+			request,
+			stopSuggestion,
+			requestingState,
+			error,
+			suggestion,
+			reset: resetSuggestions,
+		} = useAiSuggestions( {
 			onSuggestion,
 			onDone,
 			onError,
@@ -78,14 +85,6 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				feature: 'ai-assistant',
 			},
 		} );
-
-		// Close the AI Control if the block is deselected.
-		useEffect( () => {
-			if ( ! isSelected ) {
-				setShowAiControl( false );
-				// TODO: reset all extension data.
-			}
-		}, [ isSelected ] );
 
 		const { id } = useBlockProps();
 
@@ -141,9 +140,17 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			debug( 'onRequestSuggestion', promptType, options );
 		};
 
-		const onClose = () => {
+		const onClose = useCallback( () => {
 			setShowAiControl( false );
-		};
+			resetSuggestions();
+		}, [ resetSuggestions ] );
+
+		// Close the AI Control if the block is deselected.
+		useEffect( () => {
+			if ( ! isSelected ) {
+				onClose();
+			}
+		}, [ isSelected, onClose ] );
 
 		const onUndo = () => {
 			// TODO: handle the undo action.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -68,7 +68,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		);
 
 		// Data and functions with block-specific implementations.
-		const { onSuggestion } = blockHandler( blockName, clientId );
+		const { onSuggestion, getContent } = blockHandler( blockName, clientId );
 
 		const {
 			request,
@@ -141,8 +141,12 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			if ( humanText ) {
 				setAction( humanText );
 			}
+
+			// Get the block's content
+			const content = getContent();
+
 			// TODO: handle the promptType and options to request the suggestion.
-			debug( 'onRequestSuggestion', promptType, options, humanText );
+			debug( 'onRequestSuggestion', promptType, options, content );
 		};
 
 		const onClose = useCallback( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -36,6 +36,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const controlRef: React.MutableRefObject< HTMLDivElement | null > = useRef( null );
 		const controlObserver = useRef< ResizeObserver | null >( null );
 		const blockStyle = useRef< string >( '' );
+		const [ action, setAction ] = useState< string >( '' );
 
 		// Only extend the allowed block types.
 		const possibleToExtendBlock = isPossibleToExtendBlock( {
@@ -134,15 +135,20 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			setShowAiControl( true );
 		};
 
-		const onRequestSuggestion: OnRequestSuggestion = ( promptType, options ) => {
+		const onRequestSuggestion: OnRequestSuggestion = ( promptType, options, humanText ) => {
 			setShowAiControl( true );
+
+			if ( humanText ) {
+				setAction( humanText );
+			}
 			// TODO: handle the promptType and options to request the suggestion.
-			debug( 'onRequestSuggestion', promptType, options );
+			debug( 'onRequestSuggestion', promptType, options, humanText );
 		};
 
 		const onClose = useCallback( () => {
 			setShowAiControl( false );
 			resetSuggestions();
+			setAction( '' );
 		}, [ resetSuggestions ] );
 
 		// Close the AI Control if the block is deselected.
@@ -169,6 +175,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 						requestingError={ error }
 						suggestion={ suggestion }
 						wrapperRef={ controlRef }
+						action={ action }
 						request={ request }
 						stopSuggestion={ stopSuggestion }
 						close={ onClose }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -36,7 +36,6 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const controlRef: React.MutableRefObject< HTMLDivElement | null > = useRef( null );
 		const controlObserver = useRef< ResizeObserver | null >( null );
 		const blockStyle = useRef< string >( '' );
-		const [ block, setBlock ] = useState< HTMLElement | null >( null );
 
 		// Only extend the allowed block types.
 		const possibleToExtendBlock = isPossibleToExtendBlock( {
@@ -91,11 +90,8 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const { id } = useBlockProps();
 
 		useEffect( () => {
-			// Keep the block reference.
-			setBlock( document.getElementById( id ) );
-		}, [ id ] );
+			const block = document.getElementById( id );
 
-		useEffect( () => {
 			if ( ! block ) {
 				return;
 			}
@@ -123,7 +119,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				controlObserver.current.disconnect();
 				controlObserver.current = null;
 			}
-		}, [ block, clientId, controlObserver, id, showAiControl ] );
+		}, [ clientId, controlObserver, id, showAiControl ] );
 
 		// Only extend the target block.
 		if ( ! possibleToExtendBlock ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/backend-prompt.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/prompt/backend-prompt.ts
@@ -50,7 +50,7 @@ export function buildInitialMessageForBackendPrompt( promptType: PromptTypeProp 
  * @param {string} relevantContent - The relevant content.
  * @returns {PromptItemProps} The initial message.
  */
-function buildRelevantContentMessageForBackendPrompt(
+export function buildRelevantContentMessageForBackendPrompt(
 	isContentGenerated?: boolean,
 	relevantContent?: string | null
 ): PromptItemProps | null {
@@ -172,7 +172,7 @@ function getSubject(
  * @param {BuildPromptProps} options - The prompt options.
  * @returns {object} The context.
  */
-function buildMessageContextForUserPrompt( {
+export function buildMessageContextForUserPrompt( {
 	options,
 	type,
 	userPrompt,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/capitalize.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/lib/utils/capitalize.ts
@@ -1,0 +1,7 @@
+export function capitalize( text: string ) {
+	if ( ! text || typeof text !== 'string' ) {
+		return '';
+	}
+
+	return text.charAt( 0 ).toUpperCase() + text.slice( 1 );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37101 
Part of #37015 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `getContent` function to the block handler to get its own content in Markdown
* Links the toolbar actions to actual requests with the block content as context

TODO on follow-ups:
Undo functionality.
The case of an empty Heading

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the feature (see previous PRs)
* Go to the block editor
* Add a Heading element with some content (the toolbar is not yet disabled when there is no content)
* Use the toolbar options to edit the content
* Check that the input displays the suggestion text during the request
* Use the input to ask for some modification
* Check that the request is aware of the content
