### PR TITLE
AI Plugin: Sync content across Settings and Jetpack sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-plugin-sidebar
+++ b/projects/plugins/jetpack/changelog/update-ai-plugin-sidebar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Sync ai plugin content across settings and jetpack sidebar

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -3,10 +3,9 @@
  */
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { Button, PanelBody, PanelRow, BaseControl } from '@wordpress/components';
+import { PanelBody, PanelRow, BaseControl } from '@wordpress/components';
 import { PluginPrePublishPanel, PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { createInterpolateElement, useCallback } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import React from 'react';
 /**
@@ -15,12 +14,18 @@ import React from 'react';
 import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout';
 import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
-import { TierProp } from '../../../../store/wordpress-com/types';
-import FeaturedImage, { FEATURED_IMAGE_PLACEMENT_JETPACK_SIDEBAR } from '../featured-image';
+import FeaturedImage from '../featured-image';
 import Proofread from '../proofread';
 import TitleOptimization from '../title-optimization';
 import UsagePanel from '../usage-panel';
-import { USAGE_PANEL_PLACEMENT_JETPACK_SIDEBAR } from '../usage-panel/types';
+import {
+	JetpackSettingsContentProps,
+	PLACEMENT_DOCUMENT_SETTINGS,
+	PLACEMENT_JETPACK_SIDEBAR,
+	PLACEMENT_PRE_PUBLISH,
+} from './types';
+import Upgrade from './upgrade';
+
 import './style.scss';
 
 const debug = debugFactory( 'jetpack-ai-assistant-plugin:sidebar' );
@@ -37,62 +42,54 @@ const isAITitleOptimizationAvailable =
 	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'ai-title-optimization' ]?.available ||
 	false;
 
-const Upgrade = ( {
-	onClick,
-	type,
-	placement = '',
-	currentTier,
-}: {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	onClick: ( event: any ) => void;
-	type: string;
-	placement?: string;
-	currentTier?: TierProp;
-} ) => {
-	const { tracks } = useAnalytics();
+const JetpackAndSettingsContent = ( {
+	placement,
+	requireUpgrade,
+	upgradeType,
+}: JetpackSettingsContentProps ) => {
+	const { autosaveAndRedirect, isRedirecting } = useAICheckout();
 
-	const handleClick = useCallback(
-		evt => {
-			tracks.recordEvent( 'jetpack_ai_upgrade_button', { placement } );
-			onClick?.( evt );
-		},
-		[ onClick, tracks, placement ]
+	return (
+		<>
+			{ isAITitleOptimizationAvailable && (
+				<PanelRow className="jetpack-ai-title-optimization__header">
+					<BaseControl label={ __( 'Optimize Publishing', 'jetpack' ) }>
+						<TitleOptimization
+							placement={ placement }
+							busy={ isRedirecting }
+							disabled={ requireUpgrade }
+						/>
+					</BaseControl>
+				</PanelRow>
+			) }
+			<PanelRow className="jetpack-ai-proofread-control__header">
+				<BaseControl label={ __( 'AI feedback on post', 'jetpack' ) }>
+					<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
+				</BaseControl>
+			</PanelRow>
+			{ isAIFeaturedImageAvailable && (
+				<PanelRow className="jetpack-ai-featured-image-control__header">
+					<BaseControl label={ __( 'AI Featured Image', 'jetpack' ) }>
+						<FeaturedImage
+							busy={ isRedirecting }
+							disabled={ requireUpgrade }
+							placement={ placement }
+						/>
+					</BaseControl>
+				</PanelRow>
+			) }
+			{ requireUpgrade && ! isUsagePanelAvailable && (
+				<PanelRow>
+					<Upgrade placement={ placement } onClick={ autosaveAndRedirect } type={ upgradeType } />
+				</PanelRow>
+			) }
+			{ isUsagePanelAvailable && (
+				<PanelRow>
+					<UsagePanel placement={ placement } />
+				</PanelRow>
+			) }
+		</>
 	);
-
-	const requestLimit = currentTier?.value && currentTier?.value !== 1 ? currentTier.limit : 20;
-
-	const freeLimitUpgradePrompt = __(
-		'You have reached the limit of <strong>20 free</strong> requests. <button>Upgrade to continue generating feedback.</button>',
-		'jetpack'
-	);
-	const tierLimitUpgradePrompt = sprintf(
-		/* translators: number is the request limit for the current tier/plan */
-		__(
-			'You have reached the limit of <strong>%d requests</strong>. <button>Upgrade to continue generating feedback.</button>',
-			'jetpack'
-		),
-		requestLimit
-	);
-
-	const messageForVip = createInterpolateElement(
-		__(
-			"You've reached the Jetpack AI rate limit. <strong>Please reach out to your VIP account team.</strong>",
-			'jetpack'
-		),
-		{
-			strong: <strong />,
-		}
-	);
-
-	const defaultUpgradeMessage = createInterpolateElement(
-		requestLimit === 20 ? freeLimitUpgradePrompt : tierLimitUpgradePrompt,
-		{
-			strong: <strong />,
-			button: <Button variant="link" onClick={ handleClick } />,
-		}
-	);
-
-	return <p>{ type === 'vip' ? messageForVip : defaultUpgradeMessage }</p>;
 };
 
 export default function AiAssistantPluginSidebar() {
@@ -114,52 +111,28 @@ export default function AiAssistantPluginSidebar() {
 					title={ title }
 					initialOpen={ false }
 					onToggle={ isOpen => {
-						isOpen && panelToggleTracker( 'jetpack-sidebar' );
+						isOpen && panelToggleTracker( PLACEMENT_JETPACK_SIDEBAR );
 					} }
 				>
-					{ isAITitleOptimizationAvailable && (
-						<PanelRow className="jetpack-ai-title-optimization__header">
-							<BaseControl label={ __( 'Optimize Publishing', 'jetpack' ) }>
-								<TitleOptimization
-									placement="jetpack-sidebar"
-									busy={ isRedirecting }
-									disabled={ requireUpgrade }
-								/>
-							</BaseControl>
-						</PanelRow>
-					) }
-					<PanelRow className="jetpack-ai-proofread-control__header">
-						<BaseControl label={ __( 'AI feedback on post', 'jetpack' ) }>
-							<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
-						</BaseControl>
-					</PanelRow>
-					{ isAIFeaturedImageAvailable && (
-						<PanelRow className="jetpack-ai-featured-image-control__header">
-							<BaseControl label={ __( 'AI Featured Image', 'jetpack' ) }>
-								<FeaturedImage
-									busy={ isRedirecting }
-									disabled={ requireUpgrade }
-									placement={ FEATURED_IMAGE_PLACEMENT_JETPACK_SIDEBAR }
-								/>
-							</BaseControl>
-						</PanelRow>
-					) }
-					{ requireUpgrade && ! isUsagePanelAvailable && (
-						<PanelRow>
-							<Upgrade
-								placement="jetpack-sidebar"
-								onClick={ autosaveAndRedirect }
-								type={ upgradeType }
-							/>
-						</PanelRow>
-					) }
-					{ isUsagePanelAvailable && (
-						<PanelRow>
-							<UsagePanel placement={ USAGE_PANEL_PLACEMENT_JETPACK_SIDEBAR } />
-						</PanelRow>
-					) }
+					<JetpackAndSettingsContent
+						placement={ PLACEMENT_JETPACK_SIDEBAR }
+						requireUpgrade={ requireUpgrade }
+						upgradeType={ upgradeType }
+					/>
 				</PanelBody>
 			</JetpackPluginSidebar>
+
+			<PluginDocumentSettingPanel
+				icon={ <JetpackEditorPanelLogo /> }
+				title={ title }
+				name="jetpack-ai-assistant"
+			>
+				<JetpackAndSettingsContent
+					placement={ PLACEMENT_DOCUMENT_SETTINGS }
+					requireUpgrade={ requireUpgrade }
+					upgradeType={ upgradeType }
+				/>
+			</PluginDocumentSettingPanel>
 
 			<PluginPrePublishPanel
 				title={ title }
@@ -169,7 +142,7 @@ export default function AiAssistantPluginSidebar() {
 				<>
 					{ isAITitleOptimizationAvailable && (
 						<TitleOptimization
-							placement="pre-publish"
+							placement={ PLACEMENT_PRE_PUBLISH }
 							busy={ isRedirecting }
 							disabled={ requireUpgrade }
 						/>
@@ -177,7 +150,7 @@ export default function AiAssistantPluginSidebar() {
 					<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
 					{ requireUpgrade && (
 						<Upgrade
-							placement="pre-publish"
+							placement={ PLACEMENT_PRE_PUBLISH }
 							onClick={ autosaveAndRedirect }
 							type={ upgradeType }
 							currentTier={ currentTier }
@@ -185,41 +158,6 @@ export default function AiAssistantPluginSidebar() {
 					) }
 				</>
 			</PluginPrePublishPanel>
-
-			<PluginDocumentSettingPanel
-				icon={ <JetpackEditorPanelLogo /> }
-				title={ title }
-				name="jetpack-ai-assistant"
-			>
-				{ isAITitleOptimizationAvailable && (
-					<PanelRow className="jetpack-ai-title-optimization__header">
-						<BaseControl label={ __( 'Optimize Publishing', 'jetpack' ) }>
-							<TitleOptimization
-								placement="document-setting"
-								busy={ isRedirecting }
-								disabled={ requireUpgrade }
-							/>
-						</BaseControl>
-					</PanelRow>
-				) }
-
-				<PanelRow className="jetpack-ai-proofread-control__header">
-					<BaseControl label={ __( 'AI feedback on post', 'jetpack' ) }>
-						<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
-					</BaseControl>
-				</PanelRow>
-
-				{ requireUpgrade && (
-					<PanelRow>
-						<Upgrade
-							placement="document-setting"
-							onClick={ autosaveAndRedirect }
-							type={ upgradeType }
-							currentTier={ currentTier }
-						/>
-					</PanelRow>
-				) }
-			</PluginDocumentSettingPanel>
 		</>
 	);
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/types.ts
@@ -1,0 +1,9 @@
+export const PLACEMENT_JETPACK_SIDEBAR = 'jetpack-sidebar' as const;
+export const PLACEMENT_DOCUMENT_SETTINGS = 'document-settings' as const;
+export const PLACEMENT_PRE_PUBLISH = 'pre-publish' as const;
+
+export type JetpackSettingsContentProps = {
+	placement: typeof PLACEMENT_JETPACK_SIDEBAR | typeof PLACEMENT_DOCUMENT_SETTINGS;
+	requireUpgrade: boolean;
+	upgradeType: string;
+};

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/upgrade.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/upgrade.tsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { Button } from '@wordpress/components';
+import { createInterpolateElement, useCallback } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { TierProp } from '../../../../store/wordpress-com/types';
+
+export default function Upgrade( {
+	onClick,
+	type,
+	placement = '',
+	currentTier,
+}: {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	onClick: ( event: any ) => void;
+	type: string;
+	placement?: string;
+	currentTier?: TierProp;
+} ) {
+	const { tracks } = useAnalytics();
+
+	const handleClick = useCallback(
+		evt => {
+			tracks.recordEvent( 'jetpack_ai_upgrade_button', { placement } );
+			onClick?.( evt );
+		},
+		[ onClick, tracks, placement ]
+	);
+
+	const requestLimit = currentTier?.value && currentTier?.value !== 1 ? currentTier.limit : 20;
+
+	const freeLimitUpgradePrompt = __(
+		'You have reached the limit of <strong>20 free</strong> requests. <button>Upgrade to continue generating feedback.</button>',
+		'jetpack'
+	);
+	const tierLimitUpgradePrompt = sprintf(
+		/* translators: number is the request limit for the current tier/plan */
+		__(
+			'You have reached the limit of <strong>%d requests</strong>. <button>Upgrade to continue generating feedback.</button>',
+			'jetpack'
+		),
+		requestLimit
+	);
+
+	const messageForVip = createInterpolateElement(
+		__(
+			"You've reached the Jetpack AI rate limit. <strong>Please reach out to your VIP account team.</strong>",
+			'jetpack'
+		),
+		{
+			strong: <strong />,
+		}
+	);
+
+	const defaultUpgradeMessage = createInterpolateElement(
+		requestLimit === 20 ? freeLimitUpgradePrompt : tierLimitUpgradePrompt,
+		{
+			strong: <strong />,
+			button: <Button variant="link" onClick={ handleClick } />,
+		}
+	);
+
+	return <p>{ type === 'vip' ? messageForVip : defaultUpgradeMessage }</p>;
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -22,12 +22,15 @@ import {
 } from '../../../../shared/use-plan-type';
 import usePostContent from '../../hooks/use-post-content';
 import useSaveToMediaLibrary from '../../hooks/use-save-to-media-library';
+import {
+	PLACEMENT_JETPACK_SIDEBAR,
+	PLACEMENT_DOCUMENT_SETTINGS,
+} from '../ai-assistant-plugin-sidebar/types';
 import AiAssistantModal from '../modal';
 import Carrousel, { CarrouselImageData, CarrouselImages } from './carrousel';
 import UsageCounter from './usage-counter';
 
 const FEATURED_IMAGE_FEATURE_NAME = 'featured-post-image';
-export const FEATURED_IMAGE_PLACEMENT_JETPACK_SIDEBAR = 'jetpack-sidebar';
 export const FEATURED_IMAGE_PLACEMENT_MEDIA_SOURCE_DROPDOWN = 'media-source-dropdown';
 
 export default function FeaturedImage( {
@@ -332,7 +335,8 @@ export default function FeaturedImage( {
 
 	return (
 		<div>
-			{ placement === FEATURED_IMAGE_PLACEMENT_JETPACK_SIDEBAR && (
+			{ ( placement === PLACEMENT_JETPACK_SIDEBAR ||
+				placement === PLACEMENT_DOCUMENT_SETTINGS ) && (
 				<>
 					<p>{ __( 'Create and use an AI generated featured image for your post.', 'jetpack' ) }</p>
 					<Button

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/types.ts
@@ -1,14 +1,18 @@
 import { PlanType } from '../../../../shared/use-plan-type';
+import {
+	PLACEMENT_DOCUMENT_SETTINGS,
+	PLACEMENT_JETPACK_SIDEBAR,
+} from '../ai-assistant-plugin-sidebar/types';
 
-export const USAGE_PANEL_PLACEMENT_JETPACK_SIDEBAR = 'jetpack_sidebar';
-export const USAGE_PANEL_PLACEMENT_BLOCK_SETTINGS_SIDEBAR = 'block_settings_sidebar';
+export const USAGE_PANEL_PLACEMENT_BLOCK_SETTINGS_SIDEBAR = 'block_settings_sidebar' as const;
 
 /*
  * Props for the usage panel component.
  */
 export type UsagePanelProps = {
 	placement?:
-		| typeof USAGE_PANEL_PLACEMENT_JETPACK_SIDEBAR
+		| typeof PLACEMENT_JETPACK_SIDEBAR
+		| typeof PLACEMENT_DOCUMENT_SETTINGS
 		| typeof USAGE_PANEL_PLACEMENT_BLOCK_SETTINGS_SIDEBAR;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Sync the content that's used in Settings and Jetpack sidebar, to avoid future problems.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create new types for placement specific usage.
* Create new component that sync the content across Settings and Jetpack sidebar.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to your editor.
* Open `Ai Assistant` panel on Settings (Post tab) sidebar and Jetpack sidebar.
* Both should have the same content.

