### PR TITLE
Untangling: Record events for sidebar notices

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-untangling-sidebar-notice-tracks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-untangling-sidebar-notice-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin menu: Record events in Tracks for sidebar notices

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.js
@@ -1,11 +1,25 @@
 /* global wp, wpcomSidebarNotice */
 
+const wpcomSidebarNoticeRecordEvent = event => {
+	if ( ! event ) {
+		return;
+	}
+	window._tkq = window._tkq || [];
+	window._tkq.push( [
+		'identifyUser',
+		wpcomSidebarNotice.user.ID,
+		wpcomSidebarNotice.user.username,
+	] );
+	window._tkq.push( [ 'recordEvent', event.name, event.props ] );
+};
+
 const wpcomShowSidebarNotice = () => {
 	const adminMenu = document.querySelector( '#adminmenu' );
 	if ( ! adminMenu || typeof wpcomSidebarNotice === 'undefined' ) {
 		return;
 	}
 
+	// Render notice.
 	adminMenu.insertAdjacentHTML(
 		'afterbegin',
 		`
@@ -24,7 +38,7 @@ const wpcomShowSidebarNotice = () => {
 							<div class="upsell_banner__text">${ wpcomSidebarNotice.text }</div>
 							<button type="button" class="upsell_banner__action button">${ wpcomSidebarNotice.action }</button>
 							${
-								wpcomSidebarNotice.dismissible === '1'
+								wpcomSidebarNotice.dismissible
 									? '<button type="button" class="upsell_banner__dismiss button button-link">' +
 									  wpcomSidebarNotice.dismissLabel +
 									  '</button>'
@@ -37,13 +51,16 @@ const wpcomShowSidebarNotice = () => {
 		`
 	);
 
-	const sidebarNotice = adminMenu.firstElementChild;
+	// Record impression event in Tracks.
+	wpcomSidebarNoticeRecordEvent( wpcomSidebarNotice.tracks?.display );
 
+	const sidebarNotice = adminMenu.firstElementChild;
 	sidebarNotice.addEventListener( 'click', event => {
 		if (
 			event.target.classList.contains( 'upsell_banner__dismiss' ) ||
 			event.target.closest( '.upsell_banner__dismiss' )
 		) {
+			// Handle dismiss.
 			event.preventDefault();
 			wp.ajax.post( 'wpcom_dismiss_sidebar_notice', {
 				id: sidebarNotice.dataset.id,
@@ -51,6 +68,12 @@ const wpcomShowSidebarNotice = () => {
 				_ajax_nonce: wpcomSidebarNotice.dismissNonce,
 			} );
 			sidebarNotice.remove();
+
+			// Record dismiss event in Tracks.
+			wpcomSidebarNoticeRecordEvent( wpcomSidebarNotice.tracks?.dismiss );
+		} else {
+			// Record click event in Tracks.
+			wpcomSidebarNoticeRecordEvent( wpcomSidebarNotice.tracks?.click );
 		}
 	} );
 };

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -234,24 +234,46 @@ function wpcom_site_menu_enqueue_scripts() {
 
 	$notice = wpcom_get_sidebar_notice();
 	if ( $notice ) {
-		$link = $notice['link'];
+		$link = $notice->link;
 		if ( str_starts_with( $link, '/' ) ) {
 			$link = 'https://wordpress.com' . $link;
 		}
 
-		wp_localize_script(
+		$user_id    = null;
+		$user_login = null;
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			global $current_user;
+			$user_id    = $current_user->ID;
+			$user_login = $current_user->user_login;
+		} else {
+			$connection_manager = new Connection_Manager();
+			$wpcom_user_data    = $connection_manager->get_connected_user_data();
+			if ( $wpcom_user_data ) {
+				$user_id    = $wpcom_user_data['ID'];
+				$user_login = $wpcom_user_data['username'];
+			}
+		}
+
+		$data = (object) array(
+			'url'          => esc_url( $link ),
+			'text'         => wp_kses( $notice->content, array() ),
+			'action'       => wp_kses( $notice->cta, array() ),
+			'dismissible'  => $notice->dismissible,
+			'dismissLabel' => esc_html__( 'Dismiss', 'jetpack-mu-wpcom' ),
+			'id'           => $notice->id,
+			'featureClass' => $notice->feature_class,
+			'dismissNonce' => wp_create_nonce( 'wpcom_dismiss_sidebar_notice' ),
+			'tracks'       => $notice->tracks,
+			'user'         => (object) array(
+				'ID'       => $user_id,
+				'username' => $user_login,
+			),
+		);
+
+		wp_add_inline_script(
 			'wpcom-site-menu',
-			'wpcomSidebarNotice',
-			array(
-				'url'          => esc_url( $link ),
-				'text'         => wp_kses( $notice['content'], array() ),
-				'action'       => wp_kses( $notice['cta'], array() ),
-				'dismissible'  => $notice['dismissible'],
-				'dismissLabel' => esc_html__( 'Dismiss', 'jetpack-mu-wpcom' ),
-				'id'           => $notice['id'],
-				'featureClass' => $notice['feature_class'],
-				'dismissNonce' => wp_create_nonce( 'wpcom_dismiss_sidebar_notice' ),
-			)
+			'window.wpcomSidebarNotice = ' . wp_json_encode( $data ) . ';'
 		);
 	}
 }
@@ -260,7 +282,7 @@ add_action( 'admin_enqueue_scripts', 'wpcom_site_menu_enqueue_scripts' );
 /**
  * Returns the first available sidebar notice.
  *
- * @return array | null
+ * @return object | null
  */
 function wpcom_get_sidebar_notice() {
 	$message_path = 'calypso:sites:sidebar_notice';
@@ -287,13 +309,14 @@ function wpcom_get_sidebar_notice() {
 	// Serialize message as object (on Simple sites we have an array, on Atomic sites we have an object).
 	$message = json_decode( wp_json_encode( $message[0] ) );
 
-	return array(
+	return (object) array(
 		'content'       => $message->content->message,
 		'cta'           => $message->CTA->message, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		'link'          => $message->CTA->link, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		'dismissible'   => $message->is_dismissible,
 		'feature_class' => $message->feature_class,
 		'id'            => $message->id,
+		'tracks'        => $message->tracks ?? null,
 	);
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -251,7 +251,7 @@ function wpcom_site_menu_enqueue_scripts() {
 			$wpcom_user_data    = $connection_manager->get_connected_user_data();
 			if ( $wpcom_user_data ) {
 				$user_id    = $wpcom_user_data['ID'];
-				$user_login = $wpcom_user_data['username'];
+				$user_login = $wpcom_user_data['login'];
 			}
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -255,7 +255,7 @@ function wpcom_site_menu_enqueue_scripts() {
 			}
 		}
 
-		$data = (object) array(
+		$data = array(
 			'url'          => esc_url( $link ),
 			'text'         => wp_kses( $notice->content, array() ),
 			'action'       => wp_kses( $notice->cta, array() ),
@@ -265,7 +265,7 @@ function wpcom_site_menu_enqueue_scripts() {
 			'featureClass' => $notice->feature_class,
 			'dismissNonce' => wp_create_nonce( 'wpcom_dismiss_sidebar_notice' ),
 			'tracks'       => $notice->tracks,
-			'user'         => (object) array(
+			'user'         => array(
 				'ID'       => $user_id,
 				'username' => $user_login,
 			),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -234,7 +234,7 @@ function wpcom_site_menu_enqueue_scripts() {
 
 	$notice = wpcom_get_sidebar_notice();
 	if ( $notice ) {
-		$link = $notice->link;
+		$link = $notice['link'];
 		if ( str_starts_with( $link, '/' ) ) {
 			$link = 'https://wordpress.com' . $link;
 		}
@@ -257,14 +257,14 @@ function wpcom_site_menu_enqueue_scripts() {
 
 		$data = array(
 			'url'          => esc_url( $link ),
-			'text'         => wp_kses( $notice->content, array() ),
-			'action'       => wp_kses( $notice->cta, array() ),
-			'dismissible'  => $notice->dismissible,
+			'text'         => wp_kses( $notice['content'], array() ),
+			'action'       => wp_kses( $notice['cta'], array() ),
+			'dismissible'  => $notice['dismissible'],
 			'dismissLabel' => esc_html__( 'Dismiss', 'jetpack-mu-wpcom' ),
-			'id'           => $notice->id,
-			'featureClass' => $notice->feature_class,
+			'id'           => $notice['id'],
+			'featureClass' => $notice['feature_class'],
 			'dismissNonce' => wp_create_nonce( 'wpcom_dismiss_sidebar_notice' ),
-			'tracks'       => $notice->tracks,
+			'tracks'       => $notice['tracks'],
 			'user'         => array(
 				'ID'       => $user_id,
 				'username' => $user_login,
@@ -282,7 +282,7 @@ add_action( 'admin_enqueue_scripts', 'wpcom_site_menu_enqueue_scripts' );
 /**
  * Returns the first available sidebar notice.
  *
- * @return object | null
+ * @return array | null
  */
 function wpcom_get_sidebar_notice() {
 	$message_path = 'calypso:sites:sidebar_notice';
@@ -309,7 +309,7 @@ function wpcom_get_sidebar_notice() {
 	// Serialize message as object (on Simple sites we have an array, on Atomic sites we have an object).
 	$message = json_decode( wp_json_encode( $message[0] ) );
 
-	return (object) array(
+	return array(
 		'content'       => $message->content->message,
 		'cta'           => $message->CTA->message, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		'link'          => $message->CTA->link, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase


### PR DESCRIPTION
## Proposed changes:

This PR ensures that events for the sidebar notices introduced in https://github.com/Automattic/jetpack/pull/36797 are recorded in Tracks.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
Not for self-hosted sites, only for WP.com sites

## Testing instructions:

- Activate the classic admin interface style on a WP.com test site
  - Simple sites: 
    - Open `wp shell` in your sandbox
    - Run these commands: `update_blog_option( blog_id, 'wpcom_admin_interface', 'wp-admin' );` and `update_blog_option( blog_id, 'wpcom_classic_early_release', 1 );`
  - Atomic sites
    - Go to https://wordpress.com/hosting-config
    - Select your site
    - Change the admin interface style to Classic
    - Go to `<SITE_DOMAIN>/_cli`
    - Run this command: `wp option update wpcom_classic_early_release 1`
- Apply these changes on your site using the instructions from the auto-generated comment below.
- Go to `/wp-admin`
- Make sure the sidebar notice shows up correctly
- Click on it
- Wait a few minutes and go to MC > Tracks > Live view
- Filter the events by `calypso_upgrade_nudge_%` and enter your username
- You should see the impression and click events triggered from WP Admin
- AFAICS none of the existing JITMs register a dismiss event, so they cannot be tested