### PR TITLE
Scheduled Updates: Make sure sync options maintains all required data

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-sync-option
+++ b/projects/packages/scheduled-updates/changelog/fix-sync-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a bug where rest_fileds were not registered when composing the sync option.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -193,6 +193,10 @@ class Scheduled_Updates {
 	 * Save the schedules for sync after cron option saving.
 	 */
 	public static function update_option_cron() {
+		Scheduled_Updates_Logs::add_log_fields();
+		Scheduled_Updates_Active::add_active_field();
+		Scheduled_Updates_Health_Paths::add_health_check_paths_field();
+
 		$endpoint = new \WPCOM_REST_API_V2_Endpoint_Update_Schedules();
 		$events   = $endpoint->get_items( new \WP_REST_Request() );
 

--- a/projects/packages/scheduled-updates/tests/php/class-pre-rest-api-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-pre-rest-api-test.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Test class for functions and behavior that runs outside REST API requests.
+ *
+ * At this point in the test suite, `rest_api_init` has not been called yet, so endpoints are not registered.
+ *
+ * @package automattic/scheduled-updates
+ */
+
+use Automattic\Jetpack\Scheduled_Updates;
+
+/**
+ * Test class for behavior that runs outside REST API requests.
+ */
+class Pre_Rest_Api_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Set up.
+	 *
+	 * @before
+	 */
+	protected function set_up() {
+		parent::set_up_wordbless();
+		Scheduled_Updates::init();
+	}
+
+	/**
+	 * Test that the scheduled updates option contains all expected data.
+	 *
+	 * @covers \Automattic\Jetpack\Scheduled_Updates::update_option_cron
+	 */
+	public function test_update_option_cron() {
+		$plugins = array( 'gutenberg/gutenberg.php' );
+		wp_schedule_event( strtotime( 'next Monday 8:00' ), 'daily', Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins, true );
+
+		$option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$event  = array_pop( $option );
+
+		$this->assertIsObject( $event );
+
+		$this->assertObjectHasProperty( 'hook', $event );
+		$this->assertObjectHasProperty( 'timestamp', $event );
+		$this->assertObjectHasProperty( 'schedule', $event );
+		$this->assertObjectHasProperty( 'args', $event );
+		$this->assertObjectHasProperty( 'interval', $event );
+		$this->assertObjectHasProperty( 'last_run_timestamp', $event );
+		$this->assertObjectHasProperty( 'last_run_status', $event );
+		$this->assertObjectHasProperty( 'active', $event );
+		$this->assertObjectHasProperty( 'health_check_paths', $event );
+	}
+}

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-active-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-active-test.php
@@ -69,7 +69,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 		wp_set_current_user( $this->admin_id );
 
 		Scheduled_Updates::init();
-		do_action( 'rest_api_init' );
 	}
 
 	/**


### PR DESCRIPTION
See p1715008234142659-slack-C01A60HCGUA

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Manually register known rest fields to complete sync option content.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Unit tests should cover it.

For manual testing:
* Check out this branch.
* Make an update to an exist schedule.
* Wait until the option has synced.
* On your sandbox, switch to your test site and make sure the option value is correct.