### PR TITLE
cli: Recommend re-running with `-v` when certain commands fail

### DIFF
--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -210,6 +210,11 @@ export async function handler( argv ) {
 					}
 				}
 			}
+			if ( ! argv.v ) {
+				console.error(
+					chalk.yellow( 'You might try running with `-v` to get more information on the failure' )
+				);
+			}
 			process.exit( err.exitCode || 1 );
 		} );
 }

--- a/tools/cli/commands/cli.js
+++ b/tools/cli/commands/cli.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
+import chalk from 'chalk';
 import { execaCommand, execaCommandSync } from 'execa';
 import Listr from 'listr';
 import UpdateRenderer from 'listr-update-renderer';
@@ -59,6 +60,11 @@ function cliLink( options ) {
 
 	linker.run().catch( err => {
 		console.error( err );
+		if ( ! options.v ) {
+			console.error(
+				chalk.yellow( 'You might try running with `-v` to get more information on the failure' )
+			);
+		}
 		process.exit( err.exitCode || 1 );
 	} );
 }
@@ -94,6 +100,11 @@ function cliUnlink( options ) {
 
 	unlinker.run().catch( err => {
 		console.error( err );
+		if ( ! options.v ) {
+			console.error(
+				chalk.yellow( 'You might try running with `-v` to get more information on the failure' )
+			);
+		}
 		process.exit( err.exitCode || 1 );
 	} );
 }

--- a/tools/cli/commands/install.js
+++ b/tools/cli/commands/install.js
@@ -119,6 +119,11 @@ export async function handler( argv ) {
 	} );
 	await listr.run().catch( err => {
 		console.error( err );
+		if ( ! argv.v ) {
+			console.error(
+				chalk.yellow( 'You might try running with `-v` to get more information on the failure' )
+			);
+		}
 		process.exit( err.exitCode || 1 );
 	} );
 }

--- a/tools/cli/commands/test.js
+++ b/tools/cli/commands/test.js
@@ -154,7 +154,15 @@ async function runTest( argv ) {
 			renderer: argv.v ? VerboseRenderer : UpdateRenderer,
 		}
 	);
-	await installer.run();
+	await installer.run().catch( err => {
+		console.error( err );
+		if ( ! argv.v ) {
+			console.error(
+				chalk.yellow( 'You might try running with `-v` to get more information on the failure' )
+			);
+		}
+		process.exit( err.exitCode || 1 );
+	} );
 
 	console.log( chalk.green( `Running ${ argv.testScript } tests for ${ argv.project }` ) );
 	const res = child_process.spawnSync( 'composer', [ 'run', '--timeout=0', argv.testScript ], {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Some commands, particularly those using listr for more friendly output on successful runs, don't produce useful error messages when things fail. Have those commands recommend re-running with `-v` in those situations.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #37524

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The new message inviting use of `-v` should appear for the following tests:

* Introduce an error for `composer install` in some project (e.g. change a composer dependency to a nonexistent version). Then:
  * Run `jetpack build` for the project.
  * Run `jetpack test` for the project.
  * Run `jetpack phan` for the project.
* Introduce a build error in some project. Then run `jetpack build` for it.
* Add `echo FAIL; exit 1` to `projects/packages/status/.phan/pre-run`, then run `jetpack phan packages/status`.
* Add a `throw` to some project's `.phan/config.php`, then run `jetpack phan` for that project.
* Arrange for `jetpack cli link` to fail (how? 🤷), and run that.

The new message inviting use of `-v` should _not_ appear for the following tests:

* Do any of the above with `-v`.
* Run `jetpack build`, `jetpack test`, and `jetpack phan` without having introduced any errors.
* Introduce a failing test (e.g. stick `$this->fail( "!" );` in any phpunit test), then run `jetpack test` for the project.
* Introduce a Phan issue (e.g. delete a suppression from `.phan/baseline.php`), then run `jetpack phan` for the project.
