### PR TITLE
cli: Remove test-only deps when building for mirrors

### DIFF
--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -644,16 +644,31 @@ async function buildProject( t ) {
 				}
 			}
 
-			if ( Object.keys( versions ).length > 0 ) {
-				t.output( `\n=== Munging composer.json to fetch built packages ===\n\n` );
-				composerJson.repositories.splice( idx, 0, {
-					type: 'path',
-					url: t.argv.forMirrors + '/*/*',
-					options: {
-						monorepo: true,
-						versions,
-					},
-				} );
+			if (
+				Object.keys( versions ).length > 0 ||
+				composerJson.extra?.dependencies?.[ 'test-only' ]?.length > 0
+			) {
+				t.output(
+					`\n=== Munging composer.json to fetch built packages and/or remove test-only deps ===\n\n`
+				);
+				if ( Object.keys( versions ).length > 0 ) {
+					composerJson.repositories.splice( idx, 0, {
+						type: 'path',
+						url: t.argv.forMirrors + '/*/*',
+						options: {
+							monorepo: true,
+							versions,
+						},
+					} );
+				}
+				if ( composerJson.extra?.dependencies?.[ 'test-only' ]?.length > 0 ) {
+					for ( const dep of composerJson.extra.dependencies[ 'test-only' ] ) {
+						const depName = JSON.parse(
+							await fs.readFile( `projects/${ dep }/composer.json`, { encoding: 'utf8' } )
+						).name;
+						delete composerJson[ 'require-dev' ]?.[ depName ];
+					}
+				}
 				await writeFileAtomic(
 					`${ t.cwd }/composer.json`,
 					JSON.stringify( composerJson, null, '\t' ) + '\n',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We added the idea of test-only deps in #37140, to allow Phan to be able to analyze packages with circular dependencies while still being able to determine a consistent build order.

Turns out that when building for the mirrors, composer gets confused if there are depended-on packages existing in the output dir that aren't listed in the composer.json `.repositories.[].options.versions` field. To avoid this, let's have the for-mirrors build delete the test-only dependencies from `require-dev` so Composer won't try to use them.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1715976089072739-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build still works? Any changes in the artifact make sense?
  * [x] Comparing the artifacts from https://github.com/Automattic/jetpack/actions/runs/9133895319 and https://github.com/Automattic/jetpack/actions/runs/9134494797, the only real differences are the dropping of these require-dev entries from composer.json, composer.lock, and installed.json files, and some hashes in various files. 👍 
* See if this fixes the build on #36968.