### PR TITLE
Social | Fix Disconnect button not shown in editor connection modal

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-editor-modal-behavior
+++ b/projects/js-packages/publicize-components/changelog/fix-editor-modal-behavior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Made the editor connections modal behavior similar to the modal on the social admin page

--- a/projects/js-packages/publicize-components/src/components/services/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/services/style.module.scss
@@ -163,7 +163,7 @@
 
 
 	.disconnect {
-		&:global(.components-button) {
+		&:global(.components-button.is-tertiary) {
 			font-size: 1rem;
 			font-weight: 400;
 			color: var(--jp-gray-50);

--- a/projects/packages/publicize/changelog/fix-social-connection-disconnect-button-not-shown
+++ b/projects/packages/publicize/changelog/fix-social-connection-disconnect-button-not-shown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Disconnect button not shown for connections in the editor

--- a/projects/packages/publicize/src/class-connections-post-field.php
+++ b/projects/packages/publicize/src/class-connections-post-field.php
@@ -138,6 +138,12 @@ class Connections_Post_Field {
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
+				'can_disconnect'  => array(
+					'description' => __( 'Whether the current user can disconnect this connection', 'jetpack-publicize-pkg' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
 			),
 		);
 	}
@@ -208,6 +214,8 @@ class Connections_Post_Field {
 
 			$output_connection['id']            = (string) $connection['unique_id'];
 			$output_connection['connection_id'] = (string) $connection['id'];
+
+			$output_connection['can_disconnect'] = Publicize::can_manage_connection( $connection );
 
 			$output_connections[] = $output_connection;
 		}

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -961,6 +961,7 @@ abstract class Publicize_Base {
 					'toggleable'      => $toggleable,
 					'global'          => 0 == $connection_data['user_id'], // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual,WordPress.PHP.StrictComparisons.LooseComparison -- Other types can be used at times.
 					'external_id'     => $connection_meta['external_id'] ?? '',
+					'user_id'         => $connection_data['user_id'],
 				);
 			}
 		}

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -260,7 +260,7 @@ class Publicize extends Publicize_Base {
 								array(
 									'service_name'   => $service_name,
 									'connection_id'  => $connection['connection_data']['id'],
-									'can_disconnect' => current_user_can( 'edit_others_posts' ) || get_current_user_id() === $user_id,
+									'can_disconnect' => self::can_manage_connection( $connection['connection_data'] ),
 									'profile_link'   => $this->get_profile_link( $service_name, $connection ),
 								)
 							);
@@ -292,6 +292,17 @@ class Publicize extends Publicize_Base {
 	 */
 	public function get_connection_unique_id( $connection ) {
 		return $connection['connection_data']['token_id'];
+	}
+
+	/**
+	 * Whether the current user can manage a connection.
+	 *
+	 * @param array $connection_data The connection data.
+	 *
+	 * @return bool
+	 */
+	public static function can_manage_connection( $connection_data ) {
+		return current_user_can( 'edit_others_posts' ) || get_current_user_id() === (int) $connection_data['user_id'];
 	}
 
 	/**


### PR DESCRIPTION
Right now the disconnect button is not shown in the editor connections modal

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Pass `can_disconnect` prop via post meta for editor to ensure "Disconnect" button is displayed
* Make editor modal reconnection behavior similar to the admin page one, i.e. to have an explicit close modal function instead of toggle and to reopen it if there is a keyring result.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post
* Open Social sidebar
* Click on the + icon under "Share this post" section
* Confirm that you see the "Disconnect" button
* Confirm that it works as expected.


<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <td>
<img width="1050" alt="Screenshot 2024-05-23 at 11 11 44 AM" src="https://github.com/Automattic/jetpack/assets/18226415/3d92ccd0-5374-46b0-b23c-e20d8a761e7d">
</td>
            <td>
<img width="1052" alt="image" src="https://github.com/Automattic/jetpack/assets/18226415/b98496b7-1476-4907-8ea7-59118eed9296">

</td>
        </tr>
    </tbody>
</table>
