### PR TITLE
Newsletter settings: add toggle sections

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/index.jsx
@@ -11,6 +11,7 @@ import Newsletter from './newsletter';
 import NewsletterCategories from './newsletter-categories';
 import PaidNewsletter from './paid-newsletter';
 import SubscriptionsSettings from './subscriptions-settings';
+import './style.scss';
 
 /**
  * Newsletter Section.

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -1,4 +1,3 @@
-import './style.scss';
 import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';

--- a/projects/plugins/jetpack/_inc/client/newsletter/style.scss
+++ b/projects/plugins/jetpack/_inc/client/newsletter/style.scss
@@ -58,8 +58,13 @@
 .jp-form-settings-group.newsletter-group .sender-name {
 	--vertical-gutter: 8px;
 }
+
 .sender-name-example {
 	font-size: var( --font-body-small );
 	color: var( --jp-gray-20 );
 	margin-top: 8px;
+}
+
+#jp-settings-subscriptions .jp-form-fieldset:not(:first-of-type) {
+	margin-top: 24px;
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -191,7 +191,7 @@ function SubscriptionsSettings( props ) {
 					/>
 				</FormFieldset>
 				{ isSubscriptionSiteEditSupported && (
-					<FormFieldset style={ { 'margin-top': '24px' } }>
+					<FormFieldset>
 						<FormLegend>{ __( 'Navigation', 'jetpack' ) }</FormLegend>
 						<ToggleControl
 							checked={ isSubscriptionsActive && isSubscribeNavigationEnabled }
@@ -235,7 +235,7 @@ function SubscriptionsSettings( props ) {
 						/>
 					</FormFieldset>
 				) }
-				<FormFieldset style={ { 'margin-top': '24px' } }>
+				<FormFieldset>
 					<FormLegend>{ __( 'Comments', 'jetpack' ) }</FormLegend>
 					<ToggleControl
 						checked={ isSubscriptionsActive && isStbEnabled }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -130,7 +130,7 @@ function SubscriptionsSettings( props ) {
 					) }
 				</p>
 				<FormFieldset>
-					<FormLegend>{ __( 'Posts', 'jetpack' ) }</FormLegend>
+					<FormLegend>{ __( 'Posts & homepage', 'jetpack' ) }</FormLegend>
 					<ToggleControl
 						checked={ isSubscriptionsActive && isSubscribePostEndEnabled }
 						disabled={ isDisabled }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -190,7 +190,7 @@ function SubscriptionsSettings( props ) {
 						}
 					/>
 				</FormFieldset>
-				<FormFieldset style={ { 'margin-top': '10px' } }>
+				<FormFieldset style={ { 'margin-top': '20px' } }>
 					<FormLegend>{ __( 'Comments', 'jetpack' ) }</FormLegend>
 					<ToggleControl
 						checked={ isSubscriptionsActive && isStbEnabled }
@@ -219,7 +219,7 @@ function SubscriptionsSettings( props ) {
 					/>
 				</FormFieldset>
 				{ isSubscriptionSiteEditSupported && (
-					<FormFieldset style={ { 'margin-top': '10px' } }>
+					<FormFieldset style={ { 'margin-top': '20px' } }>
 						<FormLegend>{ __( 'Navigation', 'jetpack' ) }</FormLegend>
 						<ToggleControl
 							checked={ isSubscriptionsActive && isSubscribeNavigationEnabled }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -130,7 +130,7 @@ function SubscriptionsSettings( props ) {
 					) }
 				</p>
 				<FormFieldset>
-					<FormLegend>{ __( 'Posts & homepage', 'jetpack' ) }</FormLegend>
+					<FormLegend>{ __( 'Homepage and posts', 'jetpack' ) }</FormLegend>
 					<ToggleControl
 						checked={ isSubscriptionsActive && isSubscribePostEndEnabled }
 						disabled={ isDisabled }
@@ -190,36 +190,8 @@ function SubscriptionsSettings( props ) {
 						}
 					/>
 				</FormFieldset>
-				<FormFieldset style={ { 'margin-top': '20px' } }>
-					<FormLegend>{ __( 'Comments', 'jetpack' ) }</FormLegend>
-					<ToggleControl
-						checked={ isSubscriptionsActive && isStbEnabled }
-						disabled={ isDisabled }
-						toggling={ isSavingAnyOption( [ 'stb_enabled' ] ) }
-						onChange={ handleSubscribeToBlogToggleChange }
-						label={
-							<span className="jp-form-toggle-explanation">
-								{ __( 'Enable the “subscribe to site” option on your comment form', 'jetpack' ) }
-							</span>
-						}
-					/>
-					<ToggleControl
-						checked={ isSubscriptionsActive && isStcEnabled }
-						disabled={ isDisabled }
-						toggling={ isSavingAnyOption( [ 'stc_enabled' ] ) }
-						onChange={ handleSubscribeToCommentToggleChange }
-						label={
-							<span className="jp-form-toggle-explanation">
-								{ __(
-									'Enable the “subscribe to comments” option on your comment form',
-									'jetpack'
-								) }
-							</span>
-						}
-					/>
-				</FormFieldset>
 				{ isSubscriptionSiteEditSupported && (
-					<FormFieldset style={ { 'margin-top': '20px' } }>
+					<FormFieldset style={ { 'margin-top': '24px' } }>
 						<FormLegend>{ __( 'Navigation', 'jetpack' ) }</FormLegend>
 						<ToggleControl
 							checked={ isSubscriptionsActive && isSubscribeNavigationEnabled }
@@ -263,6 +235,34 @@ function SubscriptionsSettings( props ) {
 						/>
 					</FormFieldset>
 				) }
+				<FormFieldset style={ { 'margin-top': '24px' } }>
+					<FormLegend>{ __( 'Comments', 'jetpack' ) }</FormLegend>
+					<ToggleControl
+						checked={ isSubscriptionsActive && isStbEnabled }
+						disabled={ isDisabled }
+						toggling={ isSavingAnyOption( [ 'stb_enabled' ] ) }
+						onChange={ handleSubscribeToBlogToggleChange }
+						label={
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Enable the “subscribe to site” option on your comment form', 'jetpack' ) }
+							</span>
+						}
+					/>
+					<ToggleControl
+						checked={ isSubscriptionsActive && isStcEnabled }
+						disabled={ isDisabled }
+						toggling={ isSavingAnyOption( [ 'stc_enabled' ] ) }
+						onChange={ handleSubscribeToCommentToggleChange }
+						label={
+							<span className="jp-form-toggle-explanation">
+								{ __(
+									'Enable the “subscribe to comments” option on your comment form',
+									'jetpack'
+								) }
+							</span>
+						}
+					/>
+				</FormFieldset>
 			</SettingsGroup>
 		</SettingsCard>
 	);

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -190,7 +190,7 @@ function SubscriptionsSettings( props ) {
 						}
 					/>
 				</FormFieldset>
-				<FormFieldset>
+				<FormFieldset style={ { 'margin-top': '10px' } }>
 					<FormLegend>{ __( 'Comments', 'jetpack' ) }</FormLegend>
 					<ToggleControl
 						checked={ isSubscriptionsActive && isStbEnabled }
@@ -219,8 +219,8 @@ function SubscriptionsSettings( props ) {
 					/>
 				</FormFieldset>
 				{ isSubscriptionSiteEditSupported && (
-					<FormFieldset>
-						<FormLegend>{ __( 'Comments', 'jetpack' ) }</FormLegend>
+					<FormFieldset style={ { 'margin-top': '10px' } }>
+						<FormLegend>{ __( 'Navigation', 'jetpack' ) }</FormLegend>
 						<ToggleControl
 							checked={ isSubscriptionsActive && isSubscribeNavigationEnabled }
 							disabled={ isDisabled }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -2,7 +2,7 @@ import { ToggleControl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { FormFieldset } from 'components/forms';
+import { FormLegend, FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -130,6 +130,7 @@ function SubscriptionsSettings( props ) {
 					) }
 				</p>
 				<FormFieldset>
+					<FormLegend>{ __( 'Posts', 'jetpack' ) }</FormLegend>
 					<ToggleControl
 						checked={ isSubscriptionsActive && isSubscribePostEndEnabled }
 						disabled={ isDisabled }
@@ -188,6 +189,9 @@ function SubscriptionsSettings( props ) {
 							</span>
 						}
 					/>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLegend>{ __( 'Comments', 'jetpack' ) }</FormLegend>
 					<ToggleControl
 						checked={ isSubscriptionsActive && isStbEnabled }
 						disabled={ isDisabled }
@@ -213,53 +217,52 @@ function SubscriptionsSettings( props ) {
 							</span>
 						}
 					/>
-					{ isSubscriptionSiteEditSupported && (
-						<>
-							<ToggleControl
-								checked={ isSubscriptionsActive && isSubscribeNavigationEnabled }
-								disabled={ isDisabled }
-								toggling={ isSavingAnyOption( [
-									'jetpack_subscriptions_subscribe_navigation_enabled',
-								] ) }
-								onChange={ handleSubscribeNavigationToggleChange }
-								label={
-									<span className="jp-form-toggle-explanation">
-										{ __( 'Add the Subscribe block to the navigation', 'jetpack' ) }
-										{ headerTemplateEditorUrl && (
-											<>
-												{ '. ' }
-												<ExternalLink href={ headerTemplateEditorUrl }>
-													{ __( 'Preview and edit', 'jetpack' ) }
-												</ExternalLink>
-											</>
-										) }
-									</span>
-								}
-							/>
-							<ToggleControl
-								checked={ isSubscriptionsActive && isLoginNavigationEnabled }
-								disabled={ isDisabled }
-								toggling={ isSavingAnyOption( [
-									'jetpack_subscriptions_login_navigation_enabled',
-								] ) }
-								onChange={ handleLoginNavigationToggleChange }
-								label={
-									<span className="jp-form-toggle-explanation">
-										{ __( 'Add the Subscriber Login block to the navigation', 'jetpack' ) }
-										{ headerTemplateEditorUrl && (
-											<>
-												{ '. ' }
-												<ExternalLink href={ headerTemplateEditorUrl }>
-													{ __( 'Preview and edit', 'jetpack' ) }
-												</ExternalLink>
-											</>
-										) }
-									</span>
-								}
-							/>
-						</>
-					) }
 				</FormFieldset>
+				{ isSubscriptionSiteEditSupported && (
+					<FormFieldset>
+						<FormLegend>{ __( 'Comments', 'jetpack' ) }</FormLegend>
+						<ToggleControl
+							checked={ isSubscriptionsActive && isSubscribeNavigationEnabled }
+							disabled={ isDisabled }
+							toggling={ isSavingAnyOption( [
+								'jetpack_subscriptions_subscribe_navigation_enabled',
+							] ) }
+							onChange={ handleSubscribeNavigationToggleChange }
+							label={
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Add the Subscribe block to the navigation', 'jetpack' ) }
+									{ headerTemplateEditorUrl && (
+										<>
+											{ '. ' }
+											<ExternalLink href={ headerTemplateEditorUrl }>
+												{ __( 'Preview and edit', 'jetpack' ) }
+											</ExternalLink>
+										</>
+									) }
+								</span>
+							}
+						/>
+						<ToggleControl
+							checked={ isSubscriptionsActive && isLoginNavigationEnabled }
+							disabled={ isDisabled }
+							toggling={ isSavingAnyOption( [ 'jetpack_subscriptions_login_navigation_enabled' ] ) }
+							onChange={ handleLoginNavigationToggleChange }
+							label={
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Add the Subscriber Login block to the navigation', 'jetpack' ) }
+									{ headerTemplateEditorUrl && (
+										<>
+											{ '. ' }
+											<ExternalLink href={ headerTemplateEditorUrl }>
+												{ __( 'Preview and edit', 'jetpack' ) }
+											</ExternalLink>
+										</>
+									) }
+								</span>
+							}
+						/>
+					</FormFieldset>
+				) }
 			</SettingsGroup>
 		</SettingsCard>
 	);

--- a/projects/plugins/jetpack/changelog/update-newsletter-settings-toggle-sections
+++ b/projects/plugins/jetpack/changelog/update-newsletter-settings-toggle-sections
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscription settings: add headings to divide toggles into groups


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds sections to improve the readability of multiple toggles in newsletter settings

**Before**

<img width="1084" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/6485be46-cdcc-4464-8f49-1901b5872e2a">


**After**

<img width="1067" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/9fb51321-b5d8-4a65-bfe9-7c6f7b1aa90d">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test settings page `/wp-admin/admin.php?page=jetpack#/newsletter`
