### PR TITLE
Repo Gardening: Attempt to Fix OSS Workflow

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/fix-oss-workflow
+++ b/projects/github-actions/repo-gardening/changelog/fix-oss-workflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Repo Gardening: fix workflow for adding [OSS Citizen] label.

--- a/projects/github-actions/repo-gardening/src/tasks/flag-oss/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/flag-oss/index.js
@@ -15,41 +15,44 @@ async function flagOss( payload, octokit ) {
 	const { head, base } = pull_request;
 	const { owner, name } = repository;
 
+	// Assume PR author is org member if the PR isn't from a fork.
 	if ( head.repo.full_name === base.repo.full_name ) {
 		return;
 	}
 
 	// Check if PR author is org member
 	// https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-	const orgMembershipRequest = await octokit.rest.orgs.checkMembershipForUser( {
-		org: owner.login,
-		username: head.user.login,
-	} );
+	try {
+		const orgMembershipRequest = await octokit.rest.orgs.checkMembershipForUser( {
+			org: owner.login,
+			username: head.user.login,
+		} );
 
-	if ( 204 === orgMembershipRequest.status ) {
-		return;
+		if ( 204 === orgMembershipRequest.status ) {
+			return;
+		}
+	} catch ( error ) {
+		debug( `flag-oss: Adding OSS Citizen label to PR #${ number }` );
+		await octokit.rest.issues.addLabels( {
+			owner: owner.login,
+			repo: name,
+			issue_number: number,
+			labels: [ 'OSS Citizen' ],
+		} );
+
+		const channel = getInput( 'slack_team_channel' );
+		if ( ! channel ) {
+			setFailed( `flag-oss: Input slack_team_channel is required but missing. Aborting.` );
+			return;
+		}
+
+		debug( `flag-oss: Sending in OSS Slack message about PR #${ number }.` );
+		await sendSlackMessage(
+			`An external contributor submitted this PR. Be sure to go welcome them! 👏`,
+			channel,
+			payload
+		);
 	}
-
-	debug( `flag-oss: Adding OSS Citizen label to PR #${ number }` );
-	await octokit.rest.issues.addLabels( {
-		owner: owner.login,
-		repo: name,
-		issue_number: number,
-		labels: [ 'OSS Citizen' ],
-	} );
-
-	const channel = getInput( 'slack_team_channel' );
-	if ( ! channel ) {
-		setFailed( `flag-oss: Input slack_team_channel is required but missing. Aborting.` );
-		return;
-	}
-
-	debug( `flag-oss: Sending in OSS Slack message about PR #${ number }.` );
-	await sendSlackMessage(
-		`An external contributor submitted this PR. Be sure to go welcome them! 👏`,
-		channel,
-		payload
-	);
 }
 
 module.exports = flagOss;


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Tests from non-a12ns currently immediately fail - eg. #37251

> main: Starting task flagOss
Error: main: Task flagOss failed with error: HttpError: User does not exist or is not a public member of the organization - https://docs.github.com/rest/orgs/members#check-public-organization-membership-for-a-user

I think it should be okay if the check is wrapped in a `try` statement rather than assuming it won't error? Seems like the error is intentional.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Not sure this is possible for an OSS citizen to actually test, so would appreciate some eyes on whether this seems logical.

cc @jeherve - sorry, assuming that you won't be notified unless I ping you until this is fixed. 