### PR TITLE
Untangling: Correctly highlight Dashboard and Settings submenu when active

### DIFF
--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -628,7 +628,7 @@ class Main extends React.Component {
 				break;
 		}
 
-		if ( this.props.isWoaSite ) {
+		if ( this.props.isWoaSite && ! this.props.showMyJetpack ) {
 			window.wpNavMenuClassChange( { dashboard: 1, settings: 1 } );
 		} else if ( ! this.props.isLinked && ! this.props.showMyJetpack ) {
 			window.wpNavMenuClassChange( { dashboard: 1, settings: 2 } );

--- a/projects/plugins/jetpack/changelog/untangling-fix-highlight
+++ b/projects/plugins/jetpack/changelog/untangling-fix-highlight
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Correctly highlight Dashboard and Settings submenu when active, in WoA sites that show My Jetpack


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/6852

## Proposed changes:

In https://github.com/Automattic/jetpack/pull/21658, we fixed submenu highlighting by assuming that Atomic sites don't have Jetpack -> My Jetpack.

However, for Atomic sites with Early Classic interface, Jetpack -> My Jetpack exists, so we should exclude such sites from the above logic.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare an Atomic site.
2. Install Jetpack Beta Tester and activate this branch.
3. Verify that the fix in https://github.com/Automattic/jetpack/pull/21658 is still valid (no regression).
4. Activate Early Classic interface (Settings -> Hosting Configuration -> Admin interface style -> Classic, and `/_cli` -> `wp option update wpcom_classic_early_release 1`)
5. Go to Jetpack -> Dashboard and verify that the submenu is highlighted.
5. Go to Jetpack -> Settings and verify that the submenu is highlighted.
