### PR TITLE
Backup: Add a LoadingPlaceholder while waiting for Backup plan price

### DIFF
--- a/projects/js-packages/components/changelog/add-loading-placeholder-while-waiting-price
+++ b/projects/js-packages/components/changelog/add-loading-placeholder-while-waiting-price
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack Backup: Add a LoadingPlaceholder while waiting for Jetpack Backup price

--- a/projects/js-packages/components/components/pricing-card/index.tsx
+++ b/projects/js-packages/components/components/pricing-card/index.tsx
@@ -1,4 +1,5 @@
 import { getCurrencyObject } from '@automattic/format-currency';
+import { LoadingPlaceholder } from '@automattic/jetpack-components';
 import { Button } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import TermsOfService from '../terms-of-service';
@@ -54,7 +55,7 @@ const PricingCard: React.FC< PricingCardProps > = ( {
 			) }
 			<h1 className="jp-components__pricing-card__title">{ props.title }</h1>
 			<div className="jp-components__pricing-card__pricing">
-				{ props.priceBefore !== props.priceAfter && (
+				{ props.priceBefore !== props.priceAfter && props.priceAfter > 0 ? (
 					<div className="jp-components__pricing-card__price-before">
 						<span className="jp-components__pricing-card__currency">
 							{ currencyObjectBefore.symbol }
@@ -70,21 +71,27 @@ const PricingCard: React.FC< PricingCardProps > = ( {
 						) }
 						<div className="jp-components__pricing-card__price-strikethrough"></div>
 					</div>
+				) : (
+					<LoadingPlaceholder width="100%" height={ 48 } />
 				) }
-				<div className="jp-components__pricing-card__price-after">
-					<span className="jp-components__pricing-card__currency">
-						{ currencyObjectAfter.symbol }
-					</span>
-					<span className="jp-components__pricing-card__price">
-						{ currencyObjectAfter.integer }
-					</span>
-					{ showPriceDecimals( currencyObjectAfter ) && (
-						<span className="jp-components__pricing-card__price-decimal">
-							{ currencyObjectAfter.fraction }
-						</span>
-					) }
-				</div>
-				<span className="jp-components__pricing-card__price-details">{ priceDetails }</span>
+				{ props.priceAfter > 0 && (
+					<>
+						<div className="jp-components__pricing-card__price-after">
+							<span className="jp-components__pricing-card__currency">
+								{ currencyObjectAfter.symbol }
+							</span>
+							<span className="jp-components__pricing-card__price">
+								{ currencyObjectAfter.integer }
+							</span>
+							{ showPriceDecimals( currencyObjectAfter ) && (
+								<span className="jp-components__pricing-card__price-decimal">
+									{ currencyObjectAfter.fraction }
+								</span>
+							) }
+						</div>
+						<span className="jp-components__pricing-card__price-details">{ priceDetails }</span>
+					</>
+				) }
 			</div>
 
 			{ props.children && (

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.52.1",
+	"version": "0.53.0-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack-backup-team/issues/414

When you first render the VaultPress Backup pricing card, it says that costs is $0, and then it refreshes to $4.95.

## Proposed changes:
* Add a LoadingPlaceholder while is waiting for the price

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install the branch `add/loading-placeholder-while-waiting-price` of Jetpack Backup in a site without backup
* Check the plugin and verify a loading placeholder is shown before the final price

<img src="https://github.com/Automattic/jetpack/assets/2747834/45c86990-22fd-49bd-b975-683ac79d01f2" width="400">

