### PR TITLE
WordPress.com Toolbar: Remove "My Sites" text and only display icon

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-my-sites-text-masterbar
+++ b/projects/plugins/jetpack/changelog/remove-my-sites-text-masterbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordPress.com Toolbar: Remove "My Sites" text and only display icon

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -977,18 +977,15 @@ class Masterbar {
 			$blog_name = mb_substr( html_entity_decode( $blog_name, ENT_QUOTES ), 0, 20 ) . '&hellip;';
 		}
 
-		$my_site_url   = 'https://wordpress.com/sites/' . $this->primary_site_url;
-		$my_site_title = _n( 'My Site', 'My Sites', $this->user_site_count, 'jetpack' );
+		$my_site_url = 'https://wordpress.com/sites/' . $this->primary_site_url;
 		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
-			$my_site_url   = 'https://wordpress.com/sites';
-			$my_site_title = esc_html__( 'My Sites', 'jetpack' );
+			$my_site_url = 'https://wordpress.com/sites';
 		}
 
 		$wp_admin_bar->add_menu(
 			array(
 				'parent' => 'root-default',
 				'id'     => 'blog',
-				'title'  => $my_site_title,
 				'href'   => $my_site_url,
 				'meta'   => array(
 					'class' => 'my-sites mb-trackable',

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/overrides.css
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/overrides.css
@@ -3,6 +3,11 @@
     min-height: unset !important;
 }
 
+/* Remove margin between icon and text since the my-sites menu does not have text */
+#wpadminbar .my-sites .ab-item:before {
+	margin-right: 0;
+}
+
 /* Overwrite a core style which breaks the overflow for .my-sites in Safari */
 #wpadminbar li.menupop.my-sites {
 	overflow: visible;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6888
Counterpart of D146362-code and https://github.com/Automattic/wp-calypso/pull/89469

## Proposed changes:

Removes the "My Sites" text from the admin top bar when the WordPress.com Toolbar module is enabled.

Before | After
--- | ---
<img width="241" alt="Screenshot 2024-05-09 at 15 50 10" src="https://github.com/Automattic/jetpack/assets/1233880/7622ee0e-6bc1-4e03-a8cb-fa9d9028f0f9"> | <img width="259" alt="Screenshot 2024-05-09 at 16 11 25" src="https://github.com/Automattic/jetpack/assets/1233880/975d513a-c576-4249-a4b4-747a715a7aa9">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to a Jetpack or WoA site
- If you're testing on a Jetpack site, activate the WordPress.com Toolbar module (https://jetpack.com/support/masterbar/)
- If you're testing on a WoA site, make sure to select the default admin interface in wordpress.com/hosting-config
- Go to `/wp-admin`
- Make sure the first item of the admin top bar only has a icon and no longer includes the "My Sites" text