### PR TITLE
Nav: Highlight plugins menu in redesigned menus

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-plugins-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-plugins-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Navigation: Change the plugins link on wpcom


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/6940 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In Calypso the Plugins menu item always points to /plugins/:site
In wp-admin the Plugins menu always points to plugins.php

Plugins.php will include a button directing people to the WPCom
marketplace, and if necessary will also prompt them to upgrade.

This change ensures that the Plugins menu is always correctly
highlighted in the menu when on a Plugins page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

0. Apply patch using the commands in the comment
1. Switch to an untangled simple site using a non-superuser account.
2. Press Plugins in the menu
3. You should arrive at /wp-admin/plugins.php and see a splash screen. The Plugins menu should be highlighted.
4. Click on the "Browse plugins" button
5. You should see the plugins marketplace screen. The Plugins menu should be highlighted
6. Repeat on an untangled atomic site, the same should occur.
7. Repeat on tangled sites, they should act as they do in production.
