### PR TITLE
Jetpack plugin structure: Revert esc_html which will break links in deprecated Identity crisis package

### DIFF
--- a/projects/packages/identity-crisis/changelog/update-escape-echoed-variables-properly
+++ b/projects/packages/identity-crisis/changelog/update-escape-echoed-variables-properly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Removed esc_html on echoes with links

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -635,11 +635,11 @@ class Identity_Crisis {
 		<div class="jp-idc-notice__first-step">
 			<div class="jp-idc-notice__content-header">
 				<h3 class="jp-idc-notice__content-header__lead">
-					<?php echo esc_html( $this->get_first_step_header_lead() ); ?>
+					<?php echo $this->get_first_step_header_lead(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</h3>
 
 				<p class="jp-idc-notice__content-header__explanation">
-					<?php echo esc_html( $this->get_first_step_header_explanation() ); ?>
+					<?php echo $this->get_first_step_header_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				</p>
 			</div>
 
@@ -648,7 +648,7 @@ class Identity_Crisis {
 			<div class="jp-idc-notice__actions">
 				<div class="jp-idc-notice__action">
 					<p class="jp-idc-notice__action__explanation">
-						<?php echo esc_html( $this->get_confirm_safe_mode_action_explanation() ); ?>
+						<?php echo $this->get_confirm_safe_mode_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</p>
 					<button id="jp-idc-confirm-safe-mode-action" class="dops-button">
 						<?php echo esc_html( $this->get_confirm_safe_mode_button_text() ); ?>
@@ -657,7 +657,7 @@ class Identity_Crisis {
 
 				<div class="jp-idc-notice__action">
 					<p class="jp-idc-notice__action__explanation">
-						<?php echo esc_html( $this->get_first_step_fix_connection_action_explanation() ); ?>
+						<?php echo $this->get_first_step_fix_connection_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</p>
 					<button id="jp-idc-fix-connection-action" class="dops-button">
 						<?php echo esc_html( $this->get_first_step_fix_connection_button_text() ); ?>
@@ -690,7 +690,7 @@ class Identity_Crisis {
 			<div class="jp-idc-notice__actions">
 				<div class="jp-idc-notice__action">
 					<p class="jp-idc-notice__action__explanation">
-						<?php echo esc_html( $this->get_migrate_site_action_explanation() ); ?>
+						<?php echo $this->get_migrate_site_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</p>
 					<button id="jp-idc-migrate-action" class="dops-button">
 						<?php echo esc_html( $this->get_migrate_site_button_text() ); ?>
@@ -699,7 +699,7 @@ class Identity_Crisis {
 
 				<div class="jp-idc-notice__action">
 					<p class="jp-idc-notice__action__explanation">
-						<?php echo esc_html( $this->get_start_fresh_action_explanation() ); ?>
+						<?php echo $this->get_start_fresh_action_explanation(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</p>
 					<button id="jp-idc-reconnect-site-action" class="dops-button">
 						<?php echo esc_html( $this->get_start_fresh_button_text() ); ?>
@@ -709,7 +709,7 @@ class Identity_Crisis {
 			</div>
 
 			<p class="jp-idc-notice__unsure-prompt">
-				<?php echo esc_html( $this->get_unsure_prompt() ); ?>
+				<?php echo $this->get_unsure_prompt(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</p>
 		</div>
 		<?php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/339
Fallback from #37395 
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* As explained by this [comment](https://github.com/Automattic/jetpack/pull/37395#discussion_r1601972676) some of the escaped messages included links that get broken by using `esc_html`.
* Reverted the changes for the ones that had links in them and added the `phpcs:ignore` for now.



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Not much to test.

