### PR TITLE
Subscription overlay: adjustments to group layout

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriber-overlay-group-layout
+++ b/projects/plugins/jetpack/changelog/update-subscriber-overlay-group-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscription overlay: adjustments to group layout

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -103,10 +103,11 @@ class Jetpack_Subscribe_Overlay {
 		$skip_to_content = __( 'Skip to content', 'jetpack' );
 
 		return <<<HTML
-	<!-- wp:group {"layout":{"type":"constrained","contentSize":"400px"}} -->
-	<div class="wp-block-group">
-		<!-- wp:site-logo {"width":90,"isLink":false,"shouldSyncIcon":true,"align":"center","className":"is-style-rounded"} /-->
-	
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|10","margin":{"top":"0px","bottom":"0px"}},"position":{"type":""},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"background","layout":{"type":"flex","orientation":"vertical","justifyContent":"center","verticalAlignment":"center"}} -->
+<div class="wp-block-group has-background-background-color has-background" style="min-height:100vh;margin-top:0px;margin-bottom:0px;padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)">
+
+		<!-- wp:site-logo {"width":90,"isLink":false,"shouldSyncIcon":false,"align":"center","className":"is-style-rounded"} /-->
+
 		<!-- wp:site-title {"textAlign":"center","isLink":false} /-->
 
 		<!-- wp:site-tagline {"textAlign":"center"} /-->

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
@@ -24,11 +24,18 @@ body.jetpack-subscribe-overlay-open {
 	visibility: hidden;
 	overflow: hidden;
 	top: 100%;
-	margin: 15% auto;
+	/*margin: 15% auto;*/
 	width: 100%;
-	max-width: 400px;
+	/*max-width: 400px;*/
 	transition: top 0.4s, visibility 0.4s;
 	text-wrap: pretty;
+}
+
+/* These should be coming from the editor :-( */
+.jetpack-subscribe-overlay__content .wp-block-group.is-layout-flex {
+	align-items: center;
+	flex-direction: column;
+	justify-content: center;
 }
 
 .jetpack-subscribe-overlay__close {

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
@@ -46,6 +46,7 @@ body.jetpack-subscribe-overlay-open {
 	right: 32px;
 	width: 24px;
 	height: 24px;
+	z-index: 50001;
 }
 
 body.admin-bar .jetpack-subscribe-overlay__close {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Testing moving styling into the editor more from fixed CSS:

<img width="1463" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/f23a3db4-0247-4561-b617-8a577410ffba">

<img width="1378" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/fee8e848-9557-48b1-9acc-da97b347c0c1">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

