### PR TITLE
Google Analytics: automatically label changes to package

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-google-analytics
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-google-analytics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Auto-labeling: label changes to the Google Analytics package.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -143,6 +143,12 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			keywords.add( '[Feature] SSO' );
 		}
 
+		// The Google Analytics feature nows lives in both a package and a Jetpack module.
+		const googleAnalytics = file.match( /^projects\/packages\/google-analytics\// );
+		if ( googleAnalytics !== null ) {
+			keywords.add( '[Feature] Google Analytics' );
+		}
+
 		// The WooCommerce Analytics feature now lives in both a package and a Jetpack module.
 		const wooCommerceAnalytics = file.match( /^projects\/packages\/woocommerce-analytics\// );
 		if ( wooCommerceAnalytics !== null ) {


### PR DESCRIPTION
See #37137

## Proposed changes:

The Google Analytics feature now also lives in a package. Let's handle that in our action.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* #36920

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> This can only be tested in a fork.

* In your fork, merge this branch to `trunk`.
* Open a new PR in your fork, for a new branch to `trunk`, making a change to one of the files in `projects/packages/google-analytics/`.
    * The "[Feature] Google Analytics" label should be automatically added to the PR.
