### PR TITLE
Backport mu-wpcom-plugin 2.1.27, jetpack 13.5-a.3 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2024-05-20
+### Added
+- AI Client: Expose HTML render rules type. [#37386]
+- AI Featured Image: Support Stable Diffusion image generation. [#37413]
+
+### Changed
+- AI Client: Change default behavior of Message components [#37365]
+- Updated package dependencies. [#37379] [#37380]
+
 ## [0.13.1] - 2024-05-13
 ### Added
 - AI Client: Add className to AI Control component. [#37322]
@@ -314,6 +323,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.14.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.12.4...v0.13.0
 [0.12.4]: https://github.com/Automattic/jetpack-ai-client/compare/v0.12.3...v0.12.4

--- a/projects/js-packages/ai-client/changelog/renovate-react-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/changelog/update-ai-featured-image-experiment-with-stable-diffusion
+++ b/projects/js-packages/ai-client/changelog/update-ai-featured-image-experiment-with-stable-diffusion
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-AI Featured Image: support stable diffusion image generation.

--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extension-feedback
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extension-feedback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-AI Client: Change default behavior of Message components

--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extension-heading-production
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extension-heading-production
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-AI Client: Expose HTML render rules type

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.14.0-alpha",
+	"version": "0.14.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.33.11] - 2024-05-20
+### Changed
+- Updated package dependencies. [#37379] [#37380] [#37382]
+
 ## [0.33.10] - 2024-05-08
 ### Changed
 - Update dependencies.
@@ -761,6 +765,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.33.11]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.10...v0.33.11
 [0.33.10]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.9...v0.33.10
 [0.33.9]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.8...v0.33.9
 [0.33.8]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.7...v0.33.8

--- a/projects/js-packages/connection/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/connection/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/changelog/renovate-react-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/connection/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.33.11-alpha",
+	"version": "0.33.11",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.13 - 2024-05-20
+### Changed
+- Updated package dependencies. [#37379] [#37380] [#37382]
+
 ## 0.12.12 - 2024-05-08
 ### Changed
 - Update dependencies.

--- a/projects/js-packages/licensing/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/licensing/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/changelog/renovate-react-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/licensing/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.12.13-alpha",
+	"version": "0.12.13",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.78 - 2024-05-20
+### Changed
+- Updated package dependencies. [#37379] [#37380] [#37382]
+
 ## 0.2.77 - 2024-05-13
 ### Changed
 - Update dependencies. [#37280]

--- a/projects/js-packages/partner-coupon/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/partner-coupon/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/changelog/renovate-react-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.78-alpha",
+	"version": "0.2.78",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.51.1] - 2024-05-20
+### Added
+- Added globalize/unglobalize connection UI. [#37377]
+- Social: Wired up confirmation UI with connect button. [#37295]
+
+### Changed
+- Social: Updated connection modal UI. [#37420]
+- Updated package dependencies. [#37379] [#37380] [#37382]
+
 ## [0.51.0] - 2024-05-13
 ### Added
 - Add connect form/button for connection management. [#37196]
@@ -675,6 +684,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.51.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.51.0...v0.51.1
 [0.51.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.50.0...v0.51.0
 [0.50.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.49.3...v0.50.0
 [0.49.3]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.49.2...v0.49.3

--- a/projects/js-packages/publicize-components/changelog/add-connection-shared-ui
+++ b/projects/js-packages/publicize-components/changelog/add-connection-shared-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added globalize/unglobalize connection UI

--- a/projects/js-packages/publicize-components/changelog/add-social-account-connect
+++ b/projects/js-packages/publicize-components/changelog/add-social-account-connect
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Social | Wired up confirmation UI with connect button

--- a/projects/js-packages/publicize-components/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/publicize-components/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/renovate-react-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/publicize-components/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/publicize-components/changelog/update-social-connections-modal-ui
+++ b/projects/js-packages/publicize-components/changelog/update-social-connections-modal-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social | Updated connection modal UI

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.51.1-alpha",
+	"version": "0.51.1",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.13] - 2024-05-20
+### Changed
+- Updated package dependencies. [#37379] [#37380] [#37382]
+
 ## [0.14.12] - 2024-05-13
 ### Changed
 - Update dependencies. [#37280]
@@ -380,6 +384,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.14.13]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.12...0.14.13
 [0.14.12]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.11...0.14.12
 [0.14.11]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.10...0.14.11
 [0.14.10]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.9...0.14.10

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-react-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/shared-extension-utils/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.14.13-alpha",
+	"version": "0.14.13",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.11] - 2024-05-20
+### Changed
+- Internal updates.
+
 ## [2.1.10] - 2024-05-16
 ### Added
 - Assets: Adding comments to explain why we use variables within translation functions [#37397]
@@ -446,6 +450,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[2.1.11]: https://github.com/Automattic/jetpack-assets/compare/v2.1.10...v2.1.11
 [2.1.10]: https://github.com/Automattic/jetpack-assets/compare/v2.1.9...v2.1.10
 [2.1.9]: https://github.com/Automattic/jetpack-assets/compare/v2.1.8...v2.1.9
 [2.1.8]: https://github.com/Automattic/jetpack-assets/compare/v2.1.7...v2.1.8

--- a/projects/packages/assets/changelog/update-assets-phpcs-ignore-comments-i18n
+++ b/projects/packages/assets/changelog/update-assets-phpcs-ignore-comments-i18n
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Updating a phpcs:ignore comment
-
-

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.12] - 2024-05-20
+### Changed
+- Updated package dependencies. [#37379] [#37380] [#37382]
+
 ## [3.3.11] - 2024-05-09
 ### Changed
 - Update dependencies. [#37280]
@@ -624,6 +628,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.3.12]: https://github.com/Automattic/jetpack-backup/compare/v3.3.11...v3.3.12
 [3.3.11]: https://github.com/Automattic/jetpack-backup/compare/v3.3.10...v3.3.11
 [3.3.10]: https://github.com/Automattic/jetpack-backup/compare/v3.3.9...v3.3.10
 [3.3.9]: https://github.com/Automattic/jetpack-backup/compare/v3.3.8...v3.3.9

--- a/projects/packages/backup/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/packages/backup/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/changelog/renovate-react-monorepo
+++ b/projects/packages/backup/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.3.12-alpha';
+	const PACKAGE_VERSION = '3.3.12';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.4] - 2024-05-20
+### Changed
+- Updated package dependencies. [#37379] [#37380]
+
 ## [0.21.3] - 2024-05-13
 ### Changed
 - Update dependencies. [#37280]
@@ -365,6 +369,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.21.4]: https://github.com/automattic/jetpack-blaze/compare/v0.21.3...v0.21.4
 [0.21.3]: https://github.com/automattic/jetpack-blaze/compare/v0.21.2...v0.21.3
 [0.21.2]: https://github.com/automattic/jetpack-blaze/compare/v0.21.1...v0.21.2
 [0.21.1]: https://github.com/automattic/jetpack-blaze/compare/v0.21.0...v0.21.1

--- a/projects/packages/blaze/changelog/renovate-react-monorepo
+++ b/projects/packages/blaze/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.21.4-alpha",
+	"version": "0.21.4",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.21.4-alpha';
+	const PACKAGE_VERSION = '0.21.4';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/blocks/CHANGELOG.md
+++ b/projects/packages/blocks/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2024-05-20
+### Changed
+- Internal updates.
+
 ## [2.0.3] - 2024-04-22
 ### Changed
 - Internal updates.
@@ -182,6 +186,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Blocks: introduce new package for block management
 
+[2.0.4]: https://github.com/Automattic/jetpack-blocks/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/Automattic/jetpack-blocks/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/jetpack-blocks/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-blocks/compare/v2.0.0...v2.0.1

--- a/projects/packages/blocks/changelog/add-phan-plugin-refs
+++ b/projects/packages/blocks/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
-
-

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.3] - 2024-05-20
+### Changed
+- Internal updates.
+
 ## [2.8.2] - 2024-05-16
 ### Added
 - Connection: Ensuring direct file access is disabled in class-jetpack-ixr-client.php [#37398]
@@ -1069,6 +1073,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.8.3]: https://github.com/Automattic/jetpack-connection/compare/v2.8.2...v2.8.3
 [2.8.2]: https://github.com/Automattic/jetpack-connection/compare/v2.8.1...v2.8.2
 [2.8.1]: https://github.com/Automattic/jetpack-connection/compare/v2.8.0...v2.8.1
 [2.8.0]: https://github.com/Automattic/jetpack-connection/compare/v2.7.7...v2.8.0

--- a/projects/packages/connection/changelog/add-phan-plugin-refs
+++ b/projects/packages/connection/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
-
-

--- a/projects/packages/connection/changelog/fix-sso-better_accessibility_on_tooltip
+++ b/projects/packages/connection/changelog/fix-sso-better_accessibility_on_tooltip
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Follow-on to #37302 to improve accessibility.
-
-

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.8.3-alpha';
+	const PACKAGE_VERSION = '2.8.3';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.3] - 2024-05-20
+### Changed
+- Forms: Ensure non-minified JS file location is also an option when loading the tiny-mce-plugin-form-button script file. [#37351]
+- Updated package dependencies. [#37379] [#37380] [#37382]
+
 ## [0.31.2] - 2024-05-13
 ### Changed
 - Update dependencies. [#37280]
@@ -572,6 +577,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.31.3]: https://github.com/automattic/jetpack-forms/compare/v0.31.2...v0.31.3
 [0.31.2]: https://github.com/automattic/jetpack-forms/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/automattic/jetpack-forms/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/automattic/jetpack-forms/compare/v0.30.18...v0.31.0

--- a/projects/packages/forms/changelog/add-phan-plugin-refs
+++ b/projects/packages/forms/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
-
-

--- a/projects/packages/forms/changelog/add-phan-wordpress-globals
+++ b/projects/packages/forms/changelog/add-phan-wordpress-globals
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix phpdoc return type of `Contact_Form_Plugin::personal_data_search_filter`.
-
-

--- a/projects/packages/forms/changelog/fix-contact-form-package-script-build
+++ b/projects/packages/forms/changelog/fix-contact-form-package-script-build
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Forms: Ensuring non minified JS file location is also an option when loading the tiny-mce-plugin-form-button script file.

--- a/projects/packages/forms/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/packages/forms/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/changelog/renovate-react-monorepo
+++ b/projects/packages/forms/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.31.3-alpha",
+	"version": "0.31.3",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.31.3-alpha';
+	const PACKAGE_VERSION = '0.31.3';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/identity-crisis/CHANGELOG.md
+++ b/projects/packages/identity-crisis/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2024-05-20
+### Removed
+- IDC: Remove deprecated code. [#37421]
+
 ## [0.19.0] - 2024-05-16
 ### Added
-- IDC: Added escapes to echo statements [#37395]
+- IDC: Add escapes to echo statements. [#37395]
 
 ### Changed
 - Updated package dependencies. [#37379]
@@ -555,6 +559,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Connection/Urls for home_url and site_url functions migrated from Sync.
 
+[0.20.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.6...v0.19.0
 [0.18.6]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.5...v0.18.6
 [0.18.5]: https://github.com/Automattic/jetpack-identity-crisis/compare/v0.18.4...v0.18.5

--- a/projects/packages/identity-crisis/changelog/update-remove-identity-crisis-deprecated-code
+++ b/projects/packages/identity-crisis/changelog/update-remove-identity-crisis-deprecated-code
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-IDC: Remove deprecated code

--- a/projects/packages/identity-crisis/package.json
+++ b/projects/packages/identity-crisis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-identity-crisis",
-	"version": "0.20.0-alpha",
+	"version": "0.20.0",
 	"description": "Jetpack Identity Crisis",
 	"main": "_inc/admin.jsx",
 	"repository": {

--- a/projects/packages/identity-crisis/src/class-identity-crisis.php
+++ b/projects/packages/identity-crisis/src/class-identity-crisis.php
@@ -26,7 +26,7 @@ class Identity_Crisis {
 	/**
 	 * Package Version
 	 */
-	const PACKAGE_VERSION = '0.20.0-alpha';
+	const PACKAGE_VERSION = '0.20.0';
 
 	/**
 	 * Package Slug

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2024-05-20
+### Changed
+- Internal updates.
+
 ## [0.4.0] - 2024-05-06
 ### Removed
 - Lazy Loading: Removed compatibility script for Jetpack Lazy Loading module. [#37069]
@@ -89,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add image CDN package. [#29561]
 
+[0.4.1]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.3.7...v0.4.0
 [0.3.7]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.3.5...v0.3.6

--- a/projects/packages/image-cdn/changelog/add-phan-plugin-refs
+++ b/projects/packages/image-cdn/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
-
-

--- a/projects/packages/image-cdn/changelog/add-phan-plugin-refs#2
+++ b/projects/packages/image-cdn/changelog/add-phan-plugin-refs#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add phan suppression for the remove_filter of old Jetpack functions this package replaces. No point in stubbing those.
-
-

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Image_CDN;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.4.1-alpha';
+	const PACKAGE_VERSION = '0.4.1';
 
 	/**
 	 * Singleton.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,18 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.31.1] - 2024-05-20
+### Changed
+- Untangling: Replace Hosting -> Connections with Hosting -> Marketing. [#37431]
+
 ## [5.31.0] - 2024-05-16
 ### Added
-- Admin Interface Style: Add the track event when the value is changed [#37373]
-- WordPress.com Features: Add wp-admin sync with Calypso locale [#37352]
+- Admin Interface Style: Add the track event when the value is changed. [#37373]
+- WordPress.com Features: Add wp-admin sync with Calypso locale. [#37352]
 
 ### Changed
-- Remove the need to have posts published in the ai-assembler launchpad [#36942]
+- Remove the need to have posts published in the ai-assembler launchpad. [#36942]
 - Updated package dependencies. [#37379]
 
 ### Fixed
-- Untangling: correctly show the All Sites menu in the top bar [#37393]
-- Verbum Comments: translate block editor [#37367]
+- Untangling: correctly show the All Sites menu in the top bar. [#37393]
+- Verbum Comments: translate block editor. [#37367]
 
 ## [5.30.0] - 2024-05-14
 ### Added
@@ -819,6 +823,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.31.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.31.0...v5.31.1
 [5.31.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.30.0...v5.31.0
 [5.30.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.29.1...v5.30.0
 [5.29.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.29.0...v5.29.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-phan-plugin-refs
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-phan-wordpress-globals
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-phan-wordpress-globals
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove no-longer-needed Phan suppression of PhanImpossibleTypeComparison
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/untangling-marketing
+++ b/projects/packages/jetpack-mu-wpcom/changelog/untangling-marketing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Untangling: Replace Hosting -> Connections with Hosting -> Marketing

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.31.1-alpha",
+	"version": "5.31.1",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.31.1-alpha';
+	const PACKAGE_VERSION = '5.31.1';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/logo/CHANGELOG.md
+++ b/projects/packages/logo/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2024-05-20
+### Changed
+- Replaced heredoc syntax with strings. [#37396]
+
 ## [2.0.2] - 2024-03-18
 ### Changed
 - Internal updates.
@@ -174,6 +178,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Add a basic Jetpack Logo package
 
+[2.0.3]: https://github.com/Automattic/jetpack-logo/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/jetpack-logo/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-logo/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-logo/compare/v1.6.3...v2.0.0

--- a/projects/packages/logo/changelog/update-heredoc-replacements
+++ b/projects/packages/logo/changelog/update-heredoc-replacements
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Replaced heredoc syntax with strings.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.23.3] - 2024-05-20
+### Added
+- Add tracks events for dropdown on action buttons. [#37292]
+
+### Changed
+- Updated package dependencies. [#37379] [#37380] [#37382]
+
 ## [4.23.2] - 2024-05-09
 ### Changed
 - My Jetpack Agency banner copy change. [#37248]
@@ -1471,6 +1478,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.23.3]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.23.2...4.23.3
 [4.23.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.23.1...4.23.2
 [4.23.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.23.0...4.23.1
 [4.23.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.22.3...4.23.0

--- a/projects/packages/my-jetpack/changelog/add-phan-plugin-refs
+++ b/projects/packages/my-jetpack/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
-
-

--- a/projects/packages/my-jetpack/changelog/add-tracks-events-for-my-jetpack-product-card-action-button-dropdown
+++ b/projects/packages/my-jetpack/changelog/add-tracks-events-for-my-jetpack-product-card-action-button-dropdown
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add tracks events for dropdown on action buttons

--- a/projects/packages/my-jetpack/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/packages/my-jetpack/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/renovate-react-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/my-jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.23.3-alpha",
+	"version": "4.23.3",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.23.3-alpha';
+	const PACKAGE_VERSION = '4.23.3';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/plugins-installer/CHANGELOG.md
+++ b/projects/packages/plugins-installer/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2024-05-20
+### Deprecated
+- Extract the 'is_current_request_activating_plugin_from_plugins_screen' method into Status package. [#37430]
+
 ## [0.3.5] - 2024-05-06
 ### Changed
 - Internal updates.
@@ -82,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix method logic
 
+[0.4.0]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.3.5...v0.4.0
 [0.3.5]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Automattic/jetpack-plugins-installer/compare/v0.3.2...v0.3.3

--- a/projects/packages/plugins-installer/changelog/update-plugin-installer-extraction
+++ b/projects/packages/plugins-installer/changelog/update-plugin-installer-extraction
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Extract the 'is_current_request_activating_plugin_from_plugins_screen' method into Status package.

--- a/projects/packages/plugins-installer/src/class-plugins-installer.php
+++ b/projects/packages/plugins-installer/src/class-plugins-installer.php
@@ -242,14 +242,14 @@ class Plugins_Installer {
 	/**
 	 * Determine if the current request is activating a plugin from the plugins page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 0.4.0
 	 * @see Paths::is_current_request_activating_plugin_from_plugins_screen()
 	 *
 	 * @param string $plugin Plugin file path to check.
 	 * @return bool
 	 */
 	public static function is_current_request_activating_plugin_from_plugins_screen( $plugin ) {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Paths::is_current_request_activating_plugin_from_plugins_screen()' );
+		_deprecated_function( __METHOD__, '0.4.0', 'Automattic\\Jetpack\\Paths::is_current_request_activating_plugin_from_plugins_screen()' );
 		return ( new Paths() )->is_current_request_activating_plugin_from_plugins_screen( $plugin );
 	}
 }

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.1] - 2024-05-20
+### Changed
+- Changed the connections management feature flag check to include the WP.com plan feature. [#37425]
+- Social: Updated connection modal UI. [#37420]
+- Updated package dependencies. [#37379]
+
+### Fixed
+- Added back the previous Open Graph filter function. [#37368]
+- Fixed the typo in the Open Graph hook. [#37411]
+
 ## [0.44.0] - 2024-05-13
 ### Added
 - Add connect form/button for connection management. [#37196]
@@ -548,6 +558,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.44.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.44.0...v0.44.1
 [0.44.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.13...v0.43.0
 [0.42.13]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.12...v0.42.13

--- a/projects/packages/publicize/changelog/add-phan-plugin-refs
+++ b/projects/packages/publicize/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
-
-

--- a/projects/packages/publicize/changelog/add-phan-plugin-refs#2
+++ b/projects/packages/publicize/changelog/add-phan-plugin-refs#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Swap `jetpack_photon_url()` call for `jetpack_photon_url` filter, which works with packages/image-cdn too.
-
-

--- a/projects/packages/publicize/changelog/add-social-connections-feature-flag
+++ b/projects/packages/publicize/changelog/add-social-connections-feature-flag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Changed the connections management feature flag check to include the WPCOM plan feature

--- a/projects/packages/publicize/changelog/fix-open-graph-hook
+++ b/projects/packages/publicize/changelog/fix-open-graph-hook
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed the typo in the Open Graph hook

--- a/projects/packages/publicize/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/publicize/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/publicize/changelog/revert-35038
+++ b/projects/packages/publicize/changelog/revert-35038
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Added back the previous OpenGraph filter function

--- a/projects/packages/publicize/changelog/update-social-connections-modal-ui
+++ b/projects/packages/publicize/changelog/update-social-connections-modal-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social | Updated connection modal UI

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.44.1-alpha",
+	"version": "0.44.1",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2] - 2024-05-20
+### Fixed
+- Add plugins field default. [#37419]
+
 ## [0.12.1] - 2024-05-16
 ### Changed
 - Moves install/managed check for plugins into API endpoint validation callback [#37291]
@@ -174,6 +178,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.12.2]: https://github.com/Automattic/scheduled-updates/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/Automattic/scheduled-updates/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Automattic/scheduled-updates/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Automattic/scheduled-updates/compare/v0.10.0...v0.11.0

--- a/projects/packages/scheduled-updates/changelog/add-test-empty-plugins
+++ b/projects/packages/scheduled-updates/changelog/add-test-empty-plugins
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Added unit test
-
-

--- a/projects/packages/scheduled-updates/changelog/fix-plugins-param-default
+++ b/projects/packages/scheduled-updates/changelog/fix-plugins-param-default
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Add plugins field default

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.12.2-alpha';
+	const PACKAGE_VERSION = '0.12.2';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.7] - 2024-05-20
+### Changed
+- Updated package dependencies. [#37379] [#37380] [#37382]
+
 ## [0.44.6] - 2024-05-13
 ### Changed
 - Update dependencies. [#37280]
@@ -963,6 +967,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.44.7]: https://github.com/Automattic/jetpack-search/compare/v0.44.6...v0.44.7
 [0.44.6]: https://github.com/Automattic/jetpack-search/compare/v0.44.5...v0.44.6
 [0.44.5]: https://github.com/Automattic/jetpack-search/compare/v0.44.4...v0.44.5
 [0.44.4]: https://github.com/Automattic/jetpack-search/compare/v0.44.3...v0.44.4

--- a/projects/packages/search/changelog/add-phan-plugin-refs
+++ b/projects/packages/search/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
-
-

--- a/projects/packages/search/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/packages/search/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/renovate-react-monorepo
+++ b/projects/packages/search/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.7-alpha",
+	"version": "0.44.7",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.7-alpha';
+	const VERSION = '0.44.7';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.19.2 - 2024-05-20
+### Fixed
+- Stats: Use user language instead of site language for translations. [#37423]
+
 ## 0.19.1 - 2024-05-06
 ### Changed
 - Internal updates.

--- a/projects/packages/stats-admin/changelog/fix-stats-locale
+++ b/projects/packages/stats-admin/changelog/fix-stats-locale
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Stats: Use user language instead of site language for translations 

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.19.2-alpha",
+	"version": "0.19.2",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.19.2-alpha';
+	const VERSION = '0.19.2';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2024-05-20
+### Added
+- Add the 'is_current_request_activating_plugin_from_plugins_screen' method extracted from the Plugin Install package. [#37430]
+
 ## [3.0.3] - 2024-05-08
 ### Fixed
 - Status: Added check for compatibility reasons [#37256]
@@ -349,6 +353,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[3.1.0]: https://github.com/Automattic/jetpack-status/compare/v3.0.3...v3.1.0
 [3.0.3]: https://github.com/Automattic/jetpack-status/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/Automattic/jetpack-status/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/Automattic/jetpack-status/compare/v3.0.0...v3.0.1

--- a/projects/packages/status/changelog/add-phan-plugin-refs
+++ b/projects/packages/status/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
-
-

--- a/projects/packages/status/changelog/add-phan-wordpress-globals
+++ b/projects/packages/status/changelog/add-phan-wordpress-globals
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove no-longer-needed `@phan-var`
-
-

--- a/projects/packages/status/changelog/update-plugin-installer-extraction
+++ b/projects/packages/status/changelog/update-plugin-installer-extraction
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the 'is_current_request_activating_plugin_from_plugins_screen' method extracted from the Plugin Install package.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.4] - 2024-05-20
+### Changed
+- Replaced heredoc syntax with strings. [#37396]
+
 ## [2.16.3] - 2024-05-16
 ### Fixed
 - Jetpack Sync: Fixed undefined array key Warnings in HPOS orders module [#37401]
@@ -1148,6 +1152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[2.16.4]: https://github.com/Automattic/jetpack-sync/compare/v2.16.3...v2.16.4
 [2.16.3]: https://github.com/Automattic/jetpack-sync/compare/v2.16.2...v2.16.3
 [2.16.2]: https://github.com/Automattic/jetpack-sync/compare/v2.16.1...v2.16.2
 [2.16.1]: https://github.com/Automattic/jetpack-sync/compare/v2.16.0...v2.16.1

--- a/projects/packages/sync/changelog/add-phan-plugin-refs
+++ b/projects/packages/sync/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
-
-

--- a/projects/packages/sync/changelog/add-phan-wordpress-globals
+++ b/projects/packages/sync/changelog/add-phan-wordpress-globals
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Add int casts on various `$wpdb->get_var( "SELECT COUNT(*) ..." )` to make Phan happy
-
-

--- a/projects/packages/sync/changelog/add-phan-wordpress-globals#2
+++ b/projects/packages/sync/changelog/add-phan-wordpress-globals#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Adjust an `is_countable()` test so Phan can correctly infer something is countable.
-
-

--- a/projects/packages/sync/changelog/update-heredoc-replacements
+++ b/projects/packages/sync/changelog/update-heredoc-replacements
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Replaced heredoc syntax with strings.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.16.4-alpha';
+	const PACKAGE_VERSION = '2.16.4';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.22] - 2024-05-20
+### Changed
+- Updated package dependencies. [#37379] [#37380] [#37382]
+
+### Fixed
+- VideoPress: Fix localization of block text. [#37360]
+
 ## [0.23.21] - 2024-05-13
 ### Changed
 - Update dependencies. [#37280]
@@ -1341,6 +1348,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.22]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.21...v0.23.22
 [0.23.21]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.20...v0.23.21
 [0.23.20]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.19...v0.23.20
 [0.23.19]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.18...v0.23.19

--- a/projects/packages/videopress/changelog/add-phan-plugin-refs
+++ b/projects/packages/videopress/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add refs to monorepo plugins in Phan config. Like stubs but simpler.
-
-

--- a/projects/packages/videopress/changelog/add-phan-plugin-refs#2
+++ b/projects/packages/videopress/changelog/add-phan-plugin-refs#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Make sure a variable is defined by initializing it unconditionally.
-
-

--- a/projects/packages/videopress/changelog/add-phan-wordpress-globals
+++ b/projects/packages/videopress/changelog/add-phan-wordpress-globals
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Correct phpdoc return type on `Tus_File::get_wp_filesystem()`
-
-

--- a/projects/packages/videopress/changelog/fix-videopress-block-l10n
+++ b/projects/packages/videopress/changelog/fix-videopress-block-l10n
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-VideoPress: Fix localization of block text

--- a/projects/packages/videopress/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/packages/videopress/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-react-monorepo
+++ b/projects/packages/videopress/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.22-alpha",
+	"version": "0.23.22",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.22-alpha';
+	const PACKAGE_VERSION = '0.23.22';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/waf/CHANGELOG.md
+++ b/projects/packages/waf/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.8] - 2024-05-20
+### Changed
+- Internal updates.
+
 ## [0.16.7] - 2024-05-06
 ### Changed
 - Internal updates.
@@ -317,6 +321,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: do not ship .phpcs.dir.xml in production builds.
 
+[0.16.8]: https://github.com/Automattic/jetpack-waf/compare/v0.16.7...v0.16.8
 [0.16.7]: https://github.com/Automattic/jetpack-waf/compare/v0.16.6...v0.16.7
 [0.16.6]: https://github.com/Automattic/jetpack-waf/compare/v0.16.5...v0.16.6
 [0.16.5]: https://github.com/Automattic/jetpack-waf/compare/v0.16.4...v0.16.5

--- a/projects/packages/waf/changelog/add-phan-wordpress-globals
+++ b/projects/packages/waf/changelog/add-phan-wordpress-globals
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove no-longer-needed `@phan-var`s
-
-

--- a/projects/packages/woocommerce-analytics/CHANGELOG.md
+++ b/projects/packages/woocommerce-analytics/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2024-05-20
+### Fixed
+- Customer creation: avoid PHP warnings when other plugins hook into customer creation process and return malformed user data. [#37440]
+
 ## [0.1.5] - 2024-05-06
 ### Changed
 - Ensure the package can only be initialized once. [#37154]
@@ -35,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix namespace issue with WooCommerce class reference. [#35857]
 - General: bail early when WooCommerce is not active. [#36278]
 
+[0.1.6]: https://github.com/Automattic/woocommerce-analytics/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/Automattic/woocommerce-analytics/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/Automattic/woocommerce-analytics/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/Automattic/woocommerce-analytics/compare/v0.1.2...v0.1.3

--- a/projects/packages/woocommerce-analytics/changelog/fix-conflict-woo-analytics-malformed-user-info
+++ b/projects/packages/woocommerce-analytics/changelog/fix-conflict-woo-analytics-malformed-user-info
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Customer creation: avoid PHP warnings when other plugins hook into customer creation process and return malformed user data.

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -20,7 +20,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.1.6-alpha';
+	const PACKAGE_VERSION = '0.1.6';
 
 	/**
 	 * Initializer.

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.19] - 2024-05-20
+### Changed
+- Updated package dependencies. [#37379] [#37380] [#37382]
+
 ## [0.3.18] - 2024-05-13
 ### Changed
 - Update dependencies. [#37280]
@@ -37,8 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.11] - 2024-03-12
 ### Changed
 - Updated package dependencies. [#36325]
-- Update to the most recent version of the @automattic/calypso-color-schemes package. [#36187]
-- Update to the most recent version of the @automattic/calypso-color-schemes package. [#36227]
+- Update to the most recent version of the @automattic/calypso-color-schemes package. [#36187] [#36227]
 
 ## [0.3.10] - 2024-03-04
 ### Changed
@@ -351,6 +354,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.19]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.18...v0.3.19
 [0.3.18]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.17...v0.3.18
 [0.3.17]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.16...v0.3.17
 [0.3.16]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.15...v0.3.16

--- a/projects/packages/wordads/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/packages/wordads/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/changelog/renovate-react-monorepo
+++ b/projects/packages/wordads/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.19-alpha",
+	"version": "0.3.19",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.19-alpha';
+	const VERSION = '0.3.19';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.5-a.3 - 2024-05-20
+### Enhancements
+- AI Assistant: Enable inline Heading extension. [#37386]
+- Subscribe block: Adds button-only style. [#37341]
+- Subscribe block: Allow inside navigation block. [#37439]
+
+### Improved compatibility
+- Block Editor: Remove External Link icon styling fix now that the change has been made in WordPress itself. [#37394]
+
+### Bug fixes
+- Slideshow: Fix className issue on frontend - ensures autoplay works properly. [#37378]
+- WordAds: Prevent fatal when post content is null. [#37384]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Add some missing abstract methods to SAL_Site, and implement in Jetpack_Site. [#37344]
+- AI Assistant: Add chat history to inline extension [#37429]
+- AI Assistant: Inline extension testing feedback changes [#37365]
+- AI Featured Image: add support to Stable Diffusion image generation. [#37413]
+- Fix `SAL_Token::is_global()`. [#37344]
+- Minor typos [#37387]
+- Monetize: correctly updates and delete paid content meta. [#37346]
+- Prevent JS error when subscription module is not enabled. [#36276]
+- Remove `jetpack_server_sandbox()` and `jetpack_server_sandbox_request_parameters()`. [#37344]
+- Remove `Jetpack_User_Agent_Info::is_OperaMobile()`. [#37344]
+- SSO: Switch to loading feature from the Connection package. [#37153]
+- Subscription paywall: Simplify paid access question for logged out subscribers. [#37434]
+- Subscriptions: Add Subscribe Overlay toggle. [#37433]
+- Subscriptions: Add Welcome Overlay behind the feature flag. [#37372]
+- Subscriptions: Subscribe Overlay default tagline. [#37446]
+- Updated package dependencies. [#37348] [#37379] [#37380] [#37382]
+
 ## 13.5-a.1 - 2024-05-13
 ### Enhancements
 - SSO: Improve accessibility of tooltips on WP Admin users page. [#37302]

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -5,15 +5,15 @@
 ## 13.5-a.3 - 2024-05-20
 ### Enhancements
 - AI Assistant: Enable inline Heading extension. [#37386]
-- Subscribe block: Adds button-only style. [#37341]
-- Subscribe block: Allow inside navigation block. [#37439]
+- Subscribe block: Add button-only style. [#37341]
+- Subscribe block: Allow in the Navigation block. [#37439]
 
 ### Improved compatibility
 - Block Editor: Remove External Link icon styling fix now that the change has been made in WordPress itself. [#37394]
 
 ### Bug fixes
-- Slideshow: Fix className issue on frontend - ensures autoplay works properly. [#37378]
-- WordAds: Prevent fatal when post content is null. [#37384]
+- Slideshow: Ensures autoplay works properly. [#37378]
+- WordAds: Prevent fatal error when post content is null. [#37384]
 
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
 - Add some missing abstract methods to SAL_Site, and implement in Jetpack_Site. [#37344]

--- a/projects/plugins/jetpack/changelog/add-phan-plugin-refs
+++ b/projects/plugins/jetpack/changelog/add-phan-plugin-refs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Add refs to monorepo plugins in Phan config (and also one file in packages/jetpack-mu-wpcom). Like stubs but simpler.
-
-

--- a/projects/plugins/jetpack/changelog/add-phan-plugin-refs#2
+++ b/projects/plugins/jetpack/changelog/add-phan-plugin-refs#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix phpdoc type for `Jetpack_Admin_Page::wrap_ui()` `$callback` param.
-
-

--- a/projects/plugins/jetpack/changelog/add-phan-wordpress-globals
+++ b/projects/plugins/jetpack/changelog/add-phan-wordpress-globals
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Add int casts on various `$wpdb->get_var( "SELECT COUNT(*) ..." )` to make Phan happy
-
-

--- a/projects/plugins/jetpack/changelog/add-phan-wordpress-globals#2
+++ b/projects/plugins/jetpack/changelog/add-phan-wordpress-globals#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix some phpdoc return types.
-
-

--- a/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues
+++ b/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: #16434 removed the jetpack-device-detect function this was calling, but missed this caller.
-
-Remove `Jetpack_User_Agent_Info::is_OperaMobile()`, it would have thrown fatals since October 2021.

--- a/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#2
+++ b/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Due to a wrong namespace in #21128, the stubs never actually worked.
-
-Remove `jetpack_server_sandbox()` and `jetpack_server_sandbox_request_parameters()`. They'd have thrown fatals since October 2021.

--- a/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#3
+++ b/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Use `$skin` instead of `$upgrader->skin`, it's the same object but not typed as a parent class. Should be no change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#4
+++ b/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Add some missing methods to `WPCOM_JSON_API`.
-
-

--- a/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#5
+++ b/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#5
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Add some missing abstract methods to SAL_Site, and implement in Jetpack_Site.

--- a/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#6
+++ b/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix `SAL_Token::is_global()`.

--- a/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#7
+++ b/projects/plugins/jetpack/changelog/fix-misc-phan-undeclared-issues#7
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Remove views/admin/deactivation-dialog.php, unused since #21048.
-
-

--- a/projects/plugins/jetpack/changelog/fix-misc-various_small_unrelated_fixes_bundled_into_one_branch
+++ b/projects/plugins/jetpack/changelog/fix-misc-various_small_unrelated_fixes_bundled_into_one_branch
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Minor typos

--- a/projects/plugins/jetpack/changelog/fix-newsletter-reply-to-setting-validation
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-reply-to-setting-validation
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: This feature is not yet shipped and doesn't have any impact on the users
-
-

--- a/projects/plugins/jetpack/changelog/fix-paid-content-meta
+++ b/projects/plugins/jetpack/changelog/fix-paid-content-meta
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Monetize: correctly updates and delete paid content meta.

--- a/projects/plugins/jetpack/changelog/fix-slideshow-autoplay-frontend
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-autoplay-frontend
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Slideshow: Fix className issue on frontend - ensures autoplay works properly.

--- a/projects/plugins/jetpack/changelog/fix-sync-callables-set-late-default
+++ b/projects/plugins/jetpack/changelog/fix-sync-callables-set-late-default
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated Sync related unit tests
-
-

--- a/projects/plugins/jetpack/changelog/fix-wordads-inline_insert_fatal
+++ b/projects/plugins/jetpack/changelog/fix-wordads-inline_insert_fatal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-WordAds: Prevent fatal when post content is null.

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-major-js-unit-testing-packages
+++ b/projects/plugins/jetpack/changelog/renovate-major-js-unit-testing-packages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-react-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-react-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/rm-external-link-fix
+++ b/projects/plugins/jetpack/changelog/rm-external-link-fix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-Block Editor: remove External Link icon styling fix, now that the change has been made in WordPress itself.

--- a/projects/plugins/jetpack/changelog/update-ai-featured-image-experiment-with-stable-diffusion
+++ b/projects/plugins/jetpack/changelog/update-ai-featured-image-experiment-with-stable-diffusion
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-AI Featured Image: add support to Stable Diffusion image generation.

--- a/projects/plugins/jetpack/changelog/update-escape-echoed-variables
+++ b/projects/plugins/jetpack/changelog/update-escape-echoed-variables
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-feedback
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-feedback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Inline extension testing feedback changes

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-heading-history
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-heading-history
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Add chat history to inline extension

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-heading-production
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-heading-production
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-AI Assistant: Enable inline Heading extension

--- a/projects/plugins/jetpack/changelog/update-overlay-toggle
+++ b/projects/plugins/jetpack/changelog/update-overlay-toggle
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriptions: Add Subscribe Overlay toggle

--- a/projects/plugins/jetpack/changelog/update-paywall-block-prevent-js-error
+++ b/projects/plugins/jetpack/changelog/update-paywall-block-prevent-js-error
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Prevent JS error when subscription module is not enabled.

--- a/projects/plugins/jetpack/changelog/update-plugin-installer-extraction
+++ b/projects/plugins/jetpack/changelog/update-plugin-installer-extraction
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-remove-identity-crisis-deprecated-code
+++ b/projects/plugins/jetpack/changelog/update-remove-identity-crisis-deprecated-code
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-sso-use-package
+++ b/projects/plugins/jetpack/changelog/update-sso-use-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-SSO: switch to loading feature from the Connection package.

--- a/projects/plugins/jetpack/changelog/update-subsciptions-allow-in-navi
+++ b/projects/plugins/jetpack/changelog/update-subsciptions-allow-in-navi
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscription block: allow adding inside navigation block

--- a/projects/plugins/jetpack/changelog/update-subscribe-button-only
+++ b/projects/plugins/jetpack/changelog/update-subscribe-button-only
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscribe block: adds button-only style

--- a/projects/plugins/jetpack/changelog/update-subscribe-welcome-overlay
+++ b/projects/plugins/jetpack/changelog/update-subscribe-welcome-overlay
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscriptions: Add Welcome Overlay behind the feature flag

--- a/projects/plugins/jetpack/changelog/update-subscriptions-simplify-access-question
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-simplify-access-question
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscription paywall: simplify paid access question for logged out subscribers

--- a/projects/plugins/jetpack/changelog/update-welcome-overlay-default-tagline
+++ b/projects/plugins/jetpack/changelog/update-welcome-overlay-default-tagline
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Subscribe Overlay default tagline

--- a/projects/plugins/jetpack/class.json-api.php
+++ b/projects/plugins/jetpack/class.json-api.php
@@ -385,7 +385,7 @@ class WPCOM_JSON_API {
 	 * Checks if the current request is authorized with an upload token.
 	 * This method is overridden by a child class in WPCOM.
 	 *
-	 * @since $$next-version$$
+	 * @since 13.5
 	 * @return boolean
 	 */
 	public function is_authorized_with_upload_token() {
@@ -1031,7 +1031,7 @@ class WPCOM_JSON_API {
 	 * Return a count of comment likes.
 	 * This method is overridden by a child class in WPCOM.
 	 *
-	 * @since $$next-version$$
+	 * @since 13.5
 	 * @return int
 	 */
 	public function comment_like_count() {

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_2",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_3",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.5-a.2
+ * Version: 13.5-a.3
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.5-a.2' );
+define( 'JETPACK__VERSION', '13.5-a.3' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/sso.php
+++ b/projects/plugins/jetpack/modules/sso.php
@@ -29,6 +29,6 @@ add_action(
 /**
  * Legacy, deprecated class.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.5
  */
 class Jetpack_SSO extends SSO {}

--- a/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
+++ b/projects/plugins/jetpack/modules/sso/class-jetpack-force-2fa.php
@@ -4,7 +4,7 @@
  *
  * Ported from original repo at https://github.com/automattic/jetpack-force-2fa
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Connection\Manager\SSO instead.
+ * @deprecated 13.5 Use Automattic\Jetpack\Connection\Manager\SSO instead.
  *
  * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
  *
@@ -14,7 +14,7 @@
 /**
  * Force users to use two factor authentication.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.5
  */
 class Jetpack_Force_2FA {
 
@@ -24,7 +24,7 @@ class Jetpack_Force_2FA {
 	 * Defaults to manage_options via the plugins_loaded function.
 	 * Can be modified with the jetpack_force_2fa_cap filter.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 *
 	 * @var string
 	 */
@@ -33,38 +33,38 @@ class Jetpack_Force_2FA {
 	/**
 	 * Constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Force_2FA::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Force_2FA::__construct' );
 	}
 
 	/**
 	 * Load the plugin via the plugins_loaded hook.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 */
 	public function plugins_loaded() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Force_2FA::plugins_loaded' );
+		_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Force_2FA::plugins_loaded' );
 	}
 
 	/**
 	 * Display an admin notice if Jetpack SSO is not active.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 */
 	public function admin_notice() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Force_2FA::admin_notice' );
+		_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Force_2FA::admin_notice' );
 	}
 
 	/**
 	 * Specifically set the two step filter for Jetpack SSO.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 *
 	 * @param Object $user_data The user data from WordPress.com.
 	 */
 	public function jetpack_set_two_step( $user_data ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Force_2FA::jetpack_set_two_step' );
+		_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Force_2FA::jetpack_set_two_step' );
 	}
 }

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-helpers.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-helpers.php
@@ -2,7 +2,7 @@
 /**
  * A collection of helper functions used in the SSO module.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Connection\Manager\SSO instead.
+ * @deprecated 13.5 Use Automattic\Jetpack\Connection\Manager\SSO instead.
  *
  * @package automattic/jetpack
  */
@@ -16,7 +16,7 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 	/**
 	 * A collection of helper functions used in the SSO module.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 *
 	 * @since 4.1.0
 	 */
@@ -24,12 +24,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		/**
 		 * Determine if the login form should be hidden or not
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @return bool
 		 **/
 		public static function should_hide_login_form() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::should_hide_login_form' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::should_hide_login_form' );
 
 			return Helpers::should_hide_login_form();
 		}
@@ -38,12 +38,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 * Returns a boolean value for whether logging in by matching the WordPress.com user email to a
 		 * Jetpack site user's email is allowed.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @return bool
 		 */
 		public static function match_by_email() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::match_by_email' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::match_by_email' );
 
 			return Helpers::match_by_email();
 		}
@@ -52,13 +52,13 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 * Returns a boolean for whether users are allowed to register on the Jetpack site with SSO,
 		 * even though the site disallows normal registrations.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param object|null $user_data WordPress.com user information.
 		 * @return bool
 		 */
 		public static function new_user_override( $user_data = null ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::new_user_override' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::new_user_override' );
 
 			return Helpers::new_user_override( $user_data );
 		}
@@ -68,12 +68,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 *
 		 * @since 4.1.0
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @return bool
 		 */
 		public static function is_two_step_required() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::is_two_step_required' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::is_two_step_required' );
 
 			return Helpers::is_two_step_required();
 		}
@@ -82,12 +82,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 * Returns a boolean for whether a user that is attempting to log in will be automatically
 		 * redirected to WordPress.com to begin the SSO flow.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @return bool
 		 */
 		public static function bypass_login_forward_wpcom() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::bypass_login_forward_wpcom' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::bypass_login_forward_wpcom' );
 
 			return Helpers::bypass_login_forward_wpcom();
 		}
@@ -98,12 +98,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 *
 		 * @since 4.1.0
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @return bool
 		 */
 		public static function show_sso_login() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::show_sso_login' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::show_sso_login' );
 
 			return Helpers::show_sso_login();
 		}
@@ -113,12 +113,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 *
 		 * @since 4.1.0
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @return bool
 		 */
 		public static function is_require_two_step_checkbox_disabled() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::is_require_two_step_checkbox_disabled' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::is_require_two_step_checkbox_disabled' );
 
 			return Helpers::is_require_two_step_checkbox_disabled();
 		}
@@ -128,12 +128,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 *
 		 * @since 4.1.0
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @return bool
 		 */
 		public static function is_match_by_email_checkbox_disabled() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::is_match_by_email_checkbox_disabled' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::is_match_by_email_checkbox_disabled' );
 
 			return Helpers::is_match_by_email_checkbox_disabled();
 		}
@@ -147,7 +147,7 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 * @since 4.3.0
 		 * @since 4.6.0 Added public-api.wordpress.com as an allowed redirect
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param array  $hosts Allowed redirect hosts.
 		 * @param string $api_base Base API URL.
@@ -155,7 +155,7 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 * @return array
 		 */
 		public static function allowed_redirect_hosts( $hosts, $api_base = JETPACK__API_BASE ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::allowed_redirect_hosts' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::allowed_redirect_hosts' );
 
 			return Helpers::allowed_redirect_hosts( $hosts, $api_base );
 		}
@@ -163,12 +163,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		/**
 		 * Generate a new user from a SSO attempt.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param object $user_data WordPress.com user information.
 		 */
 		public static function generate_user( $user_data ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Utils::generate_user' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Utils::generate_user' );
 
 			return Utils::generate_user( $user_data );
 		}
@@ -176,12 +176,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		/**
 		 * Determines how long the auth cookie is valid for when a user logs in with SSO.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @return int result of the jetpack_sso_auth_cookie_expiration filter.
 		 */
 		public static function extend_auth_cookie_expiration_for_sso() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::extend_auth_cookie_expiration_for_sso' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::extend_auth_cookie_expiration_for_sso' );
 
 			return Helpers::extend_auth_cookie_expiration_for_sso();
 		}
@@ -191,14 +191,14 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 *
 		 * @since 4.6.0
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $action SSO action being performed.
 		 *
 		 * @return bool  Is SSO allowed for the current action?
 		 */
 		public static function display_sso_form_for_action( $action ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::display_sso_form_for_action' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::display_sso_form_for_action' );
 
 			return Helpers::display_sso_form_for_action( $action );
 		}
@@ -209,12 +209,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 *
 		 * @since 4.6.0
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @return array|bool
 		 */
 		public static function get_json_api_auth_environment() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::get_json_api_auth_environment' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::get_json_api_auth_environment' );
 
 			return Helpers::get_json_api_auth_environment();
 		}
@@ -223,12 +223,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 * Check if the site has a custom login page URL, and return it.
 		 * If default login page URL is used (`wp-login.php`), `null` will be returned.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @return string|null
 		 */
 		public static function get_custom_login_url() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::get_custom_login_url' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::get_custom_login_url' );
 
 			return Helpers::get_custom_login_url();
 		}
@@ -237,10 +237,10 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 * Clear the cookies that store the profile information for the last
 		 * WPCOM user to connect.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 */
 		public static function clear_wpcom_profile_cookies() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::clear_wpcom_profile_cookies' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::clear_wpcom_profile_cookies' );
 
 			return Helpers::clear_wpcom_profile_cookies();
 		}
@@ -248,12 +248,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		/**
 		 * Remove an SSO connection for a user.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param int $user_id The local user id.
 		 */
 		public static function delete_connection_for_user( $user_id ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::delete_connection_for_user' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\Helpers::delete_connection_for_user' );
 
 			return Helpers::delete_connection_for_user( $user_id );
 		}
@@ -263,12 +263,12 @@ if ( ! class_exists( 'Jetpack_SSO_Helpers' ) ) :
 		 *
 		 * @since 13.3
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param int $user_id Local User information.
 		 */
 		public static function is_user_connected( $user_id = 0 ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager->is_user_connected' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager->is_user_connected' );
 
 			return ( new Manager() )->is_user_connected( $user_id );
 		}

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-notices.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-notices.php
@@ -2,7 +2,7 @@
 /**
  * A collection of helper functions used in the SSO module.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Connection\Manager\SSO instead.
+ * @deprecated 13.5 Use Automattic\Jetpack\Connection\Manager\SSO instead.
  *
  * @package automattic/jetpack
  */
@@ -14,7 +14,7 @@ if ( ! class_exists( 'Jetpack_SSO_Notices' ) ) :
 	/**
 	 * A collection of helper functions used in the SSO module.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 *
 	 * @since 4.4.0
 	 */
@@ -25,13 +25,13 @@ if ( ! class_exists( 'Jetpack_SSO_Notices' ) ) :
 		 *
 		 * @since 2.7
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $message Error message.
 		 * @return string
 		 **/
 		public static function error_msg_enable_two_step( $message ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::error_msg_enable_two_step' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::error_msg_enable_two_step' );
 
 			return Notices::error_msg_enable_two_step( $message );
 		}
@@ -41,13 +41,13 @@ if ( ! class_exists( 'Jetpack_SSO_Notices' ) ) :
 		 * is off and they already have an account with their email address on
 		 * this site.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $message Error message.
 		 * @return string
 		 */
 		public static function error_msg_email_already_exists( $message ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::error_msg_email_already_exists' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::error_msg_email_already_exists' );
 
 			return Notices::error_msg_email_already_exists( $message );
 		}
@@ -57,14 +57,14 @@ if ( ! class_exists( 'Jetpack_SSO_Notices' ) ) :
 		 *
 		 * @since 4.3.2
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $message Error Message.
 		 *
 		 * @return string
 		 */
 		public static function error_msg_identity_crisis( $message ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::error_msg_identity_crisis' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::error_msg_identity_crisis' );
 
 			return Notices::error_msg_identity_crisis( $message );
 		}
@@ -75,14 +75,14 @@ if ( ! class_exists( 'Jetpack_SSO_Notices' ) ) :
 		 *
 		 * @since 4.3.2
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $message Error message.
 		 *
 		 * @return string
 		 */
 		public static function error_invalid_response_data( $message ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::error_invalid_response_data' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::error_invalid_response_data' );
 
 			return Notices::error_invalid_response_data( $message );
 		}
@@ -93,14 +93,14 @@ if ( ! class_exists( 'Jetpack_SSO_Notices' ) ) :
 		 *
 		 * @since 4.3.2
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $message Error message.
 		 *
 		 * @return string
 		 */
 		public static function error_unable_to_create_user( $message ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::error_unable_to_create_user' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::error_unable_to_create_user' );
 
 			return Notices::error_unable_to_create_user( $message );
 		}
@@ -109,14 +109,14 @@ if ( ! class_exists( 'Jetpack_SSO_Notices' ) ) :
 		 * When the default login form is hidden, this method is called on the 'authenticate' filter with a priority of 30.
 		 * This method disables the ability to submit the default login form.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param WP_User|WP_Error $user Either the user attempting to login or an existing authentication failure.
 		 *
 		 * @return WP_Error
 		 */
 		public static function disable_default_login_form( $user ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::disable_default_login_form' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::disable_default_login_form' );
 
 			return Notices::disable_default_login_form( $user );
 		}
@@ -127,14 +127,14 @@ if ( ! class_exists( 'Jetpack_SSO_Notices' ) ) :
 		 *
 		 * @since 2.7
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $message Error message.
 		 *
 		 * @return string
 		 **/
 		public static function msg_login_by_jetpack( $message ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::msg_login_by_jetpack' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::msg_login_by_jetpack' );
 
 			return Notices::msg_login_by_jetpack( $message );
 		}
@@ -142,12 +142,12 @@ if ( ! class_exists( 'Jetpack_SSO_Notices' ) ) :
 		/**
 		 * Get the message for SSO required.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @return string
 		 */
 		public static function get_sso_required_message() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::get_sso_required_message' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::get_sso_required_message' );
 
 			return Notices::get_sso_required_message();
 		}
@@ -155,14 +155,14 @@ if ( ! class_exists( 'Jetpack_SSO_Notices' ) ) :
 		/**
 		 * Message displayed when the user can not be found after approving the SSO process on WordPress.com
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $message Error message.
 		 *
 		 * @return string
 		 */
 		public static function cant_find_user( $message ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::cant_find_user' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::cant_find_user' );
 
 			return Notices::cant_find_user( $message );
 		}
@@ -172,14 +172,14 @@ if ( ! class_exists( 'Jetpack_SSO_Notices' ) ) :
 		 *
 		 * @since 4.4.0
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $message Error message.
 		 *
 		 * @return string
 		 */
 		public static function sso_not_allowed_in_staging( $message ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::sso_not_allowed_in_staging' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\Manager\\SSO\\Notices::sso_not_allowed_in_staging' );
 
 			return Notices::sso_not_allowed_in_staging( $message );
 		}

