### PR TITLE
Remove plugins check on WPCOM environment

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-wpcom-installed-plugins
+++ b/projects/packages/scheduled-updates/changelog/fix-wpcom-installed-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove plugins check on WPCOM environment

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -399,7 +399,9 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 			return $result;
 		}
 
-		$installed_plugins = array_filter( $plugins, array( $this, 'is_plugin_installed' ) );
+		// We don't need to check if plugins are installed if we're on WPCOM.
+		$installed_plugins = defined( 'IS_WPCOM' ) && IS_WPCOM ? $plugins : array_filter( $plugins, array( $this, 'is_plugin_installed' ) );
+
 		if ( empty( $installed_plugins ) ) {
 			add_filter( 'rest_request_after_callbacks', array( $this, 'transform_error_response' ) );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Context p1715846525119559-slack-C01A60HCGUA

https://github.com/Automattic/jetpack/pull/37291 broke WPCOM passthrough API. The new `is_managed_plugin` check performed in `validate_plugins_param` always returns false when run on WPCOM (do not find the files).

The `WP_Error` spawned during validation blocks this passthrough pair:

1. `WPCOM_REST_API_V2_Endpoint_Update_Schedules::create_item`
2. `WPCOM_REST_API_V2_Endpoint_Update_Schedules::update_item`

An error passed to `WPCOM_REST_API_V2_Jetpack_Bridge::proxy_jetpack` blocks the procedure and so the `Jetpack_Client::remote_request` call is never performed in the target WoA site.

This PR makes a quick fix that prevents the function from running if it is not on the WoA site. The check made on the target site is enough.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a WPCOM check in the validate plugins function

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*