### PR TITLE
AI Assistant: Fix selected block while using the AI Assistant extension on a nested block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-inline-extension-nested-input
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-inline-extension-nested-input
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Fix selected block while using the AI Assistant extension on a nested block

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -54,8 +54,8 @@ unreleasedInlineExtensions.forEach( block => {
 } );
 
 // Since the lists depend on the feature flag, we need to define the types manually.
-export type ExtendedBlockProp = 'core/paragraph' | 'core/list';
-export type ExtendedInlineBlockProp = 'core/heading';
+export type ExtendedBlockProp = 'core/list';
+export type ExtendedInlineBlockProp = 'core/heading' | 'core/paragraph';
 
 type BlockSettingsProps = {
 	supports: {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-auto-scroll/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-auto-scroll/index.ts
@@ -7,7 +7,7 @@ import debugFactory from 'debug';
 const debug = debugFactory( 'jetpack-ai-assistant:use-auto-scroll' );
 
 const useAutoScroll = (
-	blockRef: React.MutableRefObject< HTMLElement >,
+	blockRef: React.MutableRefObject< HTMLElement | null >,
 	contentRef?: React.MutableRefObject< HTMLElement >,
 	useBlockAsTarget: boolean = false
 ) => {
@@ -85,7 +85,7 @@ const useAutoScroll = (
 	}, [ blockRef, contentRef, useBlockAsTarget, userScrollHandler ] );
 
 	const getScrollParent = useCallback(
-		( el: HTMLElement | null ): HTMLElement | Document | null => {
+		( el: HTMLElement | null | undefined ): HTMLElement | Document | null => {
 			if ( el == null ) {
 				return null;
 			}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -21,6 +21,7 @@ import type { RequestingErrorProps, RequestingStateProp } from '@automattic/jetp
 import type { ReactElement, MouseEvent } from 'react';
 
 export type AiAssistantInputProps = {
+	className?: string;
 	requestingState: RequestingStateProp;
 	requestingError?: RequestingErrorProps;
 	inputRef?: React.MutableRefObject< HTMLInputElement | null >;
@@ -34,12 +35,13 @@ export type AiAssistantInputProps = {
 	tryAgain?: () => void;
 };
 
-const className = classNames(
+const defaultClassNames = classNames(
 	'jetpack-ai-assistant-extension-ai-input',
 	'wp-block' // Some themes, like Twenty Twenty, use this class to set the element's side margins.
 );
 
 export default function AiAssistantInput( {
+	className,
 	requestingState,
 	requestingError,
 	inputRef,
@@ -156,7 +158,7 @@ export default function AiAssistantInput( {
 
 	return (
 		<ExtensionAIControl
-			className={ className }
+			className={ classNames( defaultClassNames, className ) }
 			placeholder={ placeholder }
 			disabled={ disabled }
 			value={ value }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/style.scss
@@ -1,3 +1,4 @@
-.jetpack-ai-assistant-extension-ai-input {
+.jetpack-components-ai-control__container-wrapper.jetpack-ai-assistant-extension-ai-input {
   z-index: 1;
+  position: sticky;
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -87,8 +87,9 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 			return { postId: getCurrentPostId() };
 		}, [] );
-		// The block's id to find it in the DOM for the positioning adjustments.
-		const { id } = useBlockProps();
+		// The block's id to find it in the DOM for the positioning adjustments
+		// The classname is used by nested blocks to determine which block's toolbar to display when the input is focused.
+		const { id, className } = useBlockProps();
 		// Jetpack AI Assistant feature functions.
 		const { increaseRequestsCount, dequeueAsyncRequest, requireUpgrade } = useAiFeature();
 
@@ -100,6 +101,10 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			undefined,
 			true
 		);
+
+		const focusInput = useCallback( () => {
+			inputRef.current?.focus();
+		}, [] );
 
 		// Data and functions with block-specific implementations.
 		const {
@@ -216,9 +221,16 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			// Make sure the block element has the necessary bottom padding, as it can be replaced or changed
 			setTimeout( () => {
 				adjustBlockPadding();
-				inputRef.current?.focus();
+				focusInput();
 			}, 100 );
-		}, [ disableAutoScroll, onBlockDone, increaseRequestsCount, getContent, adjustBlockPadding ] );
+		}, [
+			disableAutoScroll,
+			onBlockDone,
+			increaseRequestsCount,
+			getContent,
+			adjustBlockPadding,
+			focusInput,
+		] );
 
 		// Called when an error is received.
 		const onError = useCallback(
@@ -305,8 +317,8 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			disableAutoScroll();
 			stopSuggestion();
 
-			inputRef.current?.focus();
-		}, [ disableAutoScroll, stopSuggestion ] );
+			focusInput();
+		}, [ disableAutoScroll, stopSuggestion, focusInput ] );
 
 		// Called when the user clicks the "Try Again" button in the input error message.
 		const handleTryAgain = useCallback( () => {
@@ -348,9 +360,9 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				// Save the block's ownerDocument to use it later, as the editor can be in an iframe.
 				ownerDocument.current = inputRef.current.ownerDocument;
 				// Focus the input when the AI Control is displayed.
-				inputRef.current.focus();
+				focusInput();
 			}
-		}, [ showAiControl ] );
+		}, [ showAiControl, focusInput ] );
 
 		// Adjusts the input position in the editor by increasing the block's bottom-padding
 		// and setting the control's margin-top, "wrapping" the input with the block.
@@ -418,6 +430,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 				{ showAiControl && (
 					<AiAssistantInput
+						className={ className }
 						requestingState={ requestingState }
 						requestingError={ error }
 						wrapperRef={ controlRef }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37518

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the blockProp's `className` to the input, so both elements have the same className and are understood by the editor to be part of the same block when nested.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add a Columns block with a column in it
* Add an extended block inside the column (a Heading or Paragraph)
* Use the `Ask AI Assistant` toolbar action to open the input
* Check that the input stays open and the toolbar does not change

A video comparison for reference:

Before:

https://github.com/Automattic/jetpack/assets/8486249/8dfbf606-c58d-4974-b854-99b9901e60c5

After:

https://github.com/Automattic/jetpack/assets/8486249/cef2e40d-a8da-4e05-aa40-743cffd5796e
