### PR TITLE
Repo Gardening: update the board where Stats issues get triaged

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-gardening-stats-board
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-stats-board
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Board triage: update board used to triage Stats issues.

--- a/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
@@ -142,7 +142,7 @@ export const automatticAssignments = {
 			'[Stats] Subscribers',
 		],
 		slack_id: 'C0438NHCLSY',
-		board_id: 'https://github.com/orgs/Automattic/projects/484',
+		board_id: 'https://github.com/orgs/Automattic/projects/1028',
 	},
 	'Super Cache': {
 		team: 'Heart of Gold',


### PR DESCRIPTION
## Proposed changes:

The previous board has now been closed.

This will fix gardening workflow failures like the ones discussed in p1716297091114199/1716293107.064109-slack-C05PV073SG3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Check that the new board URL matches a board used to triage stats issues.
