### PR TITLE
Triage: update alert word for Jetpack Developer Ambassadors

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-gardening-jetpack-ha
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-jetpack-ha
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Triage: update alert word for Jetpack Developer Ambassadors guild

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.js
@@ -153,7 +153,7 @@ function formatSlackMessage( payload, channel, message ) {
 	let dris = '';
 	switch ( repository.full_name ) {
 		case 'Automattic/jetpack':
-			dris = '@jpop-da';
+			dris = '@jetpack-da';
 			break;
 		case 'Automattic/zero-bs-crm':
 		case 'Automattic/sensei':

--- a/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/reply-to-customers-reminder/index.js
@@ -37,7 +37,7 @@ function formatSlackMessage( payload, channel, message ) {
 	let dris = '@bug_herders';
 	switch ( repository.full_name ) {
 		case 'Automattic/jetpack':
-			dris = '@jpop-da';
+			dris = '@jetpack-da';
 			break;
 		case 'Automattic/zero-bs-crm':
 		case 'Automattic/sensei':


### PR DESCRIPTION
## Proposed changes:

Update the alert word to `jetpack-da`, now that we've moved away from `jpop` in our Jetpack Happiness teams.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1715896413452559/1715879659.462689-slack-C0CMN0V97

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This can only be tested in a fork, by linking your fork to a Slack bot and the right Slack channel.
In this case, I do not think it's worth testing.
