### PR TITLE
AI Featured Image: Change upgrade prompt style and other small UI fixes

### DIFF
--- a/projects/plugins/jetpack/changelog/update-featured-image-generator-ui-changes
+++ b/projects/plugins/jetpack/changelog/update-featured-image-generator-ui-changes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Featured Image: change upgrade prompt layout and fix UI issues.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -9,17 +9,19 @@ import debugFactory from 'debug';
 /*
  * Internal dependencies
  */
-import { Nudge } from '../../../../shared/components/upgrade-nudge';
+import { Nudge as StandardNudge } from '../../../../shared/components/upgrade-nudge';
 import { PLAN_TYPE_TIERED, usePlanType } from '../../../../shared/use-plan-type';
 import useAICheckout from '../../hooks/use-ai-checkout';
 import useAiFeature from '../../hooks/use-ai-feature';
 import { canUserPurchasePlan } from '../../lib/connection';
+import { LightNudge } from './light-nudge';
 import type { ReactElement } from 'react';
 import './style.scss';
 
 type UpgradePromptProps = {
 	placement?: string;
 	description?: string;
+	useLightNudge?: boolean;
 };
 
 const debug = debugFactory( 'jetpack-ai-assistant:upgrade-prompt' );
@@ -33,7 +35,10 @@ const debug = debugFactory( 'jetpack-ai-assistant:upgrade-prompt' );
 const DefaultUpgradePrompt = ( {
 	placement = null,
 	description = null,
+	useLightNudge = false,
 }: UpgradePromptProps ): ReactElement => {
+	const Nudge = useLightNudge ? LightNudge : StandardNudge;
+
 	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
 	const canUpgrade = canUserPurchasePlan();
 	const {
@@ -181,9 +186,17 @@ const DefaultUpgradePrompt = ( {
  *
  * @param {object} props - Component props.
  * @param {string} props.description - The description to display in the prompt.
+ * @param {boolean} props.useLightNudge - Wheter to use the light variant of the nudge, or the standard one.
  * @returns {ReactElement} the Nudge component with the prompt.
  */
-const VIPUpgradePrompt = ( { description = null }: { description?: string } ): ReactElement => {
+const VIPUpgradePrompt = ( {
+	description = null,
+	useLightNudge = false,
+}: {
+	description?: string;
+	useLightNudge?: boolean;
+} ): ReactElement => {
+	const Nudge = useLightNudge ? LightNudge : StandardNudge;
 	const vipDescription = createInterpolateElement(
 		__(
 			"You've reached the Jetpack AI rate limit. <strong>Please reach out to your VIP account team.</strong>",
@@ -215,7 +228,10 @@ const UpgradePrompt = props => {
 
 	// If the user is on a VIP site, show the VIP upgrade prompt.
 	if ( upgradeType === 'vip' ) {
-		return VIPUpgradePrompt( { description: props.description } );
+		return VIPUpgradePrompt( {
+			description: props.description,
+			useLightNudge: props?.useLightNudge,
+		} );
 	}
 
 	return DefaultUpgradePrompt( props );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/light-nudge.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/light-nudge.tsx
@@ -1,0 +1,37 @@
+import { Button, Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+import './style.scss';
+
+export const LightNudge = ( {
+	title,
+	description,
+	buttonText = null,
+	checkoutUrl = null,
+	goToCheckoutPage = null,
+	isRedirecting = false,
+	showButton = true,
+} ) => {
+	const redirectingText = __( 'Redirecting…', 'jetpack' );
+
+	return (
+		<div className="jetpack-upgrade-plan-banner-light">
+			<Notice status="warning" isDismissible={ false }>
+				<p>
+					{ title && <strong>{ title }</strong> }
+					{ description }{ ' ' }
+					{ showButton && (
+						<Button
+							href={ isRedirecting ? null : checkoutUrl } // Only for server-side rendering, since onClick doesn't work there.
+							onClick={ goToCheckoutPage }
+							variant="link"
+							target="_top"
+						>
+							{ isRedirecting ? redirectingText : buttonText }
+						</Button>
+					) }
+				</p>
+			</Notice>
+		</div>
+	);
+};

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/style.scss
@@ -12,3 +12,7 @@
         }
     }
 }
+
+.jetpack-upgrade-plan-banner-light {
+    margin-bottom: 8px;
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/style.scss
@@ -12,7 +12,3 @@
         }
     }
 }
-
-.jetpack-upgrade-plan-banner-light {
-    margin-bottom: 8px;
-}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -383,7 +383,11 @@ export default function FeaturedImage( {
 							<div className="ai-assistant-featured-image__actions-right">
 								<div className="ai-assistant-featured-image__action-buttons">
 									{ currentPointer?.error ? (
-										<Button onClick={ handleTryAgain } variant="secondary">
+										<Button
+											onClick={ handleTryAgain }
+											variant="secondary"
+											disabled={ ! userPrompt && ! postContent }
+										>
 											{ __( 'Try again', 'jetpack' ) }
 										</Button>
 									) : (
@@ -392,7 +396,11 @@ export default function FeaturedImage( {
 												onClick={ handleRegenerate }
 												variant="secondary"
 												isBusy={ currentPointer?.generating }
-												disabled={ notEnoughRequests || currentPointer?.generating }
+												disabled={
+													notEnoughRequests ||
+													currentPointer?.generating ||
+													( ! userPrompt && ! postContent )
+												}
 											>
 												{ __( 'Generate again', 'jetpack' ) }
 											</Button>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -424,6 +424,7 @@ export default function FeaturedImage( {
 											  )
 											: null
 									}
+									useLightNudge={ true }
 								/>
 							) }
 							<Carrousel

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -147,7 +147,7 @@ export default function FeaturedImage( {
 				{
 					generating: false,
 					error: new Error(
-						__( "You don't have enough requests to generate another image", 'jetpack' )
+						__( "You don't have enough requests to generate another image.", 'jetpack' )
 					),
 				},
 				pointer.current
@@ -158,7 +158,15 @@ export default function FeaturedImage( {
 		// Ensure the user prompt or the post content are set.
 		if ( ! userPrompt && ! postContent ) {
 			updateImages(
-				{ generating: false, error: new Error( __( 'No content to generate image', 'jetpack' ) ) },
+				{
+					generating: false,
+					error: new Error(
+						__(
+							'No content to generate image. Please type custom instructions and try again.',
+							'jetpack'
+						)
+					),
+				},
 				pointer.current
 			);
 			return;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -370,6 +370,23 @@ export default function FeaturedImage( {
 								></textarea>
 							</div>
 						</div>
+						{ ( requireUpgrade || notEnoughRequests ) && ! currentPointer?.generating && (
+							<UpgradePrompt
+								description={
+									notEnoughRequests
+										? sprintf(
+												// Translators: %d is the cost of generating a featured image.
+												__(
+													"Featured image generation costs %d requests per image. You don't have enough requests to generate another image.",
+													'jetpack'
+												),
+												featuredImageCost
+										  )
+										: null
+								}
+								useLightNudge={ true }
+							/>
+						) }
 						<div className="ai-assistant-featured-image__actions">
 							<div className="ai-assistant-featured-image__actions-left">
 								{ ! isUnlimited && featuredImageCost && requestsLimit && (
@@ -410,23 +427,6 @@ export default function FeaturedImage( {
 							</div>
 						</div>
 						<div className="ai-assistant-featured-image__image-canvas">
-							{ ( requireUpgrade || notEnoughRequests ) && ! currentPointer?.generating && (
-								<UpgradePrompt
-									description={
-										notEnoughRequests
-											? sprintf(
-													// Translators: %d is the cost of generating a featured image.
-													__(
-														"Featured image generation costs %d requests per image. You don't have enough requests to generate another image.",
-														'jetpack'
-													),
-													featuredImageCost
-											  )
-											: null
-									}
-									useLightNudge={ true }
-								/>
-							) }
 							<Carrousel
 								images={ images }
 								current={ current }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/style.scss
@@ -34,6 +34,10 @@
 			padding: 12px;
 			color: var(--studio-black);
 		}
+
+		textarea:disabled {
+			opacity: 0.5;
+		}
 	}
 
 	&__actions-left {

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/index.js
@@ -27,7 +27,7 @@ export const internalMediaSources = [
 export const featuredImageExclusiveMediaSources = [
 	{
 		id: SOURCE_JETPACK_AI_FEATURED_IMAGE,
-		label: __( 'Generated with AI', 'jetpack' ),
+		label: __( 'Generate with AI', 'jetpack' ),
 		icon: aiAssistantIcon,
 		keyword: 'jetpack ai',
 	},

--- a/projects/plugins/jetpack/extensions/shared/external-media/sources/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/sources/index.js
@@ -27,7 +27,7 @@ export const internalMediaSources = [
 export const featuredImageExclusiveMediaSources = [
 	{
 		id: SOURCE_JETPACK_AI_FEATURED_IMAGE,
-		label: __( 'AI Generated Image', 'jetpack' ),
+		label: __( 'Generated with AI', 'jetpack' ),
 		icon: aiAssistantIcon,
 		keyword: 'jetpack ai',
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use the core notice component as the base for the upgrade prompt
* Update media source entrypoint label to "Generate with AI"
* Disable generation buttons when no content and no user prompt are available
* Make sure the user prompt textarea looks disabled when it's disabled
* Small changes on the validation messages

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a new test site so it's easy to test the upgrade messaging
* Go to the block editor and don't add any content yet
* On the settings sidebar, look for the "Featured Image" section
* Click on the button, then confirm the label for the AI option is "Generate with AI"

<img width="250" alt="Screenshot 2024-05-03 at 12 58 50" src="https://github.com/Automattic/jetpack/assets/6760046/8c128e8d-728a-4d95-b1e3-ce918c0956df">

* Click the "Generate with AI" option and check the modal:
   * confirm you see an error message saying there is no content to generate image
   * confirm the "try again" button is disabled, and will be enabled again when you type something on the user prompt field

| Button disabled | Button enabled |
| --- | --- |
| <img width="400" alt="Screenshot 2024-05-03 at 15 56 48" src="https://github.com/Automattic/jetpack/assets/6760046/0145a9b8-9f67-4c3c-abdb-148017f343fd"> | <img width="400" alt="Screenshot 2024-05-03 at 15 57 01" src="https://github.com/Automattic/jetpack/assets/6760046/d77bcb9b-9b59-4269-ae56-44ee6cd27d4e"> |

* Type something on the user prompt field, for example "a boat floating in the sea", then click "try again"
* Confirm you get one image back

<img width="500" alt="Screenshot 2024-05-03 at 15 58 13" src="https://github.com/Automattic/jetpack/assets/6760046/8495c147-0cc1-48c5-821e-672a11fd5b51">

* Change the user prompt to generate a new image, for example: "a boat floating in the sea, with a dolphin near to it", and generate the image
* Confirm you get another image back
* Confirm you see the upgrade prompt on the UI, and it's now based on the notice component, as designed on h2dd8EQsaVoiTlLBwkoEgL-fi-4590_209
* Confirm the user prompt and generate button are disabled

<img width="500" alt="Screenshot 2024-05-03 at 16 00 14" src="https://github.com/Automattic/jetpack/assets/6760046/9f715ebc-eada-4730-a370-739a409d1f26">

* Confirm you can click on the upgrade link and follow the upgrade path

---

Notes:

- the error state when there is no content is not friendly, and the button saying "Try again" is not the best label in this case; we want to follow up on this as soon as possible to make it more friendly, but it's a separated issue