### PR TITLE
Carousel: be more defensive when checking for info from attachment

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-attachment-check
+++ b/projects/plugins/jetpack/changelog/update-carousel-attachment-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: be more defensive when fetching info about attachment.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -105,7 +105,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_5",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_5_a_6",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.5-a.5
+ * Version: 13.5-a.6
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.5-a.5' );
+define( 'JETPACK__VERSION', '13.5-a.6' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -920,8 +920,8 @@ class Jetpack_Carousel {
 	 * @see add_data_img_tags_and_enqueue_assets()
 	 * @see https://developer.wordpress.org/reference/functions/wp_get_attachment_image/ Documentation about wp_get_attachment_image
 	 *
-	 * @param string[] $attr Array of attribute values for the image markup, keyed by attribute name.
-	 * @param WP_Post  $attachment Image attachment post.
+	 * @param string[]     $attr       Array of attribute values for the image markup, keyed by attribute name.
+	 * @param null|WP_Post $attachment Image attachment post.
 	 *
 	 * @return string[] Modified image attributes.
 	 */
@@ -933,11 +933,15 @@ class Jetpack_Carousel {
 			return $attr;
 		}
 
-		$attachment_id = (int) $attachment->ID;
-		if ( ! wp_attachment_is_image( $attachment_id ) ) {
+		if (
+			! $attachment instanceof WP_Post
+			|| ! isset( $attachment->ID )
+			|| ! wp_attachment_is_image( $attachment )
+		) {
 			return $attr;
 		}
 
+		$attachment_id   = (int) $attachment->ID;
 		$orig_file       = wp_get_attachment_image_src( $attachment_id, 'full' );
 		$orig_file       = isset( $orig_file[0] ) ? $orig_file[0] : wp_get_attachment_url( $attachment_id );
 		$meta            = wp_get_attachment_metadata( $attachment_id );
@@ -966,10 +970,9 @@ class Jetpack_Carousel {
 		$large_file_info = wp_get_attachment_image_src( $attachment_id, 'large' );
 		$large_file      = isset( $large_file_info[0] ) ? $large_file_info[0] : '';
 
-		$attachment         = get_post( $attachment_id );
-		$attachment_title   = ! empty( $attachment ) ? wptexturize( $attachment->post_title ) : '';
-		$attachment_desc    = ! empty( $attachment ) ? wpautop( wptexturize( $attachment->post_content ) ) : '';
-		$attachment_caption = ! empty( $attachment ) ? wpautop( wptexturize( $attachment->post_excerpt ) ) : '';
+		$attachment_title   = wptexturize( $attachment->post_title );
+		$attachment_desc    = wpautop( wptexturize( $attachment->post_content ) );
+		$attachment_caption = wpautop( wptexturize( $attachment->post_excerpt ) );
 
 		// See https://github.com/Automattic/jetpack/issues/2765.
 		if ( isset( $img_meta['keywords'] ) ) {

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.5.0-a.5",
+	"version": "13.5.0-a.6",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",


### PR DESCRIPTION
## Proposed changes:

This should avoid errors like this one:

```
Warning: Attempt to read property "ID" on null in wp-content/plugins/jetpack/modules/carousel/jetpack-carousel.php on line 93
```

This also consolidates the code a bit, as a follow-up to 8d654cbb0cbf1f43cb38da96813fbe94de420666: we do not need to be fetching the full attachment post when it's already provided to us as a parameter of the method. We also do not need to check if attachment exists when we do it higher up in the method.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal discussion: p1716818804902439-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Carousel should continue to work as expected when used with the different gallery types we can provide today:

- Classic gallery in a classic block
- Tiled gallery in a classic block
- Gallery block
- Tiled Gallery block
- Single image in a classic block, linking to attachment page.
- Single image block linking to attachment page.

Information about the image (title, description, caption) should be pulled and displayed in the carousel view as expected (click on the icon to show more information to see all the fields).

No errors should appear in the logs.
