### PR TITLE
Jetpack Sync: Ensure 'jetpack_sync_callable_whitelist' filter is respected when added late

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-callables-set-late-default
+++ b/projects/packages/sync/changelog/fix-sync-callables-set-late-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Sync: Ensure 'jetpack_sync_callable_whitelist' filter is respected when added late

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.16.1';
+	const PACKAGE_VERSION = '2.16.2-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/modules/class-callables.php
+++ b/projects/packages/sync/src/modules/class-callables.php
@@ -96,7 +96,6 @@ class Callables extends Module {
 
 	/**
 	 * Set module defaults.
-	 * Define the callable whitelist based on whether this is a single site or a multisite installation.
 	 *
 	 * @access public
 	 */
@@ -107,6 +106,28 @@ class Callables extends Module {
 			$this->callable_whitelist = Defaults::get_callable_whitelist();
 		}
 		$this->force_send_callables_on_next_tick = false; // Resets here as well mostly for tests.
+	}
+
+	/**
+	 * Set module defaults at a later time.
+	 *
+	 * @see Automattic\Jetpack\Sync\Modules::set_module_defaults
+	 * @access public
+	 */
+	public function set_late_default() {
+		if ( is_multisite() ) {
+			$late_callables = array_merge(
+				apply_filters( 'jetpack_sync_callable_whitelist', array() ),
+				apply_filters( 'jetpack_sync_multisite_callable_whitelist', array() )
+			);
+		} else {
+			$late_callables = apply_filters( 'jetpack_sync_callable_whitelist', array() );
+		}
+		if ( ! empty( $late_callables ) && is_array( $late_callables ) ) {
+			if ( count( $late_callables ) > count( $this->callable_whitelist ) ) {
+				$this->callable_whitelist = array_merge( $this->callable_whitelist, $late_callables );
+			}
+		}
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-callables.php
+++ b/projects/packages/sync/src/modules/class-callables.php
@@ -124,9 +124,7 @@ class Callables extends Module {
 			$late_callables = apply_filters( 'jetpack_sync_callable_whitelist', array() );
 		}
 		if ( ! empty( $late_callables ) && is_array( $late_callables ) ) {
-			if ( count( $late_callables ) > count( $this->callable_whitelist ) ) {
-				$this->callable_whitelist = array_merge( $this->callable_whitelist, $late_callables );
-			}
+			$this->callable_whitelist = array_merge( $this->callable_whitelist, $late_callables );
 		}
 	}
 

--- a/projects/packages/sync/src/modules/class-callables.php
+++ b/projects/packages/sync/src/modules/class-callables.php
@@ -96,6 +96,7 @@ class Callables extends Module {
 
 	/**
 	 * Set module defaults.
+	 * Define the callable whitelist based on whether this is a single site or a multisite installation.
 	 *
 	 * @access public
 	 */
@@ -110,6 +111,8 @@ class Callables extends Module {
 
 	/**
 	 * Set module defaults at a later time.
+	 * Reset the callable whitelist if needed to account for plugins adding the 'jetpack_sync_callable_whitelist'
+	 * and 'jetpack_sync_multisite_callable_whitelist' filters late.
 	 *
 	 * @see Automattic\Jetpack\Sync\Modules::set_module_defaults
 	 * @access public

--- a/projects/plugins/jetpack/changelog/fix-sync-callables-set-late-default
+++ b/projects/plugins/jetpack/changelog/fix-sync-callables-set-late-default
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated Sync related unit tests
+
+

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.5-a.1
+ * Version: 13.5-a.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.5-a.1' );
+define( 'JETPACK__VERSION', '13.5-a.2' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.5.0-a.1",
+	"version": "13.5.0-a.2",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -231,6 +231,26 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	/**
+	 * Tests that calling set_late_default works as expected.
+	 *
+	 * Return null
+	 */
+	public function test_sync_callable_set_late_default() {
+		$this->callable_module->set_callable_whitelist( array() );
+
+		add_filter( 'jetpack_sync_callable_whitelist', array( $this, 'filter_sync_callable_whitelist' ) );
+
+		$this->callable_module->set_late_default();
+
+		remove_filter( 'jetpack_sync_callable_whitelist', array( $this, 'filter_sync_callable_whitelist' ) );
+
+		$this->sender->do_sync();
+
+		$synced_value = $this->server_replica_storage->get_callable( 'jetpack_foo' );
+		$this->assertEquals( jetpack_foo_is_callable(), $synced_value );
+	}
+
+	/**
 	 * Tests that updating the theme should result in the no callabled transient being set.
 	 *
 	 * Return null
@@ -974,6 +994,18 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$parsed_url = wp_parse_url( $url );
 
 		return "{$parsed_url['scheme']}://www.{$parsed_url['host']}";
+	}
+
+	/**
+	 * Filters the sync callable whitelist.
+	 *
+	 * @param array $whitelist The sync callable whitelist.
+	 * @return array
+	 */
+	public function filter_sync_callable_whitelist( $whitelist ) {
+		$whitelist['jetpack_foo'] = 'jetpack_foo_is_callable';
+
+		return $whitelist;
 	}
 
 	/**


### PR DESCRIPTION
Fixes a sync related bug exposed by https://github.com/Automattic/jetpack/pull/37153.
When the `jetpack_sync_callable_whitelist` filter is added late, eg on `plugins_loaded` with a priority >= 90 then it's not respected.
This happens because the sync callable whitelist is set on `plugins_loaded` with priority 90 as configured [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-main.php#L26).
Looks like there's prior art for handling such cases with the [options module](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/modules/class-options.php#L110), where the options whitelist is refreshed **if needed** via `set_late_default`.
When a Sync module defines a `set_late_default` method, this will run on `init` with a 90 priority as defined in `Modules::set_module_defaults` [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-modules.php#L159)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Automattic\Jetpack\Sync\Modules\Callables: Add `set_late_default` method for updating the sync callable whitelist on `init` _if needed_

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
- Add the following snippet using a plugin like Code Snippets:
```
add_action( 'plugins_loaded', 'jp_add_sync_callable_filter', 91 );

function jetpack_foo_is_callable() {
	return rand();
}

function jp_add_sync_callable_filter() {
	add_filter( 'jetpack_sync_callable_whitelist', 'jp_update_callable_whitelist', 1000, 1 );
}

function jp_update_callable_whitelist( $whitelist ) {
	$whitelist['foo'] = 'jetpack_foo_is_callable';
	return $whitelist;
}
```
Ensure that `foo` will be sent to WPCOM with the rest Sync callables with the PR applied, while not on current trunk. 
You can do this by watching the corresponding Sync actions in your sandbox.
Alternatively, you can add logging inside `maybe_sync_callables` and ensure that `foo` is returned by the `get_all_callables` call [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/modules/class-callables.php#L459)