### PR TITLE
Autoloader: be more defensive to avoid deprecation notice

### DIFF
--- a/projects/packages/autoloader/changelog/fix-autoloader-deprecation-notice
+++ b/projects/packages/autoloader/changelog/fix-autoloader-deprecation-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid deprecation notices when plugin path is null

--- a/projects/packages/autoloader/src/AutoloadGenerator.php
+++ b/projects/packages/autoloader/src/AutoloadGenerator.php
@@ -21,7 +21,7 @@ use Composer\Util\PackageSorter;
  */
 class AutoloadGenerator {
 
-	const VERSION = '3.0.6';
+	const VERSION = '3.0.7-alpha';
 
 	/**
 	 * IO object.

--- a/projects/packages/autoloader/src/class-path-processor.php
+++ b/projects/packages/autoloader/src/class-path-processor.php
@@ -121,7 +121,7 @@ class Path_Processor {
 	 * @return bool True if the path is absolute, otherwise false.
 	 */
 	private function is_absolute_path( $path ) {
-		if ( 0 === strlen( $path ) || '.' === $path[0] ) {
+		if ( empty( $path ) || 0 === strlen( $path ) || '.' === $path[0] ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #37172

## Proposed changes:

This should avoid this type of errors:

```
strlen(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html3/mylf/wp-content/plugins/woocommerce/vendor/jetpack-autoloader/class-path-processor.php on line 132
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

I was not able to reproduce on my end but I do not have an environment running PHP 8.3 yet. If you can, I would recommend going through the steps described in #37172
