### PR TITLE
AI Assistant: Inline extension testing feedback changes

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extension-feedback
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extension-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: Change default behavior of Message components

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.13.1",
+	"version": "0.13.2-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
@@ -16,7 +16,7 @@ import './style.scss';
 /**
  * Types
  */
-import type { RequestingStateProp } from '../../types.js';
+import type { RequestingErrorProps, RequestingStateProp } from '../../types.js';
 import type { ReactElement, MouseEvent } from 'react';
 
 type ExtensionAIControlProps = {
@@ -28,7 +28,7 @@ type ExtensionAIControlProps = {
 	isTransparent?: boolean;
 	state?: RequestingStateProp;
 	showGuideLine?: boolean;
-	error?: string;
+	error?: RequestingErrorProps;
 	requestsRemaining?: number;
 	showUpgradeMessage?: boolean;
 	wrapperRef?: React.MutableRefObject< HTMLDivElement | null >;
@@ -202,8 +202,16 @@ export function ExtensionAIControl(
 	);
 
 	let message = null;
-	if ( error ) {
-		message = <ErrorMessage error={ error } onTryAgainClick={ tryAgainHandler } />;
+
+	if ( error?.message ) {
+		message = (
+			<ErrorMessage
+				error={ error.message }
+				code={ error.code }
+				onTryAgainClick={ tryAgainHandler }
+				onUpgradeClick={ upgradeHandler }
+			/>
+		);
 	} else if ( showUpgradeMessage ) {
 		message = (
 			<UpgradeMessage requestsRemaining={ requestsRemaining } onUpgradeClick={ upgradeHandler } />

--- a/projects/js-packages/ai-client/src/components/ai-control/stories/ai-control.stories.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/stories/ai-control.stories.tsx
@@ -36,7 +36,12 @@ export default {
 			mapping: {
 				None: null,
 				'Guideline message': <GuidelineMessage />,
-				'Error message': <ErrorMessage onTryAgainClick={ action( 'onTryAgainClick' ) } />,
+				'Error message': (
+					<ErrorMessage
+						onTryAgainClick={ action( 'onTryAgainClick' ) }
+						onUpgradeClick={ action( 'onUpgradeClick' ) }
+					/>
+				),
 				'Upgrade message': (
 					<UpgradeMessage requestsRemaining={ 10 } onUpgradeClick={ action( 'onUpgradeClick' ) } />
 				),

--- a/projects/js-packages/ai-client/src/components/ai-control/stories/block-ai-control.stories.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/stories/block-ai-control.stories.tsx
@@ -50,7 +50,12 @@ export default {
 			mapping: {
 				None: null,
 				'Guideline message': <GuidelineMessage />,
-				'Error message': <ErrorMessage onTryAgainClick={ action( 'onTryAgainClick' ) } />,
+				'Error message': (
+					<ErrorMessage
+						onTryAgainClick={ action( 'onTryAgainClick' ) }
+						onUpgradeClick={ action( 'onUpgradeClick' ) }
+					/>
+				),
 				'Upgrade message': (
 					<UpgradeMessage requestsRemaining={ 10 } onUpgradeClick={ action( 'onUpgradeClick' ) } />
 				),

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -39,6 +39,7 @@ export type MessageProps = {
 
 export type UpgradeMessageProps = {
 	requestsRemaining: number;
+	severity?: MessageSeverityProp;
 	onUpgradeClick: ( event?: React.MouseEvent< HTMLButtonElement > ) => void;
 };
 
@@ -113,10 +114,17 @@ export function GuidelineMessage(): React.ReactElement {
  */
 export function UpgradeMessage( {
 	requestsRemaining,
+	severity,
 	onUpgradeClick,
 }: UpgradeMessageProps ): React.ReactElement {
+	let messageSeverity = severity;
+
+	if ( messageSeverity == null ) {
+		messageSeverity = requestsRemaining > 0 ? MESSAGE_SEVERITY_INFO : MESSAGE_SEVERITY_WARNING;
+	}
+
 	return (
-		<Message severity={ MESSAGE_SEVERITY_WARNING }>
+		<Message severity={ messageSeverity }>
 			<span>
 				{ sprintf(
 					// translators: %1$d: number of requests remaining

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -10,9 +10,11 @@ import classNames from 'classnames';
  */
 import './style.scss';
 import errorExclamation from '../../icons/error-exclamation.js';
+import { ERROR_QUOTA_EXCEEDED } from '../../types.js';
 /**
  * Types
  */
+import type { SuggestionErrorCode } from '../../types.js';
 import type React from 'react';
 
 export const MESSAGE_SEVERITY_WARNING = 'warning';
@@ -37,15 +39,19 @@ export type MessageProps = {
 	children: React.ReactNode;
 };
 
+export type OnUpgradeClick = ( event?: React.MouseEvent< HTMLButtonElement > ) => void;
+
 export type UpgradeMessageProps = {
 	requestsRemaining: number;
 	severity?: MessageSeverityProp;
-	onUpgradeClick: ( event?: React.MouseEvent< HTMLButtonElement > ) => void;
+	onUpgradeClick: OnUpgradeClick;
 };
 
 export type ErrorMessageProps = {
 	error?: string;
+	code?: SuggestionErrorCode;
 	onTryAgainClick: () => void;
+	onUpgradeClick: OnUpgradeClick;
 };
 
 const messageIconsMap = {
@@ -145,7 +151,12 @@ export function UpgradeMessage( {
  * @param {number} requestsRemaining - Number of requests remaining.
  * @returns {React.ReactElement } - Message component.
  */
-export function ErrorMessage( { error, onTryAgainClick }: ErrorMessageProps ): React.ReactElement {
+export function ErrorMessage( {
+	error,
+	code,
+	onTryAgainClick,
+	onUpgradeClick,
+}: ErrorMessageProps ): React.ReactElement {
 	const errorMessage = error || __( 'Something went wrong', 'jetpack-ai-client' );
 
 	return (
@@ -157,9 +168,15 @@ export function ErrorMessage( { error, onTryAgainClick }: ErrorMessageProps ): R
 					errorMessage
 				) }
 			</span>
-			<Button variant="link" onClick={ onTryAgainClick }>
-				{ __( 'Try Again', 'jetpack-ai-client' ) }
-			</Button>
+			{ code === ERROR_QUOTA_EXCEEDED ? (
+				<Button variant="link" onClick={ onUpgradeClick }>
+					{ __( 'Upgrade now', 'jetpack-ai-client' ) }
+				</Button>
+			) : (
+				<Button variant="link" onClick={ onTryAgainClick }>
+					{ __( 'Try Again', 'jetpack-ai-client' ) }
+				</Button>
+			) }
 		</Message>
 	);
 }

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -174,7 +174,7 @@ export function ErrorMessage( {
 				</Button>
 			) : (
 				<Button variant="link" onClick={ onTryAgainClick }>
-					{ __( 'Try Again', 'jetpack-ai-client' ) }
+					{ __( 'Try again', 'jetpack-ai-client' ) }
 				</Button>
 			) }
 		</Message>

--- a/projects/js-packages/ai-client/src/components/message/stories/index.stories.tsx
+++ b/projects/js-packages/ai-client/src/components/message/stories/index.stories.tsx
@@ -6,7 +6,15 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import Message, { GuidelineMessage, UpgradeMessage, ErrorMessage } from '../index.js';
+import Message, {
+	GuidelineMessage,
+	UpgradeMessage,
+	ErrorMessage,
+	MESSAGE_SEVERITY_WARNING,
+	MESSAGE_SEVERITY_ERROR,
+	MESSAGE_SEVERITY_SUCCESS,
+	MESSAGE_SEVERITY_INFO,
+} from '../index.js';
 
 export default {
 	title: 'JS Packages/AI Client/Message',
@@ -44,6 +52,7 @@ const UpgradeTemplate = args => {
 	return (
 		<UpgradeMessage
 			requestsRemaining={ args.requestsRemaining }
+			severity={ args.severity }
 			onUpgradeClick={ action( 'onUpgradeClick' ) }
 		/>
 	);
@@ -51,10 +60,26 @@ const UpgradeTemplate = args => {
 
 const UpgradeArgs = {
 	requestsRemaining: 10,
+	severity: null,
 };
 
 export const Upgrade = UpgradeTemplate.bind( {} );
 Upgrade.args = UpgradeArgs;
+Upgrade.argTypes = {
+	severity: {
+		control: {
+			type: 'select',
+		},
+		options: [ 'Default', 'Info', 'Warning', 'Error', 'Success' ],
+		mapping: {
+			Default: null,
+			Info: MESSAGE_SEVERITY_INFO,
+			Warning: MESSAGE_SEVERITY_WARNING,
+			Error: MESSAGE_SEVERITY_ERROR,
+			Success: MESSAGE_SEVERITY_SUCCESS,
+		},
+	},
+};
 
 const ErrorTemplate = args => {
 	return <ErrorMessage error={ args.error } onTryAgainClick={ action( 'onTryAgainClick' ) } />;

--- a/projects/js-packages/ai-client/src/components/message/stories/index.stories.tsx
+++ b/projects/js-packages/ai-client/src/components/message/stories/index.stories.tsx
@@ -6,6 +6,15 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import {
+	ERROR_SERVICE_UNAVAILABLE,
+	ERROR_QUOTA_EXCEEDED,
+	ERROR_MODERATION,
+	ERROR_CONTEXT_TOO_LARGE,
+	ERROR_NETWORK,
+	ERROR_UNCLEAR_PROMPT,
+	ERROR_RESPONSE,
+} from '../../../types.js';
 import Message, {
 	GuidelineMessage,
 	UpgradeMessage,
@@ -82,12 +91,45 @@ Upgrade.argTypes = {
 };
 
 const ErrorTemplate = args => {
-	return <ErrorMessage error={ args.error } onTryAgainClick={ action( 'onTryAgainClick' ) } />;
+	return (
+		<ErrorMessage
+			error={ args.error }
+			code={ args.code }
+			onTryAgainClick={ action( 'onTryAgainClick' ) }
+			onUpgradeClick={ action( 'onUpgradeClick' ) }
+		/>
+	);
 };
 
 const ErrorArgs = {
-	error: 'An error occurred',
+	error: 'An error occurred.',
+	code: 'error_service_unavailable',
 };
 
 export const Error = ErrorTemplate.bind( {} );
 Error.args = ErrorArgs;
+Error.argTypes = {
+	code: {
+		control: {
+			type: 'select',
+		},
+		options: [
+			'Service Unavailable',
+			'Quota Exceeded',
+			'Moderation',
+			'Context Too Large',
+			'Network',
+			'Unclear Prompt',
+			'Response',
+		],
+		mapping: {
+			'Service Unavailable': ERROR_SERVICE_UNAVAILABLE,
+			'Quota Exceeded': ERROR_QUOTA_EXCEEDED,
+			Moderation: ERROR_MODERATION,
+			'Context Too Large': ERROR_CONTEXT_TOO_LARGE,
+			Network: ERROR_NETWORK,
+			'Unclear Prompt': ERROR_UNCLEAR_PROMPT,
+			Response: ERROR_RESPONSE,
+		},
+	},
+};

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-feedback
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Inline extension testing feedback changes

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/block-handler.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/block-handler.tsx
@@ -33,6 +33,7 @@ export function blockHandler(
 
 	return {
 		onSuggestion: handler.onSuggestion.bind( handler ),
+		onDone: handler.onDone.bind( handler ),
 		getContent: handler.getContent.bind( handler ),
 	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -162,7 +162,7 @@ export default function AiAssistantInput( {
 			value={ value }
 			state={ requestingState }
 			showGuideLine={ true }
-			error={ requestingError?.message }
+			error={ requestingError }
 			requestsRemaining={ requestsRemaining }
 			showUpgradeMessage={ showUpgradeMessage }
 			onChange={ setValue }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -54,7 +54,6 @@ export default function AiAssistantInput( {
 }: AiAssistantInputProps ): ReactElement {
 	const [ value, setValue ] = useState( '' );
 	const [ placeholder, setPlaceholder ] = useState( __( 'Ask Jetpack AI to edit…', 'jetpack' ) );
-	const [ showGuideLine, setShowGuideLine ] = useState( false );
 	const { autosaveAndRedirect } = useAICheckout();
 	const { tracks } = useAnalytics();
 	const [ requestsRemaining, setRequestsRemaining ] = useState( 0 );
@@ -139,28 +138,21 @@ export default function AiAssistantInput( {
 		}
 	}, [ action ] );
 
-	// Shows the guideline message when there is some text in the input.
+	// Changes the displayed message according to the input value.
 	useEffect( () => {
-		setShowGuideLine( value.length > 0 );
-	}, [ value ] );
+		setShowUpgradeMessage(
+			! loadingAiFeature && // Don't display the upgrade message while loading the feature, as we don't have the tier data yet.
+				!! nextTier && // Only display it when there is a next tier to upgrade to...
+				value.length === 0 // ...and the input is empty.
+		);
+	}, [ loadingAiFeature, nextTier, value ] );
 
-	// Updates the remaining requests count and controls when to show the upgrade message.
+	// Updates the remaining requests count
 	useEffect( () => {
 		const remaining = Math.max( requestsLimit - requestsCount, 0 );
-		setRequestsRemaining( remaining );
 
-		const quarterPlanLimit = requestsLimit ? requestsLimit / 4 : 5;
-		setShowUpgradeMessage(
-			// if the feature is not loading
-			! loadingAiFeature &&
-				// and there is a next plan
-				!! nextTier &&
-				// and the user requires an upgrade
-				( requireUpgrade ||
-					// or the user has reached a multiple of the quarter plan limit, e.g. 100, 75, 50, 25, and 0 on the 100 tier.
-					remaining % quarterPlanLimit === 0 )
-		);
-	}, [ requestsLimit, requestsCount, loadingAiFeature, nextTier, requireUpgrade ] );
+		setRequestsRemaining( remaining );
+	}, [ requestsLimit, requestsCount ] );
 
 	return (
 		<ExtensionAIControl
@@ -169,7 +161,7 @@ export default function AiAssistantInput( {
 			disabled={ disabled }
 			value={ value }
 			state={ requestingState }
-			showGuideLine={ showGuideLine }
+			showGuideLine={ true }
 			error={ requestingError?.message }
 			requestsRemaining={ requestsRemaining }
 			showUpgradeMessage={ showUpgradeMessage }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/heading/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/heading/index.tsx
@@ -53,6 +53,10 @@ export class HeadingHandler implements IBlockHandler {
 		this.replaceBlockContent( HTML );
 	}
 
+	public onDone(): void {
+		this.firstUpdate = true;
+	}
+
 	private replaceBlockContent( newContent: string ): void {
 		// Create a new block with the raw HTML content.
 		const [ newBlock ] = rawHandler( { HTML: newContent } );

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/types.ts
@@ -11,6 +11,7 @@ export type OnSuggestion = ( suggestion: string ) => void;
 
 export interface IBlockHandler {
 	onSuggestion: OnSuggestion;
+	onDone: () => void;
 	getContent: () => string;
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -84,7 +84,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		// The block's id to find it in the DOM for the positioning adjustments.
 		const { id } = useBlockProps();
 		// Jetpack AI Assistant feature functions.
-		const { increaseRequestsCount, dequeueAsyncRequest } = useAiFeature();
+		const { increaseRequestsCount, dequeueAsyncRequest, requireUpgrade } = useAiFeature();
 
 		// Data and functions with block-specific implementations.
 		const {
@@ -208,6 +208,11 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			( promptType, options, humanText ) => {
 				setShowAiControl( true );
 
+				// If the user needs to upgrade, don't make the request, but show the input with the upgrade message.
+				if ( requireUpgrade ) {
+					return;
+				}
+
 				if ( humanText ) {
 					setAction( humanText );
 				}
@@ -227,7 +232,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 				request( messages );
 			},
-			[ dequeueAsyncRequest, getRequestMessages, request ]
+			[ dequeueAsyncRequest, getRequestMessages, request, requireUpgrade ]
 		);
 
 		// Called when the user types a custom prompt.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.5-a.1
+ * Version: 13.5-a.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.5-a.1' );
+define( 'JETPACK__VERSION', '13.5-a.2' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.5.0-a.1",
+	"version": "13.5.0-a.2",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37364
Fixes #37363
Fixes #37361
Fixes #37359

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes undo functionality to undo only the last action
* Changes the error message link from "Try again" to "Upgrade now" when the error of type `quota_exceeded`
* Changes the default severity of the upgrade message to be dynamic, using `warning` when there are no requests left and `info` otherwise
* Always display the upgrade message/requests counter when there is no typed content in the input (when the guideline message is shown)
* Fixes the block padding after the request is done 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor

Block padding:
* On a Heading block, ask for any change or use the "Ask AI Assistant" button
* On this and all subsequent requests, check that the input is shown bellow the heading as expected

Undo:
* Make consecutive requests and then click on the Undo icon. Check that only the last action is undone

Requests count:
* Check that the requests count with upgrade link is displayed regardless of the count, but only if nothing is typed in the input, in which case the disclaimer is shown
* When you have no more requests left, check that the upgrade message has a yellowish background
* Deselect the Heading block so the input is removed
* Select the Heading block again and use one of the quick actions (tone change, for example)
* Check that the input is displayed with the upgrade message, but the request is not sent

Error message:
* Now go to your sandbox and simulate that you do have requests available (Check the "Simulating tiers" pinned thread, set your all time requests count to 19)
* Sandbox the public API 
* Reload the page (this populates the initial state with the wrong data)
* Set the requests count back to 20 on your sandbox (so now the sandbox is right, but your page thinks it has a request)
* Use the extension to send a request
* Check that the error message has a link to the upgrade page

Storybook can be used to check the Message component:
* Run Storybook
* Go to JS Packages/AI Client/Message/Upgrade
* Check that the background is gray, but changes to yellow if `requestsRemaining` is set to 0
* Go to JS Packages/AI Client/Message/Error
* Check that the link changes from `Try again` to `Upgrade now` if you select `Quota Exceeded` as the error code
