### PR TITLE
Monetize: Fix paid content meta

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-paid-content-meta
+++ b/projects/plugins/jetpack/changelog/fix-paid-content-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Monetize: correctly updates and delete paid content meta.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -151,6 +151,10 @@ function stripe_nudge( $checkout_url, $description, $button_text ) {
  * @return void
  */
 function add_paid_content_post_meta( int $post_id, WP_Post $post ) {
+	if ( $post->post_type !== 'post' ) {
+		return;
+	}
+
 	$contains_paid_content = has_block( 'premium-content/container', $post );
 	if ( $contains_paid_content ) {
 		update_post_meta(

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -151,7 +151,7 @@ function stripe_nudge( $checkout_url, $description, $button_text ) {
  * @return void
  */
 function add_paid_content_post_meta( int $post_id, WP_Post $post ) {
-	if ( $post->post_type !== 'post' ) {
+	if ( $post->post_type !== 'post' && $post->post_type !== 'page' ) {
 		return;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -67,7 +67,7 @@ function register_block() {
 		}
 	);
 
-	add_action( 'save_post_post', __NAMESPACE__ . '\add_paid_content_post_meta', 99, 2 );
+	add_action( 'wp_after_insert_post', __NAMESPACE__ . '\add_paid_content_post_meta', 99, 2 );
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
@@ -152,9 +152,17 @@ function stripe_nudge( $checkout_url, $description, $button_text ) {
  */
 function add_paid_content_post_meta( int $post_id, WP_Post $post ) {
 	$contains_paid_content = has_block( 'premium-content/container', $post );
-	update_post_meta(
-		$post_id,
-		META_NAME_CONTAINS_PAID_CONTENT,
-		$contains_paid_content
-	);
+	if ( $contains_paid_content ) {
+		update_post_meta(
+			$post_id,
+			META_NAME_CONTAINS_PAID_CONTENT,
+			$contains_paid_content
+		);
+	}
+	if ( ! $contains_paid_content ) {
+		delete_post_meta(
+			$post_id,
+			META_NAME_CONTAINS_PAID_CONTENT
+		);
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -171,7 +171,7 @@ function register_block() {
 
 	add_action( 'init', __NAMESPACE__ . '\maybe_prevent_super_cache_caching' );
 
-	add_action( 'wp_after_insert_post', __NAMESPACE__ . '\add_paywalled_content_post_meta', 99, 1 );
+	add_action( 'wp_after_insert_post', __NAMESPACE__ . '\add_paywalled_content_post_meta', 99, 2 );
 
 	add_filter(
 		'jetpack_options_whitelist',
@@ -224,10 +224,15 @@ function register_newsletter_access_column( $columns ) {
 /**
  * Add a meta to prevent publication on firehose, ES AI or Reader
  *
- * @param int $post_id Post id being saved.
+ * @param int      $post_id Post id being saved.
+ * @param \WP_Post $post Post being saved.
  * @return void
  */
-function add_paywalled_content_post_meta( int $post_id ) {
+function add_paywalled_content_post_meta( int $post_id, \WP_Post $post ) {
+	if ( $post->post_type !== 'post' ) {
+		return;
+	}
+
 	$access_level = get_post_meta( $post_id, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
 
 	$is_paywalled = false;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -171,7 +171,7 @@ function register_block() {
 
 	add_action( 'init', __NAMESPACE__ . '\maybe_prevent_super_cache_caching' );
 
-	add_action( 'save_post_post', __NAMESPACE__ . '\add_paywalled_content_post_meta', 99, 1 );
+	add_action( 'wp_after_insert_post', __NAMESPACE__ . '\add_paywalled_content_post_meta', 99, 1 );
 
 	add_filter(
 		'jetpack_options_whitelist',
@@ -237,7 +237,12 @@ function add_paywalled_content_post_meta( int $post_id ) {
 		case Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_SUBSCRIBERS:
 			$is_paywalled = true;
 	}
-	update_post_meta( $post_id, META_NAME_CONTAINS_PAYWALLED_CONTENT, $is_paywalled );
+	if ( $is_paywalled ) {
+		update_post_meta( $post_id, META_NAME_CONTAINS_PAYWALLED_CONTENT, $is_paywalled );
+	}
+	if ( ! $is_paywalled ) {
+		delete_post_meta( $post_id, META_NAME_CONTAINS_PAYWALLED_CONTENT );
+	}
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

* Post meta was being updated based on secondary post meta
* The lifecycle action previously used (`save_post_post`) was happening before post meta was saved
* This created two problems: we were basing the knock-on meta on the previous save and then it would be overwritten by its previous value
* Post meta was being set even if it was `false`

Fixes https://github.com/Automattic/gold/issues/391

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes the lifecycle action to `wp_after_insert_post`
* Deletes the meta value if it would be assigned `false`

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync to your sandbox or docker
* On your sandbox, call the following after each save to verify post meta:
```
 wp post meta list POST_ID --url=DOMAIN_URL
 ```
 Depending on your post content, you should see:
`_jetpack_memberships_contains_paywalled_content` absent or with `1` (not paywalled, paywalled)
`_jetpack_memberships_contains_paid_content` absent or with `1` (not contians paid-content block, does contain paid-content block)
* Create a post w/ paywalled content and save
* Remove the paywalled content (Access: Everyone) and save
* Create a post w/ a paid content block and save
* Remove the paid content block and save
* Create a post with both and save
* Remove both and save
* Add back either or both and save