### PR TITLE
Backport mu-wpcom-plugin 2.1.23 Changes

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.53.2] - 2024-05-13
+### Added
+- Added --jp-gray-5 as an alias of --jp-gray to the theme [#37327]
+
+### Fixed
+- Fixed notices z-index for global notices when modal is open [#37196]
+
 ## [0.53.1] - 2024-05-09
 ### Added
 - Added GlobalNotices component and useGlobalNotices hook [#37286]
@@ -1023,6 +1030,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.53.2]: https://github.com/Automattic/jetpack-components/compare/0.53.1...0.53.2
 [0.53.1]: https://github.com/Automattic/jetpack-components/compare/0.53.0...0.53.1
 [0.53.0]: https://github.com/Automattic/jetpack-components/compare/0.52.1...0.53.0
 [0.52.1]: https://github.com/Automattic/jetpack-components/compare/0.52.0...0.52.1

--- a/projects/js-packages/components/changelog/add-social-connect-button
+++ b/projects/js-packages/components/changelog/add-social-connect-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed notices z-index for global notices when modal is open

--- a/projects/js-packages/components/changelog/fix-social-icon-colours
+++ b/projects/js-packages/components/changelog/fix-social-icon-colours
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added --jp-gray-5 as an alias of --jp-gray to the theme

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.53.2-alpha",
+	"version": "0.53.2",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2024-05-13
+### Added
+- SSO: Ensuring tooltips are accessible [#37302]
+
+### Changed
+- SSO: Improve user invite error logging [#37144]
+
 ## [2.7.7] - 2024-05-09
 ### Fixed
 - SSO: Fix tooltip display on view all users page [#37257]
@@ -1051,6 +1058,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.8.0]: https://github.com/Automattic/jetpack-connection/compare/v2.7.7...v2.8.0
 [2.7.7]: https://github.com/Automattic/jetpack-connection/compare/v2.7.6...v2.7.7
 [2.7.6]: https://github.com/Automattic/jetpack-connection/compare/v2.7.5...v2.7.6
 [2.7.5]: https://github.com/Automattic/jetpack-connection/compare/v2.7.4...v2.7.5

--- a/projects/packages/connection/changelog/update-invite-user-error-response-logging
+++ b/projects/packages/connection/changelog/update-invite-user-error-response-logging
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-SSO: Improve user invite error logging

--- a/projects/packages/connection/changelog/update-jetpack-sso-tooltip-accessibility
+++ b/projects/packages/connection/changelog/update-jetpack-sso-tooltip-accessibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-SSO: Ensuring tooltips are accessible

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.8.0-alpha';
+	const PACKAGE_VERSION = '2.8.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.29.1] - 2024-05-13
+### Changed
+- WP.com menu: Add "Hosting > Add-ons" menu to Atomic sites [#37318]
+
 ## [5.29.0] - 2024-05-09
 ### Added
 - Jetpack-mu-wpcom: Add classic theme helper package as a requirement [#37284]
@@ -795,6 +799,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.29.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.29.0...v5.29.1
 [5.29.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.28.0...v5.29.0
 [5.28.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.27.0...v5.28.0
 [5.27.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.26.1...v5.27.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-themes-button-visited-style
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-themes-button-visited-style
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: We're changing a css rule for a button on one specific screen that only affects wpcom
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-nav-redesign-add-ons-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-nav-redesign-add-ons-menu
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-WP.com menu: Add "Hosting > Add-ons" menu to Atomic sites

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.29.1-alpha",
+	"version": "5.29.1",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.29.1-alpha';
+	const PACKAGE_VERSION = '5.29.1';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.23 - 2024-05-13
+### Changed
+- Internal updates.
+
 ## 2.1.22 - 2024-05-09
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-invite-user-error-response-logging
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-invite-user-error-response-logging
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_23_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_23"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.23-alpha
+ * Version: 2.1.23
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.23-alpha",
+	"version": "2.1.23",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.23

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.