### PR TITLE
Subscriptions: Add Subscribe Overlay toggle

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -18,6 +18,10 @@ import {
 import { getModule } from 'state/modules';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
+// Check for feature flag
+const urlParams = new URLSearchParams( window.location.search );
+const isWelcomeOverlayEnabled = urlParams.get( 'enable-welcome-overlay' ) === 'true';
+
 /**
  * Subscription settings component.
  *
@@ -160,25 +164,27 @@ function SubscriptionsSettings( props ) {
 							</>
 						}
 					/>
-					<ToggleControl
-						checked={ isSubscriptionsActive && isSubscribeOverlayEnabled }
-						disabled={ isDisabled }
-						toggling={ isSavingAnyOption( [ 'jetpack_subscribe_overlay_enabled' ] ) }
-						onChange={ handleSubscribeOverlayToggleChange }
-						label={
-							<>
-								{ __( 'Subscription overlay on homepage', 'jetpack' ) }
-								{ isBlockTheme && subscribeOverlayEditorUrl && (
-									<>
-										{ '. ' }
-										<ExternalLink href={ subscribeOverlayEditorUrl }>
-											{ __( 'Preview and edit', 'jetpack' ) }
-										</ExternalLink>
-									</>
-								) }
-							</>
-						}
-					/>
+					{ isWelcomeOverlayEnabled && (
+						<ToggleControl
+							checked={ isSubscriptionsActive && isSubscribeOverlayEnabled }
+							disabled={ isDisabled }
+							toggling={ isSavingAnyOption( [ 'jetpack_subscribe_overlay_enabled' ] ) }
+							onChange={ handleSubscribeOverlayToggleChange }
+							label={
+								<>
+									{ __( 'Subscription overlay on homepage', 'jetpack' ) }
+									{ isBlockTheme && subscribeOverlayEditorUrl && (
+										<>
+											{ '. ' }
+											<ExternalLink href={ subscribeOverlayEditorUrl }>
+												{ __( 'Preview and edit', 'jetpack' ) }
+											</ExternalLink>
+										</>
+									) }
+								</>
+							}
+						/>
+					) }
 					<ToggleControl
 						checked={ isSubscriptionsActive && isStbEnabled }
 						disabled={ isDisabled }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -31,6 +31,7 @@ function SubscriptionsSettings( props ) {
 		isStbEnabled,
 		isStcEnabled,
 		isSmEnabled,
+		isSubscribeOverlayEnabled,
 		isSubscribePostEndEnabled,
 		isLoginNavigationEnabled,
 		isSubscriptionSiteEditSupported,
@@ -47,6 +48,15 @@ function SubscriptionsSettings( props ) {
 			? addQueryArgs( `${ siteAdminUrl }site-editor.php`, {
 					postType: 'wp_template_part',
 					postId: `${ themeStylesheet }//jetpack-subscribe-modal`,
+					canvas: 'edit',
+			  } )
+			: null;
+
+	const subscribeOverlayEditorUrl =
+		siteAdminUrl && themeStylesheet
+			? addQueryArgs( `${ siteAdminUrl }site-editor.php`, {
+					postType: 'wp_template_part',
+					postId: `${ themeStylesheet }//jetpack-subscribe-overlay`,
 					canvas: 'edit',
 			  } )
 			: null;
@@ -75,6 +85,10 @@ function SubscriptionsSettings( props ) {
 
 	const handleSubscribeModalToggleChange = useCallback( () => {
 		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, 'sm_enabled' );
+	}, [ updateFormStateModuleOption ] );
+
+	const handleSubscribeOverlayToggleChange = useCallback( () => {
+		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, 'jetpack_subscribe_overlay_enabled' );
 	}, [ updateFormStateModuleOption ] );
 
 	const handleSubscribePostEndToggleChange = useCallback( () => {
@@ -147,6 +161,25 @@ function SubscriptionsSettings( props ) {
 						}
 					/>
 					<ToggleControl
+						checked={ isSubscriptionsActive && isSubscribeOverlayEnabled }
+						disabled={ isDisabled }
+						toggling={ isSavingAnyOption( [ 'jetpack_subscribe_overlay_enabled' ] ) }
+						onChange={ handleSubscribeOverlayToggleChange }
+						label={
+							<>
+								{ __( 'Subscription overlay on homepage', 'jetpack' ) }
+								{ isBlockTheme && subscribeOverlayEditorUrl && (
+									<>
+										{ '. ' }
+										<ExternalLink href={ subscribeOverlayEditorUrl }>
+											{ __( 'Preview and edit', 'jetpack' ) }
+										</ExternalLink>
+									</>
+								) }
+							</>
+						}
+					/>
+					<ToggleControl
 						checked={ isSubscriptionsActive && isStbEnabled }
 						disabled={ isDisabled }
 						toggling={ isSavingAnyOption( [ 'stb_enabled' ] ) }
@@ -201,6 +234,7 @@ export default withModuleSettingsFormHelpers(
 			isStbEnabled: ownProps.getOptionValue( 'stb_enabled' ),
 			isStcEnabled: ownProps.getOptionValue( 'stc_enabled' ),
 			isSmEnabled: ownProps.getOptionValue( 'sm_enabled' ),
+			isSubscribeOverlayEnabled: ownProps.getOptionValue( 'jetpack_subscribe_overlay_enabled' ),
 			isSubscribePostEndEnabled: ownProps.getOptionValue(
 				'jetpack_subscriptions_subscribe_post_end_enabled'
 			),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2659,6 +2659,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
+			'jetpack_subscribe_overlay_enabled'     => array(
+				'description'       => esc_html__( 'Show subscribe overlay on homepage.', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'subscriptions',
+			),
 			'jetpack_subscriptions_subscribe_post_end_enabled' => array(
 				'description'       => esc_html__( 'Add Subscribe block at the end of each post.', 'jetpack' ),
 				'type'              => 'boolean',

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -993,6 +993,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				case 'stb_enabled':
 				case 'stc_enabled':
 				case 'sm_enabled':
+				case 'jetpack_subscribe_overlay_enabled':
 				case 'wpcom_newsletter_categories_enabled':
 				case 'wpcom_featured_image_in_email':
 				case 'wpcom_subscription_emails_use_excerpt':

--- a/projects/plugins/jetpack/changelog/update-overlay-toggle
+++ b/projects/plugins/jetpack/changelog/update-overlay-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscriptions: Add Subscribe Overlay toggle

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -121,6 +121,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 			'rss_use_excerpt'                         => '(bool) Whether the RSS feed will use post excerpts',
 			'launchpad_screen'                        => '(string) Whether or not launchpad is presented and what size it will be',
 			'sm_enabled'                              => '(bool) Whether the newsletter subscribe modal is enabled',
+			'jetpack_subscribe_overlay_enabled'       => '(bool) Whether the newsletter subscribe overlay is enabled',
 			'jetpack_subscriptions_subscribe_post_end_enabled' => '(bool) Whether the Subscribe block at the end of each post placement is enabled',
 			'jetpack_subscriptions_login_navigation_enabled' => '(bool) Whether the Subscriber Login block navigation placement is enabled',
 			'wpcom_ai_site_prompt'                    => '(string) User input in the AI site prompt',
@@ -456,6 +457,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'wpcom_newsletter_categories'      => $newsletter_category_ids,
 						'wpcom_newsletter_categories_enabled' => (bool) get_option( 'wpcom_newsletter_categories_enabled' ),
 						'sm_enabled'                       => (bool) get_option( 'sm_enabled' ),
+						'jetpack_subscribe_overlay_enabled' => (bool) get_option( 'jetpack_subscribe_overlay_enabled' ),
 						'jetpack_subscriptions_subscribe_post_end_enabled' => (bool) get_option( 'jetpack_subscriptions_subscribe_post_end_enabled' ),
 						'jetpack_subscriptions_login_navigation_enabled' => (bool) get_option( 'jetpack_subscriptions_login_navigation_enabled' ),
 						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ),
@@ -1104,6 +1106,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'sm_enabled':
 					update_option( 'sm_enabled', (int) (bool) $value );
+					$updated[ $key ] = (int) (bool) $value;
+					break;
+
+				case 'jetpack_subscribe_overlay_enabled':
+					update_option( 'jetpack_subscribe_overlay_enabled', (int) (bool) $value );
 					$updated[ $key ] = (int) (bool) $value;
 					break;
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -123,6 +123,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'wpcom_newsletter_categories'             => '(array) Array of post category ids that are marked as newsletter categories',
 			'wpcom_newsletter_categories_enabled'     => '(bool) Whether the newsletter categories are enabled or not',
 			'sm_enabled'                              => '(bool) Whether the newsletter Subscribe Modal is enabled or not',
+			'jetpack_subscribe_overlay_enabled'       => '(bool) Whether the newsletter Subscribe Overlay is enabled or not',
 			'jetpack_subscriptions_subscribe_post_end_enabled' => '(bool) Whether adding Subscribe block at the end of each post is enabled or not',
 			'jetpack_subscriptions_login_navigation_enabled' => '(bool) Whether the Subscriber Login block navigation placement is enabled or not',
 			'wpcom_gifting_subscription'              => '(bool) Whether gifting is enabled for non auto-renew sites',

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -40,6 +40,15 @@ class Jetpack_Subscribe_Overlay {
 		}
 
 		add_filter( 'get_block_template', array( $this, 'get_block_template_filter' ), 10, 3 );
+
+		add_filter(
+			'jetpack_options_whitelist',
+			function ( $options ) {
+				$options[] = 'jetpack_subscribe_overlay_enabled';
+
+				return $options;
+			}
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -34,7 +34,7 @@ class Jetpack_Subscribe_Overlay {
 	 * Jetpack_Subscribe_Overlay class constructor.
 	 */
 	public function __construct() {
-		if ( apply_filters( 'jetpack_subscribe_overlay_enabled', false ) ) {
+		if ( get_option( 'jetpack_subscribe_overlay_enabled', false ) ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 			add_action( 'wp_footer', array( $this, 'add_subscribe_overlay_to_frontend' ) );
 		}

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -86,6 +86,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'stb_enabled'                                  => true,
 			'stc_enabled'                                  => false,
 			'sm_enabled'                                   => false,
+			'jetpack_subscribe_overlay_enabled'            => false,
 			'jetpack_subscriptions_subscribe_post_end_enabled' => false,
 			'jetpack_subscriptions_login_navigation_enabled' => false,
 			'jetpack_subscriptions_reply_to'               => 'no-reply',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/issues/36208

## Proposed changes:

It:
- adds the "Subscription overlay on homepage" toggle behind the feature flag
- adds the related option to the WPCOM API and sync whitelist

<img width="1052" alt="Screenshot 2024-05-17 at 10 43 56" src="https://github.com/Automattic/jetpack/assets/4068554/b10895c5-95d3-4c44-a4b2-7972d5b98b35">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to Newsletter settings making sure the toggle is not visible
2. Open your site homepage making sure the overlay doesn't open
3. Add the `enable-welcome-overlay=true` query param to the Newsletter settings URL (`/wp-admin/admin.php?enable-welcome-overlay=true&page=jetpack#/newsletter`) making sure the toggle is now visible and disabled
4. Check whether the toggle works as expected.

