### PR TITLE
Add mechanism to track previously working plugins

### DIFF
--- a/projects/packages/connection/changelog/add-mechanism-to-track-previously-working-plugins
+++ b/projects/packages/connection/changelog/add-mechanism-to-track-previously-working-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add mechanism to track previously working plugins

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -128,6 +128,7 @@ class Jetpack_Options {
 			'identity_crisis_url_secret',          // (array) The IDC URL secret and its expiration date.
 			'identity_crisis_ip_requester',        // (array) The IDC IP address and its expiration date.
 			'dismissed_welcome_banner',            // (bool) Determines if the welcome banner has been dismissed or not.
+			'historically_active_modules',         // (array) List of installed plugins/enabled modules that have at one point in time been active and working
 		);
 	}
 

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -920,16 +920,6 @@ class Manager {
 			return false;
 		}
 
-		/**
-		 * Fires before the current user has been unlinked from WordPress.com.
-		 *
-		 * @since 2.8.5
-		 * @since-jetpack 13.6.0
-		 *
-		 * @param int $user_id The current user's ID.
-		 */
-		do_action( 'jetpack_before_unlinking_user', $user_id );
-
 		// Attempt to disconnect the user from WordPress.com.
 		$is_disconnected_from_wpcom = $this->unlink_user_from_wpcom( $user_id );
 

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -924,7 +924,7 @@ class Manager {
 		 * Fires before the current user has been unlinked from WordPress.com.
 		 *
 		 * @since 2.8.5
-		 * @since-jetpack 13.5.0
+		 * @since-jetpack 13.6.0
 		 *
 		 * @param int $user_id The current user's ID.
 		 */

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -920,6 +920,16 @@ class Manager {
 			return false;
 		}
 
+		/**
+		 * Fires before the current user has been unlinked from WordPress.com.
+		 *
+		 * @since 2.8.5
+		 * @since-jetpack 13.5.0
+		 *
+		 * @param int $user_id The current user's ID.
+		 */
+		do_action( 'jetpack_before_unlinking_user', $user_id );
+
 		// Attempt to disconnect the user from WordPress.com.
 		$is_disconnected_from_wpcom = $this->unlink_user_from_wpcom( $user_id );
 
@@ -2126,7 +2136,7 @@ class Manager {
 		( new Nonce_Handler() )->clean_all();
 
 		/**
-		 * Fires when a site is disconnected.
+		 * Fires before a site is disconnected.
 		 *
 		 * @since 1.36.3
 		 */

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.9.2';
+	const PACKAGE_VERSION = '2.9.3-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/my-jetpack/changelog/add-mechanism-to-track-previously-working-plugins
+++ b/projects/packages/my-jetpack/changelog/add-mechanism-to-track-previously-working-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add mechanism to track previously working plugins

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -515,7 +515,7 @@ class Initializer {
 			'jetpack_site_before_disconnected',
 			'jetpack_site_registered',
 			'jetpack_user_authorized',
-			'jetpack_before_unlinking_user',
+			'jetpack_unlinked_user',
 			'activated_plugin',
 			'my_jetpack_init',
 		);

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -531,7 +531,7 @@ class Initializer {
 	/**
 	 * Update historically active Jetpack plugins
 	 * Historically active is defined as the Jetpack plugins that are installed and active with the required connections
-	 * This array will conxsist of any plugins that were active at one point in time and are still enabled on the site
+	 * This array will consist of any plugins that were active at one point in time and are still enabled on the site
 	 *
 	 * @return void
 	 */
@@ -546,8 +546,8 @@ class Initializer {
 			'site_connection_error',
 			'user_connection_error',
 		);
-		// This is defined as the statuses in which the user has purposely disabled the module
-		// whether it be by uninstalling the plugin, disabling the module, or not renewing their plan.
+		// This is defined as the statuses in which the user willingly has the module disabled whether it be by
+		// default, uninstalling the plugin, disabling the module, or not renewing their plan.
 		$disabled_module_statuses = array(
 			'inactive',
 			'module_disabled',
@@ -567,7 +567,7 @@ class Initializer {
 				continue;
 			}
 
-			// If the module is active and not aready in the array, add it
+			// If the module is active and not already in the array, add it
 			if (
 				in_array( $status, $active_module_statuses, true ) &&
 				! in_array( $product_slug, $historically_active_modules, true )
@@ -582,7 +582,7 @@ class Initializer {
 			}
 		}
 
-		\Jetpack_Options::update_option( 'historically_active_modules', $historically_active_modules );
+		\Jetpack_Options::update_option( 'historically_active_modules', array_unique( $historically_active_modules ) );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -78,8 +78,6 @@ class Initializer {
 			return;
 		}
 
-		self::setup_historically_active_jetpack_modules_sync();
-
 		// Extend jetpack plugins action links.
 		Products::extend_plugins_action_links();
 
@@ -519,6 +517,7 @@ class Initializer {
 			'jetpack_user_authorized',
 			'jetpack_before_unlinking_user',
 			'activated_plugin',
+			'my_jetpack_init',
 		);
 
 		foreach ( $actions as $action ) {
@@ -579,7 +578,7 @@ class Initializer {
 			// If the module has been disabled due to a manual user action,
 			// or because of a missing plan error, remove it from the array
 			if ( in_array( $status, $disabled_module_statuses, true ) ) {
-				$historically_active_modules = array_diff( $historically_active_modules, array( $product_slug ) );
+				$historically_active_modules = array_values( array_diff( $historically_active_modules, array( $product_slug ) ) );
 			}
 		}
 

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -582,7 +582,6 @@ class Initializer {
 				$historically_active_modules = array_diff( $historically_active_modules, array( $product_slug ) );
 			}
 		}
-		l( $historically_active_modules );
 
 		\Jetpack_Options::update_option( 'historically_active_modules', $historically_active_modules );
 	}


### PR DESCRIPTION
## Proposed changes:

* Adding a frequently updated array that tracks what plugins were active before user or site disconnection

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-aGl-p2#comment-22247
PT: pbNhbs-akp-p2

## Does this pull request change what data or activity we track or use?

No, I don't think we'll need to be adding any tracks for this

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
(If you want to do extensive testing, you'll probably want to set up your local dev environment and log the results of `$historically_active_modules` [here in this function](https://github.com/Automattic/jetpack/pull/37537/files#diff-2be902912ee7edeeeed04156e4456f5966e480fea3067586ff451c63b2bf2624R585) so you can see when it is being updated more clearly)
2. Connect your site and user account to the site
3. Make sure you do not have the Social sharing features active and the social plugin is not installed
![image](https://github.com/Automattic/jetpack/assets/65001528/8df2e178-9c26-42b7-9464-4451eeeeb347)
4. Go to My Jetpack, and in the console, log out `myJetpackInitialState.lifeCycleStats.historicallyActiveModules`. If you have not activated anything manually, the array should only be `[ 'creator', 'extras', 'stats' ]` as they are activated by a user connection only
5. Select `Activate` on the Social card and reload the page (the backend is updated in realtime, the frontend is not, so you'll need the page refresh)
6. Log out the historicallyActiveModules again and you should see that `social` has been added to the array
![image](https://github.com/Automattic/jetpack/assets/65001528/79071bbd-34c0-424e-92a6-683e4d5db82b)
(Note: AI had been active on my site when I was making these testing instructions, ignore that one)
7. Now disconnect your site and user account
8. Check `historicallyActiveModules` again and you should still see Social in the list even though it is now not working because of the connection issue
9. Now reconnect at least your user connection and go to `/admin.php?page=jetpack#/sharing` and disable the social modules
10. Go back to My Jetpack and check the `historicallyActiveModules` variable and it should now have "social" removed since it was disabled manually
![image](https://github.com/Automattic/jetpack/assets/65001528/5f371523-394c-4b5f-8af7-0491aad83f60)


For extra testing you can follow the scenario where
1. You disable the social module while you are user connected
2. Disconnect your user account
3. Go to My Jetpack to make sure Social is still removed from the array as it should be

Also feel free to try any scenarios you can think of so that this array is accurate when it needs to be