### PR TITLE
My Jetpack: Add featured image video to Jetpack AI product page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -40,14 +40,16 @@ export default function () {
 	const [ showNotice, setShowNotice ] = useState( false );
 	const { isRegistered } = useConnection();
 
-	const videoTitle1 = __(
+	const videoTitleContentGeneration = __(
 		'Generate and edit content faster with Jetpack AI Assistant',
 		'jetpack-my-jetpack'
 	);
-	const videoTitle2 = __( 'Build forms using prompts', 'jetpack-my-jetpack' );
-	const videoTitle3 = __( 'Get feedback on posts', 'jetpack-my-jetpack' );
-	const videoTitle4 = __( 'Create featured images with one click', 'jetpack-my-jetpack' );
-	const featuredImageLink = getRedirectUrl( 'jetpack-ai-product-page-featured-image-link' );
+	const videoTitleFeaturedImages = __(
+		'Create featured images with one click',
+		'jetpack-my-jetpack'
+	);
+	const videoTitleForms = __( 'Build forms using prompts', 'jetpack-my-jetpack' );
+	const videoTitleContentFeedback = __( 'Get feedback on posts', 'jetpack-my-jetpack' );
 
 	debug( aiAssistantFeature );
 	const {
@@ -67,6 +69,7 @@ export default function () {
 	const showAllTimeUsage = hasPaidTier || hasUnlimited;
 	const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
 	const feedbackURL = getRedirectUrl( 'jetpack-ai-feedback' );
+	const videoLinkFeaturedImages = getRedirectUrl( 'jetpack-ai-product-page-featured-image-link' );
 
 	// isRegistered works as a flag to know if the page can link to a post creation or not
 	const ctaURL = isRegistered
@@ -266,13 +269,13 @@ export default function () {
 										src="https://videopress.com/embed/GdXmtVtW?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F02%2Fimage-37.png%3Fw%3D560"
 										allowFullScreen
 										allow="clipboard-write"
-										title={ videoTitle1 }
+										title={ videoTitleContentGeneration }
 									></iframe>
 									<script src="https://videopress.com/videopress-iframe.js"></script>
 								</div>
 								<div className={ styles[ 'product-interstitial__usage-videos-content' ] }>
 									<div className={ styles[ 'product-interstitial__usage-videos-heading' ] }>
-										{ videoTitle1 }
+										{ videoTitleContentGeneration }
 									</div>
 									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
 										{ __(
@@ -298,13 +301,13 @@ export default function () {
 										src="https://videopress.com/embed/HJCf8cXc?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F02%2Fone-click-featured-images.png%3Fw%3D560"
 										allowFullScreen
 										allow="clipboard-write"
-										title={ videoTitle4 }
+										title={ videoTitleFeaturedImages }
 									></iframe>
 									<script src="https://videopress.com/videopress-iframe.js"></script>
 								</div>
 								<div className={ styles[ 'product-interstitial__usage-videos-content' ] }>
 									<div className={ styles[ 'product-interstitial__usage-videos-heading' ] }>
-										{ videoTitle4 }
+										{ videoTitleFeaturedImages }
 									</div>
 									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
 										{ __(
@@ -316,7 +319,7 @@ export default function () {
 										className={ styles[ 'product-interstitial__usage-videos-link' ] }
 										icon={ help }
 										target="_blank"
-										href={ featuredImageLink }
+										href={ videoLinkFeaturedImages }
 									>
 										{ __( 'Learn about featured images', 'jetpack-my-jetpack' ) }
 									</Button>
@@ -331,13 +334,13 @@ export default function () {
 										src="https://videopress.com/embed/OMI3zqid?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F02%2Fimage-38.png%3Fw%3D560"
 										allowFullScreen
 										allow="clipboard-write"
-										title={ videoTitle2 }
+										title={ videoTitleForms }
 									></iframe>
 									<script src="https://videopress.com/videopress-iframe.js"></script>
 								</div>
 								<div className={ styles[ 'product-interstitial__usage-videos-content' ] }>
 									<div className={ styles[ 'product-interstitial__usage-videos-heading' ] }>
-										{ videoTitle2 }
+										{ videoTitleForms }
 									</div>
 									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
 										{ __(
@@ -355,6 +358,7 @@ export default function () {
 									</Button>
 								</div>
 							</div>
+
 							<div className={ styles[ 'product-interstitial__usage-videos-item' ] }>
 								<div className={ styles[ 'product-interstitial__usage-videos-video' ] }>
 									<iframe
@@ -363,13 +367,13 @@ export default function () {
 										src="https://videopress.com/embed/0vb0OJm7?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F02%2Fimage-39.png%3Fw%3D560"
 										allowFullScreen
 										allow="clipboard-write"
-										title={ videoTitle3 }
+										title={ videoTitleContentFeedback }
 									></iframe>
 									<script src="https://videopress.com/videopress-iframe.js"></script>
 								</div>
 								<div className={ styles[ 'product-interstitial__usage-videos-content' ] }>
 									<div className={ styles[ 'product-interstitial__usage-videos-heading' ] }>
-										{ videoTitle3 }
+										{ videoTitleContentFeedback }
 									</div>
 									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
 										{ __(

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -46,6 +46,8 @@ export default function () {
 	);
 	const videoTitle2 = __( 'Build forms using prompts', 'jetpack-my-jetpack' );
 	const videoTitle3 = __( 'Get feedback on posts', 'jetpack-my-jetpack' );
+	const videoTitle4 = __( 'Create featured images with one click', 'jetpack-my-jetpack' );
+	const featuredImageLink = getRedirectUrl( 'jetpack-ai-product-page-featured-image-link' );
 
 	debug( aiAssistantFeature );
 	const {
@@ -287,6 +289,40 @@ export default function () {
 									</Button>
 								</div>
 							</div>
+
+							<div className={ styles[ 'product-interstitial__usage-videos-item' ] }>
+								<div className={ styles[ 'product-interstitial__usage-videos-video' ] }>
+									<iframe
+										width="280"
+										height="157"
+										src="https://videopress.com/embed/HJCf8cXc?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F02%2Fone-click-featured-images.png%3Fw%3D560"
+										allowFullScreen
+										allow="clipboard-write"
+										title={ videoTitle4 }
+									></iframe>
+									<script src="https://videopress.com/videopress-iframe.js"></script>
+								</div>
+								<div className={ styles[ 'product-interstitial__usage-videos-content' ] }>
+									<div className={ styles[ 'product-interstitial__usage-videos-heading' ] }>
+										{ videoTitle4 }
+									</div>
+									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
+										{ __(
+											'Create featured images to illustrate your content and make it more engaging with just one click. Use prompts to generate adjusted new featured images.',
+											'jetpack-my-jetpack'
+										) }
+									</div>
+									<Button
+										className={ styles[ 'product-interstitial__usage-videos-link' ] }
+										icon={ help }
+										target="_blank"
+										href={ featuredImageLink }
+									>
+										{ __( 'Learn about featured images', 'jetpack-my-jetpack' ) }
+									</Button>
+								</div>
+							</div>
+
 							<div className={ styles[ 'product-interstitial__usage-videos-item' ] }>
 								<div className={ styles[ 'product-interstitial__usage-videos-video' ] }>
 									<iframe

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -70,6 +70,10 @@ export default function () {
 	const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
 	const feedbackURL = getRedirectUrl( 'jetpack-ai-feedback' );
 	const videoLinkFeaturedImages = getRedirectUrl( 'jetpack-ai-product-page-featured-image-link' );
+	const videoLinkForms = getRedirectUrl( 'jetpack-ai-product-page-form-link' );
+	const videoLinkContentFeedback = getRedirectUrl(
+		'jetpack-ai-product-page-content-feedback-link'
+	);
 
 	// isRegistered works as a flag to know if the page can link to a post creation or not
 	const ctaURL = isRegistered
@@ -352,7 +356,7 @@ export default function () {
 										className={ styles[ 'product-interstitial__usage-videos-link' ] }
 										icon={ help }
 										target="_blank"
-										href="https://jetpack.com/support/jetpack-blocks/contact-form/#forms-with-ai"
+										href={ videoLinkForms }
 									>
 										{ __( 'Learn about forms', 'jetpack-my-jetpack' ) }
 									</Button>
@@ -385,7 +389,7 @@ export default function () {
 										className={ styles[ 'product-interstitial__usage-videos-link' ] }
 										icon={ help }
 										target="_blank"
-										href="https://jetpack.com/support/jetpack-blocks/jetpack-ai-assistant-block/"
+										href={ videoLinkContentFeedback }
 									>
 										{ __( 'Learn more', 'jetpack-my-jetpack' ) }
 									</Button>

--- a/projects/packages/my-jetpack/changelog/update-jetpack-ai-add-featured-image-video-to-product-page
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-ai-add-featured-image-video-to-product-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack AI: include video about featured image generation on the product page.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37191.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add section for the Featured Image generation feature
* Rename some var to make it easy do changes on the page in the future
* Change the forms link and the content feedback link to use dynamic links too

| Before | After |
| --- | --- |
| <img width="500" alt="Screenshot 2024-05-02 at 16 06 22" src="https://github.com/Automattic/jetpack/assets/6760046/8cc91790-9984-4c1a-b3f7-a8e7231324ae"> | <img width="500" alt="Screenshot 2024-05-02 at 15 39 43" src="https://github.com/Automattic/jetpack/assets/6760046/f882b317-4b46-4fcd-8662-f5b3918d047e"> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get a new site running and connect it
* Visit the My Jetpack page and look for the "AI" product card
* Click the `Learn more` button

<img width="200" alt="Screenshot 2024-05-02 at 16 03 13" src="https://github.com/Automattic/jetpack/assets/6760046/f8ac303c-ab75-4559-9a28-c0d0bf4fcb52">

* On the following page, choose to keep using Jetpack AI for free (or upgrade, it does not affect the end result)

<img width="500" alt="Screenshot 2024-05-02 at 16 03 58" src="https://github.com/Automattic/jetpack/assets/6760046/78a651c3-15a8-4c09-a451-19d8fff80b9e">

* You will land on the Jetpack AI product page
* Confirm the page now shows 4 videos instead of 3:

<img width="500" alt="Screenshot 2024-05-02 at 15 39 43" src="https://github.com/Automattic/jetpack/assets/6760046/f882b317-4b46-4fcd-8662-f5b3918d047e">

* Confirm the second video of the page is related to the featured image generation
* Confirm the title, description and link have the correct words (check p1HpG7-sig-p2 for reference)
* Confirm the video plays correctly and is the correct video
* Confirm the thumbnail for the video is correct
* Confirm the link on the video leads you to the https://wordpress.com/support/featured-images/ support page

---

* Since we are changing the forms link and the content feedback link to use dynamic links too:
* Confirm the Forms link (third video) leads to the correct page
* Confirm the Content Feedback link (fourth video) leads to the page it was leading before (not ideal, but probably the only one we could put at the time)