### PR TITLE
CRM: Increase city field size

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-3465-increase-city-field-size-companies
+++ b/projects/plugins/crm/changelog/fix-crm-3465-increase-city-field-size-companies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Companies: Increased city field size from 100 to 200

--- a/projects/plugins/crm/changelog/fix-crm-3465-increase-city-field-size-contacts
+++ b/projects/plugins/crm/changelog/fix-crm-3465-increase-city-field-size-contacts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contacts: Increased city field size from 100 to 200

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Companies.php
@@ -101,7 +101,7 @@ class zbsDAL_companies extends zbsDAL_ObjectLayer {
             'placeholder'=> 'e.g. New York',
             'area'=> 'Main Address',
             'migrate'=>'addresses',
-            'max_len' => 100
+            'max_len' => 200, // phpcs:ignore Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed, WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
         ),
         'county'            => array(
             // db model:
@@ -174,7 +174,7 @@ class zbsDAL_companies extends zbsDAL_ObjectLayer {
             'area'=> 'Second Address',
             'migrate'=>'addresses',
             'opt'=>'secondaddress',
-            'max_len' => 100,
+            'max_len' => 200, // phpcs:ignore Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed, WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
             'dal1key' => 'secaddr_city' // previous field name
         ),
         'seccounty'            => array(

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Obj.Contacts.php
@@ -167,7 +167,7 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 					'placeholder' => 'e.g. New York',
 					'area'        => 'Main Address',
 					'migrate'     => 'addresses',
-					'max_len'     => 100,
+					'max_len'     => 200,
 				),
 				'county'        => array(
 					// db model:
@@ -244,7 +244,7 @@ class zbsDAL_contacts extends zbsDAL_ObjectLayer {
 					'area'        => 'Second Address',
 					'migrate'     => 'addresses',
 					'opt'         => 'secondaddress',
-					'max_len'     => 100,
+					'max_len'     => 200,
 					'dal1key'     => 'secaddr_city', // previous field name
 				),
 				'seccounty'     => array(

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -40,6 +40,7 @@ global $zeroBSCRM_migrations; $zeroBSCRM_migrations = array(
 	'regenerate_tag_slugs', // Regenerate tag slugs
 	'create_workflows_table', // Create "workflows" table.
 	'invoice_language_fixes', // Store invoice statuses and mappings consistently
+	'gh3465_increase_city_field_size',  // from gh issue 3465, increases the city field size to 200
 	);
 
 global $zeroBSCRM_migrations_requirements; $zeroBSCRM_migrations_requirements = array(
@@ -1247,6 +1248,21 @@ function zeroBSCRM_migration_invoice_language_fixes() {
 	}
 
 	zeroBSCRM_migrations_markComplete( 'invoice_language_fixes', array( 'updated' => 1 ) );
+}
+
+/**
+ * From Gh Issue 3465, this migration increases the city field size to 200 chars
+ */
+function zeroBSCRM_migration_gh3465_increase_city_field_size() {
+	global $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
+	$sql = 'ALTER TABLE ' . $ZBSCRM_t['contacts'] . ' MODIFY COLUMN `zbsc_city` VARCHAR(200);'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+	$sql = 'ALTER TABLE ' . $ZBSCRM_t['companies'] . ' MODIFY COLUMN `zbsco_city` VARCHAR(200);'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+	zeroBSCRM_migrations_markComplete( 'gh3465_increase_city_field_size', array( 'updated' => 1 ) );
 }
 
 /* ======================================================

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -1259,7 +1259,13 @@ function zeroBSCRM_migration_gh3465_increase_city_field_size() {
 	$sql = 'ALTER TABLE ' . $ZBSCRM_t['contacts'] . ' MODIFY COLUMN `zbsc_city` VARCHAR(200);'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 
+	$sql = 'ALTER TABLE ' . $ZBSCRM_t['contacts'] . ' MODIFY COLUMN `zbsc_seccity` VARCHAR(200);'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
 	$sql = 'ALTER TABLE ' . $ZBSCRM_t['companies'] . ' MODIFY COLUMN `zbsco_city` VARCHAR(200);'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+
+	$sql = 'ALTER TABLE ' . $ZBSCRM_t['companies'] . ' MODIFY COLUMN `zbsco_seccity` VARCHAR(200);'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 
 	zeroBSCRM_migrations_markComplete( 'gh3465_increase_city_field_size', array( 'updated' => 1 ) );


### PR DESCRIPTION
Fixes https://github.com/Automattic/zero-bs-crm/issues/3465

## Proposed changes:

* This PR increases the field size from both companies and contacts from 100 to 200 chars.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/zero-bs-crm/issues/3465

## Does this pull request change what data or activity we track or use?

## Testing instructions:

* Load up this branch
* Visit your CRM site
* Verify inside the database that the city field for the contacts and companies tables has increased from 100 to 200

