### PR TITLE
Social | Fix connection schema fields for front-end

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-fix-connection-schema-fields
+++ b/projects/js-packages/publicize-components/changelog/update-social-fix-connection-schema-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Updated connection fields to match the API schema

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
@@ -21,19 +21,15 @@ export function ConnectionStatus( {
 	service,
 	onConfirmReconnect,
 }: ConnectionStatusProps ) {
-	if ( connection.status === undefined || connection.status === 'ok' ) {
+	if ( connection.status !== 'broken' ) {
 		return null;
-	}
-
-	let notice = __( 'There is an issue with this connection.', 'jetpack' );
-
-	if ( connection.status === 'refresh-failed' ) {
-		notice = __( 'The connection seems to have expired.', 'jetpack' );
 	}
 
 	return (
 		<div>
-			<span className="description">{ notice }</span>
+			<span className="description">
+				{ __( 'There is an issue with this connection.', 'jetpack' ) }
+			</span>
 			&nbsp;
 			<Reconnect
 				connection={ connection }

--- a/projects/js-packages/publicize-components/src/social-store/actions/connection-data.js
+++ b/projects/js-packages/publicize-components/src/social-store/actions/connection-data.js
@@ -266,20 +266,18 @@ export function createConnection( data ) {
 
 			dispatch( creatingConnection() );
 
+			/**
+			 * @type {import('../types').Connection}
+			 */
 			const connection = await apiFetch( { method: 'POST', path, data } );
 
 			if ( connection ) {
 				dispatch(
 					addConnection( {
 						...connection,
-						// TODO fix this messy data structure
-						connection_id: connection.ID.toString(),
-						display_name: connection.external_display,
-						service_name: connection.service,
-						external_id: connection.external_ID,
-						profile_link: connection.external_profile_URL,
-						profile_picture: connection.external_profile_picture,
 						can_disconnect: true,
+						// For editor, we always enable the connection by default.
+						enabled: true,
 					} )
 				);
 

--- a/projects/js-packages/publicize-components/src/social-store/reducer/connection-data.js
+++ b/projects/js-packages/publicize-components/src/social-store/reducer/connection-data.js
@@ -10,6 +10,13 @@ import {
 	UPDATING_CONNECTION,
 } from '../actions/constants';
 
+/**
+ * Connection data reducer
+ *
+ * @param {import('../types').ConnectionData} state - Current state.
+ * @param {object} action - Action object.
+ * @returns {import('../types').ConnectionData} The new state.
+ */
 const connectionData = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case ADD_CONNECTION:
@@ -27,15 +34,9 @@ const connectionData = ( state = {}, action ) => {
 		case DELETE_CONNECTION:
 			return {
 				...state,
-				connections: state.connections.filter( connection => {
-					// If the connection has a connection_id, then give it priority.
-					// Otherwise, use the id.
-					const isTargetConnection = connection.connection_id
-						? connection.connection_id === action.connectionId
-						: connection.id === action.connectionId;
-
-					return ! isTargetConnection;
-				} ),
+				connections: state.connections.filter(
+					( { connection_id } ) => connection_id !== action.connectionId
+				),
 			};
 
 		case DELETING_CONNECTION: {
@@ -60,11 +61,7 @@ const connectionData = ( state = {}, action ) => {
 			return {
 				...state,
 				connections: state.connections.map( connection => {
-					// If the connection has a connection_id, then give it priority.
-					// Otherwise, use the id.
-					const isTargetConnection = connection.connection_id
-						? connection.connection_id === action.connectionId
-						: connection.id === action.connectionId;
+					const isTargetConnection = connection.connection_id === action.connectionId;
 
 					if ( isTargetConnection ) {
 						return {

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.js
@@ -18,7 +18,7 @@ export function getConnections( state ) {
  * @returns {import("../types").Connection | undefined} The connection.
  */
 export function getConnectionById( state, connectionId ) {
-	return getConnections( state ).find( connection => connection.id === connectionId );
+	return getConnections( state ).find( connection => connection.connection_id === connectionId );
 }
 
 /**

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -7,7 +7,7 @@ export type SharesData = {
 	shared_posts_count: number;
 };
 
-export type ConnectionStatus = 'ok' | 'must_reauth' | 'invalid' | 'broken' | 'refresh-failed';
+export type ConnectionStatus = 'ok' | 'broken';
 
 export type Connection = {
 	id: string;


### PR DESCRIPTION
Extracted out of #37390, this PR updates the front-end connection fields to ensure they match the backend schema

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update connection fields to match backend schema

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Ensure that feature flag is ON - `define( 'JETPACK_SOCIAL_USE_ADMIN_UI_V1', true );`
- Test the following for both Jetpack and Social plugin and for the editor
    - Goto connections management UI
    - Confirm that connections are displayed as before
    - Add a connection
    - Mark a connection as shared and then unmark
    - Disconnect an account
    - Confirm that all the above works as expected
