### PR TITLE
Sidebar: Fix showing the double arrow on active menu when RTL

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-double-menu-arrow-when-rtl
+++ b/projects/plugins/jetpack/changelog/fix-double-menu-arrow-when-rtl
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sidebar: Fix showing the double arrow on active menu when RTL

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/_admin.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/_admin.scss
@@ -332,7 +332,7 @@ textarea:focus {
 
 ul#adminmenu a.wp-has-current-submenu:after,
 ul#adminmenu > li.current > a.current:after {
-    border-right-color: $body-background;
+    border-inline-end-color: $body-background;
 }
 
 #adminmenu li.current a.menu-top,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6914

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix showing the double arrow on active menu when RTL

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/jetpack/assets/13596067/1b895cac-e43e-4cf3-9c34-64e0741093a3) | ![image](https://github.com/Automattic/jetpack/assets/13596067/a6454388-150a-4faf-9615-b8776fe137b9) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow https://github.com/Automattic/jetpack/pull/37204#issuecomment-2092646749 to apply this change
* Go to wordpress.com/me > Account settings
* Change to the Sakura color scheme.
* Change to an RTL language.
* Open /wp-admin for a Simple site.
* Make sure the double arrow on the active menu is gone
* Remember to disable the cache if it doesn't work
