### PR TITLE
Paid content block: swap login flow to magic link flow intead of code login flow

### DIFF
--- a/projects/plugins/jetpack/changelog/update-paid-content-auth-url
+++ b/projects/plugins/jetpack/changelog/update-paid-content-auth-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Paid content block: swap out the login flow

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
+use Jetpack_Options;
 
 require_once dirname( __DIR__ ) . '/_inc/subscription-service/include.php';
 
@@ -32,6 +33,56 @@ function register_login_button_block() {
 add_action( 'init', __NAMESPACE__ . '\register_login_button_block' );
 
 /**
+ * Returns current URL.
+ *
+ * @return string
+ */
+function get_current_url() {
+	if ( ! isset( $_SERVER['HTTP_HOST'] ) || ! isset( $_SERVER['REQUEST_URI'] ) ) {
+		return '';
+	}
+
+	return ( is_ssl() ? 'https://' : 'http://' ) . wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+}
+
+/**
+ * Returns subscriber log in URL.
+ *
+ * @param string $redirect Path to redirect to on login.
+ *
+ * @return string
+ */
+function get_subscriber_login_url( $redirect ) {
+	$redirect = ! empty( $redirect ) ? $redirect : get_site_url();
+
+	if ( ( new Host() )->is_wpcom_simple() ) {
+		// On WPCOM we will redirect immediately
+		return wpcom_logmein_redirect_url( $redirect, false, null, 'link', get_current_blog_id() );
+	}
+
+	// On self-hosted we will save and hide the token
+	$redirect_url = get_site_url() . '/wp-json/jetpack/v4/subscribers/auth';
+	$redirect_url = add_query_arg( 'redirect_url', $redirect, $redirect_url );
+
+	return add_query_arg(
+		array(
+			'site_id'      => intval( Jetpack_Options::get_option( 'id' ) ),
+			'redirect_url' => rawurlencode( $redirect_url ),
+		),
+		'https://subscribe.wordpress.com/memberships/jwt/'
+	);
+}
+
+/**
+ * Determines whether the current visitor is a logged in user or a subscriber.
+ *
+ * @return bool
+ */
+function is_subscriber_logged_in() {
+	return is_user_logged_in() || Abstract_Token_Subscription_Service::has_token_from_cookie();
+}
+
+/**
  * Render callback.
  *
  * @param array  $attributes Array containing the block attributes.
@@ -44,19 +95,15 @@ function render_login_button_block( $attributes, $content ) {
 		return '';
 	}
 
-	$has_auth_cookie = isset( $_COOKIE[ Abstract_Token_Subscription_Service::JWT_AUTH_TOKEN_COOKIE_NAME ] );
-	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$has_token_parameter = isset( $_GET['token'] );
-
-	$is_user_logged_in_on_wpcom = ( new Host() )->is_wpcom_simple() && is_user_logged_in();
-	if ( $is_user_logged_in_on_wpcom || $has_auth_cookie || $has_token_parameter ) {
-		// The viewer is logged it, so they shouldn't see the login button.
+	// The viewer is logged it, so they shouldn't see the login button.
+	if ( is_subscriber_logged_in() ) {
 		return '';
 	}
 
 	Jetpack_Gutenberg::load_styles_as_required( LOGIN_BUTTON_NAME );
 
-	$url = subscription_service()->access_url();
+	$redirect_url = get_current_url();
+	$url          = get_subscriber_login_url( $redirect_url );
 
 	return preg_replace( '/(<a\b[^><]*)>/i', '$1 href="' . esc_url( $url ) . '">', $content );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds magic link flow to paid content block, replacing the emailed code -flow

Methods copied from [subscriber login block](https://github.com/Automattic/jetpack/blob/9bf534ca0f1524ada48b6fdd083135649ba17f4e/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

As already logged in subscriber, but not a paid customer, you won't see login button but will see subscribe button:

<img width="2157" alt="Screenshot 2024-05-02 at 15 29 55" src="https://github.com/Automattic/jetpack/assets/87168/364c9d2c-5e1a-4f58-b16e-c8c024e75fad">

As logged out at site, but logged in at WP.com, login button simply logs you in:

https://github.com/Automattic/jetpack/assets/87168/adb00326-c4ce-422b-b5c0-ea84413c4740

As logged out at the site and logged out at WP.com, you'll go through the WP.com magic link flow and land back at the site:

<img width="800" alt="Screenshot 2024-05-02 at 15 32 39" src="https://github.com/Automattic/jetpack/assets/87168/15ebd741-29fe-496f-a561-b2fc1654b04a">
<img width="800" alt="Screenshot 2024-05-02 at 15 32 47" src="https://github.com/Automattic/jetpack/assets/87168/ed877684-15ba-4000-a052-8b2c6fa4608d">
<img width="800" alt="Screenshot 2024-05-02 at 15 32 57" src="https://github.com/Automattic/jetpack/assets/87168/58687cf0-b43e-4fd2-9279-4d93a2829e4f">
<img width="800" alt="Screenshot 2024-05-02 at 15 33 14" src="https://github.com/Automattic/jetpack/assets/87168/d409edf3-3851-41fe-bf9f-8a442e05d27a">
