### PR TITLE
WordAds - Catch inline insert PHP fatal

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wordads-inline_insert_fatal
+++ b/projects/plugins/jetpack/changelog/fix-wordads-inline_insert_fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+WordAds: Prevent fatal when post content is null.

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -208,7 +208,7 @@ class WordAds_Smart {
 	 * @param string|null $content The post content.
 	 * @return string|null The post content with the marker appended.
 	 */
-	private function insert_inline_marker( $content ) {
+	public function insert_inline_marker( $content ) {
 		if ( $content === null ) {
 			return $content;
 		}

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -205,10 +205,13 @@ class WordAds_Smart {
 	/**
 	 * Places marker at the end of the content so inline can identify the post content container.
 	 *
-	 * @param string $content The post content.
-	 * @return string The post content with the marker appended.
+	 * @param string|null $content The post content.
+	 * @return string|null The post content with the marker appended.
 	 */
-	private function insert_inline_marker( string $content ): string {
+	private function insert_inline_marker( $content ) {
+		if ( $content === null ) {
+			return $content;
+		}
 		$inline_ad_marker = '<span id="wordads-inline-marker" style="display: none;"></span>';
 
 		// Append the ad to the post content.

--- a/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
+++ b/projects/plugins/jetpack/modules/wordads/php/class-wordads-smart.php
@@ -154,9 +154,7 @@ class WordAds_Smart {
 			if ( $this->is_inline_enabled ) {
 				add_filter(
 					'the_content',
-					function ( $content ) {
-						return $this->insert_inline_marker( $content );
-					},
+					array( $this, 'insert_inline_marker' ),
 					10
 				);
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

If content passed to the `the_content` filter is `null` it would give a PHP fatal because `WordAds_Smart->insert_inline_marker` had a type declaration of `string`.

Ideally we'd just add a union type declaration, but `?string` requires PHP 7.1 and `string|null` requires PHP 8.x, and we need to support PHP 7.0. As such, this PR simply removes the type declaration (both in the method param and the return type), and updates the PHPDoc.

Also, it swaps out the anonymous function hook param per WP coding standards:
https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#closures-anonymous-functions

Initially reported in p1715698833999239-slack-C01U2KGS2PQ.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Unsure how to test this, but hopefully at least the code looks right.