### PR TITLE
Docs: Updating package readme with project composer package requirement for use in new projects

### DIFF
--- a/projects/packages/README.md
+++ b/projects/packages/README.md
@@ -43,7 +43,7 @@ and that will install the required Composer packages.
 
 Before using a package within another project, you will need to require the package in the project's `composer.json` file. Then, run `tools/fixup-project-versions.sh` to update the `composer.lock` file in the proect, and reinstall the project with the `jetpack install` command.
 
-As an example, if you want to require the Logo package in the Jetpack plugin, add `"automattic/jetpack-logo": "@dev",` underneath `require` to require it. After updating the project versions run `jetpack install plugins/jetpack` to pull the new package.
+As an example, if you want to require the Logo package in the Jetpack plugin, add `"automattic/jetpack-logo": "@dev",` underneath `require` in the Jetpack plugin's `composer.json` file to require it. After updating the project versions run `jetpack install plugins/jetpack` to pull the new package.
 
 To use something from a package, you have to declare it at the top of the file before any other instruction, and then use it in the code. For example, the logo can be used like this:
 

--- a/projects/packages/README.md
+++ b/projects/packages/README.md
@@ -41,6 +41,10 @@ and that will install the required Composer packages.
 
 ### Using packages
 
+Before using a package within another project, you will need to require the package in the projects `composer.json` file. Then, run `tools/fixup-project-versions.sh` to update the `composer.lock` file in the proect, and reinstall the project with the `jetpack install` command.
+
+As an example, if we want to require the Logo package in the Jetpack plugin, we add `"automattic/jetpack-logo": "@dev",` underneath `require` to require it. After updating the project versions we'll run `jetpack install plugins/jetpack` to pull the new package.
+
 To use something from a package, you have to declare it at the top of the file before any other instruction, and then use it in the code. For example, the logo can be used like this:
 
 ```php

--- a/projects/packages/README.md
+++ b/projects/packages/README.md
@@ -41,9 +41,9 @@ and that will install the required Composer packages.
 
 ### Using packages
 
-Before using a package within another project, you will need to require the package in the projects `composer.json` file. Then, run `tools/fixup-project-versions.sh` to update the `composer.lock` file in the proect, and reinstall the project with the `jetpack install` command.
+Before using a package within another project, you will need to require the package in the project's `composer.json` file. Then, run `tools/fixup-project-versions.sh` to update the `composer.lock` file in the proect, and reinstall the project with the `jetpack install` command.
 
-As an example, if we want to require the Logo package in the Jetpack plugin, we add `"automattic/jetpack-logo": "@dev",` underneath `require` to require it. After updating the project versions we'll run `jetpack install plugins/jetpack` to pull the new package.
+As an example, if you want to require the Logo package in the Jetpack plugin, add `"automattic/jetpack-logo": "@dev",` underneath `require` to require it. After updating the project versions run `jetpack install plugins/jetpack` to pull the new package.
 
 To use something from a package, you have to declare it at the top of the file before any other instruction, and then use it in the code. For example, the logo can be used like this:
 


### PR DESCRIPTION
## Proposed changes:

* This PR updates the package README.md to add additional info on requiring a package in a project's `composer.json` file, plus updating project versions and rebuilding, in order to be able to then use that package in another project.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1715621684054849/1715618744.314119-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Proof-read - the info is based on this Slack thread: p1715621684054849/1715618744.314119-slack-C05PV073SG3