--- a/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
+++ b/projects/plugins/jetpack/modules/sso/class.jetpack-sso-user-admin.php
@@ -2,7 +2,7 @@
 /**
  * Extra UI elements added to the User Menu for the SSO feature.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Connection\Manager\SSO instead.
+ * @deprecated 13.5 Use Automattic\Jetpack\Connection\Manager\SSO instead.
  *
  * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
  *
@@ -13,158 +13,158 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 	/**
 	 * Jetpack sso user admin class.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.5
 	 */
 	class Jetpack_SSO_User_Admin {
 		/**
 		 * Constructor function.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 */
 		public function __construct() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin' );
 		}
 
 		/**
 		 * Enqueue assets for user-new.php.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 */
 		public function jetpack_new_users_styles() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->jetpack_new_users_styles' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->jetpack_new_users_styles' );
 		}
 
 		/**
 		 * Intercept the arguments for building the table, and create WP_User_Query instance
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param array $args The search arguments.
 		 */
 		public function set_user_query( $args ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->set_user_query' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->set_user_query' );
 		}
 
 		/**
 		 * Revokes WordPress.com invitation.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param int $user_id The user ID.
 		 */
 		public function revoke_user_invite( $user_id ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->revoke_user_invite' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->revoke_user_invite' );
 		}
 
 		/**
 		 * Renders invitations errors/success messages in users.php.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 */
 		public function handle_invitation_results() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->handle_invitation_results' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->handle_invitation_results' );
 		}
 
 		/**
 		 * Invites a user to connect to WordPress.com to allow them to log in via SSO.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 */
 		public function invite_user_to_wpcom() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->invite_user_to_wpcom' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->invite_user_to_wpcom' );
 		}
 
 		/**
 		 * Revokes a user's invitation to connect to WordPress.com.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $invite_id The ID of the invite to revoke.
 		 */
 		public function send_revoke_wpcom_invite( $invite_id ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->send_revoke_wpcom_invite' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->send_revoke_wpcom_invite' );
 		}
 
 		/**
 		 * Handles logic to revoke user invite.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 */
 		public function handle_request_revoke_invite() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->handle_request_revoke_invite' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->handle_request_revoke_invite' );
 		}
 
 		/**
 		 * Handles resend user invite.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 */
 		public function handle_request_resend_invite() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->handle_request_resend_invite' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->handle_request_resend_invite' );
 		}
 
 		/**
 		 * Adds 'Revoke invite' and 'Resend invite' link to user table row actions.
 		 * Removes 'Reset password' link.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param array   $actions - User row actions.
 		 * @param WP_User $user_object - User object.
 		 */
 		public function jetpack_user_table_row_actions( $actions, $user_object ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->jetpack_user_table_row_actions' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->jetpack_user_table_row_actions' );
 		}
 
 		/**
 		 * Render the invitation email message.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 */
 		public function render_invitation_email_message() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->render_invitation_email_message' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->render_invitation_email_message' );
 		}
 
 		/**
 		 * Render a note that wp.com invites will be automatically revoked.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 */
 		public function render_invitations_notices_for_deleted_users() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->render_invitations_notices_for_deleted_users' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->render_invitations_notices_for_deleted_users' );
 		}
 
 		/**
 		 * Render WordPress.com invite checkbox for new user registration.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $type The type of new user form the hook follows.
 		 */
 		public function render_wpcom_invite_checkbox( $type ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->render_wpcom_invite_checkbox' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->render_wpcom_invite_checkbox' );
 		}
 
 		/**
 		 * Render a checkbox to differentiate if a user is external.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $type The type of new user form the hook follows.
 		 */
 		public function render_wpcom_external_user_checkbox( $type ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->render_wpcom_external_user_checkbox' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->render_wpcom_external_user_checkbox' );
 		}
 
 		/**
 		 * Render the custom email message form field for new user registration.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $type The type of new user form the hook follows.
 		 */
 		public function render_custom_email_message_form_field( $type ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->render_custom_email_message_form_field' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->render_custom_email_message_form_field' );
 		}
 
 		/**
@@ -172,36 +172,36 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		 * It should be sent when SSO is disabled or when admins opt-out of WordPress.com invites intentionally.
 		 * If the "Send User Notification" checkbox is checked, the core invitation email should be sent.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param boolean $send_wp_email Whether the core invitation email should be sent.
 		 */
 		public function should_send_wp_mail_new_user( $send_wp_email ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->should_send_wp_mail_new_user' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->should_send_wp_mail_new_user' );
 		}
 
 		/**
 		 * Send user invitation to WordPress.com if user has no errors.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param WP_Error $errors The WP_Error object.
 		 * @param bool     $update Whether the user is being updated or not.
 		 * @param stdClass $user   The User object about to be created.
 		 */
 		public function send_wpcom_mail_user_invite( $errors, $update, $user ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->send_wpcom_mail_user_invite' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->send_wpcom_mail_user_invite' );
 		}
 
 		/**
 		 * Adds a column in the user admin table to display user connection status and actions.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param array $columns User list table columns.
 		 */
 		public function jetpack_user_connected_th( $columns ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->jetpack_user_connected_th' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->jetpack_user_connected_th' );
 		}
 
 		/**
@@ -210,45 +210,45 @@ if ( ! class_exists( 'Jetpack_SSO_User_Admin' ) ) :
 		 * @access private
 		 * @static
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $email The user email.
 		 */
 		public static function get_pending_cached_wpcom_invite( $email ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->get_pending_cached_wpcom_invite' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->get_pending_cached_wpcom_invite' );
 		}
 
 		/**
 		 * Show Jetpack SSO user connection status.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param string $val HTML for the column.
 		 * @param string $col User list table column.
 		 * @param int    $user_id User ID.
 		 */
 		public function jetpack_show_connection_status( $val, $col, $user_id ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->jetpack_show_connection_status' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->jetpack_show_connection_status' );
 		}
 
 		/**
 		 * Creates error notices and redirects the user to the previous page.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 *
 		 * @param array $query_params - query parameters added to redirection URL.
 		 */
 		public function create_error_notice_and_redirect( $query_params ) {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->create_error_notice_and_redirect' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->create_error_notice_and_redirect' );
 		}
 
 		/**
 		 * Style the Jetpack user rows and columns.
 		 *
-		 * @deprecated $$next-version$$
+		 * @deprecated 13.5
 		 */
 		public function jetpack_user_table_styles() {
-			_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->jetpack_user_table_styles' );
+			_deprecated_function( __METHOD__, 'jetpack-13.5', 'Automattic\\Jetpack\\Connection\\SSO\\User_Admin->jetpack_user_table_styles' );
 		}
 	}
 endif;

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -3,7 +3,7 @@
  * Adds support for Jetpack Subscribe Overlay feature
  *
  * @package automattic/jetpack-subscriptions
