### PR TITLE
Fix/newsletter reply to setting validation

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3409,8 +3409,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error
 	 */
 	public static function validate_subscriptions_reply_to( $value, $request, $param ) {
-		$valid_values = array( 'author', 'no-reply' );
-		if ( ! empty( $value ) && ! in_array( $value, $valid_values, true ) ) {
+		require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
+		if ( ! empty( $value ) && ! Automattic\Jetpack\Modules\Subscriptions\Settings::is_valid_reply_to( $value ) ) {
 			return new WP_Error(
 				'invalid_param',
 				sprintf(

--- a/projects/plugins/jetpack/changelog/fix-newsletter-reply-to-setting-validation
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-reply-to-setting-validation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: This feature is not yet shipped and doesn't have any impact on the users
+
+


### PR DESCRIPTION
## Proposed changes:
This improves the way that we validate reply_to by using the new method. 
The new method was not yet shipped and the comment type is only supported by .com simple sites for now. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Go to /wp-admin/admin.php?page=jetpack#/newsletter
And save the Reply to setting. 
Notice it saves as expected. 

