### PR TITLE
Add site name to command palette data

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-command-palette-name
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-command-palette-name
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: trivial
+
+

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.31.1",
+	"version": "5.31.2-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.31.1';
+	const PACKAGE_VERSION = '5.31.2-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-command-palette/wpcom-command-palette.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-command-palette/wpcom-command-palette.php
@@ -74,6 +74,7 @@ function wpcom_load_command_palette() {
 			'isP2'             => $is_p2_site,
 			'shouldUseWpAdmin' => 'wp-admin' === get_option( 'wpcom_admin_interface' ),
 			'siteHostname'     => wpcom_get_site_slug(),
+			'siteName'         => get_option( 'blogname' ),
 			'isWpcomStore'     => $host->is_woa_site() && is_plugin_active( 'woocommerce/woocommerce.php' ),
 		)
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related https://github.com/Automattic/wp-calypso/pull/90891

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds the blogname to the data provided to the command palette

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Apply patch to WordPress.com
2. View source and check that `siteName` is present in window.commandPaletteConfig and is set to the sites name

If you like you can also follow the test instructions on https://github.com/Automattic/wp-calypso/pull/90891 which will consume this data.

