### PR TITLE
Hide "Grow your business" and "Launch your site" launchpad options on trial plan

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-hide-launchpad-options-on-trial
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-hide-launchpad-options-on-trial
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+In trial plans, we don't show "Grow your business" and "Launch your site" tasks.

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -57,7 +57,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.29.x-dev"
+			"dev-trunk": "5.30.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.29.1",
+	"version": "5.30.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.29.1';
+	const PACKAGE_VERSION = '5.30.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1229,9 +1229,27 @@ function wpcom_launchpad_is_mobile_app_installed( $task, $is_complete ) {
 /**
  * Determines whether or not the WooCommerce setup task should be visible.
  *
+ * @param Task $task The task object.
  * @return bool True if the site is a WOA site and WooCommerce is active.
  */
-function wpcom_launchpad_is_woocommerce_setup_visible() {
+function wpcom_launchpad_is_woocommerce_setup_visible( $task ) {
+	// Get current plan
+	$is_ecommerce_trial_plan = false;
+	if ( function_exists( 'wpcom_get_site_purchases' ) ) {
+		$purchases = wpcom_get_site_purchases();
+		foreach ( $purchases as $purchase ) {
+			if ( 'ecommerce-trial-bundle-monthly' === $purchase->product_slug ) {
+				$is_ecommerce_trial_plan = true;
+				break;
+			}
+		}
+	}
+
+	// Hide these tasks in ecommerce trial plan
+	if ( in_array( $task['id'], array( 'woo_marketing', 'woo_launch_site' ), true ) && $is_ecommerce_trial_plan ) {
+		return false;
+	}
+
 	$is_atomic_site = ( new Automattic\Jetpack\Status\Host() )->is_woa_site();
 	if ( ! $is_atomic_site ) {
 		return false;

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-hide-launchpad-options-on-trial
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-hide-launchpad-options-on-trial
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_24"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_25_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -755,7 +755,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "191291eb4f1a71ae7876635df2036166a88ad97f"
+                "reference": "05fc78019eb12e7c234523b1dc7eb3e25ce838c4"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -784,7 +784,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.29.x-dev"
+                    "dev-trunk": "5.30.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.24
+ * Version: 2.1.25-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.24",
+	"version": "2.1.25-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7094

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR hides the "Grow your business" and "Launch your site" options in the launchpad when the site plan is e-commerce trial.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Create a WordPress.com site using `wordpress.com/setup/entrepreneur/start`. Upgrade it to Entrepreneur plan using SA.
- Install and activate the [Jetpack Tester plugin](https://jetpack.com/download-jetpack-beta/) and select this branch (update/hide-launchpad-options-on-trial) in its settings, in the `WordPress.com Features` section.
- Go to `https://wordpress.com/home/[your-site-here]?flags=entrepreneur-my-home`. Check that the launchpad includes every task.
- Now, downgrade your site to WooExpress trial plan in SA. Remember to select the 2024 price in the dropdown.
- Go again to `https://wordpress.com/home/[your-site-here]?flags=entrepreneur-my-home`. You should see the launchpad without the "Grow your business" and "Launch your site" tasks.

