### PR TITLE
Hotfix: Fix empty custom post type URLs

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
@@ -122,6 +122,9 @@ class Source_Providers {
 			// For each provider,
 			// Gather a list of URLs that are going to be used as Critical CSS source.
 			foreach ( $provider::get_critical_source_urls() as $group => $urls ) {
+				if ( empty( $urls ) ) {
+					continue;
+				}
 				$key = $provider_name . '_' . $group;
 
 				// For each URL

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Post_ID_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Post_ID_Provider.php
@@ -41,7 +41,10 @@ class Post_ID_Provider extends Provider {
 
 		foreach ( $query->posts as $post ) {
 			if ( empty( $context_post_ids ) || in_array( $post->ID, $context_post_ids, true ) ) {
-				$results[ $post->ID ] = array( get_permalink( $post ) );
+				$url = get_permalink( $post );
+				if ( ! empty( $url ) ) {
+					$results[ $post->ID ] = array( $url );
+				}
 			}
 		}
 

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Singular_Post_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Singular_Post_Provider.php
@@ -49,7 +49,10 @@ class Singular_Post_Provider extends Provider {
 			$query = self::post_type_query( $post_type );
 
 			foreach ( $query->posts as $post ) {
-				$links[ $post_type ][] = get_permalink( $post );
+				$url = get_permalink( $post );
+				if ( $url ) {
+					$links[ $post_type ][] = $url;
+				}
 			}
 		}
 

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Singular_Post_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Singular_Post_Provider.php
@@ -50,7 +50,7 @@ class Singular_Post_Provider extends Provider {
 
 			foreach ( $query->posts as $post ) {
 				$url = get_permalink( $post );
-				if ( $url ) {
+				if ( ! empty( $url ) ) {
 					$links[ $post_type ][] = $url;
 				}
 			}

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Taxonomy_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Taxonomy_Provider.php
@@ -55,7 +55,10 @@ class Taxonomy_Provider extends Provider {
 			}
 
 			foreach ( $terms as $term ) {
-				$results[ $taxonomy ][] = get_term_link( $term, $taxonomy );
+				$url = get_term_link( $term, $taxonomy );
+				if ( ! empty( $url ) ) {
+					$results[ $taxonomy ][] = $url;
+				}
 			}
 		}
 

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Taxonomy_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Taxonomy_Provider.php
@@ -56,7 +56,7 @@ class Taxonomy_Provider extends Provider {
 
 			foreach ( $terms as $term ) {
 				$url = get_term_link( $term, $taxonomy );
-				if ( ! empty( $url ) ) {
+				if ( ! is_wp_error( $url ) && ! empty( $url ) ) {
 					$results[ $taxonomy ][] = $url;
 				}
 			}

--- a/projects/plugins/boost/changelog/fix-boost-ccss-missing-urls
+++ b/projects/plugins/boost/changelog/fix-boost-ccss-missing-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hotfix: Remove post types with empty Critical CSS URLs


### PR DESCRIPTION
## Proposed changes:
Fixes Critical CSS when the post type URLs are empty

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
Remove URLs from your desired post type and run critical css generator:

```php
function tpt_remove_permalink($post_link, $post) {
    if ($post->post_type == 'tpt') {
        return ''; // Return an empty string to effectively remove the permalink
    }
    return $post_link;
}
add_filter( 'post_type_link', 'tpt_remove_permalink', 10, 2 );

```
