### PR TITLE
Stats: Deprecating old Stats experience - toggle update

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -284,11 +284,16 @@ class SiteStatsComponent extends React.Component {
 										checked={ !! this.props.getOptionValue( 'enable_odyssey_stats' ) }
 										disabled={
 											! isStatsActive ||
+											! optedOutOfOdyssey ||
 											unavailableInOfflineMode ||
 											this.props.isSavingAnyOption( [ 'stats' ] )
 										}
 										toggling={ this.props.isSavingAnyOption( [ 'enable_odyssey_stats' ] ) }
-										onChange={ this.handleStatsOptionToggle( 'enable_odyssey_stats' ) }
+										onChange={
+											optedOutOfOdyssey
+												? this.handleStatsOptionToggle( 'enable_odyssey_stats' )
+												: null
+										}
 										label={
 											<>
 												{ /* This toggle enables Odyssey Stats. */ }

--- a/projects/plugins/jetpack/changelog/update-stats-red-11-deprecate-old-stats-toggle
+++ b/projects/plugins/jetpack/changelog/update-stats-red-11-deprecate-old-stats-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Stats: Deprecated old stats experience


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/red-team/issues/11

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* disabling toggle pointing to the deprecated experience for sites with new Stats

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack -> Settings 
* verify that the toggle allowing to disable new Stats is disabled
* comment out the new code locally and verify that if you have old experience enabled you can still enable new experience from the settings page

