### PR TITLE
Social | Update "My Connections" UI

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-cleanup-connections-list-ui
+++ b/projects/js-packages/publicize-components/changelog/update-cleanup-connections-list-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Cleaned up connections management list

--- a/projects/js-packages/publicize-components/src/components/connection-management/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/index.tsx
@@ -67,7 +67,6 @@ const ConnectionManagement = ( { className = null } ) => {
 
 	return (
 		<div className={ classNames( styles.wrapper, className ) }>
-			<h3>{ __( 'My Connections', 'jetpack' ) }</h3>
 			{ connections.length ? (
 				<ul className={ styles[ 'connection-list' ] }>
 					{ connections.map( connection => {
@@ -88,9 +87,7 @@ const ConnectionManagement = ( { className = null } ) => {
 						);
 					} ) }
 				</ul>
-			) : (
-				<span>{ __( 'There are no connections added yet.', 'jetpack' ) }</span>
-			) }
+			) : null }
 			<Button onClick={ openModal } variant={ connections.length ? 'secondary' : 'primary' }>
 				{ __( 'Add connection', 'jetpack' ) }
 			</Button>

--- a/projects/js-packages/publicize-components/src/components/connection-management/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/index.tsx
@@ -68,25 +68,28 @@ const ConnectionManagement = ( { className = null } ) => {
 	return (
 		<div className={ classNames( styles.wrapper, className ) }>
 			{ connections.length ? (
-				<ul className={ styles[ 'connection-list' ] }>
-					{ connections.map( connection => {
-						const isUpdatingOrDeleting =
-							updatingConnections.includes( connection.connection_id ) ||
-							deletingConnections.includes( connection.connection_id );
+				<>
+					<h3>{ __( 'Connected accounts', 'jetpack' ) }</h3>
+					<ul className={ styles[ 'connection-list' ] }>
+						{ connections.map( connection => {
+							const isUpdatingOrDeleting =
+								updatingConnections.includes( connection.connection_id ) ||
+								deletingConnections.includes( connection.connection_id );
 
-						return (
-							<li className={ styles[ 'connection-list-item' ] } key={ connection.connection_id }>
-								<Disabled isDisabled={ isUpdatingOrDeleting }>
-									<ConnectionInfo
-										connection={ connection }
-										service={ servicesByName[ connection.service_name ] }
-										onConfirmReconnect={ openModal }
-									/>
-								</Disabled>
-							</li>
-						);
-					} ) }
-				</ul>
+							return (
+								<li className={ styles[ 'connection-list-item' ] } key={ connection.connection_id }>
+									<Disabled isDisabled={ isUpdatingOrDeleting }>
+										<ConnectionInfo
+											connection={ connection }
+											service={ servicesByName[ connection.service_name ] }
+											onConfirmReconnect={ openModal }
+										/>
+									</Disabled>
+								</li>
+							);
+						} ) }
+					</ul>
+				</>
 			) : null }
 			<Button onClick={ openModal } variant={ connections.length ? 'secondary' : 'primary' }>
 				{ __( 'Add connection', 'jetpack' ) }

--- a/projects/js-packages/publicize-components/src/components/connection-management/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/index.tsx
@@ -92,7 +92,7 @@ const ConnectionManagement = ( { className = null } ) => {
 				</>
 			) : null }
 			<Button onClick={ openModal } variant={ connections.length ? 'secondary' : 'primary' }>
-				{ __( 'Add connection', 'jetpack' ) }
+				{ __( 'Connect an account', 'jetpack' ) }
 			</Button>
 			{ shouldModalBeOpen ? <AddConnectionModal onCloseModal={ closeModal } /> : null }
 		</div>

--- a/projects/js-packages/publicize-components/src/components/connection-management/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/connection-management/style.module.scss
@@ -6,9 +6,10 @@
 	align-items: start;
 	gap: 1.5rem;
 	width: 100%;
+	padding-top: 1rem;
 
 	> h3 {
-		margin-bottom: 0;
+		margin-block: 0;
 	}
 }
 

--- a/projects/js-packages/publicize-components/src/components/services/use-supported-services.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/use-supported-services.tsx
@@ -40,7 +40,7 @@ export function useSupportedServices(): Array< SupportedService > {
 			);
 	}, [] );
 
-	return [
+	const supportedServices: Array< SupportedService > = [
 		{
 			...availableServices.facebook,
 			icon: props => <SocialServiceIcon serviceName="facebook" { ...props } />,
@@ -256,7 +256,8 @@ export function useSupportedServices(): Array< SupportedService > {
 				),
 			],
 		},
-	].filter(
+	];
+	return supportedServices.filter(
 		// Return only the ones that are present in the available services.
 		service => Boolean( service.ID )
 	);


### PR DESCRIPTION
We don't want to show "My connections" header and the no connections text on Social admin page

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove "My connections" header from connections list when there are no connections
* Remove the text displayed when there are no connections yet.
* Change the label from "My Connections" to "Connected accounts" when there are connections
* Changed the CTA label from "Add connection" to "Connect an account"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Ensure that feature flag is ON - `define( 'JETPACK_SOCIAL_USE_ADMIN_UI_V1', true );`
- Test the following for both Jetpack and Social plugin
    - Goto connections management UI
    - Remove all the connections if you have any
    - Confirm that you no longer see "My connections" header
    - Confirm that you don't see the text `There are no connections added yet.`
    - Add a connection
    - Confirm that the heading now appears and says, "Connected accounts"
    - Confirm that the button below the list has the label "Connect an account"

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <th colspan="2">Social</th>
        </tr>
        <tr>
            <td>
<img width="856" alt="Screenshot 2024-05-27 at 12 32 25 PM" src="https://github.com/Automattic/jetpack/assets/18226415/7df4e640-e40e-4517-94af-d998d25e96a3">
</td>
            <td>
<img width="819" alt="Screenshot 2024-05-27 at 12 31 35 PM" src="https://github.com/Automattic/jetpack/assets/18226415/85caeb13-0a86-4314-b3ba-eb0122bfe44d">
</td>
        </tr>
        <tr>
            <th colspan="2">Jetpack</th>
        </tr>
        <tr>
            <td>
<img width="1050" alt="Screenshot 2024-05-27 at 12 32 32 PM" src="https://github.com/Automattic/jetpack/assets/18226415/b4a5d2a2-e29c-47f2-ba21-851496d33ec5">
</td>
            <td>
<img width="1057" alt="Screenshot 2024-05-27 at 2 48 02 PM" src="https://github.com/Automattic/jetpack/assets/18226415/b078c13e-834d-45ca-9970-40dec82de0f3">
</td>
        </tr>
        <tr>
            <th colspan="2">When there are connections</th>
        </tr>
        <tr>
            <td>
<img width="811" alt="Screenshot 2024-05-27 at 2 37 35 PM" src="https://github.com/Automattic/jetpack/assets/18226415/aaaaf1dc-a284-4f85-82ae-ef72e1079225">
</td>
            <td>
<img width="767" alt="Screenshot 2024-05-27 at 2 37 00 PM" src="https://github.com/Automattic/jetpack/assets/18226415/a9e33b98-5005-409b-a64c-02ae7179cbf5">
</td>
        </tr>
    </tbody>
</table>