### PR TITLE
Boost: Update critical css errors UI

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/error-description/error-description.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/error-description/error-description.tsx
@@ -1,21 +1,13 @@
 import classNames from 'classnames';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import {
-	describeErrorSet,
-	suggestion,
-	rawError,
-} from '../lib/describe-critical-css-recommendations';
-import actionLinkInterpolateVar from '$lib/utils/action-link-interpolate-var';
-import { type InterpolateVars } from '$lib/utils/interplate-vars-types';
-import supportLinkInterpolateVar from '$lib/utils/support-link-interpolate-var';
+import { describeErrorSet, rawError } from '../lib/describe-critical-css-recommendations';
 import FoldingElement from '../folding-element/folding-element';
 import MoreList from '../more-list/more-list';
 import styles from './error-description.module.scss';
 import Suggestion from '../suggestion/suggestion';
 import { CriticalCssErrorDescriptionTypes, FormattedURL } from './types';
-import { useRegenerateCriticalCssAction } from '../lib/stores/critical-css-state';
-import { useNavigate } from 'react-router-dom';
+import getCriticalCssErrorSetInterpolateVars from '$lib/utils/get-critical-css-error-set-interpolate-vars';
 
 /**
  * Remove GET parameters that are used to cache-bust from display URLs, as they add visible noise
@@ -23,7 +15,7 @@ import { useNavigate } from 'react-router-dom';
  *
  * @param url The URL to strip cache parameters from.
  */
-function stripCacheParams( url: string ): string {
+export function stripCacheParams( url: string ): string {
 	const urlObj = new URL( url );
 	urlObj.searchParams.delete( 'donotcachepage' );
 	return urlObj.toString();
@@ -49,26 +41,7 @@ const CriticalCssErrorDescription: React.FC< CriticalCssErrorDescriptionTypes > 
 	} );
 
 	const rawErrors = rawError( errorSet );
-	const regenerateAction = useRegenerateCriticalCssAction();
-	const navigate = useNavigate();
-
-	function retry() {
-		regenerateAction.mutate();
-		navigate( '/' );
-	}
-
-	const intepolateVars: InterpolateVars = {
-		...actionLinkInterpolateVar( retry, 'retry' ),
-		...supportLinkInterpolateVar(),
-		b: <b />,
-	};
-
-	if ( 'listLink' in suggestion( errorSet ) ) {
-		intepolateVars.link = (
-			// eslint-disable-next-line jsx-a11y/anchor-has-content
-			<a href={ suggestion( errorSet ).listLink } target="_blank" rel="noreferrer" />
-		);
-	}
+	const intepolateVars = getCriticalCssErrorSetInterpolateVars( errorSet );
 
 	return (
 		<div className={ styles[ 'error-description' ] }>

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/folding-element/folding-element.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/folding-element/folding-element.module.scss
@@ -2,7 +2,6 @@
 	&.foldable-element-control {
 		color: var( --primary-black );
 		font-size: 16px;
-		margin-bottom: 24px;
 	}
 }
 
@@ -27,6 +26,16 @@
 	animation-name: fadeIn;
 }
 
