### PR TITLE
Fix Theme buttons have correct visited style

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-themes-button-visited-style
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-themes-button-visited-style
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: We're changing a css rule for a button on one specific screen that only affects wpcom
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/css/ui-fixes.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/css/ui-fixes.css
@@ -1,3 +1,3 @@
-.button:visited {
+.theme-browser .button:visited {
 	color: #fff;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/css/ui-fixes.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/css/ui-fixes.css
@@ -1,0 +1,3 @@
+.button:visited {
+	color: #fff;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
@@ -45,12 +45,6 @@ function wpcom_themes_show_banner() {
 		array(),
 		Jetpack_Mu_Wpcom::PACKAGE_VERSION
 	);
-	wp_enqueue_style(
-		'wpcom-themes-ui-fixes',
-		plugins_url( 'css/ui-fixes.css', __FILE__ ),
-		array(),
-		Jetpack_Mu_Wpcom::PACKAGE_VERSION
-	);
 }
 add_action( 'load-theme-install.php', 'wpcom_themes_show_banner' );
 
@@ -91,6 +85,13 @@ function wpcom_themes_remove_wpcom_actions() {
 			'in_footer' => true,
 		)
 	);
+}
+add_action( 'load-themes.php', 'wpcom_themes_remove_wpcom_actions' );
+
+/**
+ * Adds a CSS file to fix UI issues in the theme browser.
+ */
+function wpcom_themes_load_ui_fixes() {
 	wp_enqueue_style(
 		'wpcom-themes-ui-fixes',
 		plugins_url( 'css/ui-fixes.css', __FILE__ ),
@@ -98,4 +99,4 @@ function wpcom_themes_remove_wpcom_actions() {
 		Jetpack_Mu_Wpcom::PACKAGE_VERSION
 	);
 }
-add_action( 'load-themes.php', 'wpcom_themes_remove_wpcom_actions' );
+add_action( 'load-themes.php', 'wpcom_themes_load_ui_fixes' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
@@ -91,5 +91,11 @@ function wpcom_themes_remove_wpcom_actions() {
 			'in_footer' => true,
 		)
 	);
+	wp_enqueue_style(
+		'wpcom-themes-ui-fixes',
+		plugins_url( 'css/ui-fixes.css', __FILE__ ),
+		array(),
+		Jetpack_Mu_Wpcom::PACKAGE_VERSION
+	);
 }
 add_action( 'load-themes.php', 'wpcom_themes_remove_wpcom_actions' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
@@ -45,6 +45,12 @@ function wpcom_themes_show_banner() {
 		array(),
 		Jetpack_Mu_Wpcom::PACKAGE_VERSION
 	);
+	wp_enqueue_style(
+		'wpcom-themes-ui-fixes',
+		plugins_url( 'css/ui-fixes.css', __FILE__ ),
+		array(),
+		Jetpack_Mu_Wpcom::PACKAGE_VERSION
+	);
 }
 add_action( 'load-theme-install.php', 'wpcom_themes_show_banner' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:
- https://github.com/Automattic/dotcom-forge/issues/7087

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changed the button :visited style so that it's correctly styled on Simple and Atomic sites

| Before       | After          |
|--------------|----------------|
|![Screenshot 2024-05-08 at 12 21 34](https://github.com/Automattic/jetpack/assets/1989914/9c1c0e8c-af81-4370-87c2-ef45d00ac593)|![Screenshot 2024-05-10 at 15 49 44](https://github.com/Automattic/jetpack/assets/1989914/5c373253-e59c-4a9c-b297-21a67dcfd3de)|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes
* Go to `/wp-admin/themes.php`
* You can either click on the customize button of the active theme or apply the :visited CSS modifier with Chrome.
* The text should be readable.
* Change your dashboard color scheme at `https://wordpress.com/me/account`
* Check that the buttons are readable.
* Repeat the steps on Simple and Atomic. 


https://github.com/Automattic/jetpack/assets/1989914/c10b7a87-b811-4941-ac01-5e2c10b2c6a7

