### PR TITLE
Subscriptions: Subscribe Overlay default tagline

### DIFF
--- a/projects/plugins/jetpack/changelog/update-welcome-overlay-default-tagline
+++ b/projects/plugins/jetpack/changelog/update-welcome-overlay-default-tagline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Subscribe Overlay default tagline

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -112,8 +112,8 @@ class Jetpack_Subscribe_Overlay {
 		$site_tagline    = get_bloginfo( 'description' );
 		$default_tagline = __( 'Stay informed with curated content and the latest headlines, all delivered straight to your inbox. Subscribe now to stay ahead and never miss a beat!', 'jetpack' );
 		$tagline_block   = empty( $site_tagline )
-			? '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center">' . $default_tagline . '</p><!-- /wp:paragraph -->'
-			: '<!-- wp:site-tagline {"textAlign":"center"} /-->';
+			? '<!-- wp:paragraph {"align":"center","fontSize":"medium"} --><p class="has-text-align-center has-medium-font-size">' . $default_tagline . '</p><!-- /wp:paragraph -->'
+			: '<!-- wp:site-tagline {"textAlign":"center","fontSize":"medium"} /-->';
 		$skip_to_content = __( 'Skip to content', 'jetpack' );
 
 		return <<<HTML
@@ -121,7 +121,7 @@ class Jetpack_Subscribe_Overlay {
 	<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 		<!-- wp:site-logo {"width":90,"isLink":false,"shouldSyncIcon":true,"align":"center","className":"is-style-rounded"} /-->
 	
-		<!-- wp:site-title {"textAlign":"center","isLink":false} /-->
+		<!-- wp:site-title {"textAlign":"center","isLink":false,"fontSize":"x-large"} /-->
 
 		$tagline_block
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -109,16 +109,21 @@ class Jetpack_Subscribe_Overlay {
 	 * @return string
 	 */
 	public function get_subscribe_overlay_template_content() {
+		$site_tagline    = get_bloginfo( 'description' );
+		$default_tagline = __( 'Stay informed with curated content and the latest headlines, all delivered straight to your inbox. Subscribe now to stay ahead and never miss a beat!', 'jetpack' );
+		$tagline_block   = empty( $site_tagline )
+			? '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center">' . $default_tagline . '</p><!-- /wp:paragraph -->'
+			: '<!-- wp:site-tagline {"textAlign":"center"} /-->';
 		$skip_to_content = __( 'Skip to content', 'jetpack' );
 
 		return <<<HTML
-	<!-- wp:group {"layout":{"type":"constrained","contentSize":"400px"}} -->
-	<div class="wp-block-group">
+	<!-- wp:group {"style":{"spacing":"padding":{"right":"0","left":"0","top":"0","bottom":"0"}}},"layout":{"type":"constrained","contentSize":"400px"}} -->
+	<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 		<!-- wp:site-logo {"width":90,"isLink":false,"shouldSyncIcon":true,"align":"center","className":"is-style-rounded"} /-->
 	
 		<!-- wp:site-title {"textAlign":"center","isLink":false} /-->
 
-		<!-- wp:site-tagline {"textAlign":"center"} /-->
+		$tagline_block
 
 		<!-- wp:jetpack/subscriptions /-->
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/issues/36208
Related to p1715942259402229-slack-C052XEUUBL4

## Proposed changes:

It:
- adds default tagline rendered on the overlay
- resets the overlay content padding to not use the global ones from the theme
- use custom font sizes for title and tagline

#### Before

<img width="444" alt="Screenshot 2024-05-20 at 11 13 10" src="https://github.com/Automattic/jetpack/assets/4068554/2fe1118d-11a6-4927-95cc-49a5dc8a97ec">

#### After

<img width="444" alt="Screenshot 2024-05-20 at 11 12 44" src="https://github.com/Automattic/jetpack/assets/4068554/9802a02a-209d-475e-9044-9a585b15e3c5">
<br><br>

I know some of the colors are still wrong but I'll work on them in next iteration.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Clean the site tagline
* Make sure the overlay is using a fallback