### PR TITLE
 AI Assistant: Add messages to inline extensions

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extensions-error
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extensions-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: Add event to upgrade handler function of Extension AI Control

--- a/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
@@ -17,7 +17,7 @@ import './style.scss';
  * Types
  */
 import type { RequestingStateProp } from '../../types.js';
-import type { ReactElement } from 'react';
+import type { ReactElement, MouseEvent } from 'react';
 
 type ExtensionAIControlProps = {
 	disabled?: boolean;
@@ -36,7 +36,7 @@ type ExtensionAIControlProps = {
 	onStop?: () => void;
 	onClose?: () => void;
 	onUndo?: () => void;
-	onUpgrade?: () => void;
+	onUpgrade?: ( event: MouseEvent< HTMLButtonElement > ) => void;
 };
 
 /**
@@ -118,9 +118,12 @@ export function ExtensionAIControl(
 		onUndo?.();
 	}, [ onUndo ] );
 
-	const upgradeHandler = useCallback( () => {
-		onUpgrade?.();
-	}, [ onUpgrade ] );
+	const upgradeHandler = useCallback(
+		( event: MouseEvent< HTMLButtonElement > ) => {
+			onUpgrade?.( event );
+		},
+		[ onUpgrade ]
+	);
 
 	useKeyboardShortcut(
 		'enter',

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -39,7 +39,7 @@ export type MessageProps = {
 
 export type UpgradeMessageProps = {
 	requestsRemaining: number;
-	onUpgradeClick: () => void;
+	onUpgradeClick: ( event?: React.MouseEvent< HTMLButtonElement > ) => void;
 };
 
 export type ErrorMessageProps = {

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-error
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add messages to inline extensions

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/index.tsx
@@ -10,7 +10,6 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { Nudge } from '../../../../shared/components/upgrade-nudge';
-import { PLAN_TYPE_TIERED, usePlanType } from '../../../../shared/use-plan-type';
 import useAICheckout from '../../hooks/use-ai-checkout';
 import useAiFeature from '../../hooks/use-ai-feature';
 import { canUserPurchasePlan } from '../../lib/connection';
@@ -36,17 +35,7 @@ const DefaultUpgradePrompt = ( {
 }: UpgradePromptProps ): ReactElement => {
 	const { checkoutUrl, autosaveAndRedirect, isRedirecting } = useAICheckout();
 	const canUpgrade = canUserPurchasePlan();
-	const {
-		nextTier,
-		tierPlansEnabled,
-		currentTier,
-		requestsCount: allTimeRequestsCount,
-		usagePeriod,
-	} = useAiFeature();
-
-	const planType = usePlanType( currentTier );
-	const requestsCount =
-		planType === PLAN_TYPE_TIERED ? usagePeriod?.requestsCount : allTimeRequestsCount;
+	const { nextTier, tierPlansEnabled, currentTier, requestsCount } = useAiFeature();
 
 	const { tracks } = useAnalytics();
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
@@ -9,6 +9,10 @@ import {
 } from '@automattic/jetpack-shared-extension-utils';
 import useAutosaveAndRedirect from '../../../../shared/use-autosave-and-redirect';
 import useAiFeature from '../use-ai-feature';
+/*
+ * Types
+ */
+import type { MouseEvent } from 'react';
 
 const getWPComRedirectToURL = () => {
 	const searchParams = new URLSearchParams( window.location.search );
@@ -24,8 +28,7 @@ const getWPComRedirectToURL = () => {
 
 export default function useAICheckout(): {
 	checkoutUrl: string;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	autosaveAndRedirect: ( event: any ) => void;
+	autosaveAndRedirect: ( event: MouseEvent< HTMLButtonElement > ) => void;
 	isRedirecting: boolean;
 } {
 	const { nextTier, tierPlansEnabled } = useAiFeature();
@@ -34,12 +37,12 @@ export default function useAICheckout(): {
 
 	const wpcomCheckoutUrl = tierPlansEnabled
 		? getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
-				site: getSiteFragment(),
+				site: getSiteFragment() as string,
 				path: `jetpack_ai_yearly:-q-${ nextTier?.limit }`,
 				query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
 		  } )
 		: getRedirectUrl( 'jetpack-ai-monthly-plan-ai-assistant-block-banner', {
-				site: getSiteFragment(),
+				site: getSiteFragment() as string,
 		  } );
 
 	const checkoutUrl =

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
+import { PLAN_TYPE_FREE, PLAN_TYPE_TIERED, usePlanType } from '../../../../shared/use-plan-type';
 import type { WordPressPlansSelectors } from 'extensions/store/wordpress-com';
 
 export default function useAiFeature() {
@@ -17,6 +18,19 @@ export default function useAiFeature() {
 	}, [] );
 
 	const {
+		currentTier,
+		usagePeriod,
+		requestsCount: allTimeRequestsCount,
+		requestsLimit: freeRequestsLimit,
+	} = data;
+
+	const planType = usePlanType( currentTier );
+
+	const requestsCount =
+		planType === PLAN_TYPE_TIERED ? usagePeriod?.requestsCount : allTimeRequestsCount;
+	const requestsLimit = planType === PLAN_TYPE_FREE ? freeRequestsLimit : currentTier?.limit;
+
+	const {
 		fetchAiAssistantFeature: loadFeatures,
 		increaseAiAssistantRequestsCount: increaseRequestsCount,
 		dequeueAiAssistantFeatureAsyncRequest: dequeueAsyncRequest,
@@ -24,6 +38,8 @@ export default function useAiFeature() {
 
 	return {
 		...data,
+		requestsCount,
+		requestsLimit,
 		loading,
 		error: null, // @todo: handle error at store level
 		refresh: loadFeatures,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -19,6 +19,7 @@ export default function useAiFeature() {
 	const {
 		fetchAiAssistantFeature: loadFeatures,
 		increaseAiAssistantRequestsCount: increaseRequestsCount,
+		dequeueAiAssistantFeatureAsyncRequest: dequeueAsyncRequest,
 	} = useDispatch( 'wordpress-com/plans' );
 
 	return {
@@ -27,5 +28,6 @@ export default function useAiFeature() {
 		error: null, // @todo: handle error at store level
 		refresh: loadFeatures,
 		increaseRequestsCount,
+		dequeueAsyncRequest,
 	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { ExtensionAIControl } from '@automattic/jetpack-ai-client';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import React, { useCallback } from 'react';
+import React from 'react';
 /*
  * Internal dependencies
  */

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -36,6 +36,7 @@ export default function AiAssistantInput( {
 	undo?: () => void;
 } ): ReactElement {
 	const [ value, setValue ] = useState( '' );
+	const [ showGuideLine, setShowGuideLine ] = useState( false );
 	const disabled = [ 'requesting', 'suggesting' ].includes( requestingState );
 
 	function handleSend(): void {
@@ -70,12 +71,18 @@ export default function AiAssistantInput( {
 		setValue( action || '' );
 	}, [ action ] );
 
+	// Show the guideline message when there is some text in the input.
+	useEffect( () => {
+		setShowGuideLine( value.length > 0 );
+	}, [ value ] );
+
 	return (
 		<ExtensionAIControl
 			placeholder={ __( 'Ask Jetpack AI to edit…', 'jetpack' ) }
 			disabled={ disabled }
 			value={ value }
 			state={ requestingState }
+			showGuideLine={ showGuideLine }
 			error={ requestingError?.message }
 			onChange={ setValue }
 			onSend={ handleSend }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -13,6 +13,7 @@ import type { ReactElement } from 'react';
 
 export default function AiAssistantInput( {
 	requestingState,
+	requestingError,
 	wrapperRef,
 	inputRef,
 	action,
@@ -75,6 +76,7 @@ export default function AiAssistantInput( {
 			disabled={ disabled }
 			value={ value }
 			state={ requestingState }
+			error={ requestingError?.message }
 			onChange={ setValue }
 			onSend={ handleSend }
 			onStop={ handleStopSuggestion }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -8,7 +8,7 @@ import {
 } from '@automattic/jetpack-ai-client';
 import { BlockControls, useBlockProps } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { dispatch, select, useDispatch } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 import { useCallback, useEffect, useState, useRef } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import debugFactory from 'debug';
@@ -17,6 +17,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { EXTENDED_INLINE_BLOCKS } from '../extensions/ai-assistant';
+import useAiFeature from '../hooks/use-ai-feature';
 import { BuildPromptOptionsProps, buildPromptForExtensions } from '../lib/prompt';
 import { blockHandler } from './block-handler';
 import AiAssistantInput from './components/ai-assistant-input';
@@ -45,7 +46,9 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const blockStyle = useRef< string >( '' );
 		const ownerDocument = useRef< Document >( document );
 		const [ action, setAction ] = useState< string >( '' );
-		const [ requestCount, setRequestCount ] = useState( 0 );
+		const [ consecutiveRequestCount, setConsecutiveRequestCount ] = useState( 0 );
+		const [ requestsRemaining, setRequestsRemaining ] = useState( 0 );
+		const [ showUpgradeMessage, setShowUpgradeMessage ] = useState( false );
 
 		// Only extend the allowed block types.
 		const possibleToExtendBlock = isPossibleToExtendBlock( {
@@ -58,13 +61,44 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const { getCurrentPostId } = select( 'core/editor' );
 		const postId = getCurrentPostId();
 
-		const { increaseAiAssistantRequestsCount, dequeueAiAssistantFeatureAsyncRequest } =
-			useDispatch( 'wordpress-com/plans' );
+		const {
+			increaseRequestsCount,
+			dequeueAsyncRequest,
+			requireUpgrade,
+			currentTier: { limit: requestsLimit },
+			loading: loadingAiFeature,
+			usagePeriod: { requestsCount },
+			nextTier,
+		} = useAiFeature();
+
+		useEffect( () => {
+			const remaining = Math.max( requestsLimit - requestsCount, 0 );
+			setRequestsRemaining( remaining );
+
+			const quarterPlanLimit = requestsLimit ? requestsLimit / 4 : 5;
+			setShowUpgradeMessage(
+				// if the feature is not loading
+				! loadingAiFeature &&
+					// and there is a next plan
+					!! nextTier &&
+					// and the user requires an upgrade
+					( requireUpgrade ||
+						// or the user has reached a multiple of the quarter plan limit, e.g. 100, 75, 50, 25, and 0 on the 100 tier.
+						remaining % quarterPlanLimit === 0 )
+			);
+		}, [
+			requestsLimit,
+			requestsCount,
+			loadingAiFeature,
+			nextTier,
+			requireUpgrade,
+			requestsRemaining,
+		] );
 
 		const onDone = useCallback( () => {
-			increaseAiAssistantRequestsCount();
-			setRequestCount( count => count + 1 );
-		}, [ increaseAiAssistantRequestsCount ] );
+			increaseRequestsCount();
+			setConsecutiveRequestCount( count => count + 1 );
+		}, [ increaseRequestsCount ] );
 
 		const onError = useCallback(
 			error => {
@@ -73,9 +107,9 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					return;
 				}
 
-				increaseAiAssistantRequestsCount();
+				increaseRequestsCount();
 			},
-			[ increaseAiAssistantRequestsCount ]
+			[ increaseRequestsCount ]
 		);
 
 		const { id } = useBlockProps();
@@ -101,7 +135,6 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			stopSuggestion,
 			requestingState,
 			error,
-			suggestion,
 			reset: resetSuggestions,
 		} = useAiSuggestions( {
 			onSuggestion,
@@ -212,7 +245,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			 * in case there is one pending,
 			 * when performing a new AI suggestion request.
 			 */
-			dequeueAiAssistantFeatureAsyncRequest();
+			dequeueAsyncRequest();
 
 			request( messages );
 		};
@@ -221,7 +254,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			setShowAiControl( false );
 			resetSuggestions();
 			setAction( '' );
-			setRequestCount( 0 );
+			setConsecutiveRequestCount( 0 );
 		}, [ resetSuggestions ] );
 
 		const onUserRequest = ( userPrompt: string ) => {
@@ -240,7 +273,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		}, [ isSelected, onClose ] );
 
 		const onUndo = async () => {
-			for ( let i = 0; i < requestCount; i++ ) {
+			for ( let i = 0; i < consecutiveRequestCount; i++ ) {
 				await dispatch( 'core/editor' ).undo();
 			}
 
@@ -253,14 +286,14 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 				{ showAiControl && (
 					<AiAssistantInput
-						clientId={ clientId }
-						postId={ postId }
 						requestingState={ requestingState }
 						requestingError={ error }
-						suggestion={ suggestion }
 						wrapperRef={ controlRef }
 						inputRef={ inputRef }
 						action={ action }
+						showUpgradeMessage={ showUpgradeMessage }
+						requireUpgrade={ requireUpgrade }
+						requestsRemaining={ requestsRemaining }
 						request={ onUserRequest }
 						stopSuggestion={ stopSuggestion }
 						close={ onClose }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -58,7 +58,8 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const { getCurrentPostId } = select( 'core/editor' );
 		const postId = getCurrentPostId();
 
-		const { increaseAiAssistantRequestsCount } = useDispatch( 'wordpress-com/plans' );
+		const { increaseAiAssistantRequestsCount, dequeueAiAssistantFeatureAsyncRequest } =
+			useDispatch( 'wordpress-com/plans' );
 
 		const onDone = useCallback( () => {
 			increaseAiAssistantRequestsCount();
@@ -205,6 +206,13 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			const messages = getRequestMessages( { promptType, options } );
 
 			debug( 'onRequestSuggestion', promptType, options );
+
+			/*
+			 * Always dequeue/cancel the AI Assistant feature async request,
+			 * in case there is one pending,
+			 * when performing a new AI suggestion request.
+			 */
+			dequeueAiAssistantFeatureAsyncRequest();
 
 			request( messages );
 		};

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -98,6 +98,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const onDone = useCallback( () => {
 			increaseRequestsCount();
 			setConsecutiveRequestCount( count => count + 1 );
+			inputRef.current?.focus();
 		}, [ increaseRequestsCount ] );
 
 		const onError = useCallback(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -65,9 +65,9 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			increaseRequestsCount,
 			dequeueAsyncRequest,
 			requireUpgrade,
-			currentTier: { limit: requestsLimit },
+			requestsCount,
+			requestsLimit,
 			loading: loadingAiFeature,
-			usagePeriod: { requestsCount },
 			nextTier,
 		} = useAiFeature();
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/featured-image/index.tsx
@@ -14,12 +14,7 @@ import { Icon, external } from '@wordpress/icons';
 import './style.scss';
 import UpgradePrompt from '../../../../blocks/ai-assistant/components/upgrade-prompt';
 import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
-import {
-	PLAN_TYPE_FREE,
-	PLAN_TYPE_TIERED,
-	PLAN_TYPE_UNLIMITED,
-	usePlanType,
-} from '../../../../shared/use-plan-type';
+import { PLAN_TYPE_UNLIMITED, usePlanType } from '../../../../shared/use-plan-type';
 import usePostContent from '../../hooks/use-post-content';
 import useSaveToMediaLibrary from '../../hooks/use-save-to-media-library';
 import {
@@ -69,18 +64,14 @@ export default function FeaturedImage( {
 	// Get feature data
 	const {
 		requireUpgrade,
-		requestsCount: allTimeRequestsCount,
-		requestsLimit: freeRequestsLimit,
-		usagePeriod,
+		requestsCount,
+		requestsLimit,
 		currentTier,
 		increaseRequestsCount,
 		costs,
 	} = useAiFeature();
 	const planType = usePlanType( currentTier );
 	const featuredImageCost = costs?.[ FEATURED_IMAGE_FEATURE_NAME ]?.image;
-	const requestsCount =
-		planType === PLAN_TYPE_TIERED ? usagePeriod?.requestsCount : allTimeRequestsCount;
-	const requestsLimit = planType === PLAN_TYPE_FREE ? freeRequestsLimit : currentTier?.limit;
 	const isUnlimited = planType === PLAN_TYPE_UNLIMITED;
 	const requestsBalance = requestsLimit - requestsCount;
 	const notEnoughRequests = requestsBalance < featuredImageCost;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -161,20 +161,9 @@ export default function ConnectedUsagePanel( { placement = null }: UsagePanelPro
 	const canUpgrade = canUserPurchasePlan();
 
 	// fetch usage data
-	const {
-		requestsCount: allTimeRequestsCount,
-		requestsLimit: freeRequestsLimit,
-		isOverLimit,
-		usagePeriod,
-		currentTier,
-		nextTier,
-		loading,
-	} = useAiFeature();
+	const { requestsCount, requestsLimit, isOverLimit, usagePeriod, currentTier, nextTier, loading } =
+		useAiFeature();
 	const planType = usePlanType( currentTier );
-
-	const requestsCount =
-		planType === PLAN_TYPE_TIERED ? usagePeriod?.requestsCount : allTimeRequestsCount;
-	const requestsLimit = planType === PLAN_TYPE_FREE ? freeRequestsLimit : currentTier?.limit;
 
 	const handleUpgradeClick = useCallback(
 		( event: React.MouseEvent< HTMLButtonElement > ) => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/index.tsx
@@ -177,7 +177,7 @@ export default function ConnectedUsagePanel( { placement = null }: UsagePanelPro
 	const requestsLimit = planType === PLAN_TYPE_FREE ? freeRequestsLimit : currentTier?.limit;
 
 	const handleUpgradeClick = useCallback(
-		( event: React.MouseEvent< HTMLElement > ) => {
+		( event: React.MouseEvent< HTMLButtonElement > ) => {
 			event.preventDefault();
 			tracks.recordEvent( 'jetpack_ai_upgrade_button', {
 				current_tier_slug: currentTier?.slug,
@@ -190,7 +190,7 @@ export default function ConnectedUsagePanel( { placement = null }: UsagePanelPro
 	);
 
 	const handleContactUsClick = useCallback(
-		( event: React.MouseEvent< HTMLElement > ) => {
+		( event: React.MouseEvent< HTMLButtonElement > ) => {
 			event.preventDefault();
 			tracks.recordEvent( 'jetpack_ai_upgrade_button', {
 				current_tier_slug: currentTier?.slug,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/usage-panel/types.ts
@@ -28,7 +28,7 @@ export type InternalUsagePanelProps = {
 	showContactUsCallToAction: boolean;
 	isRedirecting: boolean;
 	contactUsURL: string;
-	handleContactUsClick: ( event: React.MouseEvent< HTMLElement > ) => void;
+	handleContactUsClick: ( event: React.MouseEvent< HTMLButtonElement > ) => void;
 	checkoutUrl: string;
-	handleUpgradeClick: ( event: React.MouseEvent< HTMLElement > ) => void;
+	handleUpgradeClick: ( event: React.MouseEvent< HTMLButtonElement > ) => void;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37212

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds error messages to the input
* Adds the guideline message when there is any typed content
* Adds the upgrade message when required or when on a quarter of the tier usage

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

For simulating tiers: p1714772679703189-slack-C054LN8RNVA

* Go to the editor and use the extension to ask for something that makes no sense or disable the browser network to cause an error
* Check that the error message is displayed correctly
* Check that the upgrade message is displayed when reaching a multiple of a quarter of the tier, e.g. 100, 75, 50, 25 and 0 remaining requests for the 100 tier
* Check that the upgrade message is displayed when an upgrade is required and the input is disabled
* Check that the guideline message is displayed when no other message is displayed and there is any typed content in the input

![2024-05-03_18-34-09](https://github.com/Automattic/jetpack/assets/8486249/f1141f31-9670-4805-9bc4-dc313830a74d)
![2024-05-03_18-33-48](https://github.com/Automattic/jetpack/assets/8486249/a1078284-0d26-492c-b2bd-f70e4ee42793)
![2024-05-03_18-33-07](https://github.com/Automattic/jetpack/assets/8486249/a3e7b96a-cac2-4712-add9-ebfef4f76c87)
![2024-05-03_18-05-34](https://github.com/Automattic/jetpack/assets/8486249/2d6ebfa0-4b26-4e5e-bf4b-78aba4c74e54)