### PR TITLE
Subscriptions paywall: simplify access question

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriptions-simplify-access-question
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-simplify-access-question
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscription paywall: simplify paid access question for logged out subscribers

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -1154,7 +1154,7 @@ function get_paywall_blocks( $newsletter_access_level ) {
 <!-- /wp:paragraph -->';
 		}
 	} else {
-		$access_question = get_paywall_access_question( $newsletter_access_level );
+		$access_question = $is_paid_post ? esc_html__( 'Already a paid subscriber?', 'jetpack' ) : esc_html__( 'Already a subscriber?', 'jetpack' );
 		$login_block     = '<!-- wp:group {"style":{"typography":{"fontSize":"14px"}},"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-group" style="font-size:14px">
 	<!-- wp:jetpack/subscriber-login {"logInLabel":"' . $access_question . '"} /-->
@@ -1184,31 +1184,6 @@ function get_paywall_blocks( $newsletter_access_level ) {
 </div>
 <!-- /wp:group -->
 ';
-}
-
-/**
- * Returns Get Access question for the paywall
- *
- * @param string $post_access_level The newsletter access level.
- * @return string
- */
-function get_paywall_access_question( $post_access_level ) {
-	switch ( $post_access_level ) {
-		case Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS:
-		case Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS_ALL_TIERS:
-			$tier = Jetpack_Memberships::get_post_tier();
-			if ( $tier !== null ) {
-				return sprintf(
-				// translators:  Placeholder is the tier name
-					__( 'Already a higher-tier paid subscriber?', 'jetpack' ),
-					esc_html( $tier->post_title )
-				);
-			} else {
-				return esc_html__( 'Already a paid subscriber?', 'jetpack' );
-			}
-		default:
-			return esc_html__( 'Already a subscriber?', 'jetpack' );
-	}
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

For logged-out subscribers, in paid posts, for posts which require a higher tier plan, we show _"Already a higher-tier paid subscriber?"_ -question.

Otherwise, we'd show _"Already a paid subscriber?"_

This changes the question to always be "Already a paid subscriber?" regardless, just to keep the copy simpler and understandable. Free posts will still have "Already a subscriber?" question.

<img width="759" alt="Screenshot 2024-05-17 at 13 14 29" src="https://github.com/Automattic/jetpack/assets/87168/12aeb09c-1589-4b61-af04-716d9f102bfc">

While doing this, we get to simplify the code a bit too.

<img width="612" alt="Screenshot 2024-05-17 at 13 29 03" src="https://github.com/Automattic/jetpack/assets/87168/389d944b-f058-4924-b5e3-7dd8f3c506cc">
<img width="604" alt="Screenshot 2024-05-17 at 13 28 53" src="https://github.com/Automattic/jetpack/assets/87168/14c56333-8f43-44af-bf2e-8054fc08a02e">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create subscribers-only post, and apaid post
* Test logged out, and logged in

Access questions ("switch user" / "already a subscriber") should still make logically sense.
