### PR TITLE
SSO: ensure JS files are properly built

### DIFF
--- a/projects/packages/connection/changelog/fix-connection-build-js-css-issues
+++ b/projects/packages/connection/changelog/fix-connection-build-js-css-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+SSO: ensure the dist files are generated properly, without overwriting each other.

--- a/projects/packages/connection/webpack.config.js
+++ b/projects/packages/connection/webpack.config.js
@@ -6,12 +6,14 @@ const ssoEntries = {};
 // Add all js files in the src/sso directory.
 for ( const file of glob.sync( './src/sso/*.js' ) ) {
 	const name = path.basename( file, path.extname( file ) );
-	ssoEntries[ name ] = file;
+	ssoEntries[ name ] ??= [];
+	ssoEntries[ name ].push( file );
 }
 // Add all css files as well.
 for ( const file of glob.sync( './src/sso/*.css' ) ) {
 	const name = path.basename( file, path.extname( file ) );
-	ssoEntries[ name ] = file;
+	ssoEntries[ name ] ??= [];
+	ssoEntries[ name ].push( file );
 }
 
 module.exports = [


### PR DESCRIPTION
Follow-up to #36587

## Proposed changes:

This change will ensure the JS files are not overwritten by the SSO files in the list of files to build.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Discussion: p1716324473644999-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Let the build complete
* In the Build artifacts, look at the `dist` directory in the Connection package.
    * Both the CSS SSO entries and the JS SSO entries should all have contents.
