### PR TITLE
Scheduled Updates: Move log fields to using rest fields.

### DIFF
--- a/projects/packages/scheduled-updates/changelog/update-logs-fields
+++ b/projects/packages/scheduled-updates/changelog/update-logs-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Moved last_run_status and last_run_timestamp data to using rest fields

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-logs.php
@@ -246,6 +246,56 @@ class Scheduled_Updates_Logs {
 	}
 
 	/**
+	 * Registers the last_run_timestamp field for the update-schedule REST API.
+	 */
+	public static function add_log_fields() {
+		register_rest_field(
+			'update-schedule',
+			'last_run_timestamp',
+			array(
+				/**
+				 * Populates the last_run_timestamp field.
+				 *
+				 * @param array $item Prepared response array.
+				 * @return int|null
+				 */
+				'get_callback' => function ( $item ) {
+					$status = static::infer_status_from_logs( $item['schedule_id'] );
+
+					return $status['last_run_timestamp'] ?? null;
+				},
+				'schema'       => array(
+					'description' => 'Unix timestamp (UTC) for when the last run occurred.',
+					'type'        => 'integer',
+				),
+			)
+		);
+
+		register_rest_field(
+			'update-schedule',
+			'last_run_status',
+			array(
+				/**
+				 * Populates the last_run_status field.
+				 *
+				 * @param array $item Prepared response array.
+				 * @return string|null
+				 */
+				'get_callback' => function ( $item ) {
+					$status = static::infer_status_from_logs( $item['schedule_id'] );
+
+					return $status['last_run_status'] ?? null;
+				},
+				'schema'       => array(
+					'description' => 'Status of last run.',
+					'type'        => 'string',
+					'enum'        => array( 'success', 'failure-and-rollback', 'failure-and-rollback-fail' ),
+				),
+			)
+		);
+	}
+
+	/**
 	 * Splits the logs into runs based on the PLUGIN_UPDATES_START action.
 	 *
 	 * @param array $logs The logs to split into runs.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -53,6 +53,7 @@ class Scheduled_Updates {
 		add_action( 'deleted_plugin', array( __CLASS__, 'deleted_plugin' ), 10, 2 );
 
 		add_action( 'rest_api_init', array( __CLASS__, 'add_is_managed_extension_field' ) );
+		add_action( 'rest_api_init', array( Scheduled_Updates_Logs::class, 'add_log_fields' ) );
 		add_action( 'rest_api_init', array( Scheduled_Updates_Active::class, 'add_active_field' ) );
 
 		add_filter( 'plugins_list', array( Scheduled_Updates_Admin::class, 'add_scheduled_updates_context' ) );
@@ -69,7 +70,6 @@ class Scheduled_Updates {
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Health_Paths::class, 'clear' ) );
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'delete_logs_schedule_id' ), 10, 3 );
 
-		add_filter( 'jetpack_scheduled_response_item', array( __CLASS__, 'response_filter' ), 10, 2 );
 		add_filter( 'jetpack_scheduled_response_item', array( Scheduled_Updates_Health_Paths::class, 'response_filter' ), 10, 2 );
 
 		// Update cron sync option after options update.
@@ -421,28 +421,6 @@ class Scheduled_Updates {
 				Scheduled_Updates_Logs::replace_logs_schedule_id( $id, $schedule_id );
 			}
 		}
-	}
-
-	/**
-	 * REST prepare_item_for_response filter.
-	 *
-	 * @param array            $item    WP Cron event.
-	 * @param \WP_REST_Request $request Request object.
-	 * @return array Response array on success.
-	 */
-	public static function response_filter( $item, $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$status = self::get_scheduled_update_status( $item['schedule_id'] );
-
-		if ( ! $status ) {
-			$status = array(
-				'last_run_timestamp' => null,
-				'last_run_status'    => null,
-			);
-		}
-
-		$item = array_merge( $item, $status );
-
-		return $item;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -490,15 +490,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'description' => 'The interval time in seconds for the schedule.',
 					'type'        => 'integer',
 				),
-				'last_run_timestamp' => array(
-					'description' => 'Unix timestamp (UTC) for when the last run occurred.',
-					'type'        => 'integer',
-				),
-				'last_run_status'    => array(
-					'description' => 'Status of last run.',
-					'type'        => 'string',
-					'enum'        => array( 'success', 'failure-and-rollback', 'failure-and-rollback-fail' ),
-				),
 				'health_check_paths' => array(
 					'description' => 'Paths to check for site health.',
 					'type'        => 'array',

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -136,7 +136,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			// Add the schedule_id to the object.
 			$event->schedule_id = $schedule_id;
 
-			// Run through the prepare_item_for_response method to add the last run status.
+			// Run through the prepare_item_for_response method to add any registered rest fields.
 			$response[ $schedule_id ] = $this->prepare_response_for_collection(
 				$this->prepare_item_for_response( $event, $request )
 			);


### PR DESCRIPTION
Needs to wait until  #37221 is in.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves last_run_status and last_run_timestamp data to using rest fields

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Ideally, unit tests should cover this diff. There shouldn't be any functional changes.

