### PR TITLE
AI Assistant: Fix inline extension styles on P2 and some themes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-style
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Fix inline extension styles on P2 and some themes

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -5,6 +5,7 @@ import { ExtensionAIControl } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
 import React from 'react';
 /*
  * Internal dependencies
@@ -32,6 +33,11 @@ export type AiAssistantInputProps = {
 	undo?: () => void;
 	tryAgain?: () => void;
 };
+
+const className = classNames(
+	'jetpack-ai-assistant-extension-ai-input',
+	'wp-block' // Some themes, like Twenty Twenty, use this class to set the element's side margins.
+);
 
 export default function AiAssistantInput( {
 	requestingState,
@@ -158,7 +164,7 @@ export default function AiAssistantInput( {
 
 	return (
 		<ExtensionAIControl
-			className="jetpack-ai-assistant-extension-ai-input"
+			className={ className }
 			placeholder={ placeholder }
 			disabled={ disabled }
 			value={ value }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37335

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Generalizes the input positioning solution adjusting margins to work on other themes and, specially, P2
* Adds a CSS class to constrain the input width on the Twenty Twenty and Twenty Twenty One themes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the inline extensions ([instructions](https://github.com/Automattic/jetpack/pull/37082))
* Enable the Twenty Twenty or Twenty Twenty theme
* Add a Heading block and click on "Ask AI Assistant"
* Check that the input has the correct width
* Use the command to test on Simple that is commented below by the github-actions bot
* Sandbox a P2 blog
* Enable the inline extension by adding the flag command to the `0-sandbox.php` file
* In a P2 post, use a Heading as the first block, followed by some other block
* Check that the input is shown as normal (check the images for the difference)

| Before | After |
| ---------- | --------|
| ![2024-05-09_20-07-45](https://github.com/Automattic/jetpack/assets/8486249/410d4b58-7375-47eb-ac9b-2189c25cb332) | ![2024-05-09_20-11-14](https://github.com/Automattic/jetpack/assets/8486249/1e9b4985-a082-4810-95ec-10dd9c351ce9) |
|  ![2024-05-09_20-04-05](https://github.com/Automattic/jetpack/assets/8486249/dcad794d-ca8c-40b3-85e1-5c43db6c6832) | ![2024-05-09_20-03-23](https://github.com/Automattic/jetpack/assets/8486249/e38e30ed-cd27-4ee0-a44f-a86f07f2753b) |



