### PR TITLE
ignorefile: Import more tests from node-ignore

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -13,7 +13,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/ignorefile",
-                "reference": "89185202e00673d6c11a84c10b6da8373e0f371c"
+                "reference": "8bec1af06b593110bf4aeca06b05c1ba1841960c"
             },
             "require": {
                 "php": ">=7.0"
@@ -30,7 +30,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "2.0.x-dev"
+                    "dev-trunk": "2.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/packages/ignorefile/README.md
+++ b/projects/packages/ignorefile/README.md
@@ -42,9 +42,13 @@ foreach ( $iter as $file ) {
 }
 ```
 
+### Strict mode
+
+To match `git`'s behavior, invalid patterns passed to `add()` will be silently ignored. If you'd rather have exceptions thrown, set `$ignore->strictMode` to true.
+
 ## Known incompatibilities with git
 
-As of git 2.32.0-rc0.
+As of git 2.43.0.
 
 The [gitignore documentation](gitignore) refers to [fnmatch] for specifics of `*`, `?`, and bracket expressions.
 That in turn refers to a few other documents.

--- a/projects/packages/ignorefile/changelog/update-ignorefile-with-new-node-ignore-tests
+++ b/projects/packages/ignorefile/changelog/update-ignorefile-with-new-node-ignore-tests
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add "strict mode", defaulting to off. When off, InvalidPatternException will no longer be thrown, instead the pattern will just be ignored to match `git` behavior.

--- a/projects/packages/ignorefile/changelog/update-ignorefile-with-new-node-ignore-tests#2
+++ b/projects/packages/ignorefile/changelog/update-ignorefile-with-new-node-ignore-tests#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ignore a UTF-8 BOM when a string is passed to `->add()`, to match `git` behavior when reading the `.gitignore` file.

--- a/projects/packages/ignorefile/changelog/update-ignorefile-with-new-node-ignore-tests#3
+++ b/projects/packages/ignorefile/changelog/update-ignorefile-with-new-node-ignore-tests#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Import more tests from node-ignore.
+
+

--- a/projects/packages/ignorefile/composer.json
+++ b/projects/packages/ignorefile/composer.json
@@ -41,7 +41,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "2.0.x-dev"
+			"dev-trunk": "2.1.x-dev"
 		}
 	}
 }

--- a/projects/packages/ignorefile/tests/php/IgnoreFileTestData.jsonc
+++ b/projects/packages/ignorefile/tests/php/IgnoreFileTestData.jsonc
@@ -3,11 +3,56 @@
 
 {
 	//////////////////////
-	// Cases copied from https://github.com/kaelzhang/node-ignore/blob/7cc95d22ea9a647442c06f4383a73e7a439a48d6/test/fixtures/cases.js
+	// Cases copied from https://github.com/kaelzhang/node-ignore/blob/b00eaa3db955da3473265b14997f3cbbaa918b99/test/fixtures/cases.js
 	// Assuming this is original enough to attract copyright in the first place, this data is under the terms of that project's MIT license.
-	// @see https://github.com/kaelzhang/node-ignore/blob/7cc95d22ea9a647442c06f4383a73e7a439a48d6/LICENSE-MIT
+	// @see https://github.com/kaelzhang/node-ignore/blob/b00eaa3db955da3473265b14997f3cbbaa918b99/LICENSE-MIT
 	//////////////////////
 
+	"#108: gitignore rules with BOM": {
+		"rules": "﻿node_modules\n",
+		"expects": {
+			"node_modules": "ignored"
+		}
+	},
+	"charactor ?": {
+		"rules": [
+			"foo?bar"
+		],
+		"expects": {
+			"foo/bar": "nomatch",
+			"fooxbar" :"ignored",
+			"fooxxbar": "nomatch"
+		}
+	},
+	"#57, normal * and normal consecutive *": {
+		"rules": [
+			"**foo",
+			"*bar",
+			"ba*z",
+			"folder/other-folder/**/**js"
+		],
+		"expects": {
+			"foo": "ignored",
+			"a/foo": "ignored",
+			"afoo": "ignored",
+			"abfoo": "ignored",
+			"abcfoo": "ignored",
+			"bar": "ignored",
+			"abar": "ignored",
+			"baz": "ignored",
+			"ba/z": "nomatch",
+			"baaaaaaz": "ignored",
+			"folder/other-folder/dir/main.js": "ignored"
+		}
+	},
+	"#76 (invalid), comments with no heading whitespace": {
+		"rules": [
+			"node_modules# comments"
+		],
+		"expects": {
+			"node_modules/a.js": "nomatch"
+		}
+	},
 	"#59 and more cases about range notation (1)": {
 		"rules": [
 			"src/\\[foo\\]",
@@ -840,6 +885,23 @@
 			"some/special/path/to/目录/test/ignored.js": "ignored"
 		}
 	},
+	"#81: invalid trailing backslash at the end should not throw, test non-windows env only" : {
+		"rules": [
+			"test\\",
+			"testa\\\\",
+			"\\",
+			"foo/*",
+			// test negative pattern
+			"!foo/test\\"
+		],
+		"expects": {
+			"test": "nomatch",
+			"test\\": "nomatch",
+			"testa\\": "ignored",
+			"\\": "nomatch",
+			"foo/test\\": "ignored"
+		}
+	},
 	"linux: back slashes on paths": {
 		"rules": [
 			"a",
@@ -907,6 +969,19 @@
 		"expects": {
 			"folder/folder/testFile.txt": "ignored",
 			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafolde": "nomatch"
+		}
+	},
+
+	"#76 (invalid), comments with no heading whitespace - additional tests": {
+		"rules": [
+			"foo # comments",
+			"bar# comments"
+		],
+		"expects": {
+			"foo": "nomatch",
+			"foo # comments": "ignored",
+			"bar": "nomatch",
+			"bar# comments": "ignored"
 		}
 	},
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The new tests bring to light two needed fixes:

* `git`, when encountering an invalid pattern, ignores just that line from the `.gitignore` file. We should do the same by default. Add a `strictMode` option for people who want the existing behavior.
* `git` ignores a UTF-8 BOM at the start of `.gitignore`. We should do the same when passed a string rather than an array of strings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?