### PR TITLE
phan: Add "stubs" for in-monorepo plugins

### DIFF
--- a/projects/packages/blocks/.phan/baseline.php
+++ b/projects/packages/blocks/.phan/baseline.php
@@ -10,16 +10,13 @@
 return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 2 occurrences
-    // PhanUndeclaredClassMethod : 2 occurrences
     // PhanDeprecatedFunction : 1 occurrence
     // PhanPluginDuplicateConditionalNullCoalescing : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
-    // PhanUndeclaredClassInCallable : 1 occurrence
-    // PhanUndeclaredClassReference : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-blocks.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
+        'src/class-blocks.php' => ['PhanDeprecatedFunction', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal'],
         'tests/php/test-blocks.php' => ['PhanTypeMismatchArgument'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/blocks/.phan/config.php
+++ b/projects/packages/blocks/.phan/config.php
@@ -10,4 +10,18 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'amp' ) ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'+stubs'          => array( 'amp' ),
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in other packages like this! Generally packages should be listed in composer.json 'require'.
+			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
+			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack-gutenberg.php', // class Jetpack_Gutenberg
+		),
+	)
+);

--- a/projects/packages/blocks/changelog/add-phan-plugin-refs
+++ b/projects/packages/blocks/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/packages/connection/.phan/baseline.php
+++ b/projects/packages/connection/.phan/baseline.php
@@ -19,7 +19,6 @@ return [
     // PhanNoopNew : 8 occurrences
     // PhanTypeMismatchReturnProbablyReal : 8 occurrences
     // PhanUndeclaredProperty : 8 occurrences
-    // PhanUndeclaredClassMethod : 6 occurrences
     // PhanRedundantCondition : 5 occurrences
     // PhanTypeArraySuspiciousNullable : 5 occurrences
     // PhanTypeMismatchDefault : 5 occurrences
@@ -38,6 +37,7 @@ return [
     // PhanPluginDuplicateAdjacentStatement : 1 occurrence
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanTypeMismatchDeclaredParamNullable : 1 occurrence
+    // PhanUndeclaredClassMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
@@ -45,7 +45,7 @@ return [
         'legacy/class-jetpack-options.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal'],
         'legacy/class-jetpack-signature.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentInternal'],
         'legacy/class-jetpack-tracks-client.php' => ['PhanNonClassMethodCall', 'PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyProbablyReal'],
-        'legacy/class-jetpack-xmlrpc-server.php' => ['PhanAccessMethodInternal', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredProperty'],
+        'legacy/class-jetpack-xmlrpc-server.php' => ['PhanAccessMethodInternal', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanUndeclaredProperty'],
         'src/class-error-handler.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-heartbeat.php' => ['PhanTypeMismatchPropertyDefault'],
         'src/class-manager.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/connection/.phan/config.php
+++ b/projects/packages/connection/.phan/config.php
@@ -10,4 +10,19 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'wpcom' ) ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'+stubs'          => array( 'wpcom' ),
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in other packages like this! Generally packages should be listed in composer.json 'require'.
+			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
+			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack-network.php',        // class Jetpack_Network
+			__DIR__ . '/../../../plugins/jetpack/class-jetpack-xmlrpc-methods.php', // class Jetpack_XMLRPC_Methods
+		),
+	)
+);

--- a/projects/packages/connection/changelog/add-phan-plugin-refs
+++ b/projects/packages/connection/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/packages/forms/.phan/baseline.php
+++ b/projects/packages/forms/.phan/baseline.php
@@ -17,12 +17,10 @@ return [
     // PhanDeprecatedFunction : 5 occurrences
     // PhanRedundantCondition : 4 occurrences
     // PhanTypePossiblyInvalidDimOffset : 3 occurrences
-    // PhanUndeclaredClassMethod : 3 occurrences
     // PhanPluginRedundantAssignment : 2 occurrences
     // PhanTypeConversionFromArray : 2 occurrences
     // PhanTypeMismatchArgumentNullableInternal : 2 occurrences
     // PhanTypeMismatchReturn : 2 occurrences
-    // PhanUndeclaredFunction : 2 occurrences
     // PhanParamTooMany : 1 occurrence
     // PhanPluginDuplicateAdjacentStatement : 1 occurrence
     // PhanPluginMixedKeyNoKey : 1 occurrence
@@ -30,21 +28,18 @@ return [
     // PhanPossiblyUndeclaredVariable : 1 occurrence
     // PhanTypeArraySuspiciousNullable : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
-    // PhanUndeclaredConstant : 1 occurrence
     // PhanUndeclaredProperty : 1 occurrence
     // PhanUnreferencedUseNormal : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/blocks/contact-form/class-contact-form-block.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
-        'src/class-wpcom-rest-api-v2-endpoint-forms.php' => ['PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredFunction'],
+        'src/class-wpcom-rest-api-v2-endpoint-forms.php' => ['PhanTypePossiblyInvalidDimOffset'],
         'src/contact-form/class-admin.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
-        'src/contact-form/class-contact-form-field.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyNullTypeMismatchProperty', 'PhanTypeConversionFromArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredProperty'],
+        'src/contact-form/class-contact-form-field.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyNullTypeMismatchProperty', 'PhanTypeConversionFromArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
         'src/contact-form/class-contact-form-plugin.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginRedundantAssignment', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form-shortcode.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'src/contact-form/class-contact-form.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginRedundantAssignment', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
         'src/dashboard/class-dashboard-view-switch.php' => ['PhanUnreferencedUseNormal'],
-        'src/dashboard/class-dashboard.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredConstant'],
         'src/service/class-google-drive.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'tests/php/contact-form/test-class.contact-form-plugin.php' => ['PhanPluginMixedKeyNoKey'],
         'tests/php/contact-form/test-class.contact-form.php' => ['PhanDeprecatedFunction'],

