### PR TITLE
Boost: Add speculation rules

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -395,14 +395,14 @@ const Index = () => {
 					slug="speculative_loading"
 					title={
 						<>
-							{ __( 'Speculative Loading', 'jetpack-boost' ) }
+							{ __( 'Prerender Pages', 'jetpack-boost' ) }
 							<span className={ styles.beta }>Beta</span>
 						</>
 					}
 					description={
 						<p>
 							{ __(
-								'Preload pages before the user navigates to them, so they load faster when the user clicks on them.',
+								'Preload pages that are likely to be visited next, so they load faster when the user clicks on them.',
 								'jetpack-boost'
 							) }
 						</p>

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -390,6 +390,24 @@ const Index = () => {
 				>
 					{ isaState?.active && <RecommendationsMeta isCdnActive={ !! imageCdn?.active } /> }
 				</Module>
+
+				<Module
+					slug="speculative_loading"
+					title={
+						<>
+							{ __( 'Speculative Loading', 'jetpack-boost' ) }
+							<span className={ styles.beta }>Beta</span>
+						</>
+					}
+					description={
+						<p>
+							{ __(
+								'Preload pages before the user navigates to them, so they load faster when the user clicks on them.',
+								'jetpack-boost'
+							) }
+						</p>
+					}
+				/>
 			</div>
 
 			{ ! pageCache?.active && <SuperCacheInfo /> }

--- a/projects/plugins/boost/app/modules/Modules_Index.php
+++ b/projects/plugins/boost/app/modules/Modules_Index.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_JS;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Render_Blocking_JS\Render_Blocking_JS;
 use Automattic\Jetpack_Boost\Modules\Performance_History\Performance_History;
+use Automattic\Jetpack_Boost\Optimizations\Speculative_Loading\Speculative_Loading;
 
 class Modules_Index {
 	const DISABLE_MODULE_QUERY_VAR = 'jb-disable-modules';
@@ -37,6 +38,7 @@ class Modules_Index {
 		Image_CDN::class,
 		Performance_History::class,
 		Page_Cache::class,
+		Speculative_Loading::class,
 	);
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/speculative-loading/Speculative_Loading.php
+++ b/projects/plugins/boost/app/modules/optimizations/speculative-loading/Speculative_Loading.php
@@ -2,14 +2,24 @@
 
 namespace Automattic\Jetpack_Boost\Optimizations\Speculative_Loading;
 
+use Automattic\Jetpack_Boost\Contracts\Changes_Page_Output;
 use Automattic\Jetpack_Boost\Contracts\Optimization;
 use Automattic\Jetpack_Boost\Contracts\Pluggable;
 
-class Speculative_Loading implements Pluggable, Optimization {
+class Speculative_Loading implements Pluggable, Optimization, Changes_Page_Output {
 	public static function is_available(): bool {
-		return defined( 'JETPACK_BOOST_ALPHA_FEATURES' ) ? \JETPACK_BOOST_ALPHA_FEATURES : false;
+		if ( defined( 'JETPACK_BOOST_ALPHA_FEATURES' ) ) {
+			return \JETPACK_BOOST_ALPHA_FEATURES === true;
+		}
+
+		return false;
 	}
 
+	/**
+	 * Setup the module.
+	 *
+	 * @return void
+	 */
 	public function setup() {
 		add_action( 'wp_footer', array( $this, 'add_speculative_loading' ) );
 	}

--- a/projects/plugins/boost/app/modules/optimizations/speculative-loading/Speculative_Loading.php
+++ b/projects/plugins/boost/app/modules/optimizations/speculative-loading/Speculative_Loading.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Optimizations\Speculative_Loading;
+
+use Automattic\Jetpack_Boost\Contracts\Optimization;
+use Automattic\Jetpack_Boost\Contracts\Pluggable;
+
+class Speculative_Loading implements Pluggable, Optimization {
+	public static function is_available(): bool {
+		return defined( 'JETPACK_BOOST_ALPHA_FEATURES' ) ? \JETPACK_BOOST_ALPHA_FEATURES : false;
+	}
+
+	public function setup() {
+		add_action( 'wp_footer', array( $this, 'add_speculative_loading' ) );
+	}
+
+	public static function get_slug() {
+		return 'speculative_loading';
+	}
+
+	public function is_ready() {
+		return true;
+	}
+
+	private function get_rules() {
+		return array(
+			'prerender' => array(
+				array(
+					'source'    => 'document',
+					'where'     => array(
+						'and' => array(
+							array(
+								'href_matches' => site_url() . '/*', // Any internal URL.
+							),
+							array(
+								'not' => array(
+									'href_matches' => array(
+										'*.php', // Avoid PHP files.
+										'/wp-admin/*', // Avoid admin pages.
+										'?*=*', // Avoid any URL with query parameters.
+									),
+								),
+							),
+						),
+					),
+					'eagerness' => 'moderate',
+				),
+			),
+		);
+	}
+
+	public function add_speculative_loading() {
+		echo '<script type="speculationrules">';
+		echo wp_json_encode( $this->get_rules() );
+		echo '</script>';
+	}
+}

--- a/projects/plugins/boost/changelog/add-speculation-rules
+++ b/projects/plugins/boost/changelog/add-speculation-rules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Prerender Pages: Added a new module for prerendering pages.


### PR DESCRIPTION
## Proposed changes:
* Add [speculative loading](https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API) module.

> [!NOTE]  
> This is something core is experimenting with and will likely add to core soon. There is also a [Speculative Loading](https://wordpress.org/plugins/speculation-rules/) plugin from core performance team as part of the experiment. This implementation is similar, but it tries to be more conservative by excluding external URLs, and URLs with query parameter to avoid pitfalls.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* define `JETPACK_BOOST_ALPHA_FEATURES` as `true`
* If you are using uBlock origin, uncheck "Disable pre-fetching (to prevent any connection for blocked network requests)"
<img width="618" alt="image" src="https://github.com/Automattic/jetpack/assets/3737780/644ae806-21de-4882-b064-1593d1746c64">

* Enable "Prerender Pages" from Boost settings
* Go to the front end of the site.
* Hover over any internal URL that and give it a moment before clicking.
* The page should load almost instantly because it's speculatively loading in the background.

