### PR TITLE
Fix/ newsletter from name site setting endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-from-name-site-setting-endpoint
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-from-name-site-setting-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: this is a bug fix that hasn't shipped to end users yet
+
+

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -466,6 +466,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'wpcom_reader_views_enabled'       => (bool) get_option( 'wpcom_reader_views_enabled', true ),
 						'wpcom_subscription_emails_use_excerpt' => $this->get_wpcom_subscription_emails_use_excerpt_option(),
 						'jetpack_subscriptions_reply_to'   => (string) $this->get_subscriptions_reply_to_option(),
+						'jetpack_subscriptions_from_name'  => (string) get_option( 'jetpack_subscriptions_from_name' ),
 						'show_on_front'                    => (string) get_option( 'show_on_front' ),
 						'page_on_front'                    => (string) get_option( 'page_on_front' ),
 						'page_for_posts'                   => (string) get_option( 'page_for_posts' ),


### PR DESCRIPTION
## Proposed changes:
* This PR is needed to make saving of the new `jetpack_subscriptions_from_name` option work as expected for .com sites. 


### Other information:

This was discoed while developing https://github.com/Automattic/wp-calypso/pull/91216 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Apply this patch to .com 
Notice that once you run https://github.com/Automattic/wp-calypso/pull/91216  it works as expected.