--- a/projects/packages/forms/.phan/config.php
+++ b/projects/packages/forms/.phan/config.php
@@ -10,4 +10,23 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'akismet', 'wpcom' ) ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'+stubs'          => array( 'akismet', 'wpcom' ),
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in other packages like this! Generally packages should be listed in composer.json 'require'.
+			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
+			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
+			__DIR__ . '/../../../plugins/jetpack/jetpack.php',                                // JETPACK__PLUGIN_DIR
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack.php',                          // class Jetpack
+			__DIR__ . '/../../../plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php',       // class Jetpack_AI_Helper
+			__DIR__ . '/../../../plugins/jetpack/3rd-party/class.jetpack-amp-support.php',    // class Jetpack_AMP_Support
+			__DIR__ . '/../../../plugins/jetpack/functions.global.php',                       // function jetpack_is_frontend
+			__DIR__ . '/../../../plugins/jetpack/_inc/lib/core-api/load-wpcom-endpoints.php', // function wpcom_rest_api_v2_load_plugin
+		),
+	)
+);

--- a/projects/packages/forms/changelog/add-phan-plugin-refs
+++ b/projects/packages/forms/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/packages/image-cdn/.phan/baseline.php
+++ b/projects/packages/image-cdn/.phan/baseline.php
@@ -13,12 +13,10 @@ return [
     // PhanPluginSimplifyExpressionBool : 6 occurrences
     // PhanParamTooMany : 5 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
-    // PhanUndeclaredFunctionInCallable : 4 occurrences
     // PhanPossiblyUndeclaredVariable : 3 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
     // PhanTypeMismatchPropertyProbablyReal : 2 occurrences
     // PhanTypeMismatchReturn : 2 occurrences
-    // PhanUndeclaredClassMethod : 2 occurrences
     // PhanNonClassMethodCall : 1 occurrence
     // PhanTypeArraySuspicious : 1 occurrence
     // PhanTypeMismatchArgumentInternal : 1 occurrence
@@ -26,17 +24,16 @@ return [
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
     // PhanTypeObjectUnsetDeclaredProperty : 1 occurrence
-    // PhanUndeclaredClassInCallable : 1 occurrence
     // PhanUndeclaredMethod : 1 occurrence
     // PhanUndeclaredStaticMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-image-cdn-core.php' => ['PhanTypeMismatchReturn'],
-        'src/class-image-cdn-image-sizes.php' => ['PhanPluginSimplifyExpressionBool', 'PhanUndeclaredClassInCallable'],
-        'src/class-image-cdn.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod'],
-        'src/compatibility/photon.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredFunctionInCallable'],
-        'tests/php/test_class.image_cdn.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredMethod', 'PhanUndeclaredStaticMethod'],
+        'src/class-image-cdn-image-sizes.php' => ['PhanPluginSimplifyExpressionBool'],
+        'src/class-image-cdn.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset'],
+        'src/compatibility/photon.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgumentNullableInternal'],
+        'tests/php/test_class.image_cdn.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredMethod', 'PhanUndeclaredStaticMethod'],
         'tests/php/test_class.image_cdn_core.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeObjectUnsetDeclaredProperty'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/image-cdn/.phan/config.php
+++ b/projects/packages/image-cdn/.phan/config.php
@@ -10,4 +10,17 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in other packages like this! Generally packages should be listed in composer.json 'require'.
+			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
+			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
+			__DIR__ . '/../../../plugins/jetpack/3rd-party/class.jetpack-amp-support.php', // class Jetpack_AMP_Support
+		),
+	)
+);

--- a/projects/packages/image-cdn/changelog/add-phan-plugin-refs
+++ b/projects/packages/image-cdn/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/packages/image-cdn/changelog/add-phan-plugin-refs#2
+++ b/projects/packages/image-cdn/changelog/add-phan-plugin-refs#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add phan suppression for the remove_filter of old Jetpack functions this package replaces. No point in stubbing those.
+
+

