### PR TITLE
Dashboard: Introduce the wpcom site management widget

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-wpcom-site-management-widget
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-wpcom-site-management-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: Introduce the wpcom site management widget

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -85,6 +85,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';
 		require_once __DIR__ . '/features/site-editor-dashboard-link/site-editor-dashboard-link.php';
+		require_once __DIR__ . '/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php';
 		require_once __DIR__ . '/features/wpcom-site-menu/wpcom-site-menu.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-themes.php';
 		require_once __DIR__ . '/features/calypso-locale-sync/sync-wp-admin-to-calypso.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
@@ -49,6 +49,10 @@ class WPCOM_Site_Management_Widget {
 				color: #1e1e1e;
 			}
 
+			#wpcom_site_management_widget .postbox-title-action {
+				display: none;
+			}
+
 			#wpcom_site_management_widget .wpcom_site_management_widget__header {
 				display: flex;
 				align-items: center;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * A class that adds the WPCOM site management widget to the WordPress admin dashboard.
+ *
+ * @package automattic/jetpack-mu-plugins
+ */
+
+/**
+ * Class that adds the WPCOM site management widget to the WordPress admin dashboard.
+ */
+class WPCOM_Site_Management_Widget {
+	const WPCOM_SITE_MANAGEMENT_WIDGET_ID = 'wpcom_site_management_widget';
+
+	/**
+	 * Singleton instance of the widget, not to show more than once.
+	 *
+	 * @var array
+	 */
+	public static $instance = null;
+
+	/**
+	 * Gets the instance of this singleton class
+	 */
+	public static function get_instance() {
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Register widget with WordPress.
+	 */
+	public function __construct() {
+		add_action( 'admin_head', array( $this, 'admin_head' ) );
+		add_action( 'wp_dashboard_setup', array( $this, 'wp_dashboard_setup' ) );
+	}
+
+	/**
+	 * JavaScript and CSS for the widget.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public function admin_head() {
+		?>
+		<style type="text/css">
+			#wpcom_site_management_widget {
+				color: #1e1e1e;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__header {
+				display: flex;
+				align-items: center;
+				gap: 12px;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__site-favicon {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				flex-shrink: 0;
+				width: 38px;
+				height: 38px;
+				overflow: hidden;
+				font-size: 24px;
+				color: #0073aa;
+				background-color: #f5f7f7;
+				border: 1px solid #eeeeee;
+				border-radius: 4px;
+				cursor: default;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__site-favicon img {
+				width: 100%;
+				height: auto;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__site-info {
+				flex-grow: 1;
+				overflow: hidden;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__site-name {
+				font-size: 14px;
+				font-weight: 500;
+				line-height: 20px;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__site-url {
+				color: #3a434a;
+				font-size: 12px;
+				font-weight: 400;
+				line-height: 16px;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__site-actions {
+				flex-shrink: 0;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__content p {
+				margin: 12px 0;
+				font-size: 13px;
+				font-weight: 400;
+				line-height: 18px;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__dev-tools-title {
+				margin-bottom: 12px;
+				font-size: 11px;
+				font-weight: 600;
+				line-height: 16px;
+				text-transform: uppercase;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__dev-tools-content ul {
+				display: grid;
+				grid-template-columns: 1fr 1fr;
+				gap: 12px;
+				margin-bottom: 0;
+				list-style: disc inside;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__dev-tools-content li {
+				margin: 0 8px;
+				color: #0073aa;
+				font-size: 13px;
+				font-weight: 400;
+				line-height: 18px;
+			}
+
+			#wpcom_site_management_widget .wpcom_site_management_widget__dev-tools-content li::marker {
+				margin-inline-end: 2px;
+			}
+		</style>
+		<?php
+	}
+
+	/**
+	 * Sets up the WPCOM site management widget in the WordPress admin dashboard.
+	 */
+	public function wp_dashboard_setup() {
+		wp_add_dashboard_widget(
+			self::WPCOM_SITE_MANAGEMENT_WIDGET_ID,
+			__( 'Site management panel', 'jetpack-mu-wpcom' ),
+			array( $this, 'render_wpcom_site_management_widget' ),
+			fn() => '',
+			array(),
+			'normal',
+			'high'
+		);
+	}
+
+	/**
+	 * Renders the widget.
+	 */
+	public function render_wpcom_site_management_widget() {
+		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
+
+		?>
+		<div id="wpcom_site_management_widget" class="wpcom_site_management_widget" style="min-height: 200px;">
+			<div class="hide-if-js"><?php esc_html_e( 'Your Site management widget requires JavaScript to function properly.', 'jetpack-mu-wpcom' ); ?></div>
+			<div class="hide-if-no-js" style="height: 100%">
+				<div class="wpcom_site_management_widget__header">
+					<div class="wpcom_site_management_widget__site-favicon">
+						<?php $this->render_wpcom_site_management_widget_fav_icon(); ?>
+					</div>
+					<div class="wpcom_site_management_widget__site-info">
+						<div class="wpcom_site_management_widget__site-name"><?php echo esc_html( get_bloginfo( 'name' ) ); ?></div>
+						<div class="wpcom_site_management_widget__site-url"><?php echo esc_html( $domain ); ?></div>
+					</div>
+					<div class="wpcom_site_management_widget__site-actions">
+						<a class="button-primary" href="<?php echo esc_url( "https://wordpress.com/overview/$domain" ); ?>">
+							<?php esc_html_e( 'Hosting Overview', 'jetpack-mu-wpcom' ); ?>
+						</a>
+					</div>
+				</div>
+				<div class="wpcom_site_management_widget__content">
+					<p><?php esc_html_e( 'Get a quick overview of your plans, storage, and domains, or easily access your development tools using the links provided below:', 'jetpack-mu-wpcom' ); ?></p>
+					<div class="wpcom_site_management_widget__dev-tools">
+						<div class="wpcom_site_management_widget__dev-tools-title"><?php esc_html_e( 'DEV TOOLS:', 'jetpack-mu-wpcom' ); ?></div>
+						<div class="wpcom_site_management_widget__dev-tools-content">
+							<ul>
+							<?php
+								$dev_tools_items = array(
+									array(
+										'name' => __( 'Hosting config', 'jetpack-mu-wpcom' ),
+										'href' => "/hosting-config/$domain",
+									),
+									array(
+										'name' => __( 'Monitoring', 'jetpack-mu-wpcom' ),
+										'href' => "/site-monitoring/$domain",
+									),
+									array(
+										'name' => __( 'GitHub Deployments', 'jetpack-mu-wpcom' ),
+										'href' => "/github-deployments/$domain",
+									),
+									array(
+										'name' => __( 'PHP Logs', 'jetpack-mu-wpcom' ),
+										'href' => "/site-monitoring/$domain/php",
+									),
+									array(
+										'name' => __( 'Server Logs', 'jetpack-mu-wpcom' ),
+										'href' => "/site-monitoring/$domain/web",
+									),
+								);
+								foreach ( $dev_tools_items as $item ) {
+									printf( '<li><a href="https://wordpress.com%1$s">%2$s</a></li>', esc_url( $item['href'] ), esc_html( $item['name'] ) );
+								}
+								?>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Renders the fav icon.
+	 */
+	public function render_wpcom_site_management_widget_fav_icon() {
+		$site_icon_url = get_site_icon_url( 38 );
+
+		// webclip.png is the default on WoA sites. Anything other than that means we have a custom site icon.
+		if ( ! empty( $site_icon_url ) && $site_icon_url !== 'https://s0.wp.com/i/webclip.png' ) {
+			printf( '<img src="%1$s" />', esc_url( $site_icon_url ) );
+		} else {
+			printf( '<span>%1$s</span>', esc_html( mb_substr( get_bloginfo( 'name' ), 0, 1 ) ) );
+		}
+	}
+}
+
+WPCOM_Site_Management_Widget::get_instance();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
@@ -14,7 +14,7 @@ class WPCOM_Site_Management_Widget {
 	/**
 	 * Singleton instance of the widget, not to show more than once.
 	 *
-	 * @var array
+	 * @var WPCOM_Site_Management_Widget
 	 */
 	public static $instance = null;
 
@@ -150,7 +150,7 @@ class WPCOM_Site_Management_Widget {
 			self::WPCOM_SITE_MANAGEMENT_WIDGET_ID,
 			__( 'Site management panel', 'jetpack-mu-wpcom' ),
 			array( $this, 'render_wpcom_site_management_widget' ),
-			fn() => '',
+			function () {},
 			array(),
 			'normal',
 			'high'

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
@@ -148,7 +148,7 @@ class WPCOM_Site_Management_Widget {
 	public function wp_dashboard_setup() {
 		wp_add_dashboard_widget(
 			self::WPCOM_SITE_MANAGEMENT_WIDGET_ID,
-			__( 'Site management panel', 'jetpack-mu-wpcom' ),
+			__( 'Site Management Panel', 'jetpack-mu-wpcom' ),
 			array( $this, 'render_wpcom_site_management_widget' ),
 			function () {},
 			array(),
@@ -190,7 +190,7 @@ class WPCOM_Site_Management_Widget {
 							<?php
 								$dev_tools_items = array(
 									array(
-										'name' => __( 'Hosting config', 'jetpack-mu-wpcom' ),
+										'name' => __( 'Hosting Config', 'jetpack-mu-wpcom' ),
 										'href' => "/hosting-config/$domain",
 									),
 									array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7356

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Register the “Site management panel” widget on the WP Dashboard. Note that the style of the button is basd the color scheme.

![image](https://github.com/Automattic/jetpack/assets/13596067/87aa5ad2-dc79-4909-8855-9af218a70af1)
![image](https://github.com/Automattic/jetpack/assets/13596067/b0ae6eb4-fb2a-4028-bb92-8c9465ae47e6)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow https://github.com/Automattic/jetpack/pull/37504#issuecomment-2126559448 to apply changes to your sites
* Go to /wp-admin/index.php
* Make sure you can see the “Site management panel” widget on the WP Dashboard
* Make sure all links work as expected
  * ~~I'll propose a PR on Calypso to redirect the pages to `/dev-tools-promo/:domain` for unsupported sites, e.g.: simple sites or atomic sites with expired plan.~~ It's supported by the `redirectHomeIfIneligible`
