### PR TITLE
Pay with PayPal: ensure proper price formatting

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-currencies.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-currencies.php
@@ -154,7 +154,10 @@ class Jetpack_Currencies {
 	 * @return string           Formatted price.
 	 */
 	public static function format_price( $price, $currency, $symbol = true ) {
-		$price = (float) $price;
+		// Add some basic formatting for the price.
+		$formatted_number = new NumberFormatter( get_locale(), NumberFormatter::DECIMAL );
+		$price            = (float) $formatted_number->parse( $price );
+
 		// Fall back to unspecified currency symbol like `¤1,234.05`.
 		// @link https://en.wikipedia.org/wiki/Currency_sign_(typography).
 		if ( ! array_key_exists( $currency, self::CURRENCIES ) ) {

--- a/projects/plugins/jetpack/changelog/update-formatting-price-string-float
+++ b/projects/plugins/jetpack/changelog/update-formatting-price-string-float
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Pay with PayPal: ensure prices are correctly formatted.


### PR DESCRIPTION
Fixes #14496

## Proposed changes:

Follow-up from #37530 to address the additional concerns from https://github.com/Automattic/jetpack/issues/14496#issuecomment-2129623083

The example below is for a site using `fr_FR`

```php
<?php

$price3 = '$1,249.00';
$formatted_number = new NumberFormatter( get_locale(), NumberFormatter::DECIMAL );
echo (float) $formatted_number->parse( $price3 ); // '0' as the cast will see the "$" and assume it isn't a number.

echo "\r\n";

$price4 = '1,249.00';
$formatted_number = new NumberFormatter( get_locale(), NumberFormatter::DECIMAL );
echo (float) $formatted_number->parse( $price4 ); // 1.249
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Conversation: p1716490240939649-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Code review should be enough in this case
* Related unit tests should also pass

