### PR TITLE
Subscription overlay: Transition fix

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscription-overlay-transition-fix
+++ b/projects/plugins/jetpack/changelog/update-subscription-overlay-transition-fix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscriptions: Update transition for Subscription overlay

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
@@ -8,26 +8,22 @@ body.jetpack-subscribe-overlay-open {
 
 	visibility: hidden;
 	position: fixed;
-	z-index: 50000; /* Same as WP.com Action bar */
-	left: 0;
-	top: 0;
-	width: 100%;
-	height: 100%;
 	overflow: hidden;
+	z-index: 50000;
+	top: -100%; /* Start from above the viewport */
+	width: 100%;
+    height: 100%;
+
+	display: flex;
+    align-items: center;
+    justify-content: center;
 	background-color: transparent;
-	transition: background-color 0.4s, visibility 0.4s;
-	color: var(--jetpack-subscribe-overlay--text-color);
+	transition: top 1s, background-color 0.2s, visibility 1s;
 }
 
 .jetpack-subscribe-overlay__content {
-	position: relative;
-	visibility: hidden;
-	overflow: hidden;
-	top: 100%;
-	margin: 15% auto;
-	width: 100%;
+	width: auto;
 	max-width: 400px;
-	transition: top 0.4s, visibility 0.4s;
 	text-wrap: pretty;
 }
 
@@ -46,8 +42,7 @@ body.admin-bar .jetpack-subscribe-overlay__close {
 }
 
 .jetpack-subscribe-overlay__to-content {
-	display: none;
-	position: fixed;
+	position: absolute;
 	bottom: 64px;
 	left: 0;
 	right: 0;
@@ -55,6 +50,7 @@ body.admin-bar .jetpack-subscribe-overlay__close {
 }
 
 .jetpack-subscribe-overlay.open {
+	top: 0; /* Move to the correct position */
 	background-color: var(--jetpack-subscribe-overlay--background-color);
 	visibility: visible;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of https://github.com/Automattic/jetpack/issues/36208

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Added a transition that starts at the top (instead of the bottom). To do this I had to change a little bit of CSS and add a `display:flex` to position all the elements as I needed.


https://github.com/Automattic/jetpack/assets/25607244/96405e6a-c196-4d67-b605-a304251b8f69


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Testing instructions:
* Switch to this branch, enable Welcome Overlay and visit your site.

