### PR TITLE
Boost: remove the BETA tag from the Cache module

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -159,12 +159,7 @@ const Index = () => {
 			</Module>
 			<Module
 				slug="page_cache"
-				title={
-					<>
-						{ __( 'Cache Site Pages', 'jetpack-boost' ) }
-						<span className={ styles.beta }>Beta</span>
-					</>
-				}
+				title={ <>{ __( 'Cache Site Pages', 'jetpack-boost' ) }</> }
 				onBeforeToggle={ status => {
 					setIsPageCacheSettingUp( status );
 					if ( status === false ) {

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -159,7 +159,7 @@ const Index = () => {
 			</Module>
 			<Module
 				slug="page_cache"
-				title={ <>{ __( 'Cache Site Pages', 'jetpack-boost' ) }</> }
+				title={ __( 'Cache Site Pages', 'jetpack-boost' ) }
 				onBeforeToggle={ status => {
 					setIsPageCacheSettingUp( status );
 					if ( status === false ) {

--- a/projects/plugins/boost/changelog/update-boost-remove-beta-cache-tag
+++ b/projects/plugins/boost/changelog/update-boost-remove-beta-cache-tag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: remove Beta tag from Cache module


### PR DESCRIPTION
The Cache module is working very well now and doesn't need that BETA tag on it any more.

Fixes #37183

## Proposed changes:
* remove the line containing the BETA tag.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-2QH-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Apply this PR through the beta plugin.
* Confirm the BETA tag is missing from the UI of the Cache module.