### PR TITLE
Super Cache: modify advanced-cache.php notice to say Boost Cache module can be disabled

### DIFF
--- a/projects/plugins/super-cache/changelog/update-super-cache-confirm-delete-boost-cache
+++ b/projects/plugins/super-cache/changelog/update-super-cache-confirm-delete-boost-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Super Cache: add a form to delete the Boost advanced-cache.php so WPSC can be used
+Super Cache: tell user that Cache module of Boost must be deactivated to use WPSC

--- a/projects/plugins/super-cache/changelog/update-super-cache-confirm-delete-boost-cache
+++ b/projects/plugins/super-cache/changelog/update-super-cache-confirm-delete-boost-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Super Cache: add a form to delete the Boost advanced-cache.php so WPSC can be used

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -48,5 +48,6 @@ function wpsc_delete_boost_loader_form() {
  */
 function wpsc_delete_boost_loader() {
 	global $wpsc_advanced_cache_filename;
-	return wp_delete_file( $wpsc_advanced_cache_filename );
+	// Cannot use wp_delete_file() because it doesn't return a boolean.
+	return @unlink( $wpsc_advanced_cache_filename ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
 }

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -9,7 +9,7 @@ function wpsc_deactivate_boost_cache_notice() {
 	?>
 	<div style="width: 50%" class="notice notice-error"><h2><?php esc_html_e( 'Warning! Jetpack Boost Cache Detected', 'wp-super-cache' ); ?></h2>
 		<?php // translators: %s is the filename of the advanced-cache.php file ?>
-		<p><?php sprintf( esc_html__( 'The file %s was created by the Jetpack Boost plugin.', 'wp-super-cache' ), esc_html( $wpsc_advanced_cache_filename ) ); ?></p>
+		<p><?php printf( esc_html__( 'The file %s was created by the Jetpack Boost plugin.', 'wp-super-cache' ), esc_html( $wpsc_advanced_cache_filename ) ); ?></p>
 		<p><?php esc_html_e( 'You can use Jetpack Boost and WP Super Cache at the same time but only if the Cache Site Pages module in Boost is disabled. To use WP Super Cache for caching:', 'wp-super-cache' ); ?></p>
 		<ol>
 			<?php // translators: %s is a html link to the Boost settings page ?>

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Handle the wpsc_delete_boost_loader action.
+ * Redirects to the WP Super Cache settings page after deleting the Jetpack Boost cache loader.
+ */
+function wpsc_handle_delete_boost_loader() {
+	if ( isset( $_POST['action'] ) && $_POST['action'] === 'wpsc_delete_boost_loader' ) {
+		check_admin_referer( 'wpsc_delete_boost_loader' );
+
+		$deleted = wpsc_delete_boost_loader();
+		if ( $deleted ) {
+			$redirect = add_query_arg( 'wpsc_boost_loader_deleted', '1' );
+			wp_safe_redirect( $redirect );
+			exit;
+		}
+	}
+}
+
+if ( isset( $_GET['page'] ) && $_GET['page'] === 'wpsupercache' && isset( $_POST['action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
+	add_action( 'admin_init', 'wpsc_handle_delete_boost_loader' );
+}
+
+/**
+ * Add a notice to the WP Super Cache settings page if Jetpack Boost cache loader is detected.
+ * The notice contains a form to delete the Jetpack Boost cache loader.
+ */
+function wpsc_delete_boost_loader_form() {
+	global $wpsc_advanced_cache_filename;
+	?>
+	<div style="padding: 10px; width: 50%" class="notice notice-error"><h2><?php esc_html_e( 'Warning! Jetpack Boost Cache Detected', 'wp-super-cache' ); ?></h2>
+	<?php // translators: %s is the filename of the advanced-cache.php file ?>
+	<p><?php printf( esc_html__( 'The file %s was created by the Jetpack Boost plugin.', 'wp-super-cache' ), esc_html( $wpsc_advanced_cache_filename ) ); ?></p>
+	<p><?php esc_html_e( 'Please confirm that you want to use WP Super Cache instead of Jetpack Boost for caching:', 'wp-super-cache' ); ?></p>
+	<form method="POST">
+		<input type="hidden" name="action" value="wpsc_delete_boost_loader" />
+		<?php wp_nonce_field( 'wpsc_delete_boost_loader' ); ?>
+		<input type="submit" class="button button-primary" value="<?php esc_html_e( 'Use WP Super Cache for caching', 'wp-super-cache' ); ?>" class="button" />
+	</form>
+	</div>
+	<?php
+}
+
+/**
+ * Delete the Jetpack Boost cache loader.
+ *
+ * @return bool True if the cache loader was deleted, false otherwise.
+ */
+function wpsc_delete_boost_loader() {
+	global $wpsc_advanced_cache_filename;
+	return wp_delete_file( $wpsc_advanced_cache_filename );
+}

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -31,7 +31,7 @@ function wpsc_delete_boost_loader_form() {
 	<div style="padding: 10px; width: 50%" class="notice notice-error"><h2><?php esc_html_e( 'Warning! Jetpack Boost Cache Detected', 'wp-super-cache' ); ?></h2>
 	<?php // translators: %s is the filename of the advanced-cache.php file ?>
 	<p><?php printf( esc_html__( 'The file %s was created by the Jetpack Boost plugin.', 'wp-super-cache' ), esc_html( $wpsc_advanced_cache_filename ) ); ?></p>
-	<p><?php esc_html_e( 'Please confirm that you want to use WP Super Cache instead of Jetpack Boost for caching:', 'wp-super-cache' ); ?></p>
+	<p><?php esc_html_e( 'Please confirm that you want to use WP Super Cache instead of Jetpack Boost for caching.', 'wp-super-cache' ); ?></p>
 	<form method="POST">
 		<input type="hidden" name="action" value="wpsc_delete_boost_loader" />
 		<?php wp_nonce_field( 'wpsc_delete_boost_loader' ); ?>

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -15,7 +15,7 @@ function wpsc_deactivate_boost_cache_notice() {
 			<?php // translators: %s is a html link to the Boost settings page ?>
 			<li><?php printf( esc_html__( 'Deactivate the "Cache Site Pages" module of Jetpack Boost on the %s page.', 'wp-super-cache' ), '<a href="' . esc_url( admin_url( 'admin.php?page=jetpack-boost' ) ) . '">' . esc_html__( 'Boost Settings', 'wp-super-cache' ) . '</a>' ); ?></li>
 			<li><?php esc_html_e( 'Reload this page to configure WP Super Cache.', 'wp-super-cache' ); ?></li>
-			<li><?php esc_html_e( 'Activate the Jetpack Boost plugin again.', 'wp-super-cache' ); ?></li>
+			<li><?php esc_html_e( 'You can continue to use the other features of Jetpack Boost.', 'wp-super-cache' ); ?></li>
 		</ol>
 	</div>
 	<?php

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -1,53 +1,36 @@
 <?php
 
 /**
- * Handle the wpsc_delete_boost_loader action.
- * Redirects to the WP Super Cache settings page after deleting the Jetpack Boost cache loader.
+ * Add a notice to the settings page if the Jetpack Boost cache module is detected.
+ * The notice contains instructions on how to disable the Boost Cache module.
  */
-function wpsc_handle_delete_boost_loader() {
-	if ( isset( $_POST['action'] ) && $_POST['action'] === 'wpsc_delete_boost_loader' ) {
-		check_admin_referer( 'wpsc_delete_boost_loader' );
-
-		$deleted = wpsc_delete_boost_loader();
-		if ( $deleted ) {
-			$redirect = add_query_arg( 'wpsc_boost_loader_deleted', '1' );
-			wp_safe_redirect( $redirect );
-			exit;
-		}
-	}
-}
-
-if ( isset( $_GET['page'] ) && $_GET['page'] === 'wpsupercache' && isset( $_POST['action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
-	add_action( 'admin_init', 'wpsc_handle_delete_boost_loader' );
-}
-
-/**
- * Add a notice to the WP Super Cache settings page if Jetpack Boost cache loader is detected.
- * The notice contains a form to delete the Jetpack Boost cache loader.
- */
-function wpsc_delete_boost_loader_form() {
+function wpsc_deactivate_boost_cache_notice() {
 	global $wpsc_advanced_cache_filename;
 	?>
-	<div style="padding: 10px; width: 50%" class="notice notice-error"><h2><?php esc_html_e( 'Warning! Jetpack Boost Cache Detected', 'wp-super-cache' ); ?></h2>
-	<?php // translators: %s is the filename of the advanced-cache.php file ?>
-	<p><?php printf( esc_html__( 'The file %s was created by the Jetpack Boost plugin.', 'wp-super-cache' ), esc_html( $wpsc_advanced_cache_filename ) ); ?></p>
-	<p><?php esc_html_e( 'Please confirm that you want to use WP Super Cache instead of Jetpack Boost for caching.', 'wp-super-cache' ); ?></p>
-	<form method="POST">
-		<input type="hidden" name="action" value="wpsc_delete_boost_loader" />
-		<?php wp_nonce_field( 'wpsc_delete_boost_loader' ); ?>
-		<input type="submit" class="button button-primary" value="<?php esc_html_e( 'Use WP Super Cache for caching', 'wp-super-cache' ); ?>" class="button" />
-	</form>
+	<div style="width: 50%" class="notice notice-error"><h2><?php esc_html_e( 'Warning! Jetpack Boost Cache Detected', 'wp-super-cache' ); ?></h2>
+		<?php // translators: %s is the filename of the advanced-cache.php file ?>
+		<p><?php sprintf( esc_html__( 'The file %s was created by the Jetpack Boost plugin.', 'wp-super-cache' ), esc_html( $wpsc_advanced_cache_filename ) ); ?></p>
+		<p><?php esc_html_e( 'You can use Jetpack Boost and WP Super Cache at the same time but only if the Cache Site Pages module in Boost is disabled. To use WP Super Cache for caching:', 'wp-super-cache' ); ?></p>
+		<ol>
+			<?php // translators: %s is a html link to the Boost settings page ?>
+			<li><?php printf( esc_html__( 'Deactivate the "Cache Site Pages" module of Jetpack Boost on the %s page.', 'wp-super-cache' ), '<a href="' . esc_url( admin_url( 'admin.php?page=jetpack-boost' ) ) . '">' . esc_html__( 'Boost Settings', 'wp-super-cache' ) . '</a>' ); ?></li>
+			<li><?php esc_html_e( 'Reload this page to configure WP Super Cache.', 'wp-super-cache' ); ?></li>
+			<li><?php esc_html_e( 'Activate the Jetpack Boost plugin again.', 'wp-super-cache' ); ?></li>
+		</ol>
 	</div>
 	<?php
+	set_transient( 'wpsc_boost_cache_notice_displayed', true, WEEK_IN_SECONDS );
 }
 
 /**
- * Delete the Jetpack Boost cache loader.
- *
- * @return bool True if the cache loader was deleted, false otherwise.
+ * Tell Jetpack when the cache is moved from Jetpack Boost to WP Super Cache.
  */
-function wpsc_delete_boost_loader() {
-	global $wpsc_advanced_cache_filename;
-	// Cannot use wp_delete_file() because it doesn't return a boolean.
-	return @unlink( $wpsc_advanced_cache_filename ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
+function wpsc_track_move_from_boost() {
+	if ( ! get_transient( 'wpsc_boost_cache_notice_displayed' ) ) {
+		return;
+	}
+	delete_transient( 'wpsc_boost_cache_notice_displayed' );
+
+	do_action( 'jb_cache_moved_to_wpsc' );
 }
+add_action( 'wpsc_created_advanced_cache', 'wpsc_track_move_from_boost' );

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -2302,6 +2302,7 @@ function wp_cache_create_advanced_cache() {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 		fwrite( $fp, $file );
 		fclose( $fp );
+		do_action( 'wpsc_created_advanced_cache' );
 	} else {
 		$ret = false;
 	}
@@ -2328,7 +2329,7 @@ function wpsc_check_advanced_cache() {
 
 	if ( false == $ret ) {
 		if ( $other_advanced_cache === 'BOOST' ) {
-			wpsc_delete_boost_loader_form();
+			wpsc_deactivate_boost_cache_notice();
 		} elseif ( $other_advanced_cache ) {
 			echo '<div style="width: 50%" class="notice notice-error"><h2>' . __( 'Warning! You may not be allowed to use this plugin on your site.', 'wp-super-cache' ) . "</h2>";
 			echo '<p>' .

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -33,6 +33,7 @@ define( 'WPSC_VERSION', '1.9.1-alpha' );
 
 require_once( __DIR__. '/inc/delete-cache-button.php');
 require_once( __DIR__. '/inc/preload-notification.php');
+require_once __DIR__ . '/inc/boost.php';
 
 if ( ! function_exists( 'wp_cache_phase2' ) ) {
 	require_once( __DIR__. '/wp-cache-phase2.php');
@@ -2327,15 +2328,7 @@ function wpsc_check_advanced_cache() {
 
 	if ( false == $ret ) {
 		if ( $other_advanced_cache === 'BOOST' ) {
-			echo '<div style="width: 50%" class="notice notice-error"><h2>' . esc_html__( 'Warning! Jetpack Boost Cache Detected', 'wp-super-cache' ) . '</h2>';
-			// translators: %s is the filename of the advanced-cache.php file
-			echo '<p>' . sprintf( esc_html__( 'The file %s was created by the Jetpack Boost plugin.', 'wp-super-cache' ), esc_html( $wpsc_advanced_cache_filename ) ) . '</p>';
-			echo '<p>' . esc_html__( 'You can use Jetpack Boost and WP Super Cache at the same time but only if the Cache Site Pages module in Boost is disabled. To use WP Super Cache for caching:', 'wp-super-cache' ) . '</p>';
-			// translators: %s is a html link to the plugins page
-			echo '<ol><li>' . sprintf( esc_html__( 'Deactivate Jetpack Boost on the %s page.', 'wp-super-cache' ), '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">' . esc_html__( 'Plugins', 'wp-super-cache' ) . '</a>' ) . '</li>';
-			echo '<li>' . esc_html__( 'Reload this page to configure WP Super Cache.', 'wp-super-cache' ) . '</li>';
-			echo '<li>' . esc_html__( 'Activate the Jetpack Boost plugin again.', 'wp-super-cache' ) . '</li>';
-			echo '</ol>';
+			wpsc_delete_boost_loader_form();
 		} elseif ( $other_advanced_cache ) {
 			echo '<div style="width: 50%" class="notice notice-error"><h2>' . __( 'Warning! You may not be allowed to use this plugin on your site.', 'wp-super-cache' ) . "</h2>";
 			echo '<p>' .


### PR DESCRIPTION
If the advanced-cache.php created by Jetpack Boost is found, the plugin displays a warning message saying that Boost must be deactivated before WP Super Cache can be used. This PR changes that message to say that only the Cache module of Boost must be disabled.
With that done, and on refreshing that page WPSC can be configured. We send a message to Boost to let it know the move was successful.

ref: https://github.com/Automattic/jetpack/issues/37227

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* add a new file inc/boost.php to hold Boost related functionality.
* The notice and tracking code is in this file.
* Load that notice from wp-cache.php
* Replace the original warning message with the updated the one.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-2QH-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Apply this PR using the beta plugin
* Activate Jetpack Boost and enable the Cache module.
* From the Plugins page, activate WP Super Cache.
* Go to the WP Super Cache settings page and note the new notice that says Boost was found.
* Although the notice says that the Cache module can be disabled, that is not the case right now. JB must be disabled.
* Refresh the page with the notice, and it will reload into the "Easy" settings page of the plugin.
* Visit the Boost settings page. The Cache module will be disabled but show a warning about the advanced-cache.php

Before:
![Screenshot 2024-05-09 at 13 43 42](https://github.com/Automattic/jetpack/assets/5656673/bd638c59-aba5-4b01-82bb-f77809f92094)

After:
![Screenshot 2024-05-27 at 16 25 11](https://github.com/Automattic/jetpack/assets/5656673/c4d4bc0e-69e6-41a4-aa27-9f4acc844aba)

