### PR TITLE
Add/copy for ai feature on connection screen

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-screen/body.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/body.tsx
@@ -34,6 +34,7 @@ const ConnectionScreenBody: React.FC< ConnectScreenProps > = props => {
 					{ __( 'Receive notifications about new likes and comments', 'jetpack-my-jetpack' ) }
 				</li>
 				<li>{ __( 'Let visitors share your content on social media', 'jetpack-my-jetpack' ) }</li>
+				<li>{ __( 'Create better content with powerful AI tools', 'jetpack-my-jetpack' ) }</li>
 				<li>
 					{ __( 'And more!', 'jetpack-my-jetpack' ) }{ ' ' }
 					<a

--- a/projects/packages/my-jetpack/changelog/add-copy-for-ai-feature-on-connection-screen
+++ b/projects/packages/my-jetpack/changelog/add-copy-for-ai-feature-on-connection-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add copy for AI features on connection screen


### PR DESCRIPTION
## Proposed changes:

* Add copy for AI features on My Jetpack connection screen

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-rOl-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to `/wp-admin/admin.php?page=my-jetpack#/connection`
3. Make sure the AI copy is shown
![Screenshot 2024-05-03 at 12 07 50 PM](https://github.com/Automattic/jetpack/assets/65001528/0f7b2f50-ed54-4b26-9d2b-703ad033e235)
