### PR TITLE
Scheduled Updates: Allow custom rest fields to register validation/sanitization callbacks.

### DIFF
--- a/projects/packages/scheduled-updates/changelog/use-fields-api
+++ b/projects/packages/scheduled-updates/changelog/use-fields-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switched endpoint args to be built from a schema and switched active field to use register_rest_field as an example for future changes.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-active.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-active.php
@@ -71,15 +71,25 @@ class Scheduled_Updates_Active {
 	}
 
 	/**
-	 * REST prepare_item_for_response filter.
-	 *
-	 * @param array            $item    WP Cron event.
-	 * @param \WP_REST_Request $request Request object.
-	 * @return array Response array on success.
+	 * Registers the active field for the update-schedule REST API.
 	 */
-	public static function response_filter( $item, $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$item['active'] = self::get( $item['schedule_id'] );
-
-		return $item;
+	public static function add_active_field() {
+		register_rest_field(
+			'update-schedule',
+			'active',
+			array(
+				/**
+				 * Populates the active field.
+				 *
+				 * @param array $item Prepared response array.
+				 * @return bool
+				 */
+				'get_callback' => fn ( $item ) => self::get( $item['schedule_id'] ),
+				'schema'       => array(
+					'description' => 'Whether the schedule is active or paused.',
+					'type'        => 'boolean',
+				),
+			)
+		);
 	}
 }

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-active.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-active.php
@@ -84,7 +84,9 @@ class Scheduled_Updates_Active {
 				 * @param array $item Prepared response array.
 				 * @return bool
 				 */
-				'get_callback' => fn ( $item ) => self::get( $item['schedule_id'] ),
+				'get_callback' => function ( $item ) {
+					return self::get( $item['schedule_id'] );
+				},
 				'schema'       => array(
 					'description' => 'Whether the schedule is active or paused.',
 					'type'        => 'boolean',

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -49,9 +49,11 @@ class Scheduled_Updates {
 		}
 
 		add_action( self::PLUGIN_CRON_HOOK, array( __CLASS__, 'run_scheduled_update' ), 10, 10 );
-		add_action( 'rest_api_init', array( __CLASS__, 'add_is_managed_extension_field' ) );
 		add_filter( 'auto_update_plugin', array( __CLASS__, 'allowlist_scheduled_plugins' ), 10, 2 );
 		add_action( 'deleted_plugin', array( __CLASS__, 'deleted_plugin' ), 10, 2 );
+
+		add_action( 'rest_api_init', array( __CLASS__, 'add_is_managed_extension_field' ) );
+		add_action( 'rest_api_init', array( Scheduled_Updates_Active::class, 'add_active_field' ) );
 
 		add_filter( 'plugins_list', array( Scheduled_Updates_Admin::class, 'add_scheduled_updates_context' ) );
 		add_filter( 'views_plugins', array( Scheduled_Updates_Admin::class, 'add_scheduled_updates_view' ) );
@@ -68,7 +70,6 @@ class Scheduled_Updates {
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'delete_logs_schedule_id' ), 10, 3 );
 
 		add_filter( 'jetpack_scheduled_response_item', array( __CLASS__, 'response_filter' ), 10, 2 );
-		add_filter( 'jetpack_scheduled_response_item', array( Scheduled_Updates_Active::class, 'response_filter' ), 10, 2 );
 		add_filter( 'jetpack_scheduled_response_item', array( Scheduled_Updates_Health_Paths::class, 'response_filter' ), 10, 2 );
 
 		// Update cron sync option after options update.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -8,7 +8,6 @@
  */
 
 use Automattic\Jetpack\Scheduled_Updates;
-use Automattic\Jetpack\Scheduled_Updates_Health_Paths;
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Update_Schedules
@@ -60,7 +59,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_item' ),
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
-					'args'                => $this->get_object_params(),
+					'args'                => $this->get_object_params( WP_REST_Server::CREATABLE ),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
@@ -95,7 +94,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 								'required'    => true,
 							),
 						),
-						$this->get_object_params()
+						$this->get_object_params( WP_REST_Server::EDITABLE )
 					),
 				),
 				array(
@@ -195,6 +194,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		 * @param WP_REST_Request $request The request object.
 		 */
 		do_action( 'jetpack_scheduled_update_created', $id, $event, $request );
+
+		$event              = wp_get_scheduled_event( Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins, $schedule['timestamp'] );
+		$event->schedule_id = $id;
+		$this->update_additional_fields_for_object( $event, $request );
 
 		return rest_ensure_response( $id );
 	}
