### PR TITLE
Add GlobalNotices component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       '@wordpress/icons':
         specifier: 9.47.0
         version: 9.47.0(react@18.2.0)
+      '@wordpress/notices':
+        specifier: 4.24.0
+        version: 4.24.0(react@18.2.0)
       classnames:
         specifier: 2.3.2
         version: 2.3.2

--- a/projects/js-packages/components/changelog/add-global-notices-component
+++ b/projects/js-packages/components/changelog/add-global-notices-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added GlobalNotices component and useGlobalNotices hook

--- a/projects/js-packages/components/components/global-notices/global-notices.tsx
+++ b/projects/js-packages/components/components/global-notices/global-notices.tsx
@@ -1,0 +1,31 @@
+import { SnackbarList } from '@wordpress/components';
+import styles from './styles.module.scss';
+import { useGlobalNotices } from './use-global-notices';
+
+export type GlobalNoticesProps = {
+	maxVisibleNotices?: number;
+};
+
+/**
+ * Renders the global notices.
+ *
+ * @param {GlobalNoticesProps} props - Component props.
+ *
+ * @returns {import('react').ReactNode} The rendered notices list.
+ */
+export function GlobalNotices( { maxVisibleNotices = 3 }: GlobalNoticesProps ) {
+	const { getNotices, removeNotice } = useGlobalNotices();
+
+	const snackbarNotices = getNotices()
+		.filter( ( { type } ) => type === 'snackbar' )
+		// Slices from the tail end of the list.
+		.slice( -maxVisibleNotices );
+
+	return (
+		<SnackbarList
+			notices={ snackbarNotices }
+			className={ styles[ 'global-notices' ] }
+			onRemove={ removeNotice }
+		/>
+	);
+}

--- a/projects/js-packages/components/components/global-notices/index.ts
+++ b/projects/js-packages/components/components/global-notices/index.ts
@@ -1,0 +1,3 @@
+export * from './global-notices';
+export * from './use-global-notices';
+export { store as globalNoticesStore } from '@wordpress/notices';

--- a/projects/js-packages/components/components/global-notices/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/global-notices/stories/index.stories.tsx
@@ -1,0 +1,53 @@
+import { useCallback } from 'react';
+import Button from '../../button';
+import { GlobalNotices, useGlobalNotices } from '../index';
+import type { Meta } from '@storybook/react';
+
+export default {
+	title: 'JS Packages/Components/GlobalNotices',
+	component: GlobalNotices,
+	decorators: [ story => <div style={ { padding: '3rem' } }>{ story() }</div> ],
+} satisfies Meta< typeof GlobalNotices >;
+
+const Template = args => {
+	const { createErrorNotice, createSuccessNotice, createInfoNotice, createWarningNotice } =
+		useGlobalNotices();
+
+	return (
+		<div>
+			<GlobalNotices { ...args } />
+			<div style={ { display: 'flex', alignItems: 'start', gap: '1rem', flexDirection: 'column' } }>
+				<Button
+					onClick={ useCallback( () => {
+						createSuccessNotice( 'This is a success notice' );
+					}, [ createSuccessNotice ] ) }
+				>
+					Create Success Notice
+				</Button>
+				<Button
+					onClick={ useCallback( () => {
+						createErrorNotice( 'This is an error notice' );
+					}, [ createErrorNotice ] ) }
+				>
+					Create Error Notice
+				</Button>
+				<Button
+					onClick={ useCallback( () => {
+						createInfoNotice( 'This is an info notice' );
+					}, [ createInfoNotice ] ) }
+				>
+					Create Info Notice
+				</Button>
+				<Button
+					onClick={ useCallback( () => {
+						createWarningNotice( 'This is a warning notice' );
+					}, [ createWarningNotice ] ) }
+				>
+					Create Warning Notice
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export const _Default = Template.bind( {} );

--- a/projects/js-packages/components/components/global-notices/styles.module.scss
+++ b/projects/js-packages/components/components/global-notices/styles.module.scss
@@ -1,0 +1,21 @@
+@import '@automattic/jetpack-base-styles/gutenberg-base-styles';
+
+.global-notices {
+	&:global(.components-snackbar-list) {
+		position: fixed;
+		inset-block-start: auto; // top
+		inset-block-end: 0; // bottom
+		inset-inline: 0; // left and right
+
+		@include break-small {
+			width: auto;
+			inset-inline: unset; // left and right
+			inset-block-start: 4rem;
+			inset-inline-end: 1rem;
+		}
+
+		@include break-medium {
+			inset-block-start: 3rem;
+		}
+	}
+}

--- a/projects/js-packages/components/components/global-notices/use-global-notices.ts
+++ b/projects/js-packages/components/components/global-notices/use-global-notices.ts
@@ -1,0 +1,37 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+
+type NoticesStore = ReturnType< ( typeof noticesStore )[ 'instantiate' ] >;
+
+export type TGlobalNotices = ReturnType< NoticesStore[ 'getActions' ] > &
+	ReturnType< NoticesStore[ 'getSelectors' ] >;
+
+/**
+ * The global notices hook.
+ *
+ * @returns {TGlobalNotices} The global notices selectors and actions.
+ */
+export function useGlobalNotices(): TGlobalNotices {
+	const actionCreators = useDispatch( noticesStore );
+	const notices = useSelect( select => select( noticesStore ).getNotices(), [] );
+
+	return {
+		...actionCreators,
+		createNotice( status, content, options ) {
+			return actionCreators.createNotice( status, content, { type: 'snackbar', ...options } );
+		},
+		createErrorNotice( content, options ) {
+			return actionCreators.createErrorNotice( content, { type: 'snackbar', ...options } );
+		},
+		createInfoNotice( content, options ) {
+			return actionCreators.createInfoNotice( content, { type: 'snackbar', ...options } );
+		},
+		createSuccessNotice( content, options ) {
+			return actionCreators.createSuccessNotice( content, { type: 'snackbar', ...options } );
+		},
+		createWarningNotice( content, options ) {
+			return actionCreators.createWarningNotice( content, { type: 'snackbar', ...options } );
+		},
+		getNotices: () => notices,
+	};
+}

--- a/projects/js-packages/components/index.ts
+++ b/projects/js-packages/components/index.ts
@@ -75,3 +75,4 @@ export { default as ProgressBar } from './components/progress-bar';
 export { default as UpsellBanner } from './components/upsell-banner';
 export { getUserLocale, cleanLocale } from './lib/locale';
 export { default as RadioControl } from './components/radio-control';
+export * from './components/global-notices';

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.53.0",
+	"version": "0.53.1-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -25,6 +25,7 @@
 		"@wordpress/element": "5.33.0",
 		"@wordpress/i18n": "4.56.0",
 		"@wordpress/icons": "9.47.0",
+		"@wordpress/notices": "4.24.0",
 		"classnames": "2.3.2",
 		"prop-types": "^15.7.2",
 		"qrcode.react": "3.1.0",


### PR DESCRIPTION
Extracted from #37237 as a separate PR

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `GlobalNotices` component to use for toast feedback
* Add `useGlobalNotices` hook to consume or create notices

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `cd projects/js-packages/storybook`
* Run `pnpm run storybook:dev`
* Select `GlobalNotices` component from the sidebar
* Confirm that it works as expected

https://github.com/Automattic/jetpack/assets/18226415/60a90149-7fd9-45cd-b3ce-cbce01d612d8


