### PR TITLE
Untangling: Only show WP.com themes banner on Popular, Latest, and Block Themes

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-untangling-themes-banner-visibility
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-untangling-themes-banner-visibility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Insignificant change for the WP.com themes banner
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/js/banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/js/banner.js
@@ -29,9 +29,10 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	const wpcomThemesObserver = new MutationObserver( () => {
 		if (
-			document.querySelector(
-				'[data-sort="popular"].current, [data-sort="new"].current, [data-sort="block-themes"].current'
-			) &&
+			( ! document.querySelector( '.wp-filter' ) ||
+				document.querySelector(
+					'[data-sort="popular"].current, [data-sort="new"].current, [data-sort="block-themes"].current'
+				) ) &&
 			! document.querySelector( '.no-results p.no-themes' ) &&
 			! document.querySelector( '.loading-content .spinner, .spinner.is-active' )
 		) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/js/banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/js/banner.js
@@ -14,14 +14,32 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	themeBrowser.insertAdjacentHTML(
 		'beforebegin',
 		`
-		<div class="wpcom-themes-banner">
-			<div class="wpcom-themes-banner__content">
-				<img src="${ wpcomThemesBanner.logo }" alt="WordPress.com">
-				<h3>${ wpcomThemesBanner.title }</h3>
-				<p>${ wpcomThemesBanner.description }</p>
-				<a href="${ wpcomThemesBanner.actionUrl }">${ wpcomThemesBanner.actionText }</a>
+			<div class="wpcom-themes-banner hidden">
+				<div class="wpcom-themes-banner__content">
+					<img src="${ wpcomThemesBanner.logo }" alt="WordPress.com">
+					<h3>${ wpcomThemesBanner.title }</h3>
+					<p>${ wpcomThemesBanner.description }</p>
+					<a href="${ wpcomThemesBanner.actionUrl }">${ wpcomThemesBanner.actionText }</a>
+				</div>
 			</div>
-		</div>
-	`
+		`
 	);
+
+	const themesBanner = document.querySelector( '.wpcom-themes-banner' );
+
+	const wpcomThemesObserver = new MutationObserver( () => {
+		if (
+			document.querySelector(
+				'[data-sort="popular"].current, [data-sort="new"].current, [data-sort="block-themes"].current'
+			) &&
+			! document.querySelector( '.no-results p.no-themes' ) &&
+			! document.querySelector( '.loading-content .spinner, .spinner.is-active' )
+		) {
+			themesBanner.classList.remove( 'hidden' );
+		} else {
+			themesBanner.classList.add( 'hidden' );
+		}
+	} );
+	wpcomThemesObserver.observe( themeBrowser, { childList: true, subtree: true } );
+	wpcomThemesObserver.observe( document.body, { attributes: true } );
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/js/banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/js/banner.js
@@ -14,7 +14,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	themeBrowser.insertAdjacentHTML(
 		'beforebegin',
 		`
-			<div class="wpcom-themes-banner hidden">
+			<div class="wpcom-themes-banner">
 				<div class="wpcom-themes-banner__content">
 					<img src="${ wpcomThemesBanner.logo }" alt="WordPress.com">
 					<h3>${ wpcomThemesBanner.title }</h3>
@@ -29,18 +29,21 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	const wpcomThemesObserver = new MutationObserver( () => {
 		if (
-			( ! document.querySelector( '.wp-filter' ) ||
-				document.querySelector(
-					'[data-sort="popular"].current, [data-sort="new"].current, [data-sort="block-themes"].current'
-				) ) &&
-			! document.querySelector( '.no-results p.no-themes' ) &&
-			! document.querySelector( '.loading-content .spinner, .spinner.is-active' )
+			// Hide banner when loading results.
+			document.querySelector( '.loading-content .spinner' ) ||
+			// Hide banner on Favorites tab.
+			document.querySelector( '[data-sort="favorites"].current' ) ||
+			// Hide banner when using Feature Filter.
+			document.querySelector( '.show-filters .filter-drawer' ) ||
+			// Hide banner when searching (but only if there are results).
+			( document.querySelector( '#wp-filter-search-input' )?.value &&
+				! document.querySelector( '.no-results p.no-themes' ) )
 		) {
-			themesBanner.classList.remove( 'hidden' );
-		} else {
 			themesBanner.classList.add( 'hidden' );
+		} else {
+			themesBanner.classList.remove( 'hidden' );
 		}
 	} );
-	wpcomThemesObserver.observe( themeBrowser, { childList: true, subtree: true } );
+	wpcomThemesObserver.observe( themeBrowser, { childList: true } );
 	wpcomThemesObserver.observe( document.body, { attributes: true } );
 } );


### PR DESCRIPTION
## Proposed changes:
In order to replicate the behavior of the WP.com plugins banner (https://github.com/Automattic/wpcomsh/pull/1839), this PR adjusts the visibility of the WP.com themes banner so it's only displayed on the Popular, Latest, and Block Themes tab. Additionally, the banner is hidden when the results are being loaded and when there are no results.

Before | After
--- | ---
<img width="1099" alt="Screenshot 2024-05-06 at 14 58 48" src="https://github.com/Automattic/jetpack/assets/1233880/a612c900-1b63-434f-9062-859a20cd2c9e"> | <img width="1113" alt="Screenshot 2024-05-06 at 14 59 22" src="https://github.com/Automattic/jetpack/assets/1233880/427d5020-342e-4bf6-94db-9f150f64c7cd">
<img width="1110" alt="Screenshot 2024-05-06 at 14 59 03" src="https://github.com/Automattic/jetpack/assets/1233880/116b082d-63e8-4c1e-8c3c-dc6f7f73ba86"> | <img width="1114" alt="Screenshot 2024-05-06 at 14 59 49" src="https://github.com/Automattic/jetpack/assets/1233880/e9eed6c2-75dd-4875-ba5f-2c5934bd6037">
<img width="1099" alt="Screenshot 2024-05-06 at 14 59 15" src="https://github.com/Automattic/jetpack/assets/1233880/c015c8a9-cb17-4b5f-8525-886e36897cb0"> | <img width="1107" alt="Screenshot 2024-05-06 at 15 00 18" src="https://github.com/Automattic/jetpack/assets/1233880/ede73ff0-44e0-434a-84fc-1209ea3250ff">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your untangled WP.com site
- Go to `wp-admin/theme-install.php`
- Make sure the themes banner shows up only after the results have been loaded
- Switch to the Favorites tab
- Make sure the banner is hidden
- Enable any feature filter
- Make sure the banner is hidden
- Use the search input to search any theme
- Make sure the banner is hidden
- Switch to either Popular, Latest, or Block Themes
- Make sure the banner is visible