--- a/projects/packages/image-cdn/src/class-image-cdn-image-sizes.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-image-sizes.php
@@ -119,6 +119,7 @@ class Image_CDN_Image_Sizes {
 		// Compatibility fix: Ensure that Jetpack's inbuilt Photon does not get in the way.
 		// No need to re-enable this filter if present, as its functionality will be handled
 		// by the Image_CDN filter added below.
+		// @phan-suppress-next-line PhanUndeclaredClassInCallable -- Just removing this deprecated filter function. No point in stubbing it.
 		remove_filter(
 			'intermediate_image_sizes_advanced',
 			array( 'Jetpack_Photon', 'filter_photon_noresize_intermediate_sizes' )

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Image_CDN;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.4.0';
+	const PACKAGE_VERSION = '0.4.1-alpha';
 
 	/**
 	 * Singleton.

--- a/projects/packages/image-cdn/src/compatibility/photon.php
+++ b/projects/packages/image-cdn/src/compatibility/photon.php
@@ -23,9 +23,13 @@ function jetpack_image_cdn_photon_compat() {
 	 * Photon used have different functions names. They are later replaced by methods in
 	 * Image_CDN_Core class. And the filters are now handled by the Image_CDN_Core class itself.
 	 */
+	// @phan-suppress-next-line PhanUndeclaredFunctionInCallable -- Just removing this deprecated filter function. No point in stubbing it.
 	remove_filter( 'jetpack_photon_url', 'jetpack_photon_url', 10, 3 );
+	// @phan-suppress-next-line PhanUndeclaredFunctionInCallable -- Just removing this deprecated filter function. No point in stubbing it.
 	remove_filter( 'jetpack_photon_pre_args', 'jetpack_photon_parse_wpcom_query_args', 10, 2 );
+	// @phan-suppress-next-line PhanUndeclaredFunctionInCallable -- Just removing this deprecated filter function. No point in stubbing it.
 	remove_filter( 'jetpack_photon_skip_for_url', 'jetpack_photon_banned_domains', 9, 2 );
+	// @phan-suppress-next-line PhanUndeclaredFunctionInCallable -- Just removing this deprecated filter function. No point in stubbing it.
 	remove_filter( 'widget_text', 'jetpack_photon_support_text_widgets' );
 
 	/*

--- a/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
@@ -14,9 +14,9 @@ return [
     // PhanPluginDuplicateConditionalNullCoalescing : 8 occurrences
     // PhanTypeMismatchReturn : 6 occurrences
     // PhanTypeMismatchReturnProbablyReal : 4 occurrences
-    // PhanUndeclaredClassMethod : 4 occurrences
     // PhanNoopNew : 3 occurrences
     // PhanTypePossiblyInvalidDimOffset : 3 occurrences
+    // PhanUndeclaredClassMethod : 3 occurrences
     // PhanUndeclaredFunction : 3 occurrences
     // PhanEmptyFQSENInCallable : 2 occurrences
     // PhanParamTooMany : 2 occurrences
@@ -37,18 +37,13 @@ return [
     // PhanTypeMismatchReturnNullable : 1 occurrence
     // PhanTypeNonVarPassByRef : 1 occurrence
     // PhanTypeVoidArgument : 1 occurrence
-    // PhanUndeclaredClassInCallable : 1 occurrence
-    // PhanUndeclaredConstant : 1 occurrence
-    // PhanUndeclaredFunctionInCallable : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-jetpack-mu-wpcom.php' => ['PhanNoopNew'],
         'src/features/100-year-plan/enhanced-ownership.php' => ['PhanEmptyFQSENInCallable'],
         'src/features/100-year-plan/locked-mode.php' => ['PhanEmptyFQSENInCallable'],
-        'src/features/admin-color-schemes/admin-color-schemes.php' => ['PhanUndeclaredConstant'],
         'src/features/block-patterns/class-wpcom-block-patterns-utils.php' => ['PhanTypeMismatchReturnNullable'],
-        'src/features/cloudflare-analytics/cloudflare-analytics.php' => ['PhanUndeclaredClassMethod'],
         'src/features/coming-soon/coming-soon.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal', 'PhanUndeclaredFunction'],
         'src/features/coming-soon/fallback-coming-soon-page.php' => ['PhanTypeMismatchArgument', 'PhanTypeVoidArgument'],
         'src/features/error-reporting/error-reporting.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
@@ -60,7 +55,7 @@ return [
         'src/features/verbum-comments/class-verbum-comments.php' => ['PhanImpossibleTypeComparison', 'PhanNoopNew', 'PhanParamTooMany', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],
         'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-migrate-guru-key.php' => ['PhanUndeclaredClassMethod'],
-        'src/features/wpcom-site-menu/wpcom-site-menu.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredFunctionInCallable'],
+        'src/features/wpcom-site-menu/wpcom-site-menu.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'tests/lib/functions-wordpress.php' => ['PhanRedefineFunction'],
         'tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php' => ['PhanDeprecatedFunction'],
         'tests/php/features/coming-soon/class-coming-soon-test.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],

--- a/projects/packages/jetpack-mu-wpcom/.phan/config.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/config.php
@@ -10,14 +10,22 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-$root = dirname( __DIR__, 4 );
-
 return make_phan_config(
 	dirname( __DIR__ ),
 	array(
 		'+stubs'          => array( 'full-site-editing', 'photon-opencv', 'wpcom' ),
 		'parse_file_list' => array(
-			"$root/projects/plugins/jetpack/class-jetpack-stats-dashboard-widget.php",
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in other packages like this! Generally packages should be listed in composer.json 'require'.
+			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
+			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
+			__DIR__ . '/../../../plugins/jetpack/jetpack.php',                              // JETPACK__PLUGIN_FILE
+			__DIR__ . '/../../../plugins/jetpack/3rd-party/class.jetpack-amp-support.php',  // class Jetpack_AMP_Support
+			__DIR__ . '/../../../plugins/jetpack/modules/custom-css/custom-css.php',        // class Jetpack_Custom_CSS_Enhancements
+			__DIR__ . '/../../../plugins/jetpack/class-jetpack-stats-dashboard-widget.php', // class Jetpack_Stats_Dashboard_Widget
+			__DIR__ . '/../../../plugins/jetpack/modules/masterbar/nudges/bootstrap.php',   // function Automattic\Jetpack\Dashboard_Customizations\register_css_nudge_control  phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		),
 	)
 );

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-phan-plugin-refs
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/packages/my-jetpack/.phan/baseline.php
+++ b/projects/packages/my-jetpack/.phan/baseline.php
@@ -16,7 +16,6 @@ return [
     // PhanAbstractStaticMethodCallInStatic : 8 occurrences
     // PhanNoopNew : 6 occurrences
     // PhanTypeMismatchReturn : 6 occurrences
-    // PhanUndeclaredClassMethod : 6 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 5 occurrences
     // PhanTypeMismatchReturnNullable : 3 occurrences
     // PhanImpossibleCondition : 2 occurrences
@@ -26,13 +25,12 @@ return [
     // PhanRedundantCondition : 1 occurrence
     // PhanTypeMismatchArgumentInternal : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
-    // PhanUndeclaredClassStaticProperty : 1 occurrence
-    // PhanUndeclaredConstant : 1 occurrence
+    // PhanUndeclaredStaticProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-activitylog.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'src/class-initializer.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanParamTooMany', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
+        'src/class-initializer.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanParamTooMany', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-jetpack-manage.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'src/class-products.php' => ['PhanNonClassMethodCall'],
         'src/class-rest-product-data.php' => ['PhanParamTooMany', 'PhanTypeMismatchReturn'],
@@ -47,8 +45,8 @@ return [
         'src/products/class-crm.php' => ['PhanTypeMismatchPropertyDefault'],
         'src/products/class-extras.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
         'src/products/class-hybrid-product.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnNullable'],
-        'src/products/class-jetpack-ai.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
-        'src/products/class-module-product.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
+        'src/products/class-jetpack-ai.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
+        'src/products/class-module-product.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/products/class-product.php' => ['PhanAbstractStaticMethodCallInStatic', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
         'src/products/class-protect.php' => ['PhanTypeMismatchPropertyDefault'],
         'src/products/class-scan.php' => ['PhanTypeMismatchArgumentNullable'],
@@ -60,7 +58,7 @@ return [
         'src/products/class-videopress.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
         'tests/php/test-backup-product.php' => ['PhanTypeMismatchArgumentNullable'],
         'tests/php/test-hybrid-product.php' => ['PhanTypeMismatchArgumentNullable'],
-        'tests/php/test-module-product.php' => ['PhanUndeclaredClassStaticProperty', 'PhanUndeclaredConstant'],
+        'tests/php/test-module-product.php' => ['PhanUndeclaredStaticProperty'],
         'tests/php/test-product-multiple-filenames.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
         'tests/php/test-products.php' => ['PhanNonClassMethodCall'],
         'tests/php/test-search-product.php' => ['PhanTypeMismatchArgumentNullable'],

--- a/projects/packages/my-jetpack/.phan/config.php
+++ b/projects/packages/my-jetpack/.phan/config.php
@@ -10,4 +10,21 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'wpcom' ) ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'+stubs'          => array( 'wpcom' ),
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in other packages like this! Generally packages should be listed in composer.json 'require'.
+			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
+			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
+			__DIR__ . '/../../../plugins/jetpack/jetpack.php',                             // JETPACK__VERSION
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack.php',                       // class Jetpack
+			__DIR__ . '/../../../plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php',    // class Jetpack_AI_Helper
+			__DIR__ . '/../../../plugins/jetpack/3rd-party/class.jetpack-amp-support.php', // class Jetpack_AMP_Support
+		),
+	)
+);

--- a/projects/packages/my-jetpack/changelog/add-phan-plugin-refs
+++ b/projects/packages/my-jetpack/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -14,13 +14,11 @@ return [
     // PhanDeprecatedFunction : 9 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 7 occurrences
     // PhanUndeclaredStaticMethod : 6 occurrences
-    // PhanUndeclaredClassMethod : 5 occurrences
     // PhanTypeMismatchArgumentNullable : 3 occurrences
     // PhanPluginMixedKeyNoKey : 2 occurrences
     // PhanPossiblyUndeclaredVariable : 2 occurrences
     // PhanTypeMismatchReturnProbablyReal : 2 occurrences
     // PhanTypeMissingReturn : 2 occurrences
-    // PhanUndeclaredFunction : 2 occurrences
     // PhanImpossibleCondition : 1 occurrence
     // PhanParamSignatureMismatch : 1 occurrence
     // PhanPluginDuplicateExpressionAssignmentOperation : 1 occurrence
@@ -36,10 +34,10 @@ return [
         'src/auto-conversion-settings/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/class-connections-post-field.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-keyring-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault'],
-        'src/class-publicize-base.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction'],
+        'src/class-publicize-base.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn'],
         'src/class-publicize-setup.php' => ['PhanTypeMismatchArgument'],
-        'src/class-publicize-ui.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredClassMethod'],
-        'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunction', 'PhanUndeclaredStaticMethod'],
+        'src/class-publicize-ui.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchReturnProbablyReal'],
+        'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanUndeclaredStaticMethod'],
         'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'src/social-image-generator/class-post-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/social-image-generator/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],

--- a/projects/packages/publicize/.phan/config.php
+++ b/projects/packages/publicize/.phan/config.php
@@ -10,4 +10,20 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in other packages like this! Generally packages should be listed in composer.json 'require'.
+			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
+			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack.php',                                 // class Jetpack
+			__DIR__ . '/../../../plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php', // class Jetpack_Admin_Page
+			__DIR__ . '/../../../plugins/jetpack/modules/subscriptions.php',                         // class Jetpack_Subscriptions
+			__DIR__ . '/../../../plugins/jetpack/functions.global.php',                              // function jetpack_render_tos_blurb
+		),
+	)
+);

--- a/projects/packages/publicize/changelog/add-phan-plugin-refs
+++ b/projects/packages/publicize/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/packages/publicize/changelog/add-phan-plugin-refs#2
+++ b/projects/packages/publicize/changelog/add-phan-plugin-refs#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Swap `jetpack_photon_url()` call for `jetpack_photon_url` filter, which works with packages/image-cdn too.
+
+

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1655,7 +1655,8 @@ abstract class Publicize_Base {
 	 * @return string
 	 */
 	public function get_resized_image_url( $image_url, $width, $height ) {
-		return jetpack_photon_url(
+		return apply_filters(
+			'jetpack_photon_url',
 			$image_url,
 			array(
 				'w' => $width,

--- a/projects/packages/search/.phan/baseline.php
+++ b/projects/packages/search/.phan/baseline.php
@@ -21,7 +21,6 @@ return [
     // PhanTypeMismatchProperty : 4 occurrences
     // PhanPluginMixedKeyNoKey : 3 occurrences
     // PhanTypeSuspiciousEcho : 3 occurrences
-    // PhanUndeclaredClassMethod : 3 occurrences
     // PhanNoopNew : 2 occurrences
     // PhanDeprecatedPartiallySupportedCallable : 1 occurrence
     // PhanPluginRedundantAssignment : 1 occurrence
@@ -33,13 +32,12 @@ return [
     // PhanTypeMismatchDefault : 1 occurrence
     // PhanTypeMismatchDimAssignment : 1 occurrence
     // PhanTypePossiblyInvalidDimOffset : 1 occurrence
-    // PhanUndeclaredClassReference : 1 occurrence
+    // PhanUndeclaredClassMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'compatibility/jetpack.php' => ['PhanUndeclaredClassMethod'],
         'src/class-cli.php' => ['PhanTypeMismatchArgument'],
-        'src/class-helper.php' => ['PhanDeprecatedPartiallySupportedCallable', 'PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
+        'src/class-helper.php' => ['PhanDeprecatedPartiallySupportedCallable', 'PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod'],
         'src/class-options.php' => ['PhanPluginSimplifyExpressionBool'],
         'src/class-plan.php' => ['PhanDeprecatedFunction'],
         'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],

--- a/projects/packages/search/.phan/config.php
+++ b/projects/packages/search/.phan/config.php
@@ -10,4 +10,18 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'wpcom' ) ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'+stubs'          => array( 'wpcom' ),
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in other packages like this! Generally packages should be listed in composer.json 'require'.
+			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
+			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack.php', // class Jetpack
+		),
+	)
+);

--- a/projects/packages/search/changelog/add-phan-plugin-refs
+++ b/projects/packages/search/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/packages/status/.phan/baseline.php
+++ b/projects/packages/status/.phan/baseline.php
@@ -10,15 +10,11 @@
 return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 10+ occurrences
-    // PhanUndeclaredConstant : 6 occurrences
     // PhanTypeMismatchArgumentInternal : 4 occurrences
-    // PhanUndeclaredFunction : 4 occurrences
     // PhanTypeMismatchArgumentNullableInternal : 3 occurrences
-    // PhanUndeclaredClassMethod : 3 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 2 occurrences
     // PhanPluginSimplifyExpressionBool : 2 occurrences
     // PhanRedefineFunction : 2 occurrences
-    // PhanUndeclaredClassInCallable : 2 occurrences
     // PhanDeprecatedFunction : 1 occurrence
     // PhanParamTooMany : 1 occurrence
     // PhanPluginRedundantAssignment : 1 occurrence
@@ -27,13 +23,14 @@ return [
     // PhanTypeMismatchArgumentNullable : 1 occurrence
     // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
     // PhanTypeMismatchReturnProbablyReal : 1 occurrence
+    // PhanUndeclaredFunction : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-cookiestate.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginRedundantAssignment', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullableInternal'],
-        'src/class-errors.php' => ['PhanTypeMismatchArgumentInternal', 'PhanUndeclaredClassInCallable'],
+        'src/class-errors.php' => ['PhanTypeMismatchArgumentInternal'],
         'src/class-host.php' => ['PhanTypeMismatchArgumentNullable'],
-        'src/class-modules.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction'],
+        'src/class-modules.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/class-status.php' => ['PhanRedundantCondition', 'PhanUndeclaredFunction'],
         'tests/php/bootstrap.php' => ['PhanRedefineFunction', 'PhanTypeMismatchReturnProbablyReal'],
         'tests/php/test-host.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument'],

--- a/projects/packages/status/.phan/config.php
+++ b/projects/packages/status/.phan/config.php
@@ -10,4 +10,21 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'wpcom' ) ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'+stubs'          => array( 'wpcom' ),
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in other packages like this! Generally packages should be listed in composer.json 'require'.
+			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
+			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
+			__DIR__ . '/../../../plugins/jetpack/jetpack.php',                     // JETPACK__PLUGIN_DIR, JETPACK__VERSION
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack.php',               // class Jetpack
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack-client-server.php', // class Jetpack_Client_Server
+			__DIR__ . '/../../../plugins/jetpack/modules/module-headings.php',     // functions jetpack_has_no_module_info, jetpack_get_module_info, jetpack_get_all_module_header_names
+		),
+	)
+);

