### PR TITLE
Social: Use WPCOM plan feature for connections management

### DIFF
--- a/projects/packages/publicize/changelog/add-social-connections-feature-flag
+++ b/projects/packages/publicize/changelog/add-social-connections-feature-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Changed the connections management feature flag check to include the WPCOM plan feature

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1995,6 +1995,15 @@ abstract class Publicize_Base {
 	}
 
 	/**
+	 * Check if the new connections management is enabled is enabled.
+	 *
+	 * @return bool
+	 */
+	public function has_connections_management_feature() {
+		return Current_Plan::supports( 'social-connections-management' );
+	}
+
+	/**
 	 * Get a list of additional connections that are supported by the current plan.
 	 *
 	 * @return array

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -76,15 +76,16 @@ class Publicize extends Publicize_Base {
 	/**
 	 * Whether to use the v1 admin UI.
 	 */
-	public static function use_admin_ui_v1(): bool {
+	public function use_admin_ui_v1(): bool {
 
 		// If the option is set, use it.
 		if ( get_option( 'jetpack_social_use_admin_ui_v1', false ) ) {
 			return true;
 		}
 
-		// Otherwise, use the constant.
-		return defined( 'JETPACK_SOCIAL_USE_ADMIN_UI_V1' ) && JETPACK_SOCIAL_USE_ADMIN_UI_V1;
+		// Otherwise, check the constant and the plan feature.
+		return ( defined( 'JETPACK_SOCIAL_USE_ADMIN_UI_V1' ) && JETPACK_SOCIAL_USE_ADMIN_UI_V1 )
+			|| $this->has_connections_management_feature();
 	}
 
 	/**
@@ -253,7 +254,7 @@ class Publicize extends Publicize_Base {
 					$user_id = (int) $connection['connection_data']['user_id'];
 					// phpcs:ignore WordPress.PHP.YodaConditions.NotYoda
 					if ( $user_id === 0 || $this->user_id() === $user_id ) {
-						if ( self::use_admin_ui_v1() ) {
+						if ( $this->use_admin_ui_v1() ) {
 							$connections_to_return[] = array_merge(
 								$connection,
 								array(

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -182,13 +182,14 @@ class Settings {
 
 		$settings = $this->get_settings( true );
 
-		$settings['useAdminUiV1'] = $publicize->use_admin_ui_v1();
+		$settings['useAdminUiV1'] = false;
 
 		$settings['is_publicize_enabled'] = false;
 
 		$connection = new Manager();
 
 		if ( ( new Modules() )->is_active( 'publicize' ) && $connection->has_connected_user() ) {
+			$settings['useAdminUiV1']   = $publicize->use_admin_ui_v1();
 			$settings['connectionData'] = array(
 				'connections' => $publicize->get_all_connections_for_user(),
 				'adminUrl'    => esc_url_raw( $publicize->publicize_connections_url( 'jetpack-social-connections-admin-page' ) ),

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -10,7 +10,6 @@ namespace Automattic\Jetpack\Publicize\Jetpack_Social_Settings;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Modules;
-use Automattic\Jetpack\Publicize\Publicize;
 use Automattic\Jetpack\Publicize\Social_Image_Generator\Templates;
 
 /**
@@ -183,7 +182,7 @@ class Settings {
 
 		$settings = $this->get_settings( true );
 
-		$settings['useAdminUiV1'] = Publicize::use_admin_ui_v1();
+		$settings['useAdminUiV1'] = $publicize->use_admin_ui_v1();
 
 		$settings['is_publicize_enabled'] = false;
 


### PR DESCRIPTION
This updates the feature flag check to use the plan feature added in D149018-code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Remove the old connections management constant and/or option to prevent the feature from being active
* Sandbox the API
* Apply the blog sticker to your site as described in D149018-code
* Load the Social admin page twice (the plan refresh happens on the heartbeat, which appears to be after the page render)
* You should see the new connections management.
* Optionally check that removing the blog sticker reverts to the current behaviour.

