### PR TITLE
Subscription emails: custom "from" name — release by removing feature flag

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -27,9 +27,6 @@ const FEATURED_IMAGE_IN_EMAIL_OPTION = 'wpcom_featured_image_in_email';
 const SUBSCRIPTION_EMAILS_USE_EXCERPT_OPTION = 'wpcom_subscription_emails_use_excerpt';
 const REPLY_TO_OPTION = 'jetpack_subscriptions_reply_to';
 const FROM_NAME_OPTION = 'jetpack_subscriptions_from_name';
-//Check for feature flag
-const urlParams = new URLSearchParams( window.location.search );
-const isNewsletterFromNameEnabled = urlParams.get( 'enable-newsletter-from-name' ) === 'true';
 
 const EmailSettings = props => {
 	const {
@@ -177,51 +174,50 @@ const EmailSettings = props => {
 					onChange={ handleSubscriptionEmailsUseExcerptChange }
 				/>
 			</SettingsGroup>
-			{ isNewsletterFromNameEnabled && (
-				<SettingsGroup
-					hasChild
-					disableInOfflineMode
-					disableInSiteConnectionMode
-					module={ subscriptionsModule }
-					className="newsletter-group"
-				>
-					<FormLegend className="jp-form-label-wide">{ __( 'Sender name', 'jetpack' ) }</FormLegend>
-					<p>
-						{ __(
-							"This is the name that appears in subscribers' inboxes. It's usually the name of your newsletter or the author.",
-							'jetpack'
+			<SettingsGroup
+				hasChild
+				disableInOfflineMode
+				disableInSiteConnectionMode
+				module={ subscriptionsModule }
+				className="newsletter-group"
+			>
+				<FormLegend className="jp-form-label-wide">{ __( 'Sender name', 'jetpack' ) }</FormLegend>
+				<p>
+					{ __(
+						"This is the name that appears in subscribers' inboxes. It's usually the name of your newsletter or the author.",
+						'jetpack'
+					) }
+				</p>
+				<Container horizontalGap={ 0 } fluid className="sender-name">
+					<Col sm={ 3 } md={ 4 } lg={ 4 }>
+						<TextInput
+							value={ fromNameState.value }
+							disabled={ fromNameInputDisabled }
+							onChange={ handleSubscriptionFromNameChange }
+							placeholder={ siteName || __( 'Enter sender name', 'jetpack' ) }
+						/>
+					</Col>
+					<Col sm={ 1 } md={ 1 } lg={ 1 }>
+						<Button
+							primary
+							rna
+							onClick={ handleSubscriptionFromNameChangeClick }
+							disabled={ fromNameInputDisabled || ! fromNameState.hasChanged }
+						>
+							{ __( 'Save', 'jetpack' ) }
+						</Button>
+					</Col>
+					<Col className="sender-name-example">
+						{ sprintf(
+							/* translators: 1. placeholder is the user entered value for From Name, 2. is the example email */
+							__( 'Example: %1$s <%2$s>', 'jetpack' ),
+							fromNameState.value || siteName,
+							exampleEmail
 						) }
-					</p>
-					<Container horizontalGap={ 0 } fluid className="sender-name">
-						<Col sm={ 3 } md={ 4 } lg={ 4 }>
-							<TextInput
-								value={ fromNameState.value }
-								disabled={ fromNameInputDisabled }
-								onChange={ handleSubscriptionFromNameChange }
-								placeholder={ siteName || __( 'Enter sender name', 'jetpack' ) }
-							/>
-						</Col>
-						<Col sm={ 1 } md={ 1 } lg={ 1 }>
-							<Button
-								primary
-								rna
-								onClick={ handleSubscriptionFromNameChangeClick }
-								disabled={ fromNameInputDisabled || ! fromNameState.hasChanged }
-							>
-								{ __( 'Save', 'jetpack' ) }
-							</Button>
-						</Col>
-						<Col className="sender-name-example">
-							{ sprintf(
-								/* translators: 1. placeholder is the user entered value for From Name, 2. is the example email */
-								__( 'Example: %1$s <%2$s>', 'jetpack' ),
-								fromNameState.value || siteName,
-								exampleEmail
-							) }
-						</Col>
-					</Container>
-				</SettingsGroup>
-			) }
+					</Col>
+				</Container>
+			</SettingsGroup>
+
 			<SettingsGroup
 				hasChild
 				disableInOfflineMode

--- a/projects/plugins/jetpack/changelog/update-from-name-remove-flag
+++ b/projects/plugins/jetpack/changelog/update-from-name-remove-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Newsletter: Add From Name setting


### PR DESCRIPTION
This is a follow up PR to https://github.com/Automattic/jetpack/pull/37362 

That removes the feature flag. 

## Proposed changes:
* Removes the feature flag from newsletter settings for the from name setting.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In newsletter settings, set "from" email setting
* Test single email, digest email, confirm that "from" name is now different from your site's name
* When input is empty, falls back to your site's name

