### PR TITLE
Scheduled Updates: raise scheduled updates limit

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-raise-scheduled-updates-limit
+++ b/projects/packages/scheduled-updates/changelog/add-raise-scheduled-updates-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Raised limit of schedules to 24.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -489,10 +489,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$plugins = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );
 
-		if ( empty( $request['schedule_id'] ) && count( $events ) >= 24 ) {
-			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create more than 24 schedules at this time.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
-		}
-
 		foreach ( $events as $key => $event ) {
 
 			// We'll update this schedule, so none of the checks apply.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -489,8 +489,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$plugins = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );
 
-		if ( empty( $request['schedule_id'] ) && count( $events ) >= 2 ) {
-			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create more than two schedules at this time.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
+		if ( empty( $request['schedule_id'] ) && count( $events ) >= 24 ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not create more than 24 schedules at this time.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
 		}
 
 		foreach ( $events as $key => $event ) {

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -312,44 +312,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
-	 * Can't have more than two schedules.
-	 *
-	 * @covers ::validate_schedule
-	 */
-	public function test_creating_more_than_twentyfour_schedules() {
-		// Create twentyfour schedules.
-		for ( $hour = 0; $hour < 24; $hour++ ) {
-			$formatted_hour = str_pad( (string) $hour, 2, '0', STR_PAD_LEFT );
-			$plugin_name    = "plugin-{$formatted_hour}/plugin-{$formatted_hour}.php";
-
-			wp_schedule_event(
-				strtotime( "next Monday {$formatted_hour}:00" ),
-				'daily',
-				Scheduled_Updates::PLUGIN_CRON_HOOK,
-				array( $plugin_name )
-			);
-		}
-
-		// Number 25.
-		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
-		$request->set_body_params(
-			array(
-				'plugins'  => array(
-					'gutenberg/gutenberg.php',
-					'custom-plugin/custom-plugin.php',
-				),
-				'schedule' => $this->get_schedule( 'next Wednesday 10:00', 'daily' ),
-			)
-		);
-
-		wp_set_current_user( $this->admin_id );
-		$result = rest_do_request( $request );
-
-		$this->assertSame( 403, $result->get_status() );
-		$this->assertSame( 'rest_forbidden', $result->get_data()['code'] );
-	}
-
-	/**
 	 * Removes plugins from the autoupdate list when creating a schedule.
 	 *
 	 * @covers ::create_item

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -316,12 +316,21 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	 *
 	 * @covers ::validate_schedule
 	 */
-	public function test_creating_more_than_two_schedules() {
-		// Create two schedules.
-		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'weekly', Scheduled_Updates::PLUGIN_CRON_HOOK, array( 'gutenberg/gutenberg.php' ) );
-		wp_schedule_event( strtotime( 'next Tuesday 9:00' ), 'daily', Scheduled_Updates::PLUGIN_CRON_HOOK, array( 'custom-plugin/custom-plugin.php' ) );
+	public function test_creating_more_than_twentyfour_schedules() {
+		// Create twentyfour schedules.
+		for ( $hour = 0; $hour < 24; $hour++ ) {
+			$formatted_hour = str_pad( $hour, 2, '0', STR_PAD_LEFT );
+			$plugin_name = "plugin-{$formatted_hour}/plugin-{$formatted_hour}.php";
 
-		// Number 3.
+			wp_schedule_event(
+				strtotime( "next Monday {$formatted_hour}:00" ),
+				'daily',
+				Scheduled_Updates::PLUGIN_CRON_HOOK,
+				array( $plugin_name )
+			);
+		}
+
+		// Number 25.
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
 		$request->set_body_params(
 			array(

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -320,7 +320,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		// Create twentyfour schedules.
 		for ( $hour = 0; $hour < 24; $hour++ ) {
 			$formatted_hour = str_pad( $hour, 2, '0', STR_PAD_LEFT );
-			$plugin_name = "plugin-{$formatted_hour}/plugin-{$formatted_hour}.php";
+			$plugin_name    = "plugin-{$formatted_hour}/plugin-{$formatted_hour}.php";
 
 			wp_schedule_event(
 				strtotime( "next Monday {$formatted_hour}:00" ),

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -319,7 +319,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	public function test_creating_more_than_twentyfour_schedules() {
 		// Create twentyfour schedules.
 		for ( $hour = 0; $hour < 24; $hour++ ) {
-			$formatted_hour = str_pad( $hour, 2, '0', STR_PAD_LEFT );
+			$formatted_hour = str_pad( (string) $hour, 2, '0', STR_PAD_LEFT );
 			$plugin_name    = "plugin-{$formatted_hour}/plugin-{$formatted_hour}.php";
 
 			wp_schedule_event(


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/89793

## Proposed changes:
Remove the limit check

<img width="1149" alt="CleanShot 2024-05-02 at 15 45 19@2x" src="https://github.com/Automattic/jetpack/assets/528287/e1d7d97f-aa9c-4c20-9299-acb5a2ea3dc7">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Test together with https://github.com/Automattic/wp-calypso/pull/90212
- Use Jetpack Beta tester to install this branch
- See if you can make more than 2 updates for a site.
