### PR TITLE
CRM: PDF invoice logo - image not found issue. Set the tmp folder and don't add protocols

### DIFF
--- a/projects/plugins/crm/changelog/fix-3459-crm-pdf-invoice-logo-not-found
+++ b/projects/plugins/crm/changelog/fix-3459-crm-pdf-invoice-logo-not-found
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Invoices: Fix the logo, image not found, issue in the PDF invoices.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.php
@@ -3251,8 +3251,16 @@ final class ZeroBSCRM {
 		// this batch of option setting ensures we allow remote images (http/s)
 		// ... but they're only allowed from same-site urls
 		$options->set( 'isRemoteEnabled', true );
-		$options->addAllowedProtocol( 'http://', 'jpcrm_dompdf_assist_validate_remote_uri' );
-		$options->addAllowedProtocol( 'https://', 'jpcrm_dompdf_assist_validate_remote_uri' );
+
+		// We have to specify a temporary dir to download the remote images. Not all systems have a writable /tmp dir.
+		$jpcrm_storage_path = wf_jpcrm_storage_dir_path();
+		if ( $jpcrm_storage_path ) {
+			$options->setTempDir( $jpcrm_storage_path . '/tmp' );
+		}
+
+		// Commented: Not necessary. Using CDN sites (Jetpack Boost) for assets will fail because of the validation.
+		// $options->addAllowedProtocol( 'http://', 'jpcrm_dompdf_assist_validate_remote_uri' );
+		// $options->addAllowedProtocol( 'https://', 'jpcrm_dompdf_assist_validate_remote_uri' );
 
 		// use JPCRM storage dir for extra fonts
 		$options->set( 'fontDir', jpcrm_storage_fonts_dir_path() );

--- a/projects/plugins/crm/includes/ZeroBSCRM.FileUploads.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.FileUploads.php
@@ -470,6 +470,21 @@ function jpcrm_storage_dir_info() {
 	return false;
 }
 
+/**
+ * Returns the 'dir info' for the JPCRM storage folder.
+ *
+ * @return false|string
+ */
+function wf_jpcrm_storage_dir_path() {
+	$root_storage_info = jpcrm_storage_dir_info();
+
+	if ( ! $root_storage_info ) {
+		return false;
+	}
+
+	return $root_storage_info['path'];
+}
+
 /*
  * Returns the 'dir info' for the fonts folder.
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/zero-bs-crm/issues/3459

## Proposed changes:

This PR fixes our issue with the PDF invoices for rendering the logo. I've been investigating it for a while, and really, there were two issues;

The main one was a method introduced to check the remote link, but it was not working well because many sites use CDN to cache their assets, including images, which implies that the logo image has a different domain or subdomain.

The other issue was about the temporary folder to download that remote file locally and to be able the DomPdf to generate the PDF correctly. In some servers, the temporary folder is not writable, so we usually have an issue there. To fix this, we set the temporary folder inside of the JPCRM storage folder, in the wp-content folder to ensure we have a writable .temporary folder.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:

- In a JPCRM site, go to the settings and set `Your Business Logo:` to an external image link.
- Create an invoice.
- Generate the PDF.
- In trunk, you will see the error, image not found with a white box.
- In this PR, you will see the logo you selected.
