### PR TITLE
Masterbar: automatically label Masterbar changes in masterbar package

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-gardening-masterbar-label
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-masterbar-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Auto-labeling: label changes to the Masterbar feature in the Masterbar package.

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -161,6 +161,12 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			keywords.add( '[Feature] WooCommerce Analytics' );
 		}
 
+		// The Masterbar feature now lives in both a package and a Jetpack module.
+		const masterbar = file.match( /^projects\/packages\/masterbar\// );
+		if ( masterbar !== null ) {
+			keywords.add( '[Feature] Masterbar' );
+		}
+
 		// Docker.
 		const docker = file.match( /^(projects\/plugins\/boost\/docker|tools\/docker)\// );
 		if ( docker !== null ) {

--- a/projects/packages/masterbar/changelog/update-gardening-masterbar-label
+++ b/projects/packages/masterbar/changelog/update-gardening-masterbar-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Auto-labeling: label changes to the Masterbar feature in the Masterbar package.


### PR DESCRIPTION
Repo gardening: Since the Masterbar feature is being moved to its own package, this PR ensures that the `[Feature] Masterbar` label will be automatically added in PRs that touch the masterbar package codebase.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
PfwV0U-2H-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> This can only be tested in a fork.

* In your fork, merge this branch to `trunk`.
* Open a new PR in your fork, for a new branch to `trunk`, making a change to one of the files in `projects/packages/masterbar/`.
    * The Masterbar label should be automatically added to the PR.