### PR TITLE
Boost: Cleanup code around critical css errors

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/critical-css-errors.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/critical-css-errors.ts
@@ -34,9 +34,11 @@ export function isFatalError( cssState: CriticalCssState ): boolean {
 		return false;
 	}
 
-	return ! cssState.providers.some( provider =>
-		[ 'success', 'pending' ].includes( provider.status )
+	const hasActiveProvider = cssState.providers.some(
+		provider => provider.status === 'success' || provider.status === 'pending'
 	);
+
+	return ! hasActiveProvider;
 }
 
 /**
@@ -44,7 +46,7 @@ export function isFatalError( cssState: CriticalCssState ): boolean {
  *
  * @param cssState - The CSS State object.
  */
-export function getCriticalCssIssues( cssState: CriticalCssState ): Provider[] {
+export function getProvidersWithErrors( cssState: CriticalCssState ): Provider[] {
 	return cssState.providers.filter( provider => ( provider.errors?.length || 0 ) > 0 );
 }
 
@@ -54,9 +56,9 @@ export function getCriticalCssIssues( cssState: CriticalCssState ): Provider[] {
  * @param cssState - The CSS State object.
  */
 export function getPrimaryErrorSet( cssState: CriticalCssState ): ErrorSet | undefined {
-	const issues = getCriticalCssIssues( cssState );
+	const providersWithErrors = getProvidersWithErrors( cssState );
 
-	if ( ! issues.length ) {
+	if ( ! providersWithErrors.length ) {
 		return undefined;
 	}
 
@@ -68,28 +70,32 @@ export function getPrimaryErrorSet( cssState: CriticalCssState ): ErrorSet | und
 	];
 
 	for ( const key of importantProviders ) {
-		const issue = issues.find( r => r.key === key );
-		if ( issue ) {
-			return groupErrorsByFrequency( issue )[ 0 ];
+		const provider = providersWithErrors.find( p => p.key === key );
+		if ( provider && provider.errors ) {
+			return getPrimaryGroupedError( provider.errors );
 		}
 	}
 
 	return undefined;
 }
 
+export function getPrimaryGroupedError( errors: CriticalCssErrorDetails[] ): ErrorSet | undefined {
+	const groupedErrors = groupErrorsByFrequency( errors );
+	return groupedErrors.length > 0 ? groupedErrors[ 0 ] : undefined;
+}
+
 /**
- * Takes a Provider Key set of errors (in an object keyed by URL), and returns
+ * Takes a set of errors (in an object keyed by URL), and returns
  * a SortedErrorSet; an array which contains each type of error grouped. Also
  * groups things like HTTP errors by code.
  *
- * @param provider The recommendation the errors belong to.
+ * @param errors A sorted set of errors.
  */
-export function groupErrorsByFrequency( provider: Provider ): ErrorSet[] {
-	if ( ! provider.errors ) {
+export function groupErrorsByFrequency( errors: CriticalCssErrorDetails[] ): ErrorSet[] {
+	if ( ! errors ) {
 		return [];
 	}
 
-	const { errors } = provider;
 	const groupKeys = errors.map( error => groupKey( error ) );
 	const groupOrder = sortByFrequency( groupKeys );
 

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/critical-css-errors.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/critical-css-errors.ts
@@ -62,14 +62,9 @@ export function getPrimaryErrorSet( cssState: CriticalCssState ): ErrorSet | und
 		return undefined;
 	}
 
-	const importantProviders = [
-		'core_front_page',
-		'core_posts_page',
-		'singular_page',
-		'singular_post',
-	];
+	const primaryProviders = [ 'core_front_page', 'core_posts_page' ];
 
-	for ( const key of importantProviders ) {
+	for ( const key of primaryProviders ) {
 		const provider = providersWithErrors.find( p => p.key === key );
 		if ( provider && provider.errors ) {
 			return getPrimaryGroupedError( provider.errors );

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
@@ -7,7 +7,7 @@ import RefreshIcon from '$svg/refresh';
 import { createInterpolateElement } from '@wordpress/element';
 import { Link } from 'react-router-dom';
 import { useRegenerateCriticalCssAction } from '../lib/stores/critical-css-state';
-import { getCriticalCssIssues, isFatalError } from '../lib/critical-css-errors';
+import { getProvidersWithErrors, isFatalError } from '../lib/critical-css-errors';
 import ShowStopperError from '../show-stopper-error/show-stopper-error';
 import { Button } from '@automattic/jetpack-components';
 import styles from './status.module.scss';
@@ -34,7 +34,7 @@ const Status: React.FC< StatusTypes > = ( {
 	const regenerateAction = useRegenerateCriticalCssAction();
 	const successCount =
 		cssState.providers.filter( provider => provider.status === 'success' ).length || 0;
-	const issues = getCriticalCssIssues( cssState );
+	const providersWithErrors = getProvidersWithErrors( cssState );
 
 	// If there has been a fatal error, show it.
 	if ( isFatalError( cssState ) ) {
@@ -72,7 +72,7 @@ const Status: React.FC< StatusTypes > = ( {
 					</div>
 				) }
 
-				{ cssState.status !== 'pending' && issues.length > 0 && (
+				{ cssState.status !== 'pending' && providersWithErrors.length > 0 && (
 					<div className={ classNames( 'failures', styles.failures ) }>
 						<InfoIcon />
 
@@ -83,10 +83,10 @@ const Status: React.FC< StatusTypes > = ( {
 									_n(
 										'%d file could not be automatically generated. Visit the <advanced>advanced recommendations page</advanced> to optimize this file.',
 										'%d files could not be automatically generated. Visit the <advanced>advanced recommendations page</advanced> to optimize these files.',
-										issues.length,
+										providersWithErrors.length,
 										'jetpack-boost'
 									),
-									issues.length
+									providersWithErrors.length
 								),
 								{
 									advanced: <Link to="/critical-css-advanced" />,

--- a/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.tsx
@@ -5,7 +5,7 @@ import {
 	useCriticalCssState,
 	useSetProviderErrorDismissedAction,
 } from '$features/critical-css/lib/stores/critical-css-state';
-import { groupErrorsByFrequency } from '$features/critical-css/lib/critical-css-errors';
+import { getPrimaryGroupedError } from '$features/critical-css/lib/critical-css-errors';
 import { BackButton, CloseButton } from '$features/ui';
 import CriticalCssErrorDescription from '$features/critical-css/error-description/error-description';
 import InfoIcon from '$svg/info';
@@ -136,6 +136,15 @@ const HeadingMeta = ( { dismissedIssues, showDismissedIssues }: HeadingMetaProps
 };
 
 const Recommendation = ( { provider, setDismissed }: RecommendationProps ) => {
+	if ( provider.errors && provider.errors.length === 0 ) {
+		return null;
+	}
+
+	const errorSet = getPrimaryGroupedError( provider.errors ? provider.errors : [] );
+	if ( ! errorSet ) {
+		return null;
+	}
+
 	const [ isDismissed, setIsDismissed ] = useState( provider.error_status === 'dismissed' );
 
 	const [ ref, { height } ] = useMeasure();
@@ -163,7 +172,7 @@ const Recommendation = ( { provider, setDismissed }: RecommendationProps ) => {
 				</h4>
 
 				<div className={ styles.problem }>
-					<CriticalCssErrorDescription errorSet={ groupErrorsByFrequency( provider )[ 0 ] } />
+					<CriticalCssErrorDescription errorSet={ errorSet } />
 				</div>
 			</div>
 		</animated.div>

--- a/projects/plugins/boost/changelog/update-cleanup-critical-css-errors-code
+++ b/projects/plugins/boost/changelog/update-cleanup-critical-css-errors-code
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Refactor code related to primary error shown in show stopper section. Updated list of primary providers.
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* A small refactor around primary error shown in show stopper section. Some variable/function names didn't match their contents;
* Updated list of primary providers that the error shown in the show stopper section (image below for reference) is based on. This was because the bare minimum for that error is either a home page or a blog page. We don't need pages or posts.

![image](https://github.com/Automattic/jetpack/assets/11799079/d2bfdcb4-2869-49e7-b378-faf06432963a)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pc9hqz-2Qp-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Make sure c.css generation works

* Setup Boost free;
* Make sure critical css generation works as expected;

### Make sure show stopper works

* Break all front-end pages on the website. You can use the snippet provided below;
* Make sure the show stopper section properly shows the home page and the error corresponds to the way it was broken.

```php
<?php

add_action( 'template_redirect', function () {
	if ( str_contains( remove_query_arg( 'NONEXISTENTQUERYKEY' ), 'jb-generate-critical-css' ) ) {
		header( 'HTTP/1.0 500 Internal Server Error' );
		die();
	}
} );
```