### PR TITLE
Subscriptions: add block hook to add subscribe block to navigation

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -112,6 +112,13 @@ function SubscriptionsSettings( props ) {
 		);
 	}, [ updateFormStateModuleOption ] );
 
+	const handleSubscribeNavigationToggleChange = useCallback( () => {
+		updateFormStateModuleOption(
+			SUBSCRIPTIONS_MODULE_NAME,
+			'jetpack_subscriptions_subscribe_navigation_enabled'
+		);
+	}, [ updateFormStateModuleOption ] );
+
 	const isDisabled = ! isSubscriptionsActive || unavailableInOfflineMode;
 
 	return (
@@ -223,7 +230,7 @@ function SubscriptionsSettings( props ) {
 									toggling={ isSavingAnyOption( [
 										'jetpack_subscriptions_subscribe_navigation_enabled',
 									] ) }
-									onChange={ handleLoginNavigationToggleChange }
+									onChange={ handleSubscribeNavigationToggleChange }
 									label={
 										<span className="jp-form-toggle-explanation">
 											{ __( 'Add the Subscribe block to the navigation', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -18,9 +18,11 @@ import {
 import { getModule } from 'state/modules';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 
-// Check for feature flag
+// Check for feature flags
 const urlParams = new URLSearchParams( window.location.search );
 const isWelcomeOverlayEnabled = urlParams.get( 'enable-welcome-overlay' ) === 'true';
+const isSubscriptionNavigationToggleEnabled =
+	urlParams.get( 'enable-subscription-navigation' ) === 'true';
 
 /**
  * Subscription settings component.
@@ -38,6 +40,7 @@ function SubscriptionsSettings( props ) {
 		isSubscribeOverlayEnabled,
 		isSubscribePostEndEnabled,
 		isLoginNavigationEnabled,
+		isSubscribeNavigationEnabled,
 		isSubscriptionSiteEditSupported,
 		isSubscriptionsActive,
 		subscriptions,
@@ -212,25 +215,52 @@ function SubscriptionsSettings( props ) {
 						}
 					/>
 					{ isSubscriptionSiteEditSupported && (
-						<ToggleControl
-							checked={ isSubscriptionsActive && isLoginNavigationEnabled }
-							disabled={ isDisabled }
-							toggling={ isSavingAnyOption( [ 'jetpack_subscriptions_login_navigation_enabled' ] ) }
-							onChange={ handleLoginNavigationToggleChange }
-							label={
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Add the Subscriber Login Block to the navigation', 'jetpack' ) }
-									{ headerTemplateEditorUrl && (
-										<>
-											{ '. ' }
-											<ExternalLink href={ headerTemplateEditorUrl }>
-												{ __( 'Preview and edit', 'jetpack' ) }
-											</ExternalLink>
-										</>
-									) }
-								</span>
-							}
-						/>
+						<>
+							{ isSubscriptionNavigationToggleEnabled && (
+								<ToggleControl
+									checked={ isSubscriptionsActive && isSubscribeNavigationEnabled }
+									disabled={ isDisabled }
+									toggling={ isSavingAnyOption( [
+										'jetpack_subscriptions_subscribe_navigation_enabled',
+									] ) }
+									onChange={ handleLoginNavigationToggleChange }
+									label={
+										<span className="jp-form-toggle-explanation">
+											{ __( 'Add the Subscribe block to the navigation', 'jetpack' ) }
+											{ headerTemplateEditorUrl && (
+												<>
+													{ '. ' }
+													<ExternalLink href={ headerTemplateEditorUrl }>
+														{ __( 'Preview and edit', 'jetpack' ) }
+													</ExternalLink>
+												</>
+											) }
+										</span>
+									}
+								/>
+							) }
+							<ToggleControl
+								checked={ isSubscriptionsActive && isLoginNavigationEnabled }
+								disabled={ isDisabled }
+								toggling={ isSavingAnyOption( [
+									'jetpack_subscriptions_login_navigation_enabled',
+								] ) }
+								onChange={ handleLoginNavigationToggleChange }
+								label={
+									<span className="jp-form-toggle-explanation">
+										{ __( 'Add the Subscriber Login block to the navigation', 'jetpack' ) }
+										{ headerTemplateEditorUrl && (
+											<>
+												{ '. ' }
+												<ExternalLink href={ headerTemplateEditorUrl }>
+													{ __( 'Preview and edit', 'jetpack' ) }
+												</ExternalLink>
+											</>
+										) }
+									</span>
+								}
+							/>
+						</>
 					) }
 				</FormFieldset>
 			</SettingsGroup>
@@ -255,6 +285,9 @@ export default withModuleSettingsFormHelpers(
 			),
 			isLoginNavigationEnabled: ownProps.getOptionValue(
 				'jetpack_subscriptions_login_navigation_enabled'
+			),
+			isSubscribeNavigationEnabled: ownProps.getOptionValue(
+				'jetpack_subscriptions_subscribe_navigation_enabled'
 			),
 			isSubscriptionSiteEditSupported: subscriptionSiteEditSupported( state ),
 			isBlockTheme: currentThemeIsBlockTheme( state ),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2687,6 +2687,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
+			'jetpack_subscriptions_subscribe_navigation_enabled' => array(
+				'description'       => esc_html__( 'Add Subscribe block to the navigation.', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'subscriptions',
+			),
 			'social_notifications_subscribe'        => array(
 				'description'       => esc_html__( 'Send email notification when someone subscribes to my blog', 'jetpack' ),
 				'type'              => 'boolean',

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1004,6 +1004,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 				case 'wpcom_subscription_emails_use_excerpt':
 				case 'jetpack_subscriptions_subscribe_post_end_enabled':
 				case 'jetpack_subscriptions_login_navigation_enabled':
+				case 'jetpack_subscriptions_subscribe_navigation_enabled':
 					// Convert the false value to 0. This allows the option to be updated if it doesn't exist yet.
 					$sub_value = $value ? $value : 0;
 					$updated   = (string) get_option( $option ) !== (string) $sub_value ? update_option( $option, $sub_value ) : true;

--- a/projects/plugins/jetpack/changelog/add-subscriber-block-navigation-hook
+++ b/projects/plugins/jetpack/changelog/add-subscriber-block-navigation-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscribe block: ability to add subscribe block to navigation with a simple toggle.

--- a/projects/plugins/jetpack/changelog/add-subscriber-block-navigation-hook
+++ b/projects/plugins/jetpack/changelog/add-subscriber-block-navigation-hook
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Subscribe block: ability to add subscribe block to navigation with a simple toggle.
+Subscriptions: adds a toggle to add subscribe block automatically to site's navigation

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -105,7 +105,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_5",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_6",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -152,6 +152,25 @@ class Jetpack_Subscription_Site {
 			10,
 			4
 		);
+
+		add_filter(
+			'hooked_block_jetpack/subscriptions',
+			function ( $hooked_block, $hooked_block_type, $relative_position, $anchor_block ) {
+				$is_navigation_anchor_block = isset( $anchor_block['blockName'] ) && $anchor_block['blockName'] === 'core/navigation';
+
+				if ( $is_navigation_anchor_block ) {
+					$class_name = ( ! empty( $hooked_block['attrs'] ) && ! empty( $hooked_block['attrs']['className'] ) )
+						? $hooked_block['attrs']['className'] . ' is-style-button'
+						: 'is-style-button';
+
+					$hooked_block['attrs']['className'] = $class_name;
+				}
+
+				return $hooked_block;
+			},
+			10,
+			4
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -10,6 +10,8 @@ namespace Automattic\Jetpack\Extensions\Subscriptions;
 
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Memberships;
+use WP_Block_Template;
+use WP_Post;
 
 /**
  * Jetpack_Subscription_Site class.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\Jetpack\Extensions\Subscriptions;
 
+use Automattic\Jetpack\Status\Host;
 use Jetpack_Memberships;
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -42,15 +42,6 @@ class Jetpack_Subscription_Site {
 	public function handle_subscribe_block_placements() {
 		$this->handle_subscribe_block_post_end_placement();
 		$this->handle_subscribe_block_navigation_placement();
-
-		add_filter(
-			'jetpack_options_whitelist',
-			function ( $options ) {
-				$options[] = 'jetpack_subscriptions_subscribe_navigation_enabled';
-
-				return $options;
-			}
-		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -8,7 +8,6 @@
 
 namespace Automattic\Jetpack\Extensions\Subscriptions;
 
-use Automattic\Jetpack\Status\Host;
 use Jetpack_Memberships;
 use WP_Block_Template;
 use WP_Post;
@@ -42,6 +41,7 @@ class Jetpack_Subscription_Site {
 	 */
 	public function handle_subscribe_block_placements() {
 		$this->handle_subscribe_block_post_end_placement();
+		$this->handle_subscribe_block_navigation_placement();
 
 		add_filter(
 			'jetpack_options_whitelist',
@@ -51,18 +51,6 @@ class Jetpack_Subscription_Site {
 				return $options;
 			}
 		);
-
-		// If called via REST API, we need to register later in the lifecycle
-		if ( ( new Host() )->is_wpcom_platform() && ! jetpack_is_frontend() ) {
-			add_action(
-				'restapi_theme_init',
-				function () {
-					Jetpack_Subscription_Site::init()->handle_subscribe_block_navigation_placement();
-				}
-			);
-		} else {
-			self::init()->handle_subscribe_block_navigation_placement();
-		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -177,6 +177,7 @@ function register_block() {
 		'jetpack_options_whitelist',
 		function ( $options ) {
 			$options[] = 'jetpack_subscriptions_subscribe_post_end_enabled';
+			$options[] = 'jetpack_subscriptions_subscribe_navigation_enabled';
 
 			return $options;
 		}

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.5-a.5
+ * Version: 13.5-a.6
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.5-a.5' );
+define( 'JETPACK__VERSION', '13.5-a.6' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -124,6 +124,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint(
 			'jetpack_subscribe_overlay_enabled'       => '(bool) Whether the newsletter subscribe overlay is enabled',
 			'jetpack_subscriptions_subscribe_post_end_enabled' => '(bool) Whether the Subscribe block at the end of each post placement is enabled',
 			'jetpack_subscriptions_login_navigation_enabled' => '(bool) Whether the Subscriber Login block navigation placement is enabled',
+			'jetpack_subscriptions_subscribe_navigation_enabled' => '(Bool) Whether the Subscribe block navigation placement is enabled',
 			'wpcom_ai_site_prompt'                    => '(string) User input in the AI site prompt',
 		),
 
@@ -460,6 +461,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'jetpack_subscribe_overlay_enabled' => (bool) get_option( 'jetpack_subscribe_overlay_enabled' ),
 						'jetpack_subscriptions_subscribe_post_end_enabled' => (bool) get_option( 'jetpack_subscriptions_subscribe_post_end_enabled' ),
 						'jetpack_subscriptions_login_navigation_enabled' => (bool) get_option( 'jetpack_subscriptions_login_navigation_enabled' ),
+						'jetpack_subscriptions_subscribe_navigation_enabled' => (bool) get_option( 'jetpack_subscriptions_subscribe_navigation_enabled' ),
 						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ),
 						'wpcom_reader_views_enabled'       => (bool) get_option( 'wpcom_reader_views_enabled', true ),
 						'wpcom_subscription_emails_use_excerpt' => $this->get_wpcom_subscription_emails_use_excerpt_option(),
@@ -1126,6 +1128,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'jetpack_subscriptions_login_navigation_enabled':
 					update_option( 'jetpack_subscriptions_login_navigation_enabled', (int) (bool) $value );
+					$updated[ $key ] = (int) (bool) $value;
+					break;
+
+				case 'jetpack_subscriptions_subscribe_navigation_enabled':
+					update_option( 'jetpack_subscriptions_subscribe_navigation_enabled', (int) (bool) $value );
 					$updated[ $key ] = (int) (bool) $value;
 					break;
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -126,6 +126,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'jetpack_subscribe_overlay_enabled'       => '(bool) Whether the newsletter Subscribe Overlay is enabled or not',
 			'jetpack_subscriptions_subscribe_post_end_enabled' => '(bool) Whether adding Subscribe block at the end of each post is enabled or not',
 			'jetpack_subscriptions_login_navigation_enabled' => '(bool) Whether the Subscriber Login block navigation placement is enabled or not',
+			'jetpack_subscriptions_subscribe_navigation_enabled' => '(bool) Whether the Subscribe block navigation placement is enabled or not',
 			'wpcom_gifting_subscription'              => '(bool) Whether gifting is enabled for non auto-renew sites',
 			'wpcom_reader_views_enabled'              => '(bool) Whether showing post views in WordPress.com Reader is enabled for the site',
 			'wpcom_subscription_emails_use_excerpt'   => '(bool) Whether site subscription emails (e.g. New Post email notification) will use post excerpts',

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.5.0-a.5",
+	"version": "13.5.0-a.6",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -89,6 +89,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'jetpack_subscribe_overlay_enabled'            => false,
 			'jetpack_subscriptions_subscribe_post_end_enabled' => false,
 			'jetpack_subscriptions_login_navigation_enabled' => false,
+			'jetpack_subscriptions_subscribe_navigation_enabled' => false,
 			'jetpack_subscriptions_reply_to'               => 'no-reply',
 			'jetpack_subscriptions_from_name'              => 'newsletter name',
 			'comment_registration'                         => 'pineapple',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

**Before merging**, whitelist the option on the server side, done at D150073-code


Follow up to:
- https://github.com/Automattic/jetpack/pull/37439
- https://github.com/Automattic/jetpack/pull/37341

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a toggle in settings for subscription block hook
* Adds hook to inject subscription block in the 

<img width="1094" alt="Screenshot 2024-05-27 at 16 18 02" src="https://github.com/Automattic/jetpack/assets/87168/36d29645-dd86-4fba-a808-253d8584408c">
<img width="543" alt="Screenshot 2024-05-27 at 16 18 34" src="https://github.com/Automattic/jetpack/assets/87168/be2a8d5f-737c-40f9-a728-1941c6564b9b">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* At Jetpack settings -> Newsletters, add URL arg: `/wp-admin/admin.php?enable-subscription-navigation=true&page=jetpack#/newsletter`
* See the toggle, enable it
* See the navigation block in site editor
* See the navigation block on front of the site

