### PR TITLE
Woo Analytics: avoid warning with malformed user data

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-conflict-woo-analytics-malformed-user-info
+++ b/projects/packages/woocommerce-analytics/changelog/fix-conflict-woo-analytics-malformed-user-info
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Customer creation: avoid PHP warnings when other plugins hook into customer creation process and return malformed user data.

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -510,7 +510,11 @@ class Universal {
 	 */
 	public function capture_created_customer( $customer_id, $new_customer_data ) {
 		$session = WC()->session;
-		if ( is_object( $session ) ) {
+		if (
+			is_object( $session )
+			&& is_array( $new_customer_data )
+			&& ! empty( $new_customer_data['source'] )
+		) {
 			if ( str_contains( $new_customer_data['source'], 'store-api' ) ) {
 				$session->set( 'wc_checkout_createaccount_used', true );
 				$session->save_data();

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -20,7 +20,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.1.5';
+	const PACKAGE_VERSION = '0.1.6-alpha';
 
 	/**
 	 * Initializer.


### PR DESCRIPTION
## Proposed changes:

This should avoid notices like the one reported in this thread:
https://wordpress.org/support/topic/create-a-vendor-account-2/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

I wasn't able to reproduce the original issue, I assume it's triggered by a specific set of plugins and settings. I would consequently recommend testing those changes by reviewing the code and ensuring the added defensive code makes sense.
