### PR TITLE
Allow users to turn off "Related posts" in Reading Settings

### DIFF
--- a/projects/plugins/jetpack/changelog/update-hide-related-posts
+++ b/projects/plugins/jetpack/changelog/update-hide-related-posts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Allow users to turn off "Related posts" in Reading Settings

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -726,36 +726,25 @@ EOT;
 			esc_html__( 'Preview:', 'jetpack' )
 		);
 
-		if ( ! $this->allow_feature_toggle() ) {
-			$template = <<<EOT
-<input type="hidden" name="jetpack_relatedposts[enabled]" value="1" />
-%s
-EOT;
-			printf(
-				$template, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				$ui_settings // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- data is escaped when variable is set.
-			);
-		} else {
-			$template = <<<EOT
+		$template = <<<EOT
 <ul id="settings-reading-relatedposts">
-	<li>
-		<label><input type="radio" name="jetpack_relatedposts[enabled]" value="0" class="tog" %s /> %s</label>
-	</li>
-	<li>
-		<label><input type="radio" name="jetpack_relatedposts[enabled]" value="1" class="tog" %s /> %s</label>
-		%s
-	</li>
+<li>
+	<label><input type="radio" name="jetpack_relatedposts[enabled]" value="0" class="tog" %s /> %s</label>
+</li>
+<li>
+	<label><input type="radio" name="jetpack_relatedposts[enabled]" value="1" class="tog" %s /> %s</label>
+	%s
+</li>
 </ul>
 EOT;
-			printf(
-				$template, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				checked( $options['enabled'], false, false ),
-				esc_html__( 'Hide related content after posts', 'jetpack' ),
-				checked( $options['enabled'], true, false ),
-				esc_html__( 'Show related content after posts', 'jetpack' ),
-				$ui_settings // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- data is escaped when variable is set.
-			);
-		}
+		printf(
+			$template, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			checked( $options['enabled'], false, false ),
+			esc_html__( 'Hide related content after posts', 'jetpack' ),
+			checked( $options['enabled'], true, false ),
+			esc_html__( 'Show related content after posts', 'jetpack' ),
+			$ui_settings // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- data is escaped when variable is set.
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR proposes allowing users to turn off the "Related posts" feature regardless of permission to toggle this feature. 

Please refer to https://github.com/Automattic/dotcom-forge/issues/6526#issuecomment-2124064612 for a detailed background.

Users who have permission to toggle this feature: 
| before | after |
|--------|--------|
| <img width="1003" alt="Screenshot 2024-05-23 at 10 06 57" src="https://github.com/Automattic/jetpack/assets/5287479/d5de533c-ebbd-4243-959d-7d1477b0a57a"> | <img width="994" alt="Screenshot 2024-05-23 at 10 06 09" src="https://github.com/Automattic/jetpack/assets/5287479/254fa928-c69c-4e9c-b300-55640049c00b"> | 

Users who do **not** have permission to toggle this feature (No change): 
| before | after |
|--------|--------|
| <img width="994" alt="Screenshot 2024-05-23 at 10 06 09" src="https://github.com/Automattic/jetpack/assets/5287479/254fa928-c69c-4e9c-b300-55640049c00b"> | <img width="994" alt="Screenshot 2024-05-23 at 10 06 09" src="https://github.com/Automattic/jetpack/assets/5287479/254fa928-c69c-4e9c-b300-55640049c00b"> | 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings > Reading
* Confirm "Related posts > 'Hide related content after posts'" is shown
* Confirm "Related posts > 'Hide related content after posts'" can be saved