### PR TITLE
Jetpack Sync: Fix undefined array key Warnings in HPOS orders module

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-hpos-warnings
+++ b/projects/packages/sync/changelog/fix-sync-hpos-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Sync: Fixed undefined array key Warnings in HPOS orders module

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -262,7 +262,7 @@ class WooCommerce_HPOS_Orders extends Module {
 			 *
 			 * @see Automattic\Jetpack\Sync\Functions::json_wrap as the return value of get_object_vars can vary depending on PHP version.
 			 */
-			if ( in_array( $key, array( 'date_created', 'date_modified', 'date_paid', 'date_completed' ), true ) ) {
+			if ( in_array( $key, array( 'date_created', 'date_modified', 'date_paid', 'date_completed' ), true ) && isset( $order_data[ $key ] ) ) {
 				if ( is_a( $order_data[ $key ], 'WC_DateTime' ) ) {
 					$filtered_order_data[ $key ] = (object) (array) $order_data[ $key ];
 					continue;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes undefined array key Warnings in HPOS orders module.
When attempting to refund an order, we get the following Warnings from `class-woocommerce-hpos-orders.php`:
- Undefined array key "date_completed"
- Undefined array key "date_paid"

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders`: In `filter_order_data` we ensure that the corresponding key exists in the order data before attempting to convert WC_DateTime objects to stdClass objects 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1715736086889879/1715690616.152789-slack-C011ENB20Q1
p1715765300344019/1714134001.874539-slack-CGGCLBN58

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using JN create a new site with the Jetpack plugin on the current branch (via Jetpack Beta) and WooPayments active
* Try to refund an order (There's a video on how to reproduce this in the linked product discussions in case you are not familiar)
* Confirm the Warnings mentioned above are present on trunk but not present with the current branch