### PR TITLE
Jetpack_Currencies: Fix PHP8 Fatal in format_price when passing a string in number_format

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -118,7 +118,6 @@ return [
         '_inc/lib/admin-pages/class-jetpack-redux-state-helper.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimAssignment'],
         '_inc/lib/admin-pages/class.jetpack-admin-page.php' => ['PhanDeprecatedProperty', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
         '_inc/lib/class-jetpack-ai-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyDefault'],
-        '_inc/lib/class-jetpack-currencies.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal'],
         '_inc/lib/class-jetpack-google-drive-helper.php' => ['PhanTypeMismatchReturnProbablyReal'],
         '_inc/lib/class-jetpack-instagram-gallery-helper.php' => ['PhanTypeMismatchArgument'],
         '_inc/lib/class-jetpack-mapbox-helper.php' => ['PhanTypeMismatchArgumentNullable'],

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-currencies.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-currencies.php
@@ -154,6 +154,7 @@ class Jetpack_Currencies {
 	 * @return string           Formatted price.
 	 */
 	public static function format_price( $price, $currency, $symbol = true ) {
+		$price = (float) $price;
 		// Fall back to unspecified currency symbol like `¤1,234.05`.
 		// @link https://en.wikipedia.org/wiki/Currency_sign_(typography).
 		if ( ! array_key_exists( $currency, self::CURRENCIES ) ) {

--- a/projects/plugins/jetpack/changelog/fix-jetpack-currencies-format_price-number_format-fatal
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-currencies-format_price-number_format-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack_Currencies: Fix PHP8 Fatal in format_price when passing a string in number_format


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/14496

Fixes the following Fatal in PHP8+
`Uncaught TypeError: number_format(): Argument #1 ($num) must be of type float, string given`

in prior PHP versions this would produce a Warning instead.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Jetpack_Currencies`: Ensure `$price` argument is cast to float before passing it to `number_format` or `number_format_i18n`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code review should be enough in this case
* Related unit tests should also pass

