### PR TITLE
Update/search to require user connection

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-search-to-require-user-connection
+++ b/projects/packages/my-jetpack/changelog/update-search-to-require-user-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Search to require user connection

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -77,7 +77,7 @@ class Search extends Hybrid_Product {
 	 *
 	 * @var boolean
 	 */
-	public static $requires_user_connection = false;
+	public static $requires_user_connection = true;
 
 	/**
 	 * Get the product name


### PR DESCRIPTION
## Proposed changes:

* Update Search product in My Jetpack as needing user connection

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1716322034669439-slack-C02ME06LF

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect your user account and purchase a "Search Free" plan
3. Disconnect your user account (make sure you still have a site connection)
4. Go to My Jetpack and make sure Search asks you to fix the connection
![image](https://github.com/Automattic/jetpack/assets/65001528/9f100cd1-9e5a-4e68-bd60-6cd91ef2e640)

