### PR TITLE
Subscribe overlay & popup: add name for the group block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-overlay-group-name
+++ b/projects/plugins/jetpack/changelog/update-subscribe-overlay-group-name
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscription overlays: add name to the group block

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -147,9 +147,10 @@ class Jetpack_Subscribe_Modal {
 		$discover_more_from = sprintf( __( 'Discover more from %s', 'jetpack' ), get_bloginfo( 'name' ) );
 		$continue_reading   = __( 'Continue reading', 'jetpack' );
 		$subscribe_text     = __( 'Subscribe now to keep reading and get access to the full archive.', 'jetpack' );
+		$group_block_name   = esc_attr__( 'Subscription pop-up container', 'jetpack' );
 
 		return <<<HTML
-	<!-- wp:group {"style":{"spacing":{"padding":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
+	<!-- wp:group {"metadata":{"name":"$group_block_name"},{"style":{"spacing":{"padding":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
 	<div class="wp-block-group has-border-color" style="border-color:#dddddd;border-width:1px;margin-top:0;margin-bottom:0;padding-top:32px;padding-right:32px;padding-bottom:32px;padding-left:32px">
 
 	<!-- wp:heading {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"600","fontSize":"26px"},"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"4px","bottom":"10px"}}}} -->

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -150,7 +150,7 @@ class Jetpack_Subscribe_Modal {
 		$group_block_name   = esc_attr__( 'Subscription pop-up container', 'jetpack' );
 
 		return <<<HTML
-	<!-- wp:group {"metadata":{"name":"$group_block_name"},{"style":{"spacing":{"padding":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
+	<!-- wp:group {"metadata":{"name":"$group_block_name"},"style":{"spacing":{"padding":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
 	<div class="wp-block-group has-border-color" style="border-color:#dddddd;border-width:1px;margin-top:0;margin-bottom:0;padding-top:32px;padding-right:32px;padding-bottom:32px;padding-left:32px">
 
 	<!-- wp:heading {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"600","fontSize":"26px"},"layout":{"selfStretch":"fit","flexSize":null},"spacing":{"margin":{"top":"4px","bottom":"10px"}}}} -->

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -118,7 +118,7 @@ class Jetpack_Subscribe_Overlay {
 		$group_block_name = esc_attr__( 'Subscribe overlay container', 'jetpack' );
 
 		return <<<HTML
-	<!-- wp:group {"metadata":{"name":"$group_block_name"},{"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"constrained","contentSize":"400px"}} -->
+	<!-- wp:group {"metadata":{"name":"$group_block_name"},"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"constrained","contentSize":"400px"}} -->
 	<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 		<!-- wp:site-logo {"width":90,"isLink":false,"shouldSyncIcon":true,"align":"center","className":"is-style-rounded"} /-->
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -109,18 +109,19 @@ class Jetpack_Subscribe_Overlay {
 	 * @return string
 	 */
 	public function get_subscribe_overlay_template_content() {
-		$site_tagline    = get_bloginfo( 'description' );
-		$default_tagline = __( 'Stay informed with curated content and the latest headlines, all delivered straight to your inbox. Subscribe now to stay ahead and never miss a beat!', 'jetpack' );
-		$tagline_block   = empty( $site_tagline )
+		$site_tagline     = get_bloginfo( 'description' );
+		$default_tagline  = __( 'Stay informed with curated content and the latest headlines, all delivered straight to your inbox. Subscribe now to stay ahead and never miss a beat!', 'jetpack' );
+		$tagline_block    = empty( $site_tagline )
 			? '<!-- wp:paragraph {"align":"center","fontSize":"medium"} --><p class="has-text-align-center has-medium-font-size">' . $default_tagline . '</p><!-- /wp:paragraph -->'
 			: '<!-- wp:site-tagline {"textAlign":"center","fontSize":"medium"} /-->';
-		$skip_to_content = __( 'Skip to content', 'jetpack' );
+		$skip_to_content  = __( 'Skip to content', 'jetpack' );
+		$group_block_name = esc_attr__( 'Subscribe overlay container', 'jetpack' );
 
 		return <<<HTML
-	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"constrained","contentSize":"400px"}} -->
+	<!-- wp:group {"metadata":{"name":"$group_block_name"},{"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}},"layout":{"type":"constrained","contentSize":"400px"}} -->
 	<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 		<!-- wp:site-logo {"width":90,"isLink":false,"shouldSyncIcon":true,"align":"center","className":"is-style-rounded"} /-->
-	
+
 		<!-- wp:site-title {"textAlign":"center","isLink":false,"fontSize":"x-large"} /-->
 
 		$tagline_block


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Simple addition that can help guide customers to add content inside the group block, instead of outside it. The name appears on the list view panel:

<img width="1084" alt="Screenshot 2024-05-27 at 14 36 20" src="https://github.com/Automattic/jetpack/assets/87168/b1571189-d93b-4d23-9fc1-46ef105d4944">

Noted as best practise in https://developer.wordpress.org/news/2024/03/19/pattern-design-tips-and-tricks-for-developers/

> _Consider naming blocks within your pattern. It is currently possible to name blocks such as groups, rows or stacks. You can opt to [name different sections](https://make.wordpress.org/core/2023/10/25/whats-new-in-gutenberg-16-9-25-october-2/#rename-almost-all-blocks-from-the-editor) after their contents or functionality, like “Title Area” or “Image Area” vs. just “Group”. This can help users wrap their heads around patterns and make it easier to navigate their structure._ > _To rename a block you can either use the List View and click on the block you wish to rename or you can see the block name field in the Inspector > Advanced._

## Proposed changes:
* Adds names for the group block in subscribe overlay and post pop-up templates

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* At newsletter settings, choose overlay or pop-up and edit them in the side editor. Note the list view panel.