-.expanded {
-	margin-bottom: 24px;
+.expanded p {
+	padding-top: 1em;
+	padding-bottom: 1em;
+	margin: 0 !important;
+}
+
+.expanded p:last-child {
+	padding-bottom: 0;
+}
+
+.foldable-element-control {
+	font-weight: 600;
 }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/folding-element/folding-element.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/folding-element/folding-element.tsx
@@ -2,6 +2,8 @@ import useMeasure from 'react-use-measure';
 import { animated, useSpring } from '@react-spring/web';
 import classNames from 'classnames';
 import { useState } from 'react';
+import ChevronDown from '$svg/chevron-down';
+import ChevronUp from '$svg/chevron-up';
 import styles from './folding-element.module.scss';
 
 type PropTypes = {
@@ -34,6 +36,7 @@ const FoldingElement: React.FC< PropTypes > = ( {
 				onClick={ () => setExpanded( ! expanded ) }
 			>
 				{ label }
+				{ expanded ? <ChevronUp /> : <ChevronDown /> }
 			</button>
 
 			<animated.div

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/generate-critical-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/generate-critical-css.ts
@@ -191,7 +191,7 @@ async function generateForKeys(
 		CriticalCSSGeneratorSchema.parse( CriticalCSSGenerator );
 	} catch ( err ) {
 		recordBoostEvent( 'critical_css_library_failure', {} );
-		throw new Error( 'Critical CSS Generator library is either not found or invalid.' );
+		throw new Error( 'css-gen-library-failure' );
 	}
 
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/numbered-list/numbered-list.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/numbered-list/numbered-list.module.scss
@@ -1,24 +1,31 @@
 .numbered-list {
 	list-style-type: none;
 	margin-left: 0;
+	margin: 0;
 
 	li {
-		margin-bottom: 0.5em;
+		margin-bottom: 1em;
 		display: flex;
 	}
 
+	li:last-child {
+		margin-bottom: 0;
+	}
+
 	.text {
-	  	flex: 1;
+		flex: 1;
+		line-height: 1.3em;
 	}
 
 	.index {
 		border: 1px solid #ccc;
 		border-radius: 50%;
 		display: block;
-		width: 1.5em;
-		height: 1.5em;
+		width: 1.4em;
+		height: 1.4em;
 		text-align: center;
-		line-height: 1.4em;
+		line-height: 1.3em;
+		font-size: 14px;
 		margin-right: 5px;
 	}
 }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
@@ -26,16 +26,6 @@ const ShowStopperError: React.FC< ShowStopperErrorTypes > = ( {
 	const primaryErrorSet = getPrimaryErrorSet( cssState );
 	const showLearnSection = primaryErrorSet && cssState.status === 'generated';
 
-	const firstTimeError = __(
-		'An unexpected error has occurred. As this error may be temporary, please try and refresh the Critical CSS.',
-		'jetpack-boost'
-	);
-
-	const secondTimeError = __(
-		"Hmm, looks like something went wrong. We're still seeing an unexpected error. Please reach out to our support to get help.",
-		'jetpack-boost'
-	);
-
 	return (
 		<>
 			<Notice
@@ -58,50 +48,12 @@ const ShowStopperError: React.FC< ShowStopperErrorTypes > = ( {
 						</FoldingElement>
 					</>
 				) : (
-					<>
-						{ cssState.status_error === 'css-gen-library-failure' ? (
-							<>
-								<p>
-									{ __(
-										'Critical CSS Generator library is either not found or invalid.',
-										'jetpack-boost'
-									) }
-								</p>
-								<DocumentationSection
-									message={ __(
-										'<link>Learn how</link> to fix this by visiting our documentation.',
-										'jetpack-boost'
-									) }
-									errorType={ cssState.status_error }
-								/>
-							</>
-						) : (
-							<>
-								<p>{ showRetry ? firstTimeError : secondTimeError }</p>
-								<p>
-									{ sprintf(
-										/* translators: %s: error message */
-										__( `Error: %s`, 'jetpack-boost' ),
-										cssState.status_error
-									) }
-								</p>
-								{ showRetry ? (
-									<button className="secondary" onClick={ retry }>
-										{ __( 'Refresh', 'jetpack-boost' ) }
-									</button>
-								) : (
-									<a
-										className="button button-secondary"
-										href={ supportLink }
-										target="_blank"
-										rel="noreferrer"
-									>
-										{ __( 'Contact Support', 'jetpack-boost' ) }
-									</a>
-								) }
-							</>
-						) }
-					</>
+					<OtherErrors
+						cssState={ cssState }
+						retry={ retry }
+						showRetry={ showRetry }
+						supportLink={ supportLink }
+					/>
 				) }
 			</Notice>
 		</>
@@ -163,6 +115,65 @@ const DocumentationSection = ( {
 				),
 			} ) }
 		</p>
+	);
+};
+
+const OtherErrors = ( { cssState, retry, showRetry, supportLink }: ShowStopperErrorTypes ) => {
+	const firstTimeError = __(
+		'An unexpected error has occurred. As this error may be temporary, please try and refresh the Critical CSS.',
+		'jetpack-boost'
+	);
+
+	const secondTimeError = __(
+		"Hmm, looks like something went wrong. We're still seeing an unexpected error. Please reach out to our support to get help.",
+		'jetpack-boost'
+	);
+
+	return (
+		<>
+			{ cssState.status_error === 'css-gen-library-failure' ? (
+				<>
+					<p>
+						{ __(
+							'Critical CSS Generator library is either not found or invalid.',
+							'jetpack-boost'
+						) }
+					</p>
+					<DocumentationSection
+						message={ __(
+							'<link>Learn how</link> to fix this by visiting our documentation.',
+							'jetpack-boost'
+						) }
+						errorType={ cssState.status_error }
+					/>
+				</>
+			) : (
+				<>
+					<p>{ showRetry ? firstTimeError : secondTimeError }</p>
+					<p>
+						{ sprintf(
+							/* translators: %s: error message */
+							__( `Error: %s`, 'jetpack-boost' ),
+							cssState.status_error
+						) }
+					</p>
+					{ showRetry ? (
+						<button className="secondary" onClick={ retry }>
+							{ __( 'Refresh', 'jetpack-boost' ) }
+						</button>
+					) : (
+						<a
+							className="button button-secondary"
+							href={ supportLink }
+							target="_blank"
+							rel="noreferrer"
+						>
+							{ __( 'Contact Support', 'jetpack-boost' ) }
+						</a>
+					) }
+				</>
+			) }
+		</>
 	);
 };
 

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import FoldingElement from '../folding-element/folding-element';
 import { ErrorSet, getPrimaryErrorSet } from '../lib/critical-css-errors';
 import { CriticalCssState } from '../lib/stores/critical-css-state-types';
@@ -78,6 +78,13 @@ const ShowStopperError: React.FC< ShowStopperErrorTypes > = ( {
 						) : (
 							<>
 								<p>{ showRetry ? firstTimeError : secondTimeError }</p>
+								<p>
+									{ sprintf(
+										/* translators: %s: error message */
+										__( `Error: %s`, 'jetpack-boost' ),
+										cssState.status_error
+									) }
+								</p>
 								{ showRetry ? (
 									<button className="secondary" onClick={ retry }>
 										{ __( 'Refresh', 'jetpack-boost' ) }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
@@ -1,9 +1,14 @@
 import { __ } from '@wordpress/i18n';
-import ErrorNotice from '$features/error-notice/error-notice';
 import FoldingElement from '../folding-element/folding-element';
-import ErrorDescription from '../error-description/error-description';
-import { getPrimaryErrorSet } from '../lib/critical-css-errors';
+import { ErrorSet, getPrimaryErrorSet } from '../lib/critical-css-errors';
 import { CriticalCssState } from '../lib/stores/critical-css-state-types';
+import { Notice } from '@automattic/jetpack-components';
+import { describeErrorSet, suggestion } from '../lib/describe-critical-css-recommendations';
+import { createInterpolateElement } from '@wordpress/element';
+import getSupportLinkCriticalCss from '$lib/utils/get-support-link-critical-css';
+import NumberedList from '../numbered-list/numbered-list';
+import getCriticalCssErrorSetInterpolateVars from '$lib/utils/get-critical-css-error-set-interpolate-vars';
+import formatErrorSetUrls from '$lib/utils/format-error-set-urls';
 
 type ShowStopperErrorTypes = {
 	supportLink?: string;
@@ -19,8 +24,7 @@ const ShowStopperError: React.FC< ShowStopperErrorTypes > = ( {
 	showRetry,
 } ) => {
 	const primaryErrorSet = getPrimaryErrorSet( cssState );
-	const showErrorDescription = primaryErrorSet && cssState.status === 'generated';
-	const showFoldingElement = showErrorDescription || cssState.status_error;
+	const showLearnSection = primaryErrorSet && cssState.status === 'generated';
 
 	const firstTimeError = __(
 		'An unexpected error has occurred. As this error may be temporary, please try and refresh the Critical CSS.',
@@ -33,47 +37,125 @@ const ShowStopperError: React.FC< ShowStopperErrorTypes > = ( {
 	);
 
 	return (
-		<ErrorNotice
-			title={ __( 'Failed to generate Critical CSS', 'jetpack-boost' ) }
-			variant="module"
-			actionButton={
-				showRetry ? (
-					<button className="secondary" onClick={ retry }>
-						{ __( 'Refresh', 'jetpack-boost' ) }
-					</button>
+		<>
+			<Notice
+				level="error"
+				title={ __( 'Failed to generate Critical CSS', 'jetpack-boost' ) }
+				hideCloseButton={ true }
+			>
+				{ showLearnSection ? (
+					<>
+						<Description errorSet={ primaryErrorSet } />
+						<FoldingElement
+							labelExpandedText={ __( 'Learn what to do', 'jetpack-boost' ) }
+							labelCollapsedText={ __( 'Learn what to do', 'jetpack-boost' ) }
+						>
+							<div className="raw-error">
+								<p>{ __( 'Please follow the troubleshooting steps below', 'jetpack-boost' ) }</p>
+								<Steps errorSet={ primaryErrorSet } />
+								<DocumentationSection errorType={ primaryErrorSet.type.toString() } />
+							</div>
+						</FoldingElement>
+					</>
 				) : (
-					<a
-						className="button button-secondary"
-						href={ supportLink }
-						target="_blank"
-						rel="noreferrer"
-					>
-						{ __( 'Contact Support', 'jetpack-boost' ) }
-					</a>
-				)
-			}
-		>
-			<p>{ showRetry ? firstTimeError : secondTimeError }</p>
-			{ showFoldingElement && (
-				<FoldingElement
-					labelExpandedText={ __( 'See error message', 'jetpack-boost' ) }
-					labelCollapsedText={ __( 'Hide error message', 'jetpack-boost' ) }
-				>
-					<div className="raw-error">
-						{ showErrorDescription ? (
-							<ErrorDescription
-								errorSet={ primaryErrorSet }
-								showSuggestion={ true }
-								showClosingParagraph={ false }
-								foldRawErrors={ false }
-							/>
+					<>
+						{ cssState.status_error === 'css-gen-library-failure' ? (
+							<>
+								<p>
+									{ __(
+										'Critical CSS Generator library is either not found or invalid.',
+										'jetpack-boost'
+									) }
+								</p>
+								<DocumentationSection
+									message={ __(
+										'<link>Learn how</link> to fix this by visiting our documentation.',
+										'jetpack-boost'
+									) }
+									errorType={ cssState.status_error }
+								/>
+							</>
 						) : (
-							cssState.status_error
+							<>
+								<p>{ showRetry ? firstTimeError : secondTimeError }</p>
+								{ showRetry ? (
+									<button className="secondary" onClick={ retry }>
+										{ __( 'Refresh', 'jetpack-boost' ) }
+									</button>
+								) : (
+									<a
+										className="button button-secondary"
+										href={ supportLink }
+										target="_blank"
+										rel="noreferrer"
+									>
+										{ __( 'Contact Support', 'jetpack-boost' ) }
+									</a>
+								) }
+							</>
 						) }
-					</div>
-				</FoldingElement>
-			) }
-		</ErrorNotice>
+					</>
+				) }
+			</Notice>
+		</>
+	);
+};
+
+const Description = ( { errorSet }: { errorSet: ErrorSet } ) => {
+	const displayUrls = formatErrorSetUrls( errorSet );
+
+	return (
+		<p>
+			{ createInterpolateElement( describeErrorSet( errorSet ), {
+				b: <b />,
+			} ) }{ ' ' }
+			{ displayUrls.map( ( { href, label }, index ) => (
+				<a href={ href } target="_blank" rel="noreferrer" key={ index }>
+					{ label }
+				</a>
+			) ) }
+		</p>
+	);
+};
+
+const Steps = ( { errorSet }: { errorSet: ErrorSet } ) => {
+	const details = suggestion( errorSet );
+	if ( ! details.list ) {
+		return null;
+	}
+
+	const interpolateVars = getCriticalCssErrorSetInterpolateVars( errorSet );
+
+	return <NumberedList items={ details.list } interpolateVars={ interpolateVars } />;
+};
+
+const DocumentationSection = ( {
+	message,
+	errorType,
+}: {
+	message?: string;
+	errorType: string;
+} ) => {
+	if ( message === undefined ) {
+		message = __(
+			'If you are still experiencing this issue, <link>learn more</link> from our documentation.',
+			'jetpack-boost'
+		);
+	}
+
+	return (
+		<p>
+			{ createInterpolateElement( message, {
+				link: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a
+						href={ getSupportLinkCriticalCss( errorType ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			} ) }
+		</p>
 	);
 };
 

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
@@ -9,6 +9,7 @@ import getSupportLinkCriticalCss from '$lib/utils/get-support-link-critical-css'
 import NumberedList from '../numbered-list/numbered-list';
 import getCriticalCssErrorSetInterpolateVars from '$lib/utils/get-critical-css-error-set-interpolate-vars';
 import formatErrorSetUrls from '$lib/utils/format-error-set-urls';
+import actionLinkInterpolateVar from '$lib/utils/action-link-interpolate-var';
 
 type ShowStopperErrorTypes = {
 	supportLink?: string;
@@ -146,6 +147,17 @@ const OtherErrors = ( { cssState, retry, showRetry, supportLink }: ShowStopperEr
 						) }
 						errorType={ cssState.status_error }
 					/>
+					<p>
+						{ createInterpolateElement(
+							__(
+								'If the problem has been resolved, refresh the page and click <retry>here</retry> to try regenerating critical css.',
+								'jetpack-boost'
+							),
+							{
+								...actionLinkInterpolateVar( retry, 'retry' ),
+							}
+						) }
+					</p>
 				</>
 			) : (
 				<>

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/format-error-set-urls.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/format-error-set-urls.ts
@@ -1,0 +1,18 @@
+import { stripCacheParams } from '$features/critical-css/error-description/error-description';
+import { FormattedURL } from '$features/critical-css/error-description/types';
+import { ErrorSet } from '$features/critical-css/lib/critical-css-errors';
+
+function formatErrorSetUrls( errorSet: ErrorSet ): FormattedURL[] {
+	return Object.entries( errorSet.byUrl ).map( ( [ url, error ] ) => {
+		let href = url;
+		if ( error.meta.url && typeof error.meta.url === 'string' ) {
+			href = error.meta.url;
+		}
+		return {
+			href,
+			label: stripCacheParams( url ),
+		};
+	} );
+}
+
+export default formatErrorSetUrls;

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/get-critical-css-error-set-interpolate-vars.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/get-critical-css-error-set-interpolate-vars.tsx
@@ -1,0 +1,34 @@
+import { useNavigate } from 'react-router-dom';
+import actionLinkInterpolateVar from '$lib/utils/action-link-interpolate-var';
+import { InterpolateVars } from '$lib/utils/interplate-vars-types';
+import supportLinkInterpolateVar from '$lib/utils/support-link-interpolate-var';
+import { useRegenerateCriticalCssAction } from '$features/critical-css/lib/stores/critical-css-state';
+import { suggestion } from '$features/critical-css/lib/describe-critical-css-recommendations';
+import { ErrorSet } from '$features/critical-css/lib/critical-css-errors';
+
+function getCriticalCssErrorSetInterpolateVars( errorSet: ErrorSet ) {
+	const regenerateAction = useRegenerateCriticalCssAction();
+	const navigate = useNavigate();
+
+	function retry() {
+		regenerateAction.mutate();
+		navigate( '/' );
+	}
+
+	const interpolateVars: InterpolateVars = {
+		...actionLinkInterpolateVar( retry, 'retry' ),
+		...supportLinkInterpolateVar(),
+		b: <b />,
+	};
+
+	if ( 'listLink' in suggestion( errorSet ) ) {
+		interpolateVars.link = (
+			// eslint-disable-next-line jsx-a11y/anchor-has-content
+			<a href={ suggestion( errorSet ).listLink } target="_blank" rel="noreferrer" />
+		);
+	}
+
+	return interpolateVars;
+}
+
+export default getCriticalCssErrorSetInterpolateVars;

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/get-support-link-critical-css.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/get-support-link-critical-css.ts
@@ -1,0 +1,24 @@
+function getPrettyError( error: string ) {
+	const errorMap: { [ key: string ]: string } = {
+		SuccessTargetError: 'success-target-error',
+		UrlError: 'url-error',
+		HttpError: 'http-error',
+		UnknownError: 'unknown-error',
+		CrossDomainError: 'cross-domain-error',
+		LoadTimeoutError: 'load-timeout-error',
+		RedirectError: 'redirect-error',
+		UrlVerifyError: 'url-verify-error',
+		EmptyCSSError: 'empty-css-error',
+		XFrameDenyError: 'x-frame-deny-error',
+	};
+
+	return errorMap[ error as keyof typeof errorMap ] || error;
+}
+
+function getSupportLinkCriticalCss( errorType: string ) {
+	return `https://jetpack.com/support/jetpack-boost/troubleshooting-critical-css-issues/#${ getPrettyError(
+		errorType
+	) }`;
+}
+
+export default getSupportLinkCriticalCss;

--- a/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.module.scss
@@ -18,7 +18,7 @@
 	position: relative;
 	border: 1px solid $gray_5;
 	border-radius: 4px;
-	padding: 24px 69px 0 27px;
+	padding: 24px 69px 24px 27px;
 
 	li {
 		@include word-wrap();

--- a/projects/plugins/boost/app/assets/src/js/svg/chevron-up.tsx
+++ b/projects/plugins/boost/app/assets/src/js/svg/chevron-up.tsx
@@ -11,7 +11,7 @@ const ChevronUp = () => (
 			/>
 		</mask>
 		<g mask="url(#mask0_4507_36473)">
-			<rect width="16" height="16" fill="#069E08" />
+			<rect width="16" height="16" fill="none" />
 		</g>
 	</svg>
 );

--- a/projects/plugins/boost/changelog/update-critical-css-error-ui
+++ b/projects/plugins/boost/changelog/update-critical-css-error-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Critical CSS: Improve UI when errors are present.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #37092, https://github.com/Automattic/boost-cloud/issues/457.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the "show stopper" UI to match proposed designs in pc9hqz-2SV-p2. Final version is here - pc9hqz-2SV-p2#comment-2128.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pc9hqz-2SV-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost free;
* Test CSS generation to make sure it works;
* Break css generation via the snippet below to see the updated UI.

```php
<?php

add_action( 'template_redirect', function () {
	exit;
} );
```