### PR TITLE
SSO: even better accessibility on tooltip

### DIFF
--- a/projects/packages/connection/changelog/fix-sso-better_accessibility_on_tooltip
+++ b/projects/packages/connection/changelog/fix-sso-better_accessibility_on_tooltip
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Follow-on to #37302 to improve accessibility.
+
+

--- a/projects/packages/connection/changelog/fix-sso-better_accessibility_on_tooltip
+++ b/projects/packages/connection/changelog/fix-sso-better_accessibility_on_tooltip
@@ -1,5 +1,5 @@
 Significance: patch
-Type: other
+Type: fixed
 Comment: Follow-on to #37302 to improve accessibility.
 
 

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.8.2';
+	const PACKAGE_VERSION = '2.8.3-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/sso/jetpack-sso-users.js
+++ b/projects/packages/connection/src/sso/jetpack-sso-users.js
@@ -52,8 +52,13 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 	/**
 	 * Remove the SSO invitation tooltip textbox.
+	 *
+	 * @param {Event} event - Triggering event.
 	 */
-	function removeSSOInvitationTooltip() {
+	function removeSSOInvitationTooltip( event ) {
+		if ( document.activeElement === event.target ) {
+			return;
+		}
 		this.querySelector( '.jetpack-sso-invitation-tooltip' ).style.display = 'none';
 	}
 } );

--- a/projects/packages/connection/src/sso/jetpack-sso-users.js
+++ b/projects/packages/connection/src/sso/jetpack-sso-users.js
@@ -27,6 +27,10 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			 * Remove the tooltip textbox.
 			 */
 			function removeTooltip() {
+				// Only remove tooltip if the element isn't currently active.
+				if ( document.activeElement === tooltip ) {
+					return;
+				}
 				tooltip.removeChild( tooltipTextbox );
 			}
 		} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #37302, we added accessibility to tooltips. Yay!

One small edge case failure I noticed when smoke testing is that if one does a mouseover on the tooltip that was activated by element focus, the tooltip disappears. This could be particularly frustrating if someone uses a screen reader bumps their mouse in a way that triggers the edge case.

This PR ensures the tooltip is persistent while the element is in focus with a check using `document.activeElement` prior to removing the tooltip.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure SSO is enabled: `/wp-admin/admin.php?page=jetpack_modules`
2. Go to the WP Users page: `/wp-admin/users.php`
3. Tab to the "SSO Status" column header (hint: if you click the "Posts" column header first, it's just one tab). The tooltip will appear.
4. Pass your mouse over and off the "SSO Status" column header.

In `trunk`, the tooltip will disappear.

In the `fix/sso/better_accessibility_on_tooltip` branch, the tooltip will remain active. Tabbing/changing focus to a different element will continue to remove the tooltip.