### PR TITLE
Connection: Ensuring we disable direct file access in class-jetpack-ixr-client.php

### DIFF
--- a/projects/packages/connection/changelog/add-connection-file-access
+++ b/projects/packages/connection/changelog/add-connection-file-access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Connection: Ensuring direct file access is disabled in class-jetpack-ixr-client.php

--- a/projects/packages/connection/legacy/class-jetpack-ixr-client.php
+++ b/projects/packages/connection/legacy/class-jetpack-ixr-client.php
@@ -12,6 +12,13 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
 
+/**
+ * Disable direct access.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( ! class_exists( IXR_Client::class ) ) {
 	require_once ABSPATH . WPINC . '/class-IXR.php';
 }

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.8.1';
+	const PACKAGE_VERSION = '2.8.2-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 


### PR DESCRIPTION

Fixes https://github.com/Automattic/vulcan/issues/341

## Proposed changes:

* This PR adds a check to ensure that direct file access is not possible in `packages/connection/legacy/class-jetpack-ixr-client.php`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/vulcan/issues/341

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* In trunk, try accessing the file directly: `yoursite.com/wp-content/plugins/automattic-for-agencies-client/jetpack_vendor/automattic/jetpack-connection/legacy/class-jetpack-ixr-client.php`
* You will see a notice saying that the ABSBATH constant is not defined (referring to this line: `require_once ABSPATH . WPINC . '/class-IXR.php';`).
* Apply the PR, you should now not see anything when visiting that page.

