### PR TITLE
Contact form: Unhook the deprecated jetpack_form_register_pattern function

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-jetpack_form_register_pattern-hook
+++ b/projects/plugins/jetpack/changelog/remove-jetpack_form_register_pattern-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Contact Form: Unhook the jetpack_form_register_pattern function to prevent most deprecation notices.

--- a/projects/plugins/jetpack/modules/contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form.php
@@ -127,5 +127,3 @@ function jetpack_form_register_pattern() {
 		register_block_pattern( $name, $pattern );
 	}
 }
-
-add_action( 'init', 'jetpack_form_register_pattern' );


### PR DESCRIPTION
## Proposed changes:

* In https://github.com/Automattic/jetpack/pull/37157  the `jetpack_form_register_pattern` function was deprecated. This isn't used needed anymore as we use the version from the package, but it is still hooked in, which means the deprecation notices are quite loud on sites who have debug enabled.
* This PR unhooks the function (within the module file) to prevent a large amount of those deprecation notices.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1715157328517149-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To replicate the issue, on a site with the contact module enabled visit the debug log and you will see frequent logs showing `Deprecated: Function jetpack_form_register_pattern is deprecated since version jetpack-13.4! Use Automattic\Jetpack\Forms\ContactForm\Util::register_pattern instead.`
* Apply this PR, and on a site with the contact module enabled visit the debug log - those shouldn't be displaying for now.