### PR TITLE
changelogger: Normalize UTC timezone

### DIFF
--- a/projects/packages/changelogger/changelog/fix-changelogger-getRepoData-test
+++ b/projects/packages/changelogger/changelog/fix-changelogger-getRepoData-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fix test by always using `Z`, not `+00:00`, for UTC timezones. No functionality change as both are equivalent ISO timestamps.
+
+

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.2.3';
+	const VERSION = '4.2.4-alpha';
 
 	/**
 	 * Constructor.

--- a/projects/packages/changelogger/src/Utils.php
+++ b/projects/packages/changelogger/src/Utils.php
@@ -171,6 +171,10 @@ class Utils {
 				// Timestamp.
 				if ( isset( $cmd_output[0] ) && preg_match( '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$/', $cmd_output[0] ) ) {
 					$repo_data['timestamp'] = $cmd_output[0];
+					// Normalize UTC
+					if ( substr( $repo_data['timestamp'], -6 ) === '+00:00' ) {
+						$repo_data['timestamp'] = substr( $repo_data['timestamp'], 0, -6 ) . 'Z';
+					}
 				}
 
 				// PR number.

--- a/projects/packages/changelogger/tests/php/tests/src/UtilsTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/UtilsTest.php
@@ -390,7 +390,7 @@ class UtilsTest extends TestCase {
 
 		$this->assertSame(
 			array(
-				'timestamp' => '2021-02-02T22:22:22+00:00',
+				'timestamp' => '2021-02-02T22:22:22Z',
 				'pr-num'    => '123',
 			),
 			Utils::getRepoData( 'in-git.txt', $output, $helper )
@@ -399,7 +399,7 @@ class UtilsTest extends TestCase {
 		// Test the second commit.
 		$this->assertSame(
 			array(
-				'timestamp' => '2021-02-02T22:22:22+00:00',
+				'timestamp' => '2021-02-02T22:22:22Z',
 				'pr-num'    => '124',
 			),
 			Utils::getRepoData( 'in-git2.txt', $output, $helper )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It seems that some versions of git may be returning `Z` rather than `+00:00` when reporting timezones from `%cI`, which broke a test. Normalize it to `Z` always so the test can have a consistent value to expect.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1715947110475729-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy now?