### PR TITLE
constants: Fix type for `set_constant()` value

### DIFF
--- a/projects/packages/constants/.phan/baseline.php
+++ b/projects/packages/constants/.phan/baseline.php
@@ -8,12 +8,9 @@
  * (can be combined with --load-baseline)
  */
 return [
-    // # Issue statistics:
-    // PhanTypeMismatchArgumentProbablyReal : 3 occurrences
-
+    // This baseline has no suppressions
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'tests/php/test-constants.php' => ['PhanTypeMismatchArgumentProbablyReal'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/constants/changelog/fix-phan-issues-in-constants-pkg
+++ b/projects/packages/constants/changelog/fix-phan-issues-in-constants-pkg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix phpdoc type on `Constants::set_constant()` value parameter.

--- a/projects/packages/constants/src/class-constants.php
+++ b/projects/packages/constants/src/class-constants.php
@@ -91,8 +91,8 @@ class Constants {
 	/**
 	 * Sets the value of the "constant" within constants Manager.
 	 *
-	 * @param string $name The name of the constant.
-	 * @param scalar $value The value of the constant.
+	 * @param string                           $name The name of the constant.
+	 * @param int|float|string|bool|array|null $value The value of the constant.
 	 */
 	public static function set_constant( $name, $value ) {
 		self::$set_constants[ $name ] = $value;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PHP's `define()` allows any of int|float|string|bool|array|null, so let's go with that to match.

~~This fixes 57 Phan issues across the monorepo.~~

Just as I was about to create this PR, #36968 changed it to `scalar`. Which fixed 54 of those 57 errors, but as it left out the possibility of array and null 3 were still left.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷 Not much to check here.
