### PR TITLE
Scheduled Updates: Move install/managed check into validation callback

### DIFF
--- a/projects/packages/scheduled-updates/.phan/baseline.php
+++ b/projects/packages/scheduled-updates/.phan/baseline.php
@@ -9,14 +9,13 @@
  */
 return [
     // # Issue statistics:
-    // PhanUndeclaredProperty : 40+ occurrences
     // PhanTypeArraySuspiciousNullable : 2 occurrences
     // PhanCompatibleAccessMethodOnTraitDefinition : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/pluggable.php' => ['PhanTypeArraySuspiciousNullable'],
-        'tests/php/class-scheduled-updates-test.php' => ['PhanCompatibleAccessMethodOnTraitDefinition', 'PhanUndeclaredProperty'],
+        'tests/php/class-scheduled-updates-test.php' => ['PhanCompatibleAccessMethodOnTraitDefinition'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/scheduled-updates/changelog/update-plugin-validation
+++ b/projects/packages/scheduled-updates/changelog/update-plugin-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Moves install/managed check for plugins into API endpoint validation callback

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -77,8 +77,6 @@ class Scheduled_Updates {
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Health_Paths::class, 'clear' ) );
 		add_action( 'jetpack_scheduled_update_deleted', array( Scheduled_Updates_Logs::class, 'delete_logs_schedule_id' ), 10, 3 );
 
-		add_filter( 'jetpack_scheduled_update_verify_plugins', array( __CLASS__, 'verify_plugins' ) );
-
 		// Update cron sync option after options update.
 		$callback = array( __CLASS__, 'update_option_cron' );
 
@@ -362,16 +360,11 @@ class Scheduled_Updates {
 				/**
 				* Populates the is_managed field.
 				*
-				* Users could have their own plugins folder with symlinks pointing to it, so we need to check if the
-				* link target is within the `/wordpress` directory to determine if the plugin is managed.
-				*
-				* @see p9o2xV-3Nx-p2#comment-8728
-				*
 				* @param array $data Prepared response array.
 				* @return bool
 				*/
 				'get_callback' => function ( $data ) {
-					return self::is_plugin_managed( $data['plugin'] );
+					return self::is_managed_plugin( $data['plugin'] );
 				},
 				'schema'       => array(
 					'description' => 'Whether the plugin is managed by the host.',
@@ -447,55 +440,20 @@ class Scheduled_Updates {
 	}
 
 	/**
-	 * Check if a plugin is installed.
-	 *
-	 * @param string $plugin The plugin to check.
-	 * @return bool
-	 */
-	public static function is_plugin_installed( $plugin ) {
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-		$installed_plugins = get_plugins();
-		return array_key_exists( $plugin, $installed_plugins );
-	}
-
-	/**
 	 * Check if a plugin is managed by the host.
 	 *
+	 * Users could have their own plugins folder with symlinks pointing to it, so we need to check if the
+	 * link target is within the `/wordpress` directory to determine if the plugin is managed.
+	 *
+	 * @see p9o2xV-3Nx-p2#comment-8728
+	 *
 	 * @param string $plugin The plugin to check.
 	 * @return bool
 	 */
-	public static function is_plugin_managed( $plugin ) {
+	public static function is_managed_plugin( $plugin ) {
 		$folder = WP_PLUGIN_DIR . '/' . strtok( $plugin, '/' );
 		$target = is_link( $folder ) ? realpath( $folder ) : false;
+
 		return $target && 0 === strpos( $target, '/wordpress/' );
-	}
-
-	/**
-	 * Verify that the plugins are installed.
-	 *
-	 * @param array $plugins List of plugins to update.
-	 * @return bool|\WP_Error
-	 */
-	public static function verify_plugins( $plugins ) {
-		$request_plugins_not_installed_or_managed = true;
-
-		foreach ( $plugins as $plugin ) {
-			if ( self::is_plugin_installed( $plugin ) && ! self::is_plugin_managed( $plugin ) ) {
-				$request_plugins_not_installed_or_managed = false;
-				break;
-			}
-		}
-
-		if ( $request_plugins_not_installed_or_managed ) {
-			return new \WP_Error(
-				'rest_forbidden',
-				__( 'None of the specified plugins are installed or all of them are managed.', 'jetpack-scheduled-updates' ),
-				array( 'status' => 403 )
-			);
-		}
-
-		return true;
 	}
 }

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.12.0';
+	const PACKAGE_VERSION = '0.12.1-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -399,7 +399,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return $result;
 		}
 
-		$installed_plugins = array_filter( $plugins, array( Scheduled_Updates::class, 'is_plugin_installed' ) );
+		$installed_plugins = array_filter( $plugins, array( $this, 'is_plugin_installed' ) );
 		if ( empty( $installed_plugins ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
@@ -408,7 +408,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			);
 		}
 
-		$unmanaged_plugins = array_diff( $plugins, array_filter( $plugins, array( Scheduled_Updates::class, 'is_plugin_managed' ) ) );
+		$unmanaged_plugins = array_diff( $plugins, array_filter( $plugins, array( Scheduled_Updates::class, 'is_managed_plugin' ) ) );
 		if ( empty( $unmanaged_plugins ) ) {
 			return new \WP_Error(
 				'rest_forbidden',
@@ -418,6 +418,20 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Check if a plugin is installed.
+	 *
+	 * @param string $plugin The plugin to check.
+	 * @return bool
+	 */
+	public function is_plugin_installed( $plugin ) {
+		if ( ! function_exists( 'validate_plugin' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		return 0 === validate_plugin( $plugin );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -404,8 +404,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			add_filter( 'rest_request_after_callbacks', array( $this, 'transform_error_response' ) );
 
 			return new \WP_Error(
-				'rest_forbidden',
-				__( 'None of the specified plugins are installed.', 'jetpack-scheduled-updates' ),
+				'rest_invalid_param',
+				__( 'The specified plugins are not installed on the website. Please make sure the plugins are installed before attempting to schedule updates.', 'jetpack-scheduled-updates' ),
 				array( 'status' => 400 )
 			);
 		}
@@ -415,8 +415,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			add_filter( 'rest_request_after_callbacks', array( $this, 'transform_error_response' ) );
 
 			return new \WP_Error(
-				'rest_forbidden',
-				__( 'All of the specified plugins are managed.', 'jetpack-scheduled-updates' ),
+				'rest_invalid_param',
+				__( 'The specified plugins are managed and auto-updated by WordPress.com.', 'jetpack-scheduled-updates' ),
 				array( 'status' => 400 )
 			);
 		}

--- a/projects/packages/scheduled-updates/tests/php/bootstrap.php
+++ b/projects/packages/scheduled-updates/tests/php/bootstrap.php
@@ -5,6 +5,12 @@
  * @package automattic/scheduled-updates
  */
 
+// Constants.
+const WP_PLUGIN_DIR = __DIR__ . '/data/plugins';
+if ( ! file_exists( WP_PLUGIN_DIR ) ) {
+	mkdir( WP_PLUGIN_DIR, 0777, true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+}
+
 /**
  * Include the composer autoloader and dependencies.
  */

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
@@ -46,7 +46,6 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 		wp_set_current_user( $this->admin_id );
-		add_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		Scheduled_Updates::init();
 	}
@@ -59,7 +58,6 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 	public function tear_down() {
 		wp_delete_user( $this->admin_id );
 		delete_option( Scheduled_Updates_Health_Paths::OPTION_NAME );
-		remove_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 		parent::tear_down_wordbless();
 	}
 

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
@@ -59,7 +59,6 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 		wp_set_current_user( $this->admin_id );
-		add_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 	}
 
 	/**
@@ -69,7 +68,6 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 	 */
 	protected function tear_down() {
 		delete_option( Scheduled_Updates_Logs::OPTION_NAME );
-		remove_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 		parent::tear_down_wordbless();
 	}
 

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
@@ -286,15 +286,16 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 	 */
 	private function create_schedule( $i = 0 ) {
 		$request           = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
-		$scheduled_plugins = array( 'test/test' . $i . '.php' );
+		$scheduled_plugins = array( 'gutenberg/gutenberg.php', 'installed-plugin/installed-plugin.php' );
+		$scheduled_plugins = array_slice( $scheduled_plugins, 0, $i );
 		$request->set_body_params(
 			array(
-				'plugins'  => $scheduled_plugins,
-				'schedule' => array(
-					'timestamp'          => strtotime( "next Monday {$i}:00" ),
-					'interval'           => 'weekly',
-					'health_check_paths' => array(),
+				'plugins'            => $scheduled_plugins,
+				'schedule'           => array(
+					'timestamp' => strtotime( "next Monday {$i}:00" ),
+					'interval'  => 'weekly',
 				),
+				'health_check_paths' => array(),
 			)
 		);
 

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -681,12 +681,12 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
 		$request->set_body_params(
 			array(
-				'plugins'  => $plugins,
-				'schedule' => array(
-					'timestamp'          => strtotime( 'next Monday 8:00' ),
-					'interval'           => 'weekly',
-					'health_check_paths' => array(),
+				'plugins'            => $plugins,
+				'schedule'           => array(
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'interval'  => 'weekly',
 				),
+				'health_check_paths' => array(),
 			)
 		);
 
@@ -726,12 +726,12 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
 		$request->set_body_params(
 			array(
-				'plugins'  => $plugins,
-				'schedule' => array(
-					'timestamp'          => strtotime( 'next Monday 8:00' ),
-					'interval'           => 'weekly',
-					'health_check_paths' => array(),
+				'plugins'            => $plugins,
+				'schedule'           => array(
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'interval'  => 'weekly',
 				),
+				'health_check_paths' => array(),
 			)
 		);
 
@@ -776,12 +776,12 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
 		$request->set_body_params(
 			array(
-				'plugins'  => $plugins,
-				'schedule' => array(
-					'timestamp'          => strtotime( 'next Monday 8:00' ),
-					'interval'           => 'weekly',
-					'health_check_paths' => array(),
+				'plugins'            => $plugins,
+				'schedule'           => array(
+					'timestamp' => strtotime( 'next Monday 8:00' ),
+					'interval'  => 'weekly',
 				),
+				'health_check_paths' => array(),
 			)
 		);
 

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -22,6 +22,20 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	use \phpmock\phpunit\PHPMock;
 
 	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	public $admin_id;
+
+	/**
+	 * WordPress filesystem.
+	 *
+	 * @var \WP_Filesystem_Direct
+	 */
+	public $wp_filesystem;
+
+	/**
 	 * Set up before class.
 	 *
 	 * @see Restrictions here: https://github.com/php-mock/php-mock-phpunit?tab=readme-ov-file#restrictions
@@ -48,8 +62,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		WP_Filesystem();
 		$this->wp_filesystem = $wp_filesystem;
 
-		$this->plugin_dir = WP_PLUGIN_DIR;
-		$this->admin_id   = wp_insert_user(
+		$this->admin_id = wp_insert_user(
 			array(
 				'user_login' => 'dumasdasdasmy_user',
 				'user_pass'  => 'dummy_pass',
@@ -57,9 +70,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 		wp_set_current_user( $this->admin_id );
-
-		// Ensure plugin directory exists.
-		$this->wp_filesystem->mkdir( $this->plugin_dir );
 	}
 
 	/**
@@ -68,8 +78,12 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 * @after
 	 */
 	protected function tear_down() {
-		// Clean up the temporary plugin directory.
-		$this->wp_filesystem->rmdir( $this->plugin_dir, true );
+		$this->wp_filesystem->delete( WP_PLUGIN_DIR . '/deleted-plugin-0', true );
+		$this->wp_filesystem->delete( WP_PLUGIN_DIR . '/deleted-plugin-1', true );
+		$this->wp_filesystem->delete( WP_PLUGIN_DIR . '/deleted-plugin-2', true );
+		if ( file_exists( WP_PLUGIN_DIR . '/managed-plugin' ) ) {
+			wp_delete_file( WP_PLUGIN_DIR . '/managed-plugin' );
+		}
 
 		// Clean up the plugins cache created by get_plugins().
 		wp_cache_delete( 'plugins', 'plugins' );
@@ -87,19 +101,12 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 * @covers ::add_is_managed_extension_field
 	 */
 	public function test_unmanaged_plugins() {
-		// Direct.
-		$plugin_name = 'direct-plugin';
-		$this->wp_filesystem->mkdir( "$this->plugin_dir/$plugin_name" );
-		$this->populate_file_with_plugin_header( "$this->plugin_dir/$plugin_name/$plugin_name.php", 'direct-plugin' );
-
-		// Make sure the directory exists.
-		$this->assertTrue( $this->wp_filesystem->is_dir( "$this->plugin_dir/direct-plugin" ) );
-
 		$request       = new \WP_REST_Request( 'GET', '/wp/v2/plugins' );
 		$result        = rest_do_request( $request );
-		$plugin_result = $result->get_data()[0];
+		$plugin_result = wp_list_filter( $result->get_data(), array( 'plugin' => 'gutenberg/gutenberg' ) );
+		$plugin_result = reset( $plugin_result );
 
-		$this->assertSame( 'direct-plugin', $plugin_result['textdomain'] );
+		$this->assertSame( 'gutenberg', $plugin_result['textdomain'] );
 		$this->assertSame( false, $plugin_result['is_managed'] );
 	}
 
@@ -110,21 +117,12 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 * @covers ::add_is_managed_extension_field
 	 */
 	public function test_unmanaged_plugins_not_in_root_directory() {
-		// We simulate a symlink to a subdirectory inside a wp directory.
-		$plugin_name = 'managed-plugin';
-		$target_dir  = "$this->plugin_dir/wordpress";
-		$this->wp_filesystem->mkdir( $target_dir );
-		$this->wp_filesystem->mkdir( "$target_dir/$plugin_name" );
-		$this->populate_file_with_plugin_header( "$target_dir/$plugin_name/$plugin_name.php", 'managed-plugin' );
-		symlink( "$target_dir/$plugin_name", "$this->plugin_dir/$plugin_name" );
-
-		// Make sure the symlink exists.
-		$this->assertFalse( $this->wp_filesystem->is_dir( "$this->plugin_dir/direct-plugin" ) );
-		$this->assertTrue( is_link( "$this->plugin_dir/managed-plugin" ) );
+		symlink( WP_PLUGIN_DIR . '/wordpress/managed-plugin', WP_PLUGIN_DIR . '/managed-plugin' );
 
 		$request       = new \WP_REST_Request( 'GET', '/wp/v2/plugins' );
 		$result        = rest_do_request( $request );
-		$plugin_result = $result->get_data()[0];
+		$plugin_result = wp_list_filter( $result->get_data(), array( 'plugin' => 'managed-plugin/managed-plugin' ) );
+		$plugin_result = reset( $plugin_result );
 
 		$this->assertSame( 'managed-plugin', $plugin_result['textdomain'] );
 		$this->assertSame( false, $plugin_result['is_managed'] );
@@ -137,25 +135,16 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 * @covers ::add_is_managed_extension_field
 	 */
 	public function test_managed_plugins() {
-		// We simulate a symlink to a subdirectory inside a wp directory.
-		$plugin_name = 'managed-plugin';
-		$target_dir  = "$this->plugin_dir/wordpress";
-		$this->wp_filesystem->mkdir( $target_dir );
-		$this->wp_filesystem->mkdir( "$target_dir/$plugin_name" );
-		$this->populate_file_with_plugin_header( "$target_dir/$plugin_name/$plugin_name.php", 'managed-plugin' );
-		symlink( "$target_dir/$plugin_name", "$this->plugin_dir/$plugin_name" );
-
-		// Make sure the symlink exists.
-		$this->assertFalse( $this->wp_filesystem->is_dir( "$this->plugin_dir/direct-plugin" ) );
-		$this->assertTrue( is_link( "$this->plugin_dir/managed-plugin" ) );
+		symlink( WP_PLUGIN_DIR . '/wordpress/managed-plugin', WP_PLUGIN_DIR . '/managed-plugin' );
 
 		// Tweak realpath so that it returns `/wordpress/...`.
 		$realpath = $this->getFunctionMock( __NAMESPACE__, 'realpath' );
-		$realpath->expects( $this->once() )->willReturn( "/wordpress/plugins/$plugin_name" );
+		$realpath->expects( $this->once() )->willReturn( '/wordpress/plugins/managed-plugin' );
 
 		$request       = new \WP_REST_Request( 'GET', '/wp/v2/plugins' );
 		$result        = rest_do_request( $request );
-		$plugin_result = $result->get_data()[0];
+		$plugin_result = wp_list_filter( $result->get_data(), array( 'plugin' => 'managed-plugin/managed-plugin' ) );
+		$plugin_result = reset( $plugin_result );
 
 		$this->assertSame( 'managed-plugin', $plugin_result['textdomain'] );
 		$this->assertSame( true, $plugin_result['is_managed'] );
@@ -171,9 +160,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$plugin_file = "$plugin_name/$plugin_name.php";
 		$is_deleted  = false;
 
-		$this->wp_filesystem->mkdir( "$this->plugin_dir/$plugin_name" );
-		$this->populate_file_with_plugin_header( "$this->plugin_dir/$plugin_file", $plugin_name );
-
 		$delete_hook = function ( $plugin_file, $deleted ) use ( &$is_deleted ) {
 			$is_deleted = $deleted;
 		};
@@ -183,7 +169,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$this->assertTrue( delete_plugins( array( $plugin_file ) ) );
 
 		$this->assertTrue( $is_deleted );
-		$this->assertFalse( $this->wp_filesystem->is_dir( "$this->plugin_dir/$plugin_name" ) );
+		$this->assertFalse( $this->wp_filesystem->is_dir( WP_PLUGIN_DIR . '/' . $plugin_name ) );
 		$this->assertCount( 0, wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK ) );
 
 		remove_action( 'deleted_plugin', $delete_hook );
@@ -642,8 +628,8 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 			$plugin_file = "$plugin_name/$plugin_name.php";
 			$plugins[]   = $plugin_file;
 
-			$this->wp_filesystem->mkdir( "$this->plugin_dir/$plugin_name" );
-			$this->populate_file_with_plugin_header( "$this->plugin_dir/$plugin_file", $plugin_name );
+			$this->wp_filesystem->mkdir( WP_PLUGIN_DIR . '/' . $plugin_name );
+			$this->populate_file_with_plugin_header( WP_PLUGIN_DIR . '/' . $plugin_file, $plugin_name );
 		}
 
 		return $plugins;
@@ -693,8 +679,8 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		wp_set_current_user( $this->admin_id );
 		$result = rest_do_request( $request );
 
-		$this->assertSame( 403, $result->get_status() );
-		$this->assertSame( 'None of the specified plugins are installed or all of them are managed.', $result->get_data()['message'] );
+		$this->assertSame( 400, $result->get_status() );
+		$this->assertSame( 'None of the specified plugins are installed.', $result->get_data()['data']['params']['plugins'] );
 	}
 
 	/**
@@ -704,24 +690,6 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_verify_plugins_all_managed() {
 		$plugins = array( 'managed-plugin-1/managed-plugin-1.php', 'managed-plugin-2/managed-plugin-2.php' );
-
-		foreach ( $plugins as $plugin ) {
-			$plugin_name = explode( '/', $plugin )[0];
-			$plugin_file = "$plugin_name/$plugin_name.php";
-			$target_dir  = "$this->plugin_dir/wordpress";
-			$this->wp_filesystem->mkdir( $target_dir );
-			$this->wp_filesystem->mkdir( "$target_dir/$plugin_name" );
-			$this->populate_file_with_plugin_header( "$target_dir/$plugin_file", $plugin_name );
-			symlink( "$target_dir/$plugin_name", "$this->plugin_dir/$plugin_name" );
-		}
-
-		// Tweak realpath so that it returns `/wordpress/...`.
-		$realpath = $this->getFunctionMock( __NAMESPACE__, 'realpath' );
-		$realpath->expects( $this->exactly( count( $plugins ) ) )->willReturnCallback(
-			function ( $path ) {
-				return str_replace( $this->plugin_dir, '/wordpress/plugins', $path );
-			}
-		);
 
 		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
 		$request->set_body_params(
@@ -738,8 +706,8 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		wp_set_current_user( $this->admin_id );
 		$result = rest_do_request( $request );
 
-		$this->assertSame( 403, $result->get_status() );
-		$this->assertSame( 'None of the specified plugins are installed or all of them are managed.', $result->get_data()['message'] );
+		$this->assertSame( 400, $result->get_status() );
+		$this->assertSame( 'None of the specified plugins are installed.', $result->get_data()['data']['params']['plugins'] );
 	}
 
 	/**
@@ -749,29 +717,15 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_verify_plugins_installed_mixed() {
 		$plugins = array( 'managed-plugin/managed-plugin.php', 'installed-plugin/installed-plugin.php' );
-
-		// Create a managed plugin.
-		$managed_plugin_name = 'managed-plugin';
-		$managed_plugin_file = "$managed_plugin_name/$managed_plugin_name.php";
-		$target_dir          = "$this->plugin_dir/wordpress";
-		$this->wp_filesystem->mkdir( $target_dir );
-		$this->wp_filesystem->mkdir( "$target_dir/$managed_plugin_name" );
-		$this->populate_file_with_plugin_header( "$target_dir/$managed_plugin_file", $managed_plugin_name );
-		symlink( "$target_dir/$managed_plugin_name", "$this->plugin_dir/$managed_plugin_name" );
+		symlink( WP_PLUGIN_DIR . '/wordpress/managed-plugin', WP_PLUGIN_DIR . '/managed-plugin' );
 
 		// Tweak realpath so that it returns `/wordpress/...` for the managed plugin.
 		$realpath = $this->getFunctionMock( __NAMESPACE__, 'realpath' );
 		$realpath->expects( $this->once() )->willReturnCallback(
 			function ( $path ) {
-				return str_replace( $this->plugin_dir, '/wordpress/plugins', $path );
+				return str_replace( WP_PLUGIN_DIR, '/wordpress/plugins', $path );
 			}
 		);
-
-		// Create an installed plugin that is not managed.
-		$installed_plugin_name = 'installed-plugin';
-		$installed_plugin_file = "$installed_plugin_name/$installed_plugin_name.php";
-		$this->wp_filesystem->mkdir( "$this->plugin_dir/$installed_plugin_name" );
-		$this->populate_file_with_plugin_header( "$this->plugin_dir/$installed_plugin_file", $installed_plugin_name );
 
 		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
 		$request->set_body_params(

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -680,7 +680,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$result = rest_do_request( $request );
 
 		$this->assertSame( 400, $result->get_status() );
-		$this->assertSame( 'None of the specified plugins are installed.', $result->get_data()['data']['params']['plugins'] );
+		$this->assertSame( 'None of the specified plugins are installed.', $result->get_data()['message'] );
 	}
 
 	/**
@@ -707,7 +707,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$result = rest_do_request( $request );
 
 		$this->assertSame( 400, $result->get_status() );
-		$this->assertSame( 'None of the specified plugins are installed.', $result->get_data()['data']['params']['plugins'] );
+		$this->assertSame( 'None of the specified plugins are installed.', $result->get_data()['message'] );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-test.php
@@ -680,7 +680,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$result = rest_do_request( $request );
 
 		$this->assertSame( 400, $result->get_status() );
-		$this->assertSame( 'None of the specified plugins are installed.', $result->get_data()['message'] );
+		$this->assertSame( 'rest_invalid_param', $result->get_data()['code'] );
 	}
 
 	/**
@@ -707,7 +707,7 @@ class Scheduled_Updates_Test extends \WorDBless\BaseTestCase {
 		$result = rest_do_request( $request );
 
 		$this->assertSame( 400, $result->get_status() );
-		$this->assertSame( 'None of the specified plugins are installed.', $result->get_data()['message'] );
+		$this->assertSame( 'rest_invalid_param', $result->get_data()['code'] );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-active-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-active-test.php
@@ -67,7 +67,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 		);
 
 		wp_set_current_user( $this->admin_id );
-		add_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		Scheduled_Updates::init();
 	}
@@ -81,7 +80,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 		wp_delete_user( $this->admin_id );
 		delete_option( Scheduled_Updates_Active::OPTION_NAME );
 		delete_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		remove_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		parent::tear_down_wordbless();
 	}

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-logs-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-logs-test.php
@@ -35,7 +35,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Logs_Test extends \WorDBless\B
 			)
 		);
 		wp_set_current_user( 0 );
-		add_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		Scheduled_Updates::init();
 	}
@@ -47,7 +46,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Logs_Test extends \WorDBless\B
 	 */
 	public function tear_down() {
 		wp_delete_user( $this->admin_id );
-		remove_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 		parent::tear_down_wordbless();
 	}
 

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-logs-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-logs-test.php
@@ -197,9 +197,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Logs_Test extends \WorDBless\B
 	 *
 	 * @param int $i Schedule index.
 	 */
-	private function create_test_schedule( $i = 0 ) {
+	private function create_test_schedule( $i = 1 ) {
 		$request           = new \WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
-		$scheduled_plugins = array( 'test/test' . $i . '.php' );
+		$scheduled_plugins = array( 'gutenberg/gutenberg.php', 'installed-plugin/installed-plugin.php' );
+		$scheduled_plugins = array_slice( $scheduled_plugins, 0, $i );
 		$request->set_body_params(
 			array(
 				'plugins'  => $scheduled_plugins,

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -606,7 +606,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . Scheduled_Updates::generate_schedule_id( array() ) );
 		$request->set_body_params(
 			array(
-				'plugins'  => array(),
+				'plugins'  => array( 'gutenberg/gutenberg.php' ),
 				'schedule' => $this->get_schedule( 'next Tuesday 9:00', 'daily' ),
 			)
 		);

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -56,7 +56,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 			)
 		);
 		wp_set_current_user( 0 );
-		add_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		Scheduled_Updates::init();
 
@@ -77,7 +76,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 		wp_clear_scheduled_hook( Scheduled_Updates::PLUGIN_CRON_HOOK );
 		delete_option( 'jetpack_scheduled_update_statuses' );
 		delete_option( Scheduled_Updates::PLUGIN_CRON_HOOK );
-		remove_filter( 'jetpack_scheduled_update_verify_plugins', '__return_true', 11 );
 
 		self::$sync_counter = 0;
 		remove_action( 'add_option', array( __CLASS__, 'sync_callback' ) );

--- a/projects/packages/scheduled-updates/tests/php/data/plugins/gutenberg/gutenberg.php
+++ b/projects/packages/scheduled-updates/tests/php/data/plugins/gutenberg/gutenberg.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Plugin Name: Gutenberg
+ * Plugin URI: https://jetpack.com/
+ * Description: Gutenberg
+ * Version: 4.0.0
+ * Author: Automattic
+ * Text Domain: gutenberg
+ *
+ * @package automattic/scheduled-updates
+ */

--- a/projects/packages/scheduled-updates/tests/php/data/plugins/installed-plugin/installed-plugin.php
+++ b/projects/packages/scheduled-updates/tests/php/data/plugins/installed-plugin/installed-plugin.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Plugin Name: installed-plugin
+ * Plugin URI: https://jetpack.com/
+ * Description: installed-plugin
+ * Version: 4.0.0
+ * Author: Automattic
+ * Text Domain: installed-plugin
+ *
+ * @package automattic/scheduled-updates
+ */

--- a/projects/packages/scheduled-updates/tests/php/data/plugins/wordpress/managed-plugin/managed-plugin.php
+++ b/projects/packages/scheduled-updates/tests/php/data/plugins/wordpress/managed-plugin/managed-plugin.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Plugin Name: managed-plugin
+ * Plugin URI: https://jetpack.com/
+ * Description: managed-plugin
+ * Version: 4.0.0
+ * Author: Automattic
+ * Text Domain: managed-plugin
+ *
+ * @package automattic/scheduled-updates
+ */


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves error handling for `plugins` parameter into REST API endpoint
* Update unit tests to work with a mocked plugin directory
* Transforms nested error message to a top-level error message so it can be used in UI.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this diff to a test site.
* Try to create a schedule with plugins that don't exist on the test site or that are managed on the test site
* Make sure the error response is correct.

