### PR TITLE
Social: Add sharing limit clarification

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-social-limit-clarification
+++ b/projects/js-packages/publicize-components/changelog/add-social-limit-clarification
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social Limits: Added clarification of cycle reset

--- a/projects/js-packages/publicize-components/src/components/form/share-count-info.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/share-count-info.tsx
@@ -26,7 +26,7 @@ export const ShareCountInfo: React.FC = () => {
 				<ThemeProvider>
 					<div className={ styles[ 'title-container' ] }>
 						<Text variant="body-extra-small" className={ styles[ 'auto-share-title' ] }>
-							{ __( 'Auto-share usage', 'jetpack' ) }
+							{ __( 'Auto-shares this cycle', 'jetpack' ) }
 						</Text>
 						<IconTooltip inline={ false } shift iconSize={ 16 } placement="top-end">
 							<Text variant="body-small">

--- a/projects/js-packages/publicize-components/src/components/form/share-count-info.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/share-count-info.tsx
@@ -1,4 +1,4 @@
-import { Text, ThemeProvider } from '@automattic/jetpack-components';
+import { IconTooltip, Text, ThemeProvider } from '@automattic/jetpack-components';
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { Button, PanelRow } from '@wordpress/components';
@@ -24,9 +24,19 @@ export const ShareCountInfo: React.FC = () => {
 		<PanelRow>
 			<div className={ styles[ 'share-count-info' ] }>
 				<ThemeProvider>
-					<Text variant="body-extra-small" className={ styles[ 'auto-share-title' ] }>
-						{ __( 'Auto-share usage', 'jetpack' ) }
-					</Text>
+					<div className={ styles[ 'title-container' ] }>
+						<Text variant="body-extra-small" className={ styles[ 'auto-share-title' ] }>
+							{ __( 'Auto-share usage', 'jetpack' ) }
+						</Text>
+						<IconTooltip inline={ false } shift iconSize={ 16 } placement="top-end">
+							<Text variant="body-small">
+								{ __(
+									'As a free Jetpack Social user, you get 30 shares within every rolling 30-day window.',
+									'jetpack'
+								) }
+							</Text>
+						</IconTooltip>
+					</div>
 					<ShareCountNotice />
 					<ShareLimitsBar
 						usedCount={ usedCount }

--- a/projects/js-packages/publicize-components/src/components/form/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/form/styles.module.scss
@@ -54,3 +54,8 @@ p.auto-share-title {
 	font-weight: 600;
 	text-transform: uppercase;
 }
+
+.title-container {
+	display: flex;
+	gap: 0.4rem;
+}

--- a/projects/js-packages/publicize-components/src/components/share-limits-bar/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-limits-bar/index.tsx
@@ -11,6 +11,7 @@ export type ShareLimitsBarProps = {
 	usedCount: number;
 	scheduledCount: number;
 	remainingCount?: number;
+	remainingLabel?: string;
 	className?: string;
 	noticeType?: NoticeType;
 	legendCaption?: string;
@@ -32,6 +33,7 @@ export const ShareLimitsBar = ( {
 	usedCount,
 	scheduledCount,
 	remainingCount,
+	remainingLabel,
 	className,
 	noticeType = 'default',
 	legendCaption,
@@ -53,14 +55,16 @@ export const ShareLimitsBar = ( {
 			{
 				count: remainingCount,
 				backgroundColor: 'var(--jp-gray-off)',
-				label: _x(
-					'left',
-					'Referring to the quantity remaning, not the direction - left/right.',
-					'jetpack'
-				),
+				label:
+					remainingLabel ||
+					_x(
+						'left',
+						'Referring to the quantity remaning, not the direction - left/right.',
+						'jetpack'
+					),
 			},
 		].filter( Boolean );
-	}, [ usedCount, noticeType, scheduledCount, remainingCount ] );
+	}, [ noticeType, scheduledCount, usedCount, remainingCount, remainingLabel ] );
 
 	return (
 		<div className={ classNames( styles.wrapper, className ) }>

--- a/projects/plugins/social/changelog/add-social-limit-clarification
+++ b/projects/plugins/social/changelog/add-social-limit-clarification
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social Limits: Added clarification of cycle reset

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -90,6 +90,7 @@ const Header = () => {
 								usedCount={ usedCount }
 								scheduledCount={ scheduledCount }
 								remainingCount={ remainingCount }
+								remainingLabel={ __( 'left in this cycle', 'jetpack-social' ) }
 								legendCaption={ __( 'Auto-share usage', 'jetpack-social' ) }
 								noticeType={ noticeType }
 								className={ styles[ 'bar-wrapper' ] }

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -7,6 +7,7 @@ import {
 	SocialIcon,
 	getRedirectUrl,
 	getUserLocale,
+	Text,
 } from '@automattic/jetpack-components';
 import { ConnectionError, useConnectionErrorNotice } from '@automattic/jetpack-connection';
 import {
@@ -15,6 +16,7 @@ import {
 	useShareLimits,
 } from '@automattic/jetpack-publicize-components';
 import { useSelect } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, postList } from '@wordpress/icons';
 import StatCards from '../stat-cards';
@@ -92,6 +94,17 @@ const Header = () => {
 								noticeType={ noticeType }
 								className={ styles[ 'bar-wrapper' ] }
 							/>
+							<Text variant="small" className={ styles[ 'bar-description' ] }>
+								{ createInterpolateElement(
+									__(
+										'<i>As a free Jetpack Social user, you get 30 shares within every rolling 30-day window.</i>',
+										'jetpack-social'
+									),
+									{
+										i: <i />,
+									}
+								) }
+							</Text>
 							<ContextualUpgradeTrigger
 								className={ styles.cut }
 								description={ __(

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -16,7 +16,6 @@ import {
 	useShareLimits,
 } from '@automattic/jetpack-publicize-components';
 import { useSelect } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, postList } from '@wordpress/icons';
 import StatCards from '../stat-cards';
@@ -96,15 +95,12 @@ const Header = () => {
 								className={ styles[ 'bar-wrapper' ] }
 							/>
 							<Text variant="small" className={ styles[ 'bar-description' ] }>
-								{ createInterpolateElement(
-									__(
-										'<i>As a free Jetpack Social user, you get 30 shares within every rolling 30-day window.</i>',
+								<i>
+									{ __(
+										'As a free Jetpack Social user, you get 30 shares within every rolling 30-day window.',
 										'jetpack-social'
-									),
-									{
-										i: <i />,
-									}
-								) }
+									) }
+								</i>
 							</Text>
 							<ContextualUpgradeTrigger
 								className={ styles.cut }

--- a/projects/plugins/social/src/js/components/header/styles.module.scss
+++ b/projects/plugins/social/src/js/components/header/styles.module.scss
@@ -56,7 +56,7 @@
 }
 
 .cut {
-	margin-top: calc( var( --spacing-base ) * 3 );
+	margin-top: calc( var( --spacing-base ) * 2 );
 }
 
 .connection-error-col {
@@ -64,6 +64,8 @@
 }
 
 .bar-wrapper {
+	margin-bottom: var( --spacing-base );
+	
 	:global .record-meter-bar {
 		padding-block: 0;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/315

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a tooltip to the editor
* Added an inline text for the admin page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/315
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the changes on the Social admin page, and in a new post while on the Social free plan.

![CleanShot 2024-05-13 at 13 45 56 png](https://github.com/Automattic/jetpack/assets/36671565/eb10aeca-56be-42cf-8d85-b0e3bcc58693)

![CleanShot 2024-05-13 at 13 45 37 png](https://github.com/Automattic/jetpack/assets/36671565/ccb78242-f9f7-467e-908e-46cfd59f61fb)
