### PR TITLE
cli: Don't copy `changelog/` for `jetpack generate` from starter plugin

### DIFF
--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -377,10 +377,17 @@ async function generatePluginFromStarter( projDir, answers ) {
 	} );
 	files = files.split( '\n' ).map( str => str.replace( 'projects/plugins/starter-plugin', '' ) );
 	files.forEach( file => {
-		if ( file ) {
+		if ( file && ! file.startsWith( 'changelog/' ) ) {
 			copyFile( path.join( projDir, file ), path.join( starterDir, file ) );
 		}
 	} );
+
+	// Initialize changelog dir.
+	mergeDirs(
+		fileURLToPath( new URL( '../skeletons/common/changelog', import.meta.url ) ),
+		path.join( projDir, 'changelog' ),
+		answers.name
+	);
 
 	// Replace strings.
 	await searchReplaceInFolder( projDir, 'jetpack-starter-plugin', normalizeSlug( answers.name ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When using `jetpack generate` to create a new plugin based on the starter plugin, we need to make sure that the contents of the `changelog/` directory are not copied. The new plugin should start with an empty changelog directory.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/37259#discussion_r1592713306

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use `jetpack generate` to generate a new plugin using the starter plugin. Verify that the `changelog/` dir in your new plugin has only `.gitkeep` and `initial-version`, no other files.
