### PR TITLE
Subscribe block: adds button-only style

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-button-only
+++ b/projects/plugins/jetpack/changelog/update-subscribe-button-only
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe block: adds button-only style

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/block.json
@@ -18,13 +18,17 @@
 	},
 	"styles": [
 		{
+			"name": "split",
+			"label": "Split",
+			"isDefault": true
+		},
+		{
 			"name": "compact",
 			"label": "Compact"
 		},
 		{
-			"name": "split",
-			"label": "Split",
-			"isDefault": true
+			"name": "button",
+			"label": "Button only"
 		}
 	],
 	"attributes": {
@@ -107,6 +111,9 @@
 			"default": "Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm' to start subscribing."
 		},
 		"appSource": {
+			"type": "string"
+		},
+		"className": {
 			"type": "string"
 		}
 	},

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/edit.js
@@ -16,6 +16,7 @@ import { useEffect } from '@wordpress/element';
 import { _n, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { isEqual } from 'lodash';
+import { getActiveStyleName } from '../../shared/block-styles';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import { isNewsletterFeatureEnabled } from '../../shared/memberships/edit';
 import GetAddPaidPlanButton from '../../shared/memberships/utils';
@@ -87,6 +88,7 @@ export function SubscriptionEdit( props ) {
 		borderRadius,
 		borderWeight,
 		buttonWidth,
+		className,
 		includeSocialFollowers,
 		padding,
 		spacing,
@@ -96,6 +98,8 @@ export function SubscriptionEdit( props ) {
 		buttonOnNewLine,
 		successMessage = DEFAULT_SUCCESS_MESSAGE,
 	} = validatedAttributes;
+
+	const activeStyleName = getActiveStyleName( metadata.styles, className );
 
 	const { subscriberCount, subscriberCountString } = useSelect( select => {
 		if ( ! isModuleActive ) {
@@ -202,11 +206,16 @@ export function SubscriptionEdit( props ) {
 		...( ! buttonBackgroundColor.color && buttonGradient.gradientValue
 			? { background: buttonGradient.gradientValue }
 			: { backgroundColor: buttonBackgroundColor.color } ),
-		...( buttonOnNewLine
-			? { marginTop: getSpacingStyleValue( spacing ) + 'px' }
-			: { marginLeft: getSpacingStyleValue( spacing ) + 'px' } ),
 		width: buttonWidth,
 	};
+
+	if ( activeStyleName !== 'button' ) {
+		if ( buttonOnNewLine ) {
+			buttonStyles.marginTop = getSpacingStyleValue( spacing ) + 'px';
+		} else {
+			buttonStyles.marginLeft = getSpacingStyleValue( spacing ) + 'px';
+		}
+	}
 
 	const previousButtonBackgroundColor = usePrevious( buttonBackgroundColor );
 
@@ -285,15 +294,17 @@ export function SubscriptionEdit( props ) {
 					<div className="wp-block-jetpack-subscriptions__container is-not-subscriber">
 						<div className="wp-block-jetpack-subscriptions__form" role="form">
 							<div className="wp-block-jetpack-subscriptions__form-elements">
-								<TextControl
-									placeholder={ subscribePlaceholder }
-									disabled={ true }
-									className={ classnames(
-										emailFieldClasses,
-										'wp-block-jetpack-subscriptions__textfield'
-									) }
-									style={ emailFieldStyles }
-								/>
+								{ activeStyleName !== 'button' && (
+									<TextControl
+										placeholder={ subscribePlaceholder }
+										disabled={ true }
+										className={ classnames(
+											emailFieldClasses,
+											'wp-block-jetpack-subscriptions__textfield'
+										) }
+										style={ emailFieldStyles }
+									/>
+								) }
 								<RichText
 									className={ classnames(
 										buttonClasses,

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -470,7 +470,7 @@ function is_button_only_style( $class_name ) {
  * @return array
  */
 function get_element_styles_from_attributes( $attributes ) {
-	$is_button_only_style = is_button_only_style( get_attribute( $attributes, 'className' ) );
+	$is_button_only_style = is_button_only_style( get_attribute( $attributes, 'className', '' ) );
 
 	$button_background_style = ! has_attribute( $attributes, 'buttonBackgroundColor' ) && has_attribute( $attributes, 'customButtonGradient' )
 		? get_attribute( $attributes, 'customButtonGradient' )
@@ -735,7 +735,7 @@ function render_for_website( $data, $classes, $styles ) {
 	$form_id              = 'subscribe-blog' . $widget_id_suffix;
 	$form_url             = 'https://wordpress.com/email-subscriptions';
 	$post_access_level    = get_post_access_level_for_current_post();
-	$is_button_only_style = isset( $data['class_name'] ) ? is_button_only_style( $data['class_name'] ) : false;
+	$is_button_only_style = ! empty( $data['class_name'] ) ? is_button_only_style( $data['class_name'] ) : false;
 
 	// Post ID is used for pulling post-specific paid status, and returning to the right post after confirming subscription
 	$post_id = null;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -454,6 +454,8 @@ function get_element_class_names_from_attributes( $attributes ) {
  * @return array
  */
 function get_element_styles_from_attributes( $attributes ) {
+	$is_button_only_style = get_attribute( $attributes, 'className' ) === 'is-style-button';
+
 	$button_background_style = ! has_attribute( $attributes, 'buttonBackgroundColor' ) && has_attribute( $attributes, 'customButtonGradient' )
 		? get_attribute( $attributes, 'customButtonGradient' )
 		: get_attribute( $attributes, 'customButtonBackgroundColor' );
@@ -493,11 +495,14 @@ function get_element_styles_from_attributes( $attributes ) {
 	$email_field_styles   .= $style;
 
 	$button_spacing = get_attribute( $attributes, 'spacing', DEFAULT_SPACING_VALUE );
-	if ( true === get_attribute( $attributes, 'buttonOnNewLine' ) ) {
-		$submit_button_styles .= sprintf( 'margin-top: %dpx;', $button_spacing );
-	} else {
-		$submit_button_styles .= 'margin: 0px; '; // Reset Safari's 2px default margin for buttons affecting input and button union
-		$submit_button_styles .= sprintf( 'margin-left: %dpx;', $button_spacing );
+	if ( ! $is_button_only_style ) {
+		$button_spacing = get_attribute( $attributes, 'spacing', DEFAULT_SPACING_VALUE );
+		if ( true === get_attribute( $attributes, 'buttonOnNewLine' ) ) {
+			$submit_button_styles .= sprintf( 'margin-top: %dpx;', $button_spacing );
+		} else {
+			$submit_button_styles .= 'margin: 0; '; // Reset Safari's 2px default margin for buttons affecting input and button union
+			$submit_button_styles .= sprintf( 'margin-left: %dpx;', $button_spacing );
+		}
 	}
 
 	if ( has_attribute( $attributes, 'borderColor' ) ) {
@@ -674,6 +679,7 @@ function render_block( $attributes ) {
 		),
 		'source'                        => 'subscribe-block',
 		'app_source'                    => get_attribute( $attributes, 'appSource', null ),
+		'class_name'                    => get_attribute( $attributes, 'className' ),
 	);
 
 	if ( ! jetpack_is_frontend() ) {
@@ -707,12 +713,13 @@ function get_post_access_level_for_current_post() {
  * @return string
  */
 function render_for_website( $data, $classes, $styles ) {
-	$lang              = get_locale();
-	$blog_id           = \Jetpack_Options::get_option( 'id' );
-	$widget_id_suffix  = Jetpack_Subscriptions_Widget::$instance_count > 1 ? '-' . Jetpack_Subscriptions_Widget::$instance_count : '';
-	$form_id           = 'subscribe-blog' . $widget_id_suffix;
-	$form_url          = 'https://wordpress.com/email-subscriptions';
-	$post_access_level = get_post_access_level_for_current_post();
+	$lang                 = get_locale();
+	$blog_id              = \Jetpack_Options::get_option( 'id' );
+	$widget_id_suffix     = Jetpack_Subscriptions_Widget::$instance_count > 1 ? '-' . Jetpack_Subscriptions_Widget::$instance_count : '';
+	$form_id              = 'subscribe-blog' . $widget_id_suffix;
+	$form_url             = 'https://wordpress.com/email-subscriptions';
+	$post_access_level    = get_post_access_level_for_current_post();
+	$is_button_only_style = $data['class_name'] === 'is-style-button';
 
 	// Post ID is used for pulling post-specific paid status, and returning to the right post after confirming subscription
 	$post_id = null;
@@ -769,7 +776,7 @@ function render_for_website( $data, $classes, $styles ) {
 					id="<?php echo esc_attr( $form_id ); ?>"
 				>
 					<div class="wp-block-jetpack-subscriptions__form-elements">
-						<?php if ( ! $is_subscribed ) : ?>
+						<?php if ( ! $is_subscribed && ! $is_button_only_style ) : ?>
 						<p id="subscribe-email">
 							<label
 								id="<?php echo esc_attr( $subscribe_field_id . '-label' ); ?>"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -446,6 +446,22 @@ function get_element_class_names_from_attributes( $attributes ) {
 }
 
 /**
+ * Checks if block style is "button only"
+ *
+ * @param string $class_name Block attribute className; multiple names are spearated by space.
+ *
+ * @return bool
+ */
+function is_button_only_style( $class_name ) {
+	if ( empty( $class_name ) ) {
+		return false;
+	}
+
+	$class_names = explode( ' ', $class_name );
+	return in_array( 'is-style-button', $class_names, true );
+}
+
+/**
  * Uses block attributes to generate an array containing the styles for various block elements.
  * Based on Jetpack_Subscriptions_Widget::do_subscription_form() which the block was originally using.
  *
@@ -454,7 +470,7 @@ function get_element_class_names_from_attributes( $attributes ) {
  * @return array
  */
 function get_element_styles_from_attributes( $attributes ) {
-	$is_button_only_style = get_attribute( $attributes, 'className' ) === 'is-style-button';
+	$is_button_only_style = is_button_only_style( get_attribute( $attributes, 'className' ) );
 
 	$button_background_style = ! has_attribute( $attributes, 'buttonBackgroundColor' ) && has_attribute( $attributes, 'customButtonGradient' )
 		? get_attribute( $attributes, 'customButtonGradient' )
@@ -719,7 +735,7 @@ function render_for_website( $data, $classes, $styles ) {
 	$form_id              = 'subscribe-blog' . $widget_id_suffix;
 	$form_url             = 'https://wordpress.com/email-subscriptions';
 	$post_access_level    = get_post_access_level_for_current_post();
-	$is_button_only_style = $data['class_name'] === 'is-style-button';
+	$is_button_only_style = isset( $data['class_name'] ) ? is_button_only_style( $data['class_name'] ) : false;
 
 	// Post ID is used for pulling post-specific paid status, and returning to the right post after confirming subscription
 	$post_id = null;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.js
@@ -54,11 +54,14 @@ domReady( function () {
 					return;
 				}
 
-				const emailInput = form.querySelector( 'input[type=email]' );
-				const email = emailInput ? emailInput.value : form.dataset.subscriber_email;
+				// If email is empty, we will ask for it in the modal that opens
+				// Email input can be hidden for "button only style" for example.
+				let email = form.querySelector( 'input[type=email]' )?.value ?? '';
 
-				if ( ! email ) {
-					return;
+				// Fallback to provided email from the logged in user when set
+				if ( ! email && form.dataset.subscriber_email ) {
+					// eslint-disable-next-line no-console
+					email = form.dataset.subscriber_email;
 				}
 
 				const action = form.querySelector( 'input[name=action]' ).value;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Supersedes https://github.com/Automattic/jetpack/pull/33921
Resolves https://github.com/Automattic/jetpack/issues/35708

Requires D148314-code merged first.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds "button only" style which basically just hides the email input.

<img width="210" alt="Screenshot 2024-05-13 at 12 15 24" src="https://github.com/Automattic/jetpack/assets/87168/568d7b80-8af4-47a8-aedd-e7adea72826a">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In editor, add subscribe block and change style to "button only"
* Test with D148314-code and sandbox `subscribe.wordpress.com`
* Flow now asks for your email.
* Test logged in, logged out, already subsribed, etc flows.
* Test different styling options from the block sidebar.
* On regular subscribe blocks, not filling email still yelds error:

    <img width="458" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/aef469fd-2246-4056-ab36-d1a5363fc442">

