### PR TITLE
Add updated_at field to ensure the option is always on sync

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-su-cache-sync-issue
+++ b/projects/packages/scheduled-updates/changelog/fix-su-cache-sync-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add updated_at field to ensure the option is always on sync.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -211,13 +211,18 @@ class Scheduled_Updates {
 		Scheduled_Updates_Active::add_active_field();
 		Scheduled_Updates_Health_Paths::add_health_check_paths_field();
 
-		$endpoint = new \WPCOM_REST_API_V2_Endpoint_Update_Schedules();
-		$events   = $endpoint->get_items( new \WP_REST_Request() );
+		$endpoint   = new \WPCOM_REST_API_V2_Endpoint_Update_Schedules();
+		$events     = $endpoint->get_items( new \WP_REST_Request() );
+		$updated_at = time();
 
 		if ( ! is_wp_error( $events ) ) {
 			$option = array_map(
-				function ( $event ) {
-					return (object) $event;
+				function ( $event ) use ( $updated_at ) {
+					$ret = (object) $event;
+					// Add updated_at field to ensure the option is always on sync.
+					$ret->updated_at = $updated_at;
+
+					return $ret;
 				},
 				$events->get_data()
 			);

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -826,6 +826,65 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
+	 * The sync option should have a different updated field when the schedule is updated.
+	 *
+	 * @covers ::create_item
+	 */
+	public function test_sync_option_should_have_different_updated_at_field() {
+		wp_set_current_user( $this->admin_id );
+
+		$data    = array(
+			'plugins'  => array(
+				'custom-plugin/custom-plugin.php',
+				'gutenberg/gutenberg.php',
+			),
+			'schedule' => $this->get_schedule(),
+		);
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params( $data );
+
+		// Create.
+		$schedule_id = Scheduled_Updates::generate_schedule_id( $data['plugins'] );
+		$result      = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( $schedule_id, $result->get_data() );
+		$this->assertSame( 1, self::$sync_counter );
+
+		$option = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertArrayHasKey( $schedule_id, $option );
+		$this->assertLessThanOrEqual( time(), $option[ $schedule_id ]->updated_at );
+
+		// Update.
+		$request          = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $schedule_id );
+		$data['schedule'] = $this->get_schedule( 'next Monday 9:00' );
+		$request->set_body_params( $data );
+
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( $schedule_id, $result->get_data() );
+		$this->assertSame( 2, self::$sync_counter );
+
+		$option_2 = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertArrayHasKey( $schedule_id, $option );
+		$this->assertLessThanOrEqual( $option[ $schedule_id ]->updated_at, $option_2[ $schedule_id ]->updated_at );
+
+		$request          = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $schedule_id );
+		$data['schedule'] = $this->get_schedule();
+		$request->set_body_params( $data );
+
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertSame( $schedule_id, $result->get_data() );
+		$this->assertSame( 3, self::$sync_counter );
+
+		$option_3 = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$this->assertArrayHasKey( $schedule_id, $option );
+		$this->assertLessThanOrEqual( $option[ $schedule_id ]->updated_at, $option_3[ $schedule_id ]->updated_at );
+	}
+	/**
 	 * A callback run when a sync is performed.
 	 *
 	 * @param string $option Option name.

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -882,7 +882,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 
 		$option_3 = get_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
 		$this->assertArrayHasKey( $schedule_id, $option );
-		$this->assertLessThanOrEqual( $option[ $schedule_id ]->updated_at, $option_3[ $schedule_id ]->updated_at );
+		$this->assertLessThanOrEqual( $option_2[ $schedule_id ]->updated_at, $option_3[ $schedule_id ]->updated_at );
 	}
 	/**
 	 * A callback run when a sync is performed.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Context: p1715163429959349-slack-C01A60HCGUA

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add an `updated_at` field to sync option to ensure it is always different.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*