### PR TITLE
Backport mu-wpcom-plugin 2.1.22 Changes

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.53.1] - 2024-05-09
+### Added
+- Added GlobalNotices component and useGlobalNotices hook [#37286]
+
 ## [0.53.0] - 2024-05-08
 ### Added
 - Social: Added add connection modal [#37211]
@@ -1019,6 +1023,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.53.1]: https://github.com/Automattic/jetpack-components/compare/0.53.0...0.53.1
 [0.53.0]: https://github.com/Automattic/jetpack-components/compare/0.52.1...0.53.0
 [0.52.1]: https://github.com/Automattic/jetpack-components/compare/0.52.0...0.52.1
 [0.52.0]: https://github.com/Automattic/jetpack-components/compare/0.51.0...0.52.0

--- a/projects/js-packages/components/changelog/add-global-notices-component
+++ b/projects/js-packages/components/changelog/add-global-notices-component
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added GlobalNotices component and useGlobalNotices hook

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.53.1-alpha",
+	"version": "0.53.1",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/classic-theme-helper/CHANGELOG.md
+++ b/projects/packages/classic-theme-helper/CHANGELOG.md
@@ -5,3 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2024-05-09
+### Added
+- Classic Theme Helper: Added Featured content code to the package [#37202]
+- Initial version. [#37175]
+
+### Changed
+- Add wordpress folder on gitignore [#37177]

--- a/projects/packages/classic-theme-helper/changelog/add-wordpress-class-theme-helper-gitignore
+++ b/projects/packages/classic-theme-helper/changelog/add-wordpress-class-theme-helper-gitignore
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Add wordpress folder on gitignore

--- a/projects/packages/classic-theme-helper/changelog/initial-version
+++ b/projects/packages/classic-theme-helper/changelog/initial-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Initial version.

--- a/projects/packages/classic-theme-helper/changelog/update-move-featured-content-to-classic-theme-helper-package
+++ b/projects/packages/classic-theme-helper/changelog/update-move-featured-content-to-classic-theme-helper-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Classic Theme Helper: Added Featured content code to the package

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-classic-theme-helper",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"description": "Features used with classic themes",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/classic-theme-helper/#readme",
 	"bugs": {

--- a/projects/packages/classic-theme-helper/src/class-classic-theme-helper.php
+++ b/projects/packages/classic-theme-helper/src/class-classic-theme-helper.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack;
  */
 class Classic_Theme_Helper {
 
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	const PACKAGE_VERSION = '0.1.0';
 
 	/**
 	 * Modules to include.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.7] - 2024-05-09
+### Fixed
+- SSO: Fix tooltip display on view all users page [#37257]
+
 ## [2.7.6] - 2024-05-06
 ### Added
 - Bring in authentication methods needed for SSO feature. [#36924]
@@ -1047,6 +1051,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.7.7]: https://github.com/Automattic/jetpack-connection/compare/v2.7.6...v2.7.7
 [2.7.6]: https://github.com/Automattic/jetpack-connection/compare/v2.7.5...v2.7.6
 [2.7.5]: https://github.com/Automattic/jetpack-connection/compare/v2.7.4...v2.7.5
 [2.7.4]: https://github.com/Automattic/jetpack-connection/compare/v2.7.3...v2.7.4

--- a/projects/packages/connection/changelog/fix-sso-tooltip-display
+++ b/projects/packages/connection/changelog/fix-sso-tooltip-display
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-SSO: Fix tooltip display on view all users page

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.7.7-alpha';
+	const PACKAGE_VERSION = '2.7.7';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.29.0] - 2024-05-09
+### Added
+- Jetpack-mu-wpcom: Add classic theme helper package as a requirement [#37284]
+- Settings: Add Admin Interface Style options. [#37273]
+
+### Removed
+- Nav Redesign: Revert Hosting menu changes [#37254]
+
+### Fixed
+- Themes: Fixed an issue that was showing a broken Theme Showcase action in the active theme details [#37258]
+- WordPress.com Features: Don't load admin color schemes if Jetpack is not active [#37233]
+
 ## [5.28.0] - 2024-05-06
 ### Added
 - Add plugins link to menu for simple classic users. [#37182]
@@ -783,6 +795,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.29.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.28.0...v5.29.0
 [5.28.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.27.0...v5.28.0
 [5.27.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.26.1...v5.27.0
 [5.26.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.26.0...v5.26.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-admin-interface-style-to-settings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-admin-interface-style-to-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Settings: Add Admin Interface Style options.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-deactivated-jetpack-fatal-error-on-classic-view
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-deactivated-jetpack-fatal-error-on-classic-view
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-WordPress.com Features: Don't load admin color schemes if Jetpack is not active

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-untangling-themes-single-theme-broken-action
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-untangling-themes-single-theme-broken-action
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Themes: Fixed an issue that was showing a broken Theme Showcase action in the active theme details

--- a/projects/packages/jetpack-mu-wpcom/changelog/nav-redesign-hosting-menu-revert
+++ b/projects/packages/jetpack-mu-wpcom/changelog/nav-redesign-hosting-menu-revert
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Nav Redesign: Revert Hosting menu changes

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-add-classic-theme-helper-to-jetpack-mu-wpcom-package
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-add-classic-theme-helper-to-jetpack-mu-wpcom-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Jetpack-mu-wpcom: Add classic theme helper package as a requirement

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.29.0-alpha",
+	"version": "5.29.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.29.0-alpha';
+	const PACKAGE_VERSION = '5.29.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2024-05-09
+### Changed
+- Scheduled Updates: Verify plugins when creating a schedule [#37235]
+
+### Removed
+- Remove sync option backward-compatibility temporary solution [#37132]
+- Scheduled Updates: Remove unused status api [#37299]
+
+### Fixed
+- Add updated_at field to ensure the option is always on sync. [#37282]
+- Fixed a bug where rest_fileds were not registered when composing the sync option. [#37240]
+- Fix multiple sync issue [#37266]
+
 ## [0.11.0] - 2024-05-06
 ### Added
 - Added a new Scheduled Updates active endpoint. [#37130]
@@ -154,6 +167,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.12.0]: https://github.com/Automattic/scheduled-updates/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Automattic/scheduled-updates/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/Automattic/scheduled-updates/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/Automattic/scheduled-updates/compare/v0.9.0...v0.9.1

--- a/projects/packages/scheduled-updates/changelog/add-guarding-non-exist-plugins
+++ b/projects/packages/scheduled-updates/changelog/add-guarding-non-exist-plugins
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Scheduled Updates: Verify plugins when creating a schedule

--- a/projects/packages/scheduled-updates/changelog/fix-flaky-test
+++ b/projects/packages/scheduled-updates/changelog/fix-flaky-test
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Unit test changes only
-
-

--- a/projects/packages/scheduled-updates/changelog/fix-remove-temp-backward-code
+++ b/projects/packages/scheduled-updates/changelog/fix-remove-temp-backward-code
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Remove sync option backward-compatibility temporary solution

--- a/projects/packages/scheduled-updates/changelog/fix-su-cache-sync-issue
+++ b/projects/packages/scheduled-updates/changelog/fix-su-cache-sync-issue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Add updated_at field to ensure the option is always on sync.

--- a/projects/packages/scheduled-updates/changelog/fix-su-multiple-sync-issue
+++ b/projects/packages/scheduled-updates/changelog/fix-su-multiple-sync-issue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix multiple sync issue

--- a/projects/packages/scheduled-updates/changelog/fix-sync-option
+++ b/projects/packages/scheduled-updates/changelog/fix-sync-option
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a bug where rest_fileds were not registered when composing the sync option.

--- a/projects/packages/scheduled-updates/changelog/update-remove-status-api
+++ b/projects/packages/scheduled-updates/changelog/update-remove-status-api
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Scheduled Updates: Remove unused status api

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.12.0-alpha';
+	const PACKAGE_VERSION = '0.12.0';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.1] - 2024-05-09
+### Changed
+- Internal updates.
+
 ## [2.16.0] - 2024-05-08
 ### Added
 - Options: sync WordAds inline ads toggle option [#37170]
@@ -1135,6 +1139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.16.1]: https://github.com/Automattic/jetpack-sync/compare/v2.16.0...v2.16.1
 [2.16.0]: https://github.com/Automattic/jetpack-sync/compare/v2.15.1...v2.16.0
 [2.15.1]: https://github.com/Automattic/jetpack-sync/compare/v2.15.0...v2.15.1
 [2.15.0]: https://github.com/Automattic/jetpack-sync/compare/v2.14.0...v2.15.0

--- a/projects/packages/sync/changelog/fix-phan-issues-sync-modules-get_module
+++ b/projects/packages/sync/changelog/fix-phan-issues-sync-modules-get_module
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Add `@phan-var` for many calls to `Sync\Modules::get_module()` to specify which module subclass it returned. Should be no change to functionality.
-
-

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.16.1-alpha';
+	const PACKAGE_VERSION = '2.16.1';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.22 - 2024-05-09
+### Changed
+- Internal updates.
+
 ## 2.1.21 - 2024-05-06
 ### Changed
 - Update formalized dependencies in Scheduled Updates. [#37008]

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-admin-interface-style-to-settings
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-admin-interface-style-to-settings
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-guarding-non-exist-plugins
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-guarding-non-exist-plugins
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-wordads-blaze
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-wordads-blaze
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-add-classic-theme-helper-to-jetpack-mu-wpcom-package
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-add-classic-theme-helper-to-jetpack-mu-wpcom-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_22_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_22"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.22-alpha
+ * Version: 2.1.22
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.22-alpha",
+	"version": "2.1.22",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.22

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.