### PR TITLE
Address Gravatar's profile widget PHP warning

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-gravatar-profile-array-warning
+++ b/projects/plugins/jetpack/changelog/fix-gravatar-profile-array-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed a warning thrown by the gravatar profile widget.

--- a/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
+++ b/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
@@ -217,6 +217,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 			<ul class="grofile-urls grofile-links">
 
 			<?php foreach ( $personal_links as $personal_link ) : ?>
+				<?php if ( is_array( $personal_link ) ) : ?>
 				<li>
 					<a href="<?php echo esc_url( $personal_link['value'] ); ?>">
 						<?php
@@ -225,6 +226,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 						?>
 					</a>
 				</li>
+				<?php endif; ?>
 			<?php endforeach; ?>
 			</ul>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
I noticed the following piece of code occasionally throwing a warning on WP.com when `$personal_link` is not an array.  
Adding the following check gets rid of the warning and while I'm not exactly sure if this is the expected behavior (the code hasn't been changed in a long while), it doesn't affect the functionality either since the widget would not display correctly anyway if the data is missing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

TBA

