### PR TITLE
Add/tracks events for my jetpack product card action button dropdown

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -206,7 +206,7 @@ const ActionButton = ( {
 	);
 
 	const recordDropdownStateChange = useCallback( () => {
-		recordEvent( 'jetpack_myjetpack_product_card_dropdown_toggled', {
+		recordEvent( 'jetpack_myjetpack_product_card_dropdown_toggle', {
 			product: slug,
 			state: ! isDropdownOpen ? 'open' : 'closed',
 		} );
@@ -251,7 +251,7 @@ const ActionButton = ( {
 						setCurrentAction( allActions[ index ] );
 						setIsDropdownOpen( false );
 
-						recordEvent( 'jetpack_myjetpack_product_card_dropdown_action_clicked', {
+						recordEvent( 'jetpack_myjetpack_product_card_dropdown_action_click', {
 							product: slug,
 							action: label,
 						} );

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.jsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import useAnalytics from '../../hooks/use-analytics';
 import Card from '../card';
 import ActionButton, { PRODUCT_STATUSES } from './action-button';

--- a/projects/packages/my-jetpack/_inc/hooks/use-outside-alerter/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-outside-alerter/index.ts
@@ -1,7 +1,10 @@
 import { useEffect } from 'react';
 import type { MutableRefObject } from 'react';
 
-const useOutsideAlerter = ( ref: MutableRefObject< HTMLElement >, onClickOutside: () => void ) => {
+const useOutsideAlerter = (
+	ref: MutableRefObject< HTMLElement >,
+	onClickOutside: ( event: Event ) => void
+) => {
 	useEffect( () => {
 		const handleClickOutside = ( event: Event ) => {
 			if (
@@ -9,7 +12,7 @@ const useOutsideAlerter = ( ref: MutableRefObject< HTMLElement >, onClickOutside
 				ref.current &&
 				! ref.current.contains( event.target )
 			) {
-				onClickOutside();
+				onClickOutside( event );
 			}
 		};
 

--- a/projects/packages/my-jetpack/changelog/add-tracks-events-for-my-jetpack-product-card-action-button-dropdown
+++ b/projects/packages/my-jetpack/changelog/add-tracks-events-for-my-jetpack-product-card-action-button-dropdown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add tracks events for dropdown on action buttons

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.23.2",
+	"version": "4.23.3-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.23.2';
+	const PACKAGE_VERSION = '4.23.3-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
## Proposed changes:

* Add tracks events for My Jetpack product card action button dropdown
* Fixed issue where chevron was not closing dropdown, only opening it
* Fixed typo with with the connection banner

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1714642553738749-slack-C06CVN9QVFY

## Does this pull request change what data or activity we track or use?

Yes, we are adding tracks for the dropdown button for backups

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Purchase VaultPress Backup for your site
3. Wait for a backup to happen and then add an image or audio file or something to trigger an activity action that can be undone
4. Go to `/wp-admin/admin.php?page=my-jetpack` and confirm you can see the dropdown (Screenshot doesn't have activity log item because I was forcing it visible in testing)
![image](https://github.com/Automattic/jetpack/assets/65001528/7cc7057b-66c2-4c2b-8224-3be5f0dcd6ff)
5. Open the dropdown and confirm you see the following event in Tracks Vigilante
![image](https://github.com/Automattic/jetpack/assets/65001528/b4e4f07c-60f1-4ef4-8322-fe19823b5f27)
6. Try closing it with the Chevron or by clicking outside of it and confirm you see a tracks event like this
![image](https://github.com/Automattic/jetpack/assets/65001528/c8397d2e-2618-45da-b75e-33c7b5844852)
7. Select the items inside of it and confirm you see tracks events for this
![image](https://github.com/Automattic/jetpack/assets/65001528/ccec9ac7-5396-4736-9724-1e872194c378)
![image](https://github.com/Automattic/jetpack/assets/65001528/0f7e9826-f74d-4944-ae51-b16d772280fb)
8. Make sure opening the dropdown and closing it works as expected
9. If you want, connect your site from the banner and make sure Connected is spelled correctly
