### PR TITLE
Fix/reply to comment option

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -982,8 +982,12 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 
 				case 'jetpack_subscriptions_reply_to':
 					// If option value was the same, consider it done.
-					$sub_value = in_array( $value, array( 'no-reply', 'author' ), true ) ? $value : 'no-reply';
-					$updated   = (string) get_option( $option ) !== (string) $sub_value ? update_option( $option, $sub_value ) : true;
+					require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
+					$sub_value = Automattic\Jetpack\Modules\Subscriptions\Settings::is_valid_reply_to( $value )
+						? $value
+						: Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();
+
+						$updated = (string) get_option( $option ) !== (string) $sub_value ? update_option( $option, $sub_value ) : true;
 					break;
 
 				case 'stb_enabled':

--- a/projects/plugins/jetpack/changelog/fix-reply-to-comment-option
+++ b/projects/plugins/jetpack/changelog/fix-reply-to-comment-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscription: add comment as a subscription reply to type only availave for simple sites now.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1028,7 +1028,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 
 				case 'jetpack_subscriptions_reply_to':
-					$to_set_value = (string) in_array( $value, array( 'no-reply', 'author' ), true ) ? $value : 'no-reply';
+					require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
+					$to_set_value = Automattic\Jetpack\Modules\Subscriptions\Settings::is_valid_reply_to( $value )
+						? $value
+						: Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();
+
 					update_option( 'jetpack_subscriptions_reply_to', (string) $to_set_value );
 					$updated[ $key ] = (bool) $value;
 					break;
@@ -1291,7 +1295,8 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	protected function get_subscriptions_reply_to_option() {
 		$reply_to = get_option( 'jetpack_subscriptions_reply_to', null );
 		if ( $reply_to === null ) {
-			return 'no-reply';
+			require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
+			return Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();
 		}
 		return $reply_to;
 	}

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * The Subscriptions settings.
+ *
+ * This is a class that contains helper functions for the Subscriptions settings module.
+ *
+ * @package automattic/jetpack-subscriptions
+ */
+
+namespace Automattic\Jetpack\Modules\Subscriptions;
+
+use Automattic\Jetpack\Status\Host;
+
+/**
+ * Class Settings
+ */
+class Settings {
+
+	/**
+	 * Validate the reply-to option.
+	 *
+	 * @param string $reply_to The reply-to option to validate.
+	 * @return bool Whether the reply-to option is valid or not.
+	 */
+	public static function is_valid_reply_to( $reply_to ) {
+		$valid_values = array( 'author', 'no-reply', 'comment' );
+		if ( in_array( $reply_to, $valid_values, true ) ) {
+			return true;
+		}
+		return false;
+	}
+	/**
+	 * Get the default reply-to option.
+	 *
+	 * @return string The default reply-to option.
+	 */
+	public static function get_default_reply_to() {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return 'comment';
+		}
+
+		return 'no-reply';
+	}
+}


### PR DESCRIPTION
This Pr adds `comment` as the reply to type.
This is needed for https://github.com/Automattic/wp-calypso/pull/90059 to work as expected and should also be shipped to simple sites as soon as possible.

## Proposed changes:

* Adds a new settings class that make it easier to get the default reply to setting and check the validitity of this settings. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Apply this setting to PR to .com 
* Sandbox public-api.wordpress.com 
* Load up https://github.com/Automattic/wp-calypso/pull/90059. Save the reply different options. 
* Note that the setting is set as expected.

