### PR TITLE
Social: Add external_id field to connections

### DIFF
--- a/projects/packages/publicize/changelog/change-social-add-connections-external-id
+++ b/projects/packages/publicize/changelog/change-social-add-connections-external-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added external_id to connections field

--- a/projects/packages/publicize/src/class-connections-post-field.php
+++ b/projects/packages/publicize/src/class-connections-post-field.php
@@ -132,6 +132,12 @@ class Connections_Post_Field {
 					'context'     => array( 'edit' ),
 					'readonly'    => true,
 				),
+				'external_id'     => array(
+					'description' => __( 'The external ID of the connected account', 'jetpack-publicize-pkg' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
 			),
 		);
 	}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -827,6 +827,7 @@ abstract class Publicize_Base {
 	 *     @type bool   'done'             Has this connection already been publicized to?
 	 *     @type bool   'toggleable'       Is the user allowed to change the value for the connection?
 	 *     @type bool   'global'           Is this connection a global one?
+	 *     @type string 'external_id'      External ID for the connection.
 	 * }
 	 */
 	public function get_filtered_connection_data( $selected_post_id = null ) {
@@ -959,6 +960,7 @@ abstract class Publicize_Base {
 					'done'            => $done,
 					'toggleable'      => $toggleable,
 					'global'          => 0 == $connection_data['user_id'], // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual,WordPress.PHP.StrictComparisons.LooseComparison -- Other types can be used at times.
+					'external_id'     => $connection_meta['external_id'] ?? '',
 				);
 			}
 		}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/publicize-connections.php
@@ -94,6 +94,10 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 				'description' => __( 'Is this connection available to all users?', 'jetpack' ),
 				'type'        => 'boolean',
 			),
+			'external_id'          => array(
+				'description' => __( 'The external ID of the connected account', 'jetpack' ),
+				'type'        => 'string',
+			),
 		);
 	}
 
@@ -140,6 +144,7 @@ class WPCOM_REST_API_V2_Endpoint_List_Publicize_Connections extends WP_REST_Cont
 					'profile_picture'      => ! empty( $connection_meta['profile_picture'] ) ? $connection_meta['profile_picture'] : '',
 					// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual -- We expect an integer, but do loose comparison below in case some other type is stored.
 					'global'               => 0 == $connection_data['user_id'],
+					'external_id'          => $connection_meta['external_id'] ?? '',
 				);
 			}
 		}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -154,6 +154,12 @@ class WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WPCOM_REST_API_
 					'context'     => array( 'edit' ),
 					'readonly'    => true,
 				),
+				'external_id'     => array(
+					'description' => __( 'The external ID of the connected account', 'jetpack' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
 			),
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Merges into #37405.

Fixes the issue where in the editor already connected accounts show up as not connected.
Fixes https://github.com/Automattic/jetpack-reach/issues/334

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `external_id` to the connections field

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/334
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test this with both Social only, and then with Jetpack enabled

* Go to the new post page.
* Add a connection from the editor with the new modal while you already have another connection from that service.
* It should show correctly that one of them is connected already.

Alternatively you can log `existingConnections` in `projects/js-packages/publicize-components/src/components/add-connection-modal/confirmation-form/index.tsx` and make sure it has `external_id` as a prop


https://github.com/Automattic/jetpack/assets/36671565/8edff8b7-1c10-48bf-ba9f-2761b5f8ef92

