### PR TITLE
Subscription settings: remove extraneus "support info" bubble

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -101,7 +101,13 @@ function SubscriptionsSettings( props ) {
 			module={ SUBSCRIPTIONS_MODULE_NAME }
 			header={ __( 'Subscriptions', 'jetpack' ) }
 		>
-			<SettingsGroup disableInOfflineMode disableInSiteConnectionMode module={ subscriptions }>
+			<SettingsGroup disableInOfflineMode disableInSiteConnectionMode module={ subscriptions } >
+				<p>
+					{ __(
+						'Automatically add subscription forms to your site and turn visitors into subscribers.',
+						'jetpack'
+					) }
+				</p>
 				<FormFieldset>
 					<ToggleControl
 						checked={ isSubscriptionsActive && isSubscribePostEndEnabled }
@@ -122,39 +128,25 @@ function SubscriptionsSettings( props ) {
 							</>
 						}
 					/>
-					<div className="jp-toggle-set">
-						<ToggleControl
-							checked={ isSubscriptionsActive && isSmEnabled }
-							disabled={ isDisabled }
-							toggling={ isSavingAnyOption( [ 'sm_enabled' ] ) }
-							onChange={ handleSubscribeModalToggleChange }
-							label={
-								<>
-									{ __( 'Show subscription pop-up when scrolling a post', 'jetpack' ) }
-									{ isBlockTheme && subscribeModalEditorUrl && (
-										<>
-											{ '. ' }
-											<ExternalLink href={ subscribeModalEditorUrl }>
-												{ __( 'Preview and edit', 'jetpack' ) }
-											</ExternalLink>
-										</>
-									) }
-								</>
-							}
-						/>
-						<SupportInfo
-							text={ __(
-								'Automatically add a subscription form pop-up to every post and turn visitors into subscribers. It will appear as readers scroll through your posts.',
-								'jetpack'
-							) }
-							link={ getRedirectUrl( 'jetpack-support-subscriptions', {
-								anchor: 'enable-a-subscriber-pop-up-for-your-posts',
-							} ) }
-							privacyLink={ getRedirectUrl( 'jetpack-support-subscriptions', {
-								anchor: 'privacy',
-							} ) }
-						/>
-					</div>
+					<ToggleControl
+						checked={ isSubscriptionsActive && isSmEnabled }
+						disabled={ isDisabled }
+						toggling={ isSavingAnyOption( [ 'sm_enabled' ] ) }
+						onChange={ handleSubscribeModalToggleChange }
+						label={
+							<>
+								{ __( 'Show subscription pop-up when scrolling a post', 'jetpack' ) }
+								{ isBlockTheme && subscribeModalEditorUrl && (
+									<>
+										{ '. ' }
+										<ExternalLink href={ subscribeModalEditorUrl }>
+											{ __( 'Preview and edit', 'jetpack' ) }
+										</ExternalLink>
+									</>
+								) }
+							</>
+						}
+					/>
 					<ToggleControl
 						checked={ isSubscriptionsActive && isStbEnabled }
 						disabled={ isDisabled }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -1,4 +1,4 @@
-import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -6,7 +6,6 @@ import { FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
-import SupportInfo from 'components/support-info';
 import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 import { isCurrentUserLinked, isUnavailableInOfflineMode, isOfflineMode } from 'state/connection';
@@ -101,7 +100,7 @@ function SubscriptionsSettings( props ) {
 			module={ SUBSCRIPTIONS_MODULE_NAME }
 			header={ __( 'Subscriptions', 'jetpack' ) }
 		>
-			<SettingsGroup disableInOfflineMode disableInSiteConnectionMode module={ subscriptions } >
+			<SettingsGroup disableInOfflineMode disableInSiteConnectionMode module={ subscriptions }>
 				<p>
 					{ __(
 						'Automatically add subscription forms to your site and turn visitors into subscribers.',

--- a/projects/plugins/jetpack/changelog/update-newsletter-settings-support-bubble
+++ b/projects/plugins/jetpack/changelog/update-newsletter-settings-support-bubble
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscription settings: remove extraneus "support info" bubble


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Before

<img width="1094" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/75ec6413-db29-40ca-8f70-aa8aa60685d7">


After

<img width="1101" alt="Screenshot 2024-05-08 at 14 51 50" src="https://github.com/Automattic/jetpack/assets/87168/bdb2d371-8c05-4525-b1a3-135b33cd6fde">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove extra support link + privacy link from modal setting, as it seemed so disattached
* Adds descriptive line under "subscriptions" settings section.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