--- a/projects/packages/status/.phan/pre-run
+++ b/projects/packages/status/.phan/pre-run
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ../../plugins/jetpack
+php tools/build-module-headings-translations.php

--- a/projects/packages/status/changelog/add-phan-plugin-refs
+++ b/projects/packages/status/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -44,15 +44,13 @@ return [
     // PhanTypeMismatchDefault : 1 occurrence
     // PhanTypeMismatchProperty : 1 occurrence
     // PhanTypeMismatchPropertyProbablyReal : 1 occurrence
-    // PhanUndeclaredClassMethod : 1 occurrence
-    // PhanUndeclaredFunction : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-actions.php' => ['PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/class-data-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-dedicated-sender.php' => ['PhanTypeInvalidLeftOperandOfNumericOp'],
-        'src/class-functions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanUndeclaredClassMethod'],
+        'src/class-functions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset'],
         'src/class-listener.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-lock.php' => ['PhanTypeMismatchReturn'],
         'src/class-queue.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal'],
@@ -72,7 +70,7 @@ return [
         'src/modules/class-meta.php' => ['PhanParamSignatureMismatch', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/modules/class-module.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-network-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/modules/class-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
+        'src/modules/class-options.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-plugins.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/modules/class-posts.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginUseReturnValueInternalKnown', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnProbablyReal'],
         'src/modules/class-term-relationships.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument'],

--- a/projects/packages/sync/.phan/config.php
+++ b/projects/packages/sync/.phan/config.php
@@ -10,4 +10,19 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'amp', 'woocommerce', 'woocommerce-internal' ) ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'+stubs'          => array( 'amp', 'woocommerce', 'woocommerce-internal' ),
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in other packages like this! Generally packages should be listed in composer.json 'require'.
+			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
+			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack-admin.php',                   // class Jetpack_Admin
+			__DIR__ . '/../../../plugins/jetpack/modules/site-icon/site-icon-functions.php', // function jetpack_site_icon_url
+		),
+	)
+);

