### PR TITLE
Social: Standardize social rest endpoints. 

### DIFF
--- a/projects/packages/publicize/changelog/update-standarize-social-endpoints
+++ b/projects/packages/publicize/changelog/update-standarize-social-endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Standardized the rest endpoint structure for jetpack social connections.

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -7,8 +7,10 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Tokens;
 use Jetpack_IXR_Client;
+use Jetpack_Options;
 use WP_Error;
 use WP_Post;
 
@@ -145,7 +147,7 @@ class Publicize extends Publicize_Base {
 	}
 
 	/**
-	 * Set updated Publicize connections.
+	 * Set updated Publicize connections in a transient.
 	 *
 	 * @param mixed $publicize_connections Updated connections.
 	 * @return true
@@ -179,7 +181,13 @@ class Publicize extends Publicize_Base {
 	 */
 	public function get_all_connections() {
 		$this->refresh_connections();
+
 		$connections = get_transient( self::JETPACK_SOCIAL_CONNECTIONS_TRANSIENT );
+
+		if ( $connections === false ) {
+			$connections = array();
+		}
+
 		if ( isset( $connections['google_plus'] ) ) {
 			unset( $connections['google_plus'] );
 		}
@@ -220,9 +228,15 @@ class Publicize extends Publicize_Base {
 	/**
 	 * Get all connections for a specific user.
 	 *
+	 * @param array $args Arguments to run operations such as force refresh and connection test results.
+
 	 * @return array
 	 */
-	public function get_all_connections_for_user() {
+	public function get_all_connections_for_user( $args = array() ) {
+		if ( ( isset( $args['clear_cache'] ) && $args['clear_cache'] )
+		|| ( isset( $args['run_connection_tests'] ) && $args['run_connection_tests'] ) ) {
+			$this->clear_connections_transient();
+		}
 		$connections = $this->get_all_connections();
 
 		$connections_to_return = array();
@@ -238,8 +252,10 @@ class Publicize extends Publicize_Base {
 								array(
 									'service_name'   => $service_name,
 									'connection_id'  => $connection['connection_data']['id'],
-									'can_disconnect' => self::can_manage_connection( $connection['connection_data'] ),
+									'can_disconnect' => current_user_can( 'edit_others_posts' ) || get_current_user_id() === $user_id,
 									'profile_link'   => $this->get_profile_link( $service_name, $connection ),
+									'shared'         => $connection['connection_data']['user_id'] === '0',
+									'status'         => 'ok',
 								)
 							);
 						} else {
@@ -249,7 +265,55 @@ class Publicize extends Publicize_Base {
 				}
 			}
 		}
+
+		if ( self::use_admin_ui_v1() && isset( $args['run_connection_tests'] ) && $args['run_connection_tests'] && count( $connections_to_return ) > 0 ) {
+			$connections_to_return = $this->add_connection_test_results( $connections_to_return );
+		}
+
 		return $connections_to_return;
+	}
+
+	/**
+	 * To add the connection test results to the connections.
+	 *
+	 * @param array $connections The Jetpack Social connections.
+
+	 * @return array
+	 */
+	public function add_connection_test_results( $connections ) {
+		$path                   = sprintf( '/sites/%d/publicize/connection-test-results', absint( Jetpack_Options::get_option( 'id' ) ) );
+		$response               = Client::wpcom_json_api_request_as_user( $path, '2', array(), null, 'wpcom' );
+		$connection_results     = json_decode( wp_remote_retrieve_body( $response ), true );
+		$connection_results_map = array();
+		foreach ( $connection_results as $connection_result ) {
+			$connection_results_map[ $connection_result['connection_id'] ] = $connection_result['test_success'];
+		}
+
+		return array_map(
+			function ( $connection ) use ( $connection_results_map ) {
+				if ( isset( $connection_results_map[ $connection['connection_id'] ] ) ) {
+						$connection['status'] = $connection_results_map[ $connection['connection_id'] ] ? 'ok' : 'broken';
+				}
+				return $connection;
+			},
+			$connections
+		);
+	}
+
+	/**
+	 * Get a connections for a user.
+	 *
+	 * @param int $connection_id The connection_id.
+
+	 * @return array
+	 */
+	public function get_connection_for_user( $connection_id ) {
+		foreach ( $this->get_all_connections_for_user() as $connection ) {
+			if ( (int) $connection['connection_id'] === (int) $connection_id ) {
+				return $connection;
+			}
+		}
+		return array();
 	}
 
 	/**
@@ -432,26 +496,24 @@ class Publicize extends Publicize_Base {
 	}
 
 	/**
-	 * Grabs a fresh copy of the publicize connections data.
-	 * Only refreshes once every 4 hours or retry immediately.
+	 * Grabs a fresh copy of the publicize connections data, if the cache is busted.
 	 */
 	public function refresh_connections() {
-		if ( get_transient( self::JETPACK_SOCIAL_CONNECTIONS_TRANSIENT ) ) {
-			return;
-		}
-		$xml = new Jetpack_IXR_Client();
-		$xml->query( 'jetpack.fetchPublicizeConnections' );
-
-		if ( ! $xml->isError() ) {
-			$response = $xml->getResponse();
-			$this->receive_updated_publicize_connections( $response );
-		} else {
-			$this->clear_connections_transient();
+		$connections = get_transient( self::JETPACK_SOCIAL_CONNECTIONS_TRANSIENT );
+		if ( $connections === false ) {
+			$xml = new Jetpack_IXR_Client();
+			$xml->query( 'jetpack.fetchPublicizeConnections' );
+			if ( ! $xml->isError() ) {
+				$response = $xml->getResponse();
+				$this->receive_updated_publicize_connections( $response );
+			} else {
+				$this->clear_connections_transient();
+			}
 		}
 	}
 
 	/**
-	 * Delete the connections transient, so we force refresh the connection data.
+	 * Delete the transient.
 	 */
 	public function clear_connections_transient() {
 		delete_transient( self::JETPACK_SOCIAL_CONNECTIONS_TRANSIENT );

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -285,19 +285,17 @@ class Publicize extends Publicize_Base {
 		$response               = Client::wpcom_json_api_request_as_user( $path, '2', array(), null, 'wpcom' );
 		$connection_results     = json_decode( wp_remote_retrieve_body( $response ), true );
 		$connection_results_map = array();
+
 		foreach ( $connection_results as $connection_result ) {
-			$connection_results_map[ $connection_result['connection_id'] ] = $connection_result['test_success'];
+			$connection_results_map[ $connection_result['connection_id'] ] = $connection_result['test_success'] ? 'ok' : 'broken';
+		}
+		foreach ( $connections as $key => $connection ) {
+			if ( isset( $connection_results_map[ $connection['connection_id'] ] ) ) {
+				$connections[ $key ]['status'] = $connection_results_map[ $connection['connection_id'] ];
+			}
 		}
 
-		return array_map(
-			function ( $connection ) use ( $connection_results_map ) {
-				if ( isset( $connection_results_map[ $connection['connection_id'] ] ) ) {
-						$connection['status'] = $connection_results_map[ $connection['connection_id'] ] ? 'ok' : 'broken';
-				}
-				return $connection;
-			},
-			$connections
-		);
+		return $connections;
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -234,7 +234,7 @@ class Publicize extends Publicize_Base {
 	 */
 	public function get_all_connections_for_user( $args = array() ) {
 		if ( ( isset( $args['clear_cache'] ) && $args['clear_cache'] )
-		|| ( isset( $args['run_connection_tests'] ) && $args['run_connection_tests'] ) ) {
+		|| ( isset( $args['test_connections'] ) && $args['test_connections'] ) ) {
 			$this->clear_connections_transient();
 		}
 		$connections = $this->get_all_connections();
@@ -266,7 +266,7 @@ class Publicize extends Publicize_Base {
 			}
 		}
 
-		if ( self::use_admin_ui_v1() && isset( $args['run_connection_tests'] ) && $args['run_connection_tests'] && count( $connections_to_return ) > 0 ) {
+		if ( self::use_admin_ui_v1() && isset( $args['test_connections'] ) && $args['test_connections'] && count( $connections_to_return ) > 0 ) {
 			$connections_to_return = $this->add_connection_test_results( $connections_to_return );
 		}
 

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -252,7 +252,7 @@ class Publicize extends Publicize_Base {
 								array(
 									'service_name'   => $service_name,
 									'connection_id'  => $connection['connection_data']['id'],
-									'can_disconnect' => current_user_can( 'edit_others_posts' ) || get_current_user_id() === $user_id,
+									'can_disconnect' => self::can_manage_connection( $connection['connection_data'] ),
 									'profile_link'   => $this->get_profile_link( $service_name, $connection ),
 									'shared'         => $connection['connection_data']['user_id'] === '0',
 									'status'         => 'ok',

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -285,13 +285,13 @@ class REST_Controller {
 	 * @param WP_REST_Request $request The request object, which includes the parameters.
 	 */
 	public function get_publicize_connections( $request ) {
-		$run_test_results = $request->get_param( 'run_connection_tests' );
+		$run_test_results = $request->get_param( 'test_connections' );
 		$clear_cache      = $request->get_param( 'clear_cache' );
 
 		$args = array();
 
 		if ( ! empty( $run_test_results ) ) {
-			$args['run_connection_tests'] = true;
+			$args['test_connections'] = true;
 		}
 
 		if ( ! empty( $clear_cache ) ) {

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -548,7 +548,7 @@ class REST_Controller {
 
 		return new WP_Error(
 			'could_not_create_connection',
-			__( 'Something went wrogn while creating a connection.', 'jetpack-publicize-pkg' )
+			__( 'Something went wrong while creating a connection.', 'jetpack-publicize-pkg' )
 		);
 	}
 }

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -467,6 +467,8 @@ class REST_Controller {
 			'wpcom'
 		);
 
+		$response = $this->make_proper_response( $response );
+
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
@@ -533,17 +535,20 @@ class REST_Controller {
 			'wpcom'
 		);
 
+		$response = $this->make_proper_response( $response );
+
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
-		if ( isset( $response['body'] ) ) {
-			$body = json_decode( wp_remote_retrieve_body( $response ), true );
-			if ( isset( $body['ID'] ) ) {
-				global $publicize;
-				return rest_ensure_response( $publicize->get_connection_for_user( (int) $body['ID'] ) );
-			}
+		if ( isset( $response['ID'] ) ) {
+			global $publicize;
+			return rest_ensure_response( $publicize->get_connection_for_user( (int) $response['ID'] ) );
 		}
-		return rest_ensure_response( $response );
+
+		return new WP_Error(
+			'could_not_create_connection',
+			__( 'Something went wrogn while creating a connection.', 'jetpack-publicize-pkg' )
+		);
 	}
 }

--- a/projects/packages/publicize/tests/php/test-publicize-rest-controller.php
+++ b/projects/packages/publicize/tests/php/test-publicize-rest-controller.php
@@ -100,7 +100,7 @@ class Test_REST_Controller extends TestCase {
 		$request = new WP_REST_Request( 'GET', '/jetpack/v4/publicize/connections' );
 		wp_set_current_user( $this->admin_id );
 		$response = $this->dispatch_request_signed_with_blog_token( $request );
-		$this->assertCount( 2, $response->data );
+		$this->assertCount( 3, $response->data );
 	}
 
 	/**
@@ -214,6 +214,20 @@ class Test_REST_Controller extends TestCase {
 						'token_id'      => 'test-unique-id123',
 						'meta'          => array(
 							'display_name' => 'test-display-name123',
+						),
+					),
+				),
+			),
+			// Globally connected nextdoor.
+			'nextdoor' => array(
+				'id_number' => array(
+					'connection_data' => array(
+						'user_id'       => 0,
+						'id'            => '456',
+						'connection_id' => '1236',
+						'token_id'      => 'test-unique-id1234',
+						'meta'          => array(
+							'display_name' => 'test-display-name1234',
 						),
 					),
 				),

--- a/projects/packages/publicize/tests/php/test-publicize-rest-controller.php
+++ b/projects/packages/publicize/tests/php/test-publicize-rest-controller.php
@@ -100,7 +100,7 @@ class Test_REST_Controller extends TestCase {
 		$request = new WP_REST_Request( 'GET', '/jetpack/v4/publicize/connections' );
 		wp_set_current_user( $this->admin_id );
 		$response = $this->dispatch_request_signed_with_blog_token( $request );
-		$this->assertCount( 3, $response->data );
+		$this->assertCount( 2, $response->data );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Broken down from https://github.com/Automattic/jetpack/pull/37390
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updated the create and update publicize connections endpoint to call the newly added `get_connection_for_user` publicize function. 
* Updated the get publicize connections endpoint to call the existing `get_all_connections_for_user` publicize function. 
* Added `shared` key to the connections object. 
* Added `status` to the connections object to indicate connection health. Its values are `ok` or `broken`
* To refresh connection test results, add this query param `test_connections =true` to your get request. 
* To clear connection cache, add this query param `clear_cache =true` to your get request.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/37390

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Don't sandbox and test against prod. 
* Boot up a JN site on this branch or checkout this branch on your local and ensure  the blog sticker is added. 
* Have your network tab open and create a connection using the new management UI. See the response of the`POST wp-json/jetpack/v4/social/connections`. You will see toast like this:


<img width="576" alt="Screenshot 2024-05-23 at 6 58 51 PM" src="https://github.com/Automattic/jetpack/assets/6594561/b6a5d3f6-1d0a-4fa4-a283-282203839317">

but that's only because the UI hasn't adapted to changes in the API Response. That will happen in https://github.com/Automattic/jetpack/pull/37390.

* Globalize/unglobalize a connection and ensure they work fine.

* From Postman, make a get request to `wp-json/jetpack/v4/publicize/connections` and observe the response.  To run connection test results, include these query params `wp-json/jetpack/v4/publicize/connections?test_connections =true`

This is how the standardized connection object looks. 
```
{
    "refresh_token": "",
    "type": "access",
    "user_id": "",
    "provider": "nextdoor:wordpressxxxx",
    "issued": "2023-10-25 05:29:34",
    "expires": 1747224005,
    "external_id": "",
    "external_name": "Sid Darthan",
    "external_display": "Sid Darthan",
    "connection_data": {
        "id": "",
        "token_id": "",
        "blog_id": "",
        "user_id": "",
        "meta": {
            "external_user_id": ""
        }
    },
    "profile_picture": "xxxx",
    "service_name": "nextdoor",
    "connection_id": "",
    "can_disconnect": true,
    "profile_link": "https://nextdoor.com/profile/",
    "shared": false,
    "status": "ok"
}
``` 

 

