### PR TITLE
Fix/from name newsletter styling

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/text-input/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/text-input/style.scss
@@ -12,7 +12,7 @@
 	padding: 7px 14px;
 	width: 100%;
 	color: $gray-dark;
-	font-size: 14px;
+	font-size: 1rem;
 	line-height: 1.5;
 	border: 1px solid lighten( $gray, 20% );
 	background-color: $white;

--- a/projects/plugins/jetpack/changelog/fix-from-name-newsletter
+++ b/projects/plugins/jetpack/changelog/fix-from-name-newsletter
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Minor fix to admin ui.
+
+


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/37641

## Proposed changes:
* Update the input font-size to match the button. So that you can place input and button next to each other. 

Before:
<img width="503" alt="Screenshot 2024-05-30 at 1 16 33 PM" src="https://github.com/Automattic/jetpack/assets/115071/69b0991f-c071-42e3-a8f4-63b8f0b60f81">


After:
<img width="533" alt="Screenshot 2024-05-30 at 1 16 11 PM" src="https://github.com/Automattic/jetpack/assets/115071/725a1bcd-eb36-47c9-9584-3f505495606c">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Use chrome and navigate to 
/wp-admin/admin.php?page=jetpack#/newsletter 
Notice that the input is aligned to the button. 

* Go to '..'
*

