### PR TITLE
Change copy of classic intro tour

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-classic-tour-copy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-classic-tour-copy
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Copy changes
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -152,7 +152,7 @@ function wpcom_render_classic_tour_template() {
 				<div class="wpcom-classic-tour-step-current"><?php esc_html_e( 'Step {{currentStep}} of {{totalSteps}}', 'jetpack-mu-wpcom' ); ?></div>
 				<button data-action="prev" class="button button-secondary"><?php esc_html_e( 'Previous', 'jetpack-mu-wpcom' ); ?></button>
 				<button data-action="next" class="button button-primary"><?php esc_html_e( 'Next', 'jetpack-mu-wpcom' ); ?></button>
-				<button data-action="dismiss" class="button button-primary"><?php esc_html_e( 'Well done!', 'jetpack-mu-wpcom' ); ?></button>
+				<button data-action="dismiss" class="button button-primary"><?php esc_html_e( 'Got it!', 'jetpack-mu-wpcom' ); ?></button>
 			</div>
 		</div>
 	</template>
@@ -195,21 +195,21 @@ function wpcom_classic_tour_enqueue_scripts() {
 				'target'      => '.toplevel_page_wpcom-hosting-menu',
 				'placement'   => 'right-bottom',
 				'title'       => esc_html__( 'Upgrades is now Hosting', 'jetpack-mu-wpcom' ),
-				'description' => esc_html__( 'The Hosting drawer contains the My Home page and all items from the Updates drawer, including Plans, Domains, Emails, and Purchases.', 'jetpack-mu-wpcom' ),
+				'description' => esc_html__( 'The Hosting menu contains the My Home page and all items from the Upgrades menu, including Plans, Domains, Emails, and Purchases.', 'jetpack-mu-wpcom' ),
 				'position'    => 'fixed',
 			),
 			array(
 				'target'      => '.wpcom_site_management_widget__site-actions',
 				'placement'   => 'bottom',
 				'title'       => esc_html__( 'Hosting overview', 'jetpack-mu-wpcom' ),
-				'description' => esc_html__( 'Access the new site management panel and all developer tools such as hosting configuration, GitHub deployments, metrics, PHP logs, and server logs.', 'jetpack-mu-wpcom' ),
+				'description' => esc_html__( 'Access the new site management panel and all developer tools such as hosting configuration, GitHub deployments, monitoring, PHP logs, and server logs.', 'jetpack-mu-wpcom' ),
 				'position'    => 'absolute',
 			),
 			array(
 				'target'      => '.wp-admin-bar-all-sites',
 				'placement'   => 'bottom-right',
 				'title'       => esc_html__( 'All your sites', 'jetpack-mu-wpcom' ),
-				'description' => esc_html__( 'All sites consolidates all your sites, domains, notifications, help center, Reader, and more in one place.', 'jetpack-mu-wpcom' ),
+				'description' => esc_html__( 'Click here to access your sites, domains, Reader, account settings, and more.', 'jetpack-mu-wpcom' ),
 				'position'    => 'fixed',
 			),
 		),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -195,14 +195,14 @@ function wpcom_classic_tour_enqueue_scripts() {
 				'target'      => '.toplevel_page_wpcom-hosting-menu',
 				'placement'   => 'right-bottom',
 				'title'       => esc_html__( 'Upgrades is now Hosting', 'jetpack-mu-wpcom' ),
-				'description' => esc_html__( 'The Hosting menu contains the My Home page and all items from the Upgrades menu, including Plans, Domains, Emails, and Purchases.', 'jetpack-mu-wpcom' ),
+				'description' => esc_html__( 'The Hosting menu contains the My Home page and all items from the Upgrades menu, including Plans, Domains, Emails, Purchases, and more.', 'jetpack-mu-wpcom' ),
 				'position'    => 'fixed',
 			),
 			array(
 				'target'      => '.wpcom_site_management_widget__site-actions',
 				'placement'   => 'bottom',
 				'title'       => esc_html__( 'Hosting overview', 'jetpack-mu-wpcom' ),
-				'description' => esc_html__( 'Access the new site management panel and all developer tools such as hosting configuration, GitHub deployments, monitoring, PHP logs, and server logs.', 'jetpack-mu-wpcom' ),
+				'description' => esc_html__( 'Access the new site management panel and all developer tools such as hosting configuration, GitHub deployments, metrics, PHP logs, and server logs.', 'jetpack-mu-wpcom' ),
 				'position'    => 'absolute',
 			),
 			array(


### PR DESCRIPTION
## Proposed changes:

Updates the copy of the new classic intro tour as per discussion in pfsHM7-17R-p2

Before | After
--- | ---
<img width="620" alt="Screenshot 2024-05-27 at 14 45 19" src="https://github.com/Automattic/jetpack/assets/1233880/f03945cb-d691-41ee-a3b5-a5e607fb7722"> | <img width="566" alt="Screenshot 2024-05-29 at 10 35 30" src="https://github.com/Automattic/jetpack/assets/1233880/41518e49-12be-479b-ab9c-00184cb9f5a9">
<img width="556" alt="Screenshot 2024-05-27 at 14 45 25" src="https://github.com/Automattic/jetpack/assets/1233880/66168093-4035-4d43-9c1d-17740ffadf1b"> | <img width="422" alt="Screenshot 2024-05-29 at 10 35 36" src="https://github.com/Automattic/jetpack/assets/1233880/02309169-3812-4a23-8a49-2891d7ac917e">
<img width="482" alt="Screenshot 2024-05-27 at 14 45 32" src="https://github.com/Automattic/jetpack/assets/1233880/e6237661-89bf-46aa-8697-22b7f23060c4"> | <img width="424" alt="Screenshot 2024-05-29 at 10 35 41" src="https://github.com/Automattic/jetpack/assets/1233880/cf3132cd-f8c5-42f4-bcd6-d6af86e47bde">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com testing site
- If you previously dismissed/completed the tour, remove the `wpcom_classic_tour_completed` option on your test site
- Go to wordpress.com/settings/general and select your site
- Change the admin interface to Classic
- You should land in /wp-admin/?admin-interface-changed=true
- Make sure the intro tour has the new copy
