### PR TITLE
AI Title Optimization: Add error handling for Title Optimization

### DIFF
--- a/projects/plugins/jetpack/changelog/add-title-optimization-error
+++ b/projects/plugins/jetpack/changelog/add-title-optimization-error
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add error handling on Title Optimization

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
@@ -151,7 +151,7 @@ export default function TitleOptimization( {
 							{ error ? (
 								<div className="jetpack-ai-title-optimization__error">
 									{ __(
-										'It failed to generate your suggested titles. Please try again.',
+										'The generation of your suggested titles failed. Please try again.',
 										'jetpack'
 									) }
 								</div>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
@@ -128,7 +128,7 @@ export default function TitleOptimization( {
 			<p>{ __( 'Use AI to optimize key details of your post.', 'jetpack' ) }</p>
 			<Button
 				isBusy={ busy }
-				disabled={ disabled }
+				disabled={ ! postContent || disabled }
 				onClick={ handleTitleOptimization }
 				variant="secondary"
 			>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
@@ -32,6 +32,7 @@ export default function TitleOptimization( {
 	const [ isTitleOptimizationModalVisible, setIsTitleOptimizationModalVisible ] = useState( false );
 	const [ generating, setGenerating ] = useState( false );
 	const [ options, setOptions ] = useState( [] );
+	const [ error, setError ] = useState( false );
 	const { editPost } = useDispatch( 'core/editor' );
 	const { autosave } = useAutoSaveAndRedirect();
 	const { increaseAiAssistantRequestsCount } = useDispatch( 'wordpress-com/plans' );
@@ -61,6 +62,7 @@ export default function TitleOptimization( {
 	const { request, stopSuggestion } = useAiSuggestions( {
 		onDone: handleDone,
 		onError: () => {
+			setError( true );
 			setGenerating( false );
 		},
 	} );
@@ -90,6 +92,12 @@ export default function TitleOptimization( {
 		toggleTitleOptimizationModal();
 		handleRequest();
 	}, [ handleRequest, placement, recordEvent, toggleTitleOptimizationModal ] );
+
+	const handleTryAgain = useCallback( () => {
+		setError( false );
+		setGenerating( true );
+		handleRequest();
+	}, [ handleRequest ] );
 
 	const handleAccept = useCallback(
 		( event: MouseEvent ) => {
@@ -140,25 +148,42 @@ export default function TitleOptimization( {
 						</div>
 					) : (
 						<>
-							<span className="jetpack-ai-title-optimization__intro">
-								{ __( 'Choose an optimized title below:', 'jetpack' ) }
-							</span>
-							<TitleOptimizationOptions
-								onChangeValue={ e => setSelected( e.target.value ) }
-								selected={ selected }
-								options={ options?.map?.( option => ( {
-									value: option.title,
-									label: option.title,
-									description: option.explanation,
-								} ) ) }
-							/>
+							{ error ? (
+								<div className="jetpack-ai-title-optimization__error">
+									{ __(
+										'It failed to generate your suggested titles. Please try again.',
+										'jetpack'
+									) }
+								</div>
+							) : (
+								<>
+									<span className="jetpack-ai-title-optimization__intro">
+										{ __( 'Choose an optimized title below:', 'jetpack' ) }
+									</span>
+									<TitleOptimizationOptions
+										onChangeValue={ e => setSelected( e.target.value ) }
+										selected={ selected }
+										options={ options?.map?.( option => ( {
+											value: option.title,
+											label: option.title,
+											description: option.explanation,
+										} ) ) }
+									/>
+								</>
+							) }
 							<div className="jetpack-ai-title-optimization__cta">
 								<Button variant="secondary" onClick={ toggleTitleOptimizationModal }>
 									{ __( 'Cancel', 'jetpack' ) }
 								</Button>
-								<Button variant="primary" onClick={ handleAccept }>
-									{ __( 'Replace title', 'jetpack' ) }
-								</Button>
+								{ error ? (
+									<Button variant="primary" onClick={ handleTryAgain }>
+										{ __( 'Try again', 'jetpack' ) }
+									</Button>
+								) : (
+									<Button variant="primary" onClick={ handleAccept }>
+										{ __( 'Replace title', 'jetpack' ) }
+									</Button>
+								) }
 							</div>
 						</>
 					) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/style.scss
@@ -9,7 +9,7 @@
 		justify-content: center;
 	}
 
-	&__intro {
+	&__intro, &__error {
 		margin-top: 16px;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #36947 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set a new `error` state to show a minimal message saying that an error occurred.
* Show `Try Again` button and message when error happens.
* Disable entry button if `no content`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox `public-api` and add an early error. Ex. `return new \WP_Error( 'jetpack_ai_error', __( 'There was an error processing the completion request.' ), [ 'status' => 500 ] );`
* Open your editor, if it has no content, the button should disabled.
* Ask for an title, it will fail and show the message.
* Clicking on Try Again will do a new request and show loading state again.

### Demo

https://github.com/Automattic/jetpack/assets/1663717/aed14337-fb64-487f-a6e4-93082f8e7178



