### PR TITLE
Comics CPT: add deprecation warning

### DIFF
--- a/projects/plugins/jetpack/changelog/update-deprecate-comic-cpt
+++ b/projects/plugins/jetpack/changelog/update-deprecate-comic-cpt
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: other
 
 Comics CPT: add deprecation warning

--- a/projects/plugins/jetpack/changelog/update-deprecate-comic-cpt
+++ b/projects/plugins/jetpack/changelog/update-deprecate-comic-cpt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comics CPT: add deprecation warning

--- a/projects/plugins/jetpack/modules/custom-post-types/comics.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/comics.php
@@ -21,14 +21,6 @@ class Jetpack_Comic {
 	 * @return self
 	 */
 	public static function init() {
-		$message = sprintf(
-			// translators: %s is a link to the WordPress.org documentation.
-			__( 'Jetpack no longer supports the Comics Post Type: %s', 'jetpack' ),
-			'https://jetpack.com/support/custom-content-types/#comics'
-		);
-
-		_deprecated_hook( 'Jetpack_Comic', 'jetpack-$$next-version$$', '', esc_html( $message ) );
-
 		static $instance = false;
 
 		if ( ! $instance ) {
@@ -510,6 +502,16 @@ class Jetpack_Comic {
 		 */
 		if ( current_theme_supports( self::POST_TYPE ) ) {
 			$supports_comics = true;
+		}
+
+		if ( $supports_comics ) {
+			$message = sprintf(
+				// translators: %s is a link to the WordPress.org documentation.
+				__( 'Jetpack no longer supports the Comics Post Type: %s', 'jetpack' ),
+				'https://jetpack.com/support/custom-content-types/#comics'
+			);
+
+			_deprecated_hook( 'Jetpack_Comic', 'jetpack-$$next-version$$', '', esc_html( $message ) );
 		}
 
 		/**

--- a/projects/plugins/jetpack/modules/custom-post-types/comics.php
+++ b/projects/plugins/jetpack/modules/custom-post-types/comics.php
@@ -21,6 +21,14 @@ class Jetpack_Comic {
 	 * @return self
 	 */
 	public static function init() {
+		$message = sprintf(
+			// translators: %s is a link to the WordPress.org documentation.
+			__( 'Jetpack no longer supports the Comics Post Type: %s', 'jetpack' ),
+			'https://jetpack.com/support/custom-content-types/#comics'
+		);
+
+		_deprecated_hook( 'Jetpack_Comic', 'jetpack-$$next-version$$', '', esc_html( $message ) );
+
 		static $instance = false;
 
 		if ( ! $instance ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/351

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The Comics Custom Post Type (CPT) will soon be removed from the Jetpack plugin. This PR adds a deprecation warning in the codebase that will be triggered if the theme supports the Comics CPT.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pfwV0U-bF-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Make sure you can see the server logs
- Install the Panel theme, or add `add_theme_support( 'jetpack-comic' )` to your theme
- Visit the Jetpack section in WPadmin
- You should see the following warning in the log: `PHP Deprecated:  Hook Jetpack_Comic is deprecated since version jetpack-$$next-version$$ with no alternative available. Jetpack no longer supports the Comics Post Type: https://jetpack.com/support/custom-content-types/#comics in ...`