### PR TITLE
Jetpack blocks: Only use JSON_UNESCAPED_UNICODE with UTF-8

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-only-use-json_encode-JSON_UNESCAPED_UNICODE-with-utf-8
+++ b/projects/plugins/jetpack/changelog/fix-only-use-json_encode-JSON_UNESCAPED_UNICODE-with-utf-8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: When outputting JSON data in inline script tags, only use `JSON_UNESCAPED_UNICODE` when the blog charset is UTF-8.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -457,9 +457,13 @@ class Jetpack_Gutenberg {
 		if ( ! wp_script_is( 'jetpack-blocks-assets-base-url', 'registered' ) ) {
 			// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- No actual script, so no version needed.
 			wp_register_script( 'jetpack-blocks-assets-base-url', false, array(), null, array( 'in_footer' => false ) );
+			$json_encode_flags = JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP;
+			if ( get_option( 'blog_charset' ) === 'UTF-8' ) {
+				$json_encode_flags |= JSON_UNESCAPED_UNICODE;
+			}
 			wp_add_inline_script(
 				'jetpack-blocks-assets-base-url',
-				'var Jetpack_Block_Assets_Base_Url=' . wp_json_encode( plugins_url( self::get_blocks_directory(), JETPACK__PLUGIN_FILE ), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';',
+				'var Jetpack_Block_Assets_Base_Url=' . wp_json_encode( plugins_url( self::get_blocks_directory(), JETPACK__PLUGIN_FILE ), $json_encode_flags ) . ';',
 				'before'
 			);
 		}

--- a/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
+++ b/projects/plugins/jetpack/extensions/blocks/calendly/calendly.php
@@ -106,23 +106,24 @@ function load_assets( $attr, $content ) {
 			wp_kses_post( get_attribute( $attr, 'submitButtonText' ) )
 		);
 	} else {
-		$content = sprintf(
+		$content           = sprintf(
 			'<div class="%1$s" id="%2$s"></div>',
 			esc_attr( $classes ),
 			esc_attr( $block_id )
 		);
-		$script  = <<<JS_END
+		$script            = <<<JS_END
 jetpackInitCalendly( %s, %s );
 JS_END;
+		$json_encode_flags = JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP;
+		if ( get_option( 'blog_charset' ) === 'UTF-8' ) {
+			$json_encode_flags |= JSON_UNESCAPED_UNICODE;
+		}
 		wp_add_inline_script(
 			'jetpack-calendly-external-js',
 			sprintf(
 				$script,
-				wp_json_encode(
-					esc_url_raw( $url ),
-					JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
-				),
-				wp_json_encode( $block_id, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP )
+				wp_json_encode( esc_url_raw( $url ), $json_encode_flags ),
+				wp_json_encode( $block_id, $json_encode_flags )
 			)
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When outputting data from PHP into `<script>` tags, the proper way to do this is to use `wp_json_encode()`. And to do that right, non-default flags need to be provided:

* `JSON_HEX_TAG` avoids potential issues with HTML tags in the data.
* `JSON_HEX_AMP` avoids potential issues if the blog is being served with an XHTML4 doctype.
* `JSON_UNESCAPED_SLASHES` makes paths and URLs in the output more compact and readable, avoiding [leaning toothpick syndrome]. PHP's default escaping of slashes was added to break up `</script>` in the output, but `JSON_HEX_TAG` already does that and more.
* `JSON_UNESCAPED_UNICODE` also makes the data more compact and readable, _but_ it only works if the `blog_charset` is UTF-8. If the charset has been changed we need to _not_ use this flag.

[leaning toothpick syndrome]: https://en.wikipedia.org/wiki/Leaning_toothpick_syndrome

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None really. The possibility of `blog_charset` not being UTF-8 came up in a few discussions lately around adding `wp_json_encode` while phpcsing, and I thought I should check our existing uses.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You'd have to both set `blog_charset` to something not UTF-8, and arrange for the data output in these places to include non-ASCII characters. That seems somewhat unlikely for both of these, which is probably why we never noticed a problem before.
