### PR TITLE
Top Posts & Pages Block: Remove Deleted Content

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
@@ -44,6 +44,14 @@ class Jetpack_Top_Posts_Helper {
 			$data = array( 'summary' => array( 'postviews' => array() ) );
 		}
 
+		// Remove posts that have subsequently been deleted.
+		$data['summary']['postviews'] = array_filter(
+			$data['summary']['postviews'],
+			function ( $item ) {
+				return get_post_status( $item['id'] ) === 'publish';
+			}
+		);
+
 		$posts_retrieved = is_countable( $data['summary']['postviews'] ) ? count( $data['summary']['postviews'] ) : 0;
 
 		// Fallback to random posts if user does not have enough top content.

--- a/projects/plugins/jetpack/changelog/fix-top-posts-deleted
+++ b/projects/plugins/jetpack/changelog/fix-top-posts-deleted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Top Posts & Pages Block: ensure deleted content does not display.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-calypso#90308

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Filters out deleted content from the Top Posts and Pages block. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post and view it several times from an incognito browser (note: stats are cached for five minutes)
* Add a Top Posts and Pages block
* Delete the post, and confirm that the post currently still appears in the block
* Confirm that this change ensures the post no longer appears

For context, this issue only applies to posts which are published and viewed several times, then subsequently deleted; the API endpoint still considers them a 'most viewed post', even though it has been deleted. It doesn't apply to the randomly generated posts whenever there aren't enough posts provided by the endpoint. 