### PR TITLE
sharing-button: hooked_block_types: Fail fast for incorrect positions

### DIFF
--- a/projects/plugins/jetpack/changelog/update-block-hooks
+++ b/projects/plugins/jetpack/changelog/update-block-hooks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+sharing-button: Increased performance on p2020 theme

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -225,7 +225,7 @@ function add_block_to_single_posts_template( $hooked_block_types, $relative_posi
 	// Add the block at the end of the post content.
 	if (
 		'after' !== $relative_position
-		&& 'core/post-content' !== $anchor_block_type
+		|| 'core/post-content' !== $anchor_block_type
 	) {
 		return $hooked_block_types;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -222,6 +222,14 @@ add_action( 'template_redirect', __NAMESPACE__ . '\sharing_process_requests', 9 
  * @return array
  */
 function add_block_to_single_posts_template( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+	// Add the block at the end of the post content.
+	if (
+		'after' !== $relative_position
+		&& 'core/post-content' !== $anchor_block_type
+	) {
+		return $hooked_block_types;
+	}
+
 	// Only automate the addition of the block in block-based themes.
 	if ( ! wp_is_block_theme() ) {
 		return $hooked_block_types;
@@ -272,14 +280,7 @@ function add_block_to_single_posts_template( $hooked_block_types, $relative_posi
 		return $hooked_block_types;
 	}
 
-	// Add the block at the end of the post content.
-	if (
-		'after' === $relative_position
-		&& 'core/post-content' === $anchor_block_type
-	) {
-		$hooked_block_types[] = PARENT_BLOCK_NAME;
-	}
-
+	$hooked_block_types[] = PARENT_BLOCK_NAME;
 	return $hooked_block_types;
 }
 


### PR DESCRIPTION
On some sites running the p2020 theme, we've found the number of times the `hooked_block_types` hook called to be unexpectedly high: around 10,000 times per page render. 

The equation is: 
```
(4 gutenberg `get_all_registered()` calls) * (23 patterns) * (50.6 average block traverses per pattern) 
* (2 hook calls per block traverse: before, after) * (1 hook) = 9,310 calls. 
```
(I actually saw slightly over 10,000, because sometimes a block does more than 2 calls, haven't quite figured that out though).

We do see this show up in the RUM data of these sites.

More about the investigation here: 
* p1716329120072119-slack-C4GAQ900P
* p1716406695084499-slack-C4GAQ900P

I have reported this to core [here](https://core.trac.wordpress.org/ticket/61234). 

In the mean time, I think we can make most of these 9,000-10,000 hook calls return as fast as possible by moving the parameter string checks to be the first thing checked.  Direct checks of the parameters vs the hardcoded strings passed in will fail most of the time, and are faster than `wp_is_block_theme()` in my testing.

Some alternatives would be to use static variables to save recomputing things like block theme, or module turned on, or to have it unhook itself if it discovers it is uneligible. However, I found this approach to be a simple change and to have satisfactory performance. Other approaches could be fine though.

## Proposed changes:

* Change the `hooked_block_types()` hook to look at the parameters passed in first thing, before doing any other potentially expensive computations, since this hook is called many times. Behavior should be the same before and after.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*