- * @since $$next-version$$
+ * @since 13.5
  */
 
 /**

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.5.0-a.2",
+	"version": "13.5.0-a.3",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,10 +326,18 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.5-a.1 - 2024-05-13
+### 13.5-a.3 - 2024-05-20
 #### Enhancements
-- SSO: Improve accessibility of tooltips on WP Admin users page.
-- WordAds: Add inline ads within post content.
+- AI Assistant: Enable inline Heading extension.
+- Subscribe block: Adds button-only style.
+- Subscribe block: Allow inside navigation block.
+
+#### Improved compatibility
+- Block Editor: Remove External Link icon styling fix now that the change has been made in WordPress itself.
+
+#### Bug fixes
+- Slideshow: Fix className issue on frontend - ensures autoplay works properly.
+- WordAds: Prevent fatal when post content is null.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.27 - 2024-05-20
+### Changed
+- Internal updates.
+
 ## 2.1.26 - 2024-05-16
 ### Changed
 - Updated package dependencies. [#37348]

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-plugin-installer-extraction
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-plugin-installer-extraction
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-remove-identity-crisis-deprecated-code
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-remove-identity-crisis-deprecated-code
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_27_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_27"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.27-alpha
+ * Version: 2.1.27
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.27-alpha",
+	"version": "2.1.27",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.27, jetpack 13.5-a.3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.