### PR TITLE
Untangling: make sure site frontend shows All Sites icon in masterbar

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/untangling-all-sites-menu-fix
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangling-all-sites-menu-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Untangling: correctly show the All Sites menu in the top bar

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -191,6 +191,13 @@ function add_all_sites_menu_to_masterbar( $wp_admin_bar ) {
 		return;
 	}
 
+	wp_enqueue_style(
+		'wpcom-site-menu',
+		plugins_url( 'build/wpcom-site-menu/wpcom-site-menu.css', Jetpack_Mu_Wpcom::BASE_FILE ),
+		array(),
+		Jetpack_Mu_Wpcom::PACKAGE_VERSION
+	);
+
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'all-sites',
@@ -211,13 +218,6 @@ function wpcom_site_menu_enqueue_scripts() {
 	if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
 		return;
 	}
-
-	wp_enqueue_style(
-		'wpcom-site-menu',
-		plugins_url( 'build/wpcom-site-menu/wpcom-site-menu.css', Jetpack_Mu_Wpcom::BASE_FILE ),
-		array(),
-		Jetpack_Mu_Wpcom::PACKAGE_VERSION
-	);
 
 	wp_enqueue_script(
 		'wpcom-site-menu',


### PR DESCRIPTION

## Proposed changes:

This PR fixes a regression introduced by:

- https://github.com/Automattic/jetpack/pull/36797

The above PR moved the `wpcom-site-menu.css` CSS file from the `admin_bar_menu` to the `admin_enqueue_scripts` action. However, that CSS contains the definition of the icon of the All Sites menu in the top bar. So, the site frontend now no longer shows the icon.

This PR fixes by moving the CSS back to the original hook.

Before

<img width="578" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/c2283e58-85d4-4f01-8e05-466c2c668e3e">

After

<img width="594" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/cbbcc377-cbdb-49b4-8fe2-3b08fc654ee5">


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this PR to your Jetpack Beta Tester's WordPress.com Features
2. Go to the frontend of your early Atomic Classic site
3. Verify that the top bar shows the All Sites icon.
4. Verify that you can still the sidebar upsells in wp-admin (see the original PR above)

