### PR TITLE
A4A: Sanitize user inputs

### DIFF
--- a/projects/packages/connection/changelog/fix-a4a-sanitize-validate-escape
+++ b/projects/packages/connection/changelog/fix-a4a-sanitize-validate-escape
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Sanitize user inputs

--- a/projects/packages/connection/legacy/class-jetpack-signature.php
+++ b/projects/packages/connection/legacy/class-jetpack-signature.php
@@ -121,9 +121,18 @@ class Jetpack_Signature {
 		foreach ( array( 'token', 'timestamp', 'nonce', 'body-hash' ) as $parameter ) {
 			if ( isset( $override[ $parameter ] ) ) {
 				$a[ $parameter ] = $override[ $parameter ];
-			} else {
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				$a[ $parameter ] = isset( $_GET[ $parameter ] ) ? filter_var( wp_unslash( $_GET[ $parameter ] ) ) : '';
+			} elseif ( isset( $_GET[ $parameter ] ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				if ( in_array( $parameter, array( 'token', 'nonce', 'body-hash' ), true ) ) {
+					// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
+					$a[ $parameter ] = filter_var( wp_unslash( $_GET[ $parameter ] ), FILTER_SANITIZE_STRING );
+				} elseif ( 'timestamp' === $parameter ) {
+					// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.NonceVerification.Recommended
+					$a[ $parameter ] = filter_var( wp_unslash( $_GET[ $parameter ] ), FILTER_SANITIZE_NUMBER_INT );
+				}
+			} else {
+				$a[ $parameter ] = '';
 			}
 		}
 

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -394,19 +394,19 @@ class Manager {
 		}
 
 		$signature_details = array(
-			'token'     => isset( $_GET['token'] ) ? wp_unslash( $_GET['token'] ) : '',
-			'timestamp' => isset( $_GET['timestamp'] ) ? wp_unslash( $_GET['timestamp'] ) : '',
-			'nonce'     => isset( $_GET['nonce'] ) ? wp_unslash( $_GET['nonce'] ) : '',
-			'body_hash' => isset( $_GET['body-hash'] ) ? wp_unslash( $_GET['body-hash'] ) : '',
-			'method'    => isset( $_SERVER['REQUEST_METHOD'] ) ? wp_unslash( $_SERVER['REQUEST_METHOD'] ) : null,
-			'url'       => wp_unslash( ( isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : null ) . ( isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null ) ), // Temp - will get real signature URL later.
-			'signature' => isset( $_GET['signature'] ) ? wp_unslash( $_GET['signature'] ) : '',
+			'token'     => isset( $_GET['token'] ) ? filter_var( wp_unslash( $_GET['token'] ), FILTER_SANITIZE_STRING ) : '',
+			'timestamp' => isset( $_GET['timestamp'] ) ? filter_var( wp_unslash( $_GET['timestamp'] ), FILTER_SANITIZE_NUMBER_INT ) : '',
+			'nonce'     => isset( $_GET['nonce'] ) ? filter_var( wp_unslash( $_GET['nonce'] ), FILTER_SANITIZE_STRING ) : '',
+			'body_hash' => isset( $_GET['body-hash'] ) ? filter_var( wp_unslash( $_GET['body-hash'] ), FILTER_SANITIZE_STRING ) : '',
+			'method'    => isset( $_SERVER['REQUEST_METHOD'] ) ? filter_var( wp_unslash( $_SERVER['REQUEST_METHOD'] ), FILTER_SANITIZE_STRING ) : null,
+			'url'       => filter_var( wp_unslash( ( isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : null ) . ( isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null ) ), FILTER_SANITIZE_URL ), // Temp - will get real signature URL later.
+			'signature' => isset( $_GET['signature'] ) ? filter_var( wp_unslash( $_GET['signature'] ), FILTER_SANITIZE_STRING ) : '',
 		);
 
 		$error_type = 'xmlrpc';
 
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		@list( $token_key, $version, $user_id ) = explode( ':', wp_unslash( $_GET['token'] ) );
+		@list( $token_key, $version, $user_id ) = explode( ':', filter_var( wp_unslash( $_GET['token'] ), FILTER_SANITIZE_STRING ) );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		$jetpack_api_version = Constants::get_constant( 'JETPACK__API_VERSION' );
@@ -499,8 +499,8 @@ class Manager {
 		}
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$timestamp = (int) $_GET['timestamp'];
-		$nonce     = wp_unslash( (string) $_GET['nonce'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- WP Core doesn't sanitize nonces either.
+		$timestamp = filter_var( wp_unslash( $_GET['timestamp'] ), FILTER_SANITIZE_NUMBER_INT );
+		$nonce     = filter_var( wp_unslash( $_GET['nonce'] ), FILTER_SANITIZE_STRING );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		// Use up the nonce regardless of whether the signature matches.
@@ -518,7 +518,7 @@ class Manager {
 		$signature_details['expected'] = $signature;
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! hash_equals( $signature, wp_unslash( $_GET['signature'] ) ) ) {
+		if ( ! hash_equals( $signature, filter_var( wp_unslash( $_GET['signature'] ), FILTER_SANITIZE_STRING ) ) ) {
 			return new \WP_Error(
 				'signature_mismatch',
 				'Signature mismatch',

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -667,7 +667,7 @@ class REST_Connector {
 		}
 
 		// signature timestamp must be within 5min of current time.
-		if ( abs( time() - (int) $_GET['timestamp'] ) > 300 ) {
+		if ( abs( time() - filter_var( wp_unslash( $_GET['timestamp'] ), FILTER_SANITIZE_NUMBER_INT ) ) > 300 ) {
 			return false;
 		}
 
@@ -675,9 +675,9 @@ class REST_Connector {
 
 		$signature_data = wp_json_encode(
 			array(
-				'rest_route' => filter_var( wp_unslash( $_GET['rest_route'] ) ),
-				'timestamp'  => (int) $_GET['timestamp'],
-				'url'        => filter_var( wp_unslash( $_GET['url'] ) ),
+				'rest_route' => filter_var( wp_unslash( $_GET['rest_route'] ), FILTER_SANITIZE_STRING ),
+				'timestamp'  => filter_var( wp_unslash( $_GET['timestamp'] ), FILTER_SANITIZE_NUMBER_INT ),
+				'url'        => filter_var( wp_unslash( $_GET['url'] ), FILTER_SANITIZE_URL ),
 			)
 		);
 

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -434,7 +434,7 @@ class SSO {
 		$wants_to_login = false;
 
 		// Cover default WordPress behavior.
-		$action = isset( $_REQUEST['action'] ) ? filter_var( wp_unslash( $_REQUEST['action'] ) ) : 'login'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$action = isset( $_REQUEST['action'] ) ? filter_var( wp_unslash( $_REQUEST['action'], FILTER_SANITIZE_STRING ) ) : 'login'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		// And now the exceptions.
 		$action = isset( $_GET['loggedout'] ) ? 'loggedout' : $action; // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/projects/packages/connection/src/sso/class-user-admin.php
+++ b/projects/packages/connection/src/sso/class-user-admin.php
@@ -160,7 +160,7 @@ class User_Admin {
 	 */
 	public function handle_invitation_results() {
 		$valid_nonce = isset( $_GET['_wpnonce'] )
-			? wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'jetpack-sso-invite-user' )
+			? wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'jetpack-sso-invite-user' )
 			: false;
 
 		if ( ! $valid_nonce || ! isset( $_GET['jetpack-sso-invite-user'] ) ) {
@@ -862,7 +862,7 @@ class User_Admin {
 		// check for a valid nonce.
 		if (
 			! isset( $_POST['_wpnonce_create-user'] )
-			|| ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce_create-user'] ), 'create-user' )
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce_create-user'] ) ), 'create-user' )
 		) {
 			return $errors;
 		}

--- a/projects/packages/identity-crisis/changelog/fix-a4a-sanitize-validate-escape
+++ b/projects/packages/identity-crisis/changelog/fix-a4a-sanitize-validate-escape
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Sanitize user inputs

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -194,7 +194,7 @@ class Identity_Crisis {
 		if ( current_user_can( 'jetpack_disconnect' ) ) {
 			if (
 					isset( $_GET['jetpack_idc_clear_confirmation'] ) && isset( $_GET['_wpnonce'] ) &&
-					wp_verify_nonce( $_GET['_wpnonce'], 'jetpack_idc_clear_confirmation' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WordPress core doesn't unslash or verify nonces either.
+					wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'jetpack_idc_clear_confirmation' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WordPress core doesn't unslash or verify nonces either.
 			) {
 				Jetpack_Options::delete_option( 'safe_mode_confirmed' );
 				self::$is_safe_mode_confirmed = false;

--- a/projects/packages/identity-crisis/src/class-ui.php
+++ b/projects/packages/identity-crisis/src/class-ui.php
@@ -107,7 +107,7 @@ class UI {
 			'WP_API_nonce'                   => wp_create_nonce( 'wp_rest' ),
 			'wpcomHomeUrl'                   => ( is_array( $idc_urls ) && array_key_exists( 'wpcom_url', $idc_urls ) ) ? $idc_urls['wpcom_url'] : null,
 			'currentUrl'                     => ( is_array( $idc_urls ) && array_key_exists( 'current_url', $idc_urls ) ) ? $idc_urls['current_url'] : null,
-			'redirectUri'                    => isset( $_SERVER['REQUEST_URI'] ) ? str_replace( '/wp-admin/', '/', filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) : '',
+			'redirectUri'                    => isset( $_SERVER['REQUEST_URI'] ) ? str_replace( '/wp-admin/', '/', filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL ) ) : '',
 			'tracksUserData'                 => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 			'tracksEventData'                => array(
 				'isAdmin'       => $is_admin,
@@ -165,7 +165,7 @@ class UI {
 				continue;
 			}
 
-			if ( isset( $_SERVER['REQUEST_URI'] ) && str_starts_with( filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ) ), $consumer['admin_page'] ) && strlen( $consumer['admin_page'] ) > $consumer_url_length ) {
+			if ( isset( $_SERVER['REQUEST_URI'] ) && str_starts_with( filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL ), $consumer['admin_page'] ) && strlen( $consumer['admin_page'] ) > $consumer_url_length ) {
 				$consumer_chosen     = $consumer;
 				$consumer_url_length = strlen( $consumer['admin_page'] );
 			}

--- a/projects/packages/status/changelog/fix-a4a-sanitize-validate-escape
+++ b/projects/packages/status/changelog/fix-a4a-sanitize-validate-escape
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Sanitize user inputs

--- a/projects/packages/status/src/class-visitor.php
+++ b/projects/packages/status/src/class-visitor.php
@@ -33,12 +33,12 @@ class Visitor {
 			) as $key ) {
 				if ( ! empty( $_SERVER[ $key ] ) ) {
 					// @todo Some of these might actually be lists of IPs (e.g. HTTP_X_FORWARDED_FOR) or something else entirely (HTTP_VIA).
-					return filter_var( wp_unslash( $_SERVER[ $key ] ) );
+					return filter_var( wp_unslash( $_SERVER[ $key ] ), FILTER_SANITIZE_STRING );
 				}
 			}
 		}
 
-		return ! empty( $_SERVER['REMOTE_ADDR'] ) ? filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+		return ! empty( $_SERVER['REMOTE_ADDR'] ) ? filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_SANITIZE_STRING ) : '';
 	}
 
 	/**

--- a/projects/packages/sync/changelog/fix-a4a-sanitize-validate-escape
+++ b/projects/packages/sync/changelog/fix-a4a-sanitize-validate-escape
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Sanitize user inputs

--- a/projects/packages/sync/src/class-dedicated-sender.php
+++ b/projects/packages/sync/src/class-dedicated-sender.php
@@ -86,7 +86,7 @@ class Dedicated_Sender {
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.NonceVerification.Recommended
-		$check_url = self::prepare_url_for_dedicated_request_check( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		$check_url = self::prepare_url_for_dedicated_request_check( filter_var( wp_unslash( $_SERVER['REQUEST_URI'] ), FILTER_SANITIZE_URL ) );
 		if ( strpos( $check_url, 'jetpack/v4/sync/spawn-sync' ) !== false ) {
 			return true;
 		}
@@ -102,7 +102,7 @@ class Dedicated_Sender {
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.NonceVerification.Recommended
-		$check_url = self::prepare_url_for_dedicated_request_check( wp_unslash( $_GET['rest_route'] ) );
+		$check_url = self::prepare_url_for_dedicated_request_check( filter_var( wp_unslash( $_GET['rest_route'] ), FILTER_SANITIZE_STRING ) );
 		if ( strpos( $check_url, 'jetpack/v4/sync/spawn-sync' ) !== false ) {
 			return true;
 		}
@@ -284,7 +284,7 @@ class Dedicated_Sender {
 			return null;
 		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Validation happened above.
 		return wp_unslash( $_GET[ self::DEDICATED_SYNC_REQUEST_LOCK_QUERY_PARAM_NAME ] );
 	}
 

--- a/projects/packages/sync/src/class-listener.php
+++ b/projects/packages/sync/src/class-listener.php
@@ -432,7 +432,7 @@ class Listener {
 			$ip = IP_Utils::get_ip();
 
 			$actor['ip']         = $ip ? $ip : '';
-			$actor['user_agent'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : 'unknown';
+			$actor['user_agent'] = isset( $_SERVER['HTTP_USER_AGENT'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ), FILTER_SANITIZE_STRING ) : 'unknown';
 		}
 
 		return $actor;

--- a/projects/packages/sync/src/modules/class-plugins.php
+++ b/projects/packages/sync/src/modules/class-plugins.php
@@ -314,7 +314,7 @@ class Plugins extends Module {
 			return;
 		}
 
-		if ( ! wp_verify_nonce( $args['nonce'], 'edit-plugin_' . $file ) ) {
+		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $args['nonce'] ) ), 'edit-plugin_' . $file ) ) {
 			return;
 		}
 		$plugins = get_plugins();

--- a/projects/packages/sync/src/modules/class-themes.php
+++ b/projects/packages/sync/src/modules/class-themes.php
@@ -262,7 +262,7 @@ class Themes extends Module {
 			return;
 		}
 
-		if ( ! wp_verify_nonce( $args['nonce'], 'edit-theme_' . $stylesheet . '_' . $file ) ) {
+		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $args['nonce'] ) ), 'edit-theme_' . $stylesheet . '_' . $file ) ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/changelog/fix-a4a-sanitize-validate-escape
+++ b/projects/plugins/jetpack/changelog/fix-a4a-sanitize-validate-escape
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sanitize user input


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/337

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

