### PR TITLE
Change Hosting -> Site Overview to Overview

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/nav-redesign-hosting-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/nav-redesign-hosting-menu
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Nav redesign: Add Hosting -> Site Overview menu
+Nav redesign: Add Hosting -> Overview menu

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -86,8 +86,8 @@ function wpcom_add_wpcom_menu_item() {
 
 	add_submenu_page(
 		$parent_slug,
-		esc_attr__( 'Site Overview', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Site Overview', 'jetpack-mu-wpcom' ) . ' <span class="dashicons dashicons-external"></span>',
+		esc_attr__( 'Overview', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Overview', 'jetpack-mu-wpcom' ) . ' <span class="dashicons dashicons-external"></span>',
 		'manage_options',
 		esc_url( "https://wordpress.com/hosting/$domain" ),
 		null
@@ -436,7 +436,7 @@ function wpcom_add_hosting_menu_intro_notice() {
 		<div>
 			<span class="title"><?php esc_html_e( 'WordPress.com', 'jetpack-mu-wpcom' ); ?></span><br />
 			<span>
-				<?php esc_html_e( 'Click "Hosting" in the sidebar to access the site overview and settings for plans, domains, emails, etc.', 'jetpack-mu-wpcom' ); ?>
+				<?php esc_html_e( 'Click "Hosting" in the sidebar to access the hosting overview and settings for plans, domains, emails, etc.', 'jetpack-mu-wpcom' ); ?>
 			</span>
 		</div>
 		<a href="#" class="close-button" aria-label=<?php echo esc_attr__( 'Dismiss', 'jetpack-mu-wpcom' ); ?>>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of:

- https://github.com/Automattic/dotcom-forge/issues/6874

## Proposed changes:

This is a next iteration of https://github.com/Automattic/jetpack/pull/37203.

As I work on this issue and implement this across screens, I feel that "site overview" is still a too generic term, both internally and externally. Especially when they are used as links in My Home and wp-admin Dashboard.

With this PR, I am proposing that:

- We call the `/hosting/:site` url, i.e. the "Overview" tab of "GSV", the `Hosting Overview` page.
- The menu becomes `Hosting` -> `Overview ↗`
- The link in My Home will be `Go to hosting overview` (mirroring `Go to Dashboard` in GSV counterpart)

    <img width="726" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/dc7e8f6a-60a0-47fc-9600-47a2025d2846">


Another benefit is that it "teaches" the user that they should be looking for the page under the "Hosting" menu in the sidebar, as we call it "hosting overview" page.

What do you think? @allilevine @davemart-in 

|Before|After|
|-|-|
|<img width="275" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/b408c570-b54a-47b7-9003-3df3dfebba25">|<img width="275" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/fb04155d-8f71-4137-b26b-839352881afb">|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow test intructions on https://github.com/Automattic/jetpack/pull/37203.