@@ -376,46 +379,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	}
 
 	/**
-	 * Checks that the "plugins" parameter is a valid path.
-	 *
-	 * @param array $plugins List of plugins to update.
-	 * @return bool|WP_Error
-	 */
-	public function validate_plugins_param( $plugins ) {
-		$schema            = array(
-			'items'    => array( 'type' => 'string' ),
-			'maxItems' => 10,
-		);
-		$validated_plugins = rest_validate_array_value_from_schema( $plugins, $schema, 'plugins' );
-		if ( is_wp_error( $validated_plugins ) ) {
-			return $validated_plugins;
-		}
-
-		foreach ( $plugins as $plugin ) {
-			if ( ! $this->validate_plugin_param( $plugin ) ) {
-				return new WP_Error(
-					'rest_invalid_plugin',
-					/* translators: %s: plugin file */
-					sprintf( __( 'The plugin "%s" is not a valid plugin file.', 'jetpack-scheduled-updates' ), $plugin ),
-					array( 'status' => 400 )
-				);
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Sanitizes the plugin slugs contained in the "plugins" parameter.
-	 *
-	 * @param array $plugins List of plugins to update.
-	 * @return array
-	 */
-	public function sanitize_plugins_param( $plugins ) {
-		return array_map( array( $this, 'sanitize_plugin_param' ), $plugins );
-	}
-
-	/**
 	 * Checks that the "plugin" parameter is a valid path.
 	 *
 	 * @param string $file The plugin file parameter.
@@ -452,26 +415,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	public function validate_themes_param( $themes ) {
 		if ( ! empty( $themes ) ) {
 			return new WP_Error( 'rest_forbidden', __( 'Sorry, you can not schedule theme updates at this time.', 'jetpack-scheduled-updates' ), array( 'status' => 403 ) );
-		}
-
-		return true;
-	}
-
-	/**
-	 * Checks that the "paths" parameter is a valid array of paths.
-	 *
-	 * @param array $paths List of paths to check.
-	 * @return bool|WP_Error
-	 */
-	public function validate_paths_param( $paths ) {
-		foreach ( $paths as $path ) {
-			$valid = Scheduled_Updates_Health_Paths::validate( $path );
-
-			if ( is_wp_error( $valid ) ) {
-				$valid->add_data( array( 'status' => 400 ) );
-
-				return $valid;
-			}
 		}
 
 		return true;
@@ -559,10 +502,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'description' => 'Whether the schedule is active.',
 					'type'        => 'boolean',
 				),
-				'health_check_paths' => array(
-					'description' => 'Paths to check for site health.',
-					'type'        => 'array',
-				),
 			),
 		);
 
@@ -574,51 +513,54 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	/**
 	 * Retrieves the query params for scheduled updates.
 	 *
+	 * @param string $method HTTP method of the request.
+	 *                       The arguments for `CREATABLE` requests are checked for required values and may fall back to
+	 *                       a given default. This is not done on `EDITABLE` requests.
 	 * @return array[] Array of query parameters.
 	 */
-	public function get_object_params() {
-		return array(
-			'plugins'  => array(
-				'description'       => 'List of plugin slugs to update.',
-				'type'              => 'array',
-				'validate_callback' => array( $this, 'validate_plugins_param' ),
-				'sanitize_callback' => array( $this, 'sanitize_plugins_param' ),
-			),
-			'themes'   => array(
-				'description'       => 'List of theme slugs to update.',
-				'type'              => 'array',
-				'required'          => false,
-				'validate_callback' => array( $this, 'validate_themes_param' ),
-			),
-			'schedule' => array(
-				'description' => 'Update schedule.',
-				'type'        => 'object',
-				'required'    => true,
-				'properties'  => array(
-					'interval'           => array(
-						'description' => 'Interval for the schedule.',
+	public function get_object_params( $method ) {
+		$endpoint_args = array(
+			'title'      => 'update-schedule',
+			'properties' => array(
+				'plugins'  => array(
+					'description' => 'List of plugin slugs to update.',
+					'type'        => 'array',
+					'maxItems'    => 10,
+					'items'       => array(
 						'type'        => 'string',
-						'enum'        => array( 'daily', 'weekly' ),
-						'required'    => true,
-					),
-					'timestamp'          => array(
-						'description' => 'Unix timestamp (UTC) for when to first run the schedule.',
-						'type'        => 'integer',
-						'required'    => true,
-					),
-					'health_check_paths' => array(
-						'description'       => 'List of paths to check for site health after the update.',
-						'type'              => 'array',
-						'maxItems'          => 5,
-						'items'             => array(
-							'type' => 'string',
+						'arg_options' => array(
+							'validate_callback' => array( $this, 'validate_plugin_param' ),
+							'sanitize_callback' => array( $this, 'sanitize_plugin_param' ),
 						),
-						'required'          => false,
-						'default'           => array(),
-						'validate_callback' => array( $this, 'validate_paths_param' ),
+					),
+				),
+				'themes'   => array(
+					'description'       => 'List of theme slugs to update.',
+					'type'              => 'array',
+					'required'          => false,
+					'validate_callback' => array( $this, 'validate_themes_param' ),
+				),
+				'schedule' => array(
+					'description' => 'Update schedule.',
+					'type'        => 'object',
+					'required'    => true,
+					'properties'  => array(
+						'interval'  => array(
+							'description' => 'Interval for the schedule.',
+							'type'        => 'string',
+							'enum'        => array( 'daily', 'weekly' ),
+							'required'    => true,
+						),
+						'timestamp' => array(
+							'description' => 'Unix timestamp (UTC) for when to first run the schedule.',
+							'type'        => 'integer',
+							'required'    => true,
+						),
 					),
 				),
 			),
 		);
+
+		return rest_get_endpoint_args_for_schema( $this->add_additional_fields_schema( $endpoint_args ), $method );
 	}
 }

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -8,6 +8,7 @@
  */
 
 use Automattic\Jetpack\Scheduled_Updates;
+use Automattic\Jetpack\Scheduled_Updates_Health_Paths;
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Update_Schedules
@@ -541,16 +542,26 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'type'        => 'object',
 					'required'    => true,
 					'properties'  => array(
-						'interval'  => array(
+						'interval'           => array(
 							'description' => 'Interval for the schedule.',
 							'type'        => 'string',
 							'enum'        => array( 'daily', 'weekly' ),
 							'required'    => true,
 						),
-						'timestamp' => array(
+						'timestamp'          => array(
 							'description' => 'Unix timestamp (UTC) for when to first run the schedule.',
 							'type'        => 'integer',
 							'required'    => true,
+						),
+						'health_check_paths' => array(
+							'description' => 'Paths to check for site health.',
+							'type'        => 'array',
+							'items'       => array(
+								'type'        => 'string',
+								'arg_options' => array(
+									'validate_callback' => array( Scheduled_Updates_Health_Paths::class, 'validate' ),
+								),
+							),
 						),
 					),
 				),

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -498,10 +498,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'type'        => 'string',
 					'enum'        => array( 'success', 'failure-and-rollback', 'failure-and-rollback-fail' ),
 				),
-				'active'             => array(
-					'description' => 'Whether the schedule is active.',
-					'type'        => 'boolean',
-				),
 			),
 		);
 

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -499,6 +499,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'type'        => 'string',
 					'enum'        => array( 'success', 'failure-and-rollback', 'failure-and-rollback-fail' ),
 				),
+				'health_check_paths' => array(
+					'description' => 'Paths to check for site health.',
+					'type'        => 'array',
+				),
 			),
 		);
 
@@ -554,8 +558,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 							'required'    => true,
 						),
 						'health_check_paths' => array(
-							'description' => 'Paths to check for site health.',
+							'description' => 'List of paths to check for site health after the update.',
 							'type'        => 'array',
+							'maxItems'    => 5,
 							'items'       => array(
 								'type'        => 'string',
 								'arg_options' => array(

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
@@ -185,6 +185,31 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test create item with too many paths.
+	 *
+	 * @covers WPCOM_REST_API_V2_Endpoint_Update_Schedules::create_item
+	 */
+	public function test_create_item_with_too_many_paths() {
+		$plugins = array( 'gutenberg/gutenberg.php' );
+		$paths   = array_fill( 0, 6, '/a' );
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params(
+			array(
+				'plugins'  => $plugins,
+				'schedule' => array(
+					'timestamp'          => strtotime( 'next Monday 8:00' ),
+					'interval'           => 'weekly',
+					'health_check_paths' => $paths,
+				),
+			)
+		);
+		$result = rest_do_request( $request )->get_data();
+
+		$this->assertSame( 'rest_invalid_param', $result['code'] );
+		$this->assertSame( 400, $result['data']['status'] );
+	}
+
+	/**
 	 * Test remove item with paths.
 	 *
 	 * @covers WPCOM_REST_API_V2_Endpoint_Update_Schedules::create_item


### PR DESCRIPTION
By deriving endpoint args from a schema syntax, any custom rest field that defines a schema will have its parameters added to the object args. This will allow us to move the health_check_path field to a rest_field in the future.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Switch endpoint args to be built from an internal schema.
* Move `active` field to be added through `register_rest_field()`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Unit tests should be enough, there shouldn't be any functional changes.

For manual testing, checkout the branch on a test site and create/delete schedules. Make sure there are no errors returned and the `active` field returns `true`.

