### PR TITLE
Jetpack AI: open upgrade path on a new tab, part 4

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-update-target-of-sidebar-upgrade-message
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-update-target-of-sidebar-upgrade-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: open upgrade prompt from pre-publish on a new tab.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -47,7 +47,7 @@ const JetpackAndSettingsContent = ( {
 	requireUpgrade,
 	upgradeType,
 }: JetpackSettingsContentProps ) => {
-	const { autosaveAndRedirect, isRedirecting } = useAICheckout();
+	const { autosaveAndRedirect, isRedirecting, checkoutUrl } = useAICheckout();
 
 	return (
 		<>
@@ -80,7 +80,12 @@ const JetpackAndSettingsContent = ( {
 			) }
 			{ requireUpgrade && ! isUsagePanelAvailable && (
 				<PanelRow>
-					<Upgrade placement={ placement } onClick={ autosaveAndRedirect } type={ upgradeType } />
+					<Upgrade
+						placement={ placement }
+						onClick={ autosaveAndRedirect }
+						type={ upgradeType }
+						upgradeUrl={ checkoutUrl }
+					/>
 				</PanelRow>
 			) }
 			{ isUsagePanelAvailable && (
@@ -94,7 +99,7 @@ const JetpackAndSettingsContent = ( {
 
 export default function AiAssistantPluginSidebar() {
 	const { requireUpgrade, upgradeType, currentTier } = useAiFeature();
-	const { autosaveAndRedirect, isRedirecting } = useAICheckout();
+	const { autosaveAndRedirect, isRedirecting, checkoutUrl } = useAICheckout();
 
 	const { tracks } = useAnalytics();
 	const title = __( 'AI Assistant', 'jetpack' );
@@ -154,6 +159,7 @@ export default function AiAssistantPluginSidebar() {
 							onClick={ autosaveAndRedirect }
 							type={ upgradeType }
 							currentTier={ currentTier }
+							upgradeUrl={ checkoutUrl }
 						/>
 					) }
 				</>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -47,34 +47,26 @@ const JetpackAndSettingsContent = ( {
 	requireUpgrade,
 	upgradeType,
 }: JetpackSettingsContentProps ) => {
-	const { isRedirecting, checkoutUrl } = useAICheckout();
+	const { checkoutUrl } = useAICheckout();
 
 	return (
 		<>
 			{ isAITitleOptimizationAvailable && (
 				<PanelRow className="jetpack-ai-title-optimization__header">
 					<BaseControl label={ __( 'Optimize Publishing', 'jetpack' ) }>
-						<TitleOptimization
-							placement={ placement }
-							busy={ isRedirecting }
-							disabled={ requireUpgrade }
-						/>
+						<TitleOptimization placement={ placement } busy={ false } disabled={ requireUpgrade } />
 					</BaseControl>
 				</PanelRow>
 			) }
 			<PanelRow className="jetpack-ai-proofread-control__header">
 				<BaseControl label={ __( 'AI feedback on post', 'jetpack' ) }>
-					<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
+					<Proofread busy={ false } disabled={ requireUpgrade } />
 				</BaseControl>
 			</PanelRow>
 			{ isAIFeaturedImageAvailable && (
 				<PanelRow className="jetpack-ai-featured-image-control__header">
 					<BaseControl label={ __( 'AI Featured Image', 'jetpack' ) }>
-						<FeaturedImage
-							busy={ isRedirecting }
-							disabled={ requireUpgrade }
-							placement={ placement }
-						/>
+						<FeaturedImage busy={ false } disabled={ requireUpgrade } placement={ placement } />
 					</BaseControl>
 				</PanelRow>
 			) }
@@ -94,7 +86,7 @@ const JetpackAndSettingsContent = ( {
 
 export default function AiAssistantPluginSidebar() {
 	const { requireUpgrade, upgradeType, currentTier } = useAiFeature();
-	const { isRedirecting, checkoutUrl } = useAICheckout();
+	const { checkoutUrl } = useAICheckout();
 
 	const { tracks } = useAnalytics();
 	const title = __( 'AI Assistant', 'jetpack' );
@@ -143,11 +135,11 @@ export default function AiAssistantPluginSidebar() {
 					{ isAITitleOptimizationAvailable && (
 						<TitleOptimization
 							placement={ PLACEMENT_PRE_PUBLISH }
-							busy={ isRedirecting }
+							busy={ false }
 							disabled={ requireUpgrade }
 						/>
 					) }
-					<Proofread busy={ isRedirecting } disabled={ requireUpgrade } />
+					<Proofread busy={ false } disabled={ requireUpgrade } />
 					{ requireUpgrade && (
 						<Upgrade
 							placement={ PLACEMENT_PRE_PUBLISH }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -47,7 +47,7 @@ const JetpackAndSettingsContent = ( {
 	requireUpgrade,
 	upgradeType,
 }: JetpackSettingsContentProps ) => {
-	const { autosaveAndRedirect, isRedirecting, checkoutUrl } = useAICheckout();
+	const { isRedirecting, checkoutUrl } = useAICheckout();
 
 	return (
 		<>
@@ -80,12 +80,7 @@ const JetpackAndSettingsContent = ( {
 			) }
 			{ requireUpgrade && ! isUsagePanelAvailable && (
 				<PanelRow>
-					<Upgrade
-						placement={ placement }
-						onClick={ autosaveAndRedirect }
-						type={ upgradeType }
-						upgradeUrl={ checkoutUrl }
-					/>
+					<Upgrade placement={ placement } type={ upgradeType } upgradeUrl={ checkoutUrl } />
 				</PanelRow>
 			) }
 			{ isUsagePanelAvailable && (
@@ -99,7 +94,7 @@ const JetpackAndSettingsContent = ( {
 
 export default function AiAssistantPluginSidebar() {
 	const { requireUpgrade, upgradeType, currentTier } = useAiFeature();
-	const { autosaveAndRedirect, isRedirecting, checkoutUrl } = useAICheckout();
+	const { isRedirecting, checkoutUrl } = useAICheckout();
 
 	const { tracks } = useAnalytics();
 	const title = __( 'AI Assistant', 'jetpack' );
@@ -156,7 +151,6 @@ export default function AiAssistantPluginSidebar() {
 					{ requireUpgrade && (
 						<Upgrade
 							placement={ PLACEMENT_PRE_PUBLISH }
-							onClick={ autosaveAndRedirect }
 							type={ upgradeType }
 							currentTier={ currentTier }
 							upgradeUrl={ checkoutUrl }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/upgrade.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/upgrade.tsx
@@ -15,12 +15,14 @@ export default function Upgrade( {
 	type,
 	placement = '',
 	currentTier,
+	upgradeUrl,
 }: {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	onClick: ( event: any ) => void;
 	type: string;
 	placement?: string;
 	currentTier?: TierProp;
+	upgradeUrl: string;
 } ) {
 	const { tracks } = useAnalytics();
 
@@ -61,7 +63,7 @@ export default function Upgrade( {
 		requestLimit === 20 ? freeLimitUpgradePrompt : tierLimitUpgradePrompt,
 		{
 			strong: <strong />,
-			button: <Button variant="link" onClick={ handleClick } />,
+			button: <Button variant="link" onClick={ handleClick } href={ upgradeUrl } target="_blank" />,
 		}
 	);
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/upgrade.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/upgrade.tsx
@@ -18,7 +18,7 @@ export default function Upgrade( {
 	upgradeUrl,
 }: {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	onClick: ( event: any ) => void;
+	onClick?: ( event: any ) => void;
 	type: string;
 	placement?: string;
 	currentTier?: TierProp;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #37458.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add support for `upgradeUrl` on the sidebar upgrade link
* Set the `upgradeUrl` on the pre-publish panel upgrade link, so it opens a new tab

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a new site, open the editor and use all the 20 requests on it
   * Alternativelly, sandbox the `public-api` endpoint and fake the current usage so your site requires an upgrade
* Click on the "Publish" button so the pre-publish sidebar will show up:

<img width="250" alt="Screenshot 2024-05-29 at 18 36 33" src="https://github.com/Automattic/jetpack/assets/6760046/2abbae08-d317-4026-a5d2-a2b5536e2a82">

* Look for the AI Assistant section; you will see an upgrade link on it

<img width="250" alt="Screenshot 2024-05-29 at 18 37 26" src="https://github.com/Automattic/jetpack/assets/6760046/22884cf4-a922-499d-bd91-a125604b2f5d">

* Confirm the upgrade button will open on a new tab when clicked