### PR TITLE
Fix/newletter private to publish

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newletter-private-to-publish
+++ b/projects/plugins/jetpack/changelog/fix-newletter-private-to-publish
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter: previoulsy private post don't send out newsletters by default

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -132,6 +132,7 @@ class Jetpack_Subscriptions {
 		// Hide subscription messaging in Publish panel for posts that were published in the past
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
 		add_action( 'transition_post_status', array( $this, 'maybe_set_first_published_status' ), 10, 3 );
+		add_action( 'transition_post_status', array( $this, 'maybe_update_default_dont_email_sub_on_private' ), 10, 3 );
 
 		// Add Subscribers menu to Jetpack navigation.
 		add_action( 'jetpack_admin_menu', array( $this, 'add_subscribers_menu' ) );
@@ -951,6 +952,22 @@ class Jetpack_Subscriptions {
 		$was_post_ever_published = get_post_meta( $post->ID, '_jetpack_post_was_ever_published', true );
 		if ( ! $was_post_ever_published && 'publish' === $old_status && 'draft' === $new_status ) {
 			update_post_meta( $post->ID, '_jetpack_post_was_ever_published', true );
+		}
+	}
+
+	/**
+	 * Set the _jetpack_dont_email_post_to_subs to 1 when the post is set to private.
+	 *
+	 * @param string $new_status Tthe "new" post status of the transition when saved.
+	 * @param string $old_status The "old" post status of the transition when saved.
+	 * @param object $post obj The post object.
+	 */
+	public function maybe_update_default_dont_email_sub_on_private( $new_status, $old_status, $post ) {
+		if ( 'private' === $new_status ) {
+			$is_not_set = get_post_meta( $post->ID, '_jetpack_post_was_ever_published', true );
+			if ( empty( $is_not_set ) ) {
+				update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
+			}
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -964,8 +964,8 @@ class Jetpack_Subscriptions {
 	 */
 	public function maybe_update_default_dont_email_sub_on_private( $new_status, $old_status, $post ) {
 		if ( 'private' === $new_status ) {
-			$is_not_set = get_post_meta( $post->ID, '_jetpack_post_was_ever_published', true );
-			if ( empty( $is_not_set ) ) {
+			$is_not_set = get_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', true );
+			if ( empty( $is_not_set ) && $is_not_set !== '0' ) {
 				update_post_meta( $post->ID, '_jetpack_dont_email_post_to_subs', 1 );
 			}
 		}


### PR DESCRIPTION
This PR make it so that we set a flag to do not send emails when the post goes from private to public. 

D150140-code - equivalent.

## Proposed changes:
* Updates the `_jetpack_post_was_ever_published` to be false when we publish a post as private. 
* This make it so that when a user then goes on to publish the post by default the post will be set to do not notify users.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See slack p1715099210678129-slack-C03NLNTPZ2T 

## Does this pull request change what data or activity we track or use?
no

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

1. That that email subscriptions still work by creating a new post. You should receive an email. 
2. Create a private post. 
3. Update the post status now to public. The email should not be sent. 

4. Create a private post. 
5. Update the post status to draft. 
6. Publish the post. Notice that the default for sending out the newsletter is set to not send but it can be overwritten to send.