### PR TITLE
Untangling: Replace Hosting -> Connections with Marketing

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/untangling-marketing
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangling-marketing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Untangling: Replace Hosting -> Connections with Hosting -> Marketing

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.31.0",
+	"version": "5.31.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.31.0';
+	const PACKAGE_VERSION = '5.31.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -149,10 +149,10 @@ function wpcom_add_wpcom_menu_item() {
 
 	add_submenu_page(
 		$parent_slug,
-		esc_attr__( 'Connections', 'jetpack-mu-wpcom' ),
-		esc_attr__( 'Connections', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Marketing', 'jetpack-mu-wpcom' ),
+		esc_attr__( 'Marketing', 'jetpack-mu-wpcom' ),
 		'manage_options',
-		esc_url( "https://wordpress.com/marketing/connections/$domain" ),
+		esc_url( "https://wordpress.com/marketing/$domain" ),
 		null
 	);
 


### PR DESCRIPTION

Related to:

- https://github.com/Automattic/dotcom-forge/issues/7168
- https://github.com/Automattic/dotcom-forge/issues/6231

## Proposed Changes

This PR restores Calypso's Tools -> Marketing page under Hosting.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the instructions at https://github.com/Automattic/wp-calypso/pull/90835.

