### PR TITLE
Subscriptions: allow block in the navigation block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subsciptions-allow-in-navi
+++ b/projects/plugins/jetpack/changelog/update-subsciptions-allow-in-navi
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscription block: allow adding inside navigation block

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -70,6 +70,7 @@ registerJetpackPlugin( blockName, {
 	),
 } );
 
+// Allows block to be inserted inside core navigation block
 addFilter( 'blocks.registerBlockType', 'jetpack-subscriptions-nav-item', ( settings, name ) => {
 	if ( name === 'core/navigation' ) {
 		return {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -1,12 +1,13 @@
 import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
 import { createBlock } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
 import deprecated from './deprecated';
 import edit from './edit';
 import SubscribePanels from './panel';
 
-const name = metadata.name.replace( 'jetpack/', '' );
+const blockName = metadata.name.replace( 'jetpack/', '' );
 
 // Registers Subscribe block.
 registerJetpackBlockFromMetadata( metadata, {
@@ -61,10 +62,21 @@ registerJetpackBlockFromMetadata( metadata, {
 } );
 
 // Registers slot/fill panels defined via settings.render.
-registerJetpackPlugin( name, {
+registerJetpackPlugin( blockName, {
 	render: () => (
 		<>
 			<SubscribePanels />
 		</>
 	),
+} );
+
+addFilter( 'blocks.registerBlockType', 'jetpack-subscriptions-nav-item', ( settings, name ) => {
+	if ( name === 'core/navigation' ) {
+		return {
+			...settings,
+			allowedBlocks: [ ...( settings.allowedBlocks ?? [] ), 'jetpack/subscriptions' ],
+		};
+	}
+
+	return settings;
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Goes well together with button only style https://github.com/Automattic/jetpack/pull/37341 and later allows adding automated block hook to inject block into the navigation.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allow block in the navigation block

<img width="1367" alt="Screenshot 2024-05-17 at 16 38 20" src="https://github.com/Automattic/jetpack/assets/87168/f664846b-d894-44c5-8560-076c54f1e12f">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add subscribe block inside navigation block
* Try different styles

