### PR TITLE
CRM: Remove blank line below customer name in invoices

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3451-invoice-pdf-showing-space-below-customer-name
+++ b/projects/plugins/crm/changelog/fix-crm-3451-invoice-pdf-showing-space-below-customer-name
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Invoices: Remove blank line below contact name in invoices.
+Invoices: Remove the blank line below the contact name.

--- a/projects/plugins/crm/changelog/fix-crm-3451-invoice-pdf-showing-space-below-customer-name
+++ b/projects/plugins/crm/changelog/fix-crm-3451-invoice-pdf-showing-space-below-customer-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Invoices: Remove blank line below contact name in invoices.

--- a/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InvoiceBuilder.php
@@ -1355,7 +1355,7 @@ function zeroBSCRM_invoicing_generateInvPart_custTable( $inv_to = array(), $temp
 
 		case 'portal':
 			$invoice_customer_info_table_html .= '<div class="pay-to">';
-			$invoice_customer_info_table_html .= '<div class="zbs-portal-label">' . esc_html__( 'Invoice To', 'zero-bs-crm' ) . '</div><div style="margin-top:18px;">&nbsp;</div>';
+			$invoice_customer_info_table_html .= '<div class="zbs-portal-label">' . esc_html__( 'Invoice To', 'zero-bs-crm' ) . '</div>';
 			$invoice_customer_info_table_html .= '<div class="zbs-portal-biz">';
 			if ( isset( $inv_to['fname'] ) && isset( $inv_to['fname'] ) ) {
 				$invoice_customer_info_table_html .= '<div class="pay-to-name">' . esc_html( $inv_to['fname'] ) . ' ' . esc_html( $inv_to['lname'] ) . '</div>';


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3451

## Proposed changes:
* This PR removes a blank line that appears below customer names in invoices

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3451

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Go to `/wp-admin/admin.php?page=manage-invoices`
* Open up an invoice that has an assigned contact
* Preview that invoice by clicking over the 'Preview' button
* Verify that there is no line between `Invoice To` and the contact's name

`trunk`
![image](https://github.com/Automattic/jetpack/assets/37049295/00527067-19f9-4674-a88d-b46fc113dbff)


`this branch` 
![image](https://github.com/Automattic/jetpack/assets/37049295/04727215-d25a-49e1-a962-f2cad8bddf21)


