### PR TITLE
Backport mu-wpcom-plugin 2.1.25 Changes

### DIFF
--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1] - 2024-05-14
+### Changed
+- SSO: do not rely on the Jetpack class anymore. [#37153]
+
 ## [2.8.0] - 2024-05-13
 ### Added
 - SSO: Ensuring tooltips are accessible [#37302]
@@ -1058,6 +1062,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.8.1]: https://github.com/Automattic/jetpack-connection/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/Automattic/jetpack-connection/compare/v2.7.7...v2.8.0
 [2.7.7]: https://github.com/Automattic/jetpack-connection/compare/v2.7.6...v2.7.7
 [2.7.6]: https://github.com/Automattic/jetpack-connection/compare/v2.7.5...v2.7.6

--- a/projects/packages/connection/changelog/update-sso-use-package
+++ b/projects/packages/connection/changelog/update-sso-use-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-SSO: do not rely on the Jetpack class anymore.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.8.1-alpha';
+	const PACKAGE_VERSION = '2.8.1';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -132,7 +132,7 @@ class SSO {
 	/**
 	 * Add SSO callables to the sync whitelist.
 	 *
-	 * @since $$next-version$$
+	 * @since 2.8.1
 	 *
 	 * @param array $callables list of callables.
 	 *

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.30.0] - 2024-05-14
+### Added
+- WordPress.com Features: Calypso Locale Sync from wp-admin to Calypso [#37316]
+
+### Changed
+- In trial plans, we don't show "Grow your business" and "Launch your site" tasks. [#37374]
+
 ## [5.29.1] - 2024-05-13
 ### Changed
 - WP.com menu: Add "Hosting > Add-ons" menu to Atomic sites [#37318]
@@ -799,6 +806,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.30.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.29.1...v5.30.0
 [5.29.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.29.0...v5.29.1
 [5.29.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.28.0...v5.29.0
 [5.28.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.27.0...v5.28.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-calypso-locale-sync
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-calypso-locale-sync
@@ -1,5 +1,0 @@
-Significance: minor
-Type: added
-
-WordPress.com Features: Calypso Locale Sync from wp-admin to Calypso
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-hide-launchpad-options-on-trial
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-hide-launchpad-options-on-trial
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-In trial plans, we don't show "Grow your business" and "Launch your site" tasks.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.30.0-alpha",
+	"version": "5.30.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.30.0-alpha';
+	const PACKAGE_VERSION = '5.30.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.2] - 2024-05-14
+### Fixed
+- Fix phpdoc type on `Replicastore_Interface::get_term()` `$taxonomy` arg. [#37344]
+- Jetpack Sync: Ensure 'jetpack_sync_callable_whitelist' filter is respected when added late [#37370]
+
 ## [2.16.1] - 2024-05-09
 ### Changed
 - Internal updates.
@@ -1139,6 +1144,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.16.2]: https://github.com/Automattic/jetpack-sync/compare/v2.16.1...v2.16.2
 [2.16.1]: https://github.com/Automattic/jetpack-sync/compare/v2.16.0...v2.16.1
 [2.16.0]: https://github.com/Automattic/jetpack-sync/compare/v2.15.1...v2.16.0
 [2.15.1]: https://github.com/Automattic/jetpack-sync/compare/v2.15.0...v2.15.1

--- a/projects/packages/sync/changelog/fix-misc-phan-undeclared-issues
+++ b/projects/packages/sync/changelog/fix-misc-phan-undeclared-issues
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix phpdoc type on `Replicastore_Interface::get_term()` `$taxonomy` arg.

--- a/projects/packages/sync/changelog/fix-sync-callables-set-late-default
+++ b/projects/packages/sync/changelog/fix-sync-callables-set-late-default
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack Sync: Ensure 'jetpack_sync_callable_whitelist' filter is respected when added late

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.16.2-alpha';
+	const PACKAGE_VERSION = '2.16.2';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.25 - 2024-05-14
+### Changed
+- Internal updates.
+
 ## 2.1.24 - 2024-05-13
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-calypso-locale-sync
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-calypso-locale-sync
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-hide-launchpad-options-on-trial
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-hide-launchpad-options-on-trial
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_25_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_25"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.25-alpha
+ * Version: 2.1.25
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.25-alpha",
+	"version": "2.1.25",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.25

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.