### PR TITLE
Improve get_revisions performance

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-get_revisions-performance
+++ b/projects/plugins/jetpack/changelog/improve-get_revisions-performance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Improve performance of get_revisions function

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -359,7 +359,7 @@ abstract class SAL_Post {
 	}
 
 	/**
-	 * Returns an array with details of the posts revisions, or false if 'edit' isn't the current post request context.
+	 * Returns an array with post revision ids, or false if 'edit' isn't the current post request context.
 	 *
 	 * @return bool|array
 	 */
@@ -368,14 +368,16 @@ abstract class SAL_Post {
 			return false;
 		}
 
-		$revisions      = array();
-		$post_revisions = wp_get_post_revisions( $this->post->ID );
+		$args = array(
+			'posts_per_page' => -1,
+			'post_type'      => 'revision',
+			'post_status'    => 'any',
+			'fields'         => 'ids',  // Fetch only the IDs.
+			'post_parent'    => $this->post->ID,
+		);
 
-		foreach ( $post_revisions as $_post ) {
-			$revisions[] = $_post->ID;
-		}
-
-		return $revisions;
+		$revision_query = new WP_Query( $args );
+		return $revision_query->posts;  // This returns an array of revision IDs.
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1716931381473209-slack-C029GN3KD

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the `get_revisions` function to use `WP_Query` to query the DB directly for the revision IDs rather than using `wp_get_post_revisions` (which returns detailed revision data) and looping over it to filter for the IDs.
* This improves the efficiency of the `get_revisions` function for posts with lots of revision data.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test our user's broken /pages/[site] p1716931381473209-slack-C029GN3KD
* Apply this PR to your sandbox and Sandbox the API
* Log in as User
* View their /pages/[site] page. It should load fine.

Test for regressions
* Using https://developer.wordpress.com/docs/api/console/
* Using this query `/sites/[site_id]/posts?http_envelope=1&number=50&search=&author=&status=publish%2Cprivate&type=page&context=edit&page=1`
* The raw JSON data on this PR should be identical to what is in production on any site you test.