### PR TITLE
A4A Client: Only show disconnect dialog during plugin deactivation when connected

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-a4a-remove-disconnect-prompt-when-disconnected
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-a4a-remove-disconnect-prompt-when-disconnected
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Prevent disconnect dialog from displaying when site is already disconnected.
+
+

--- a/projects/plugins/automattic-for-agencies-client/src/class-automattic-for-agencies-client.php
+++ b/projects/plugins/automattic-for-agencies-client/src/class-automattic-for-agencies-client.php
@@ -37,7 +37,10 @@ class Automattic_For_Agencies_Client {
 		add_action( 'load-settings_page_' . AUTOMATTIC_FOR_AGENCIES_CLIENT_SLUG, array( static::class, 'load_scripts_styles' ) );
 
 		// Display a modal when trying to deactivate the plugin.
-		Deactivation_Handler::init( AUTOMATTIC_FOR_AGENCIES_CLIENT_SLUG, __DIR__ . '/admin/deactivation-dialog.php' );
+		$manager = new Connection_Manager( 'automattic-for-agencies-client' );
+		if ( $manager->is_connected() ) {
+			Deactivation_Handler::init( AUTOMATTIC_FOR_AGENCIES_CLIENT_SLUG, __DIR__ . '/admin/deactivation-dialog.php' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/automattic-for-agencies-dev/issues/348

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Checks if the site is connected before adding the deactivation handler that prompts to disconnect the site during plugin deactivation.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/automattic-for-agencies-dev/issues/348

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with the A4A client plugin installed.
* With a disconnected site, deactivate the plugin. Verify no interstitial connection pop-up is shown and the plugin deactivates right away.
* Re-activate the plugin, and connect the site.
* Deactivate the plugin, verify the disconnect dialog pops up before deactivating the plugin.

