### PR TITLE
AI Assistant: Fix input z-index on moving block with inline extension

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-jetpack-ai-inline-extension-z-index
+++ b/projects/js-packages/ai-client/changelog/fix-jetpack-ai-inline-extension-z-index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client: Add className to AI Control component

--- a/projects/js-packages/ai-client/src/components/ai-control/ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/ai-control.tsx
@@ -16,6 +16,7 @@ import type { RequestingStateProp } from '../../types.js';
 import type { ReactElement } from 'react';
 
 type AIControlProps = {
+	className?: string;
 	disabled?: boolean;
 	value: string;
 	placeholder?: string;
@@ -37,6 +38,7 @@ type AIControlProps = {
  * @returns {ReactElement}       Rendered component
  */
 export default function AIControl( {
+	className,
 	disabled = false,
 	value = '',
 	placeholder = '',
@@ -51,7 +53,10 @@ export default function AIControl( {
 	wrapperRef = null,
 }: AIControlProps ): ReactElement {
 	return (
-		<div className="jetpack-components-ai-control__container-wrapper" ref={ wrapperRef }>
+		<div
+			className={ classNames( 'jetpack-components-ai-control__container-wrapper', className ) }
+			ref={ wrapperRef }
+		>
 			{ error }
 			<div className="jetpack-components-ai-control__container">
 				{ banner }

--- a/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
@@ -20,6 +20,7 @@ import type { RequestingStateProp } from '../../types.js';
 import type { ReactElement, MouseEvent } from 'react';
 
 type ExtensionAIControlProps = {
+	className?: string;
 	disabled?: boolean;
 	value: string;
 	placeholder?: string;
@@ -49,6 +50,7 @@ type ExtensionAIControlProps = {
  */
 export function ExtensionAIControl(
 	{
+		className,
 		disabled = false,
 		value = '',
 		placeholder = '',
@@ -212,6 +214,7 @@ export function ExtensionAIControl(
 
 	return (
 		<AIControl
+			className={ className }
 			disabled={ disabled || loading }
 			value={ value }
 			placeholder={ placeholder }

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-z-index
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-z-index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Fix input z-index on moving block with inline extension

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -11,6 +11,7 @@ import React from 'react';
  */
 import useAICheckout from '../../../hooks/use-ai-checkout';
 import useAiFeature from '../../../hooks/use-ai-feature';
+import './style.scss';
 /*
  * Types
  */
@@ -157,6 +158,7 @@ export default function AiAssistantInput( {
 
 	return (
 		<ExtensionAIControl
+			className="jetpack-ai-assistant-extension-ai-input"
 			placeholder={ placeholder }
 			disabled={ disabled }
 			value={ value }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/style.scss
@@ -1,0 +1,3 @@
+.jetpack-ai-assistant-extension-ai-input {
+  z-index: 1;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37321

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a `className` to the AI Control component
* Uses this class name to set the z-index of the control component to match that of the block element

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On `trunk`, go to the editor and add some blocks
* Add a Heading block and use the "Ask AI Assistant" option to open the input
* Now change the order of the Heading block in the editor
* Check that it is not possible to select the input anymore, only the Heading content
* Check out this branch
* Repeat the test
* Check that it is possible to focus the input as normal
