### PR TITLE
Required Review Action: omit author from reviewer assignment

### DIFF
--- a/projects/github-actions/required-review/changelog/required-review-skip-author
+++ b/projects/github-actions/required-review/changelog/required-review-skip-author
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Don't request review from the PR author.

--- a/projects/github-actions/required-review/src/request-review.js
+++ b/projects/github-actions/required-review/src/request-review.js
@@ -11,10 +11,10 @@ async function requestReviewer( teams ) {
 	const owner = github.context.payload.repository.owner.login;
 	const repo = github.context.payload.repository.name;
 	const pr = github.context.payload.pull_request.number;
-	const author = `@${github.context.payload.pull_request.user.login}`;
-	if (teams.includes(author)) {
-		core.info( `Skipping review for author ${author}` );
-		teams = teams.filter(team => team !== author);
+	const author = `@${ github.context.payload.pull_request.user.login }`;
+	if ( teams.includes( author ) ) {
+		core.info( `Skipping review for author ${ author }` );
+		teams = teams.filter( team => team !== author );
 	}
 
 	const userReviews = [];

--- a/projects/github-actions/required-review/src/request-review.js
+++ b/projects/github-actions/required-review/src/request-review.js
@@ -11,6 +11,11 @@ async function requestReviewer( teams ) {
 	const owner = github.context.payload.repository.owner.login;
 	const repo = github.context.payload.repository.name;
 	const pr = github.context.payload.pull_request.number;
+	const author = `@${github.context.payload.pull_request.user.login}`;
+	if (teams.includes(author)) {
+		core.info( `Skipping review for author ${author}` );
+		teams = teams.filter(team => team !== author);
+	}
 
 	const userReviews = [];
 	const teamReviews = [];


### PR DESCRIPTION
Fixes #37637

## Proposed changes:
This PR fixes a bug where the required-review action would attempt to add the PR author as a reviewer if a matching rule was hit, however this is no longer allowed by GitHub and would result in the error `Review cannot be requested from pull request author.`. To avoid this, if computed reviewers list includes the PR author, a message is logged and they are filtered out of the list.

### Other information:
I was able to test [this fix](https://github.com/evan-gray/action-required-review/commit/b9211195785c8ccfdfe7bd66acc224861a54f082) on [an action](https://github.com/wormholelabs-xyz/required-review-test/blob/7c33319838538a68f4d0181a906924d5764e5096/.github/workflows/required-review.yml#L26) of an example repo [here](https://github.com/wormholelabs-xyz/required-review-test/actions/runs/9303357881/job/25605478528?pr=2).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Create a new repo
* Configure the `Automattic/action-required-review` action with `request-reviews: true`.
* Make a PR where the author is also a required reviewer as defined in the action config.
* The action should fail.
* On the default branch, change the action to `evan-gray/action-required-review@b9211195785c8ccfdfe7bd66acc224861a54f082` (which includes a compiled version of this change) and rebase the PR.
* The action should succeed and skip the author.
