### PR TITLE
codesniffer: Stop suppressing Commenting.WrongStyle in Jetpack-Tests

### DIFF
--- a/projects/packages/codesniffer/Jetpack-Tests/ruleset.xml
+++ b/projects/packages/codesniffer/Jetpack-Tests/ruleset.xml
@@ -6,26 +6,21 @@
 	<rule ref="Generic.Commenting.DocComment">
 		<exclude name="Generic.Commenting.DocComment.Missing" />
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
-		<exclude name="Generic.Commenting.DocComment.WrongStyle" />
 	</rule>
 	<rule ref="Squiz.Commenting.ClassComment">
 		<exclude name="Squiz.Commenting.ClassComment.Missing" />
-		<exclude name="Squiz.Commenting.ClassComment.WrongStyle" />
 	</rule>
 	<rule ref="Squiz.Commenting.FileComment">
 		<exclude name="Squiz.Commenting.FileComment.Missing" />
 		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
-		<exclude name="Squiz.Commenting.FileComment.WrongStyle" />
 	</rule>
 	<rule ref="Squiz.Commenting.FunctionComment">
 		<exclude name="Squiz.Commenting.FunctionComment.Missing" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
-		<exclude name="Squiz.Commenting.FunctionComment.WrongStyle" />
 	</rule>
 	<rule ref="Squiz.Commenting.VariableComment">
 		<exclude name="Squiz.Commenting.VariableComment.Missing" />
-		<exclude name="Squiz.Commenting.VariableComment.WrongStyle" />
 	</rule>
 
 	<!-- Tests aren't running inside WordPress, no need to sanitize input, escape output, or use WP-specific functions. -->

--- a/projects/packages/codesniffer/changelog/fix-codesniffer-Jetpack-Tests-WrongStyle
+++ b/projects/packages/codesniffer/changelog/fix-codesniffer-Jetpack-Tests-WrongStyle
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Jetpack-Tests: No longer exclude `Squiz.Commenting.*.WrongStyle`.

