### PR TITLE
Fix multiple scheduled update sync issue

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-su-multiple-sync-issue
+++ b/projects/packages/scheduled-updates/changelog/fix-su-multiple-sync-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix multiple sync issue

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -34,7 +34,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PLUGIN_CRON_FILTER = 'jetpack_scheduled_plugins_update_filter';
+	const PLUGIN_CRON_SYNC_HOOK = 'jetpack_scheduled_plugins_update_sync';
 
 	/**
 	 * Initialize the class.
@@ -202,8 +202,8 @@ class Scheduled_Updates {
 	 * Save the schedules for sync after cron option saving.
 	 */
 	public static function update_option_cron() {
-		// Do not update the option if the filter is set to false.
-		if ( ! apply_filters( self::PLUGIN_CRON_FILTER, true ) ) {
+		// Do not update the option if the filter returns false.
+		if ( ! apply_filters( self::PLUGIN_CRON_SYNC_HOOK, true ) ) {
 			return;
 		}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -30,6 +30,13 @@ class Scheduled_Updates {
 	const PLUGIN_CRON_HOOK = 'jetpack_scheduled_plugins_update';
 
 	/**
+	 * The cron event filter for the scheduled plugins update.
+	 *
+	 * @var string
+	 */
+	const PLUGIN_CRON_FILTER = 'jetpack_scheduled_plugins_update_filter';
+
+	/**
 	 * Initialize the class.
 	 */
 	public static function init() {
@@ -195,6 +202,11 @@ class Scheduled_Updates {
 	 * Save the schedules for sync after cron option saving.
 	 */
 	public static function update_option_cron() {
+		// Do not update the option if the filter is set to false.
+		if ( ! apply_filters( self::PLUGIN_CRON_FILTER, true ) ) {
+			return;
+		}
+
 		Scheduled_Updates_Logs::add_log_fields();
 		Scheduled_Updates_Active::add_active_field();
 		Scheduled_Updates_Health_Paths::add_health_check_paths_field();

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -278,15 +278,17 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return $verified_plugins;
 		}
 
-		add_filter( Scheduled_Updates::PLUGIN_CRON_FILTER, '__return_false' );
+		// Prevent the sync option to be updated during the deletetion. This will ensure that the sync is performed only once.
+		// Context: https://github.com/Automattic/jetpack/issues/27763
+		add_filter( Scheduled_Updates::PLUGIN_CRON_SYNC_HOOK, '__return_false' );
 		$deleted = $this->delete_item( $request );
 
 		if ( is_wp_error( $deleted ) ) {
-			remove_filter( Scheduled_Updates::PLUGIN_CRON_FILTER, '__return_false' );
 			return $deleted;
 		}
 
-		remove_filter( Scheduled_Updates::PLUGIN_CRON_FILTER, '__return_false' );
+		// Re-enable the sync option before creation.
+		remove_filter( Scheduled_Updates::PLUGIN_CRON_SYNC_HOOK, '__return_false' );
 		$item = $this->create_item( $request );
 
 		/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -278,7 +278,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return $verified_plugins;
 		}
 
-		// Prevent the sync option to be updated during the deletetion. This will ensure that the sync is performed only once.
+		// Prevent the sync option to be updated during deletion. This will ensure that the sync is performed only once.
 		// Context: https://github.com/Automattic/jetpack/issues/27763
 		add_filter( Scheduled_Updates::PLUGIN_CRON_SYNC_HOOK, '__return_false' );
 		$deleted = $this->delete_item( $request );

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -278,11 +278,15 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return $verified_plugins;
 		}
 
+		add_filter( Scheduled_Updates::PLUGIN_CRON_FILTER, '__return_false' );
 		$deleted = $this->delete_item( $request );
+
 		if ( is_wp_error( $deleted ) ) {
+			remove_filter( Scheduled_Updates::PLUGIN_CRON_FILTER, '__return_false' );
 			return $deleted;
 		}
 
+		remove_filter( Scheduled_Updates::PLUGIN_CRON_FILTER, '__return_false' );
 		$item = $this->create_item( $request );
 
 		/**

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -712,6 +712,35 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
+	 * Adds plugins to the autoupdate list when deleting a schedule.
+	 *
+	 * @covers ::create_item
+	 * @covers ::get_item
+	 * @covers ::update_item
+	 * @covers ::delete_item
+	 */
+	public function test_crud_should_sync_three_times() {
+		wp_set_current_user( $this->admin_id );
+		$plugins = array(
+			'custom-plugin/custom-plugin.php',
+			'gutenberg/gutenberg.php',
+		);
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params(
+			array(
+				'plugins'  => $plugins,
+				'schedule' => $this->get_schedule(),
+			)
+		);
+		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
+		$result      = rest_do_request( $request );
+
+		// Create.
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( $schedule_id, $result->get_data() );
+	}
+
+	/**
 	 * Get a schedule.
 	 *
 	 * @param string $timestamp Schedule timestamp.

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -720,7 +720,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	 * @covers ::delete_item
 	 */
 	public function test_crud_should_sync_three_times() {
-		echo "\n\n\n--------------------\n\n\n";
 		wp_set_current_user( $this->admin_id );
 		$plugins       = array(
 			'custom-plugin/custom-plugin.php',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes sync issues in the `wpcom/v2/update-schedules` endpoints.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the `jetpack_scheduled_plugins_update_sync` filter that can prevent updating `jetpack_scheduled_plugins_update` option
* Block sync during the delete phase found in `WPCOM_REST_API_V2_Endpoint_Update_Schedules::update_item`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Install `fix/su-multiple-sync-issue` in `WordPress.com Features`
* Be sure to have needed jobs sandboxed and the watcher running
* Add the code found in pcmemI-2Ww-p2 at "Monitoring Jetpack syncs" section
* Leave `tail -f -n 40 /tmp/php-errors` open

On `https://wordpress.com/plugins/scheduled-updates/__BLOG__`
1. Create a scheduled update.
2. Update it without changing plugins.
3. Delete it.
4. Add other scheduled updates.
5. Change plugins.
6. Etc.

The `jetpack_scheduled_plugins_update` string should appear three times in your logs. Perform other tests. The sync count should always be:
1. Read: **0**
2. Create: **+1**
3. Update: **+1**
7. Delete: **+1**

Ensure the is always on sync using `wpsh`:
```
switch_to_blog(__BLOG_ID__);
print_r( get_option('jetpack_scheduled_plugins_update') );
```