--- a/projects/packages/sync/changelog/add-phan-plugin-refs
+++ b/projects/packages/sync/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/packages/videopress/.phan/baseline.php
+++ b/projects/packages/videopress/.phan/baseline.php
@@ -10,22 +10,20 @@
 return [
     // # Issue statistics:
     // PhanPluginDuplicateConditionalNullCoalescing : 20+ occurrences
-    // PhanUndeclaredClassMethod : 10+ occurrences
     // PhanUndeclaredProperty : 8 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 7 occurrences
     // PhanTypeMismatchReturnProbablyReal : 7 occurrences
     // PhanTypeArraySuspicious : 6 occurrences
     // PhanTypeMismatchReturn : 6 occurrences
+    // PhanUndeclaredClassMethod : 6 occurrences
     // PhanCommentOverrideOnNonOverrideMethod : 4 occurrences
     // PhanNonClassMethodCall : 4 occurrences
     // PhanTypeArraySuspiciousNullable : 4 occurrences
     // PhanTypeMismatchArgument : 4 occurrences
-    // PhanUndeclaredFunction : 4 occurrences
     // PhanNoopNew : 3 occurrences
     // PhanParamTooMany : 3 occurrences
     // PhanPossiblyUndeclaredVariable : 2 occurrences
     // PhanTypeInvalidDimOffset : 2 occurrences
-    // PhanUndeclaredConstant : 2 occurrences
     // PhanUndeclaredExtendedClass : 2 occurrences
     // PhanUndeclaredMethod : 2 occurrences
     // PhanUndeclaredMethodInCallable : 2 occurrences
@@ -35,39 +33,33 @@ return [
     // PhanPluginUnreachableCode : 1 occurrence
     // PhanRedundantCondition : 1 occurrence
     // PhanTypeMismatchArgumentInternal : 1 occurrence
-    // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
     // PhanUndeclaredClass : 1 occurrence
-    // PhanUndeclaredClassConstant : 1 occurrence
-    // PhanUndeclaredClassReference : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-access-control.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction'],
-        'src/class-admin-ui.php' => ['PhanUndeclaredClassMethod'],
+        'src/class-access-control.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-attachment-handler.php' => ['PhanNonClassMethodCall', 'PhanTypeArraySuspicious'],
         'src/class-block-editor-content.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-block-editor-extensions.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-data.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeMismatchReturn'],
         'src/class-divi.php' => ['PhanUndeclaredProperty'],
-        'src/class-initializer.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal'],
+        'src/class-initializer.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-jwt-token-bridge.php' => ['PhanTypeMismatchReturn'],
         'src/class-plan.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-stats.php' => ['PhanTypeArraySuspiciousNullable'],
