### PR TITLE
Untangling Simple Classic: Update comments settings in Simple to match Jetpack site

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-comments-setting
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-comments-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update comments settings in Simple to match Jetpack site

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -59,7 +59,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.32.x-dev"
+			"dev-trunk": "5.33.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.32.0",
+	"version": "5.33.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.32.0';
+	const PACKAGE_VERSION = '5.33.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-admin.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/class-verbum-admin.php
@@ -70,16 +70,16 @@ class Verbum_Admin {
 		$this->default_allow_blocks = true;
 
 		// Default option values.
-		$this->default_greeting = __( 'Leave a comment', 'jetpack-mu-wpcom' );
+		$this->default_greeting = __( 'Leave a Reply', 'jetpack-mu-wpcom' );
 
 		// Default color scheme.
-		$this->default_color_scheme = 'transparent';
+		$this->default_color_scheme = 'light';
 
 		// Possible color schemes.
 		$this->color_schemes = array(
-			'transparent' => __( 'Transparent', 'jetpack-mu-wpcom' ),
 			'light'       => __( 'Light', 'jetpack-mu-wpcom' ),
 			'dark'        => __( 'Dark', 'jetpack-mu-wpcom' ),
+			'transparent' => __( 'Transparent', 'jetpack-mu-wpcom' ),
 		);
 	}
 
@@ -89,6 +89,14 @@ class Verbum_Admin {
 	 * Add the Jetpack settings to WordPress's discussions page
 	 */
 	public function add_settings() {
+
+		// Create the section.
+		add_settings_section(
+			'jetpack_comment_form',
+			__( 'Comments', 'jetpack-mu-wpcom' ),
+			array( $this, 'comment_form_settings_section' ),
+			'discussion'
+		);
 
 		add_settings_field(
 			'enable_verbum_commenting',
@@ -123,7 +131,8 @@ class Verbum_Admin {
 			'highlander_comment_form_prompt',
 			__( 'Greeting Text', 'jetpack-mu-wpcom' ),
 			array( $this, 'comment_form_greeting_setting' ),
-			'discussion'
+			'discussion',
+			'jetpack_comment_form'
 		);
 
 		register_setting(
@@ -139,7 +148,8 @@ class Verbum_Admin {
 			'jetpack_comment_form_color_scheme',
 			__( 'Color Scheme', 'jetpack-mu-wpcom' ),
 			array( $this, 'comment_form_color_scheme_setting' ),
-			'discussion'
+			'discussion',
+			'jetpack_comment_form'
 		);
 
 		register_setting(

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-comments-setting
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-comments-setting
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_28"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_29_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -855,7 +855,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "74981d2afd43adb4e2729467088ef7e4e246b843"
+                "reference": "6afbf5c272cdb3860f49a8bc915dfbbe1ed77ed5"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -886,7 +886,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.32.x-dev"
+                    "dev-trunk": "5.33.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.28
+ * Version: 2.1.29-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.28",
+	"version": "2.1.29-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

This PR made changes to Simple Classic to match Atomic Classic/a Jetpack site.

- Add a "Comments" header and "Adjust your Comments form with a clever greeting and color-scheme." sub-header above "Greeting Text" and "Color Scheme" 
- Changes the "Color Scheme" option order 

Part of https://github.com/Automattic/dotcom-forge/issues/6527
Related to https://github.com/Automattic/jetpack/pull/36367
Atomic version of implementation https://github.com/Automattic/jetpack/blob/7bfd57582a20db028101ce51c8e84b430bb55220/projects/plugins/jetpack/modules/comments/admin.php

| before | after |
|--------|--------|
| <img width="1012" alt="Screenshot 2024-05-28 at 14 41 43" src="https://github.com/Automattic/jetpack/assets/5287479/9e1224d8-0bed-4bd3-8248-4e89d831b889"> | <img width="652" alt="Screenshot 2024-05-28 at 14 40 11" src="https://github.com/Automattic/jetpack/assets/5287479/7233974e-4ac0-4f39-a43a-6b7e48d1c20e"> | 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your sandbox https://github.com/Automattic/jetpack/pull/37592#issuecomment-2134366291
* Go to Settings > Discussion 
* Confirm Greeting Text and Color Scheme are under the Comments header
* Confirm the order of Color Scheme is Light, Dark, Transparent

