### PR TITLE
Backport mu-wpcom-plugin 2.1.24, jetpack 13.5-a.1 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2024-05-13
+### Added
+- AI Client: Add className to AI Control component. [#37322]
+- AI Client: Add "try again" prop on Extension AI Control. [#37250]
+
+### Changed
+- AI Client: Add event to upgrade handler function of Extension AI Control. [#37224]
+
 ## [0.13.0] - 2024-05-06
 ### Added
 - AI Client: Add wrapper ref to AI Control. [#37145]
@@ -306,6 +314,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.13.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.12.4...v0.13.0
 [0.12.4]: https://github.com/Automattic/jetpack-ai-client/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/Automattic/jetpack-ai-client/compare/v0.12.2...v0.12.3

--- a/projects/js-packages/ai-client/changelog/fix-jetpack-ai-inline-extension-retry
+++ b/projects/js-packages/ai-client/changelog/fix-jetpack-ai-inline-extension-retry
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-AI Client: Add try again prop on Extension AI Control

--- a/projects/js-packages/ai-client/changelog/fix-jetpack-ai-inline-extension-z-index
+++ b/projects/js-packages/ai-client/changelog/fix-jetpack-ai-inline-extension-z-index
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-AI Client: Add className to AI Control component

--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extensions-error
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extensions-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-AI Client: Add event to upgrade handler function of Extension AI Control

--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extensions-events
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extensions-events
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: A minor fix on a message
-
-

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.13.1-alpha",
+	"version": "0.13.1",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.77 - 2024-05-13
+### Changed
+- Update dependencies. [#37280]
+
 ## 0.2.76 - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]

--- a/projects/js-packages/partner-coupon/changelog/force-a-release
+++ b/projects/js-packages/partner-coupon/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.77-alpha",
+	"version": "0.2.77",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.51.0] - 2024-05-13
+### Added
+- Add connect form/button for connection management. [#37196]
+- Social: Added add connection modal. [#37211]
+- Social Connections: Added disconnection confirmation dialog. [#37310]
+- Social Limits: Added clarification of cycle reset. [#37350]
+- Wired up disconnect button and added reconnect button. [#37237]
+
+### Fixed
+- Fixed a CSS styling issue in the connection management component. [#37304]
+- Fixed social connections list not displayed for simple sites. [#37267]
+
 ## [0.50.0] - 2024-05-06
 ### Added
 - Added feature flag for new social admin UI. [#37134]
@@ -663,6 +675,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.51.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.50.0...v0.51.0
 [0.50.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.49.3...v0.50.0
 [0.49.3]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.49.2...v0.49.3
 [0.49.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.49.1...v0.49.2

--- a/projects/js-packages/publicize-components/changelog/add-social-add-connection-modal
+++ b/projects/js-packages/publicize-components/changelog/add-social-add-connection-modal
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Social: Added add connection modal

--- a/projects/js-packages/publicize-components/changelog/add-social-connect-button
+++ b/projects/js-packages/publicize-components/changelog/add-social-connect-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add connect form/button for connection management

--- a/projects/js-packages/publicize-components/changelog/add-social-connections-disconnection-dialog
+++ b/projects/js-packages/publicize-components/changelog/add-social-connections-disconnection-dialog
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Social Connections: Added disconnection confirmation dialog

--- a/projects/js-packages/publicize-components/changelog/add-social-disconnect-reconnect-ui
+++ b/projects/js-packages/publicize-components/changelog/add-social-disconnect-reconnect-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Wired up disconnect button and added reconnect button

--- a/projects/js-packages/publicize-components/changelog/add-social-limit-clarification
+++ b/projects/js-packages/publicize-components/changelog/add-social-limit-clarification
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Social Limits: Added clarification of cycle reset

--- a/projects/js-packages/publicize-components/changelog/fix-editor-connections-list-for-simple-sites
+++ b/projects/js-packages/publicize-components/changelog/fix-editor-connections-list-for-simple-sites
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed social connections list not displayed for simple sites

--- a/projects/js-packages/publicize-components/changelog/fix-social-connection-list-styling
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connection-list-styling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a CSS styling issue in the connection management component

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.51.0-alpha",
+	"version": "0.51.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.12] - 2024-05-13
+### Changed
+- Update dependencies. [#37280]
+
 ## [0.14.11] - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]
@@ -376,6 +380,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.14.12]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.11...0.14.12
 [0.14.11]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.10...0.14.11
 [0.14.10]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.9...0.14.10
 [0.14.9]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.8...0.14.9

--- a/projects/js-packages/shared-extension-utils/changelog/force-a-release
+++ b/projects/js-packages/shared-extension-utils/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.14.12-alpha",
+	"version": "0.14.12",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.3] - 2024-05-13
+### Changed
+- Update dependencies. [#37280]
+
 ## [0.21.2] - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]
@@ -361,6 +365,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.21.3]: https://github.com/automattic/jetpack-blaze/compare/v0.21.2...v0.21.3
 [0.21.2]: https://github.com/automattic/jetpack-blaze/compare/v0.21.1...v0.21.2
 [0.21.1]: https://github.com/automattic/jetpack-blaze/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/automattic/jetpack-blaze/compare/v0.20.3...v0.21.0

--- a/projects/packages/blaze/changelog/force-a-release
+++ b/projects/packages/blaze/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.21.3-alpha",
+	"version": "0.21.3",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.21.3-alpha';
+	const PACKAGE_VERSION = '0.21.3';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.2] - 2024-05-13
+### Changed
+- Update dependencies. [#37280]
+
 ## [0.31.1] - 2024-05-07
 ### Fixed
 - Contact Form: Prevent an editor error when using the Classic Editor and contact forms are enabled. [#37270]
@@ -568,6 +572,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.31.2]: https://github.com/automattic/jetpack-forms/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/automattic/jetpack-forms/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/automattic/jetpack-forms/compare/v0.30.18...v0.31.0
 [0.30.18]: https://github.com/automattic/jetpack-forms/compare/v0.30.17...v0.30.18

--- a/projects/packages/forms/changelog/force-a-release
+++ b/projects/packages/forms/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.31.2-alpha",
+	"version": "0.31.2",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.31.2-alpha';
+	const PACKAGE_VERSION = '0.31.2';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/google-analytics/CHANGELOG.md
+++ b/projects/packages/google-analytics/CHANGELOG.md
@@ -5,3 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2024-05-13
+### Added
+- Initial version. [#37137]
+- Copy the code from the Jetpack module into the package. [#37184]
+- Migrate unit tests from the Jetpack module. [#37246]

--- a/projects/packages/google-analytics/changelog/add-google-analytics-package-code
+++ b/projects/packages/google-analytics/changelog/add-google-analytics-package-code
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Copy the code from the Jetpack module into the package.

--- a/projects/packages/google-analytics/changelog/initial-version
+++ b/projects/packages/google-analytics/changelog/initial-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Initial version.

--- a/projects/packages/google-analytics/changelog/update-move-ga-tests
+++ b/projects/packages/google-analytics/changelog/update-move-ga-tests
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Migrate unit tests from the Jetpack module.

--- a/projects/packages/google-analytics/package.json
+++ b/projects/packages/google-analytics/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-google-analytics",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"description": "Set up Google Analytics without touching a line of code.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/google-analytics/#readme",
 	"bugs": {

--- a/projects/packages/google-analytics/src/class-ga-manager.php
+++ b/projects/packages/google-analytics/src/class-ga-manager.php
@@ -15,7 +15,7 @@ namespace Automattic\Jetpack\Google_Analytics;
  */
 class GA_Manager {
 
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	const PACKAGE_VERSION = '0.1.0';
 
 	/**
 	 * Jetpack_Google_Analytics singleton instance.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.0] - 2024-05-13
+### Added
+- Add connect form/button for connection management. [#37196]
+- Social Connections: Added disconnection confirmation dialog. [#37310]
+- Wired up disconnect button and added reconnect button. [#37237]
+
 ## [0.43.0] - 2024-05-06
 ### Added
 - Added feature flag for new social admin UI. [#37134]
@@ -542,6 +548,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.44.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.13...v0.43.0
 [0.42.13]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.12...v0.42.13
 [0.42.12]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.11...v0.42.12

--- a/projects/packages/publicize/changelog/add-social-connect-button
+++ b/projects/packages/publicize/changelog/add-social-connect-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add connect form/button for connection management

--- a/projects/packages/publicize/changelog/add-social-connections-disconnection-dialog
+++ b/projects/packages/publicize/changelog/add-social-connections-disconnection-dialog
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Social Connections: Added disconnection confirmation dialog

--- a/projects/packages/publicize/changelog/add-social-disconnect-reconnect-ui
+++ b/projects/packages/publicize/changelog/add-social-disconnect-reconnect-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Wired up disconnect button and added reconnect button

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.44.0-alpha",
+	"version": "0.44.0",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.6] - 2024-05-13
+### Changed
+- Update dependencies. [#37280]
+
 ## [0.44.5] - 2024-05-06
 ### Added
 - Add missing package dependencies. [#37141]
@@ -959,6 +963,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.44.6]: https://github.com/Automattic/jetpack-search/compare/v0.44.5...v0.44.6
 [0.44.5]: https://github.com/Automattic/jetpack-search/compare/v0.44.4...v0.44.5
 [0.44.4]: https://github.com/Automattic/jetpack-search/compare/v0.44.3...v0.44.4
 [0.44.3]: https://github.com/Automattic/jetpack-search/compare/v0.44.2...v0.44.3

--- a/projects/packages/search/changelog/force-a-release
+++ b/projects/packages/search/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.6-alpha",
+	"version": "0.44.6",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.6-alpha';
+	const VERSION = '0.44.6';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.21] - 2024-05-13
+### Changed
+- Update dependencies. [#37280]
+
 ## [0.23.20] - 2024-05-07
 ### Fixed
 - Sanitize the preload value for video shortcodes and blocks. [#37271]
@@ -1337,6 +1341,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.21]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.20...v0.23.21
 [0.23.20]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.19...v0.23.20
 [0.23.19]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.18...v0.23.19
 [0.23.18]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.17...v0.23.18

--- a/projects/packages/videopress/changelog/force-a-release
+++ b/projects/packages/videopress/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.21-alpha",
+	"version": "0.23.21",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.21-alpha';
+	const PACKAGE_VERSION = '0.23.21';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.18] - 2024-05-13
+### Changed
+- Update dependencies. [#37280]
+
 ## [0.3.17] - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]
@@ -347,6 +351,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.18]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.17...v0.3.18
 [0.3.17]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.16...v0.3.17
 [0.3.16]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.15...v0.3.16
 [0.3.15]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.14...v0.3.15

--- a/projects/packages/wordads/changelog/force-a-release
+++ b/projects/packages/wordads/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.18-alpha",
+	"version": "0.3.18",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.18-alpha';
+	const VERSION = '0.3.18';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.5-a.1 - 2024-05-13
+### Enhancements
+- SSO: Improve accessibility of tooltips on WP Admin users page. [#37302]
+- WordAds: Add inline ads within post content. [#37170]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- AI Assistant: Add events to inline extensions. [#37297]
+- AI Assistant: Add messages to inline extensions. [#37224]
+- AI Assistant: Change way messages are built for inline extensions. [#37245]
+- AI Assistant: Fix inline extension styles on P2 and some themes. [#37336]
+- AI Assistant: Fix input z-index on moving block with inline extension. [#37322]
+- AI Assistant: Fix try again behavior on inline extensions. [#37250]
+- Blocks: When outputting JSON data in inline script tags, only use `JSON_UNESCAPED_UNICODE` when the blog charset is UTF-8. [#37285]
+- Custom CSS: Add deprecation warning in codebase. [#37163]
+- External Media: support editor changes in WordPress 6.5. [#36188]
+- Extract Google Analytics tests into the package. [#37246]
+- Fix an occasional PHP warning when iterating over menu items in the masterbar module. [#37315]
+- Fixed a warning thrown by the gravatar profile widget. [#37313]
+- Fixed TS compile error for image imports in js-packages. [#37211]
+- Google Analytics: switch the module to use the package. [#37189]
+- Move title optimization to production. [#37334]
+- Newsletters: Improvements to prepublish panel. [#37247]
+- Newsletters: Add tracks to email settings. [#37121]
+- Notifications: Ensures cache buster is available for wpcom-notes-admin-bar script. [#37215]
+- Remove wp-windows8 gallery shortcode special case in WPCOM API post endpoint. [#37243]
+- Rendered GlobalNotices component. [#37237]
+- Sanitize the preload value for video shortcodes and blocks. [#37271]
+- SSO: Fix tooltip display on view all users page. [#37257]
+- Subscriptions: Add comment as a subscription reply to type only availave for simple sites now. [#37244]
+- Subscriptions: Fix class Abstract_Token_Subscription_Service not found error. [#37206]
+- Subscriptions: Remove extraneous "support info" bubble in settings. [#37281]
+- Tiled Gallery: Fix view rendering issues. [#37213]
+- Updated phan baseline files. [#37151]
+- Update invite user error response logging. [#37144]
+- Update sizes and spacings on Title Optimization. [#37333]
+- WordPress.com Toolbar: Remove "My Sites" text and only display icon. [#37314]
+
 ## 13.4.1 - 2024-05-10
 ### Bug fixes
 - Contact Form: Unhook the jetpack_form_register_pattern function to prevent unwanted deprecation notices. [#37278]

--- a/projects/plugins/jetpack/changelog/add-boost-cache-rebuild
+++ b/projects/plugins/jetpack/changelog/add-boost-cache-rebuild
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated phan baseline files

--- a/projects/plugins/jetpack/changelog/add-memberships-store
+++ b/projects/plugins/jetpack/changelog/add-memberships-store
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Support for WPCOM endpoints
-
-

--- a/projects/plugins/jetpack/changelog/add-reply-to-tracks-enable
+++ b/projects/plugins/jetpack/changelog/add-reply-to-tracks-enable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add: tracks for email settings

--- a/projects/plugins/jetpack/changelog/add-social-add-connection-modal
+++ b/projects/plugins/jetpack/changelog/add-social-add-connection-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixed TS compile error for image imports in js-packages

--- a/projects/plugins/jetpack/changelog/add-social-connections-disconnection-dialog
+++ b/projects/plugins/jetpack/changelog/add-social-connections-disconnection-dialog
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-social-disconnect-reconnect-ui
+++ b/projects/plugins/jetpack/changelog/add-social-disconnect-reconnect-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Rendered GlobalNotices component

--- a/projects/plugins/jetpack/changelog/add-wordads-blaze
+++ b/projects/plugins/jetpack/changelog/add-wordads-blaze
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-WordAds: add inline ads within post content.

--- a/projects/plugins/jetpack/changelog/add-wordads-blaze#2
+++ b/projects/plugins/jetpack/changelog/add-wordads-blaze#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-admin-menu-php-warning
+++ b/projects/plugins/jetpack/changelog/fix-admin-menu-php-warning
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix an occasional PHP warning when iterating over menu items in the masterbar module.

--- a/projects/plugins/jetpack/changelog/fix-codesniffer-Jetpack-Tests-WrongStyle
+++ b/projects/plugins/jetpack/changelog/fix-codesniffer-Jetpack-Tests-WrongStyle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update comments in tests to fix `Squiz.Commenting.*.WrongStyle`.
-
-

--- a/projects/plugins/jetpack/changelog/fix-gravatar-profile-array-warning
+++ b/projects/plugins/jetpack/changelog/fix-gravatar-profile-array-warning
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixed a warning thrown by the gravatar profile widget.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-retry
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-retry
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Fix try again behavior on inline extensions

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-style
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-style
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Fix inline extension styles on P2 and some themes

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-z-index
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-z-index
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Fix input z-index on moving block with inline extension

--- a/projects/plugins/jetpack/changelog/fix-notes-script-cache-buster
+++ b/projects/plugins/jetpack/changelog/fix-notes-script-cache-buster
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-ensures notifications cache buster is available for wpcom-notes-admin-bar script

--- a/projects/plugins/jetpack/changelog/fix-only-use-json_encode-JSON_UNESCAPED_UNICODE-with-utf-8
+++ b/projects/plugins/jetpack/changelog/fix-only-use-json_encode-JSON_UNESCAPED_UNICODE-with-utf-8
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Blocks: When outputting JSON data in inline script tags, only use `JSON_UNESCAPED_UNICODE` when the blog charset is UTF-8.

--- a/projects/plugins/jetpack/changelog/fix-phan-issues-sync-modules-get_module
+++ b/projects/plugins/jetpack/changelog/fix-phan-issues-sync-modules-get_module
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Add `@phan-var` for many calls to `Sync\Modules::get_module()` to specify which module subclass it returned. Should be no change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/fix-reply-to-comment-option
+++ b/projects/plugins/jetpack/changelog/fix-reply-to-comment-option
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscription: add comment as a subscription reply to type only availave for simple sites now.

--- a/projects/plugins/jetpack/changelog/fix-sso-tooltip-display
+++ b/projects/plugins/jetpack/changelog/fix-sso-tooltip-display
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-SSO: Fix tooltip display on view all users page

--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-view
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-view
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Tiled Gallery: fix view rendering issues

--- a/projects/plugins/jetpack/changelog/fix-video-shortcode-preloadcontent-sanitize
+++ b/projects/plugins/jetpack/changelog/fix-video-shortcode-preloadcontent-sanitize
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Sanitize the preload value for video shortcodes and blocks

--- a/projects/plugins/jetpack/changelog/remove-my-sites-text-masterbar
+++ b/projects/plugins/jetpack/changelog/remove-my-sites-text-masterbar
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-WordPress.com Toolbar: Remove "My Sites" text and only display icon

--- a/projects/plugins/jetpack/changelog/remove-post-endpoint-win8-gallery
+++ b/projects/plugins/jetpack/changelog/remove-post-endpoint-win8-gallery
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Remove wp-windows8 gallery shortcode special case in WPCOM API post endpoint.

--- a/projects/plugins/jetpack/changelog/update-custom-css-to-mu-wpcom
+++ b/projects/plugins/jetpack/changelog/update-custom-css-to-mu-wpcom
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Custom CSS: add deprecation warning in codebase

--- a/projects/plugins/jetpack/changelog/update-external-media-store
+++ b/projects/plugins/jetpack/changelog/update-external-media-store
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-External Media: support editor changes in WordPress 6.5.

--- a/projects/plugins/jetpack/changelog/update-invite-user-error-response-logging
+++ b/projects/plugins/jetpack/changelog/update-invite-user-error-response-logging
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Update invite user error response logging

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-error
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Add messages to inline extensions

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-events
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Add events to inline extensions

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-prompt
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extensions-prompt
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Change way messages are built for inline extensions

--- a/projects/plugins/jetpack/changelog/update-jetpack-ga-switch-to-package
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ga-switch-to-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Google Analytics: switch the module to use the package.

--- a/projects/plugins/jetpack/changelog/update-jetpack-sso-tooltip-accessibility
+++ b/projects/plugins/jetpack/changelog/update-jetpack-sso-tooltip-accessibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-SSO: Ensuring tooltips are accessible

--- a/projects/plugins/jetpack/changelog/update-move-ga-tests
+++ b/projects/plugins/jetpack/changelog/update-move-ga-tests
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Extract Google Analytics tests into the package.

--- a/projects/plugins/jetpack/changelog/update-newsletter-settings-support-bubble
+++ b/projects/plugins/jetpack/changelog/update-newsletter-settings-support-bubble
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscription settings: remove extraneus "support info" bubble

--- a/projects/plugins/jetpack/changelog/update-phan-wpcom-stubs
+++ b/projects/plugins/jetpack/changelog/update-phan-wpcom-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Update Phan baseline
-
-

--- a/projects/plugins/jetpack/changelog/update-save-prepublish-settings
+++ b/projects/plugins/jetpack/changelog/update-save-prepublish-settings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Newsletters: improvements to prepublish panel.

--- a/projects/plugins/jetpack/changelog/update-subscriptions-fix-class-not-found
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-fix-class-not-found
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Fix class Abstract_Token_Subscription_Service not tound error

--- a/projects/plugins/jetpack/changelog/update-title-optimization-production
+++ b/projects/plugins/jetpack/changelog/update-title-optimization-production
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Move title optimization to production

--- a/projects/plugins/jetpack/changelog/update-title-optimization-sizes
+++ b/projects/plugins/jetpack/changelog/update-title-optimization-sizes
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Update sizes and spacings on Title Optimization

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_0",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.5-a.0
+ * Version: 13.5-a.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.5-a.0' );
+define( 'JETPACK__VERSION', '13.5-a.1' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/custom-css.php
+++ b/projects/plugins/jetpack/modules/custom-css.php
@@ -32,7 +32,7 @@ function custom_css_loaded() {
 		'https://wordpress.org/documentation/article/styles-overview/#applying-custom-css'
 	);
 
-	_deprecated_hook( 'custom_css_loaded', 'jetpack-$$next-version$$', 'WordPress Custom CSS', esc_html( $message ) );
+	_deprecated_hook( 'custom_css_loaded', 'jetpack-13.5', 'WordPress Custom CSS', esc_html( $message ) );
 
 	Jetpack::enable_module_configurable( __FILE__ );
 	add_filter( 'jetpack_module_configuration_url_custom-css', 'jetpack_custom_css_configuration_url' );

--- a/projects/plugins/jetpack/modules/google-analytics/classes/class-jetpack-google-amp-analytics.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/class-jetpack-google-amp-analytics.php
@@ -3,7 +3,7 @@
  * Class exists exclusively for backward compatibility.
  * Do not use.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.5
  * @package automattic/jetpack
  */
 
@@ -19,7 +19,7 @@ if ( ! class_exists( 'Jetpack_Google_AMP_Analytics' ) ) {
 	 * Class exists exclusively for backward compatibility.
 	 * Do not use.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 */
 	class Jetpack_Google_AMP_Analytics extends Automattic\Jetpack\Google_Analytics\AMP_Analytics {
 	}

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -3,7 +3,7 @@
  * Class exists exclusively for backward compatibility.
  * Do not use.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.5
  * @package automattic/jetpack
  */
 
@@ -19,7 +19,7 @@ if ( ! class_exists( 'Jetpack_Google_Analytics_Legacy' ) ) {
 	 * Class exists exclusively for backward compatibility.
 	 * Do not use.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 */
 	class Jetpack_Google_Analytics_Legacy extends Automattic\Jetpack\Google_Analytics\Legacy {
 	}

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-options.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-options.php
@@ -3,7 +3,7 @@
  * Class exists exclusively for backward compatibility.
  * Do not use.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.5
  * @package automattic/jetpack
  */
 
@@ -19,7 +19,7 @@ if ( ! class_exists( 'Jetpack_Google_Analytics_Options' ) ) {
 	 * Class exists exclusively for backward compatibility.
 	 * Do not use.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 */
 	class Jetpack_Google_Analytics_Options extends Automattic\Jetpack\Google_Analytics\Options {
 	}

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -3,7 +3,7 @@
  * Class exists exclusively for backward compatibility.
  * Do not use.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.5
  * @package automattic/jetpack
  */
 
@@ -19,7 +19,7 @@ if ( ! class_exists( 'Jetpack_Google_Analytics_Universal' ) ) {
 	 * Class exists exclusively for backward compatibility.
 	 * Do not use.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 */
 	class Jetpack_Google_Analytics_Universal extends Automattic\Jetpack\Google_Analytics\Universal {
 	}

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-utils.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-utils.php
@@ -3,7 +3,7 @@
  * Class exists exclusively for backward compatibility.
  * Do not use.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.5
  */
 
 /**
@@ -18,7 +18,7 @@ if ( ! class_exists( 'Jetpack_Google_Analytics_Utils' ) ) {
 	 * Class exists exclusively for backward compatibility.
 	 * Do not use.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 */
 	class Jetpack_Google_Analytics_Utils extends Automattic\Jetpack\Google_Analytics\Utils {
 	}

--- a/projects/plugins/jetpack/modules/google-analytics/wp-google-analytics.php
+++ b/projects/plugins/jetpack/modules/google-analytics/wp-google-analytics.php
@@ -3,7 +3,7 @@
  * Class exists exclusively for backward compatibility.
  * Do not use.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.5
  * @package automattic/jetpack
  */
 
@@ -25,7 +25,7 @@ if ( ! class_exists( 'Jetpack_Google_Analytics' ) ) {
 	 * Class exists exclusively for backward compatibility.
 	 * Do not use.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 */
 	class Jetpack_Google_Analytics extends Automattic\Jetpack\Google_Analytics\GA_Manager {
 	}

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.5.0-a.0",
+	"version": "13.5.0-a.1",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,9 +326,10 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.4.1 - 2024-05-10
-#### Bug fixes
-- Contact Form: Unhook the jetpack_form_register_pattern function to prevent unwanted deprecation notices.
+### 13.5-a.1 - 2024-05-13
+#### Enhancements
+- SSO: Improve accessibility of tooltips on WP Admin users page.
+- WordAds: Add inline ads within post content.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.24 - 2024-05-13
+### Changed
+- Internal updates.
+
 ## 2.1.23 - 2024-05-13
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_23"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_24"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.23
+ * Version: 2.1.24
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.23",
+	"version": "2.1.24",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.24, jetpack 13.5-a.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.