### PR TITLE
Fix VS Code settings and its lints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true,
+		"source.fixAll.eslint": "always"
 	},
 	"files.exclude": {
 		"**/.cache/**": true,
@@ -12,7 +12,7 @@
 		"**/CVS/**": true,
 		"**/jetpack_vendor/**": true,
 		"**/node_modules/**": true,
-		"**/vendor/**": true,
+		"**/vendor/**": true
 	},
 	"intelephense.files.exclude": [
 		"**/.cache/**",
@@ -25,7 +25,7 @@
 		"**/packages/**/wordpress/**",
 		"**/projects/**/wordpress/**",
 		"**/plugins/**/wordpress/**",
-		"**/vendor/**",		
+		"**/vendor/**"
 	],
 	"phpCodeSniffer.autoExecutable": true,
 	"phpCodeSniffer.standard": "Automatic",
@@ -35,7 +35,7 @@
 		"**/.hg/**",
 		"**/.cache/**",
 		"**/jetpack_vendor/**",
-		"**/vendor/**",
+		"**/vendor/**"
 	],
 	"prettier.prettierPath": "tools/js-tools/node_modules/prettier/index.cjs"
 }


### PR DESCRIPTION
There are lints in `.vscode/settings.json` and I don't know how but those lints are fixed everytime I run `pnpm install` or switch branches and I have to discard it everytime and it's annoying.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix lints in VS Code settings

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Just check that ESLint etc. fixes the lints in VS Code

