### PR TITLE
WP.com menu: Add "Hosting > Add-ons" menu to Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-nav-redesign-add-ons-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-nav-redesign-add-ons-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WP.com menu: Add "Hosting > Add-ons" menu to Atomic sites

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.29.0",
+	"version": "5.29.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.29.0';
+	const PACKAGE_VERSION = '5.29.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -93,16 +93,14 @@ function wpcom_add_wpcom_menu_item() {
 		null
 	);
 
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		add_submenu_page(
-			$parent_slug,
-			esc_attr__( 'Add-ons', 'jetpack-mu-wpcom' ),
-			esc_attr__( 'Add-ons', 'jetpack-mu-wpcom' ),
-			'manage_options',
-			esc_url( "https://wordpress.com/add-ons/$domain" ),
-			null
-		);
-	}
+	add_submenu_page(
+		$parent_slug,
+		esc_attr__( 'Add-ons', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Add-ons', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		esc_url( "https://wordpress.com/add-ons/$domain" ),
+		null
+	);
 
 	add_submenu_page(
 		$parent_slug,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7046

## Proposed changes:

Registers the "Hosting > Add-ons" menu for Atomic sites as well, since they can buy upgrades such as additional storage.

Before | After
--- | ---
<img width="333" alt="Screenshot 2024-05-09 at 16 56 46" src="https://github.com/Automattic/jetpack/assets/1233880/9107fc47-f416-478f-be34-2caffe28bbb0"> | <img width="349" alt="Screenshot 2024-05-09 at 16 58 44" src="https://github.com/Automattic/jetpack/assets/1233880/7a6e01ce-54ff-4396-9b7a-28f2c89183e6">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WoA site
- Switch to the classic admin interface
- Make sure the "Hosting > Add-ons" menu is registered

