### PR TITLE
Scheduled Updates: Move health_check_paths to using rest fields

### DIFF
--- a/projects/packages/scheduled-updates/changelog/update-health-check-paths
+++ b/projects/packages/scheduled-updates/changelog/update-health-check-paths
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Scheduled Update: Moved health_check_paths to using rest field and as a result changed where in the API response the field gets returned

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
@@ -84,7 +84,7 @@ class Scheduled_Updates_Health_Paths {
 	/**
 	 * Validate a path.
 	 *
-	 * @param string $path An health path.
+	 * @param string $path Path to validate.
 	 * @return string|WP_Error
 	 */
 	public static function validate( $path ) {
@@ -137,29 +137,45 @@ class Scheduled_Updates_Health_Paths {
 	}
 
 	/**
-	 * Update the health check paths for a scheduled update hook.
-	 *
-	 * @param string           $id      The ID of the schedule.
-	 * @param object           $event   The event object.
-	 * @param \WP_REST_Request $request The request object.
-	 * @return bool
+	 * Registers the health_check_paths field for the update-schedule REST API.
 	 */
-	public static function updates_health_paths( $id, $event, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$schedule = $request['schedule'];
-		$paths    = $schedule['health_check_paths'] ?? array();
-		return self::update( $id, $paths );
-	}
+	public static function add_health_check_paths_field() {
+		register_rest_field(
+			'update-schedule',
+			'health_check_paths',
+			array(
+				/**
+				 * Populates the health_check_paths field.
+				 *
+				 * @param array $item Prepared response array.
+				 * @return bool
+				 */
+				'get_callback'    => function ( $item ) {
+					return static::get( $item['schedule_id'] );
+				},
 
-	/**
-	 * REST prepare_item_for_response filter.
-	 *
-	 * @param array            $item    WP Cron event.
-	 * @param \WP_REST_Request $request Request object.
-	 * @return array Response array on success.
-	 */
-	public static function response_filter( $item, $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$item['health_check_paths'] = self::get( $item['schedule_id'] );
-
-		return $item;
+				/**
+				 * Updates the health_check_paths field.
+				 *
+				 * @param array  $paths List of health check paths.
+				 * @param object $event Event object.
+				 * @return bool
+				 */
+				'update_callback' => function ( $paths, $event ) {
+					return static::update( $event->schedule_id, $paths );
+				},
+				'schema'          => array(
+					'description' => 'List of paths to check for site health after the update.',
+					'type'        => 'array',
+					'maxItems'    => 5,
+					'items'       => array(
+						'type'        => 'string',
+						'arg_options' => array(
+							'validate_callback' => array( __CLASS__, 'validate' ),
+						),
+					),
+				),
+			)
+		);
 	}
 }

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates-health-paths.php
@@ -148,7 +148,7 @@ class Scheduled_Updates_Health_Paths {
 				 * Populates the health_check_paths field.
 				 *
 				 * @param array $item Prepared response array.
-				 * @return bool
+				 * @return array List of health check paths.
 				 */
 				'get_callback'    => function ( $item ) {
 					return static::get( $item['schedule_id'] );

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -53,15 +53,15 @@ class Scheduled_Updates {
 		add_action( 'deleted_plugin', array( __CLASS__, 'deleted_plugin' ), 10, 2 );
 
 		add_action( 'rest_api_init', array( __CLASS__, 'add_is_managed_extension_field' ) );
-		add_action( 'rest_api_init', array( Scheduled_Updates_Logs::class, 'add_log_fields' ) );
-		add_action( 'rest_api_init', array( Scheduled_Updates_Active::class, 'add_active_field' ) );
+		add_action( 'rest_api_init', array( Scheduled_Updates_Logs::class, 'add_log_fields' ), 9 );
+		add_action( 'rest_api_init', array( Scheduled_Updates_Active::class, 'add_active_field' ), 9 );
+		add_action( 'rest_api_init', array( Scheduled_Updates_Health_Paths::class, 'add_health_check_paths_field' ), 9 );
 
 		add_filter( 'plugins_list', array( Scheduled_Updates_Admin::class, 'add_scheduled_updates_context' ) );
 		add_filter( 'views_plugins', array( Scheduled_Updates_Admin::class, 'add_scheduled_updates_view' ) );
 		add_filter( 'plugin_auto_update_setting_html', array( Scheduled_Updates_Admin::class, 'show_scheduled_updates' ), 10, 2 );
 
 		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'maybe_disable_autoupdates' ), 10, 3 );
-		add_action( 'jetpack_scheduled_update_created', array( Scheduled_Updates_Health_Paths::class, 'updates_health_paths' ), 10, 3 );
 
 		add_action( 'jetpack_scheduled_update_updated', array( Scheduled_Updates_Logs::class, 'replace_logs_schedule_id' ), 10, 2 );
 
@@ -69,8 +69,6 @@ class Scheduled_Updates {
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Active::class, 'clear' ) );
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Health_Paths::class, 'clear' ) );
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'delete_logs_schedule_id' ), 10, 3 );
-
-		add_filter( 'jetpack_scheduled_response_item', array( Scheduled_Updates_Health_Paths::class, 'response_filter' ), 10, 2 );
 
 		// Update cron sync option after options update.
 		$callback = array( __CLASS__, 'update_option_cron' );

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -53,9 +53,9 @@ class Scheduled_Updates {
 		add_action( 'deleted_plugin', array( __CLASS__, 'deleted_plugin' ), 10, 2 );
 
 		add_action( 'rest_api_init', array( __CLASS__, 'add_is_managed_extension_field' ) );
-		add_action( 'rest_api_init', array( Scheduled_Updates_Logs::class, 'add_log_fields' ), 9 );
-		add_action( 'rest_api_init', array( Scheduled_Updates_Active::class, 'add_active_field' ), 9 );
-		add_action( 'rest_api_init', array( Scheduled_Updates_Health_Paths::class, 'add_health_check_paths_field' ), 9 );
+		add_action( 'rest_api_init', array( Scheduled_Updates_Logs::class, 'add_log_fields' ) );
+		add_action( 'rest_api_init', array( Scheduled_Updates_Active::class, 'add_active_field' ) );
+		add_action( 'rest_api_init', array( Scheduled_Updates_Health_Paths::class, 'add_health_check_paths_field' ) );
 
 		add_filter( 'plugins_list', array( Scheduled_Updates_Admin::class, 'add_scheduled_updates_context' ) );
 		add_filter( 'views_plugins', array( Scheduled_Updates_Admin::class, 'add_scheduled_updates_view' ) );

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules-active.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules-active.php
@@ -32,8 +32,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active extends WP_REST_Control
 	 * WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active constructor.
 	 */
 	public function __construct() {
-		// Priority 9 to run before the main endpoint and avoid "/active" being treated as a schedule ID.
-		add_action( 'rest_api_init', array( $this, 'register_routes' ), 9 );
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules-capabilities.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules-capabilities.php
@@ -33,8 +33,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Capabilities extends WP_REST_C
 	 * WPCOM_REST_API_V2_Endpoint_Update_Schedules_Capabilities constructor.
 	 */
 	public function __construct() {
-		// Priority 9 to run before the main endpoint and avoid "/capabilities" being treated as a schedule ID.
-		add_action( 'rest_api_init', array( $this, 'register_routes' ), 9 );
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -38,7 +38,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	 * WPCOM_REST_API_V2_Endpoint_Atomic_Hosting_Update_Schedule constructor.
 	 */
 	public function __construct() {
-		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+		// Priority 11 to make it easier for rest field schemas to make it into get_object_params().
+		add_action( 'rest_api_init', array( $this, 'register_routes' ), 11 );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -8,7 +8,6 @@
  */
 
 use Automattic\Jetpack\Scheduled_Updates;
-use Automattic\Jetpack\Scheduled_Updates_Health_Paths;
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Update_Schedules
@@ -490,10 +489,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'description' => 'The interval time in seconds for the schedule.',
 					'type'        => 'integer',
 				),
-				'health_check_paths' => array(
-					'description' => 'Paths to check for site health.',
-					'type'        => 'array',
-				),
 			),
 		);
 
@@ -537,27 +532,16 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'type'        => 'object',
 					'required'    => true,
 					'properties'  => array(
-						'interval'           => array(
+						'interval'  => array(
 							'description' => 'Interval for the schedule.',
 							'type'        => 'string',
 							'enum'        => array( 'daily', 'weekly' ),
 							'required'    => true,
 						),
-						'timestamp'          => array(
+						'timestamp' => array(
 							'description' => 'Unix timestamp (UTC) for when to first run the schedule.',
 							'type'        => 'integer',
 							'required'    => true,
-						),
-						'health_check_paths' => array(
-							'description' => 'List of paths to check for site health after the update.',
-							'type'        => 'array',
-							'maxItems'    => 5,
-							'items'       => array(
-								'type'        => 'string',
-								'arg_options' => array(
-									'validate_callback' => array( Scheduled_Updates_Health_Paths::class, 'validate' ),
-								),
-							),
 						),
 					),
 				),

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -545,8 +545,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 							'required'    => true,
 						),
 						'health_check_paths' => array(
-							'description' => 'Paths to check for site health.',
+							'description' => 'List of paths to check for site health after the update.',
 							'type'        => 'array',
+							'maxItems'    => 5,
 							'items'       => array(
 								'type'        => 'string',
 								'arg_options' => array(

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -466,26 +466,26 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			'title'      => 'update-schedule',
 			'type'       => 'object',
 			'properties' => array(
-				'hook'               => array(
+				'hook'      => array(
 					'description' => 'The hook name.',
 					'type'        => 'string',
 					'readonly'    => true,
 				),
-				'timestamp'          => array(
+				'timestamp' => array(
 					'description' => 'Unix timestamp (UTC) for when to next run the event.',
 					'type'        => 'integer',
 					'readonly'    => true,
 				),
-				'schedule'           => array(
+				'schedule'  => array(
 					'description' => 'How often the event should subsequently recur.',
 					'type'        => 'string',
 					'enum'        => array( 'daily', 'weekly' ),
 				),
-				'args'               => array(
+				'args'      => array(
 					'description' => 'The plugins to be updated on this schedule.',
 					'type'        => 'array',
 				),
-				'interval'           => array(
+				'interval'  => array(
 					'description' => 'The interval time in seconds for the schedule.',
 					'type'        => 'integer',
 				),

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -8,6 +8,7 @@
  */
 
 use Automattic\Jetpack\Scheduled_Updates;
+use Automattic\Jetpack\Scheduled_Updates_Health_Paths;
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Update_Schedules
@@ -532,16 +533,26 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'type'        => 'object',
 					'required'    => true,
 					'properties'  => array(
-						'interval'  => array(
+						'interval'           => array(
 							'description' => 'Interval for the schedule.',
 							'type'        => 'string',
 							'enum'        => array( 'daily', 'weekly' ),
 							'required'    => true,
 						),
-						'timestamp' => array(
+						'timestamp'          => array(
 							'description' => 'Unix timestamp (UTC) for when to first run the schedule.',
 							'type'        => 'integer',
 							'required'    => true,
+						),
+						'health_check_paths' => array(
+							'description' => 'Paths to check for site health.',
+							'type'        => 'array',
+							'items'       => array(
+								'type'        => 'string',
+								'arg_options' => array(
+									'validate_callback' => array( Scheduled_Updates_Health_Paths::class, 'validate' ),
+								),
+							),
 						),
 					),
 				),

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -8,7 +8,6 @@
  */
 
 use Automattic\Jetpack\Scheduled_Updates;
-use Automattic\Jetpack\Scheduled_Updates_Health_Paths;
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Update_Schedules
@@ -533,27 +532,16 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'type'        => 'object',
 					'required'    => true,
 					'properties'  => array(
-						'interval'           => array(
+						'interval'  => array(
 							'description' => 'Interval for the schedule.',
 							'type'        => 'string',
 							'enum'        => array( 'daily', 'weekly' ),
 							'required'    => true,
 						),
-						'timestamp'          => array(
+						'timestamp' => array(
 							'description' => 'Unix timestamp (UTC) for when to first run the schedule.',
 							'type'        => 'integer',
 							'required'    => true,
-						),
-						'health_check_paths' => array(
-							'description' => 'List of paths to check for site health after the update.',
-							'type'        => 'array',
-							'maxItems'    => 5,
-							'items'       => array(
-								'type'        => 'string',
-								'arg_options' => array(
-									'validate_callback' => array( Scheduled_Updates_Health_Paths::class, 'validate' ),
-								),
-							),
 						),
 					),
 				),

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
@@ -156,12 +156,12 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
 		$request->set_body_params(
 			array(
-				'plugins'  => $plugins,
-				'schedule' => array(
-					'timestamp'          => strtotime( 'next Monday 8:00' ),
-					'interval'           => 'weekly',
-					'health_check_paths' => $paths,
+				'plugins'            => $plugins,
+				'schedule'           => array(
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'interval'  => 'weekly',
 				),
+				'health_check_paths' => $paths,
 			)
 		);
 		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
@@ -195,12 +195,12 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
 		$request->set_body_params(
 			array(
-				'plugins'  => $plugins,
-				'schedule' => array(
-					'timestamp'          => strtotime( 'next Monday 8:00' ),
-					'interval'           => 'weekly',
-					'health_check_paths' => $paths,
+				'plugins'            => $plugins,
+				'schedule'           => array(
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'interval'  => 'weekly',
 				),
+				'health_check_paths' => $paths,
 			)
 		);
 		$result = rest_do_request( $request )->get_data();
@@ -220,12 +220,12 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 
 		$request->set_body_params(
 			array(
-				'plugins'  => $plugins,
-				'schedule' => array(
-					'timestamp'          => strtotime( 'next Monday 8:00' ),
-					'interval'           => 'weekly',
-					'health_check_paths' => array( 'a', 'b' ),
+				'plugins'            => $plugins,
+				'schedule'           => array(
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'interval'  => 'weekly',
 				),
+				'health_check_paths' => array( 'a', 'b' ),
 			)
 		);
 		$schedule_id_1 = Scheduled_Updates::generate_schedule_id( $plugins );
@@ -244,12 +244,12 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 		$schedule_id_2 = Scheduled_Updates::generate_schedule_id( $plugins );
 		$request->set_body_params(
 			array(
-				'plugins'  => $plugins,
-				'schedule' => array(
-					'timestamp'          => strtotime( 'next Monday 11:00' ),
-					'interval'           => 'daily',
-					'health_check_paths' => array( 'c', 'd' ),
+				'plugins'            => $plugins,
+				'schedule'           => array(
+					'timestamp' => strtotime( 'next Monday 11:00' ),
+					'interval'  => 'daily',
 				),
+				'health_check_paths' => array( 'c', 'd' ),
 			)
 		);
 


### PR DESCRIPTION
This is a breaking change that moves `health_check_paths` from within the `schedule` array to its own top-level property in the `update-schedule` schema.

Will have to wait until #37221 and #37222 are merged and we've had a chance to update Calypso. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Break out `health_check_paths` field into its own rest_field
* Update unit tests to account for the changed `update-schedule` schema

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Again, unit tests should cover it.

For manual testing, checkout the branch on a test site and create/delete schedules. Make sure there are no errors returned and the `health_check_paths` field gets populated correctly.

