### PR TITLE
Stats: Use user language instead of site language for translations

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-stats-locale
+++ b/projects/packages/stats-admin/changelog/fix-stats-locale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Use user language instead of site language for translations 

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.19.1",
+	"version": "0.19.2-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.19.1';
+	const VERSION = '0.19.2-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -50,7 +50,7 @@ class Odyssey_Config_Data {
 			'google_maps_and_places_api_key' => '',
 			'hostname'                       => wp_parse_url( get_site_url(), PHP_URL_HOST ),
 			'i18n_default_locale_slug'       => 'en',
-			'i18n_locale_slug'               => $this->get_site_locale(),
+			'i18n_locale_slug'               => $this->get_user_locale(),
 			'mc_analytics_enabled'           => false,
 			'meta'                           => array(),
 			'nonce'                          => wp_create_nonce( 'wp_rest' ),
@@ -158,13 +158,13 @@ class Odyssey_Config_Data {
 	/**
 	 * Get locale acceptable by Calypso.
 	 */
-	protected function get_site_locale() {
+	protected function get_user_locale() {
 		/**
 		 * In WP, locales are formatted as LANGUAGE_REGION, for example `en`, `en_US`, `es_AR`,
 		 * but Calypso expects language-region, e.g. `en-us`, `en`,  `es-ar`. So we need to convert
 		 * them to lower case and replace the underscore with a dash.
 		 */
-		$locale = strtolower( get_locale() );
+		$locale = strtolower( get_user_locale() );
 		$locale = str_replace( '_', '-', $locale );
 
 		return $locale;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6506

## Proposed changes:

Loads the translations for Stats with the user language instead of the site language so the UI is translated consistently with the rest of WP Admin.

Before | After
--- | ---
<img width="1278" alt="Screenshot 2024-05-16 at 15 39 26" src="https://github.com/Automattic/jetpack/assets/1233880/b183276b-5570-47b8-b02e-00bdd3653807"> | <img width="1278" alt="Screenshot 2024-05-16 at 15 39 45" src="https://github.com/Automattic/jetpack/assets/1233880/1df2b061-7be2-4965-bc80-2cc7ff747332">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your site
- Go to `/wp-admin/profile.php` 
- Change your user language to a language that is not the same as the site language (you can check your site language in `/wp-admin/options-general.php`)
- Go to `/wp-admin/admin.php?page=stats`
- Make sure the UI is translated for your user language

