### PR TITLE
CRM: Mailpoet Sync issue with the sync percentage calculation

### DIFF
--- a/projects/plugins/crm/changelog/fix-3462-crm-mailpoet-sync-pagination-issue
+++ b/projects/plugins/crm/changelog/fix-3462-crm-mailpoet-sync-pagination-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MailPoet Sync: Fixed the percentage difference issue calculating the pending pages to proces.


### PR DESCRIPTION
Resolves https://github.com/Automattic/zero-bs-crm/issues/3223
Resolves https://github.com/Automattic/zero-bs-crm/issues/3462

## Proposed changes:

This PR resolved the issue we had with the MailPoet Sync, calculating the complete percentage of the job. The sync process works well, the issue was about calculating the total percentage of the work. Specificaly it was about how the calculation code was handling the pagination, the current page goes from `0` to `(total_page - 1)`, and the calculation code was interpreting the current page as `1` to `total_page` range, so that was the reason because it seems stuck in the latest page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Install MailPoet
- Active the MailPoet Sync module at JPCRM
- Add a bunch of subscribers. You can use the import section on MailPoet: `/wp-admin/admin.php?page=mailpoet-import#/step_method_selection` and select the `Paste the data into a text box` method. With the help of ChatGPT create a list of 126 subscribers:

```
Follow this serie, I need 126 lines:

1@example.com, T1, TT1
2@example.com, T2, TT2
```

I copied and pated it for you here: 348ba-pb

- Then run the JPCRM sync. Everything should go well...
![image](https://github.com/Automattic/jetpack/assets/9832440/dffc3f77-ae8d-442b-b614-76049e443bae)

The debug output data should match with the expected. If you get 66% re-load the page, and it will complete it. MailPoet Sync runs one page per sync job, so you have to refresh it.