### PR TITLE
Update cta for automattic for agencies

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/jetpack-manage-banner/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/jetpack-manage-banner/index.jsx
@@ -45,7 +45,7 @@ const JetpackManageBanner = props => {
 				'Are you an agency or freelancer? We’re working on a new partnership program bringing together the best of Jetpack, Woo, WordPress.com, and Pressable. Get bulk discounts, referral commissions, and more.',
 				'jetpack-my-jetpack'
 			) }
-			primaryCtaLabel={ __( 'Register your interest', 'jetpack-my-jetpack' ) }
+			primaryCtaLabel={ __( 'Sign up now', 'jetpack-my-jetpack' ) }
 			primaryCtaURL={ getRedirectUrl( 'jetpack-for-agencies-register-interest' ) }
 			primaryCtaIsExternalLink={ true }
 			primaryCtaOnClick={ handleAgencyInterestClick }

--- a/projects/packages/my-jetpack/changelog/update-cta-for-automattic-for-agencies
+++ b/projects/packages/my-jetpack/changelog/update-cta-for-automattic-for-agencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update CTA on a4a banner in My Jetpack

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.24.1",
+	"version": "4.24.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.24.1';
+	const PACKAGE_VERSION = '4.24.2-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
## Proposed changes:

* Update A4A banner on My Jetpack to be a signup CTA instead of a register interest CTA

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Make sure you are user connected
3. Go to My Jetpack and make sure the CTA says "Sign up now"
![image](https://github.com/Automattic/jetpack/assets/65001528/2bc1d541-f848-4ba0-9970-234a30e7b8c1)

