### PR TITLE
Add Admin Interface Style options to Settings > General

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-admin-interface-style-to-settings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-admin-interface-style-to-settings
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Settings: Add Admin Interface Style options.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -56,7 +56,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.28.x-dev"
+			"dev-trunk": "5.29.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.28.1-alpha",
+	"version": "5.29.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.28.1-alpha';
+	const PACKAGE_VERSION = '5.29.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -41,6 +41,7 @@ class Jetpack_Mu_Wpcom {
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_rest_api_endpoints' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_block_theme_previews' ) );
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_command_palette' ) );
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_admin_interface' ) );
 
 		// This feature runs only on simple sites.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -289,5 +290,14 @@ class Jetpack_Mu_Wpcom {
 		if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
 			require_once __DIR__ . '/features/wpcom-simple-odyssey-stats/wpcom-simple-odyssey-stats.php';
 		}
+	}
+
+	/**
+	 * Load WPCOM Admin Interface.
+	 *
+	 * @return void
+	 */
+	public static function load_wpcom_admin_interface() {
+		require_once __DIR__ . '/features/wpcom-admin-interface/wpcom-admin-interface.php';
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -30,7 +30,7 @@ function wpcom_admin_interface_display() {
 	echo '</fieldset>';
 }
 
-if ( ! empty( get_option( 'wpcom_classic_early_release' ) ) ) {
+if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 	add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -30,7 +30,7 @@ function wpcom_admin_interface_display() {
 	echo '</fieldset>';
 }
 
-if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+if ( ! empty( get_option( 'wpcom_classic_early_release' ) ) || ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 	add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -12,7 +12,7 @@
  * The setting is displayed only if the has the wp-admin interface selected.
  */
 function wpcomsh_wpcom_admin_interface_settings_field() {
-	add_settings_field( 'wpcom_admin_interface', null, 'wpcom_admin_interface_display', 'general', 'default' );
+	add_settings_field( 'wpcom_admin_interface', '', 'wpcom_admin_interface_display', 'general', 'default' );
 
 	register_setting( 'general', 'wpcom_admin_interface', 'esc_attr' );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -14,7 +14,7 @@
 function wpcomsh_wpcom_admin_interface_settings_field() {
 	add_settings_field( 'wpcom_admin_interface', '', 'wpcom_admin_interface_display', 'general', 'default' );
 
-	register_setting( 'general', 'wpcom_admin_interface', 'esc_attr' );
+	register_setting( 'general', 'wpcom_admin_interface', array( 'sanitize_callback' => 'esc_attr' ) );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Additional wpcom_admin_interface option on settings.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Add the Admin Interface Style setting on the General settings page.
+ * This setting allows users to switch between the classic WP-Admin interface and the WordPress.com legacy dashboard.
+ * The setting is stored in the wpcom_admin_interface option.
+ * The setting is displayed only if the has the wp-admin interface selected.
+ */
+function wpcomsh_wpcom_admin_interface_settings_field() {
+	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
+		return;
+	}
+
+	add_settings_field( 'wpcom_admin_interface', null, 'wpcom_admin_interface_display', 'general', 'default' );
+
+	register_setting( 'general', 'wpcom_admin_interface', 'esc_attr' );
+}
+
+/**
+ * Display the wpcom_admin_interface setting on the General settings page.
+ */
+function wpcom_admin_interface_display() {
+	$value = get_option( 'wpcom_admin_interface' );
+
+	echo '<tr valign="top"><th scope="row"><label for="wpcom_admin_interface">' . esc_html__( 'Admin Interface Style', 'jetpack-mu-wpcom' ) . '</label></th><td>';
+	echo '<fieldset>';
+	echo '<label><input type="radio" name="wpcom_admin_interface" value="wp-admin" ' . checked( 'wp-admin', $value, false ) . '/> <span>' . esc_html__( 'Classic style', 'jetpack-mu-wpcom' ) . '</span></label><p>' . esc_html__( 'Use WP-Admin to manage your site.', 'jetpack-mu-wpcom' ) . '</p><br>';
+	echo '<label><input type="radio" name="wpcom_admin_interface" value="calypso" ' . checked( 'calypso', $value, false ) . '/> <span>' . esc_html__( 'Default style', 'jetpack-mu-wpcom' ) . '</span></label><p>' . esc_html__( 'Use WordPress.com’s legacy dashboard to manage your site.', 'jetpack-mu-wpcom' ) . '</p><br>';
+	echo '</fieldset>';
+}
+
+if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
+	add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -12,10 +12,6 @@
  * The setting is displayed only if the has the wp-admin interface selected.
  */
 function wpcomsh_wpcom_admin_interface_settings_field() {
-	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
-		return;
-	}
-
 	add_settings_field( 'wpcom_admin_interface', null, 'wpcom_admin_interface_display', 'general', 'default' );
 
 	register_setting( 'general', 'wpcom_admin_interface', 'esc_attr' );
@@ -34,6 +30,41 @@ function wpcom_admin_interface_display() {
 	echo '</fieldset>';
 }
 
-if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
+if ( ! empty( get_option( 'wpcom_classic_early_release' ) ) ) {
 	add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );
 }
+
+/**
+ * Update the wpcom_admin_interface option on wpcom as it's the persistent data.
+ *
+ * @access private
+ * @since 4.20.0
+ *
+ * @param array $new_value The new settings value.
+ * @param array $old_value The old settings value.
+ * @return array The value to update.
+ */
+function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
+	if ( $new_value === $old_value ) {
+		return $new_value;
+	}
+
+	if ( ! class_exists( 'Jetpack_Options' ) || ! class_exists( 'Automattic\Jetpack\Connection\Client' ) || ! class_exists( 'Automattic\Jetpack\Status\Host' ) ) {
+		return $new_value;
+	}
+
+	if ( ( new Automattic\Jetpack\Status\Host() )->is_wpcom_simple() ) {
+		return $new_value;
+	}
+
+	$blog_id = Jetpack_Options::get_option( 'id' );
+	Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+		"/sites/$blog_id/hosting/admin-interface",
+		'v2',
+		array( 'method' => 'POST' ),
+		array( 'interface' => $new_value )
+	);
+
+	return $new_value;
+}
+add_filter( 'pre_update_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_update_option', 10, 2 );

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-admin-interface-style-to-settings
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-admin-interface-style-to-settings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -688,7 +688,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "a2b95ed2cade4352f52bffc659c1da7b5de1d759"
+                "reference": "5f2878749d5270c40add7437c39d563c2e5f9981"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -716,7 +716,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.28.x-dev"
+                    "dev-trunk": "5.29.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
Related https://github.com/Automattic/dotcom-forge/issues/6942

## Proposed changes:
Add Admin Interface Style options to `wp-admin/options-general.php`

Show it to all Atomic sites and Simple sites with `wpcom_classic_early_release` enabled.
It should not show on Atomic sites without `wpcom_classic_early_release` or disabled.

![image](https://github.com/Automattic/jetpack/assets/402286/a56815d4-2417-4ef7-aea3-7c1417ce75db)

### To-do
- [x] Make it save the option

## Jetpack product discussion
https://github.com/Automattic/dotcom-forge/issues/6942

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Go to `/wp-admin/options-general.php`
* You should see `Admin Interface Style` on all Atomic Sites or Simple sites with `wpcom_classic_early_release` enabled
* You should not see it in a Simple Sites without `wpcom_classic_early_release`
