### PR TITLE
AI Assistant: Add undo functionality and fix input with iframe

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-undo
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-undo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add undo functionality and fix input with iframe

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -14,6 +14,7 @@ import type { ReactElement } from 'react';
 export default function AiAssistantInput( {
 	requestingState,
 	wrapperRef,
+	inputRef,
 	action,
 	request,
 	stopSuggestion,
@@ -25,6 +26,7 @@ export default function AiAssistantInput( {
 	requestingState: RequestingStateProp;
 	requestingError?: RequestingErrorProps;
 	suggestion?: string;
+	inputRef?: React.MutableRefObject< HTMLInputElement | null >;
 	wrapperRef?: React.MutableRefObject< HTMLDivElement | null >;
 	action?: string;
 	request: ( question: string ) => void;
@@ -80,6 +82,7 @@ export default function AiAssistantInput( {
 			onUndo={ handleUndo }
 			onUpgrade={ handleUpgrade }
 			wrapperRef={ wrapperRef }
+			ref={ inputRef }
 		/>
 	);
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/heading/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/heading/index.tsx
@@ -38,6 +38,11 @@ export class HeadingHandler implements IBlockHandler {
 			) } ${ suggestion }`;
 		}
 
+		// Ignore an empty suggestion, that is, a suggestion that only contains hashes and spaces.
+		if ( suggestion.match( /^#*\s*$/ ) ) {
+			return;
+		}
+
 		const HTML = renderContent( suggestion );
 		this.replaceBlockContent( HTML );
 	}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/heading/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/heading/index.tsx
@@ -53,10 +53,6 @@ export class HeadingHandler implements IBlockHandler {
 		this.replaceBlockContent( HTML );
 	}
 
-	public onDone(): void {
-		this.firstUpdate = true;
-	}
-
 	private replaceBlockContent( newContent: string ): void {
 		// Create a new block with the raw HTML content.
 		const [ newBlock ] = rawHandler( { HTML: newContent } );
@@ -64,9 +60,9 @@ export class HeadingHandler implements IBlockHandler {
 			return;
 		}
 
-		const blockEditorDispatch = dispatch( 'core/block-editor' ) as BlockEditorDispatch;
-
-		const { updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } = blockEditorDispatch;
+		const { updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } = dispatch(
+			'core/block-editor'
+		) as BlockEditorDispatch;
 
 		if ( ! this.firstUpdate ) {
 			// Mark the change as not persistent so we can undo all the changes in one step.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/types.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { dispatch } from '@wordpress/data';
+/**
  * Types
  */
 import type { Block } from '@automattic/jetpack-ai-client';
@@ -12,4 +16,10 @@ export interface IBlockHandler {
 
 export type BlockEditorSelect = {
 	getBlock: ( clientId: string ) => Block;
+};
+
+const blockEditorDispatch = dispatch( 'core/block-editor' );
+
+export type BlockEditorDispatch = typeof blockEditorDispatch & {
+	__unstableMarkNextChangeAsNotPersistent: () => void;
 };

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -43,6 +43,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const inputRef: React.MutableRefObject< HTMLInputElement | null > = useRef( null );
 		const controlObserver = useRef< ResizeObserver | null >( null );
 		const blockStyle = useRef< string >( '' );
+		const ownerDocument = useRef< Document >( document );
 		const [ action, setAction ] = useState< string >( '' );
 
 		// Only extend the allowed block types.
@@ -84,7 +85,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				onBlockSuggestion( suggestion );
 
 				// Make sure the block element has the necessary bottom padding, as it can be replaced or changed
-				const block = document.getElementById( id );
+				const block = ownerDocument.current.getElementById( id );
 				if ( block && controlRef.current ) {
 					block.style.paddingBottom = `${ controlHeight.current + 16 }px`;
 				}
@@ -110,14 +111,16 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		} );
 
 		useEffect( () => {
-			// Focus the input when the AI Control is displayed.
 			if ( inputRef.current ) {
+				// Save the block's ownerDocument to use it later, as the editor can be in an iframe.
+				ownerDocument.current = inputRef.current.ownerDocument;
+				// Focus the input when the AI Control is displayed.
 				inputRef.current.focus();
 			}
-		}, [ clientId, showAiControl ] );
+		}, [ showAiControl ] );
 
 		useEffect( () => {
-			let block = document.getElementById( id );
+			let block = ownerDocument.current.getElementById( id );
 
 			if ( ! block ) {
 				return;
@@ -131,7 +134,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				// Observe the control's height to adjust the block's bottom-padding.
 				controlObserver.current = new ResizeObserver( ( [ entry ] ) => {
 					// The block element can be replaced or changed, so we need to get it again.
-					block = document.getElementById( id );
+					block = ownerDocument.current.getElementById( id );
 					controlHeight.current = entry.contentRect.height;
 
 					if ( block && controlRef.current && controlHeight.current > 0 ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -39,6 +39,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 	return props => {
 		const { clientId, isSelected, name: blockName } = props;
 		const controlRef: React.MutableRefObject< HTMLDivElement | null > = useRef( null );
+		const inputRef: React.MutableRefObject< HTMLInputElement | null > = useRef( null );
 		const controlObserver = useRef< ResizeObserver | null >( null );
 		const blockStyle = useRef< string >( '' );
 		const [ action, setAction ] = useState< string >( '' );
@@ -93,6 +94,13 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		} );
 
 		const { id } = useBlockProps();
+
+		useEffect( () => {
+			// Focus the input when the AI Control is displayed.
+			if ( inputRef.current ) {
+				inputRef.current.focus();
+			}
+		}, [ clientId, showAiControl ] );
 
 		useEffect( () => {
 			const block = document.getElementById( id );
@@ -217,6 +225,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 						requestingError={ error }
 						suggestion={ suggestion }
 						wrapperRef={ controlRef }
+						inputRef={ inputRef }
 						action={ action }
 						request={ onUserRequest }
 						stopSuggestion={ stopSuggestion }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37015

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes an issue with the input positioning on new versions of Gutenberg (with iframe), using the `ownerDocument` of the input ref instead of `document` directly
* Fixes an issue with the input positioning when the input goes over the block (the block was changing and removing its padding, so we re-select it on each update)
* Adds auto-focus on the input when opening the assistant control
* Adds undo functionality coupled with `__unstableMarkNextChangeAsNotPersistent` to allow one undo for the whole stream

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
ref p1714672899949359/1714587601.418209-slack-C45SNKV4Z

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the Gutenberg plugin
* Go to the block editor
* Add a Heading block with some content
* Check that when clicking on the AI icon, the input is selectable as normal
* Make a couple of requests (translations to some languages is the easiest way)
* Check that the undo button works and goes back to how the heading was before all the requests
