### PR TITLE
Release script: adjust final messaging

### DIFF
--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -320,9 +320,17 @@ sed "s/%RELEASED_PLUGINS%/$PLUGINS_CHANGED/g" .github/files/BACKPORT_RELEASE_CHA
 gh pr create --title "Backport $PLUGINS_CHANGED Changes" --body "$(cat .github/files/TEMP_BACKPORT_RELEASE_CHANGES.md)" --label "[Status] Needs Review" --repo "Automattic/jetpack" --head "$(git rev-parse --abbrev-ref HEAD)"
 rm .github/files/TEMP_BACKPORT_RELEASE_CHANGES.md
 
-yellow "Release script complete! Next steps: "
-echo -e "\t1. Merge the above PR into trunk."
-echo -e "\t2. If this is NOT the Jetpack core plugin, the release will shortly be tagged to GitHub and released to SVN."
-echo -e "\t3. You can then smoke test the release and use ./tools/stable-tag.sh <plugin> to update the stable tag, and you're done!"
-echo -e "\t4. If you are releasing Jetpack-the-plugin, after the changes make it to the mirror repo, conduct a GitHub release."
-echo -e "\t5. Then run ./tools/deploy-to-svn.sh <plugin-name> <tag> to deploy to SVN, smoke test, and flip stable tag."
+yellow "Release script complete!"
+cat <<"EOM"
+
+Next you need to merge the above PR into trunk.
+
+If this is NOT the Jetpack core plugin, the release will shortly be tagged to
+GitHub and released to SVN and you can then smoke test the release. Once ready,
+use `./tools/stable-tag.sh <plugin>` to update the stable tag, and you're done!
+
+If you are releasing Jetpack (the plugin), wait for the changes to appear in
+the mirror repo and conduct a GitHub release. Next, deploy the tag to SVN by
+running `./tools/deploy-to-svn.sh <plugin> <tag>`, and smoke test. When ready,
+flip the stable tag and you're all set.
+EOM

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -323,6 +323,6 @@ rm .github/files/TEMP_BACKPORT_RELEASE_CHANGES.md
 yellow "Release script complete! Next steps: "
 echo -e "\t1. Merge the above PR into trunk."
 echo -e "\t2. If this is NOT the Jetpack core plugin, the release will shortly be tagged to GitHub and released to SVN."
-echo -e "\t3. You can then smoke test the release and use .tools/stable-tag.sh <plugin> to update the stable tag, and you're done!"
+echo -e "\t3. You can then smoke test the release and use ./tools/stable-tag.sh <plugin> to update the stable tag, and you're done!"
 echo -e "\t4. If you are releasing Jetpack-the-plugin, after the changes make it to the mirror repo, conduct a GitHub release."
 echo -e "\t5. Then run ./tools/deploy-to-svn.sh <plugin-name> <tag> to deploy to SVN, smoke test, and flip stable tag."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

When running `tools/release-plugin.sh`, the final message is this:

```
	1. Merge the above PR into trunk.
	2. If this is NOT the Jetpack core plugin, the release will shortly be tagged to GitHub and released to SVN.
	3. You can then smoke test the release and use .tools/stable-tag.sh <plugin> to update the stable tag, and you're done!
	4. If you are releasing Jetpack-the-plugin, after the changes make it to the mirror repo, conduct a GitHub release.
	5. Then run ./tools/deploy-to-svn.sh <plugin-name> <tag> to deploy to SVN, smoke test, and flip stable tag.
```

This is a bit confusing, as there are 5 steps, but step 1 is required, step 2 and 3 is one scenario, and step 4 and 5 are another scenario. It's also quite messy when dealing with an 80-char terminal.

This PR proposes the following instead (open to suggestions):
```
Next you need to merge the above PR into trunk.

If this is NOT the Jetpack core plugin, the release will shortly be tagged to
GitHub and released to SVN and you can then smoke test the release. Once ready,
use `./tools/stable-tag.sh <plugin>` to update the stable tag, and you're done!

If you are releasing Jetpack (the plugin), wait for the changes to appear in
the mirror repo and conduct a GitHub release. Next, deploy the tag to SVN by
running `./tools/deploy-to-svn.sh <plugin> <tag>`, and smoke test. When ready,
flip the stable tag and you're all set.
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Look at the code.