### PR TITLE
IDC: remove dev dependency from packages

### DIFF
--- a/projects/packages/config/changelog/delete-idc-dependency-from-packages
+++ b/projects/packages/config/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove the Identity Crisis package dev dependency.

--- a/projects/packages/config/composer.json
+++ b/projects/packages/config/composer.json
@@ -9,7 +9,6 @@
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-connection": "@dev",
-		"automattic/jetpack-identity-crisis": "@dev",
 		"automattic/jetpack-import": "@dev",
 		"automattic/jetpack-jitm": "@dev",
 		"automattic/jetpack-post-list": "@dev",

--- a/projects/packages/status/changelog/delete-idc-dependency-from-packages
+++ b/projects/packages/status/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove the Identity Crisis dev dependency.

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -12,7 +12,6 @@
 		"yoast/phpunit-polyfills": "1.1.0",
 		"automattic/jetpack-changelogger": "@dev",
 		"automattic/jetpack-connection": "@dev",
-		"automattic/jetpack-identity-crisis": "@dev",
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-ip": "@dev"
 	},

--- a/projects/plugins/automattic-for-agencies-client/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/automattic-for-agencies-client/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -311,7 +311,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+                "reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
             },
             "require": {
                 "php": ">=7.0"
@@ -319,7 +319,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-post-list": "@dev",
@@ -803,7 +802,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+                "reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -812,7 +811,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "brain/monkey": "2.6.1",

--- a/projects/plugins/backup/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/backup/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -593,7 +593,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+                "reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
             },
             "require": {
                 "php": ">=7.0"
@@ -601,7 +601,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-post-list": "@dev",
@@ -1467,7 +1466,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+                "reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1476,7 +1475,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "brain/monkey": "2.6.1",

--- a/projects/plugins/boost/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/boost/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -449,7 +449,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+                "reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
             },
             "require": {
                 "php": ">=7.0"
@@ -457,7 +457,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-post-list": "@dev",
@@ -1451,7 +1450,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+                "reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1460,7 +1459,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "brain/monkey": "2.6.1",

--- a/projects/plugins/classic-theme-helper-plugin/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -317,7 +317,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+                "reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
             },
             "require": {
                 "php": ">=7.0"
@@ -325,7 +325,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-post-list": "@dev",
@@ -495,7 +494,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+                "reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -504,7 +503,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "brain/monkey": "2.6.1",

--- a/projects/plugins/inspect/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/inspect/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -311,7 +311,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+                "reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
             },
             "require": {
                 "php": ">=7.0"
@@ -319,7 +319,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-post-list": "@dev",
@@ -625,7 +624,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+                "reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -634,7 +633,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "brain/monkey": "2.6.1",

--- a/projects/plugins/jetpack/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/jetpack/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -888,7 +888,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/config",
-				"reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+				"reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
 			},
 			"require": {
 				"php": ">=7.0"
@@ -896,7 +896,6 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-connection": "@dev",
-				"automattic/jetpack-identity-crisis": "@dev",
 				"automattic/jetpack-import": "@dev",
 				"automattic/jetpack-jitm": "@dev",
 				"automattic/jetpack-post-list": "@dev",
@@ -2502,7 +2501,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/status",
-				"reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+				"reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
 			},
 			"require": {
 				"automattic/jetpack-constants": "@dev",
@@ -2511,7 +2510,6 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-connection": "@dev",
-				"automattic/jetpack-identity-crisis": "@dev",
 				"automattic/jetpack-ip": "@dev",
 				"automattic/jetpack-plans": "@dev",
 				"brain/monkey": "2.6.1",

--- a/projects/plugins/migration/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/migration/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -593,7 +593,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+                "reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
             },
             "require": {
                 "php": ">=7.0"
@@ -601,7 +601,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-post-list": "@dev",
@@ -1467,7 +1466,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+                "reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1476,7 +1475,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "brain/monkey": "2.6.1",

--- a/projects/plugins/mu-wpcom-plugin/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/mu-wpcom-plugin/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1217,7 +1217,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+                "reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1226,7 +1226,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "brain/monkey": "2.6.1",

--- a/projects/plugins/protect/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/protect/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -506,7 +506,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+                "reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
             },
             "require": {
                 "php": ">=7.0"
@@ -514,7 +514,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-post-list": "@dev",
@@ -1380,7 +1379,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+                "reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1389,7 +1388,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "brain/monkey": "2.6.1",

--- a/projects/plugins/search/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/search/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -449,7 +449,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+                "reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
             },
             "require": {
                 "php": ">=7.0"
@@ -457,7 +457,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-post-list": "@dev",
@@ -1472,7 +1471,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+                "reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1481,7 +1480,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "brain/monkey": "2.6.1",

--- a/projects/plugins/social/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/social/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -449,7 +449,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/config",
-				"reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+				"reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
 			},
 			"require": {
 				"php": ">=7.0"
@@ -457,7 +457,6 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-connection": "@dev",
-				"automattic/jetpack-identity-crisis": "@dev",
 				"automattic/jetpack-import": "@dev",
 				"automattic/jetpack-jitm": "@dev",
 				"automattic/jetpack-post-list": "@dev",
@@ -1462,7 +1461,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/status",
-				"reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+				"reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
 			},
 			"require": {
 				"automattic/jetpack-constants": "@dev",
@@ -1471,7 +1470,6 @@
 			"require-dev": {
 				"automattic/jetpack-changelogger": "@dev",
 				"automattic/jetpack-connection": "@dev",
-				"automattic/jetpack-identity-crisis": "@dev",
 				"automattic/jetpack-ip": "@dev",
 				"automattic/jetpack-plans": "@dev",
 				"brain/monkey": "2.6.1",

--- a/projects/plugins/starter-plugin/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/starter-plugin/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -449,7 +449,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+                "reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
             },
             "require": {
                 "php": ">=7.0"
@@ -457,7 +457,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-post-list": "@dev",
@@ -1323,7 +1322,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+                "reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1332,7 +1331,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "brain/monkey": "2.6.1",

--- a/projects/plugins/videopress/changelog/delete-idc-dependency-from-packages
+++ b/projects/plugins/videopress/changelog/delete-idc-dependency-from-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -449,7 +449,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "f465e7cdeb06c75b52922d05fc5c17f7d7686a0e"
+                "reference": "e4416daf21b3fe496a53235342255bcf0cb8faa4"
             },
             "require": {
                 "php": ">=7.0"
@@ -457,7 +457,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
                 "automattic/jetpack-post-list": "@dev",
@@ -1323,7 +1322,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "aa6dffdf02a0285b3ce1632c4fe211693f4e79fe"
+                "reference": "69718826f522bd13aee8e82fa6276c992fb13fe9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1332,7 +1331,6 @@
             "require-dev": {
                 "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-identity-crisis": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
                 "brain/monkey": "2.6.1",


### PR DESCRIPTION
## Proposed changes:
* Remove IDC package dev dependency from `config` and `status` packages.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/262

## Does this pull request change what data or activity we track or use?
Make sure the checks pass.