### PR TITLE
Backport mu-wpcom-plugin 2.1.28, jetpack 13.5-a.5 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2024-05-27
+### Changed
+- AI Client: Add paragraph tweaks to Markdown conversion libs. [#37461]
+- AI Featured Image: add type info. [#37474]
+
 ## [0.14.0] - 2024-05-20
 ### Added
 - AI Client: Expose HTML render rules type. [#37386]
@@ -323,6 +328,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.14.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.12.4...v0.13.0

--- a/projects/js-packages/ai-client/changelog/update-ai-featured-image-stable-diffusion-soft-launch
+++ b/projects/js-packages/ai-client/changelog/update-ai-featured-image-stable-diffusion-soft-launch
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-AI Featured Image: add type info.

--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extension-paragraph
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-inline-extension-paragraph
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-AI Client: Add paragraph tweaks to Markdown conversion libs

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.14.1-alpha",
+	"version": "0.14.1",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.52.0] - 2024-05-27
+### Added
+- Added tests. [#37516]
+- Added the connection modal to the editor. [#37405]
+
+### Changed
+- Refactored the connection list UI. [#37437]
+- Social | Cleaned up connections management list. [#37570]
+- Social | Fixed no connections UI for editor. [#37571]
+- Social | Improved reconnect flow to automatically open the connection window. [#37467]
+- Social | Made the editor connections modal behavior similar to the modal on the social admin page. [#37501]
+- Social | Updated connection fields to match the API schema. [#37529]
+- Social | Updated the connection test results endpoint for front-end. [#37531]
+
+### Fixed
+- Fixed an issue where non-admins saw action on connection management. [#37507]
+- Fixed UI bug with border. [#37490]
+
 ## [0.51.1] - 2024-05-20
 ### Added
 - Added globalize/unglobalize connection UI. [#37377]
@@ -684,6 +702,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.52.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.51.1...v0.52.0
 [0.51.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.51.0...v0.51.1
 [0.51.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.50.0...v0.51.0
 [0.50.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.49.3...v0.50.0

--- a/projects/js-packages/publicize-components/changelog/add-social-connection-management-editor-fixed
+++ b/projects/js-packages/publicize-components/changelog/add-social-connection-management-editor-fixed
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added the connection modal to the editor

--- a/projects/js-packages/publicize-components/changelog/add-social-connection-management-tests
+++ b/projects/js-packages/publicize-components/changelog/add-social-connection-management-tests
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added tests

--- a/projects/js-packages/publicize-components/changelog/fix-editor-modal-behavior
+++ b/projects/js-packages/publicize-components/changelog/fix-editor-modal-behavior
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social | Made the editor connections modal behavior similar to the modal on the social admin page

--- a/projects/js-packages/publicize-components/changelog/fix-no-connections-ui-for-editor
+++ b/projects/js-packages/publicize-components/changelog/fix-no-connections-ui-for-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social | Fixed no connections UI for editor

--- a/projects/js-packages/publicize-components/changelog/fix-social-connection-management-layout
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connection-management-layout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed UI bug with border

--- a/projects/js-packages/publicize-components/changelog/fix-social-connection-management-non-author-globalize
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connection-management-non-author-globalize
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed an issue where non-admins saw action on connection management

--- a/projects/js-packages/publicize-components/changelog/update-cleanup-connections-list-ui
+++ b/projects/js-packages/publicize-components/changelog/update-cleanup-connections-list-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social | Cleaned up connections management list

--- a/projects/js-packages/publicize-components/changelog/update-improve-reconnection-flow-for-broken-connections
+++ b/projects/js-packages/publicize-components/changelog/update-improve-reconnection-flow-for-broken-connections
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social | Improved reconnect flow to automatically open the connection window

--- a/projects/js-packages/publicize-components/changelog/update-social-connection-list-screen
+++ b/projects/js-packages/publicize-components/changelog/update-social-connection-list-screen
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Refactored the connection list UI

--- a/projects/js-packages/publicize-components/changelog/update-social-fix-connection-schema-fields
+++ b/projects/js-packages/publicize-components/changelog/update-social-fix-connection-schema-fields
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social | Updated connection fields to match the API schema

--- a/projects/js-packages/publicize-components/changelog/update-social-use-new-endpoint-for-connection-test-results
+++ b/projects/js-packages/publicize-components/changelog/update-social-use-new-endpoint-for-connection-test-results
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social | Updated the connection test results endpoint for front-end 

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.52.0-alpha",
+	"version": "0.52.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/social-logos/CHANGELOG.md
+++ b/projects/js-packages/social-logos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.1] - 2024-05-27
+### Added
+- Added TypeScript support. [#37528]
+
 ## [3.0.0] - 2024-05-23
 ### Added
 - CSS file with encoded inline font is now automatically generated. [#36964]
@@ -78,4 +82,5 @@
 ## 2.1.0 - 2018-01-31
 - Build: Refactored (aligned build system with Gridicons).
 
+[3.0.1]: https://github.com/Automattic/social-logos/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/Automattic/social-logos/compare/v2.5.9...v3.0.0

--- a/projects/js-packages/social-logos/changelog/fix-social-logos-remove_errant_composer_line
+++ b/projects/js-packages/social-logos/changelog/fix-social-logos-remove_errant_composer_line
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: The "release-branch-prefix" key isn't meant for packages. :^)
-
-

--- a/projects/js-packages/social-logos/changelog/update-social-logos-add-typescript-support
+++ b/projects/js-packages/social-logos/changelog/update-social-logos-add-typescript-support
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Social Logos | Added TypeScript support

--- a/projects/js-packages/social-logos/package.json
+++ b/projects/js-packages/social-logos/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "social-logos",
-	"version": "3.0.1-alpha",
+	"version": "3.0.1",
 	"description": "A repository of all the social logos used on WordPress.com.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/social-logos/",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.13] - 2024-05-27
+### Changed
+- Update dependencies. [#37323]
+
 ## [3.3.12] - 2024-05-20
 ### Changed
 - Updated package dependencies. [#37379] [#37380] [#37382]
@@ -628,6 +632,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.3.13]: https://github.com/Automattic/jetpack-backup/compare/v3.3.12...v3.3.13
 [3.3.12]: https://github.com/Automattic/jetpack-backup/compare/v3.3.11...v3.3.12
 [3.3.11]: https://github.com/Automattic/jetpack-backup/compare/v3.3.10...v3.3.11
 [3.3.10]: https://github.com/Automattic/jetpack-backup/compare/v3.3.9...v3.3.10

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.3.12';
+	const PACKAGE_VERSION = '3.3.13';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.5] - 2024-05-27
+### Changed
+- Update dependencies. [#37356]
+
 ## [0.21.4] - 2024-05-20
 ### Changed
 - Updated package dependencies. [#37379] [#37380]
@@ -369,6 +373,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.21.5]: https://github.com/automattic/jetpack-blaze/compare/v0.21.4...v0.21.5
 [0.21.4]: https://github.com/automattic/jetpack-blaze/compare/v0.21.3...v0.21.4
 [0.21.3]: https://github.com/automattic/jetpack-blaze/compare/v0.21.2...v0.21.3
 [0.21.2]: https://github.com/automattic/jetpack-blaze/compare/v0.21.1...v0.21.2

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.21.4",
+	"version": "0.21.5",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.21.4';
+	const PACKAGE_VERSION = '0.21.5';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/calypsoify/CHANGELOG.md
+++ b/projects/packages/calypsoify/CHANGELOG.md
@@ -5,3 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2024-05-27
+### Added
+- Calypsoify: Copy the code from the Jetpack module into the package. [#37339]
+- Initial version. [#37306]
+
+### Changed
+- Calypsoify: Load feature from the Calypsoify package. [#37375]
+- Updated package dependencies. [#37379]

--- a/projects/packages/calypsoify/changelog/add-calypsoify-package-code
+++ b/projects/packages/calypsoify/changelog/add-calypsoify-package-code
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Calypsoify: Copy the code from the Jetpack module into the package.

--- a/projects/packages/calypsoify/changelog/initial-version
+++ b/projects/packages/calypsoify/changelog/initial-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Initial version.

--- a/projects/packages/calypsoify/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/calypsoify/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/calypsoify/changelog/update-calypsoify-load-package
+++ b/projects/packages/calypsoify/changelog/update-calypsoify-load-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Calypsoify: Load feature from the Calypsoify package

--- a/projects/packages/calypsoify/package.json
+++ b/projects/packages/calypsoify/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-calypsoify",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"description": "Calypsoify is designed to make sure specific wp-admin pages include navigation that prioritizes the Calypso navigation experience.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/calypsoify/#readme",
 	"bugs": {

--- a/projects/packages/calypsoify/src/class-jetpack-calypsoify.php
+++ b/projects/packages/calypsoify/src/class-jetpack-calypsoify.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Status;
  */
 class Jetpack_Calypsoify {
 
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	const PACKAGE_VERSION = '0.1.0';
 
 	/**
 	 * Singleton instance of `Jetpack_Calypsoify`.

--- a/projects/packages/classic-theme-helper/CHANGELOG.md
+++ b/projects/packages/classic-theme-helper/CHANGELOG.md
@@ -5,10 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2024-05-27
+### Added
+- Classic Theme Helper: Add responsive videos. [#37406]
+- Classic Theme Helper: Copied featured content code from module. [#37515]
+
 ## 0.1.0 - 2024-05-09
 ### Added
-- Classic Theme Helper: Added Featured content code to the package [#37202]
+- Classic Theme Helper: Added Featured content code to the package. [#37202]
 - Initial version. [#37175]
 
 ### Changed
-- Add wordpress folder on gitignore [#37177]
+- Add wordpress folder on gitignore. [#37177]
+
+[0.2.0]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.1.0...v0.2.0

--- a/projects/packages/classic-theme-helper/changelog/add-responsive-videos-to-classic-theme-helper-package
+++ b/projects/packages/classic-theme-helper/changelog/add-responsive-videos-to-classic-theme-helper-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Classic theme helper: Add responsive videos.

--- a/projects/packages/classic-theme-helper/changelog/update-copy-featured-content-suggest-js-into-classic-theme-helper-package
+++ b/projects/packages/classic-theme-helper/changelog/update-copy-featured-content-suggest-js-into-classic-theme-helper-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Classic Theme Helper: Copied featured content js script from module

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-classic-theme-helper",
-	"version": "0.2.0-alpha",
+	"version": "0.2.0",
 	"description": "Features used with classic themes",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/classic-theme-helper/#readme",
 	"bugs": {

--- a/projects/packages/classic-theme-helper/src/class-classic-theme-helper.php
+++ b/projects/packages/classic-theme-helper/src/class-classic-theme-helper.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack;
  */
 class Classic_Theme_Helper {
 
-	const PACKAGE_VERSION = '0.2.0-alpha';
+	const PACKAGE_VERSION = '0.2.0';
 
 	/**
 	 * Modules to include.
@@ -72,7 +72,7 @@ class Classic_Theme_Helper {
 		 *     return $files;
 		 * }
 		 *
-		 * @since $$next-version$$
+		 * @since 0.2.0
 		 *
 		 * @param array Associative array of theme compat files to load.
 		 */

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.5] - 2024-05-27
+### Fixed
+- SSO: Use filter instead of action for user custom column to prevent interference with other custom columns. [#37575]
+
 ## [2.8.4] - 2024-05-22
 ### Deprecated
 - Jetpack Connection Manager: Deprecate `request_params` arg in setup_xmlrpc_handlers method. [#37445]
@@ -1080,6 +1084,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.8.5]: https://github.com/Automattic/jetpack-connection/compare/v2.8.4...v2.8.5
 [2.8.4]: https://github.com/Automattic/jetpack-connection/compare/v2.8.3...v2.8.4
 [2.8.3]: https://github.com/Automattic/jetpack-connection/compare/v2.8.2...v2.8.3
 [2.8.2]: https://github.com/Automattic/jetpack-connection/compare/v2.8.1...v2.8.2

--- a/projects/packages/connection/changelog/fix-jetpack-sso-column-sending-back-custom-column-info
+++ b/projects/packages/connection/changelog/fix-jetpack-sso-column-sending-back-custom-column-info
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-SSO: Send User custom column back in the filter to not interfere with other custom columns.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.8.5-alpha';
+	const PACKAGE_VERSION = '2.8.5';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.4] - 2024-05-27
+### Changed
+- Update dependencies. [#37356]
+
 ## [0.31.3] - 2024-05-20
 ### Changed
 - Forms: Ensure non-minified JS file location is also an option when loading the tiny-mce-plugin-form-button script file. [#37351]
@@ -577,6 +581,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.31.4]: https://github.com/automattic/jetpack-forms/compare/v0.31.3...v0.31.4
 [0.31.3]: https://github.com/automattic/jetpack-forms/compare/v0.31.2...v0.31.3
 [0.31.2]: https://github.com/automattic/jetpack-forms/compare/v0.31.1...v0.31.2
 [0.31.1]: https://github.com/automattic/jetpack-forms/compare/v0.31.0...v0.31.1

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.31.3",
+	"version": "0.31.4",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.31.3';
+	const PACKAGE_VERSION = '0.31.4';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/import/CHANGELOG.md
+++ b/projects/packages/import/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.6] - 2024-05-27
+### Changed
+- Update dependencies.
+
 ## [0.8.5] - 2024-05-06
 ### Added
 - Add missing package dependencies. [#37141]
@@ -98,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed various imported resources hierarchies [#29012]
 
+[0.8.6]: https://github.com/Automattic/jetpack-import/compare/v0.8.5...v0.8.6
 [0.8.5]: https://github.com/Automattic/jetpack-import/compare/v0.8.4...v0.8.5
 [0.8.4]: https://github.com/Automattic/jetpack-import/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/Automattic/jetpack-import/compare/v0.8.2...v0.8.3

--- a/projects/packages/import/package.json
+++ b/projects/packages/import/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-import",
-	"version": "0.8.5",
+	"version": "0.8.6",
 	"description": "Set of REST API routes used in WPCOM Unified Importer.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/import/#readme",
 	"bugs": {

--- a/projects/packages/import/src/class-main.php
+++ b/projects/packages/import/src/class-main.php
@@ -20,7 +20,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.8.5';
+	const PACKAGE_VERSION = '0.8.6';
 
 	/**
 	 * A list of all the routes.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.32.0] - 2024-05-27
+### Added
+- Add staging sites check for menus. [#37449]
+- Dashboard: Introduce the WP.com site management widget when the nav redesign is enabled. [#37569]
+
+### Changed
+- Calypsoify: Load feature from the Calypsoify package. [#37375]
+- Update import flow reference to new `/setup/hosted-site-migration` path. [#37470]
+
 ## [5.31.1] - 2024-05-20
 ### Changed
 - Untangling: Replace Hosting -> Connections with Hosting -> Marketing. [#37431]
@@ -823,6 +832,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.32.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.31.1...v5.32.0
 [5.31.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.31.0...v5.31.1
 [5.31.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.30.0...v5.31.0
 [5.30.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.29.1...v5.30.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-scheduled-update-staging-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-scheduled-update-staging-check
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add menu item staging sites check

--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-wpcom-site-management-widget
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-wpcom-site-management-widget
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Dashboard: Introduce the wpcom site management widget when the nav redesign is enabled

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-calypsoify-load-package
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-calypsoify-load-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Calypsoify: Load feature from the Calypsoify package

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-command-palette-name
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-command-palette-name
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: trivial
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-import-wp-admin
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-import-wp-admin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update import flow reference to new `/setup/hosted-site-migration` path

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.32.0-alpha",
+	"version": "5.32.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.32.0-alpha';
+	const PACKAGE_VERSION = '5.32.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.0] - 2024-05-27
+### Changed
+- Added external_id to connections field. [#37405]
+- Changed how social connections are cached by moving to using transients. [#37500]
+- Moved "can_manage_connection" method to Publicize_Base class. [#37532]
+- Fixed no connections UI for editor. [#37571]
+- Updated the connection test results endpoint for front-end. [#37531]
+- Standardized the rest endpoint structure for Jetpack social connections. [#37510]
+
+### Fixed
+- Disconnect button was not showing for connections in the editor. [#37501]
+
 ## [0.44.1] - 2024-05-20
 ### Changed
 - Changed the connections management feature flag check to include the WP.com plan feature. [#37425]
@@ -558,6 +570,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.45.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.44.1...v0.45.0
 [0.44.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.44.0...v0.44.1
 [0.44.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.43.0...v0.44.0
 [0.43.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.42.13...v0.43.0

--- a/projects/packages/publicize/changelog/change-social-add-connections-external-id
+++ b/projects/packages/publicize/changelog/change-social-add-connections-external-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Added external_id to connections field

--- a/projects/packages/publicize/changelog/fix-no-connections-ui-for-editor
+++ b/projects/packages/publicize/changelog/fix-no-connections-ui-for-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social | Fixed no connections UI for editor

--- a/projects/packages/publicize/changelog/fix-social-connection-disconnect-button-not-shown
+++ b/projects/packages/publicize/changelog/fix-social-connection-disconnect-button-not-shown
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed Disconnect button not shown for connections in the editor

--- a/projects/packages/publicize/changelog/refactor-publicize-options-to-transient
+++ b/projects/packages/publicize/changelog/refactor-publicize-options-to-transient
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Changed how social connections are cached by moving to using transients.

--- a/projects/packages/publicize/changelog/update-social-use-new-endpoint-for-connection-test-results
+++ b/projects/packages/publicize/changelog/update-social-use-new-endpoint-for-connection-test-results
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social | Updated the connection test results endpoint for front-end 

--- a/projects/packages/publicize/changelog/update-social-wpcom-initial-state
+++ b/projects/packages/publicize/changelog/update-social-wpcom-initial-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Moved "can_manage_connection" method to Publicize_Base class

--- a/projects/packages/publicize/changelog/update-standarize-social-endpoints
+++ b/projects/packages/publicize/changelog/update-standarize-social-endpoints
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Standardized the rest endpoint structure for jetpack social connections.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.45.0-alpha",
+	"version": "0.45.0",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/scheduled-updates/CHANGELOG.md
+++ b/projects/packages/scheduled-updates/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2024-05-27
+### Added
+- Scheduled Updates: add check for staging sites. [#37449]
+
+### Fixed
+- Add additional check after scheduled update creation. [#37399]
+
 ## [0.12.2] - 2024-05-20
 ### Fixed
 - Add plugins field default. [#37419]
@@ -178,6 +185,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Generate initial package for Scheduled Updates [#35796]
 
+[0.13.0]: https://github.com/Automattic/scheduled-updates/compare/v0.12.2...v0.13.0
 [0.12.2]: https://github.com/Automattic/scheduled-updates/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/Automattic/scheduled-updates/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/Automattic/scheduled-updates/compare/v0.11.0...v0.12.0

--- a/projects/packages/scheduled-updates/changelog/add-scheduled-update-staging-check
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-update-staging-check
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Scheduled updates: add check for staging sites

--- a/projects/packages/scheduled-updates/changelog/add-scheduled-updates-cache-clear
+++ b/projects/packages/scheduled-updates/changelog/add-scheduled-updates-cache-clear
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Add additional check after scheduled update creation

--- a/projects/packages/scheduled-updates/src/class-scheduled-updates.php
+++ b/projects/packages/scheduled-updates/src/class-scheduled-updates.php
@@ -20,7 +20,7 @@ class Scheduled_Updates {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.13.0-alpha';
+	const PACKAGE_VERSION = '0.13.0';
 
 	/**
 	 * The cron event hook for the scheduled plugins update.

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.8] - 2024-05-27
+### Changed
+- Update dependencies. [#37356]
+
 ## [0.44.7] - 2024-05-20
 ### Changed
 - Updated package dependencies. [#37379] [#37380] [#37382]
@@ -967,6 +971,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.44.8]: https://github.com/Automattic/jetpack-search/compare/v0.44.7...v0.44.8
 [0.44.7]: https://github.com/Automattic/jetpack-search/compare/v0.44.6...v0.44.7
 [0.44.6]: https://github.com/Automattic/jetpack-search/compare/v0.44.5...v0.44.6
 [0.44.5]: https://github.com/Automattic/jetpack-search/compare/v0.44.4...v0.44.5

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.7",
+	"version": "0.44.8",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.7';
+	const VERSION = '0.44.8';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2024-05-27
+### Removed
+- Jetpack Sync: Remove 'admin_action_update' hook from Sync Plugins module. [#37488]
+
 ## [2.16.6] - 2024-05-23
 ### Added
 - Add reply to name setting for newsletters. [#37362]
@@ -1160,6 +1164,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[3.0.0]: https://github.com/Automattic/jetpack-sync/compare/v2.16.6...v3.0.0
 [2.16.6]: https://github.com/Automattic/jetpack-sync/compare/v2.16.5...v2.16.6
 [2.16.5]: https://github.com/Automattic/jetpack-sync/compare/v2.16.4...v2.16.5
 [2.16.4]: https://github.com/Automattic/jetpack-sync/compare/v2.16.3...v2.16.4

--- a/projects/packages/sync/changelog/update-remove-redundant-sync-action
+++ b/projects/packages/sync/changelog/update-remove-redundant-sync-action
@@ -1,4 +1,0 @@
-Significance: major
-Type: removed
-
-Jetpack Sync: Remove 'admin_action_update' hook from Sync Plugins module

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.0.0-alpha';
+	const PACKAGE_VERSION = '3.0.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.5-a.5 - 2024-05-27
+### Enhancements
+- AI Assistant: Move Paragraph extension to production. [#37495]
+- Newsletter: Add "From" name setting. [#37502]
+- Newsletter: Add "Reply to" name setting. [#37362]
+- Social: Add connection management to editor. [#37405]
+- Social: Add width to connection management container. [#37490]
+
+### Improved compatibility
+- Change how Jetpack social connections are stored on the local site. [#37500]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- AI Assistant: Add auto-scroll to inline extension. [#37481]
+- AI Assistant: Add paragraph inline extension. [#37461]
+- AI Assistant: Fix selected block while using the AI Assistant extension on a nested block. [#37519]
+- AI Assistant: Toggle inline AI input on Ask AI Assistant button. [#37480]
+- AI Featured Image: Add site type and image model to events being tracked on the tool. [#37474]
+- Fix settings endpoint when subscription_options is not modified. [#37190]
+- Deprecated Errors class. [#37451]
+- Jetpack AI: Open upgrade paths in new tab on every upgrade entry point. [#37457]
+- Jetpack_Currencies: Fix PHP8 fatal error in format_price when passing a string in number_format [#37530]
+- Pay with PayPal: Ensure prices are correctly formatted. [#37534]
+- Sharing button: Increase performance on p2020 theme. [#37497]
+- Social: Update the initial state fields for WP.com. [#37532]
+- Subscriptions: Add name to the overlay group block. [#37574]
+- Subscriptions: Do not clear the subscriber email when current user is empty. [#37485]
+- Subscriptions: Subscription overlay fixes. [#37503]
+- Updated package dependencies. [#36964]
+
 ## 13.5-a.3 - 2024-05-20
 ### Enhancements
 - AI Assistant: Enable inline Heading extension. [#37386]

--- a/projects/plugins/jetpack/changelog/add-newsletter-reply-name
+++ b/projects/plugins/jetpack/changelog/add-newsletter-reply-name
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Add reply to name setting for newsletters

--- a/projects/plugins/jetpack/changelog/add-patchwork-redefine-exit-package
+++ b/projects/plugins/jetpack/changelog/add-patchwork-redefine-exit-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Use new `automattic/patchwork-redefine-exit` package.
-
-

--- a/projects/plugins/jetpack/changelog/add-social-connection-management-editor-fixed
+++ b/projects/plugins/jetpack/changelog/add-social-connection-management-editor-fixed
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Social: Added connection management to editor

--- a/projects/plugins/jetpack/changelog/add-social-connection-management-editor-fixed#2
+++ b/projects/plugins/jetpack/changelog/add-social-connection-management-editor-fixed#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-social_logos_to_monorepo
+++ b/projects/plugins/jetpack/changelog/add-social_logos_to_monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/fix-ai-assistant-inline-extension-nested-input
+++ b/projects/plugins/jetpack/changelog/fix-ai-assistant-inline-extension-nested-input
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Fix selected block while using the AI Assistant extension on a nested block

--- a/projects/plugins/jetpack/changelog/fix-jetpack-currencies-format_price-number_format-fatal
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-currencies-format_price-number_format-fatal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack_Currencies: Fix PHP8 Fatal in format_price when passing a string in number_format

--- a/projects/plugins/jetpack/changelog/fix-jetpack-newsletter-settings-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-newsletter-settings-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fix settings endpoint when subscription_options is not modified

--- a/projects/plugins/jetpack/changelog/fix-social-connection-management-layout
+++ b/projects/plugins/jetpack/changelog/fix-social-connection-management-layout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Social: Added width for connectiion management container

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/refactor-publicize-options-to-transient
+++ b/projects/plugins/jetpack/changelog/refactor-publicize-options-to-transient
@@ -1,4 +1,0 @@
-Significance: minor
-Type: compat
-
-Changed how jetpack social connections are stored on the local site.

--- a/projects/plugins/jetpack/changelog/remove-deprecate-errors-class
+++ b/projects/plugins/jetpack/changelog/remove-deprecate-errors-class
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack: Deprecated Errors class.

--- a/projects/plugins/jetpack/changelog/remove-deprecate-errors-class#2
+++ b/projects/plugins/jetpack/changelog/remove-deprecate-errors-class#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-ai-featured-image-stable-diffusion-soft-launch
+++ b/projects/plugins/jetpack/changelog/update-ai-featured-image-stable-diffusion-soft-launch
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Featured Image: add site type and image model to events being tracked on the tool.

--- a/projects/plugins/jetpack/changelog/update-ai-inline-extension-ask-ai
+++ b/projects/plugins/jetpack/changelog/update-ai-inline-extension-ask-ai
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Toggle inline AI input on Ask Ai Assistant button

--- a/projects/plugins/jetpack/changelog/update-ai-inline-extension-auto-scroll
+++ b/projects/plugins/jetpack/changelog/update-ai-inline-extension-auto-scroll
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add auto-scroll on inline extension

--- a/projects/plugins/jetpack/changelog/update-block-hooks
+++ b/projects/plugins/jetpack/changelog/update-block-hooks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-sharing-button: Increased performance on p2020 theme

--- a/projects/plugins/jetpack/changelog/update-calypsoify-load-package
+++ b/projects/plugins/jetpack/changelog/update-calypsoify-load-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-calypsoify-load-package#2
+++ b/projects/plugins/jetpack/changelog/update-calypsoify-load-package#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-connection-processing-whole-input-comments
+++ b/projects/plugins/jetpack/changelog/update-connection-processing-whole-input-comments
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Jetpack: Update connection related unit tests
-
-

--- a/projects/plugins/jetpack/changelog/update-fix-sub-email
+++ b/projects/plugins/jetpack/changelog/update-fix-sub-email
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Do not clear the subscriber email when current user is empty

--- a/projects/plugins/jetpack/changelog/update-formatting-price-string-float
+++ b/projects/plugins/jetpack/changelog/update-formatting-price-string-float
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Pay with PayPal: ensure prices are correctly formatted.

--- a/projects/plugins/jetpack/changelog/update-from-name-remove-flag
+++ b/projects/plugins/jetpack/changelog/update-from-name-remove-flag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Newsletter: Add From Name setting

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-paragraph
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-paragraph
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Add paragraph inline extension

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-paragraph-production
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-paragraph-production
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Move Paragraph extension to production

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-open-upgrade-path-on-new-tab
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-open-upgrade-path-on-new-tab
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: open upgrade paths on a new tab, on every upgrade entrypoint

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-status-handling
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-status-handling
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-remove-redundant-sync-action
+++ b/projects/plugins/jetpack/changelog/update-remove-redundant-sync-action
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-settings-adjust-copy-size-spacing
+++ b/projects/plugins/jetpack/changelog/update-settings-adjust-copy-size-spacing
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Copy sizes and spacing
-
-

--- a/projects/plugins/jetpack/changelog/update-social-use-new-endpoint-for-connection-test-results
+++ b/projects/plugins/jetpack/changelog/update-social-use-new-endpoint-for-connection-test-results
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Social | Updated the initial state fields for WPCOM

--- a/projects/plugins/jetpack/changelog/update-subscribe-overlay-group-name
+++ b/projects/plugins/jetpack/changelog/update-subscribe-overlay-group-name
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Subscription overlays: add name to the group block

--- a/projects/plugins/jetpack/changelog/update-subscription-overlay-fixes
+++ b/projects/plugins/jetpack/changelog/update-subscription-overlay-fixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Subscriptions: Subscription Overlay fixes

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2399,13 +2399,13 @@ class Jetpack {
 	/**
 	 * Catches PHP errors.  Must be used in conjunction with output buffering.
 	 *
-	 * @deprecated since $$next-version$$
+	 * @deprecated since 13.5
 	 * @param bool $catch True to start catching, False to stop.
 	 *
 	 * @static
 	 */
 	public static function catch_errors( $catch ) {
-		_deprecated_function( __METHOD__, '$$next-version$$' );
+		_deprecated_function( __METHOD__, '13.5' );
 		// @phan-suppress-next-line PhanDeprecatedClass
 		return ( new Errors() )->catch_errors( $catch );
 	}
@@ -2413,10 +2413,10 @@ class Jetpack {
 	/**
 	 * Saves any generated PHP errors in ::state( 'php_errors', {errors} )
 	 *
-	 * @deprecated since $$next-version$$
+	 * @deprecated since 13.5
 	 */
 	public static function catch_errors_on_shutdown() {
-		_deprecated_function( __METHOD__, '$$next-version$$' );
+		_deprecated_function( __METHOD__, '13.5' );
 		self::state( 'php_errors', self::alias_directories( ob_get_clean() ) );
 	}
 

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -105,7 +105,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_4",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_5",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.5-a.4
+ * Version: 13.5-a.5
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.5-a.4' );
+define( 'JETPACK__VERSION', '13.5-a.5' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.5.0-a.4",
+	"version": "13.5.0-a.5",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,18 +326,16 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.5-a.3 - 2024-05-20
+### 13.5-a.5 - 2024-05-27
 #### Enhancements
-- AI Assistant: Enable inline Heading extension.
-- Subscribe block: Adds button-only style.
-- Subscribe block: Allow inside navigation block.
+- AI Assistant: Move Paragraph extension to production.
+- Newsletter: Add "From" name setting.
+- Newsletter: Add "Reply to" name setting.
+- Social: Add connection management to editor.
+- Social: Add width to connection management container.
 
 #### Improved compatibility
-- Block Editor: Remove External Link icon styling fix now that the change has been made in WordPress itself.
-
-#### Bug fixes
-- Slideshow: Fix className issue on frontend - ensures autoplay works properly.
-- WordAds: Prevent fatal when post content is null.
+- Change how Jetpack social connections are stored on the local site.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.28 - 2024-05-27
+### Changed
+- Internal updates.
+
 ## 2.1.27 - 2024-05-20
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-responsive-videos-to-classic-theme-helper-package
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-responsive-videos-to-classic-theme-helper-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-responsive-videos-to-classic-theme-helper-package#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-responsive-videos-to-classic-theme-helper-package#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-update-staging-check
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-update-staging-check
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-update-staging-check#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-scheduled-update-staging-check#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/remove-deprecate-errors-class
+++ b/projects/plugins/mu-wpcom-plugin/changelog/remove-deprecate-errors-class
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-calypsoify-load-package
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-calypsoify-load-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-calypsoify-load-package#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-calypsoify-load-package#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-calypsoify-load-package#3
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-calypsoify-load-package#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-remove-redundant-sync-action
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-remove-redundant-sync-action
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_28_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_28"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.28-alpha
+ * Version: 2.1.28
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.28-alpha",
+	"version": "2.1.28",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.28, jetpack 13.5-a.5

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.