### PR TITLE
Repo Gardening: auto-label changes to theme tools inside package

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-repo-gardening-theme-tools
+++ b/projects/github-actions/repo-gardening/changelog/update-repo-gardening-theme-tools
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Auto-labeling: label changes to the Classic Theme Helper package.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -149,6 +149,12 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			keywords.add( '[Feature] Google Analytics' );
 		}
 
+		// Theme Tools have now been extracted to their own package.
+		const themeTools = file.match( /^projects\/packages\/classic-theme-helper\// );
+		if ( themeTools !== null ) {
+			keywords.add( '[Feature] Theme Tools' );
+		}
+
 		// The WooCommerce Analytics feature now lives in both a package and a Jetpack module.
 		const wooCommerceAnalytics = file.match( /^projects\/packages\/woocommerce-analytics\// );
 		if ( wooCommerceAnalytics !== null ) {


### PR DESCRIPTION
## Proposed changes:

Now that Theme Tools are extracted into their own package, let's take that into account when auto-labeling PRs.

Related PR: #37175

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* pfwV0U-6Y-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:


> [!NOTE]
> This can only be tested in a fork.

* In your fork, merge this branch to `trunk`.
* Open a new PR in your fork, for a new branch to `trunk`, making a change to one of the files in `projects/packages/classic-theme-helper/`.
    * The "[Feature] Theme Tools" label should be automatically added to the PR.

