### PR TITLE
Boost: Update Image CDN UI

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/collapsible-meta/collapsible-meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/collapsible-meta/collapsible-meta.module.scss
@@ -1,13 +1,11 @@
 @use '$css/main/variables.scss' as *;
 
 .collapsible-meta {
-	margin-top: 2em;
-
 	.header {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
-		margin-bottom: 1em;
+		margin-bottom: 10px;
 		@media screen and ( max-width: 530px ) {
 			flex-direction: column;
 			align-items: flex-start;
@@ -23,7 +21,7 @@
 	}
 
 	.summary {
-		color: $gray-40;
+		color: var(--gray-50);
 		font-size: 14px;
 		line-height: 22px;
 	}

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.module.scss
@@ -1,0 +1,23 @@
+.wrapper {
+	margin-bottom: 10px;
+}
+
+.title {
+	display: flex;
+}
+
+.beta {
+	position: relative;
+	top: 4px;
+}
+
+.toggle-control {
+	margin-left: auto;
+	margin-bottom: 0 !important;
+}
+
+.description {
+	color: var(--gray-50);
+	font-size: 14px;
+	line-height: 1.6;
+}

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.tsx
@@ -6,6 +6,7 @@ import indexStyles from '../../../pages/index/index.module.scss';
 import styles from './image-cdn-liar.module.scss';
 import classNames from 'classnames';
 import ModuleSubsection from '$features/ui/module-subsection/module-subsection';
+import { recordBoostEvent } from '$lib/utils/analytics';
 
 type ImageCdnLiarProps = {
 	isPremium: boolean;
@@ -22,6 +23,12 @@ export default function ImageCdnLiar( { isPremium }: ImageCdnLiarProps ) {
 		z.boolean().catch( false )
 	);
 
+	const handleToggle = ( value: boolean ) => {
+		setImageCdnLiar.mutate( value );
+
+		recordBoostEvent( 'image_cdn_liar_toggle', { enabled: Number( value ) } );
+	};
+
 	return (
 		<ModuleSubsection>
 			<div className={ styles.wrapper }>
@@ -33,7 +40,7 @@ export default function ImageCdnLiar( { isPremium }: ImageCdnLiarProps ) {
 					<ToggleControl
 						className={ styles[ 'toggle-control' ] }
 						checked={ imageCdnLiar.data }
-						onChange={ value => setImageCdnLiar.mutate( value ) }
+						onChange={ handleToggle }
 					/>
 				</div>
 			</div>

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.tsx
@@ -4,7 +4,15 @@ import { __ } from '@wordpress/i18n';
 import { z } from 'zod';
 import styles from '../../../pages/index/index.module.scss';
 
-export default function ImageCdnLiar() {
+type ImageCdnLiarProps = {
+	isPremium: boolean;
+};
+
+export default function ImageCdnLiar( { isPremium }: ImageCdnLiarProps ) {
+	if ( ! isPremium ) {
+		return;
+	}
+
 	const [ imageCdnLiar, setImageCdnLiar ] = useDataSync(
 		'jetpack_boost_ds',
 		'image_cdn_liar',

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/image-cdn-liar/image-cdn-liar.tsx
@@ -2,7 +2,10 @@ import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
 import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { z } from 'zod';
-import styles from '../../../pages/index/index.module.scss';
+import indexStyles from '../../../pages/index/index.module.scss';
+import styles from './image-cdn-liar.module.scss';
+import classNames from 'classnames';
+import ModuleSubsection from '$features/ui/module-subsection/module-subsection';
 
 type ImageCdnLiarProps = {
 	isPremium: boolean;
@@ -20,31 +23,26 @@ export default function ImageCdnLiar( { isPremium }: ImageCdnLiarProps ) {
 	);
 
 	return (
-		<>
-			<div
-				style={ {
-					marginBottom: '10px',
-				} }
-			>
-				<span
-					style={ {
-						fontWeight: 'bold',
-					} }
-				>
-					{ __( 'Auto-Resize Lazy Images', 'jetpack-boost' ) }
-				</span>
-				<span style={ { position: 'relative', top: '4px' } } className={ styles.beta }>
-					Beta
-				</span>
+		<ModuleSubsection>
+			<div className={ styles.wrapper }>
+				<div className={ styles.title }>
+					<h4>
+						{ __( 'Auto-Resize Lazy Images', 'jetpack-boost' ) }
+						<span className={ classNames( indexStyles.beta, styles.beta ) }>Beta</span>
+					</h4>
+					<ToggleControl
+						className={ styles[ 'toggle-control' ] }
+						checked={ imageCdnLiar.data }
+						onChange={ value => setImageCdnLiar.mutate( value ) }
+					/>
+				</div>
 			</div>
-			<ToggleControl
-				label={ __(
+			<div className={ styles.description }>
+				{ __(
 					'Automatically resize images that are lazily loaded to fit the exact dimensions they occupy on the page.',
 					'jetpack-boost'
 				) }
-				checked={ imageCdnLiar.data }
-				onChange={ value => setImageCdnLiar.mutate( value ) }
-			/>
-		</>
+			</div>
+		</ModuleSubsection>
 	);
 }

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-settings/quality-settings.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-settings/quality-settings.module.scss
@@ -1,5 +1,17 @@
 .section-title {
+	display: flex;
 	font-weight: bold;
+}
+
+.body {
+	background-color: var(--gray-0);
+	padding: 16px 16px 24px;
+}
+
+:global(.jb-dashboard) .body h5 {
+	font-weight: 600;
+	font-size: 14px;
+	line-height: 1.5;
 }
 
 .info-icon {

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-settings/quality-settings.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-settings/quality-settings.tsx
@@ -1,4 +1,3 @@
-import { createInterpolateElement } from '@wordpress/element';
 import CollapsibleMeta from '../collapsible-meta/collapsible-meta';
 import { __, sprintf } from '@wordpress/i18n';
 import styles from './quality-settings.module.scss';
@@ -7,7 +6,6 @@ import QualityControl from '../quality-control/quality-control';
 import Upgraded from '$features/ui/upgraded/upgraded';
 import { imageCdnSettingsSchema, useImageCdnQuality } from '../lib/stores';
 import { z } from 'zod';
-import { Link } from 'react-router-dom';
 
 type QualitySettingsProps = {
 	isPremium: boolean;
@@ -15,12 +13,7 @@ type QualitySettingsProps = {
 
 const QualitySettings = ( { isPremium }: QualitySettingsProps ) => {
 	if ( ! isPremium ) {
-		return createInterpolateElement(
-			__( `For more control over image quality, <link>upgrade now!</link>`, 'jetpack-boost' ),
-			{
-				link: <Link to="/upgrade" />,
-			}
-		);
+		return;
 	}
 
 	const [ query, mutation ] = useImageCdnQuality();

--- a/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-settings/quality-settings.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/image-cdn/quality-settings/quality-settings.tsx
@@ -3,9 +3,9 @@ import { __, sprintf } from '@wordpress/i18n';
 import styles from './quality-settings.module.scss';
 import { IconTooltip } from '@automattic/jetpack-components';
 import QualityControl from '../quality-control/quality-control';
-import Upgraded from '$features/ui/upgraded/upgraded';
 import { imageCdnSettingsSchema, useImageCdnQuality } from '../lib/stores';
 import { z } from 'zod';
+import ModuleSubsection from '$features/ui/module-subsection/module-subsection';
 
 type QualitySettingsProps = {
 	isPremium: boolean;
@@ -48,37 +48,44 @@ const QualitySettings = ( { isPremium }: QualitySettingsProps ) => {
 
 	return (
 		imageCdnQuality && (
-			<CollapsibleMeta
-				editText={ __( 'Change Image Quality', 'jetpack-boost' ) }
-				closeEditText={ __( 'Close', 'jetpack-boost' ) }
-				header={ <Header /> }
-				summary={ <Summary imageCdnQuality={ imageCdnQuality } /> }
-			>
-				<QualityControl
-					label={ __( 'JPEG', 'jetpack-boost' ) }
-					maxValue={ 89 }
-					quality={ imageCdnQuality.jpg.quality }
-					lossless={ imageCdnQuality.jpg.lossless }
-					setQuality={ value => setQuality( 'jpg', value ) }
-					setLossless={ value => setLossless( 'jpg', value ) }
-				/>
-				<QualityControl
-					label={ __( 'PNG', 'jetpack-boost' ) }
-					maxValue={ 80 }
-					quality={ imageCdnQuality.png.quality }
-					lossless={ imageCdnQuality.png.lossless }
-					setQuality={ value => setQuality( 'png', value ) }
-					setLossless={ value => setLossless( 'png', value ) }
-				/>
-				<QualityControl
-					label={ __( 'WEBP', 'jetpack-boost' ) }
-					maxValue={ 80 }
-					quality={ imageCdnQuality.webp.quality }
-					lossless={ imageCdnQuality.webp.lossless }
-					setQuality={ value => setQuality( 'webp', value ) }
-					setLossless={ value => setLossless( 'webp', value ) }
-				/>
-			</CollapsibleMeta>
+			<ModuleSubsection>
+				<CollapsibleMeta
+					editText={ __( 'Adjust Quality', 'jetpack-boost' ) }
+					closeEditText={ __( 'Hide', 'jetpack-boost' ) }
+					header={ <Header /> }
+					summary={ <Summary imageCdnQuality={ imageCdnQuality } /> }
+				>
+					<div className={ styles.body }>
+						<h5>Adjust image quality per format</h5>
+						<div className={ styles[ 'quality-controls' ] }>
+							<QualityControl
+								label={ __( 'JPEG', 'jetpack-boost' ) }
+								maxValue={ 89 }
+								quality={ imageCdnQuality.jpg.quality }
+								lossless={ imageCdnQuality.jpg.lossless }
+								setQuality={ value => setQuality( 'jpg', value ) }
+								setLossless={ value => setLossless( 'jpg', value ) }
+							/>
+							<QualityControl
+								label={ __( 'PNG', 'jetpack-boost' ) }
+								maxValue={ 80 }
+								quality={ imageCdnQuality.png.quality }
+								lossless={ imageCdnQuality.png.lossless }
+								setQuality={ value => setQuality( 'png', value ) }
+								setLossless={ value => setLossless( 'png', value ) }
+							/>
+							<QualityControl
+								label={ __( 'WEBP', 'jetpack-boost' ) }
+								maxValue={ 80 }
+								quality={ imageCdnQuality.webp.quality }
+								lossless={ imageCdnQuality.webp.lossless }
+								setQuality={ value => setQuality( 'webp', value ) }
+								setLossless={ value => setLossless( 'webp', value ) }
+							/>
+						</div>
+					</div>
+				</CollapsibleMeta>
+			</ModuleSubsection>
 		)
 	);
 };
@@ -107,7 +114,7 @@ const Summary = ( {
 
 const Header = () => (
 	<div className={ styles[ 'section-title' ] }>
-		{ __( 'Image Quality', 'jetpack-boost' ) }
+		<h4>{ __( 'Image Quality', 'jetpack-boost' ) }</h4>
 		<IconTooltip
 			offset={ 8 }
 			placement={ 'bottom' }
@@ -119,8 +126,6 @@ const Header = () => (
 				'jetpack-boost'
 			) }
 		</IconTooltip>
-
-		<Upgraded />
 	</div>
 );
 

--- a/projects/plugins/boost/app/assets/src/js/features/ui/module-subsection/module-subsection.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/module-subsection/module-subsection.module.scss
@@ -1,0 +1,5 @@
+.wrapper {
+	margin-top: 24px;
+	border-top: 1px solid var(--gray-5);
+	padding-top: 24px;
+}

--- a/projects/plugins/boost/app/assets/src/js/features/ui/module-subsection/module-subsection.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/module-subsection/module-subsection.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+import styles from './module-subsection.module.scss';
+
+interface ModuleSubsectionProps {
+	children: ReactNode;
+}
+
+const ModuleSubsection = ( { children }: ModuleSubsectionProps ) => {
+	return <div className={ styles.wrapper }>{ children }</div>;
+};
+
+export default ModuleSubsection;

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -297,7 +297,12 @@ const Index = () => {
 			</Module>
 			<Module
 				slug="image_cdn"
-				title={ __( 'Image CDN', 'jetpack-boost' ) }
+				title={
+					<>
+						{ __( 'Image CDN', 'jetpack-boost' ) }
+						{ hasPremiumCdnFeatures && <Upgraded /> }
+					</>
+				}
 				description={
 					<>
 						<p>

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -45,6 +45,9 @@ const Index = () => {
 		pageCacheSetup.isSuccess && !! pageCache?.active
 	);
 
+	const hasPremiumCdnFeatures =
+		premiumFeatures.includes( 'image-cdn-liar' ) && premiumFeatures.includes( 'image-cdn-quality' );
+
 	const [ removePageCacheNotice ] = useMutationNotice(
 		'page-cache-setup',
 		{
@@ -296,15 +299,25 @@ const Index = () => {
 				slug="image_cdn"
 				title={ __( 'Image CDN', 'jetpack-boost' ) }
 				description={
-					<p>
-						{ __(
-							`Deliver images from Jetpack's Content Delivery Network. Automatically resizes your images to an appropriate size, converts them to modern efficient formats like WebP, and serves them from a worldwide network of servers.`,
-							'jetpack-boost'
+					<>
+						<p>
+							{ __(
+								`Deliver images from Jetpack's Content Delivery Network. Automatically resizes your images to an appropriate size, converts them to modern efficient formats like WebP, and serves them from a worldwide network of servers.`,
+								'jetpack-boost'
+							) }
+						</p>
+						{ ! hasPremiumCdnFeatures && (
+							<UpgradeCTA
+								description={ __(
+									'Auto-resize lazy images and adjust their quality.',
+									'jetpack-boost'
+								) }
+							/>
 						) }
-					</p>
+					</>
 				}
 			>
-				<ImageCdnLiar />
+				<ImageCdnLiar isPremium={ premiumFeatures.includes( 'image-cdn-liar' ) } />
 				<QualitySettings isPremium={ premiumFeatures.includes( 'image-cdn-quality' ) } />
 			</Module>
 

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -304,24 +304,22 @@ const Index = () => {
 					</>
 				}
 				description={
-					<>
-						<p>
-							{ __(
-								`Deliver images from Jetpack's Content Delivery Network. Automatically resizes your images to an appropriate size, converts them to modern efficient formats like WebP, and serves them from a worldwide network of servers.`,
-								'jetpack-boost'
-							) }
-						</p>
-						{ ! hasPremiumCdnFeatures && (
-							<UpgradeCTA
-								description={ __(
-									'Auto-resize lazy images and adjust their quality.',
-									'jetpack-boost'
-								) }
-							/>
+					<p>
+						{ __(
+							`Deliver images from Jetpack's Content Delivery Network. Automatically resizes your images to an appropriate size, converts them to modern efficient formats like WebP, and serves them from a worldwide network of servers.`,
+							'jetpack-boost'
 						) }
-					</>
+					</p>
 				}
 			>
+				{ ! hasPremiumCdnFeatures && (
+					<UpgradeCTA
+						description={ __(
+							'Auto-resize lazy images and adjust their quality.',
+							'jetpack-boost'
+						) }
+					/>
+				) }
 				<ImageCdnLiar isPremium={ premiumFeatures.includes( 'image-cdn-liar' ) } />
 				<QualitySettings isPremium={ premiumFeatures.includes( 'image-cdn-quality' ) } />
 			</Module>

--- a/projects/plugins/boost/app/lib/Premium_Features.php
+++ b/projects/plugins/boost/app/lib/Premium_Features.php
@@ -10,6 +10,7 @@ class Premium_Features {
 	const CLOUD_CSS           = 'cloud-critical-css';
 	const IMAGE_SIZE_ANALYSIS = 'image-size-analysis';
 	const PERFORMANCE_HISTORY = 'performance-history';
+	const IMAGE_CDN_LIAR      = 'image-cdn-liar';
 	const IMAGE_CDN_QUALITY   = 'image-cdn-quality';
 	const PRIORITY_SUPPORT    = 'support';
 	const PAGE_CACHE          = 'page-cache';
@@ -30,6 +31,7 @@ class Premium_Features {
 		$all_features       = array(
 			self::CLOUD_CSS,
 			self::IMAGE_SIZE_ANALYSIS,
+			self::IMAGE_CDN_LIAR,
 			self::IMAGE_CDN_QUALITY,
 			self::PERFORMANCE_HISTORY,
 			self::PRIORITY_SUPPORT,

--- a/projects/plugins/boost/app/modules/optimizations/image-cdn/class-image-cdn.php
+++ b/projects/plugins/boost/app/modules/optimizations/image-cdn/class-image-cdn.php
@@ -16,9 +16,12 @@ class Image_CDN implements Pluggable, Changes_Page_Output, Optimization {
 		if ( Premium_Features::has_feature( Premium_Features::IMAGE_CDN_QUALITY ) ) {
 			add_filter( 'jetpack_photon_pre_args', array( $this, 'add_quality_args' ), 10, 2 );
 		}
-		$image_cdn_liar = jetpack_boost_ds_get( 'image_cdn_liar' );
-		if ( $image_cdn_liar ) {
-			add_action( 'wp_footer', array( $this, 'inject_image_cdn_liar_script' ) );
+
+		if ( Premium_Features::has_feature( Premium_Features::IMAGE_CDN_LIAR ) ) {
+			$image_cdn_liar = jetpack_boost_ds_get( 'image_cdn_liar' );
+			if ( $image_cdn_liar ) {
+				add_action( 'wp_footer', array( $this, 'inject_image_cdn_liar_script' ) );
+			}
 		}
 	}
 

--- a/projects/plugins/boost/changelog/update-image-cdn-ui
+++ b/projects/plugins/boost/changelog/update-image-cdn-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Image CDN: Update UI.

--- a/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
+++ b/projects/plugins/boost/tests/e2e/lib/pages/wp-admin/JetpackBoostPage.js
@@ -152,7 +152,8 @@ export default class JetpackBoostPage extends WpPage {
 	}
 
 	async isImageCdnUpgradeSectionVisible() {
-		const selector = '[data-testid="module-image_cdn"] >> text=For more control over image quality';
+		const selector =
+			'[data-testid="module-image_cdn"] >> text=Auto-resize lazy images and adjust their quality.';
 		return this.page.isVisible( selector );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37262

![CleanShot 2024-05-07 at 17 44 51](https://github.com/Automattic/jetpack/assets/11799079/21ccebdb-b76a-45af-af7e-59d4b4aad50e)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update UI to match proposed designs as much as possible pc9hqz-2R5-p2;
  * Some colors and font-sizes are intentionally not 1 to 1 with designs, as the rest of Boost's UI uses slightly different styles altogether (than what's depicted in the designs). Despite that, I tried keeping things consistent with the rest of the UI;
  * Things like the "Adjust quality"/"Hide" icons haven't been changed intentionally to keep all accordion sections with the same icons (pencil to open, cross to close);
  * The Upgrade CTA doesn't say "Upgrade Jetpack Boost" (designs say Social, it's a typo), but instead uses the existing CTA;
  * The small `Upgraded` box has been moved next to the title. The designs depict it differently on different versions.
* Update LIAR UI/back-end to be gated behind a premium check;
* Add track event when toggling LIAR on/off;
* Clean-up some inline styles.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pc9hqz-2R5-p2 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Test the free UI
* Setup Boost free;
* Visit the Boost UI and make sure that the quality controls and the "Auto-resize lazy images" aren't showing;
* Functionality should also not be present in the front-end (there should be no JS script referencing `img[loading=lazy]`).

#### Test the premium UI/that functionality works

* Upgrade to premium;
* Make sure the UI behaves as expected;
* Visit the front-end and make sure there's a JS script referencing `img[loading=lazy]`.