### PR TITLE
Contact Form: Replacing the tinymce JS file path with non minified, preventing editor errors

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-tiny-mce-editor-min-error
+++ b/projects/packages/forms/changelog/fix-contact-form-tiny-mce-editor-min-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: Prevent an editor error when using the Classic Editor and contact forms are enabled

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.31.0",
+	"version": "0.31.1-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.31.0';
+	const PACKAGE_VERSION = '0.31.1-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-editor-view.php
+++ b/projects/packages/forms/src/contact-form/class-editor-view.php
@@ -60,7 +60,7 @@ class Editor_View {
 	 */
 	public static function mce_external_plugins( $plugin_array ) {
 		$plugin_array['grunion_form'] = Assets::get_file_url_for_environment(
-			'jetpack_vendor/automattic/jetpack-forms/dist/contact-form/js/tinymce-plugin-form-button.min.js',
+			'jetpack_vendor/automattic/jetpack-forms/dist/contact-form/js/tinymce-plugin-form-button.js',
 			'jetpack_vendor/automattic/jetpack-forms/dist/contact-form/js/tinymce-plugin-form-button.js'
 		);
 		return $plugin_array;


### PR DESCRIPTION
## Proposed changes:

* When Contact Form module files were removed in https://github.com/Automattic/jetpack/pull/37157, the package version does not build minified JS files in the same way and this resulted in errors on WoA sites who had both the Classic Editor installed and the contact form module enabled.
* This PR fixes that by changing the min file path to be the regular JS file path for now, until we can make sure minified files are properly generated in the package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Multiple reports were also made here (only relevant to recent reports): https://github.com/Automattic/jetpack/issues/10919

p1715102635937589-slack-C02FMH4G8


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To replicate the issue, on a WoA site running the most recent Jetpack version, make sure the contact form is enabled at `/wp-admin/admin.php?page=jetpack_modules`
* Also, make sure the Classic Editor plugin is installed and active
* Then attempt to create a new post - you will see an error beginning with 'Failed to load plugin url:....'  , referring to `tinymce-plugin-form-button.min.js`.

* To test the fix, on a WoA site with the Jetpack Beta tester plugin installed (or an WoA dev site using rsync), apply this patch.
* Follow the same steps as above.
* Attempt to create a new post - you should not see any errors.

The fix should also work on a Jetpack local development site (though the issue itself isn't replicable there)