### PR TITLE
Backport mu-wpcom-plugin 2.1.26 Changes

### DIFF
--- a/projects/js-packages/api/CHANGELOG.md
+++ b/projects/js-packages/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.17.7] - 2024-05-16
+### Changed
+- Updated package dependencies. [#37379]
+
 ## [0.17.6] - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]
@@ -326,6 +330,7 @@
 - Add the API methods left behind by the previous PR.
 - Initial release of jetpack-api package
 
+[0.17.7]: https://github.com/Automattic/jetpack-api/compare/v0.17.6...v0.17.7
 [0.17.6]: https://github.com/Automattic/jetpack-api/compare/v0.17.5...v0.17.6
 [0.17.5]: https://github.com/Automattic/jetpack-api/compare/v0.17.4...v0.17.5
 [0.17.4]: https://github.com/Automattic/jetpack-api/compare/v0.17.3...v0.17.4

--- a/projects/js-packages/api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/api/package.json
+++ b/projects/js-packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-api",
-	"version": "0.17.7-alpha",
+	"version": "0.17.7",
 	"description": "Jetpack Api Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/api/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.25] - 2024-05-16
+### Changed
+- Updated package dependencies. [#37379]
+
 ## [0.6.24] - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]
@@ -281,6 +285,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.25]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.24...0.6.25
 [0.6.24]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.23...0.6.24
 [0.6.23]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.22...0.6.23
 [0.6.22]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.21...0.6.22

--- a/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/base-styles/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.25-alpha",
+	"version": "0.6.25",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/boost-score-api/CHANGELOG.md
+++ b/projects/js-packages/boost-score-api/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.30] - 2024-05-16
+### Changed
+- Updated package dependencies. [#37379]
+
 ## [0.1.29] - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]
@@ -131,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create package for the boost score bar API [#30781]
 
+[0.1.30]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.29...v0.1.30
 [0.1.29]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.28...v0.1.29
 [0.1.28]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/Automattic/jetpack-boost-score-api/compare/v0.1.26...v0.1.27

--- a/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/boost-score-api/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/boost-score-api/package.json
+++ b/projects/js-packages/boost-score-api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-boost-score-api",
-	"version": "0.1.30-alpha",
+	"version": "0.1.30",
 	"description": "A package to get the Jetpack Boost score of a site",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/boost-score-api/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.53.3] - 2024-05-16
+### Added
+- Social | Wired up confirmation UI with connect button [#37295]
+
+### Changed
+- Updated package dependencies. [#37379]
+- Updated package dependencies. [#37380]
+- Updated package dependencies. [#37382]
+
 ## [0.53.2] - 2024-05-13
 ### Added
 - Added --jp-gray-5 as an alias of --jp-gray to the theme [#37327]
@@ -1030,6 +1039,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.53.3]: https://github.com/Automattic/jetpack-components/compare/0.53.2...0.53.3
 [0.53.2]: https://github.com/Automattic/jetpack-components/compare/0.53.1...0.53.2
 [0.53.1]: https://github.com/Automattic/jetpack-components/compare/0.53.0...0.53.1
 [0.53.0]: https://github.com/Automattic/jetpack-components/compare/0.52.1...0.53.0

--- a/projects/js-packages/components/changelog/add-social-account-connect
+++ b/projects/js-packages/components/changelog/add-social-account-connect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Social | Wired up confirmation UI with connect button

--- a/projects/js-packages/components/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/components/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/renovate-react-monorepo
+++ b/projects/js-packages/components/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.53.3-alpha",
+	"version": "0.53.3",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.51] - 2024-05-16
+### Changed
+- Updated package dependencies. [#37379]
+
 ## [2.0.50] - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]
@@ -229,6 +233,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.51]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.50...v2.0.51
 [2.0.50]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.49...v2.0.50
 [2.0.49]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.48...v2.0.49
 [2.0.48]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.47...v2.0.48

--- a/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/i18n-loader-webpack-plugin/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.51-alpha",
+	"version": "2.0.51",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/i18n-loader-webpack-plugin/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 0.10.72 - 2024-05-16
+### Changed
+- Updated package dependencies. [#37379]
+- Updated package dependencies. [#37380]
+
 ## 0.10.71 - 2024-05-08
 ### Changed
 - Update dependencies.

--- a/projects/js-packages/idc/changelog/renovate-react-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/idc/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "0.10.72-alpha",
+	"version": "0.10.72",
 	"description": "Jetpack Connection Component",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.2.6 - 2024-05-16
+### Changed
+- Updated package dependencies. [#37379]
+
 ## 3.2.5 - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]

--- a/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/webpack-config/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.2.6-alpha",
+	"version": "3.2.6",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.10] - 2024-05-16
+### Added
+- Assets: Adding comments to explain why we use variables within translation functions [#37397]
+
+### Changed
+- Updated package dependencies. [#37379]
+
 ## [2.1.9] - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]
@@ -439,6 +446,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[2.1.10]: https://github.com/Automattic/jetpack-assets/compare/v2.1.9...v2.1.10
 [2.1.9]: https://github.com/Automattic/jetpack-assets/compare/v2.1.8...v2.1.9
 [2.1.8]: https://github.com/Automattic/jetpack-assets/compare/v2.1.7...v2.1.8
 [2.1.7]: https://github.com/Automattic/jetpack-assets/compare/v2.1.6...v2.1.7

--- a/projects/packages/assets/changelog/add-a4a-plugin-package-text-domain-i18n-comment
+++ b/projects/packages/assets/changelog/add-a4a-plugin-package-text-domain-i18n-comment
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Assets: Adding comments to explain why we use variables within translation functions

--- a/projects/packages/assets/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/assets/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.2] - 2024-05-16
+### Added
+- Connection: Ensuring direct file access is disabled in class-jetpack-ixr-client.php [#37398]
+
+### Changed
+- Updated package dependencies. [#37379]
+
 ## [2.8.1] - 2024-05-14
 ### Changed
 - SSO: do not rely on the Jetpack class anymore. [#37153]
@@ -1062,6 +1069,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.8.2]: https://github.com/Automattic/jetpack-connection/compare/v2.8.1...v2.8.2
 [2.8.1]: https://github.com/Automattic/jetpack-connection/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/Automattic/jetpack-connection/compare/v2.7.7...v2.8.0
 [2.7.7]: https://github.com/Automattic/jetpack-connection/compare/v2.7.6...v2.7.7

--- a/projects/packages/connection/changelog/add-connection-file-access
+++ b/projects/packages/connection/changelog/add-connection-file-access
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Connection: Ensuring direct file access is disabled in class-jetpack-ixr-client.php

--- a/projects/packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.8.2-alpha';
+	const PACKAGE_VERSION = '2.8.2';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.0] - 2024-05-16
+### Added
+- IDC: Added escapes to echo statements [#37395]
+
+### Changed
+- Updated package dependencies. [#37379]
+- Updated package dependencies. [#37380]
+
 ## [0.18.6] - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]
@@ -547,6 +555,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.19.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.6...v0.19.0
 [0.18.6]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.5...v0.18.6
 [0.18.5]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.4...v0.18.5
 [0.18.4]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.3...v0.18.4

--- a/projects/packages/identity-crisis/changelog/renovate-react-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/identity-crisis/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/identity-crisis/changelog/update-escape-echoed-variables
+++ b/projects/packages/identity-crisis/changelog/update-escape-echoed-variables
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-IDC: Added escapes to echo statements

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.19.0-alpha",
+	"version": "0.19.0",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -26,7 +26,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.19.0-alpha';
+	const PACKAGE_VERSION = '0.19.0';
 
 	/**
 	 * Package Slug

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.31.0] - 2024-05-16
+### Added
+- Admin Interface Style: Add the track event when the value is changed [#37373]
+- WordPress.com Features: Add wp-admin sync with Calypso locale [#37352]
+
+### Changed
+- Remove the need to have posts published in the ai-assembler launchpad [#36942]
+- Updated package dependencies. [#37379]
+
+### Fixed
+- Untangling: correctly show the All Sites menu in the top bar [#37393]
+- Verbum Comments: translate block editor [#37367]
+
 ## [5.30.0] - 2024-05-14
 ### Added
 - WordPress.com Features: Calypso Locale Sync from wp-admin to Calypso [#37316]
@@ -806,6 +819,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.31.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.30.0...v5.31.0
 [5.30.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.29.1...v5.30.0
 [5.29.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.29.0...v5.29.1
 [5.29.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.28.0...v5.29.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-sync-wp-admin-with-calypso-locale
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-sync-wp-admin-with-calypso-locale
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-WordPress.com Features: Add wp-admin sync with Calypso locale

--- a/projects/packages/jetpack-mu-wpcom/changelog/ai-assembler-flow-without-first-post
+++ b/projects/packages/jetpack-mu-wpcom/changelog/ai-assembler-flow-without-first-post
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Remove the need to have posts published in the ai-assembler launchpad

--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-track-wpcom-admin-interface-changed
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-track-wpcom-admin-interface-changed
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Admin Interface Style: Add the track event when the value is changed

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-editor-translations
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-editor-translations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Verbum Comments: translate block editor

--- a/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jetpack-mu-wpcom/changelog/untangling-all-sites-menu-fix
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangling-all-sites-menu-fix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Untangling: correctly show the All Sites menu in the top bar

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.31.0-alpha",
+	"version": "5.31.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.31.0-alpha';
+	const PACKAGE_VERSION = '5.31.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.11] - 2024-05-16
+### Changed
+- Updated package dependencies. [#37379]
+
 ## [3.1.10] - 2024-05-06
 ### Changed
 - Updated package dependencies. [#37147]
@@ -719,6 +723,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.1.11]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.10...v3.1.11
 [3.1.10]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.9...v3.1.10
 [3.1.9]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.8...v3.1.9
 [3.1.8]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.7...v3.1.8

--- a/projects/packages/jitm/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jitm/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.1.11-alpha';
+	const PACKAGE_VERSION = '3.1.11';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1] - 2024-05-16
+### Changed
+- Moves install/managed check for plugins into API endpoint validation callback [#37291]
+
+### Fixed
+- Remove plugins check on WPCOM environment [#37416]
+
 ## [0.12.0] - 2024-05-09
 ### Changed
 - Scheduled Updates: Verify plugins when creating a schedule [#37235]
@@ -167,6 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.12.1]: https://github.com/Automattic/scheduled-updates/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Automattic/scheduled-updates/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Automattic/scheduled-updates/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/Automattic/scheduled-updates/compare/v0.9.1...v0.10.0

--- a/projects/packages/scheduled-updates/changelog/fix-wpcom-installed-plugins
+++ b/projects/packages/scheduled-updates/changelog/fix-wpcom-installed-plugins
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Remove plugins check on WPCOM environment

--- a/projects/packages/scheduled-updates/changelog/update-plugin-validation
+++ b/projects/packages/scheduled-updates/changelog/update-plugin-validation
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Moves install/managed check for plugins into API endpoint validation callback

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.12.1-alpha';
+	const PACKAGE_VERSION = '0.12.1';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.3] - 2024-05-16
+### Fixed
+- Jetpack Sync: Fixed undefined array key Warnings in HPOS orders module [#37401]
+
 ## [2.16.2] - 2024-05-14
 ### Fixed
 - Fix phpdoc type on `Replicastore_Interface::get_term()` `$taxonomy` arg. [#37344]
@@ -1144,6 +1148,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.16.3]: https://github.com/Automattic/jetpack-sync/compare/v2.16.2...v2.16.3
 [2.16.2]: https://github.com/Automattic/jetpack-sync/compare/v2.16.1...v2.16.2
 [2.16.1]: https://github.com/Automattic/jetpack-sync/compare/v2.16.0...v2.16.1
 [2.16.0]: https://github.com/Automattic/jetpack-sync/compare/v2.15.1...v2.16.0

--- a/projects/packages/sync/changelog/fix-sync-hpos-warnings
+++ b/projects/packages/sync/changelog/fix-sync-hpos-warnings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack Sync: Fixed undefined array key Warnings in HPOS orders module

--- a/projects/packages/sync/changelog/update-escape-echoed-variables
+++ b/projects/packages/sync/changelog/update-escape-echoed-variables
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Just a minor comment
-
-

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.16.3-alpha';
+	const PACKAGE_VERSION = '2.16.3';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.26 - 2024-05-16
+### Changed
+- Updated package dependencies. [#37348]
+
 ## 2.1.25 - 2024-05-14
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-sync-wp-admin-with-calypso-locale
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-sync-wp-admin-with-calypso-locale
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-sync-wp-admin-with-calypso-locale#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-sync-wp-admin-with-calypso-locale#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/ai-assembler-flow-without-first-post
+++ b/projects/plugins/mu-wpcom-plugin/changelog/ai-assembler-flow-without-first-post
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-escape-echoed-variables
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-escape-echoed-variables
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_26_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_26"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.26-alpha
+ * Version: 2.1.26
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.26-alpha",
+	"version": "2.1.26",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.26

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.