### PR TITLE
Fix CSS variables not loaded for modals on Social admin page

### DIFF
--- a/projects/plugins/social/changelog/fix-social-admin-modal-css-vars
+++ b/projects/plugins/social/changelog/fix-social-admin-modal-css-vars
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed CSS variables not loaded for modals on Social admin page

--- a/projects/plugins/social/src/js/index.js
+++ b/projects/plugins/social/src/js/index.js
@@ -14,7 +14,7 @@ function render() {
 	}
 
 	const component = (
-		<ThemeProvider>
+		<ThemeProvider targetDom={ document.body }>
 			<AdminPage />
 		</ThemeProvider>
 	);


### PR DESCRIPTION
CSS variables are not loaded in some cases for modals on Social admin page. More details here p1715680832828019-slack-C02JH7R8VSM

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set the target dom element for `ThemeProvider` to be the document body instead of the root element

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Social admin page with `define( 'JETPACK_SOCIAL_USE_ADMIN_UI_V1', true );`
* Open "Add new connection" modal
* Confirm that connect button has the styles as expected