-        'src/class-status.php' => ['PhanUndeclaredClassMethod'],
         'src/class-uploader-rest-endpoints.php' => ['PhanParamTooMany'],
         'src/class-uploader.php' => ['PhanTypeMismatchArgument'],
         'src/class-utils.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-videopresstoken.php' => ['PhanTypeMismatchReturn'],
-        'src/class-wpcom-rest-api-v2-attachment-field-videopress.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
-        'src/class-wpcom-rest-api-v2-attachment-videopress-data.php' => ['PhanUndeclaredFunction'],
-        'src/class-wpcom-rest-api-v2-endpoint-videopress.php' => ['PhanAccessMethodInternal', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],
+        'src/class-wpcom-rest-api-v2-attachment-field-videopress.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
+        'src/class-wpcom-rest-api-v2-endpoint-videopress.php' => ['PhanAccessMethodInternal', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/class-xmlrpc.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/tus/class-transient-store.php' => ['PhanParamTooMany'],
         'src/tus/class-tus-abstract-cache.php' => ['PhanTypeMismatchArgumentInternal'],
         'src/tus/class-tus-client.php' => ['PhanNonClassMethodCall', 'PhanTypeMismatchArgument'],
         'src/tus/class-tus-file.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspiciousNullable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredTypeThrowsType'],
-        'src/utility-functions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginUnreachableCode', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredConstant'],
+        'src/utility-functions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginUnreachableCode', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
         'src/videopress-divi/class-videopress-divi-extension.php' => ['PhanCommentOverrideOnNonOverrideMethod', 'PhanUndeclaredClass', 'PhanUndeclaredClassMethod', 'PhanUndeclaredExtendedClass', 'PhanUndeclaredMethod', 'PhanUndeclaredMethodInCallable', 'PhanUndeclaredProperty'],
         'src/videopress-divi/class-videopress-divi-module.php' => ['PhanUndeclaredExtendedClass', 'PhanUndeclaredProperty'],
         'tests/php/test-class-initializer.php' => ['PhanTypeMismatchArgumentProbablyReal'],

--- a/projects/packages/videopress/.phan/config.php
+++ b/projects/packages/videopress/.phan/config.php
@@ -10,4 +10,25 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'wpcom' ) ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'+stubs'          => array( 'wpcom' ),
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in other packages like this! Generally packages should be listed in composer.json 'require'.
+			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
+			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
+			__DIR__ . '/../../../plugins/jetpack/jetpack.php',                                                                                               // JETPACK__PLUGIN_DIR, JETPACK__WPCOM_JSON_API_BASE
+			__DIR__ . '/../../../plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php', // class Abstract_Token_Subscription_Service
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack.php',                                                                                         // class Jetpack
+			__DIR__ . '/../../../plugins/jetpack/modules/memberships/class-jetpack-memberships.php',                                                         // class Jetpack_Memberships
+			__DIR__ . '/../../../plugins/jetpack/modules/videopress/class.videopress-edit-attachment.php',                                                   // class VideoPress_Edit_Attachment
+			__DIR__ . '/../../../plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/interface-subscription-service.php',            // interface Subscription_Service
+			__DIR__ . '/../../../plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/include.php',                                   // function Automattic\Jetpack\Extensions\Premium_Content\subscription_service   phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+			__DIR__ . '/../../../plugins/jetpack/_inc/lib/core-api/load-wpcom-endpoints.php',                                                                // function wpcom_rest_api_v2_load_plugin
+		),
+	)
+);

