### PR TITLE
Assets: Adding phpcs:ignore comments to explain why we are ignoring i18n sniffs

### DIFF
--- a/projects/packages/assets/changelog/add-a4a-plugin-package-text-domain-i18n-comment
+++ b/projects/packages/assets/changelog/add-a4a-plugin-package-text-domain-i18n-comment
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Assets: Adding comments to explain why we use variables within translation functions"
+Assets: Adding comments to explain why we use variables within translation functions

--- a/projects/packages/assets/changelog/add-a4a-plugin-package-text-domain-i18n-comment
+++ b/projects/packages/assets/changelog/add-a4a-plugin-package-text-domain-i18n-comment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Assets: Adding comments to explain why we use variables within translation functions"

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -651,7 +651,7 @@ class Assets {
 	 */
 	public static function filter_gettext( $translation, $text, $domain ) {
 		if ( $translation === $text ) {
-			// phpcs:ignore WordPress.WP.I18n
+			// phpcs:ignore WordPress.WP.I18n -- we're including text domains from the most recent dependency package versions, of which there are generally a fair number, to ensure we have the most recent translations.
 			$newtext = __( $text, self::$domain_map[ $domain ][0] );
 			if ( $newtext !== $text ) {
 				return $newtext;
@@ -673,7 +673,7 @@ class Assets {
 	 */
 	public static function filter_ngettext( $translation, $single, $plural, $number, $domain ) {
 		if ( $translation === $single || $translation === $plural ) {
-			// phpcs:ignore WordPress.WP.I18n
+			// phpcs:ignore WordPress.WP.I18n -- we're including text domains from the most recent dependency package versions, of which there are generally a fair number, to ensure we have the most recent translations.
 			$translation = _n( $single, $plural, $number, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;
@@ -691,7 +691,7 @@ class Assets {
 	 */
 	public static function filter_gettext_with_context( $translation, $text, $context, $domain ) {
 		if ( $translation === $text ) {
-			// phpcs:ignore WordPress.WP.I18n
+			// phpcs:ignore WordPress.WP.I18n -- we're including text domains from the most recent dependency package versions, of which there are generally a fair number, to ensure we have the most recent translations.
 			$translation = _x( $text, $context, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;
@@ -711,7 +711,7 @@ class Assets {
 	 */
 	public static function filter_ngettext_with_context( $translation, $single, $plural, $number, $context, $domain ) {
 		if ( $translation === $single || $translation === $plural ) {
-			// phpcs:ignore WordPress.WP.I18n
+			// phpcs:ignore WordPress.WP.I18n -- we're including text domains from the most recent dependency package versions, of which there are generally a fair number, to ensure we have the most recent translations.
 			$translation = _nx( $single, $plural, $number, $context, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;


### PR DESCRIPTION
Fixes https://github.com/Automattic/vulcan/issues/335

## Proposed changes:

* In using the Assets package to alias_textdomains_from_file for the A4A plugin, we had been ignoring a PHPCS sniff that was flagging a few errors related to variables being used where strings were expected. 
* Below are the PHPCS errors flagged:

```
The $single parameter must be a single text string literal. Found: $single
The $plural parameter must be a single text string literal. Found: $plural
The $domain parameter must be a single text string literal. Found: self::$domain_map[$domain ][0]
```

* Our options were:
  * Don't attempt to include the most recent translations from packages (don't call `Assets::alias_textdomains_from_file`), or
  * Leave a comment as to why we are doing this, in the hopes it will be enough.

* This PR adds the comments in (also suggested in the linked issue), but should that not be enough then we'll need to come back to this and both leave a comment by `alias_textdomain` and `alias_textdomains_from_file` to explain that it should not be included for new plugins and then not call `alias_textdomains_from_file` it in the A4A plugin. Then a longer term approach will be to rethink whether we use `alias_textdomain` and `alias_textdomains_from_file` at all.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/vulcan/issues/335


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read. Are we clear enough about why we're using variables in the translation functions?