### PR TITLE
Super Cache: remove the minimum preload interval based on post count

### DIFF
--- a/projects/plugins/super-cache/changelog/update-super-cache-remove-min-post-count-preload
+++ b/projects/plugins/super-cache/changelog/update-super-cache-remove-min-post-count-preload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Super Cache: remove the preload interval based on the post count. Preload as often as you want.

--- a/projects/plugins/super-cache/partials/preload.php
+++ b/projects/plugins/super-cache/partials/preload.php
@@ -14,11 +14,8 @@ if ( ! $cache_enabled || ! $super_cache_enabled || true === defined( 'DISABLESUP
 }
 
 $count = wpsc_post_count();
-if ( $count > 1000 ) {
-	$min_refresh_interval = 720;
-} else {
-	$min_refresh_interval = 30;
-}
+
+$min_refresh_interval = wpsc_get_minimum_preload();
 
 echo '<div class="wpsc-card">';
 echo '<p>' . __( 'This will cache every published post and page on your site. It will create supercache static files so unknown visitors (including bots) will hit a cached page. This will probably help your Google ranking as they are using speed as a metric when judging websites now.', 'wp-super-cache' ) . '</p>';

--- a/projects/plugins/super-cache/partials/preload.php
+++ b/projects/plugins/super-cache/partials/preload.php
@@ -15,7 +15,7 @@ if ( ! $cache_enabled || ! $super_cache_enabled || true === defined( 'DISABLESUP
 
 $count = wpsc_post_count();
 
-$min_refresh_interval = wpsc_get_minimum_preload();
+$min_refresh_interval = wpsc_get_minimum_preload_interval();
 
 echo '<div class="wpsc-card">';
 echo '<p>' . __( 'This will cache every published post and page on your site. It will create supercache static files so unknown visitors (including bots) will hit a cached page. This will probably help your Google ranking as they are using speed as a metric when judging websites now.', 'wp-super-cache' ) . '</p>';

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3948,12 +3948,12 @@ function wpsc_post_count() {
 
 /**
  * Get the minimum interval in minutes between preload refreshes.
- * Filter the default value of 10 minutes using the `wpsc_minimum_preload` filter.
+ * Filter the default value of 10 minutes using the `wpsc_minimum_preload_interval` filter.
  *
  * @return int
  */
 function wpsc_get_minimum_preload() {
-	return apply_filters( 'wpsc_minimum_preload', 10 );
+	return apply_filters( 'wpsc_minimum_preload_interval', 10 );
 }
 
 function wpsc_preload_settings() {

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -1061,13 +1061,7 @@ table.wpsc-settings-table {
 	if ( 'preload' === $curr_tab ) {
 		if ( true == $super_cache_enabled && ! defined( 'DISABLESUPERCACHEPRELOADING' ) ) {
 			global $wp_cache_preload_interval, $wp_cache_preload_on, $wp_cache_preload_taxonomies, $wp_cache_preload_email_me, $wp_cache_preload_email_volume, $wp_cache_preload_posts, $wpdb;
-			$count = wpsc_post_count();
-			if ( $count > 1000 ) {
-				$min_refresh_interval = 720;
-			} else {
-				$min_refresh_interval = 30;
-			}
-			wpsc_preload_settings( $min_refresh_interval );
+			wpsc_preload_settings();
 			$currently_preloading = false;
 
 			echo '<div id="wpsc-preload-status"></div>';
@@ -3951,7 +3945,18 @@ function wpsc_post_count() {
 
 	return $count;
 }
-function wpsc_preload_settings( $min_refresh_interval = 'NA' ) {
+
+/**
+ * Get the minimum interval in minutes between preload refreshes.
+ * Filter the default value of 10 minutes using the `wpsc_minimum_preload` filter.
+ *
+ * @return int
+ */
+function wpsc_get_minimum_preload() {
+	return apply_filters( 'wpsc_minimum_preload', 10 );
+}
+
+function wpsc_preload_settings() {
 	global $wp_cache_preload_interval, $wp_cache_preload_on, $wp_cache_preload_taxonomies, $wp_cache_preload_email_me, $wp_cache_preload_email_volume, $wp_cache_preload_posts, $wpdb;
 
 	if ( isset( $_POST[ 'action' ] ) == false || $_POST[ 'action' ] != 'preload' )
@@ -3971,14 +3976,7 @@ function wpsc_preload_settings( $min_refresh_interval = 'NA' ) {
 		return;
 	}
 
-	if ( $min_refresh_interval == 'NA' ) {
-		$count = wpsc_post_count();
-		if ( $count > 1000 ) {
-			$min_refresh_interval = 720;
-		} else {
-			$min_refresh_interval = 30;
-		}
-	}
+	$min_refresh_interval = wpsc_get_minimum_preload();
 
 	// Set to true if the preload interval is changed, and a reschedule is required.
 	$force_preload_reschedule = false;

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3952,7 +3952,7 @@ function wpsc_post_count() {
  *
  * @return int
  */
-function wpsc_get_minimum_preload() {
+function wpsc_get_minimum_preload_interval() {
 	return apply_filters( 'wpsc_minimum_preload_interval', 10 );
 }
 
@@ -3976,7 +3976,7 @@ function wpsc_preload_settings() {
 		return;
 	}
 
-	$min_refresh_interval = wpsc_get_minimum_preload();
+	$min_refresh_interval = wpsc_get_minimum_preload_interval();
 
 	// Set to true if the preload interval is changed, and a reschedule is required.
 	$force_preload_reschedule = false;


### PR DESCRIPTION
If a site has more than 1000 posts then preload can't be scheduled sooner than 12 hours after the previous preload. This appears to be [buggy](https://wordpress.org/support/topic/preload-files-getting-deleted/#post-17787377) and not really needed. The preload process itself will schedule the next preload so there's no chance of two preloads happening on a single site at a time.
The minimum interval in the UI can be adjusted using the wpsc_minimum_preload_interval filter. This does not modify the currently set interval.

## Proposed changes:
* Add a filter called "wpsc_minimum_preload_interval" to change the minimum interval displayed in the UI.
* Remove checks on wpsc_post_count() and just use a flat minimum interval.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Apply patch.
* Enable caching and go to the preload settings page.
* The minimum preload interval should be 10, no matter how many posts are in your test site.
