### PR TITLE
autoloader: Fix phan issues

### DIFF
--- a/projects/packages/autoloader/.phan/baseline.php
+++ b/projects/packages/autoloader/.phan/baseline.php
@@ -8,37 +8,9 @@
  * (can be combined with --load-baseline)
  */
 return [
-    // # Issue statistics:
-    // PhanDeprecatedFunction : 10+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 6 occurrences
-    // PhanTypeMismatchArgument : 4 occurrences
-    // PhanTypeMismatchReturnProbablyReal : 3 occurrences
-    // PhanTypePossiblyInvalidDimOffset : 3 occurrences
-    // PhanPluginDuplicateConditionalNullCoalescing : 2 occurrences
-    // PhanPossiblyNullTypeMismatchProperty : 1 occurrence
-    // PhanTypeMismatchArgumentInternal : 1 occurrence
-    // PhanTypeMismatchArgumentNullable : 1 occurrence
-    // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
-    // PhanTypeMismatchDeclaredParamNullable : 1 occurrence
-    // PhanTypeMismatchForeach : 1 occurrence
-
+    // This baseline has no suppressions
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/AutoloadFileWriter.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'src/AutoloadGenerator.php' => ['PhanPossiblyNullTypeMismatchProperty', 'PhanTypeMismatchDeclaredParamNullable'],
-        'src/AutoloadProcessor.php' => ['PhanTypeMismatchForeach', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/class-php-autoloader.php' => ['PhanTypeMismatchReturnProbablyReal'],
-        'src/class-version-loader.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'tests/php/bootstrap.php' => ['PhanTypeMismatchArgumentInternal'],
-        'tests/php/lib/class-acceptance-test-case.php' => ['PhanTypePossiblyInvalidDimOffset'],
-        'tests/php/lib/class-test-plugin-factory.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal'],
-        'tests/php/tests/acceptance/AutoloaderTest.php' => ['PhanTypeMismatchArgument'],
-        'tests/php/tests/acceptance/CacheTest.php' => ['PhanTypeMismatchArgument'],
-        'tests/php/tests/unit/AutoloadProcessorTest.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'tests/php/tests/unit/AutoloaderHandlerTest.php' => ['PhanDeprecatedFunction'],
-        'tests/php/tests/unit/PHPAutoloaderTest.php' => ['PhanDeprecatedFunction'],
-        'tests/php/tests/unit/PluginLocatorTest.php' => ['PhanDeprecatedFunction'],
-        'tests/php/tests/unit/PluginsHandlerTest.php' => ['PhanDeprecatedFunction'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/autoloader/changelog/fix-phan-issues-in-autoloader
+++ b/projects/packages/autoloader/changelog/fix-phan-issues-in-autoloader
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+`AutoloadGenerator::__construct` no longer pretends `$io` is nullable. That never worked.

--- a/projects/packages/autoloader/src/AutoloadFileWriter.php
+++ b/projects/packages/autoloader/src/AutoloadFileWriter.php
@@ -57,7 +57,7 @@ AUTOLOADER_COMMENT;
 				continue;
 			}
 
-			$newFile = isset( $renameList[ $file ] ) ? $renameList[ $file ] : $file;
+			$newFile = $renameList[ $file ] ?? $file;
 			$content = self::prepareAutoloaderFile( $file, $suffix );
 
 			$written = file_put_contents( $outDir . '/' . $newFile, $content );

--- a/projects/packages/autoloader/src/AutoloadGenerator.php
+++ b/projects/packages/autoloader/src/AutoloadGenerator.php
@@ -21,7 +21,7 @@ use Composer\Util\PackageSorter;
  */
 class AutoloadGenerator {
 
-	const VERSION = '3.0.7';
+	const VERSION = '3.0.8-alpha';
 
 	/**
 	 * IO object.
@@ -42,7 +42,7 @@ class AutoloadGenerator {
 	 *
 	 * @param IOInterface $io IO object.
 	 */
-	public function __construct( IOInterface $io = null ) {
+	public function __construct( IOInterface $io ) {
 		$this->io         = $io;
 		$this->filesystem = new Filesystem();
 	}

--- a/projects/packages/autoloader/src/AutoloadProcessor.php
+++ b/projects/packages/autoloader/src/AutoloadProcessor.php
@@ -43,7 +43,8 @@ class AutoloadProcessor {
 	 * @param array $autoloads The autoloads we are processing.
 	 * @param bool  $scanPsrPackages Whether or not PSR packages should be converted to a classmap.
 	 *
-	 * @return array $processed
+	 * @return array|null $processed
+	 * @phan-param array{classmap:?array{path:string,version:string}[],psr-4:?array<string,array{path:string,version:string}[]>,psr-0:?array<string,array{path:string,version:string}[]>} $autoloads
 	 */
 	public function processClassmap( $autoloads, $scanPsrPackages ) {
 		// We can't scan PSR packages if we don't actually have any.
@@ -123,7 +124,7 @@ class AutoloadProcessor {
 	 * @param array $autoloads The autoloads we are processing.
 	 * @param bool  $scanPsrPackages Whether or not PSR packages should be converted to a classmap.
 	 *
-	 * @return array $processed
+	 * @return array|null $processed
 	 */
 	public function processPsr4Packages( $autoloads, $scanPsrPackages ) {
 		if ( $scanPsrPackages || empty( $autoloads['psr-4'] ) ) {

--- a/projects/packages/autoloader/src/class-php-autoloader.php
+++ b/projects/packages/autoloader/src/class-php-autoloader.php
@@ -71,7 +71,7 @@ class PHP_Autoloader {
 	public static function load_class( $class_name ) {
 		global $jetpack_autoloader_loader;
 		if ( ! isset( $jetpack_autoloader_loader ) ) {
-			return;
+			return false;
 		}
 
 		$file = $jetpack_autoloader_loader->find_class_file( $class_name );

--- a/projects/packages/autoloader/src/class-version-loader.php
+++ b/projects/packages/autoloader/src/class-version-loader.php
@@ -58,7 +58,7 @@ class Version_Loader {
 	 */
 	public function find_class_file( $class_name ) {
 		$data = $this->select_newest_file(
-			isset( $this->classmap[ $class_name ] ) ? $this->classmap[ $class_name ] : null,
+			$this->classmap[ $class_name ] ?? null,
 			$this->find_psr4_file( $class_name )
 		);
 		if ( ! isset( $data ) ) {

--- a/projects/packages/autoloader/tests/php/bootstrap.php
+++ b/projects/packages/autoloader/tests/php/bootstrap.php
@@ -30,6 +30,7 @@ define( 'WPMU_PLUGIN_DIR', WP_CONTENT_DIR . DIRECTORY_SEPARATOR . 'mu-plugins' )
 
 // Load all of the test dependencies.
 require_once TEST_PACKAGE_DIR . '/vendor/autoload.php';
+require_once __DIR__ . '/lib/with-consecutive.php';
 require_once __DIR__ . '/lib/functions-wordpress.php';
 require_once __DIR__ . '/lib/functions.php';
 require_once __DIR__ . '/lib/class-test-plugin-factory.php';
@@ -49,7 +50,7 @@ spl_autoload_register(
 		// We're only going to autoload the test autoloader files.
 		$check = substr( $class, 0, strlen( $namespace ) );
 		if ( $namespace !== $check ) {
-			return false;
+			return;
 		}
 
 		// Remove the namespace.
@@ -66,11 +67,10 @@ spl_autoload_register(
 			)
 		);
 		if ( ! is_file( $path ) ) {
-			return false;
+			return;
 		}
 
 		require_once $path;
-		return true;
 	}
 );
 

--- a/projects/packages/autoloader/tests/php/lib/class-acceptance-test-case.php
+++ b/projects/packages/autoloader/tests/php/lib/class-acceptance-test-case.php
@@ -91,7 +91,7 @@ abstract class Acceptance_Test_Case extends TestCase {
 	 * Installs a symlink to a plugin version.
 	 *
 	 * @param string $version      The version of the autoloader we want to symlink to.
-	 * @param string $is_mu_plugin Whether or not the symlink should be an mu-plugin.
+	 * @param bool   $is_mu_plugin Whether or not the symlink should be an mu-plugin.
 	 * @param string $symlink_key  The key for the symlink in the installed plugin list.
 	 */
 	protected function install_autoloader_symlink( $version, $is_mu_plugin, $symlink_key ) {
@@ -143,7 +143,7 @@ abstract class Acceptance_Test_Case extends TestCase {
 		// This isn't perfect (it won't catch successive resets from a new autoloader discovering newer autoloaders) but
 		// it will at least catch the most common reset scenarios that we can build assertions on.
 		global $jetpack_packages_classmap;
-		$reset_count = isset( $jetpack_packages_classmap ) ? $jetpack_packages_classmap['reset_count'] : null;
+		$reset_count = $jetpack_packages_classmap['reset_count'] ?? null;
 
 		require_once $plugin_dir . '/vendor/autoload_packages.php';
 
@@ -154,7 +154,7 @@ abstract class Acceptance_Test_Case extends TestCase {
 
 		// Since we can assume after every load we set the count we know a null value
 		// means this was the first time the autoloader was executed.
-		if ( ! isset( $reset_count ) ) {
+		if ( $reset_count === null ) {
 			$jetpack_packages_classmap['reset_count'] = 0;
 		} else {
 			$jetpack_packages_classmap['reset_count'] = $reset_count + 1;
@@ -297,7 +297,7 @@ abstract class Acceptance_Test_Case extends TestCase {
 	 */
 	protected function assertAutoloaderResetCount( $count ) {
 		global $jetpack_packages_classmap;
-		$reset_count = isset( $jetpack_packages_classmap ) ? $jetpack_packages_classmap['reset_count'] : 0;
+		$reset_count = $jetpack_packages_classmap['reset_count'] ?? 0;
 		$this->assertEquals( $count, $reset_count, 'The number of autoloader resets did not match what was expected.' );
 	}
 

--- a/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
+++ b/projects/packages/autoloader/tests/php/lib/class-test-plugin-factory.php
@@ -83,9 +83,9 @@ class Test_Plugin_Factory {
 	/**
 	 * Creates a new factory for the plugin and returns it.
 	 *
-	 * @param bool     $is_mu_plugin Indicates whether or not the plugin is an mu-plugin.
-	 * @param string   $slug         The slug of the plugin we're building.
-	 * @param string[] $autoloads    The composer autoloads for the plugin we're building.
+	 * @param bool   $is_mu_plugin Indicates whether or not the plugin is an mu-plugin.
+	 * @param string $slug         The slug of the plugin we're building.
+	 * @param array  $autoloads    The composer autoloads for the plugin we're building.
 	 * @return Test_Plugin_Factory
 	 * @throws \InvalidArgumentException When the slug is invalid.
 	 */
@@ -177,7 +177,7 @@ class Test_Plugin_Factory {
 			$namespace  = substr( $fqn, 0, -strlen( $class_name ) - 1 );
 		} else {
 			$class_name = $fqn;
-			$namespace  = null;
+			$namespace  = '';
 		}
 
 		$path = null;
@@ -209,7 +209,7 @@ class Test_Plugin_Factory {
 					break;
 				}
 
-				if ( ! isset( $path ) ) {
+				if ( $path === null ) {
 					throw new \InvalidArgumentException( 'The namespace for this class is not in the factory\'s autoloads.' );
 				}
 
@@ -222,12 +222,12 @@ class Test_Plugin_Factory {
 		}
 
 		$file_content = "<?php\n\n";
-		if ( isset( $namespace ) ) {
+		if ( $namespace !== '' ) {
 			$file_content .= "namespace $namespace;\n\n";
 		}
 		$file_content .= "class $class_name {\n$content\n}";
 
-		return $this->with_file( $path, $file_content );
+		return $this->with_file( (string) $path, $file_content );
 	}
 
 	/**
@@ -245,7 +245,7 @@ class Test_Plugin_Factory {
 	/**
 	 * Adds options that will be passed to the plugin's composer.json file.
 	 *
-	 * @param string[] $options The options that we want to set in the composer config.
+	 * @param array $options The options that we want to set in the composer config.
 	 * @return $this
 	 */
 	public function with_composer_config( $options ) {

--- a/projects/packages/autoloader/tests/php/lib/with-consecutive.php
+++ b/projects/packages/autoloader/tests/php/lib/with-consecutive.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * A function to replace PHPUnit's `->withConsecutive()`.
+ *
+ * @package automattic/jetpack-autoloader
+ */
+
+use PHPUnit\Framework\Constraint\Callback;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\Constraint\IsEqual;
+
+/**
+ * Reimplement `withConsecutive` for PHPUnit.
+ *
+ * Unfortunately PHPUnit deprecated withConsecutive with no replacement, so we
+ * have to roll our own version.
+ *
+ * @see https://github.com/sebastianbergmann/phpunit/issues/4026
+ *
+ * Where previously you'd have done like
+ * ```
+ * ->withConsecutive(
+ *   [ first, call, args ],
+ *   [ second, call, args ],
+ *   [ and, so, on ]
+ * )
+ * ```
+ * you can do like this now
+ * ```
+ * ->with( ...with_consecutive(
+ *   [ first, call, args ],
+ *   [ second, call, args ],
+ *   [ and, so, on ]
+ * ) )
+ * ```
+ *
+ * @param array ...$args Sets of arguments as you'd have passed to `->withConsecutive()`.
+ * @return Constraint[] Array of constraints to pass to `->with()`.
+ * @throws InvalidArgumentException If arguments are invalid.
+ */
+function with_consecutive( ...$args ) {
+	if ( ! $args ) {
+		throw new InvalidArgumentException( 'Must pass at least one set of arguments' );
+	}
+
+	$ct         = count( $args[0] );
+	$value_sets = array();
+	foreach ( $args as $group ) {
+		if ( count( $group ) !== $ct ) {
+			throw new InvalidArgumentException( 'All sets of arguments must be the same length' );
+		}
+		for ( $i = 0; $i < $ct; $i++ ) {
+			$value_sets[ $i ][] = $group[ $i ] instanceof Constraint ? $group[ $i ] : new IsEqual( $group[ $i ] );
+		}
+	}
+	$funcs = array();
+	for ( $i = 0; $i < $ct; $i++ ) {
+		$funcs[] = new Callback(
+			function ( $value ) use ( $value_sets, $i ) {
+				static $set = null;
+				$set        = $set ?? $value_sets[ $i ]; // @phan-suppress-current-line PhanTypePossiblyInvalidDimOffset -- False positive.
+				if ( ! $set ) {
+					$n = count( $value_sets[ $i ] ); // @phan-suppress-current-line PhanTypePossiblyInvalidDimOffset -- False positive.
+					throw new InvalidArgumentException( "More calls than argument sets. Use `->expects( \$this->exactly( $n ) )` or the like when mocking the method to avoid this." );
+				}
+				$expect = array_shift( $set );
+				$expect->evaluate( $value );
+				return true;
+			}
+		);
+	}
+	return $funcs;
+}

--- a/projects/packages/autoloader/tests/php/tests/unit/AutoloadProcessorTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/AutoloadProcessorTest.php
@@ -14,10 +14,22 @@ use PHPUnit\Framework\TestCase;
 class AutoloadProcessorTest extends TestCase {
 
 	/**
+	 * Callback that should not be called.
+	 *
+	 * @return never
+	 * @throws BadFunctionCallException Always.
+	 */
+	public static function never_call_callback() {
+		throw new BadFunctionCallException( 'Callback should not have been called' );
+	}
+
+	/**
 	 * Tests that all of the process functions are safe when not given an autoload they're expecting.
+	 *
+	 * @phan-suppress PhanTypeMismatchArgument -- Intentionally checking error cases.
 	 */
 	public function test_process_functions_return_null_when_empty() {
-		$processor = new AutoloadProcessor( null, null );
+		$processor = new AutoloadProcessor( array( static::class, 'never_call_callback' ), array( static::class, 'never_call_callback' ) );
 
 		$this->assertNull( $processor->processClassmap( array(), false ) );
 		$this->assertNull( $processor->processClassmap( array(), true ) );
@@ -52,6 +64,8 @@ class AutoloadProcessorTest extends TestCase {
 					'version' => 'dev-test',
 				),
 			),
+			'psr-4'    => null,
+			'psr-0'    => null,
 		);
 
 		$processed = $processor->processClassmap( $autoloads, false );
@@ -91,7 +105,7 @@ class AutoloadProcessorTest extends TestCase {
 		$processor             = new AutoloadProcessor( $classmap_scanner, $path_code_transformer );
 
 		$autoloads = array(
-			'psr-4' => array(
+			'psr-4'    => array(
 				'Jetpack\\Autoloader\\' => array(
 					array(
 						'path'    => 'src',
@@ -99,6 +113,8 @@ class AutoloadProcessorTest extends TestCase {
 					),
 				),
 			),
+			'classmap' => null,
+			'psr-0'    => null,
 		);
 
 		$processed = $processor->processClassmap( $autoloads, true );
@@ -144,6 +160,8 @@ class AutoloadProcessorTest extends TestCase {
 					'version' => 'dev-test',
 				),
 			),
+			'psr-4'    => null,
+			'psr-0'    => null,
 		);
 
 		$autoloads['exclude-from-classmap'] = array( 'TestClass' );
@@ -172,7 +190,7 @@ class AutoloadProcessorTest extends TestCase {
 		$path_code_transformer = function ( $path ) {
 			return 'converted-' . $path;
 		};
-		$processor             = new AutoloadProcessor( null, $path_code_transformer );
+		$processor             = new AutoloadProcessor( array( static::class, 'never_call_callback' ), $path_code_transformer );
 
 		$autoloads = array(
 			'psr-4' => array(
@@ -202,7 +220,7 @@ class AutoloadProcessorTest extends TestCase {
 	 * Tests that `processPsr4Packages` does not when we're indicating that we want to make them a classmap.
 	 */
 	public function test_process_psr_packages_does_nothing_when_converting_to_classmap() {
-		$processor = new AutoloadProcessor( null, null );
+		$processor = new AutoloadProcessor( array( static::class, 'never_call_callback' ), array( static::class, 'never_call_callback' ) );
 
 		$autoloads = array(
 			'psr-4' => array(
@@ -227,7 +245,7 @@ class AutoloadProcessorTest extends TestCase {
 		$path_code_transformer = function ( $path ) {
 			return 'converted-' . $path;
 		};
-		$processor             = new AutoloadProcessor( null, $path_code_transformer );
+		$processor             = new AutoloadProcessor( array( static::class, 'never_call_callback' ), $path_code_transformer );
 
 		$autoloads = array(
 			'files' => array(

--- a/projects/packages/autoloader/tests/php/tests/unit/AutoloaderHandlerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/AutoloaderHandlerTest.php
@@ -80,10 +80,12 @@ class AutoloaderHandlerTest extends TestCase {
 
 		$this->manifest_reader->expects( $this->exactly( 3 ) )
 			->method( 'read_manifests' )
-			->withConsecutive(
-				array( $plugins, 'vendor/composer/jetpack_autoload_psr4.php' ),
-				array( $plugins, 'vendor/composer/jetpack_autoload_classmap.php' ),
-				array( $plugins, 'vendor/composer/jetpack_autoload_filemap.php' )
+			->with(
+				...with_consecutive(
+					array( $plugins, 'vendor/composer/jetpack_autoload_psr4.php' ),
+					array( $plugins, 'vendor/composer/jetpack_autoload_classmap.php' ),
+					array( $plugins, 'vendor/composer/jetpack_autoload_filemap.php' )
+				)
 			);
 		$this->php_autoloader->expects( $this->once() )
 			->method( 'register_autoloader' );

--- a/projects/packages/autoloader/tests/php/tests/unit/PHPAutoloaderTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/PHPAutoloaderTest.php
@@ -70,6 +70,7 @@ class PHPAutoloaderTest extends TestCase {
 	 * Tests that class files are loaded correctly.
 	 */
 	public function test_load_class() {
+		// @phan-suppress-next-line PhanDeprecatedFunction -- Keep using setMethods until we drop PHP 7.0 support.
 		$loader = $this->getMockBuilder( Version_Loader::class )
 			->disableOriginalConstructor()
 			->setMethods( array( 'find_class_file' ) )
@@ -90,6 +91,7 @@ class PHPAutoloaderTest extends TestCase {
 	 * Tests that nothing happens when a class file isn't found.
 	 */
 	public function test_load_class_does_nothing_without_class() {
+		// @phan-suppress-next-line PhanDeprecatedFunction -- Keep using setMethods until we drop PHP 7.0 support.
 		$loader = $this->getMockBuilder( Version_Loader::class )
 			->disableOriginalConstructor()
 			->setMethods( array( 'find_class_file' ) )

--- a/projects/packages/autoloader/tests/php/tests/unit/PluginLocatorTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/PluginLocatorTest.php
@@ -95,9 +95,11 @@ class PluginLocatorTest extends TestCase {
 		);
 		$this->path_processor->expects( $this->exactly( 2 ) )
 			->method( 'find_directory_with_autoloader' )
-			->withConsecutive(
-				array( 0 ),
-				array( 'test/test.php' )
+			->with(
+				...with_consecutive(
+					array( 0 ),
+					array( 'test/test.php' )
+				)
 			)
 			->willReturn( false );
 
@@ -117,9 +119,11 @@ class PluginLocatorTest extends TestCase {
 
 		$this->path_processor->expects( $this->exactly( 2 ) )
 			->method( 'find_directory_with_autoloader' )
-			->withConsecutive(
-				array( 0 ),
-				array( 'dummy_current/dummy_current.php' )
+			->with(
+				...with_consecutive(
+					array( 0 ),
+					array( 'dummy_current/dummy_current.php' )
+				)
 			)
 			->willReturnOnConsecutiveCalls( false, WP_PLUGIN_DIR . '/dummy_current' );
 
@@ -141,9 +145,11 @@ class PluginLocatorTest extends TestCase {
 
 		$this->path_processor->expects( $this->exactly( 2 ) )
 			->method( 'find_directory_with_autoloader' )
-			->withConsecutive(
-				array( 0 ),
-				array( 'dummy_current/dummy_current.php' )
+			->with(
+				...with_consecutive(
+					array( 0 ),
+					array( 'dummy_current/dummy_current.php' )
+				)
 			)
 			->willReturnOnConsecutiveCalls( false, WP_PLUGIN_DIR . '/dummy_current' );
 
@@ -165,9 +171,11 @@ class PluginLocatorTest extends TestCase {
 
 		$this->path_processor->expects( $this->exactly( 2 ) )
 			->method( 'find_directory_with_autoloader' )
-			->withConsecutive(
-				array( 'dummy_current/dummy_current.php' ),
-				array( 123456 )
+			->with(
+				...with_consecutive(
+					array( 'dummy_current/dummy_current.php' ),
+					array( 123456 )
+				)
 			)
 			->willReturnOnConsecutiveCalls( WP_PLUGIN_DIR . '/dummy_current', false );
 
@@ -255,9 +263,11 @@ class PluginLocatorTest extends TestCase {
 
 		$this->path_processor->expects( $this->exactly( 2 ) )
 			->method( 'find_directory_with_autoloader' )
-			->withConsecutive(
-				array( 0 ),
-				array( 'dummy_current\\dummy_current.php' )
+			->with(
+				...with_consecutive(
+					array( 0 ),
+					array( 'dummy_current\\dummy_current.php' )
+				)
 			)
 			->willReturnOnConsecutiveCalls( false, WP_PLUGIN_DIR . '/dummy_current' );
 
@@ -278,9 +288,11 @@ class PluginLocatorTest extends TestCase {
 
 		$this->path_processor->expects( $this->exactly( 2 ) )
 			->method( 'find_directory_with_autoloader' )
-			->withConsecutive(
-				array( 0 ),
-				array( 'dummy_current\\dummy_current.php' )
+			->with(
+				...with_consecutive(
+					array( 0 ),
+					array( 'dummy_current\\dummy_current.php' )
+				)
 			)
 			->willReturnOnConsecutiveCalls( false, WP_PLUGIN_DIR . '/dummy_current' );
 

--- a/projects/packages/autoloader/tests/php/tests/unit/PluginsHandlerTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/PluginsHandlerTest.php
@@ -105,9 +105,11 @@ class PluginsHandlerTest extends TestCase {
 		$jetpack_autoloader_activating_plugins_paths = array( WP_PLUGIN_DIR . '/plugin_activating' );
 		$this->plugin_locator->expects( $this->exactly( 2 ) )
 			->method( 'find_using_option' )
-			->withConsecutive(
-				array( 'active_plugins', false ),
-				array( 'active_sitewide_plugins', true )
+			->with(
+				...with_consecutive(
+					array( 'active_plugins', false ),
+					array( 'active_sitewide_plugins', true )
+				)
 			)
 			->willReturnOnConsecutiveCalls(
 				array( WP_PLUGIN_DIR . '/dummy_current' ),
@@ -230,9 +232,11 @@ class PluginsHandlerTest extends TestCase {
 			->willReturn( array( WP_PLUGIN_DIR . '/dummy_newer' ) );
 		$this->plugin_locator->expects( $this->exactly( 2 ) )
 			->method( 'find_using_request_action' )
-			->withConsecutive(
-				array( array( 'activate', 'activate-selected', 'deactivate', 'deactivate-selected' ) ),
-				array( array( 'deactivate', 'deactivate-selected' ) )
+			->with(
+				...with_consecutive(
+					array( array( 'activate', 'activate-selected', 'deactivate', 'deactivate-selected' ) ),
+					array( array( 'deactivate', 'deactivate-selected' ) )
+				)
 			)
 			->willReturnOnConsecutiveCalls(
 				array( WP_PLUGIN_DIR . '/dummy_dev' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
No real functionality changes.

* `$io` parameter to `AutoloadGenerator` constructor is no longer optional. The class didn't work when omitted anyway.
* Improve some phpdocs.
* `PHP_Autoloader::load_class()` now always returns bool as documented.
* Use `??` where applicable.
* Replace `->withConsecutive()` in tests, PHPUnit deprecated it without any replacement besides rolling our own.
* Fix some test logic.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Stuff still works?
