### PR TITLE
A4A plugin structure: Variables and options must be escaped when echod

### DIFF
--- a/projects/packages/identity-crisis/changelog/update-escape-echoed-variables
+++ b/projects/packages/identity-crisis/changelog/update-escape-echoed-variables
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+IDC: Added escapes to echo statements

--- a/projects/packages/identity-crisis/composer.json
+++ b/projects/packages/identity-crisis/composer.json
@@ -66,7 +66,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.18.x-dev"
+			"dev-trunk": "0.19.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.18.6",
+	"version": "0.19.0-alpha",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -635,11 +635,11 @@ class Identity_Crisis {
 		<div class="jp-idc-notice__first-step">
 			<div class="jp-idc-notice__content-header">
 				<h3 class="jp-idc-notice__content-header__lead">
-					<?php echo $this->get_first_step_header_lead(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<?php echo esc_html( $this->get_first_step_header_lead() ); ?>
 				</h3>
 
 				<p class="jp-idc-notice__content-header__explanation">
-					<?php echo $this->get_first_step_header_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<?php echo esc_html( $this->get_first_step_header_explanation() ); ?>
 				</p>
 			</div>
 
@@ -648,19 +648,19 @@ class Identity_Crisis {
 			<div class="jp-idc-notice__actions">
 				<div class="jp-idc-notice__action">
 					<p class="jp-idc-notice__action__explanation">
-						<?php echo $this->get_confirm_safe_mode_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo esc_html( $this->get_confirm_safe_mode_action_explanation() ); ?>
 					</p>
 					<button id="jp-idc-confirm-safe-mode-action" class="dops-button">
-						<?php echo $this->get_confirm_safe_mode_button_text(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo esc_html( $this->get_confirm_safe_mode_button_text() ); ?>
 					</button>
 				</div>
 
 				<div class="jp-idc-notice__action">
 					<p class="jp-idc-notice__action__explanation">
-						<?php echo $this->get_first_step_fix_connection_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo esc_html( $this->get_first_step_fix_connection_action_explanation() ); ?>
 					</p>
 					<button id="jp-idc-fix-connection-action" class="dops-button">
-						<?php echo $this->get_first_step_fix_connection_button_text(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo esc_html( $this->get_first_step_fix_connection_button_text() ); ?>
 					</button>
 				</div>
 			</div>
@@ -681,7 +681,7 @@ class Identity_Crisis {
 		<div class="jp-idc-notice__second-step">
 			<div class="jp-idc-notice__content-header">
 				<h3 class="jp-idc-notice__content-header__lead">
-					<?php echo $this->get_second_step_header_lead(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<?php echo esc_html( $this->get_second_step_header_lead() ); ?>
 				</h3>
 			</div>
 
@@ -690,26 +690,26 @@ class Identity_Crisis {
 			<div class="jp-idc-notice__actions">
 				<div class="jp-idc-notice__action">
 					<p class="jp-idc-notice__action__explanation">
-						<?php echo $this->get_migrate_site_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo esc_html( $this->get_migrate_site_action_explanation() ); ?>
 					</p>
 					<button id="jp-idc-migrate-action" class="dops-button">
-						<?php echo $this->get_migrate_site_button_text(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo esc_html( $this->get_migrate_site_button_text() ); ?>
 					</button>
 				</div>
 
 				<div class="jp-idc-notice__action">
 					<p class="jp-idc-notice__action__explanation">
-						<?php echo $this->get_start_fresh_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo esc_html( $this->get_start_fresh_action_explanation() ); ?>
 					</p>
 					<button id="jp-idc-reconnect-site-action" class="dops-button">
-						<?php echo $this->get_start_fresh_button_text(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo esc_html( $this->get_start_fresh_button_text() ); ?>
 					</button>
 				</div>
 
 			</div>
 
 			<p class="jp-idc-notice__unsure-prompt">
-				<?php echo $this->get_unsure_prompt(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo esc_html( $this->get_unsure_prompt() ); ?>
 			</p>
 		</div>
 		<?php

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -26,7 +26,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.18.6';
+	const PACKAGE_VERSION = '0.19.0-alpha';
 
 	/**
 	 * Package Slug

--- a/projects/packages/sync/changelog/update-escape-echoed-variables
+++ b/projects/packages/sync/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Just a minor comment
+
+

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.16.2';
+	const PACKAGE_VERSION = '2.16.3-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/class-sender.php
+++ b/projects/packages/sync/src/class-sender.php
@@ -394,7 +394,7 @@ class Sender {
 		 *
 		 * @see \Automattic\Jetpack\Sync\Dedicated_Sender::can_spawn_dedicated_sync_request
 		 */
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is just a constant string used for Validation.
 		echo Dedicated_Sender::DEDICATED_SYNC_VALIDATION_STRING;
 
 		// Try to disconnect the request as quickly as possible and process things in the background.

--- a/projects/plugins/automattic-for-agencies-client/changelog/update-escape-echoed-variables
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -521,7 +521,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+                "reference": "e42a81c98788be332c6e5409b4bc901ececcd3d8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -551,7 +551,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/backup/changelog/update-escape-echoed-variables
+++ b/projects/plugins/backup/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -854,7 +854,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+                "reference": "e42a81c98788be332c6e5409b4bc901ececcd3d8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -884,7 +884,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/boost/changelog/update-escape-echoed-variables
+++ b/projects/plugins/boost/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -709,7 +709,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+                "reference": "e42a81c98788be332c6e5409b4bc901ececcd3d8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -739,7 +739,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/jetpack/changelog/update-escape-echoed-variables
+++ b/projects/plugins/jetpack/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1337,7 +1337,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/identity-crisis",
-				"reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+				"reference": "e42a81c98788be332c6e5409b4bc901ececcd3d8"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1367,7 +1367,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.18.x-dev"
+					"dev-trunk": "0.19.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/migration/changelog/update-escape-echoed-variables
+++ b/projects/plugins/migration/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -854,7 +854,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+                "reference": "e42a81c98788be332c6e5409b4bc901ececcd3d8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -884,7 +884,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-escape-echoed-variables
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -539,7 +539,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+                "reference": "e42a81c98788be332c6e5409b4bc901ececcd3d8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -569,7 +569,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/protect/changelog/update-escape-echoed-variables
+++ b/projects/plugins/protect/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -766,7 +766,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+                "reference": "e42a81c98788be332c6e5409b4bc901ececcd3d8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -796,7 +796,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/search/changelog/update-escape-echoed-variables
+++ b/projects/plugins/search/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -709,7 +709,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+                "reference": "e42a81c98788be332c6e5409b4bc901ececcd3d8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -739,7 +739,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/social/changelog/update-escape-echoed-variables
+++ b/projects/plugins/social/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -709,7 +709,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/identity-crisis",
-				"reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+				"reference": "e42a81c98788be332c6e5409b4bc901ececcd3d8"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -739,7 +739,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.18.x-dev"
+					"dev-trunk": "0.19.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/starter-plugin/changelog/update-escape-echoed-variables
+++ b/projects/plugins/starter-plugin/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -709,7 +709,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+                "reference": "e42a81c98788be332c6e5409b4bc901ececcd3d8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -739,7 +739,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/videopress/changelog/update-escape-echoed-variables
+++ b/projects/plugins/videopress/changelog/update-escape-echoed-variables
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -709,7 +709,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/identity-crisis",
-                "reference": "abd4079c124a2d3560838cf5370043763e81cccd"
+                "reference": "e42a81c98788be332c6e5409b4bc901ececcd3d8"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -739,7 +739,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-identity-crisis/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
+                    "dev-trunk": "0.19.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/339

We got 14 incidences flagged of echoes that needed to be escaped when trying to commit the A4A plugin.

- 12 of them are inside the identity crisis 
- 1 is inside the Sync Package ([code](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/class-sender.php#L398)) 
- 1 is in the connection package ([code](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/connection/src/sso/class-sso.php#L628)) Already has a comment since the function that is calling is already escaped.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
For the Identity crisis occurrences I have applied extra cautious `esc_html` since filters might be able to change the value of the already escaped variable. In any case all of this are deprecated functions.

For the Sync Package one, I added a comment since we are using a constant and I guess it's OK.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pfunGA-WJ-p2
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Not much. Check tests run fine.
If we want extra points, since the only actual changes are inside the identity-crisis package for the deprecation code, we can follow the instructions [here](https://github.com/Automattic/jetpack/pull/35444)
