### PR TITLE
Add checks for empty array elements to `hide_parent_of_hidden_submenus`

### DIFF
--- a/projects/plugins/jetpack/changelog/try-fix-pages-loop
+++ b/projects/plugins/jetpack/changelog/try-fix-pages-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix looping API bug on Posts page

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-base-admin-menu.php
@@ -503,15 +503,20 @@ abstract class Base_Admin_Menu {
 		foreach ( $menu as $menu_index => $menu_item ) {
 			$has_submenus = isset( $submenu[ $menu_item[2] ] );
 
-			// Skip if the menu doesn't have submenus.
+			// Skip if the menu doesn't have submenus or the submenu is not an array.
 			if ( ! $has_submenus || ! is_array( $submenu[ $menu_item[2] ] ) ) {
+				continue;
+			}
+
+			$submenu_items = array_values( $submenu[ $menu_item[2] ] );
+			if ( empty( $submenu_items ) ) {
 				continue;
 			}
 
 			// If the first submenu item is hidden then we should also hide the parent.
 			// Since the submenus are ordered by self::HIDE_CSS_CLASS (hidden submenus should be at the end of the array),
 			// we can say that if the first submenu is hidden then we should also hide the menu.
-			$first_submenu_item       = array_values( $submenu[ $menu_item[2] ] )[0];
+			$first_submenu_item       = $submenu_items[0];
 			$is_first_submenu_visible = $this->is_item_visible( $first_submenu_item );
 
 			// if the user does not have access to the menu and the first submenu is hidden, then hide the menu.
@@ -520,8 +525,8 @@ abstract class Base_Admin_Menu {
 				$menu[ $menu_index ][4] = self::HIDE_CSS_CLASS;
 			}
 
-			// if the menu has the same slug as the first submenu then hide the submenu.
-			if ( $menu_item[2] === $first_submenu_item[2] && ! $is_first_submenu_visible ) {
+			// If the menu has the same slug as the first submenu then hide the submenu.
+			if ( isset( $first_submenu_item[2] ) && $menu_item[2] === $first_submenu_item[2] && ! $is_first_submenu_visible ) {
 				// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				$menu[ $menu_index ][4] = self::HIDE_CSS_CLASS;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1716931381473209-slack-C029GN3KD

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds some defensive empty array element checks in the `hide_parent_of_hidden_submenus` function.
* ~~Subsequently, these checks prevent some edge case OOM errors on the `/sites/$site_id/posts` endpoint.~~ This probably is not true, but fixing these warnings is still worth addressing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to your sandbox and "sandbox" the API
* Switch to this user p1716931381473209-slack-C029GN3KD and go to the /pages/site_id page in Calypso 
* The page should load without issue
* For regression testing, go to /pages/site_id and /posts/site_id on several of your test sites and ensure they all work properly