### PR TITLE
AI Assistant: Fallback to transformation when multiple blocks are selected

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-multi-block
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-inline-extension-multi-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Fallback to transformation when multiple blocks are selected

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -27,7 +27,7 @@ export const isAiAssistantExtensionsSupportEnabled = getFeatureAvailability(
 );
 
 // The list of all extended blocks before the inline extensions were released. Does not include the list-item block.
-const ALL_EXTENDED_BLOCKS = [ 'core/paragraph', 'core/list', 'core/heading' ];
+export const ALL_EXTENDED_BLOCKS = [ 'core/paragraph', 'core/list', 'core/heading' ];
 
 // The blocks will be converted one by one to inline blocks, so we update the lists accordingly, under the feature flag.
 export let EXTENDED_TRANSFORMATIVE_BLOCKS: string[] = [ ...ALL_EXTENDED_BLOCKS ];

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-transform-to-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-transform-to-assistant/index.ts
@@ -1,0 +1,142 @@
+/*
+ * External dependencies
+ */
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from 'react';
+/*
+ * Internal dependencies
+ */
+import { ALL_EXTENDED_BLOCKS } from '../../extensions/ai-assistant';
+import { getStoreBlockId } from '../../extensions/ai-assistant/with-ai-assistant';
+import { getBlocksContent } from '../../lib/utils/block-content';
+import { transformToAIAssistantBlock } from '../../transforms';
+/*
+ * Types
+ */
+import type { AiAssistantDropdownOnChangeOptionsArgProps } from '../../components/ai-assistant-toolbar-dropdown/dropdown-content';
+import type { PromptTypeProp } from '../../lib/prompt';
+import type { Block } from '@automattic/jetpack-ai-client';
+
+type CoreBlockEditorDispatch = {
+	insertBlock: ( block: Block ) => void;
+	removeBlocks: ( clientIds: string[] ) => void;
+	replaceBlock: ( clientId: string, block: Block ) => void;
+};
+
+type CoreBlockEditorSelect = {
+	getBlock: ( clientId: string ) => Block;
+	getSelectedBlockClientIds: () => string[];
+	getBlocksByClientId: ( clientIds: string[] ) => Block[];
+	getBlockParents: ( clientId: string ) => string[];
+};
+
+const useTransformToAssistant = () => {
+	const { replaceBlock, removeBlocks } = useDispatch(
+		'core/block-editor'
+	) as CoreBlockEditorDispatch;
+	const blockEditorSelect: CoreBlockEditorSelect = useSelect(
+		select => select( 'core/block-editor' ),
+		[]
+	);
+	const { getSelectedBlockClientIds, getBlocksByClientId, getBlock, getBlockParents } =
+		blockEditorSelect;
+
+	const { tracks } = useAnalytics();
+
+	const canTransformToAIAssistant = useCallback(
+		( { clientId, blockName }: { clientId: string; blockName: string } ) => {
+			const block = getBlock( clientId );
+
+			// The block must exist
+			if ( ! block ) {
+				return false;
+			}
+
+			// The block must be an extended block
+			if ( ! ALL_EXTENDED_BLOCKS.includes( blockName ) ) {
+				return false;
+			}
+
+			// Checks if the block's parent is a list-item or list block, in which case a transformation is not allowed
+			const blockParents = getBlockParents( clientId );
+
+			if ( blockParents.length === 0 ) {
+				return true;
+			}
+
+			// The block parents array is ordered from the root block to the closest parent
+			const parentBlock = getBlock( blockParents[ blockParents.length - 1 ] );
+			const isInsideList = [ 'core/list', 'core/list-item' ].includes( parentBlock.name as string );
+
+			return ! isInsideList;
+		},
+		[ getBlock, getBlockParents ]
+	);
+
+	const transformToAIAssistant = useCallback(
+		( {
+			request,
+		}: {
+			request?: {
+				promptType: PromptTypeProp;
+				options?: AiAssistantDropdownOnChangeOptionsArgProps;
+			};
+		} = {} ) => {
+			const selectedBlockIds = getSelectedBlockClientIds();
+			const selectedBlocks = getBlocksByClientId( selectedBlockIds );
+
+			const content = getBlocksContent( selectedBlocks );
+
+			const [ firstBlock ] = selectedBlocks;
+			const [ firstClientId, ...otherBlocksIds ] = selectedBlockIds;
+
+			const extendedBlockAttributes = {
+				...( firstBlock?.attributes || {} ), // firstBlock.attributes should never be undefined, but still add a fallback
+				content,
+			};
+
+			const newAIAssistantBlock = transformToAIAssistantBlock(
+				firstBlock.name as string,
+				extendedBlockAttributes
+			);
+
+			// Store the client id of the block that needs to auto-trigger the AI Assistant request
+			if ( request?.promptType ) {
+				tracks.recordEvent( 'jetpack_editor_ai_assistant_extension_toolbar_button_click', {
+					suggestion: request.promptType,
+					block_type: firstBlock.name as string,
+				} );
+
+				// Store client id, prompt type, and options.
+				const storeObject = {
+					clientId: firstClientId,
+					type: request.promptType,
+					// When converted, the original content must be treated as generated
+					options: { ...request.options, contentType: 'generated', fromExtension: true },
+				};
+
+				localStorage.setItem(
+					getStoreBlockId( newAIAssistantBlock.clientId ),
+					JSON.stringify( storeObject )
+				);
+			} else {
+				tracks.recordEvent( 'jetpack_ai_assistant_prompt_show', {
+					block_type: firstBlock.name as string,
+				} );
+			}
+
+			replaceBlock( firstClientId, newAIAssistantBlock );
+			removeBlocks( otherBlocksIds );
+		},
+		[ getBlocksByClientId, getSelectedBlockClientIds, removeBlocks, replaceBlock, tracks ]
+	);
+
+	return {
+		canTransformToAIAssistant,
+		transformToAIAssistant,
+		getSelectedBlockClientIds,
+	};
+};
+
+export default useTransformToAssistant;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37631

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Transform to the AI Assistant block when multiple blocks are selected, except when that is not possible (list items)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add multiple paragraphs
* Select the paragraphs and use an extension action (Ask AI Assistant, Translate, etc.)
* Check that the block is transformed as it was before
* Use an action in a single paragraph
* Check that the inline extension is used instead
* Group multiple paragraphs inside another block, like a Group
* Check that both cases again
* Check single and multiple headers
* Check that Lists and List Items work as expected
* Check that when multiple List Items are selected, only the first one is acted upon, since a List cannot have an AI Assistant as child

Note: Multiple Lists are merged into a single list because Markdown does not differentiate two consecutive lists from a single one. That issue was already the case before.


https://github.com/Automattic/jetpack/assets/8486249/4ce69a94-52be-4d74-b7c0-98400641166e

