### PR TITLE
Calypsoify: auto-label changes to Calypsoify inside package

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-gardening-calypsoify-label
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-calypsoify-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Auto-labeling: label changes to the Calypsoify package

--- a/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/add-labels/index.js
@@ -167,6 +167,12 @@ async function getLabelsToAdd( octokit, owner, repo, number, isDraft, isRevert )
 			keywords.add( '[Feature] Masterbar' );
 		}
 
+		// The Calypsoify feature now lives in both a package and a Jetpack module.
+		const calypsoify = file.match( /^projects\/packages\/calypsoify\// );
+		if ( calypsoify !== null ) {
+			keywords.add( '[Feature] Calypsoify' );
+		}
+
 		// Docker.
 		const docker = file.match( /^(projects\/plugins\/boost\/docker|tools\/docker)\// );
 		if ( docker !== null ) {


### PR DESCRIPTION

## Proposed changes:

* Repo gardening: Since the Calypsoify feature is being moved to its own package, this PR ensures that the [Feature] Calypsoify label will be automatically added in PRs that touch the Calypsoify package codebase.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pfwV0U-8E-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

> [!NOTE]
> This can only be tested in a fork.

* In your fork, merge this branch to `trunk`.
* Open a new PR in your fork, for a new branch to `trunk`, making a change to one of the files in `projects/packages/calypsoify/`.
    * The "[Feature] Calypsoify" label should be automatically added to the PR.

