### PR TITLE
Jetpack AI: open AI Control upgrade link on new tab

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-open-ai-control-upgrades-on-new-tab
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-open-ai-control-upgrades-on-new-tab
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Jetpack AI: support upgrade links on the AI Control that will open on a new tab

--- a/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
@@ -31,6 +31,7 @@ type ExtensionAIControlProps = {
 	error?: RequestingErrorProps;
 	requestsRemaining?: number;
 	showUpgradeMessage?: boolean;
+	upgradeUrl?: string;
 	wrapperRef?: React.MutableRefObject< HTMLDivElement | null >;
 	onChange?: ( newValue: string ) => void;
 	onSend?: ( currentValue: string ) => void;
@@ -61,6 +62,7 @@ export function ExtensionAIControl(
 		error,
 		requestsRemaining,
 		showUpgradeMessage = false,
+		upgradeUrl,
 		wrapperRef,
 		onChange,
 		onSend,
@@ -210,11 +212,16 @@ export function ExtensionAIControl(
 				code={ error.code }
 				onTryAgainClick={ tryAgainHandler }
 				onUpgradeClick={ upgradeHandler }
+				upgradeUrl={ upgradeUrl }
 			/>
 		);
 	} else if ( showUpgradeMessage ) {
 		message = (
-			<UpgradeMessage requestsRemaining={ requestsRemaining } onUpgradeClick={ upgradeHandler } />
+			<UpgradeMessage
+				requestsRemaining={ requestsRemaining }
+				onUpgradeClick={ upgradeHandler }
+				upgradeUrl={ upgradeUrl }
+			/>
 		);
 	} else if ( showGuideLine ) {
 		message = <GuidelineMessage />;

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -137,7 +137,7 @@ export function UpgradeMessage( {
 			<span>
 				{ sprintf(
 					// translators: %1$d: number of requests remaining
-					__( 'You have %1$d free requests remaining.', 'jetpack-ai-client' ),
+					__( 'You have %1$d requests remaining.', 'jetpack-ai-client' ),
 					requestsRemaining
 				) }
 			</span>

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -45,6 +45,7 @@ export type UpgradeMessageProps = {
 	requestsRemaining: number;
 	severity?: MessageSeverityProp;
 	onUpgradeClick: OnUpgradeClick;
+	upgradeUrl?: string;
 };
 
 export type ErrorMessageProps = {
@@ -52,6 +53,7 @@ export type ErrorMessageProps = {
 	code?: SuggestionErrorCode;
 	onTryAgainClick: () => void;
 	onUpgradeClick: OnUpgradeClick;
+	upgradeUrl?: string;
 };
 
 const messageIconsMap = {
@@ -122,6 +124,7 @@ export function UpgradeMessage( {
 	requestsRemaining,
 	severity,
 	onUpgradeClick,
+	upgradeUrl,
 }: UpgradeMessageProps ): React.ReactElement {
 	let messageSeverity = severity;
 
@@ -138,7 +141,12 @@ export function UpgradeMessage( {
 					requestsRemaining
 				) }
 			</span>
-			<Button variant="link" onClick={ onUpgradeClick }>
+			<Button
+				variant="link"
+				onClick={ onUpgradeClick }
+				href={ upgradeUrl }
+				target={ upgradeUrl ? '_blank' : null }
+			>
 				{ __( 'Upgrade now', 'jetpack-ai-client' ) }
 			</Button>
 		</Message>
@@ -156,6 +164,7 @@ export function ErrorMessage( {
 	code,
 	onTryAgainClick,
 	onUpgradeClick,
+	upgradeUrl,
 }: ErrorMessageProps ): React.ReactElement {
 	const errorMessage = error || __( 'Something went wrong', 'jetpack-ai-client' );
 
@@ -169,7 +178,12 @@ export function ErrorMessage( {
 				) }
 			</span>
 			{ code === ERROR_QUOTA_EXCEEDED ? (
-				<Button variant="link" onClick={ onUpgradeClick }>
+				<Button
+					variant="link"
+					onClick={ onUpgradeClick }
+					href={ upgradeUrl }
+					target={ upgradeUrl ? '_blank' : null }
+				>
 					{ __( 'Upgrade now', 'jetpack-ai-client' ) }
 				</Button>
 			) : (

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-open-ai-control-upgrades-on-new-tab
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-open-ai-control-upgrades-on-new-tab
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: open AI Control upgrade links on a new tab.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -18,7 +18,7 @@ import './style.scss';
  */
 import type { ExtendedInlineBlockProp } from '../../../extensions/ai-assistant';
 import type { RequestingErrorProps, RequestingStateProp } from '@automattic/jetpack-ai-client';
-import type { ReactElement, MouseEvent } from 'react';
+import type { ReactElement } from 'react';
 
 export type AiAssistantInputProps = {
 	className?: string;
@@ -56,7 +56,7 @@ export default function AiAssistantInput( {
 }: AiAssistantInputProps ): ReactElement {
 	const [ value, setValue ] = useState( '' );
 	const [ placeholder, setPlaceholder ] = useState( __( 'Ask Jetpack AI to edit…', 'jetpack' ) );
-	const { autosaveAndRedirect } = useAICheckout();
+	const { checkoutUrl } = useAICheckout();
 	const { tracks } = useAnalytics();
 	const [ requestsRemaining, setRequestsRemaining ] = useState( 0 );
 	const [ showUpgradeMessage, setShowUpgradeMessage ] = useState( false );
@@ -102,18 +102,13 @@ export default function AiAssistantInput( {
 		undo?.();
 	}, [ blockType, tracks, undo ] );
 
-	const handleUpgrade = useCallback(
-		( event: MouseEvent< HTMLButtonElement > ) => {
-			tracks.recordEvent( 'jetpack_ai_upgrade_button', {
-				current_tier_slug: currentTier?.slug,
-				requests_count: requestsCount,
-				placement: 'jetpack_ai_assistant_extension',
-			} );
-
-			autosaveAndRedirect( event );
-		},
-		[ autosaveAndRedirect, currentTier?.slug, requestsCount, tracks ]
-	);
+	const handleUpgrade = useCallback( () => {
+		tracks.recordEvent( 'jetpack_ai_upgrade_button', {
+			current_tier_slug: currentTier?.slug,
+			requests_count: requestsCount,
+			placement: 'jetpack_ai_assistant_extension',
+		} );
+	}, [ currentTier?.slug, requestsCount, tracks ] );
 
 	const handleTryAgain = useCallback( () => {
 		tracks.recordEvent( 'jetpack_ai_assistant_try_again', {
@@ -167,6 +162,7 @@ export default function AiAssistantInput( {
 			error={ requestingError }
 			requestsRemaining={ requestsRemaining }
 			showUpgradeMessage={ showUpgradeMessage }
+			upgradeUrl={ checkoutUrl }
 			onChange={ setValue }
 			onSend={ handleSend }
 			onStop={ handleStopSuggestion }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #37458.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Add support for `upgradeUrl` on the AI Control component (mainly the Extension AI Control), so we can provide an upgrade URL for the upgrade link, that will open on a new tab
* Change the extension code to provide the checkout URL as `upgradeUrl` on the Extension AI Control, so the upgrade link on the extension will open on a new tab
* Remove the "free" word from the AI Control upgrade message, because we are showing it even on paid plans

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this branch on your testing site, open the editor and add some text to a paragraph
* Click the extension icon to open the AI extension on the paragraph:

<img width="500" alt="Screenshot 2024-05-29 at 17 06 52" src="https://github.com/Automattic/jetpack/assets/6760046/b60fe471-3553-4587-b809-e4d60ee48161">

* On the footer of the assistant
   * confirm the message is not mentioning "free" requests
   * confirm the upgrade link will open on a new tab

_Testing the upgrade link on the error message:_

* Sandbox the `public-api` so we can simulate a quota exceeded error
* On the first line of the `run_query` method of the Jetpack AI Query class, add this line:

```
return new \WP_Error( 'error_quota_exceeded', __( 'You exceeded your current quota, please check your plan details', 'jetpack' ), array( 'status' => 429 ) );
```

* Go back to the editor, open the AI extension on the paragraph, then type some prompt there (example, "add emoji on the end")
* Since we added the simulated error, you will see this message:

<img width="500" alt="Screenshot 2024-05-29 at 17 39 31" src="https://github.com/Automattic/jetpack/assets/6760046/5f72423a-be18-43a7-b08d-0de516e7e632">

* Confirm the upgrade link will open on a new tab