### PR TITLE
Tiled Gallery: force image aspect ratio for square and circle styles

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-img-ratio
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-img-ratio
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tiled Gallery: force image aspect ratio for square and circle styles

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/view.scss
@@ -29,6 +29,10 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 				}
 			}
 		}
+
+		.tiled-gallery__item img {
+			aspect-ratio: 1;
+		}
 	}
 
 	&.is-style-columns,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In some instances (see section below), users reported that the Tiled Gallery rendered oval images instead of circles, when the _Circles_ style was selected. This PR enforces an aspect ratio of 1 on the images to prevent this.

<img width="481" alt="Screenshot 2024-05-29 at 3 49 02 PM" src="https://github.com/Automattic/jetpack/assets/1620183/4a0091a6-85f0-46ad-bdf2-5ef2f5a40606">


## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
P2 post: p8oabR-1wt-p2#comment-7992

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### To reproduce the issue
_Note: I haven't been able to reproduce the issue consistently._

- Spin up a Jetpack site
- Create a new post
- Add a _Tiled Gallery_ block
<img width="400" alt="Screenshot 2024-05-29 at 3 37 28 PM" src="https://github.com/Automattic/jetpack/assets/1620183/8a1021ef-d24c-4110-844b-bcdc2b7c8145">

- **Before** adding any images, select the _Circles_ style
<img width="283" alt="Screenshot 2024-05-29 at 3 37 31 PM" src="https://github.com/Automattic/jetpack/assets/1620183/6b99f85b-c4f1-4da6-aae2-c4cf8c3eb6aa">

- Choose images of different sizes and ratios for the gallery (I typically selected 10)
- You may see that some images have an oval shape in the editor

### To test the fix

- Spin up a test site with this branch
- Repeat the steps above
- Images should be circles
- Check that image are circles in the preview as well