### PR TITLE
Scheduled Updates: Add unit test to avoid error when submitting schedules without plugins parameter

### DIFF
--- a/projects/packages/scheduled-updates/changelog/add-test-empty-plugins
+++ b/projects/packages/scheduled-updates/changelog/add-test-empty-plugins
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added unit test
+
+

--- a/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
+++ b/projects/packages/scheduled-updates/tests/php/class-wpcom-rest-api-v2-endpoint-update-schedules-test.php
@@ -298,6 +298,22 @@ class WPCOM_REST_API_V2_Endpoint_Update_Schedules_Test extends \WorDBless\BaseTe
 	}
 
 	/**
+	 * Can't submit a schedule without plugins parameter.
+	 *
+	 * @covers ::register_routes
+	 */
+	public function test_creating_schedule_without_plugins_parameter() {
+		$request = new WP_REST_Request( 'POST', '/wpcom/v2/update-schedules' );
+		$request->set_body_params( array( 'schedule' => $this->get_schedule() ) );
+
+		wp_set_current_user( $this->admin_id );
+		$result = rest_do_request( $request );
+
+		$this->assertSame( 400, $result->get_status() );
+		$this->assertSame( 'rest_missing_callback_param', $result->get_data()['code'] );
+	}
+
+	/**
 	 * Removes plugins from the autoupdate list when creating a schedule.
 	 *
 	 * @covers ::create_item


### PR DESCRIPTION
Follow up to #37419

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a unit test for the bug that was fixed in #37419.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Automated tests should be enough. This test fails prior to #37419.
