### PR TITLE
AI Inline Extensions: Add behavior support

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-inline-extension-behavior
+++ b/projects/plugins/jetpack/changelog/add-ai-inline-extension-behavior
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add behavior support on AI Inline Extensions

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/block-handler.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/block-handler.tsx
@@ -7,7 +7,7 @@ import { select, dispatch } from '@wordpress/data';
 /**
  * Types
  */
-import type { BlockEditorDispatch, BlockEditorSelect } from './types';
+import type { BlockBehavior, BlockEditorDispatch, BlockEditorSelect } from './types';
 import type { Block, RenderHTMLRules } from '@automattic/jetpack-ai-client';
 
 export function getMarkdown( html: string ) {
@@ -22,10 +22,16 @@ export class BlockHandler {
 	public clientId: string;
 	public renderRules: RenderHTMLRules = [];
 	public firstUpdate: boolean = true;
+	public behavior: BlockBehavior = 'dropdown' as const;
 
-	constructor( clientId: string, renderRules: RenderHTMLRules = [] ) {
+	constructor(
+		clientId: string,
+		renderRules: RenderHTMLRules = [],
+		behavior: BlockBehavior = 'dropdown'
+	) {
 		this.clientId = clientId;
 		this.renderRules = renderRules;
+		this.behavior = behavior;
 	}
 
 	public getBlock(): Block {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-toolbar-dropdown/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-toolbar-dropdown/index.tsx
@@ -13,6 +13,7 @@ import AiAssistantToolbarDropdownContent from '../../../components/ai-assistant-
 /*
  * Types
  */
+import { BlockBehavior } from '../../types';
 import type { OnRequestSuggestion } from '../../../components/ai-assistant-toolbar-dropdown/dropdown-content';
 import type { ExtendedInlineBlockProp } from '../../../extensions/ai-assistant';
 import type { ReactElement } from 'react';
@@ -56,6 +57,7 @@ function AiAssistantExtensionToolbarDropdownContent( {
 }
 
 type AiAssistantExtensionToolbarDropdownProps = {
+	behavior: BlockBehavior;
 	blockType: ExtendedInlineBlockProp;
 	label?: string;
 	onAskAiAssistant: () => void;
@@ -63,6 +65,7 @@ type AiAssistantExtensionToolbarDropdownProps = {
 };
 
 export default function AiAssistantExtensionToolbarDropdown( {
+	behavior,
 	blockType,
 	label = __( 'AI Assistant', 'jetpack' ),
 	onAskAiAssistant,
@@ -107,11 +110,22 @@ export default function AiAssistantExtensionToolbarDropdown( {
 				variant: 'toolbar',
 			} }
 			renderToggle={ ( { isOpen, onToggle } ) => {
+				const handleClick = () => {
+					switch ( behavior ) {
+						case 'action':
+							handleAskAiAssistant();
+							break;
+						case 'dropdown':
+							onToggle();
+							break;
+					}
+				};
+
 				return (
 					<ToolbarButton
 						className="jetpack-ai-assistant__button"
 						showTooltip
-						onClick={ onToggle }
+						onClick={ handleClick }
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
 						label={ label }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/get-block-handler.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/get-block-handler.tsx
@@ -49,5 +49,6 @@ export function getBlockHandler(
 		onSuggestion: handler.onSuggestion.bind( handler ),
 		onDone: handler.onDone.bind( handler ),
 		getContent: handler.getContent.bind( handler ),
+		behavior: handler.behavior,
 	};
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/types.ts
@@ -9,10 +9,13 @@ import type { Block } from '@automattic/jetpack-ai-client';
 
 export type OnSuggestion = ( suggestion: string ) => void;
 
+export type BlockBehavior = 'dropdown' | 'action';
+
 export interface IBlockHandler {
 	onSuggestion: OnSuggestion;
 	onDone: () => void;
 	getContent: () => string;
+	behavior: BlockBehavior;
 }
 
 export type BlockEditorSelect = {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -113,6 +113,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			onSuggestion: onBlockSuggestion,
 			onDone: onBlockDone,
 			getContent,
+			behavior,
 		} = useMemo( () => getBlockHandler( blockName, clientId ), [ blockName, clientId ] );
 
 		// Called when the user clicks the "Ask AI Assistant" button.
@@ -453,6 +454,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 						blockType={ blockName }
 						onAskAiAssistant={ handleAskAiAssistant }
 						onRequestSuggestion={ handleRequestSuggestion }
+						behavior={ behavior }
 					/>
 				</BlockControls>
 			</>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related with #37590 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add new `behavior` configuration, that allow the block to trigger input directly and not the dropdown.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open some of the `extensions` handler (ex. paragraph)
* Add on `constructor` a third parameter called `'action'`.
* Go to your editor and insert a paragraph block.
* Click on `AI Assistant` toolbar button.
* It should open the `Input` directly.

### Demo

https://github.com/Automattic/jetpack/assets/1663717/80477873-281d-4006-b799-ff8132bcf256



