### PR TITLE
Newsletters: Fix: Prevent Emails on 'Post Only' Setting in Newsletter

### DIFF
--- a/projects/plugins/jetpack/changelog/update-save-prepublish-settings
+++ b/projects/plugins/jetpack/changelog/update-save-prepublish-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletters: improvements to prepublish panel.

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -13,7 +13,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { useEntityProp } from '@wordpress/core-data';
+import { useEntityId, useEntityProp, store as coreDataStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PostVisibilityCheck, store as editorStore } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
@@ -301,9 +301,9 @@ export function NewsletterAccessDocumentSettings( { accessLevel } ) {
 export function NewsletterEmailDocumentSettings() {
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
+	const { saveEditedEntityRecord } = useDispatch( coreDataStore );
 	const [ postMeta, setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
-	const { __unstableSaveForPreview } = useDispatch( editorStore );
-
+	const postId = useEntityId( 'postType', postType );
 	const toggleSendEmail = value => {
 		const postMetaUpdate = {
 			...postMeta,
@@ -311,10 +311,7 @@ export function NewsletterEmailDocumentSettings() {
 			[ META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS ]: ! value,
 		};
 		setPostMeta( postMetaUpdate );
-		// @todo Remove the `if` check once WP 6.4 is the minimum supported version
-		if ( typeof __unstableSaveForPreview === 'function' ) {
-			__unstableSaveForPreview();
-		}
+		saveEditedEntityRecord( 'postType', postType, postId );
 	};
 
 	const isSendEmailEnabled = useSelect( select => {

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -302,6 +302,7 @@ export function NewsletterEmailDocumentSettings() {
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	const [ postMeta, setPostMeta ] = useEntityProp( 'postType', postType, 'meta' );
+	const { __unstableSaveForPreview } = useDispatch( editorStore );
 
 	const toggleSendEmail = value => {
 		const postMetaUpdate = {
@@ -310,6 +311,10 @@ export function NewsletterEmailDocumentSettings() {
 			[ META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS ]: ! value,
 		};
 		setPostMeta( postMetaUpdate );
+		// @todo Remove the `if` check once WP 6.4 is the minimum supported version
+		if ( typeof __unstableSaveForPreview === 'function' ) {
+			__unstableSaveForPreview();
+		}
 	};
 
 	const isSendEmailEnabled = useSelect( select => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #35998

This PR resolves the issue where emails were sent even when the "Post only" option was selected in the newsletter settings. The fix ensures the _jetpack_dont_email_post_to_subs meta` is updated correctly, aligning the email behavior with user selections.

## Proposed changes:

* Ensure `_jetpack_dont_email_post_to_subs` meta is synchronized before the `publish_post` action. (See discussion in D147226-code)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Write a Post
* Toggle the Post Only Newsletter setting
* Check the Network console and check the post is being saved