### PR TITLE
VideoPress: Fix localization of block text

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-block-l10n
+++ b/projects/packages/videopress/changelog/fix-videopress-block-l10n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix localization of block text

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.21",
+	"version": "0.23.22-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.21';
+	const PACKAGE_VERSION = '0.23.22-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -15,7 +15,6 @@ import { uploadFromLibrary } from '../../../../../hooks/use-uploader';
 import { buildVideoPressURL, pickVideoBlockAttributesFromUrl } from '../../../../../lib/url';
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../../constants';
 import { PlaceholderWrapper } from '../../edit';
-import { description, title } from '../../index';
 import { VideoPressIcon } from '../icons';
 import UploadError from './uploader-error.js';
 import UploadProgress from './uploader-progress.js';
@@ -320,8 +319,12 @@ const VideoPressUploader = ( {
 			className="is-videopress-placeholder"
 			icon={ <BlockIcon icon={ VideoPressIcon } /> }
 			labels={ {
-				title,
-				instructions: description,
+				// These strings should match the "title" and "description" in ../../block.json.
+				title: __( 'VideoPress', 'jetpack-videopress-pkg' ),
+				instructions: __(
+					'Embed a video from your media library or upload a new one with VideoPress.',
+					'jetpack-videopress-pkg'
+				),
 			} }
 			onSelect={ onSelectVideo }
 			onSelectURL={ onSelectURL }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Ref: #37013

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Copies the block's title and description from `block.json` and wraps them in `__`.

The translations of the metadata in `block.json` are rendered server-side for use in the block library. When rendering the block itself, these translations aren't available: the translations from JSON files are used.

The text will continue to be shown in English until the strings have been extracted and translated.

<img width="869" alt="image" src="https://github.com/Automattic/jetpack/assets/75777864/b7f39e3c-27ed-4764-9683-6af8d46a5af5">

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/issues/37013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Edit a post or page and add a VideoPress block.
* Confirm that the block title and description are displayed normally, in English, as per the screenshot above.

[Optional] Verify that the strings will be extracted correctly:
* `ssh` into your site and `cd` to the `video-uploader` directory.
* Run `wp i18n make-pot . out.pot --ignore-domain --include=index.js`.
* Open the resulting `out.pot` and verify that the wrapped strings can be found inside the file.


