### PR TITLE
Add plugins.php link on simple classic sites

### DIFF
--- a/.phan/stubs/wpcom-stubs.php
+++ b/.phan/stubs/wpcom-stubs.php
@@ -1126,6 +1126,7 @@ namespace {
         public const MANAGE_PLUGINS = 'manage-plugins';
         public const SCHEDULED_UPDATES = 'scheduled-updates';
         public const SUBSCRIPTION_GIFTING = 'subscription-gifting';
+        public const INSTALL_PLUGINS = 'install-plugins';
     }
     /**
      * @param string $feature

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-plugins-link-simple
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-plugins-link-simple
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+JetpackMu: Add plugins link to menu for simple classic users

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -583,3 +583,26 @@ function wpcom_add_scheduled_updates_menu() {
 	);
 }
 add_action( 'admin_menu', 'wpcom_add_scheduled_updates_menu' );
+
+/**
+ * Add the Plugins menu item to the admin menu on simple sites.
+ */
+function wpcom_add_plugins_menu() {
+
+	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+		return;
+	}
+
+	if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
+		add_menu_page(
+			__( 'Plugins', 'jetpack-mu-wpcom' ),
+			__( 'Plugins', 'jetpack-mu-wpcom' ),
+			'manage_options', // Roughly means "is a site admin"
+			'plugins.php',
+			'',
+			'dashicons-admin-plugins',
+			65
+		);
+	}
+}
+add_action( 'admin_menu', 'wpcom_add_plugins_menu' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -594,11 +594,14 @@ function wpcom_add_plugins_menu() {
 	}
 
 	if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
+		$domain              = wp_parse_url( home_url(), PHP_URL_HOST );
+		$can_install_plugins = function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( WPCOM_Features::INSTALL_PLUGINS );
+
 		add_menu_page(
 			__( 'Plugins', 'jetpack-mu-wpcom' ),
 			__( 'Plugins', 'jetpack-mu-wpcom' ),
 			'manage_options', // Roughly means "is a site admin"
-			'plugins.php',
+			$can_install_plugins ? 'https://wordpress.com/plugins/' . $domain : 'plugins.php',
 			'',
 			'dashicons-admin-plugins',
 			65

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -602,7 +602,7 @@ function wpcom_add_plugins_menu() {
 			__( 'Plugins', 'jetpack-mu-wpcom' ),
 			'manage_options', // Roughly means "is a site admin"
 			$can_install_plugins ? 'https://wordpress.com/plugins/' . $domain : 'plugins.php',
-			'',
+			null,
 			'dashicons-admin-plugins',
 			65
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/5960

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Dotcom simple sites now include a plugins link in the wp-admin nav if opted into the wpcom_classic_early_release. The link goes either to plugins.php (which displays
a splash screen and links to marketplace/plan upgrade) or directly to the marketplace, depending on whether the user needs to upgrade their plan to make use of the marketplace.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Opt a < Creator plan site into the new nav experience. Using wpsh on your sandbox:
```
update_blog_option(YOUR_BLOG_ID, 'wpcom_classic_early_release', 1);
update_blog_option(YOUR_BLOG_ID, 'wpcom_admin_interface', 'wp-admin');
```
2. Apply patch to sandbox
3. Go to https://YOUR_SITE_HERE.wordpress.com/wp-admin as a non-superadmin user.
4. Notice a plugins link in the left hand menu, just below Appearance
5. Click the link
6. You should be taken to plugins.php which displays a splash screen.
7. Upgrade the plan (or use a different sandboxed simple creator+ site)
8. You should still see a Plugins link in the wp-admin menu
9. The link should go straight to the marketplace.


