### PR TITLE
Social: Fix connection management layout

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-connection-management-layout
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connection-management-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed UI bug with border

--- a/projects/js-packages/publicize-components/src/components/connection-management/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/connection-management/style.module.scss
@@ -55,7 +55,7 @@
 	margin-bottom: 1rem;
 }
 
-.connection-panel {
+.connection-panel.connection-panel {
 	border: 0px;
 	margin-left: 3rem;
 

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -183,7 +183,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 								isLinked &&
 								useAdminUiV1 &&
 								! this.props.isSavingAnyOption( 'publicize' ) ? (
-									<FormFieldset>
+									<FormFieldset className="jp-settings__connection-management">
 										<ConnectionManagement />
 									</FormFieldset>
 								) : null }

--- a/projects/plugins/jetpack/_inc/client/sharing/style.scss
+++ b/projects/plugins/jetpack/_inc/client/sharing/style.scss
@@ -1,4 +1,5 @@
 @import '../scss/calypso-colors';
+@import "../scss/mixin_breakpoint";
 
 .jp-settings-sharing__sig-toggle {
 	span  {
@@ -19,5 +20,11 @@
 		a.dops-card__link {
 			cursor: pointer;
 		}
+	}
+}
+
+.jp-settings__connection-management {
+	@include breakpoint( '>960px' ) {
+		width: 60%;
 	}
 }

--- a/projects/plugins/jetpack/changelog/fix-social-connection-management-layout
+++ b/projects/plugins/jetpack/changelog/fix-social-connection-management-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Social: Added width for connectiion management container


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/354

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* There was an issue where a CSS rule was not strong enough in JP settings
* Added a max width to the container for the connection management as it was too bulky on big screens

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/354
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack#/sharing`
* Check the connection management
* On screen smaller than 960px it should still be 100%

BEFORE

![CleanShot 2024-05-22 at 16 20 29 png](https://github.com/Automattic/jetpack/assets/36671565/0b7db08d-fc4b-4da7-937c-c56a02e7cbdb)

AFTER

![CleanShot 2024-05-22 at 16 20 56 png](https://github.com/Automattic/jetpack/assets/36671565/62aab8ca-3019-479d-8825-9f26af255471)


