### PR TITLE
Memberships: Fix mixed membership products

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-mixed-membership-products
+++ b/projects/plugins/jetpack/changelog/fix-mixed-membership-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Memberships: fixes paid content access in some cases of mixed products

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
@@ -100,6 +100,7 @@ function current_visitor_can_access( $attributes, $block ) {
 		return false;
 	}
 
+	$can_view     = false;
 	$paywall      = subscription_service();
 	$access_level = Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS; // Only paid subscribers should be granted access to the premium content
 	$tier_ids     = \Jetpack_Memberships::get_all_newsletter_plan_ids();
@@ -140,8 +141,12 @@ function current_visitor_can_access( $attributes, $block ) {
 				break;
 			}
 		}
-	} else {
-		$can_view = $paywall->visitor_can_view_content( $selected_plan_ids, $access_level );
+	}
+
+	$non_tier_ids = array_diff( $selected_plan_ids, $tier_ids );
+	if ( ! $can_view ) {
+		// For selected plans that are not tiers, we want to check if the user has any of the selected plans.
+		$can_view = $paywall->visitor_can_view_content( $non_tier_ids, $access_level );
 	}
 
 	if ( $can_view ) {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
@@ -129,7 +129,6 @@ function current_visitor_can_access( $attributes, $block ) {
 			$payload        = $paywall->decode_token( $token );
 			$is_valid_token = ! empty( $payload );
 
-			$can_view = false;
 			if ( $is_valid_token ) {
 				$subscriptions = (array) $payload['subscriptions'];
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

* Mixing tiered memberships products will gate the access check to the tiered newsletter code path
* The tiered newsletter code path will see if the user is subscribed to any plans with a rate equal to or higher the cheapest tiered newsletter in the chosen products
* If the user subscribes with a non-tiered newsletter product that is at a rate lower than the cheapest tiered newsletter, the user won't have access

Fixes https://github.com/Automattic/gold/issues/403

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Separates product access checks into tiered and non-tiered
* Runs access checks for both product types

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Wait to apply this patch
* If testing yourself, set up with newsletters, create a post and add a premium content block to it, add a tiered newsletter product and a lower priced non-tiered product
* Alternatively, visit https://neilrobertstest.wordpress.com/2024/04/16/silver-premium-content/
* Open a private window
* Subscribe to the tiered newsletter product using a unique address (e.g. your.username+tiered@automattic.com)
* Verify you can see the subscriber view
* Open a second private window and visit the premium content
* Subscribe to the non-tiered product using a unique address (e.g. your.username+untiered@automattic.com)
* Verify you can't see the subscriber view
* Switch your Jetpack branch to this PR
* Make sure the hosts for your sandbox is pointing to that site
* Refresh both private windows and verify you can see the subscriber view