### PR TITLE
Nav redesign: add Hosting -> Site Overview menu

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/nav-redesign-hosting-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/nav-redesign-hosting-menu
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Nav redesign: Add Hosting -> Site Overview menu

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -86,6 +86,15 @@ function wpcom_add_wpcom_menu_item() {
 
 	add_submenu_page(
 		$parent_slug,
+		esc_attr__( 'Site Overview', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Site Overview', 'jetpack-mu-wpcom' ) . ' <span class="dashicons dashicons-external"></span>',
+		'manage_options',
+		esc_url( "https://wordpress.com/hosting/$domain" ),
+		null
+	);
+
+	add_submenu_page(
+		$parent_slug,
 		esc_attr__( 'Plans', 'jetpack-mu-wpcom' ),
 		esc_attr__( 'Plans', 'jetpack-mu-wpcom' ),
 		'manage_options',
@@ -128,24 +137,6 @@ function wpcom_add_wpcom_menu_item() {
 		esc_attr__( 'Purchases', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		esc_url( "https://wordpress.com/purchases/subscriptions/$domain" ),
-		null
-	);
-
-	add_submenu_page(
-		$parent_slug,
-		esc_attr__( 'Configuration', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Configuration', 'jetpack-mu-wpcom' ),
-		'manage_options',
-		esc_url( "https://wordpress.com/hosting-config/$domain" ),
-		null
-	);
-
-	add_submenu_page(
-		$parent_slug,
-		esc_attr__( 'Monitoring', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Monitoring', 'jetpack-mu-wpcom' ),
-		'manage_options',
-		esc_url( "https://wordpress.com/site-monitoring/$domain" ),
 		null
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -436,7 +436,7 @@ function wpcom_add_hosting_menu_intro_notice() {
 		<div>
 			<span class="title"><?php esc_html_e( 'WordPress.com', 'jetpack-mu-wpcom' ); ?></span><br />
 			<span>
-				<?php esc_html_e( 'To access settings for plans, domains, emails, etc., click "Hosting" in the sidebar.', 'jetpack-mu-wpcom' ); ?>
+				<?php esc_html_e( 'Click "Hosting" in the sidebar to access the site overview and settings for plans, domains, emails, etc.', 'jetpack-mu-wpcom' ); ?>
 			</span>
 		</div>
 		<a href="#" class="close-button" aria-label=<?php echo esc_attr__( 'Dismiss', 'jetpack-mu-wpcom' ); ?>>


### PR DESCRIPTION
Part of:

- https://github.com/Automattic/dotcom-forge/issues/6874

## Proposed changes:

This PR proposes a new menu under Hosting called "Site Overview", which links to `/hosting/:siteSlug`.

Additionally, this PR removes the pages which are already in the "site overview" screens: Configuration and Monitoring.

|Before|After|
|-|-|
|<img width="276" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/7a23ac05-e6bd-4ba9-bf5f-e14dac38c47c">|<img width="275" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/b408c570-b54a-47b7-9003-3df3dfebba25">|

With this, we also update the admin notice in wp-admin from:

<img width="861" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/018ec195-8363-4985-8af0-33fcc5070203">

to:

<img width="860" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/fa5b8923-990d-4161-b386-c9a61eaef279">


## Note

The external icon is only visible on wp-admin screens. When we click on one of the Hosting menus, we will be taken to Calypso screen, and the external icon will disappear. This is a known issue (https://github.com/Automattic/dotcom-forge/issues/6841)

<img width="163" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/c8c0b7d8-2b33-43ab-8cb0-842cea8f9873">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this PR to your Jetpack Beta Tester (WordPress.com Features).
2. Verify the new menus under Hosting.
3. Verify that the new `Site Overview` menu points to `/hosting/:siteSlug`.
4. Verify the new admin notice in wp-admin home.