--- a/projects/plugins/jetpack/changelog/fix-codesniffer-Jetpack-Tests-WrongStyle
+++ b/projects/plugins/jetpack/changelog/fix-codesniffer-Jetpack-Tests-WrongStyle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update comments in tests to fix `Squiz.Commenting.*.WrongStyle`.
+
+

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-recommendations.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-recommendations.php
@@ -12,7 +12,6 @@ require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-recommendations.php';
  */
 class WP_Test_Jetpack_Recommendations extends WP_UnitTestCase {
 
-	// The videopress recommendation should not be enabled if the module is on
 	public function test_videopress_is_not_recommended_if_module_enabled() {
 		\Jetpack::update_active_modules( array( 'videopress' ) );
 		$site_plan     = $this->get_free_plan_mock();
@@ -21,7 +20,6 @@ class WP_Test_Jetpack_Recommendations extends WP_UnitTestCase {
 		$this->assertFalse( Jetpack_Recommendations::should_recommend_videopress( $site_plan, $site_products ) );
 	}
 
-	// Videopress recommendation is only be enabled if the site has a free plan
 	public function test_videopress_is_not_recommended_if_plan_not_free() {
 		$plans         = array(
 			$this->get_security_plan_mock(),
@@ -34,7 +32,6 @@ class WP_Test_Jetpack_Recommendations extends WP_UnitTestCase {
 		}
 	}
 
-	// Vidopress recommendation should not be enabled if the site has videopress annual product
 	public function test_videopress_is_not_recommended_if_site_has_videopress_product() {
 		$site_plan     = $this->get_free_plan_mock();
 		$site_products = array( 'jetpack_videopress' );
@@ -42,7 +39,6 @@ class WP_Test_Jetpack_Recommendations extends WP_UnitTestCase {
 		$this->assertFalse( Jetpack_Recommendations::should_recommend_videopress( $site_plan, $site_products ) );
 	}
 
-	// Vidopress recommendation should not be enabled if the site has videopress monthly product
 	public function test_videopress_is_not_recommended_if_site_has_videopress_monthly_product() {
 		$site_plan     = $this->get_free_plan_mock();
 		$site_products = array( 'jetpack_videopress_monthly' );
@@ -50,7 +46,6 @@ class WP_Test_Jetpack_Recommendations extends WP_UnitTestCase {
 		$this->assertFalse( Jetpack_Recommendations::should_recommend_videopress( $site_plan, $site_products ) );
 	}
 
-	// Videopress recommendation is enabled when a site has a free plan and no products
 	public function test_videopress_is_recommended_with_free_plan_and_no_products() {
 		$site_plan     = $this->get_free_plan_mock();
 		$site_products = array();

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -90,7 +90,7 @@ if ( '1' !== getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 require __DIR__ . '/lib/mock-functions.php';
 require $test_root . '/includes/functions.php';
 
-// Activates this plugin in WordPress so it can be tested.
+/** Activates this plugin in WordPress so it can be tested. */
 function _manually_load_plugin() {
 	if ( '1' === getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 		require JETPACK_WOOCOMMERCE_INSTALL_DIR . '/woocommerce.php';

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-class.service-api-keys.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-fields/test-class.service-api-keys.php
@@ -18,7 +18,7 @@ class Test_WPCOM_REST_API_V2_Service_API_Keys_Endpoint extends WP_Test_Jetpack_R
 		add_filter( 'pre_http_request', array( __CLASS__, 'do_not_verify_mapbox' ), 10, 3 );
 	}
 
-	// GET
+	/** GET **/
 	public function test_get_services_api_key_mapbox() {
 		wp_set_current_user( self::$subscriber_user_id );
 		$request  = new WP_REST_Request( 'GET', '/wpcom/v2/service-api-keys/mapbox' );
@@ -41,7 +41,7 @@ class Test_WPCOM_REST_API_V2_Service_API_Keys_Endpoint extends WP_Test_Jetpack_R
 		$this->assertTrue( isset( $data['message'] ) );
 	}
 
-	// UPDATE
+	/** UPDATE **/
 	public function test_update_services_api_key_mapbox_with_permission() {
 		wp_set_current_user( self::$editor_user_id );
 		$request = new WP_REST_Request( 'POST', '/wpcom/v2/service-api-keys/mapbox' );
@@ -102,7 +102,7 @@ class Test_WPCOM_REST_API_V2_Service_API_Keys_Endpoint extends WP_Test_Jetpack_R
 		$this->assertTrue( isset( $data['message'] ) );
 	}
 
-	// DELETE
+	/** DELETE **/
 	public function test_delete_service_api_key_mapbox_with_permission() {
 		wp_set_current_user( self::$editor_user_id );
 		$request  = new WP_REST_Request( 'DELETE', '/wpcom/v2/service-api-keys/mapbox' );

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/class-test-jetpack-token-subscription-service.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/class-test-jetpack-token-subscription-service.php
@@ -4,7 +4,7 @@ namespace Tests\Automattic\Jetpack\Extensions\Premium_Content;
 
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Jetpack_Token_Subscription_Service;
 
-// Overrides the way Jetpack_Token_Subscription_Service get its JWT key
+/** Overrides the way Jetpack_Token_Subscription_Service get its JWT key. */
 class Test_Jetpack_Token_Subscription_Service extends Jetpack_Token_Subscription_Service {
 	public function get_key() {
 		return 'whatever';

--- a/projects/plugins/jetpack/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/tests/php/general/test-class.jetpack-gutenberg.php
@@ -115,7 +115,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		$this->assertEquals( 'missing_module', $availability['grape']['unavailable_reason'], 'unavailable_reason is not "missing_module"' );
 	}
 
-	// Plugins
+	/** Plugins **/
 	public function test_registered_plugin_is_available() {
 		Jetpack_Gutenberg::set_extension_available( 'jetpack/onion' );
 		$availability = Jetpack_Gutenberg::get_availability();

--- a/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
+++ b/projects/plugins/jetpack/tests/php/general/test_class.jetpack.php
@@ -12,7 +12,7 @@ use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Cache as StatusCache;
 
-// Extend with a public constructor so that can be mocked in tests
+/** Extend with a public constructor so that can be mocked in tests. */
 class MockJetpack extends Jetpack {
 
 	/**
@@ -199,7 +199,7 @@ EXPECTED;
 		$this->assertEquals( $expected, $result );
 	}
 
-	/*
+	/**
 	 * @author tonykova
 	 */
 	public function test_implode_frontend_css_enqueues_bundle_file_handle() {
@@ -341,7 +341,7 @@ EXPECTED;
 		$this->assertEquals( $active_modules, array( 'monitor', 'stats' ) );
 	}
 
-	// This filter overrides the 'monitor' module.
+	/** This filter overrides the 'monitor' module. */
 	public static function e2e_test_filter( $modules ) {
 		$disabled_modules = array( 'monitor' );
 

--- a/projects/plugins/jetpack/tests/php/lib/class-wp-test-jetpack-rest-testcase.php
+++ b/projects/plugins/jetpack/tests/php/lib/class-wp-test-jetpack-rest-testcase.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @package automattic/jetpack
+ */
 
 // This is WP_Test_REST_Controller_Testcase without the unneeded abstract methods.
 require_once __DIR__ . '/class-wp-test-spy-rest-server.php';

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/test-class.sitemaps.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/test-class.sitemaps.php
@@ -52,7 +52,7 @@ class WP_Test_Jetpack_Sitemap_Manager extends WP_UnitTestCase {
 		delete_option( 'jetpack_sitemap_location' );
 
 		// Set the location.
-		function add_location( $string ) { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+		function add_location( $string ) { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction,Squiz.Commenting.FunctionComment.WrongStyle
 			$string .= '/blah';
 			return $string;
 		}

--- a/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-test-object-factory.php
+++ b/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-test-object-factory.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore WordPress.Files.FileName
 
-// special factory that creates transient versions of various WP objects
+/** Special factory that creates transient versions of various WP objects. */
 class JetpackSyncTestObjectFactory {
 	public static $default_post_props = array(
 		'post_title'            => 'The Title',

--- a/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
+++ b/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-test-replicastore.php
@@ -239,7 +239,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 		return isset( $theme_supports[ $feature ] );
 	}
 
-	// meta
+	/** Meta **/
 	public function get_metadata( $type, $object_id, $meta_key = '', $single = false ) {
 
 		$object_id = absint( $object_id );
@@ -267,7 +267,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 		return $meta_values;
 	}
 
-	// this is just here to support checksum histograms
+	/** This is just here to support checksum histograms */
 	public function get_post_meta_by_id( $meta_id ) {
 		$matching_metas = array();
 		$metas          = $this->meta[ get_current_blog_id() ]['post'];
@@ -279,7 +279,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 		return reset( $matching_metas );
 	}
 
-	// this is just here to support checksum histograms
+	/** This is just here to support checksum histograms */
 	public function get_comment_meta_by_id( $meta_id ) {
 		$matching_metas = array();
 		$metas          = $this->meta[ get_current_blog_id() ]['comment'];
@@ -339,7 +339,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 		}
 	}
 
-	// constants
+	/** Constants **/
 	public function get_constant( $constant ) {
 		if ( ! isset( $this->constants[ get_current_blog_id() ][ $constant ] ) ) {
 			return null;
@@ -354,7 +354,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 		return $this->constants[ get_current_blog_id() ][ $constant ];
 	}
 
-	// updates
+	/** Updates **/
 	public function get_updates( $type ) {
 		if ( ! isset( $this->updates[ get_current_blog_id() ][ $type ] ) ) {
 			return null;
@@ -367,7 +367,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 		$this->updates[ get_current_blog_id() ][ $type ] = $updates;
 	}
 
-	// updates
+	/** Updates **/
 	public function get_callable( $function ) {
 		if ( ! isset( $this->callable[ get_current_blog_id() ][ $function ] ) ) {
 			return null;
@@ -380,7 +380,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 		$this->callable[ get_current_blog_id() ][ $name ] = $value;
 	}
 
-	// network options
+	/** Network options **/
 	public function get_site_option( $option ) {
 		return isset( $this->network_options[ get_current_blog_id() ][ $option ] ) ? $this->network_options[ get_current_blog_id() ][ $option ] : false;
 	}
@@ -393,7 +393,7 @@ class Jetpack_Sync_Test_Replicastore implements Replicastore_Interface {
 		$this->network_options[ get_current_blog_id() ][ $option ] = false;
 	}
 
-	// terms
+	/** Terms **/
 	public function get_terms( $taxonomy ) {
 		return isset( $this->terms[ get_current_blog_id() ][ $taxonomy ] ) ? $this->terms[ get_current_blog_id() ][ $taxonomy ] : array();
 	}

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-base.php
@@ -17,13 +17,12 @@ require_once $sync_server_dir . 'class.jetpack-sync-server-replicator.php';
 require_once $sync_server_dir . 'class.jetpack-sync-server-eventstore.php';
 require_once $sync_server_dir . 'class.jetpack-sync-test-helper.php';
 
-/*
+/**
  * Base class for Sync tests - establishes connection between local
  * Automattic\Jetpack\Sync\Sender and dummy server implementation,
  * and registers a Replicastore and Eventstore implementation to
  * process events.
  */
-
 class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 	protected $listener;
 	protected $sender;
@@ -130,9 +129,11 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		$this->assertEquals( $local->get_comments(), $remote->get_comments() );
 	}
 
-	// asserts that two objects are the same if they're both "objectified",
-	// i.e. json_encoded and then json_decoded
-	// this is useful because we json encode everything sent to the server
+	/**
+	 * Asserts that two objects are the same if they're both "objectified",
+	 * i.e. json_encoded and then json_decoded
+	 * this is useful because we json encode everything sent to the server
+	 */
 	protected function assertEqualsObject( $object_1, $object_2, $message = null ) {
 		$this->assertEquals( $this->objectify( $object_1 ), $this->objectify( $object_2 ), $message );
 	}

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -174,7 +174,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 		$this->modify_comment_helper( $comment, $expected_variable );
 	}
 
-	/*
+	/**
 	 * Updates comment, checks that event args match expected, checks event is not duplicated
 	 */
 	private function modify_comment_helper( $comment, $expected_variable ) {

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-constants.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-constants.php
@@ -25,6 +25,8 @@ class WP_Test_Jetpack_Sync_Constants extends WP_Test_Jetpack_Sync_Base {
 	// TODO:
 	// Add tests for Syncing data on shutdown
 	// Add tests that prove that we know constants change
+	// phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle -- Confuses this for a function comment.
+
 	public function test_white_listed_constant_is_synced() {
 		$helper                 = new Jetpack_Sync_Test_Helper();
 		$helper->array_override = array( 'TEST_FOO' );

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -75,7 +75,7 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( Health::get_status(), Health::STATUS_IN_SYNC );
 	}
 
-	// this only applies to the test replicastore - in production we overlay data
+	/** This only applies to the test replicastore - in production we overlay data. */
 	public function test_sync_start_resets_storage() {
 		self::factory()->post->create();
 		$this->sender->do_sync();
@@ -371,7 +371,6 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( '~0', $previous_interval_end );
 	}
 
-	// phpunit -c tests/php.multisite.xml --filter test_full_sync_sends_only_current_blog_users_in_multisite
 	public function test_full_sync_sends_only_current_blog_users_in_multisite() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Run it in multi site mode' );
@@ -557,7 +556,6 @@ class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( $this->server_replica_storage->get_option( 'non_existant' ) );
 	}
 
-	// to test run phpunit -c tests/php.multisite.xml --filter test_full_sync_sends_all_network_options
 	public function test_full_sync_sends_all_network_options() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Run it in multi site mode' );

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-full.php
@@ -93,7 +93,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( isset( $empty['comments'] ) );
 	}
 
-	// this only applies to the test replicastore - in production we overlay data
+	/** This only applies to the test replicastore - in production we overlay data */
 	public function test_sync_start_resets_storage() {
 		self::factory()->post->create();
 		$this->sender->do_sync();
@@ -540,7 +540,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->reset_data();
 	}
 
-	// phpunit -c tests/php.multisite.xml --filter test_full_sync_sends_only_current_blog_users_in_multisite
 	public function test_full_sync_sends_only_current_blog_users_in_multisite() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Run it in multi site mode' );
@@ -733,7 +732,6 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( $this->server_replica_storage->get_option( 'non_existant' ) );
 	}
 
-	// to test run phpunit -c tests/php.multisite.xml --filter test_full_sync_sends_all_network_options
 	public function test_full_sync_sends_all_network_options() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Run it in multi site mode' );

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-import.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-import.php
@@ -77,23 +77,33 @@ class WP_Test_Jetpack_Sync_Import extends WP_Test_Jetpack_Sync_Base {
 	}
 }
 
-// We try to detect importers based in extending `WP_Importer`. Mock that class, if needed.
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+/**
+ * We try to detect importers based in extending `WP_Importer`. Mock that class, if needed.
+ */
 if ( ! class_exists( 'WP_Importer', false ) ) {
 	class WP_Importer {}
 }
 
-// Mock known importer. Uses class name of a real importer plugin.
-// @phan-suppress-next-line PhanRedefinedExtendedClass -- Ignore stub definition above.
+/**
+ * Mock known importer. Uses class name of a real importer plugin.
+ */
 class RSS_Import extends WP_Importer {
+	// @phan-suppress-previous-line PhanRedefinedExtendedClass -- Ignore stub definition above.
+
+	/** Start fake import. */
 	public function start_fake_rss_import() {
 		do_action( 'import_start' );
 	}
 }
 
-// Mock unknown importer.
-// @phan-suppress-next-line PhanRedefinedExtendedClass -- Ignore stub definition above.
+/**
+ * Mock unknown importer.
+ */
 class Unknown_Import extends WP_Importer {
+	// @phan-suppress-previous-line PhanRedefinedExtendedClass -- Ignore stub definition above.
+
+	/** Start fake import. */
 	public function start_fake_import() {
 		do_action( 'import_start' );
 	}

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -33,12 +33,13 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$this->assertSame( 0, $queue->size() );
 	}
 
-	// This is trickier than you would expect because we only check against
-	// maximum queue size periodically (to avoid a counts on every request), and then
-	// we cache the "blocked on queue size" status.
-	// In addition, we should only enforce the queue size limit if the oldest (aka frontmost)
-	// item in the queue is gt 15 minutes old.
 	public function test_detects_if_exceeded_queue_size_limit_and_oldest_item_gt_15_mins() {
+		// This is trickier than you would expect because we only check against
+		// maximum queue size periodically (to avoid a counts on every request), and then
+		// we cache the "blocked on queue size" status.
+		// In addition, we should only enforce the queue size limit if the oldest (aka frontmost)
+		// item in the queue is gt 15 minutes old.
+
 		$this->listener->get_sync_queue()->reset();
 
 		// first, let's try overriding the default queue limit

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -178,7 +178,11 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		remove_action( 'my_expanding_action', array( $this->listener, 'action_handler' ) );
 	}
 
-	// expand the input to 2000 random chars
+	/**
+	 * Generate 2000 random chars.
+	 *
+	 * @return string
+	 */
 	public function expand_small_action_to_large_size() {
 		// we generate a random string so it's hard to compress (i.e. doesn't shrink when gzencoded)
 		$characters        = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -5,7 +5,7 @@ use Automattic\Jetpack\Sync\Modules;
 
 require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
-// Mock object requiered for test_theme_update()
+/** Mock object requiered for test_theme_update(). */
 class Dummy_Sync_Test_WP_Upgrader {
 	public $skin;
 

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-users.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-users.php
@@ -190,7 +190,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		}
 	}
 
-	// User meta not syncing
+	/** User meta not syncing **/
 	public function test_do_not_sync_user_data_on_user_meta_change() {
 		$this->server_event_storage->reset();
 
@@ -210,7 +210,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( $event );
 	}
 
-	// Roles syncing
+	/** Roles syncing **/
 	public function test_user_add_role_is_synced() {
 		$user = get_user_by( 'id', $this->user_id );
 		$user->add_role( 'author' );
@@ -282,7 +282,7 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $this->user_id, $save_event->args[0]->ID );
 	}
 
-	// Capabilities syncing
+	/** Capabilities syncing **/
 	public function test_user_add_capability_is_synced() {
 		$user = get_user_by( 'id', $this->user_id );
 		$user->add_cap( 'do_stuff', true );
@@ -373,7 +373,6 @@ class WP_Test_Jetpack_Sync_Users extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( get_allowed_mime_types( $this->user_id ), $server_user_file_mime_types );
 	}
 
-	// to test run phpunit -c tests/php.multisite.xml --filter test_does_not_sync_non_site_users_in_multisite
 	public function test_deletes_users_removed_from_multisite() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Run it in multi site mode' );

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-woocommerce.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-woocommerce.php
@@ -35,7 +35,7 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( (bool) Modules::get_module( 'woocommerce' ) );
 	}
 
-	// Incremental sync
+	/** Incremental sync **/
 	public function test_orders_are_synced() {
 		$order = $this->createOrderWithItem();
 
@@ -219,8 +219,7 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( (bool) $comment_approved_to_unapproved_event );
 	}
 
-	// Full Sync
-
+	/** Full Sync **/
 	public function test_full_sync_order_items() {
 		$this->markTestSkipped( 'Temporarily skip this test.' );
 		// @phan-suppress-next-line PhanPluginUnreachableCode
@@ -293,8 +292,7 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( $has_meta_entry );
 	}
 
-	// Utility functions
-
+	/** Utility functions **/
 	public function add_custom_order_status( $statuses ) {
 		$statuses['wc-custom'] = 'Custom';
 		return $statuses;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Phan depends on doc comments using `/**` openers. While we often don't bother with doc comments in tests, where we do have them we should format them correctly.

The existing cases mostly fell into a few categories:

* Actual doc comments.
* "Section" separators being confused for function comments. Converted these to a `/** ... **/` style to make the sniff happy with them.
* Useless comments about how to use `phpunit --filter`. Removed these.
* Useless comments basically repeating the test function name. Removed these too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. But see #37122 where chasing missing WrongStyle sniffs led to another fix.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
