### PR TITLE
Social: Fix non-owners seeing mark as shared component

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-connection-management-non-author-globalize
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connection-management-non-author-globalize
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue where non-admins saw action on connection management

--- a/projects/js-packages/publicize-components/src/components/services/service-connection-info.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/service-connection-info.tsx
@@ -14,28 +14,6 @@ export type ServiceConnectionInfoProps = {
 };
 
 export const ServiceConnectionInfo = ( { connection, service }: ServiceConnectionInfoProps ) => {
-	const renderConnectionActions = () => {
-		if ( connection.can_disconnect ) {
-			return (
-				<div className={ styles[ 'mark-shared-wrap' ] }>
-					<MarkAsShared connection={ connection } />
-					<IconTooltip placement="top" inline={ false } shift>
-						{ __(
-							'If enabled, the connection will be available to all administrators, editors, and authors.',
-							'jetpack'
-						) }
-					</IconTooltip>
-				</div>
-			);
-		}
-
-		return (
-			<Text className={ styles.description }>
-				{ __( 'This connection is added by a site administrator.', 'jetpack' ) }
-			</Text>
-		);
-	};
-
 	return (
 		<div className={ styles[ 'service-connection' ] }>
 			<div>
@@ -51,11 +29,31 @@ export const ServiceConnectionInfo = ( { connection, service }: ServiceConnectio
 			</div>
 			<div className={ styles[ 'connection-details' ] }>
 				<ConnectionName connection={ connection } />
-				{ connection.status === 'broken' ? (
-					<ConnectionStatus connection={ connection } service={ service } />
-				) : (
-					renderConnectionActions()
-				) }
+				{ ( conn => {
+					if ( conn.status === 'broken' ) {
+						return <ConnectionStatus connection={ conn } service={ service } />;
+					}
+
+					if ( conn.can_disconnect ) {
+						return (
+							<div className={ styles[ 'mark-shared-wrap' ] }>
+								<MarkAsShared connection={ conn } />
+								<IconTooltip placement="top" inline={ false } shift>
+									{ __(
+										'If enabled, the connection will be available to all administrators, editors, and authors.',
+										'jetpack'
+									) }
+								</IconTooltip>
+							</div>
+						);
+					}
+
+					return (
+						<Text className={ styles.description }>
+							{ __( 'This connection is added by a site administrator.', 'jetpack' ) }
+						</Text>
+					);
+				} )( connection ) }
 			</div>
 			<div className={ styles[ 'connection-actions' ] }>
 				<Disconnect

--- a/projects/js-packages/publicize-components/src/components/services/service-connection-info.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/service-connection-info.tsx
@@ -1,4 +1,4 @@
-import { IconTooltip } from '@automattic/jetpack-components';
+import { IconTooltip, Text } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import { Connection } from '../../social-store/types';
 import { ConnectionName } from '../connection-management/connection-name';
@@ -14,6 +14,28 @@ export type ServiceConnectionInfoProps = {
 };
 
 export const ServiceConnectionInfo = ( { connection, service }: ServiceConnectionInfoProps ) => {
+	const renderConnectionActions = () => {
+		if ( connection.can_disconnect ) {
+			return (
+				<div className={ styles[ 'mark-shared-wrap' ] }>
+					<MarkAsShared connection={ connection } />
+					<IconTooltip placement="top" inline={ false } shift>
+						{ __(
+							'If enabled, the connection will be available to all administrators, editors, and authors.',
+							'jetpack'
+						) }
+					</IconTooltip>
+				</div>
+			);
+		}
+
+		return (
+			<Text className={ styles.description }>
+				{ __( 'This connection is added by a site administrator.', 'jetpack' ) }
+			</Text>
+		);
+	};
+
 	return (
 		<div className={ styles[ 'service-connection' ] }>
 			<div>
@@ -32,15 +54,7 @@ export const ServiceConnectionInfo = ( { connection, service }: ServiceConnectio
 				{ connection.status === 'broken' ? (
 					<ConnectionStatus connection={ connection } service={ service } />
 				) : (
-					<div className={ styles[ 'mark-shared-wrap' ] }>
-						<MarkAsShared connection={ connection } />
-						<IconTooltip placement="top" inline={ false } shift>
-							{ __(
-								'If enabled, the connection will be available to all administrators, editors, and authors.',
-								'jetpack'
-							) }
-						</IconTooltip>
-					</div>
+					renderConnectionActions()
 				) }
 			</div>
 			<div className={ styles[ 'connection-actions' ] }>

--- a/projects/js-packages/publicize-components/src/components/services/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/services/style.module.scss
@@ -197,8 +197,3 @@
 	display: flex;
 	gap: 0.5rem;
 }
-
-.mark-shared-wrap {
-	display: flex;
-	gap: 0.5rem;
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/358

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only render `MarkAsShared` if user has permission to disconnect
* Added alternative text for non admins

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/358
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Globalize a connection on a site
* Switch to another user and make sure you do not see the MarkAsShared component


![CleanShot 2024-05-23 at 12 46 47 png](https://github.com/Automattic/jetpack/assets/36671565/3d8d9697-6035-49d3-bdea-a678d8f87561)