--- a/projects/packages/videopress/changelog/add-phan-plugin-refs
+++ b/projects/packages/videopress/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/packages/videopress/changelog/add-phan-plugin-refs#2
+++ b/projects/packages/videopress/changelog/add-phan-plugin-refs#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Make sure a variable is defined by initializing it unconditionally.
+
+

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -179,6 +179,7 @@ class Access_Control {
 			$paywall             = \Automattic\Jetpack\Extensions\Premium_Content\subscription_service();
 
 			// Only paid subscribers should be granted access to the premium content.
+			$access_level = '';
 			if ( class_exists( Abstract_Token_Subscription_Service::class ) ) {
 				$access_level = Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS;
 			}

--- a/projects/plugins/beta/.phan/baseline.php
+++ b/projects/plugins/beta/.phan/baseline.php
@@ -21,8 +21,6 @@ return [
     // PhanTypeInvalidExpressionArrayDestructuring : 1 occurrence
     // PhanTypeMismatchArgumentInternal : 1 occurrence
     // PhanTypeMismatchArgumentNullable : 1 occurrence
-    // PhanUndeclaredClassMethod : 1 occurrence
-    // PhanUndeclaredClassReference : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
@@ -33,7 +31,7 @@ return [
         'src/admin/plugin-select.template.php' => ['PhanTypeMismatchArgumentNullable'],
         'src/admin/show-needed-updates.template.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable'],
         'src/class-autoupdateself.php' => ['PhanStaticPropIsStaticType', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/class-hooks.php' => ['PhanPossiblyNullTypeMismatchProperty', 'PhanStaticPropIsStaticType', 'PhanTypeInvalidExpressionArrayDestructuring', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
+        'src/class-hooks.php' => ['PhanPossiblyNullTypeMismatchProperty', 'PhanStaticPropIsStaticType', 'PhanTypeInvalidExpressionArrayDestructuring', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal'],
         'src/class-plugin.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/plugins/beta/.phan/config.php
+++ b/projects/plugins/beta/.phan/config.php
@@ -10,4 +10,16 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in packages like this! Packages should be listed in composer.json 'require',
+			// or 'require-dev' if they're only needed in tests or build scripts.
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack.php', // class Jetpack
+		),
+	)
+);

--- a/projects/plugins/beta/changelog/add-phan-plugin-refs
+++ b/projects/plugins/beta/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/plugins/boost/.phan/baseline.php
+++ b/projects/plugins/boost/.phan/baseline.php
@@ -18,9 +18,8 @@ return [
     // PhanTypeMismatchArgument : 9 occurrences
     // PhanParamTooMany : 7 occurrences
     // PhanPossiblyUndeclaredVariable : 6 occurrences
-    // PhanUndeclaredClassMethod : 6 occurrences
-    // PhanUndeclaredFunction : 6 occurrences
     // PhanUndeclaredConstant : 5 occurrences
+    // PhanUndeclaredFunction : 4 occurrences
     // PhanPluginUseReturnValueInternalKnown : 3 occurrences
     // PhanTypeMismatchArgumentInternal : 3 occurrences
     // PhanTypeMismatchPropertyDefault : 3 occurrences
@@ -39,7 +38,7 @@ return [
     // PhanTypeMismatchArgumentNullable : 1 occurrence
     // PhanTypeMismatchDefault : 1 occurrence
     // PhanTypeMismatchProperty : 1 occurrence
-    // PhanTypeSuspiciousStringExpression : 1 occurrence
+    // PhanUndeclaredClassMethod : 1 occurrence
     // PhanUndeclaredClassReference : 1 occurrence
     // PhanUndeclaredFunctionInCallable : 1 occurrence
 
@@ -51,7 +50,6 @@ return [
         'app/data-sync/Performance_History_Entry.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious'],
         'app/features/setup-prompt/Setup_Prompt.php' => ['PhanTypeMissingReturn'],
         'app/lib/Status.php' => ['PhanTypeArraySuspiciousNullable'],
-        'app/lib/Super_Cache_Info.php' => ['PhanUndeclaredFunction'],
         'app/lib/class-cli.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'app/lib/class-viewport.php' => ['PhanTypeMismatchArgument'],
         'app/lib/critical-css/Critical_CSS_State.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable'],
@@ -87,13 +85,11 @@ return [
         'app/modules/performance-history/Performance_History.php' => ['PhanTypeMissingReturn'],
         'app/rest-api/permissions/Nonce.php' => ['PhanParamTooMany'],
         'compatibility/elementor.php' => ['PhanUndeclaredClassConstant'],
-        'compatibility/jetpack.php' => ['PhanUndeclaredClassMethod'],
-        'compatibility/lib/class-sync-jetpack-module-status.php' => ['PhanParamTooMany', 'PhanUndeclaredClassMethod'],
+        'compatibility/lib/class-sync-jetpack-module-status.php' => ['PhanParamTooMany'],
         'compatibility/page-optimize.php' => ['PhanUndeclaredFunction', 'PhanUndeclaredFunctionInCallable'],
         'compatibility/score-prompt.php' => ['PhanImpossibleTypeComparisonInGlobalScope', 'PhanTypeComparisonToArray'],
         'compatibility/web-stories.php' => ['PhanUndeclaredClassConstant'],
         'compatibility/woocommerce.php' => ['PhanTypeArraySuspicious'],
-        'compatibility/wp-super-cache.php' => ['PhanUndeclaredFunction'],
         'jetpack-boost.php' => ['PhanNoopNew'],
         'tests/bootstrap.php' => ['PhanRedefineFunction', 'PhanTypeMismatchReturnProbablyReal'],
         'wp-js-data-sync.php' => ['PhanParamTooMany'],

--- a/projects/plugins/boost/.phan/config.php
+++ b/projects/plugins/boost/.phan/config.php
@@ -10,4 +10,19 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'amp', 'woocommerce' ) ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'+stubs'          => array( 'amp', 'woocommerce' ),
+		'parse_file_list' => array(
+			// Reference files to handle code checking for stuff from Jetpack-the-plugin or other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in packages like this! Packages should be listed in composer.json 'require',
+			// or 'require-dev' if they're only needed in tests or build scripts.
+			__DIR__ . '/../../../plugins/jetpack/class.jetpack.php',       // class Jetpack
+			__DIR__ . '/../../../plugins/super-cache/wp-cache-phase2.php', // function wp_cache_clear_cache
+			__DIR__ . '/../../../plugins/super-cache/wp-cache.php',        // function wp_cache_is_enabled
+		),
+	)
+);

--- a/projects/plugins/boost/changelog/add-phan-plugin-refs
+++ b/projects/plugins/boost/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
+
+

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -10,7 +10,7 @@
 return [
     // # Issue statistics:
     // PhanTypeMismatchArgument : 510+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 300+ occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 290+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 280+ occurrences
     // PhanNoopNew : 200+ occurrences
     // PhanTypeMismatchReturn : 150+ occurrences
@@ -51,7 +51,6 @@ return [
     // PhanTypeMismatchProperty : 10+ occurrences
     // PhanTypeMismatchReturnNullable : 10+ occurrences
     // PhanPluginRedundantAssignment : 8 occurrences
-    // PhanUndeclaredClassMethod : 8 occurrences
     // PhanDeprecatedClass : 7 occurrences
     // PhanTypeMismatchArgumentInternalReal : 7 occurrences
     // PhanCommentAbstractOnInheritedMethod : 6 occurrences
@@ -87,6 +86,7 @@ return [
     // PhanStaticCallToNonStatic : 2 occurrences
     // PhanTypeMismatchArgumentInternalProbablyReal : 2 occurrences
     // PhanUndeclaredClassInCallable : 2 occurrences
+    // PhanUndeclaredClassMethod : 2 occurrences
     // PhanDeprecatedPartiallySupportedCallable : 1 occurrence
     // PhanEmptyForeach : 1 occurrence
     // PhanInfiniteRecursion : 1 occurrence
@@ -114,9 +114,9 @@ return [
         '_inc/blogging-prompts.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal'],
         '_inc/class.jetpack-provision.php' => ['PhanAccessMethodInternal', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnNullable'],
         '_inc/genericons.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        '_inc/lib/admin-pages/class-jetpack-about-page.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
+        '_inc/lib/admin-pages/class-jetpack-about-page.php' => ['PhanTypeMismatchArgument'],
         '_inc/lib/admin-pages/class-jetpack-redux-state-helper.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimAssignment'],
-        '_inc/lib/admin-pages/class.jetpack-admin-page.php' => ['PhanDeprecatedProperty', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
+        '_inc/lib/admin-pages/class.jetpack-admin-page.php' => ['PhanDeprecatedProperty', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
         '_inc/lib/class-jetpack-ai-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyDefault'],
         '_inc/lib/class-jetpack-currencies.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal'],
         '_inc/lib/class-jetpack-google-drive-helper.php' => ['PhanTypeMismatchReturnProbablyReal'],
@@ -134,8 +134,8 @@ return [
         '_inc/lib/class.media-summary.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNull', 'PhanTypeMismatchArgument'],
         '_inc/lib/class.media.php' => ['PhanTypePossiblyInvalidDimOffset'],
         '_inc/lib/core-api/class-wpcom-rest-field-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn'],
-        '_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod', 'PhanUndeclaredConstant'],
-        '_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php' => ['PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod'],
+        '_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeArraySuspicious', 'PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn', 'PhanUndeclaredConstant'],
+        '_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php' => ['PhanTypeMismatchReturn'],
         '_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php' => ['PhanTypeMismatchReturn'],
         '_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php' => ['PhanPluginMixedKeyNoKey', 'PhanPluginSimplifyExpressionBool'],
