### PR TITLE
CRM: Add WooSync status to avoid creating invoices and transactions

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-3463-woosync-avoid-creating-invoices-and-transactions-for-woo-draft
+++ b/projects/plugins/crm/changelog/update-crm-3463-woosync-avoid-creating-invoices-and-transactions-for-woo-draft
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+WooSync: Added new status mapping to avoid creating invoices and transactions from WooCommerce to Jetpack CRM

--- a/projects/plugins/crm/changelog/update-crm-3463-woosync-avoid-creating-invoices-and-transactions-for-woo-draft
+++ b/projects/plugins/crm/changelog/update-crm-3463-woosync-avoid-creating-invoices-and-transactions-for-woo-draft
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 WooSync: Added new status mapping to avoid creating invoices and transactions from WooCommerce to Jetpack CRM

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
@@ -359,7 +359,7 @@ function jpcrm_settings_page_html_woosync_main() {
 												$selected = $settings[ $mapping_key ];
 											}
 
-											if ( ! $zbs->DAL->is_valid_obj_status( $obj_type_id, $selected ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+											if ( ! $zbs->DAL->is_valid_obj_status( $obj_type_id, $selected ) && $selected !== WOOSYNC_DO_NOT_CREATE['id'] ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 												$selected = false;
 											}
 
@@ -373,8 +373,12 @@ function jpcrm_settings_page_html_woosync_main() {
 														<option value="-1" selected disabled>-- <?php esc_html_e( 'Select mapped status', 'zero-bs-crm' ); ?> --</option>
 														<?php
 													}
-													?>
-													<?php
+
+													// Include a DO_NOT_CREATE option, except for Contacts
+													if ( $obj_type_id !== ZBS_TYPE_CONTACT ) {
+														printf( '<option value="%s" %s>%s</option>', esc_attr( WOOSYNC_DO_NOT_CREATE['id'] ), ( $selected === WOOSYNC_DO_NOT_CREATE['id'] ? 'selected' : '' ), esc_html( WOOSYNC_DO_NOT_CREATE['label'] ) );
+													}
+
 													foreach ( $map_type_value['statuses'] as $status ) {
 														printf( '<option value="%s" %s>%s</option>', esc_attr( $status ), ( $selected === $status ? 'selected' : '' ), esc_html( $obj_type_id === ZBS_TYPE_INVOICE ? __( $status, 'zero-bs-crm' ) : $status ) ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
 													}

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/main.page.php
@@ -359,7 +359,7 @@ function jpcrm_settings_page_html_woosync_main() {
 												$selected = $settings[ $mapping_key ];
 											}
 
-											if ( ! $zbs->DAL->is_valid_obj_status( $obj_type_id, $selected ) && $selected !== WOOSYNC_DO_NOT_CREATE['id'] ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+											if ( ! $zbs->DAL->is_valid_obj_status( $obj_type_id, $selected ) && $selected !== JPCRM_WOOSYNC_DO_NOT_CREATE['id'] ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 												$selected = false;
 											}
 
@@ -376,7 +376,7 @@ function jpcrm_settings_page_html_woosync_main() {
 
 													// Include a DO_NOT_CREATE option, except for Contacts
 													if ( $obj_type_id !== ZBS_TYPE_CONTACT ) {
-														printf( '<option value="%s" %s>%s</option>', esc_attr( WOOSYNC_DO_NOT_CREATE['id'] ), ( $selected === WOOSYNC_DO_NOT_CREATE['id'] ? 'selected' : '' ), esc_html( WOOSYNC_DO_NOT_CREATE['label'] ) );
+														printf( '<option value="%s" %s>%s</option>', esc_attr( JPCRM_WOOSYNC_DO_NOT_CREATE['id'] ), ( $selected === JPCRM_WOOSYNC_DO_NOT_CREATE['id'] ? 'selected' : '' ), esc_html( JPCRM_WOOSYNC_DO_NOT_CREATE['label'] ) );
 													}
 
 													foreach ( $map_type_value['statuses'] as $status ) {

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -936,6 +936,7 @@ class Woo_Sync_Background_Sync_Job {
 		}
 
 		// Add/update invoice (if enabled) (previously `add_or_update_invoice`), while checking for a 'Do not create' status to avoid creating this invoice if the mapping doesn't allow it
+		// @phan-suppress PhanTypeInvalidDimOffset
 		if ( $settings['wcinv'] == 1 && isset( $crm_object_data['invoice'] ) && isset( $crm_object_data['invoice']['status'] ) && $crm_object_data['invoice']['status'] !== JPCRM_WOOSYNC_DO_NOT_CREATE['id'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 
 			// retrieve existing invoice

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -936,7 +936,7 @@ class Woo_Sync_Background_Sync_Job {
 		}
 
 		// Add/update invoice (if enabled) (previously `add_or_update_invoice`)
-		if ( $settings['wcinv'] == 1 ) {
+		if ( $settings['wcinv'] == 1 && $crm_object_data['invoice']['status'] !== WOOSYNC_DO_NOT_CREATE['id'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 
 			// retrieve existing invoice
 			// note this is substituting $crm_object_data['invoice']['existence_check_args'] for what should be $args, but it works
@@ -1763,143 +1763,143 @@ class Woo_Sync_Background_Sync_Job {
 
 		$transaction_status = $this->woosync()->translate_order_status_to_obj_status( ZBS_TYPE_TRANSACTION, $order_status );
 
-		// fill out transaction header (object)
-		$data['transaction'] = array(
+		if ( $transaction_status !== WOOSYNC_DO_NOT_CREATE['id'] ) {
+			// fill out transaction header (object)
+			$data['transaction'] = array(
 
-			'ref'                  => $order_num,
-			'type'                 => __( 'Sale', 'zero-bs-crm' ),
-			'title'                => $item_title,
-			'status'               => $transaction_status,
-			'total'                => $order_data['total'],
-			'date'                 => $transaction_creation_date_uts,
-			'created'              => $transaction_creation_date_uts,
-			'date_completed'       => $transaction_completed_date_uts,
-			'date_paid'            => $transaction_paid_date_uts,
-			'externalSources'      => array(
-				array(
-					'source' => 'woo',
-					'uid'    => $order_post_id,
-					'origin' => $origin,
-					'owner'  => 0, // for now we hard-type no owner to avoid ownership issues. As we roll out fuller ownership we may want to adapt this.
+				'ref'                  => $order_num,
+				'type'                 => __( 'Sale', 'zero-bs-crm' ),
+				'title'                => $item_title,
+				'status'               => $transaction_status,
+				'total'                => $order_data['total'],
+				'date'                 => $transaction_creation_date_uts,
+				'created'              => $transaction_creation_date_uts,
+				'date_completed'       => $transaction_completed_date_uts,
+				'date_paid'            => $transaction_paid_date_uts,
+				'externalSources'      => array(
+					array(
+						'source' => 'woo',
+						'uid'    => $order_post_id,
+						'origin' => $origin,
+						'owner'  => 0, // for now we hard-type no owner to avoid ownership issues. As we roll out fuller ownership we may want to adapt this.
+					),
 				),
-			),
-			'currency'             => $order_currency,
-			'net'                  => ( (float)$order_data['total'] - (float)$order_data['discount_total'] - (float)$order_data['total_tax'] - (float)$order_data['shipping_total'] ),
-			'tax'                  => $order_data['total_tax'],
-			'fee'                  => 0,
-			'discount'             => $order_data['discount_total'],
-			'shipping'             => $order_data['shipping_total'],
-			'existence_check_args' => $data['source'],
-			'lineitems'            => $data['lineitems'],
+				'currency'             => $order_currency,
+				'net'                  => ( (float) $order_data['total'] - (float) $order_data['discount_total'] - (float) $order_data['total_tax'] - (float) $order_data['shipping_total'] ),
+				'tax'                  => $order_data['total_tax'],
+				'fee'                  => 0,
+				'discount'             => $order_data['discount_total'],
+				'shipping'             => $order_data['shipping_total'],
+				'existence_check_args' => $data['source'],
+				'lineitems'            => $data['lineitems'],
 
-		);
+			);
 
-		// tags (transaction)
-		if ( $tag_transaction_with_item ) {
+			// tags (transaction)
+			if ( $tag_transaction_with_item ) {
 
-			$data['transaction']['tags']     = $order_tags;
-			$data['transaction']['tag_mode'] = 'append';
-
-		}
-
-		// any extra meta?
-		if ( is_array( $extra_meta ) && count( $extra_meta ) > 0 ) {
-
-			$data['transaction_extra_meta'] = $extra_meta;
-
-		}
-
-		// Sub-transactions (refunds)
-		if ( method_exists( $order, 'get_refunds' ) ) {
-
-			// process refunds
-			$refunds = $order->get_refunds();
-			if ( is_array( $refunds ) ) {
-
-				// cycle through and add as secondary transactions
-				foreach ( $refunds as $refund ) {
-
-					// retrieve refund data
-					$refund_data = $refund->get_data();
-
-					// process the refund as a secondary transaction
-					// This mimicks the main transaction, taking from the refund object where sensible
-					$refund_id = $refund->get_id();
-					$refund_title = sprintf( __( 'Refund against transaction #%s', 'zero-bs-crm' ), $order_num );
-					$refund_description = $refund_title . "\r\n" . __( 'Reason: ', 'zero-bs-crm' ) . $refund_data['reason'];
-					$refund_date_uts = strtotime( $refund_data['date_created']->__toString() );
-					if ( isset( $refund_data['currency'] ) && !empty( $refund_data['currency'] ) ) {
-						$refund_currency = $refund_data['currency'];
-					} else {
-						$refund_currency = $order_currency;
-					}
-
-					$refund_transaction = array(
-
-						'ref'                  => $refund_id,
-						'type'                 => __( 'Refund', 'zero-bs-crm' ),
-						'title'                => $refund_title,
-						'status'               => __( 'Refunded', 'zero-bs-crm' ),
-						'total'                => -$refund_data['total'],
-						'desc'                 => $refund_description,
-						'date'                 => $refund_date_uts,
-						'created'              => $refund_date_uts,
-						'date_completed'       => $transaction_completed_date_uts,
-						'date_paid'            => $transaction_paid_date_uts,
-						'externalSources'      => array(
-							array(
-								'source' => 'woo',
-								'uid'    => $refund_id, // rather than order_num, here we use the refund item id
-								'origin' => $origin,
-								'owner'  => 0, // for now we hard-type no owner to avoid ownership issues. As we roll out fuller ownership we may want to adapt this.
-							),
-						),
-						'currency'             => $refund_currency,
-						'net'                  => -( (float)$refund_data['total'] - (float)$refund_data['discount_total'] - (float)$refund_data['total_tax'] - (float)$refund_data['shipping_total'] ),
-						'tax'                  => $refund_data['total_tax'],
-						'fee'                  => 0,
-						'discount'             => $refund_data['discount_total'],
-						'shipping'             => $refund_data['shipping_total'],
-						'existence_check_args' => array(
-							'externalSource'    => 'woo',
-							'externalSourceUID' => $refund_id,
-							'origin'            => $origin,
-							'onlyID'            => true,
-						),
-						'lineitems'            => array(
-							// here we roll a single refund line item
-							array(
-								'order'    => $refund_id,
-								'currency' => $refund_currency,
-								'quantity' => 1,
-								'price'    => -$refund_data['total'],
-								'total'    => -$refund_data['total'],
-								'title'    => $refund_title,
-								'desc'     => $refund_description,
-								'tax'      => $refund_data['total_tax'],
-								'shipping' => 0,
-							),
-						),
-						'extra_meta'           => array(), // this is caught to insert as extraMeta
-
-					);
-
-					// Add any extra meta we can glean in case future useful:
-					$refund_transaction['extra_meta']['order_num'] = $order_num; // backtrace
-					if ( isset( $refund_data['refunded_by'] ) && !empty( $refund_data['refunded_by'] ) ) {
-						$refund_transaction['extra_meta']['refunded_by'] = $refund_data['refunded_by'];
-					}
-					if ( isset( $refund_data['refunded_payment'] ) && !empty( $refund_data['refunded_payment'] ) ) {
-						$refund_transaction['extra_meta']['refunded_payment'] = $refund_data['refunded_payment'];
-					}
-
-					// add it to the stack
-					$data['secondary_transactions'][] = $refund_transaction;
-
-				}
+				$data['transaction']['tags']     = $order_tags;
+				$data['transaction']['tag_mode'] = 'append';
 
 			}
 
+			// any extra meta?
+			if ( is_array( $extra_meta ) && count( $extra_meta ) > 0 ) {
+
+				$data['transaction_extra_meta'] = $extra_meta;
+
+			}
+
+			// Sub-transactions (refunds)
+			if ( method_exists( $order, 'get_refunds' ) ) {
+
+				// process refunds
+				$refunds = $order->get_refunds();
+				if ( is_array( $refunds ) ) {
+
+					// cycle through and add as secondary transactions
+					foreach ( $refunds as $refund ) {
+
+						// retrieve refund data
+						$refund_data = $refund->get_data();
+
+						// process the refund as a secondary transaction
+						// This mimicks the main transaction, taking from the refund object where sensible
+						$refund_id = $refund->get_id();
+						// translators: %s is the order number from WooCommerce.
+						$refund_title       = sprintf( __( 'Refund against transaction #%s', 'zero-bs-crm' ), $order_num );
+						$refund_description = $refund_title . "\r\n" . __( 'Reason: ', 'zero-bs-crm' ) . $refund_data['reason'];
+						$refund_date_uts    = strtotime( $refund_data['date_created']->__toString() );
+						if ( isset( $refund_data['currency'] ) && ! empty( $refund_data['currency'] ) ) {
+							$refund_currency = $refund_data['currency'];
+						} else {
+							$refund_currency = $order_currency;
+						}
+
+						$refund_transaction = array(
+
+							'ref'                  => $refund_id,
+							'type'                 => __( 'Refund', 'zero-bs-crm' ),
+							'title'                => $refund_title,
+							'status'               => __( 'Refunded', 'zero-bs-crm' ),
+							'total'                => -$refund_data['total'],
+							'desc'                 => $refund_description,
+							'date'                 => $refund_date_uts,
+							'created'              => $refund_date_uts,
+							'date_completed'       => $transaction_completed_date_uts,
+							'date_paid'            => $transaction_paid_date_uts,
+							'externalSources'      => array(
+								array(
+									'source' => 'woo',
+									'uid'    => $refund_id, // rather than order_num, here we use the refund item id
+									'origin' => $origin,
+									'owner'  => 0, // for now we hard-type no owner to avoid ownership issues. As we roll out fuller ownership we may want to adapt this.
+								),
+							),
+							'currency'             => $refund_currency,
+							'net'                  => -( (float) $refund_data['total'] - (float) $refund_data['discount_total'] - (float) $refund_data['total_tax'] - (float) $refund_data['shipping_total'] ),
+							'tax'                  => $refund_data['total_tax'],
+							'fee'                  => 0,
+							'discount'             => $refund_data['discount_total'],
+							'shipping'             => $refund_data['shipping_total'],
+							'existence_check_args' => array(
+								'externalSource'    => 'woo',
+								'externalSourceUID' => $refund_id,
+								'origin'            => $origin,
+								'onlyID'            => true,
+							),
+							'lineitems'            => array(
+								// here we roll a single refund line item
+								array(
+									'order'    => $refund_id,
+									'currency' => $refund_currency,
+									'quantity' => 1,
+									'price'    => -$refund_data['total'],
+									'total'    => -$refund_data['total'],
+									'title'    => $refund_title,
+									'desc'     => $refund_description,
+									'tax'      => $refund_data['total_tax'],
+									'shipping' => 0,
+								),
+							),
+							'extra_meta'           => array(), // this is caught to insert as extraMeta
+
+						);
+
+						// Add any extra meta we can glean in case future useful:
+						$refund_transaction['extra_meta']['order_num'] = $order_num; // backtrace
+						if ( isset( $refund_data['refunded_by'] ) && ! empty( $refund_data['refunded_by'] ) ) {
+							$refund_transaction['extra_meta']['refunded_by'] = $refund_data['refunded_by'];
+						}
+						if ( isset( $refund_data['refunded_payment'] ) && ! empty( $refund_data['refunded_payment'] ) ) {
+							$refund_transaction['extra_meta']['refunded_payment'] = $refund_data['refunded_payment'];
+						}
+
+						// add it to the stack
+						$data['secondary_transactions'][] = $refund_transaction;
+					}
+				}
+			}
 		}
 
 		// ==== Invoice

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -935,8 +935,8 @@ class Woo_Sync_Background_Sync_Job {
 
 		}
 
-		// Add/update invoice (if enabled) (previously `add_or_update_invoice`)
-		if ( $settings['wcinv'] == 1 && $crm_object_data['invoice']['status'] !== WOOSYNC_DO_NOT_CREATE['id'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		// Add/update invoice (if enabled) (previously `add_or_update_invoice`), while checking for a 'Do not create' status to avoid creating this invoice if the mapping doesn't allow it
+		if ( $settings['wcinv'] == 1 && isset( $crm_object_data['invoice'] ) && isset( $crm_object_data['invoice']['status'] ) && $crm_object_data['invoice']['status'] !== WOOSYNC_DO_NOT_CREATE['id'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 
 			// retrieve existing invoice
 			// note this is substituting $crm_object_data['invoice']['existence_check_args'] for what should be $args, but it works

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -936,7 +936,7 @@ class Woo_Sync_Background_Sync_Job {
 		}
 
 		// Add/update invoice (if enabled) (previously `add_or_update_invoice`), while checking for a 'Do not create' status to avoid creating this invoice if the mapping doesn't allow it
-		// @phan-suppress PhanTypeInvalidDimOffset
+		// @suppress PhanTypeInvalidDimOffset
 		if ( $settings['wcinv'] == 1 && isset( $crm_object_data['invoice'] ) && isset( $crm_object_data['invoice']['status'] ) && $crm_object_data['invoice']['status'] !== JPCRM_WOOSYNC_DO_NOT_CREATE['id'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 
 			// retrieve existing invoice

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -936,7 +936,7 @@ class Woo_Sync_Background_Sync_Job {
 		}
 
 		// Add/update invoice (if enabled) (previously `add_or_update_invoice`), while checking for a 'Do not create' status to avoid creating this invoice if the mapping doesn't allow it
-		if ( $settings['wcinv'] == 1 && isset( $crm_object_data['invoice'] ) && isset( $crm_object_data['invoice']['status'] ) && $crm_object_data['invoice']['status'] !== WOOSYNC_DO_NOT_CREATE['id'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+		if ( $settings['wcinv'] == 1 && isset( $crm_object_data['invoice'] ) && isset( $crm_object_data['invoice']['status'] ) && $crm_object_data['invoice']['status'] !== JPCRM_WOOSYNC_DO_NOT_CREATE['id'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 
 			// retrieve existing invoice
 			// note this is substituting $crm_object_data['invoice']['existence_check_args'] for what should be $args, but it works
@@ -1763,7 +1763,7 @@ class Woo_Sync_Background_Sync_Job {
 
 		$transaction_status = $this->woosync()->translate_order_status_to_obj_status( ZBS_TYPE_TRANSACTION, $order_status );
 
-		if ( $transaction_status !== WOOSYNC_DO_NOT_CREATE['id'] ) {
+		if ( $transaction_status !== JPCRM_WOOSYNC_DO_NOT_CREATE['id'] ) {
 			// fill out transaction header (object)
 			$data['transaction'] = array(
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -936,7 +936,7 @@ class Woo_Sync_Background_Sync_Job {
 		}
 
 		// Add/update invoice (if enabled) (previously `add_or_update_invoice`), while checking for a 'Do not create' status to avoid creating this invoice if the mapping doesn't allow it
-		// @suppress PhanTypeInvalidDimOffset
+		// @phan-suppress-next-line PhanTypeInvalidDimOffset False positive
 		if ( $settings['wcinv'] == 1 && isset( $crm_object_data['invoice'] ) && isset( $crm_object_data['invoice']['status'] ) && $crm_object_data['invoice']['status'] !== JPCRM_WOOSYNC_DO_NOT_CREATE['id'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 
 			// retrieve existing invoice

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -1558,7 +1558,7 @@ class Woo_Sync {
 			&& 
 			( 
 				$zbs->DAL->is_valid_obj_status( $obj_type_id, $settings[ $woo_order_status_mapping[ $order_status ] ] ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				|| $settings[ $woo_order_status_mapping[ $order_status ] ] === WOOSYNC_DO_NOT_CREATE['id'] // Our 'Do not create' status is also a valid one.
+				|| $settings[ $woo_order_status_mapping[ $order_status ] ] === JPCRM_WOOSYNC_DO_NOT_CREATE['id'] // Our 'Do not create' status is also a valid one.
 			)
 		) {
 			// there's a valid mapping in settings, so use that

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync.php
@@ -1555,7 +1555,11 @@ class Woo_Sync {
 
 		if (
 			! empty( $settings[ $woo_order_status_mapping[ $order_status ] ] )
-			&& $zbs->DAL->is_valid_obj_status( $obj_type_id, $settings[ $woo_order_status_mapping[ $order_status ] ] ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			&& 
+			( 
+				$zbs->DAL->is_valid_obj_status( $obj_type_id, $settings[ $woo_order_status_mapping[ $order_status ] ] ) // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				|| $settings[ $woo_order_status_mapping[ $order_status ] ] === WOOSYNC_DO_NOT_CREATE['id'] // Our 'Do not create' status is also a valid one.
+			)
 		) {
 			// there's a valid mapping in settings, so use that
 			return $settings[ $woo_order_status_mapping[ $order_status ] ];

--- a/projects/plugins/crm/modules/woo-sync/jpcrm-woo-sync-init.php
+++ b/projects/plugins/crm/modules/woo-sync/jpcrm-woo-sync-init.php
@@ -243,6 +243,17 @@ function jpcrm_woosync_is_hpos_enabled() {
 	return false;
 }
 
+// If we ever have more WooSync constants we should create a separate php file.
+if ( ! defined( 'WOOSYNC_DO_NOT_CREATE' ) ) {
+	define(
+		'WOOSYNC_DO_NOT_CREATE',
+		array(
+			'id'    => 'woo_do_not_create',
+			'label' => __( 'Do not create', 'zero-bs-crm' ),
+		)
+	);
+}
+
 // Extension legacy definitions
 if ( ! defined( 'JPCRM_WOO_SYNC_ROOT_FILE' ) ) {
   define( 'JPCRM_WOO_SYNC_ROOT_FILE', __FILE__ );

--- a/projects/plugins/crm/modules/woo-sync/jpcrm-woo-sync-init.php
+++ b/projects/plugins/crm/modules/woo-sync/jpcrm-woo-sync-init.php
@@ -244,9 +244,9 @@ function jpcrm_woosync_is_hpos_enabled() {
 }
 
 // If we ever have more WooSync constants we should create a separate php file.
-if ( ! defined( 'WOOSYNC_DO_NOT_CREATE' ) ) {
+if ( ! defined( 'JPCRM_WOOSYNC_DO_NOT_CREATE' ) ) {
 	define(
-		'WOOSYNC_DO_NOT_CREATE',
+		'JPCRM_WOOSYNC_DO_NOT_CREATE',
 		array(
 			'id'    => 'woo_do_not_create',
 			'label' => __( 'Do not create', 'zero-bs-crm' ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3463

## Proposed changes:

* This PR adds a status mapping to WooSync to avoid creating invoices and transactions in Jetpack CRM from WooCommerce

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3463

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
**Initial Setup and Verification of WooSync:**

1. **Verify WooSync Functionality:**
   - Navigate to the WooSync hub.
   - Confirm that the status displays `Status: Sync Completed`.

2. **Enable Invoice Generation:**
   - If invoice generation is not active, switch to the `trunk` branch and activate the feature at `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=woosync`.

3. **Create a WooCommerce Order:**
   - Place a new order in WooCommerce.

4. **Verify Transaction and Invoice Creation:**
   - Ensure both the transaction and invoice are correctly generated.

**Testing the New PR Setting:**

1. **Switch to the PR Branch:**
   - Change to the branch `update/crm/3463-woosync-avoid-creating-invoices-and-transactions-for-woo-draft`.

2. **Configure WooCommerce Settings:**
   - Access Woo settings at `/wp-admin/admin.php?page=zerobscrm-plugin-settings&tab=woosync`.
   - Change the status mapping from one of WooCommerce's orders for at least one Invoice and one Transaction status to `Do not Create`.

3. **Add Another WooCommerce Order:**
   - Place a new order with the new mapping and confirm that WooSync is not generating Invoices when the mapping is set to `Do not Create`.
   - Place a new order with the new mapping and confirm that WooSync is not generating Transactions when the mapping is set to `Do not Create`.

## Documentantion changes

We will need to update our CRM Knowledge Base to reflect this change. It is necessary to update our WooSync page to inform users that we now offer a new setting and explain how it works.

Pinging @StefMattana 

![image](https://github.com/Automattic/jetpack/assets/37049295/812972bd-5174-4a87-b3a6-e09959d55948)


