### PR TITLE
Assets: Updating phpcs:ignore comments to better explain why the ignores are in place

### DIFF
--- a/projects/packages/assets/changelog/update-assets-phpcs-ignore-comments-i18n
+++ b/projects/packages/assets/changelog/update-assets-phpcs-ignore-comments-i18n
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Updating a phpcs:ignore comment
+
+

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -651,7 +651,7 @@ class Assets {
 	 */
 	public static function filter_gettext( $translation, $text, $domain ) {
 		if ( $translation === $text ) {
-			// phpcs:ignore WordPress.WP.I18n -- his is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
+			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See p2gHKz-oRh-p2#problem-6-text-domains-in-composer-packages
 			$newtext = __( $text, self::$domain_map[ $domain ][0] );
 			if ( $newtext !== $text ) {
 				return $newtext;
@@ -673,7 +673,7 @@ class Assets {
 	 */
 	public static function filter_ngettext( $translation, $single, $plural, $number, $domain ) {
 		if ( $translation === $single || $translation === $plural ) {
-			// phpcs:ignore WordPress.WP.I18n -- his is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
+			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See p2gHKz-oRh-p2#problem-6-text-domains-in-composer-packages
 			$translation = _n( $single, $plural, $number, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;
@@ -691,7 +691,7 @@ class Assets {
 	 */
 	public static function filter_gettext_with_context( $translation, $text, $context, $domain ) {
 		if ( $translation === $text ) {
-			// phpcs:ignore WordPress.WP.I18n -- his is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
+			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See p2gHKz-oRh-p2#problem-6-text-domains-in-composer-packages
 			$translation = _x( $text, $context, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;
@@ -711,7 +711,7 @@ class Assets {
 	 */
 	public static function filter_ngettext_with_context( $translation, $single, $plural, $number, $context, $domain ) {
 		if ( $translation === $single || $translation === $plural ) {
-			// phpcs:ignore WordPress.WP.I18n -- his is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
+			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See p2gHKz-oRh-p2#problem-6-text-domains-in-composer-packages
 			$translation = _nx( $single, $plural, $number, $context, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -651,7 +651,7 @@ class Assets {
 	 */
 	public static function filter_gettext( $translation, $text, $domain ) {
 		if ( $translation === $text ) {
-			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See p2gHKz-oRh-p2#problem-6-text-domains-in-composer-packages
+			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
 			$newtext = __( $text, self::$domain_map[ $domain ][0] );
 			if ( $newtext !== $text ) {
 				return $newtext;
@@ -673,7 +673,7 @@ class Assets {
 	 */
 	public static function filter_ngettext( $translation, $single, $plural, $number, $domain ) {
 		if ( $translation === $single || $translation === $plural ) {
-			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See p2gHKz-oRh-p2#problem-6-text-domains-in-composer-packages
+			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
 			$translation = _n( $single, $plural, $number, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;
@@ -691,7 +691,7 @@ class Assets {
 	 */
 	public static function filter_gettext_with_context( $translation, $text, $context, $domain ) {
 		if ( $translation === $text ) {
-			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See p2gHKz-oRh-p2#problem-6-text-domains-in-composer-packages
+			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
 			$translation = _x( $text, $context, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;
@@ -711,7 +711,7 @@ class Assets {
 	 */
 	public static function filter_ngettext_with_context( $translation, $single, $plural, $number, $context, $domain ) {
 		if ( $translation === $single || $translation === $plural ) {
-			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See p2gHKz-oRh-p2#problem-6-text-domains-in-composer-packages
+			// phpcs:ignore WordPress.WP.I18n -- This is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
 			$translation = _nx( $single, $plural, $number, $context, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -651,7 +651,7 @@ class Assets {
 	 */
 	public static function filter_gettext( $translation, $text, $domain ) {
 		if ( $translation === $text ) {
-			// phpcs:ignore WordPress.WP.I18n -- we're including text domains from the most recent dependency package versions, of which there are generally a fair number, to ensure we have the most recent translations.
+			// phpcs:ignore WordPress.WP.I18n -- his is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
 			$newtext = __( $text, self::$domain_map[ $domain ][0] );
 			if ( $newtext !== $text ) {
 				return $newtext;
@@ -673,7 +673,7 @@ class Assets {
 	 */
 	public static function filter_ngettext( $translation, $single, $plural, $number, $domain ) {
 		if ( $translation === $single || $translation === $plural ) {
-			// phpcs:ignore WordPress.WP.I18n -- we're including text domains from the most recent dependency package versions, of which there are generally a fair number, to ensure we have the most recent translations.
+			// phpcs:ignore WordPress.WP.I18n -- his is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
 			$translation = _n( $single, $plural, $number, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;
@@ -691,7 +691,7 @@ class Assets {
 	 */
 	public static function filter_gettext_with_context( $translation, $text, $context, $domain ) {
 		if ( $translation === $text ) {
-			// phpcs:ignore WordPress.WP.I18n -- we're including text domains from the most recent dependency package versions, of which there are generally a fair number, to ensure we have the most recent translations.
+			// phpcs:ignore WordPress.WP.I18n -- his is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
 			$translation = _x( $text, $context, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;
@@ -711,7 +711,7 @@ class Assets {
 	 */
 	public static function filter_ngettext_with_context( $translation, $single, $plural, $number, $context, $domain ) {
 		if ( $translation === $single || $translation === $plural ) {
-			// phpcs:ignore WordPress.WP.I18n -- we're including text domains from the most recent dependency package versions, of which there are generally a fair number, to ensure we have the most recent translations.
+			// phpcs:ignore WordPress.WP.I18n -- his is a filter hook to map the text domains from our Composer packages to the domain for a containing plugin. See https://wp.me/p2gHKz-oRh#problem-6-text-domains-in-composer-packages
 			$translation = _nx( $single, $plural, $number, $context, self::$domain_map[ $domain ][0] );
 		}
 		return $translation;


### PR DESCRIPTION

Follow-up to https://github.com/Automattic/jetpack/pull/37397

## Proposed changes:

* This PR updates some phpcs:ignore comments based on a post-merge review of the above PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See https://github.com/Automattic/jetpack/pull/37397#discussion_r1601966094

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Proof-read.

