### PR TITLE
Scheduled Updates: Verify plugins when creating a schedule

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-guarding-non-exist-plugins
+++ b/projects/packages/scheduled-updates/changelog/add-guarding-non-exist-plugins
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Scheduled Updates: Verify plugins when creating a schedule

--- a/projects/packages/scheduled-updates/composer.json
+++ b/projects/packages/scheduled-updates/composer.json
@@ -53,7 +53,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.11.x-dev"
+			"dev-trunk": "0.12.x-dev"
 		},
 		"textdomain": "jetpack-scheduled-updates",
 		"version-constants": {

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.11.1-alpha';
+	const PACKAGE_VERSION = '0.12.0-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -359,10 +359,7 @@ class Scheduled_Updates {
 				* @return bool
 				*/
 				'get_callback' => function ( $data ) {
-					$folder = WP_PLUGIN_DIR . '/' . strtok( $data['plugin'], '/' );
-					$target = is_link( $folder ) ? realpath( $folder ) : false;
-
-					return $target && 0 === strpos( $target, '/wordpress/' );
+					return self::is_plugin_managed( $data['plugin'] );
 				},
 				'schema'       => array(
 					'description' => 'Whether the plugin is managed by the host.',
@@ -435,5 +432,31 @@ class Scheduled_Updates {
 	 */
 	public static function generate_schedule_id( $args ) {
 		return md5( serialize( $args ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+	}
+
+	/**
+	 * Check if a plugin is installed.
+	 *
+	 * @param string $plugin The plugin to check.
+	 * @return bool
+	 */
+	public static function is_plugin_installed( $plugin ) {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		$installed_plugins = get_plugins();
+		return array_key_exists( $plugin, $installed_plugins );
+	}
+
+	/**
+	 * Check if a plugin is managed by the host.
+	 *
+	 * @param string $plugin The plugin to check.
+	 * @return bool
+	 */
+	public static function is_plugin_managed( $plugin ) {
+		$folder = WP_PLUGIN_DIR . '/' . strtok( $plugin, '/' );
+		$target = is_link( $folder ) ? realpath( $folder ) : false;
+		return $target && 0 === strpos( $target, '/wordpress/' );
 	}
 }

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -466,7 +466,7 @@ class Scheduled_Updates {
 	 * Verify that the plugins are installed.
 	 *
 	 * @param array $plugins List of plugins to update.
-	 * @return bool|WP_Error
+	 * @return bool|\WP_Error
 	 */
 	public static function verify_plugins( $plugins ) {
 		$request_plugins_not_installed_or_managed = true;

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -174,7 +174,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
-		$verified_plugins = $this->verify_plugins( $request['plugins'] );
+
+		$verified_plugins = apply_filters( 'jetpack_scheduled_update_verify_plugins', $request['plugins'] );
 
 		if ( is_wp_error( $verified_plugins ) ) {
 			return $verified_plugins;
@@ -269,6 +270,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$result = $this->validate_schedule( $request );
 		if ( is_wp_error( $result ) ) {
 			return $result;
+		}
+
+		$verified_plugins = apply_filters( 'jetpack_scheduled_update_verify_plugins', $request['plugins'] );
+
+		if ( is_wp_error( $verified_plugins ) ) {
+			return $verified_plugins;
 		}
 
 		$deleted = $this->delete_item( $request );
@@ -555,32 +562,5 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		);
 
 		return rest_get_endpoint_args_for_schema( $this->add_additional_fields_schema( $endpoint_args ), $method );
-	}
-
-	/**
-	 * Verify that the plugins are installed.
-	 *
-	 * @param array $plugins List of plugins to update.
-	 * @return bool|WP_Error
-	 */
-	public function verify_plugins( $plugins ) {
-		$request_plugins_not_installed_or_managed = true;
-
-		foreach ( $plugins as $plugin ) {
-			if ( Scheduled_Updates::is_plugin_installed( $plugin ) && ! Scheduled_Updates::is_plugin_managed( $plugin ) ) {
-				$request_plugins_not_installed_or_managed = false;
-				break;
-			}
-		}
-
-		if ( $request_plugins_not_installed_or_managed ) {
-			return new WP_Error(
-				'rest_forbidden',
-				__( 'None of the specified plugins are installed or all of them are managed.', 'jetpack-scheduled-updates' ),
-				array( 'status' => 403 )
-			);
-		}
-
-		return true;
 	}
 }

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
@@ -46,6 +46,7 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		Scheduled_Updates::init();
 	}
@@ -58,7 +59,7 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 	public function tear_down() {
 		wp_delete_user( $this->admin_id );
 		delete_option( Scheduled_Updates_Health_Paths::OPTION_NAME );
-
+		remove_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 		parent::tear_down_wordbless();
 	}
 

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
@@ -59,6 +59,7 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 	}
 
 	/**
@@ -68,7 +69,7 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 	 */
 	protected function tear_down() {
 		delete_option( Scheduled_Updates_Logs::OPTION_NAME );
-
+		remove_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 		parent::tear_down_wordbless();
 	}
 

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -669,4 +669,125 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 				*/"
 		);
 	}
