### PR TITLE
Clear cache after a scheduler update is queued

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-cache-clear
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-cache-clear
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add additional check after scheduled update creation

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -169,10 +169,15 @@ class Scheduled_Updates {
 	 * @param int    $timestamp Timestamp of the first run.
 	 * @param string $interval  Interval of the update.
 	 * @param array  $plugins   List of plugins to update.
-	 * @return \WP_Error|bool True on success, WP_Error on failure.
+	 * @return \WP_Error|true True on success, WP_Error on failure.
 	 */
 	public static function create_scheduled_update( $timestamp, $interval, $plugins ) {
-		return wp_schedule_event( $timestamp, $interval, self::PLUGIN_CRON_HOOK, $plugins, true );
+		$res = wp_schedule_event( $timestamp, $interval, self::PLUGIN_CRON_HOOK, $plugins, true );
+
+		// Be sure to clear the cron cache after adding a cron entry.
+		self::clear_cron_cache();
+
+		return $res;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -232,11 +232,8 @@ class Scheduled_Updates {
 	 * Clear the cron cache.
 	 */
 	public static function clear_cron_cache() {
-		wp_cache_delete( 'alloptions', 'options' );
-
-		$alloptions = wp_load_alloptions( true );
-		unset( $alloptions['cron'] );
-		wp_cache_set( 'alloptions', $alloptions, 'options' );
+		wp_cache_delete( 'cron', 'options' );
+		wp_load_alloptions( true );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -234,8 +234,8 @@ class Scheduled_Updates {
 	 * Clear the cron cache.
 	 */
 	public static function clear_cron_cache() {
-		wp_cache_delete( 'cron', 'options' );
-		wp_load_alloptions( true );
+		wp_cache_delete( 'alloptions', 'options' );
+		wp_cache_delete( 'notoptions', 'options' );
 	}
 
 	/**
@@ -244,8 +244,7 @@ class Scheduled_Updates {
 	public static function clear_cron_cache_pre() {
 		// If the transient is set, it means that the cron cache must be refreshed.
 		if ( get_transient( 'jetpack_scheduled_update_created_lock' ) ) {
-			wp_cache_delete( 'alloptions', 'options' );
-			wp_cache_delete( 'notoptions', 'options' );
+			self::clear_cron_cache();
 		}
 	}
 

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -92,7 +92,7 @@ class Scheduled_Updates {
 		add_action( 'add_option_' . Scheduled_Updates_Active::OPTION_NAME, $callback );
 		add_action( 'update_option_' . Scheduled_Updates_Active::OPTION_NAME, $callback );
 
-		add_filter( 'pre_schedule_event', array( __CLASS__, 'clear_cron_cache_pre' ) );
+		add_filter( 'pre_schedule_event', array( __CLASS__, 'clear_cron_cache_pre' ), 10, 2 );
 	}
 
 	/**
@@ -206,15 +206,18 @@ class Scheduled_Updates {
 	}
 
 	/**
-	 * Reload the cron cache in pre_schedule_event hook.
+	 * Reload the cron cache in pre_schedule_event hook. Returns null to prevent short-circuit.
 	 *
-	 * @param string $event The event hook name.
+	 * @param null|bool|WP_Error $result The value to return instead. Default null to continue adding the event.
+	 * @param object             $event  The event object.
 	 */
-	public static function clear_cron_cache_pre( $event ) {
+	public static function clear_cron_cache_pre( $result, $event ) {
 		// If the transient is set and an external event is about to run, it means that the cron cache must be refreshed.
-		if ( self::PLUGIN_CRON_HOOK !== $event && get_transient( 'pre_schedule_event_clear_cron_cache' ) ) {
+		if ( self::PLUGIN_CRON_HOOK !== $event->hook && get_transient( 'pre_schedule_event_clear_cron_cache' ) ) {
 			self::clear_cron_cache();
 		}
+
+		return $result;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -69,6 +69,7 @@ class Scheduled_Updates {
 		add_filter( 'plugin_auto_update_setting_html', array( Scheduled_Updates_Admin::class, 'show_scheduled_updates' ), 10, 2 );
 
 		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'maybe_disable_autoupdates' ), 10, 3 );
+		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'reload_cron_cache' ), 10, 3 );
 
 		add_action( 'jetpack_scheduled_update_updated', array( Scheduled_Updates_Logs::class, 'replace_logs_schedule_id' ), 10, 2 );
 
@@ -234,6 +235,17 @@ class Scheduled_Updates {
 	public static function clear_cron_cache() {
 		wp_cache_delete( 'cron', 'options' );
 		wp_load_alloptions( true );
+	}
+
+	/**
+	 * Reload the cron cache in jetpack_scheduled_update_created hook.
+	 */
+	public static function reload_cron_cache() {
+		$latest_cron = _get_cron_array();
+		$alloptions  = wp_load_alloptions( true );
+
+		$alloptions['cron'] = $latest_cron;
+		wp_cache_set( 'alloptions', $alloptions, 'options' );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -242,8 +242,11 @@ class Scheduled_Updates {
 	 * Reload the cron cache in pre_schedule_event hook.
 	 */
 	public static function clear_cron_cache_pre() {
-		wp_cache_delete( 'alloptions', 'options' );
-		wp_cache_delete( 'notoptions', 'options' );
+		// If the transient is set, it means that the cron cache must be refreshed.
+		if ( get_transient( 'jetpack_scheduled_update_created_lock' ) ) {
+			wp_cache_delete( 'alloptions', 'options' );
+			wp_cache_delete( 'notoptions', 'options' );
+		}
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -174,12 +174,12 @@ class Scheduled_Updates {
 	 * @return \WP_Error|true True on success, WP_Error on failure.
 	 */
 	public static function create_scheduled_update( $timestamp, $interval, $plugins ) {
-		$res = wp_schedule_event( $timestamp, $interval, self::PLUGIN_CRON_HOOK, $plugins, true );
+		$event = wp_schedule_event( $timestamp, $interval, self::PLUGIN_CRON_HOOK, $plugins, true );
 
 		// Be sure to clear the cron cache after adding a cron entry.
 		self::clear_cron_cache();
 
-		return $res;
+		return $event;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -188,10 +188,12 @@ class Scheduled_Updates {
 	 * @return \WP_Error|bool True on success, WP_Error on failure.
 	 */
 	public static function delete_scheduled_update( $timestamp, $plugins ) {
-		// Be sure to clear the cron cache before removing a cron entry.
+		$ret = wp_unschedule_event( $timestamp, self::PLUGIN_CRON_HOOK, $plugins, true );
+
+		// Be sure to clear the cron cache after removing a cron entry.
 		self::clear_cron_cache();
 
-		return wp_unschedule_event( $timestamp, self::PLUGIN_CRON_HOOK, $plugins, true );
+		return $ret;
 	}
 
 	/**
@@ -231,6 +233,10 @@ class Scheduled_Updates {
 	 */
 	public static function clear_cron_cache() {
 		wp_cache_delete( 'alloptions', 'options' );
+
+		$alloptions = wp_load_alloptions( true );
+		unset( $alloptions['cron'] );
+		wp_cache_set( 'alloptions', $alloptions, 'options' );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -69,7 +69,6 @@ class Scheduled_Updates {
 		add_filter( 'plugin_auto_update_setting_html', array( Scheduled_Updates_Admin::class, 'show_scheduled_updates' ), 10, 2 );
 
 		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'maybe_disable_autoupdates' ), 10, 3 );
-		add_action( 'jetpack_scheduled_update_created', array( __CLASS__, 'reload_cron_cache' ), 10, 3 );
 
 		add_action( 'jetpack_scheduled_update_updated', array( Scheduled_Updates_Logs::class, 'replace_logs_schedule_id' ), 10, 2 );
 
@@ -92,6 +91,8 @@ class Scheduled_Updates {
 		// Active flag saving.
 		add_action( 'add_option_' . Scheduled_Updates_Active::OPTION_NAME, $callback );
 		add_action( 'update_option_' . Scheduled_Updates_Active::OPTION_NAME, $callback );
+
+		add_filter( 'pre_schedule_event', array( __CLASS__, 'clear_cron_cache_pre' ) );
 	}
 
 	/**
@@ -238,10 +239,11 @@ class Scheduled_Updates {
 	}
 
 	/**
-	 * Reload the cron cache in jetpack_scheduled_update_created hook.
+	 * Reload the cron cache in pre_schedule_event hook.
 	 */
-	public static function reload_cron_cache() {
+	public static function clear_cron_cache_pre() {
 		wp_cache_delete( 'alloptions', 'options' );
+		wp_cache_delete( 'notoptions', 'options' );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -243,7 +243,7 @@ class Scheduled_Updates {
 	 */
 	public static function clear_cron_cache_pre() {
 		// If the transient is set, it means that the cron cache must be refreshed.
-		if ( get_transient( 'jetpack_scheduled_update_created_lock' ) ) {
+		if ( get_transient( 'pre_schedule_event_clear_cron_cache' ) ) {
 			self::clear_cron_cache();
 		}
 	}

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -208,8 +208,8 @@ class Scheduled_Updates {
 	/**
 	 * Reload the cron cache in pre_schedule_event hook. Returns null to prevent short-circuit.
 	 *
-	 * @param null|bool|WP_Error $result The value to return instead. Default null to continue adding the event.
-	 * @param object             $event  The event object.
+	 * @param null|bool|\WP_Error $result The value to return instead. Default null to continue adding the event.
+	 * @param object              $event  The event object.
 	 */
 	public static function clear_cron_cache_pre( $result, $event ) {
 		// If the transient is set and an external event is about to run, it means that the cron cache must be refreshed.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -234,8 +234,8 @@ class Scheduled_Updates {
 	 * Clear the cron cache.
 	 */
 	public static function clear_cron_cache() {
-		wp_cache_delete( 'alloptions', 'options' );
-		wp_cache_delete( 'notoptions', 'options' );
+		wp_cache_delete( 'cron', 'options' );
+		wp_load_alloptions( true );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -190,12 +190,12 @@ class Scheduled_Updates {
 	 * @return \WP_Error|bool True on success, WP_Error on failure.
 	 */
 	public static function delete_scheduled_update( $timestamp, $plugins ) {
-		$ret = wp_unschedule_event( $timestamp, self::PLUGIN_CRON_HOOK, $plugins, true );
+		$success = wp_unschedule_event( $timestamp, self::PLUGIN_CRON_HOOK, $plugins, true );
 
 		// Be sure to clear the cron cache after removing a cron entry.
 		self::clear_cron_cache();
 
-		return $ret;
+		return $success;
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.12.2';
+	const PACKAGE_VERSION = '0.12.3-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -241,11 +241,7 @@ class Scheduled_Updates {
 	 * Reload the cron cache in jetpack_scheduled_update_created hook.
 	 */
 	public static function reload_cron_cache() {
-		$latest_cron = _get_cron_array();
-		$alloptions  = wp_load_alloptions( true );
-
-		$alloptions['cron'] = $latest_cron;
-		wp_cache_set( 'alloptions', $alloptions, 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -188,10 +188,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return $res;
 		}
 
-		$id     = Scheduled_Updates::generate_schedule_id( $plugins );
-		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
+		$id    = Scheduled_Updates::generate_schedule_id( $plugins );
+		$event = wp_get_scheduled_event( Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins, $schedule['timestamp'] );
 
-		if ( empty( $events[ $id ] ) ) {
+		if ( ! $event ) {
 			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be created.', 'jetpack-scheduled-updates' ), array( 'status' => 500 ) );
 		}
 
@@ -202,7 +202,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		 * @param object          $event   The event object.
 		 * @param WP_REST_Request $request The request object.
 		 */
-		do_action( 'jetpack_scheduled_update_created', $id, $events[ $id ], $request );
+		do_action( 'jetpack_scheduled_update_created', $id, $event, $request );
 
 		$event              = wp_get_scheduled_event( Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins, $schedule['timestamp'] );
 		$event->schedule_id = $id;

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -179,13 +179,13 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$plugins  = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );
 
-		$res = Scheduled_Updates::create_scheduled_update( $schedule['timestamp'], $schedule['interval'], $plugins );
+		$event = Scheduled_Updates::create_scheduled_update( $schedule['timestamp'], $schedule['interval'], $plugins );
 
-		if ( is_wp_error( $res ) ) {
+		if ( is_wp_error( $event ) ) {
 			// If the schedule could not be created, return an error.
-			$res->add_data( array( 'status' => 500 ) );
+			$event->add_data( array( 'status' => 500 ) );
 
-			return $res;
+			return $event;
 		}
 
 		$id    = Scheduled_Updates::generate_schedule_id( $plugins );

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -183,7 +183,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 
 		if ( is_wp_error( $event ) ) {
 			// If the schedule could not be created, return an error.
-			$event->add_data( array( 'status' => 500 ) );
+			$event->add_data( array( 'status' => 404 ) );
 
 			return $event;
 		}
@@ -204,7 +204,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		 */
 		do_action( 'jetpack_scheduled_update_created', $id, $event, $request );
 
-		$event              = wp_get_scheduled_event( Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins, $schedule['timestamp'] );
 		$event->schedule_id = $id;
 		$this->update_additional_fields_for_object( $event, $request );
 

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -192,7 +192,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$event = wp_get_scheduled_event( Scheduled_Updates::PLUGIN_CRON_HOOK, $plugins, $schedule['timestamp'] );
 
 		if ( ! $event ) {
-			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be created.', 'jetpack-scheduled-updates' ), array( 'status' => 500 ) );
+			return new WP_Error( 'rest_invalid_schedule', __( 'The schedule could not be created.', 'jetpack-scheduled-updates' ), array( 'status' => 404 ) );
 		}
 
 		/**

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -208,8 +208,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$event->schedule_id = $id;
 		$this->update_additional_fields_for_object( $event, $request );
 
-		// Lock the cache after a successful schedule creation.
-		set_transient( 'jetpack_scheduled_update_created_lock', true, 10 );
+		// Lock the cache after a successfull schedule creation.
+		set_transient( 'pre_schedule_event_clear_cron_cache', true, 10 );
 
 		return rest_ensure_response( $id );
 	}

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -208,6 +208,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		$event->schedule_id = $id;
 		$this->update_additional_fields_for_object( $event, $request );
 
+		// Lock the cache after a successful schedule creation.
+		set_transient( 'jetpack_scheduled_update_created_lock', true, 10 );
+
 		return rest_ensure_response( $id );
 	}
 

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -287,14 +287,16 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		remove_filter( Scheduled_Updates::PLUGIN_CRON_SYNC_HOOK, '__return_false' );
 		$item = $this->create_item( $request );
 
-		/**
-		 * Fires when a scheduled update is updated.
-		 *
-		 * @param string          $old_id  The ID of the schedule to update.
-		 * @param string          $new_id  The ID of the updated event.
-		 * @param WP_REST_Request $request The request object.
-		 */
-		do_action( 'jetpack_scheduled_update_updated', $request['schedule_id'], $item->data, $request );
+		if ( ! is_wp_error( $item ) ) {
+			/**
+			 * Fires when a scheduled update is updated.
+			 *
+			 * @param string          $old_id  The ID of the schedule to update.
+			 * @param string          $new_id  The ID of the updated event.
+			 * @param WP_REST_Request $request The request object.
+			 */
+			do_action( 'jetpack_scheduled_update_updated', $request['schedule_id'], $item->data, $request );
+		}
 
 		return $item;
 	}

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-health-paths-test.php
@@ -38,6 +38,10 @@ class Scheduled_Updates_Health_Paths_Test extends \WorDBless\BaseTestCase {
 		parent::set_up_wordbless();
 		\WorDBless\Users::init()->clear_all_users();
 
+		// Be sure wordbless cron is reset before each test.
+		delete_option( 'cron' );
+		update_option( 'cron', array( 'version' => 2 ), 'yes' );
+
 		$this->admin_id = wp_insert_user(
 			array(
 				'user_login' => 'dummy_path_user',

--- a/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-scheduled-updates-logs-test.php
@@ -48,7 +48,10 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 	protected function set_up() {
 		parent::set_up_wordbless();
 		\WorDBless\Users::init()->clear_all_users();
-		Scheduled_Updates::init();
+
+		// Be sure wordbless cron is reset before each test.
+		delete_option( 'cron' );
+		update_option( 'cron', array( 'version' => 2 ), 'yes' );
 
 		// Initialize the admin.
 		$this->admin_id = wp_insert_user(
@@ -59,6 +62,7 @@ class Scheduled_Updates_Logs_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 		wp_set_current_user( $this->admin_id );
+		Scheduled_Updates::init();
 	}
 
 	/**

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-active-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-active-test.php
@@ -58,6 +58,10 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Active_Test extends \WorDBless
 		parent::set_up_wordbless();
 		\WorDBless\Users::init()->clear_all_users();
 
+		// Be sure wordbless cron is reset before each test.
+		delete_option( 'cron' );
+		update_option( 'cron', array( 'version' => 2 ), 'yes' );
+
 		$this->admin_id = wp_insert_user(
 			array(
 				'user_login' => 'dummy_path_user',

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-capabilities-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-capabilities-test.php
@@ -24,7 +24,8 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Capabilities_Test extends \Wor
 	 * Set up.
 	 */
 	public function set_up() {
-		parent::set_up();
+		parent::set_up_wordbless();
+		\WorDBless\Users::init()->clear_all_users();
 
 		$this->admin_id = wp_insert_user(
 			array(

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-logs-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-logs-test.php
@@ -25,7 +25,12 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Logs_Test extends \WorDBless\B
 	 * Set up.
 	 */
 	public function set_up() {
-		parent::set_up();
+		parent::set_up_wordbless();
+		\WorDBless\Users::init()->clear_all_users();
+
+		// Be sure wordbless cron is reset before each test.
+		delete_option( 'cron' );
+		update_option( 'cron', array( 'version' => 2 ), 'yes' );
 
 		$this->admin_id = wp_insert_user(
 			array(

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -870,62 +870,6 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
-	 * Test additional scheduled event does not reset cron option
-	 */
-	public function test_another_scheduled_event_does_not_reset() {
-		$plugins = array(
-			'custom-plugin/custom-plugin.php',
-			'gutenberg/gutenberg.php',
-		);
-		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
-		$request->set_body_params(
-			array(
-				'plugins'  => $plugins,
-				'schedule' => $this->get_schedule(),
-			)
-		);
-
-		// Successful request.
-		wp_set_current_user( $this->admin_id );
-
-		$result      = rest_do_request( $request );
-		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
-
-		$this->assertSame( 200, $result->get_status() );
-		$this->assertSame( $schedule_id, $result->get_data() );
-
-		$this->assertArrayHasKey( $schedule_id, wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK ) );
-		$this->assertSame( 1, self::get_sync_counter() );
-		$this->assertSame( 1, self::$scheduled_counter );
-
-		$plugins[] = 'wp-test-plugin/wp-test-plugin.php';
-		$request   = new WP_REST_Request( 'PUT', '/wpcom/v2/update-schedules/' . $schedule_id );
-		$request->set_body_params(
-			array(
-				'plugins'  => $plugins,
-				'schedule' => $this->get_schedule(),
-			)
-		);
-
-		$result      = rest_do_request( $request );
-		$schedule_id = Scheduled_Updates::generate_schedule_id( $plugins );
-
-		$this->assertSame( 200, $result->get_status() );
-		$this->assertArrayHasKey( $schedule_id, wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK ) );
-		$this->assertSame( 2, self::get_sync_counter() );
-		$this->assertSame( 2, self::$scheduled_counter );
-		$this->assertSame( 2, self::$transients_added );
-
-		// Insert a full cron sync event.
-		wp_schedule_event( time(), 'jetpack_sync_interval', 'jetpack_sync_full_cron' );
-
-		$request = new WP_REST_Request( 'GET', '/wpcom/v2/update-schedules' );
-		$result  = rest_do_request( $request );
-
-		$this->assertSame( 200, $result->get_status() );
-	}
-
-	/**
 	 * A callback run when an option is added.
 	 *
 	 * @param string $option Name of the added option.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes: https://github.com/Automattic/wp-calypso/issues/90627
Context: p1715613932876249-slack-C01A60HCGUA

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Force a cache clear the first ten seconds after a schedule creation, so that scheduled events at the same second will obtain a fresh cache and not previous value
* `jetpack_scheduled_update_updated` is run only on successful scheduled event creation

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add this branch to Jetpack Beta
* Quickly add/create/modify a scheduled update. Better when the clock is near second zero (08:00:57 -> 08:01:03, etc.)
* Ensure everything is ok