@@ -180,7 +180,7 @@ return [
         'class.jetpack-heartbeat.php' => ['PhanTypeMismatchPropertyDefault'],
         'class.jetpack-modules-list-table.php' => ['PhanCommentAbstractOnInheritedMethod'],
         'class.jetpack-network-sites-list-table.php' => ['PhanCommentAbstractOnInheritedMethod'],
-        'class.jetpack-network.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
+        'class.jetpack-network.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
         'class.jetpack-post-images.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturnProbablyReal'],
         'class.jetpack-twitter-cards.php' => ['PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypePossiblyInvalidDimOffset'],
         'class.jetpack.php' => ['PhanAccessMethodInternal', 'PhanDeprecatedFunction', 'PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantConditionInLoop', 'PhanTypeArraySuspiciousNullable', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
@@ -221,7 +221,6 @@ return [
         'extensions/blocks/subscriptions/subscriptions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
         'extensions/blocks/top-posts/top-posts.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/wordads/wordads.php' => ['PhanNonClassMethodCall', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeMismatchArgument'],
-        'extensions/plugins/launchpad-save-modal/launchpad-save-modal.php' => ['PhanUndeclaredFunction'],
         'extensions/plugins/sharing/sharing.php' => ['PhanRedundantCondition'],
         'functions.compat.php' => ['PhanRedefineFunction', 'PhanTypeMismatchReturn'],
         'functions.global.php' => ['PhanRedundantCondition', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument'],
@@ -525,7 +524,6 @@ return [
         'sal/class.json-api-site-jetpack-base.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal'],
         'sal/class.json-api-site-jetpack.php' => ['PhanParamSignatureMismatch'],
         'sal/class.json-api-token.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
-        'src/class-jetpack-crm-data.php' => ['PhanUndeclaredFunction'],
         'src/class-jetpack-modules-overrides.php' => ['PhanRedundantCondition'],
         'tests/php/3rd-party/test__atomic.php' => ['PhanTypeMismatchArgument'],
         'tests/php/3rd-party/test_class-domain-mapping.php' => ['PhanDeprecatedFunction', 'PhanTypeMismatchArgument'],

--- a/projects/plugins/jetpack/.phan/config.php
+++ b/projects/plugins/jetpack/.phan/config.php
@@ -29,5 +29,17 @@ return make_phan_config(
 			// @todo Add type declarations so Phan won't have to do it itself. Or update to a modern less lib.
 			'modules/custom-css/custom-css/preprocessors/lessc.inc.php',
 		),
+		'parse_file_list'                 => array(
+			// Reference files to handle code checking for stuff from other in-monorepo plugins.
+			// Wherever feasible we should really clean up this sort of thing instead of adding stuff here.
+			//
+			// DO NOT add references to files in packages like this! Packages should be listed in composer.json 'require',
+			// or 'require-dev' if they're only needed in tests or build scripts.
+			__DIR__ . '/../../../plugins/vaultpress/vaultpress.php',                  // class VaultPress
+			__DIR__ . '/../../../plugins/crm/includes/ZeroBSCRM.Core.Extensions.php', // functions zeroBSCRM_isExtensionInstalled, zeroBSCRM_extension_install_jetpackforms
+
+			// Make an exception to the above for packages/jetpack-mu-wpcom. Pulling in that whole package here seems more risky than beneficial.
+			__DIR__ . '/../../../packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php', // function wpcom_launchpad_is_fse_next_steps_modal_hidden
+		),
 	)
 );

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -269,10 +269,10 @@ abstract class Jetpack_Admin_Page {
 	/**
 	 * Build header, content, and footer for admin page.
 	 *
-	 * @param string $callback Callback to produce the content of the page. The callback is responsible for any needed escaping.
-	 * @param array  $args Options for the wrapping. Also passed to the `jetpack_admin_pages_wrap_ui_after_callback` action.
-	 *   - is-wide: (bool) Set the "is-wide" class on the wrapper div, which increases the max width. Default false.
-	 *   - show-nav: (bool) Whether to show the navigation bar at the top of the page. Default true.
+	 * @param callable $callback Callback to produce the content of the page. The callback is responsible for any needed escaping.
+	 * @param array    $args Options for the wrapping. Also passed to the `jetpack_admin_pages_wrap_ui_after_callback` action.
+	 *     - is-wide: (bool) Set the "is-wide" class on the wrapper div, which increases the max width. Default false.
+	 *     - show-nav: (bool) Whether to show the navigation bar at the top of the page. Default true.
 	 */
 	public static function wrap_ui( $callback, $args = array() ) {
 		$defaults = array(

--- a/projects/plugins/jetpack/changelog/add-phan-plugin-refs
+++ b/projects/plugins/jetpack/changelog/add-phan-plugin-refs
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add refs to monorepo plugins in Phan config (and also one file in packages/jetpack-mu-wpcom). Like stubs but simpler.
+
+

--- a/projects/plugins/jetpack/changelog/add-phan-plugin-refs#2
+++ b/projects/plugins/jetpack/changelog/add-phan-plugin-refs#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix phpdoc type for `Jetpack_Admin_Page::wrap_ui()` `$callback` param.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
But instead of really creating stub files, just reference the relevant files directly from the Phan config. This is easier for what's hopefully usually a temporary situation.

There are also a handful of fixes, and in packages/image-cdn some suppressions of the callable warnings for a bunch of `remove_filter()`/`remove_action()` calls.

P.S. At some point we should probably mark methods like `Jetpack::is_module_active()` as `@deprecated` so Phan will (mostly) flag them as such for fixing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None really

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