+
+	/**
+	 * Test when all requested plugins are not installed.
+	 *
+	 * @covers ::verify_plugins
+	 */
+	public function test_verify_plugins_not_installed() {
+		$plugins = array( 'not-installed-plugin-1/not-installed-plugin-1.php', 'not-installed-plugin-2/not-installed-plugin-2.php' );
+
+		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params(
+			array(
+				'plugins'  => $plugins,
+				'schedule' => array(
+					'timestamp'          => strtotime( 'next Monday 8:00' ),
+					'interval'           => 'weekly',
+					'health_check_paths' => array(),
+				),
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 403, $result->get_status() );
+		$this->assertSame( 'None of the specified plugins are installed or all of them are managed.', $result->get_data()['message'] );
+	}
+
+	/**
+	 * Test when all requested plugins are managed.
+	 *
+	 * @covers ::verify_plugins
+	 */
+	public function test_verify_plugins_all_managed() {
+		$plugins = array( 'managed-plugin-1/managed-plugin-1.php', 'managed-plugin-2/managed-plugin-2.php' );
+
+		foreach ( $plugins as $plugin ) {
+			$plugin_name = explode( '/', $plugin )[0];
+			$plugin_file = "$plugin_name/$plugin_name.php";
+			$target_dir  = "$this->plugin_dir/wordpress";
+			$this->wp_filesystem->mkdir( $target_dir );
+			$this->wp_filesystem->mkdir( "$target_dir/$plugin_name" );
+			$this->populate_file_with_plugin_header( "$target_dir/$plugin_file", $plugin_name );
+			symlink( "$target_dir/$plugin_name", "$this->plugin_dir/$plugin_name" );
+		}
+
+		// Tweak realpath so that it returns `/wordpress/...`.
+		$realpath = $this->getFunctionMock( __NAMESPACE__, 'realpath' );
+		$realpath->expects( $this->exactly( count( $plugins ) ) )->willReturnCallback(
+			function ( $path ) {
+				return str_replace( $this->plugin_dir, '/wordpress/plugins', $path );
+			}
+		);
+
+		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params(
+			array(
+				'plugins'  => $plugins,
+				'schedule' => array(
+					'timestamp'          => strtotime( 'next Monday 8:00' ),
+					'interval'           => 'weekly',
+					'health_check_paths' => array(),
+				),
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 403, $result->get_status() );
+		$this->assertSame( 'None of the specified plugins are installed or all of them are managed.', $result->get_data()['message'] );
+	}
+
+	/**
+	 * Test when one requested plugin is installed and not managed, and another is installed but managed.
+	 *
+	 * @covers ::verify_plugins
+	 */
+	public function test_verify_plugins_installed_mixed() {
+		$plugins = array( 'managed-plugin/managed-plugin.php', 'installed-plugin/installed-plugin.php' );
+
+		// Create a managed plugin.
+		$managed_plugin_name = 'managed-plugin';
+		$managed_plugin_file = "$managed_plugin_name/$managed_plugin_name.php";
+		$target_dir          = "$this->plugin_dir/wordpress";
+		$this->wp_filesystem->mkdir( $target_dir );
+		$this->wp_filesystem->mkdir( "$target_dir/$managed_plugin_name" );
+		$this->populate_file_with_plugin_header( "$target_dir/$managed_plugin_file", $managed_plugin_name );
+		symlink( "$target_dir/$managed_plugin_name", "$this->plugin_dir/$managed_plugin_name" );
+
+		// Tweak realpath so that it returns `/wordpress/...` for the managed plugin.
+		$realpath = $this->getFunctionMock( __NAMESPACE__, 'realpath' );
+		$realpath->expects( $this->once() )->willReturnCallback(
+			function ( $path ) {
+				return str_replace( $this->plugin_dir, '/wordpress/plugins', $path );
+			}
+		);
+
+		// Create an installed plugin that is not managed.
+		$installed_plugin_name = 'installed-plugin';
+		$installed_plugin_file = "$installed_plugin_name/$installed_plugin_name.php";
+		$this->wp_filesystem->mkdir( "$this->plugin_dir/$installed_plugin_name" );
+		$this->populate_file_with_plugin_header( "$this->plugin_dir/$installed_plugin_file", $installed_plugin_name );
+
+		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params(
+			array(
+				'plugins'  => $plugins,
+				'schedule' => array(
+					'timestamp'          => strtotime( 'next Monday 8:00' ),
+					'interval'           => 'weekly',
+					'health_check_paths' => array(),
+				),
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+	}
 }

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-active-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-active-test.php
@@ -67,6 +67,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 		);
 
 		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		Scheduled_Updates::init();
 	}
@@ -80,6 +81,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 		wp_delete_user( $this->admin_id );
 		delete_option( Scheduled_Updates_Active::OPTION_NAME );
 		delete_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		remove_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		parent::tear_down_wordbless();
 	}

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-logs-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-logs-test.php
@@ -35,8 +35,20 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Logs_Test extends \WorDBless\B
 			)
 		);
 		wp_set_current_user( 0 );
