### PR TITLE
Fix: set plugins parameter as required to prevent internal errors

### DIFF
--- a/projects/packages/scheduled-updates/changelog/fix-plugins-param-default
+++ b/projects/packages/scheduled-updates/changelog/fix-plugins-param-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add plugins field default

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.12.1';
+	const PACKAGE_VERSION = '0.12.2-alpha';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -491,7 +491,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	public function validate_schedule( $request ) {
 		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
 
-		$plugins = $request['plugins'];
+		$plugins = $request['plugins'] ?? array();
 		usort( $plugins, 'strnatcasecmp' );
 
 		foreach ( $events as $key => $event ) {

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -176,7 +176,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		}
 
 		$schedule = $request['schedule'];
-		$plugins  = $request['plugins'] ?? array();
+		$plugins  = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );
 
 		$event = Scheduled_Updates::create_scheduled_update( $schedule['timestamp'], $schedule['interval'], $plugins );
@@ -491,7 +491,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 	public function validate_schedule( $request ) {
 		$events = wp_get_scheduled_events( Scheduled_Updates::PLUGIN_CRON_HOOK );
 
-		$plugins = $request['plugins'] ?? array();
+		$plugins = $request['plugins'];
 		usort( $plugins, 'strnatcasecmp' );
 
 		foreach ( $events as $key => $event ) {
@@ -592,6 +592,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 					'description' => 'List of plugin slugs to update.',
 					'type'        => 'array',
 					'maxItems'    => 10,
+					'required'    => true,
 					'arg_options' => array(
 						'validate_callback' => array( $this, 'validate_plugins_param' ),
 					),

--- a/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
+++ b/projects/packages/scheduled-updates/src/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-update-schedules.php
@@ -176,7 +176,7 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules extends WP_REST_Controller {
 		}
 
 		$schedule = $request['schedule'];
-		$plugins  = $request['plugins'];
+		$plugins  = $request['plugins'] ?? array();
 		usort( $plugins, 'strnatcasecmp' );
 
 		$event = Scheduled_Updates::create_scheduled_update( $schedule['timestamp'], $schedule['interval'], $plugins );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7222

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Set `plugins` parameter as required to prevent internal errors

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use `fix/plugins-param-default` for WordPress.com Features
* With the REST API plugin (not the API console) on `/wp-admin/tools.php?page=rest_api_console` do:

```
POST /wpcom/v2/update-schedules?schedule[interval]=daily&schedule[timestamp]=1715849595
```

Ensure no `internal_server_error: <p>There has been a critical error on this website.</p><p><a href=\"https://wordpress.org/documentation/article/faq-troubleshooting/\">Learn more about troubleshooting WordPress.</a></p>` is spawned, but `Missing parameter(s): plugins`.
