### PR TITLE
Release v1.0.0 for packages/patchwork-redefine-exit and packages/stub-generator

### DIFF
--- a/projects/packages/patchwork-redefine-exit/CHANGELOG.md
+++ b/projects/packages/patchwork-redefine-exit/CHANGELOG.md
@@ -5,3 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 - 2024-05-22
+### Added
+- Initial version. [#37476]

--- a/projects/packages/patchwork-redefine-exit/changelog/initial-version
+++ b/projects/packages/patchwork-redefine-exit/changelog/initial-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Initial version.

--- a/projects/packages/patchwork-redefine-exit/composer.json
+++ b/projects/packages/patchwork-redefine-exit/composer.json
@@ -45,7 +45,7 @@
 	"extra": {
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.1.x-dev"
+			"dev-trunk": "1.0.x-dev"
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/patchwork-redefine-exit/compare/v${old}...v${new}"

--- a/projects/packages/stub-generator/CHANGELOG.md
+++ b/projects/packages/stub-generator/CHANGELOG.md
@@ -5,6 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 1.0.0 - 2024-03-28
+## 1.0.0 - 2024-05-22
 ### Added
 - Initial version.

--- a/projects/packages/stub-generator/changelog/add-phan-allow-removing-baselines
+++ b/projects/packages/stub-generator/changelog/add-phan-allow-removing-baselines
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove empty Phan baseline. No change to functionality.
-
-

--- a/projects/packages/stub-generator/changelog/add-phan-phpunit-stub
+++ b/projects/packages/stub-generator/changelog/add-phan-phpunit-stub
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Adjust Phan suppressions in tests for new PHPUnit stub. No change to functionality.
-
-

--- a/projects/packages/stub-generator/changelog/add-stub-generator-func_get_args
+++ b/projects/packages/stub-generator/changelog/add-stub-generator-func_get_args
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add a fake `...$func_get_args` parameter to functions/methods that call `func_get_args()`.

--- a/projects/packages/stub-generator/changelog/add-stub-generator-function-return-type
+++ b/projects/packages/stub-generator/changelog/add-stub-generator-function-return-type
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Document function stub return type as "mixed" if it has a non-empty `return` but lacks any declaration or phpdoc, so Phan doesn't assume "void".

--- a/projects/packages/stub-generator/changelog/fake-change-file
+++ b/projects/packages/stub-generator/changelog/fake-change-file
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Tooling requires some file (other than .gitkeep) be touched. 🤷
-
-

--- a/projects/packages/stub-generator/changelog/fix-misc-phan-undeclared-issues-1
+++ b/projects/packages/stub-generator/changelog/fix-misc-phan-undeclared-issues-1
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Reference https://github.com/phan/phan/issues/1204 when that's the reason for Phan suppression. No change to functionality.
-
-

--- a/projects/packages/stub-generator/changelog/fix-stub-generator-namespace-kind
+++ b/projects/packages/stub-generator/changelog/fix-stub-generator-namespace-kind
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Skip setting `'kind'` on `Namespace_` nodes. The printer doesn't care.
-
-

--- a/projects/packages/stub-generator/changelog/update-symfony-console
+++ b/projects/packages/stub-generator/changelog/update-symfony-console
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Properly support symfony/console 7.0.

--- a/projects/packages/stub-generator/src/Application.php
+++ b/projects/packages/stub-generator/src/Application.php
@@ -28,7 +28,7 @@ use Throwable;
  */
 class Application extends SingleCommandApplication {
 
-	const VERSION = '1.0.1-alpha';
+	const VERSION = '1.0.0';
 
 	/**
 	 * Exit code to use.

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -3199,7 +3199,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/patchwork-redefine-exit",
-				"reference": "1b602d1100fb99492d38bb7164bdfe7d6dd55b9e"
+				"reference": "14e4719ada9d517ef6d15334f583fbdb65312eab"
 			},
 			"require": {
 				"antecedent/patchwork": "^2.1",
@@ -3213,7 +3213,7 @@
 			"extra": {
 				"autotagger": true,
 				"branch-alias": {
-					"dev-trunk": "0.1.x-dev"
+					"dev-trunk": "1.0.x-dev"
 				},
 				"changelogger": {
 					"link-template": "https://github.com/Automattic/patchwork-redefine-exit/compare/v${old}...v${new}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
I had meant to do this a while back for stub-generator, but then I forgot.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [x] Check https://packagist.org/packages/automattic/jetpack-stub-generator and https://packagist.org/packages/automattic/patchwork-redefine-exit for 1.0.0 versions having been created.