+		add_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		Scheduled_Updates::init();
+	}
+
+	/**
+	 * Clean up after test
+	 *
+	 * @after
+	 */
+	public function tear_down() {
+		wp_delete_user( $this->admin_id );
+		remove_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
+		parent::tear_down_wordbless();
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -49,6 +49,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			)
 		);
 		wp_set_current_user( 0 );
+		add_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		Scheduled_Updates::init();
 	}
@@ -65,6 +66,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		wp_clear_scheduled_hook( Scheduled_Updates::PLUGIN_CRON_HOOK );
 		delete_option( 'jetpack_scheduled_update_statuses' );
 		delete_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		remove_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 	}
 
 	/**

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-guarding-non-exist-plugins
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-guarding-non-exist-plugins
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_21"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_22_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1261,7 +1261,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "5984ee152224a26d17fa32e2252fa40f5f888330"
+                "reference": "72fafdc115e7a14df44c589b3c03a193a050107c"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1288,7 +1288,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.11.x-dev"
+                    "dev-trunk": "0.12.x-dev"
                 },
                 "textdomain": "jetpack-scheduled-updates",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.21
+ * Version: 2.1.22-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.21",
+	"version": "2.1.22-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6846

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When all of the requested plugins are not installed or managed by the host, we should not create a schedule. This PR verifies the plugins when creating/updating a schedule to make sure we don't end up with schedules that run 0 plugins updates.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run unit tests and make sure nothing breaks.
* Apply this PR via Jetpack beta tester or rsync this branch to your testing WoA site
* Navigate to http://calypso.localhost:3000/plugins/scheduled-updates and try to create a schedule with plugins that are not installed on your target site, but at least one of them should be installed and not managed on the target site.
* The schedule should be created correctly.
* Now, try to create a schedule with all the requested plugins that's not installed or managed not the target site, it should fail if non of the requested plugins are installed or are managed by the host.
* You can also use REST API Console to send POST requests to /update-schedules endpoint, an example request can look likes:
```
/wpcom/v2/update-schedules?plugins[]=rest-api-console/rest-api-console.php&schedule[interval]=daily&schedule[timestamp]=NNNNN
```

