### PR TITLE
Fix docker stuff for new mariadb:lts

### DIFF
--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -198,7 +198,7 @@ jobs:
           MARIADB_ROOT_PASSWORD: wordpress
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        options: --health-cmd="healthcheck.sh --su-mysql --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=5
     container:
       image: ghcr.io/automattic/jetpack-wordpress-dev:latest
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,12 +31,12 @@ jobs:
     needs: create-matrix
     services:
       database:
-        image: mysql:5.6
+        image: mariadb:10.4
         env:
-          MYSQL_ROOT_PASSWORD: root
+          MARIADB_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        options: --health-cmd="healthcheck.sh --su-mysql --connect --innodb_initialized" --health-interval=10s --health-timeout=5s --health-retries=5
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: ${{ matrix.timeout }}
     env:

--- a/tools/docker/bin/docker-db-start-and-autoupgrade.sh
+++ b/tools/docker/bin/docker-db-start-and-autoupgrade.sh
@@ -13,7 +13,7 @@ find /var/log/mysql \! -user mysql -exec chown mysql '{}' +
 	sleep 1
 
 	# Wait until server is up
-	while ! mysql $CREDENTIALS_PARAMS ${MYSQL_DATABASE} -e 'quit' > /dev/null 2>&1
+	while ! mariadb $CREDENTIALS_PARAMS ${MYSQL_DATABASE} -e 'quit' > /dev/null 2>&1
 	do
 		# Let's wait a bit before retrying
 		echo "Auto-updater waiting for DB to be up..."
@@ -22,7 +22,7 @@ find /var/log/mysql \! -user mysql -exec chown mysql '{}' +
 
 	echo "Trying to upgrade database..."
 
-	mysql_upgrade $CREDENTIALS_PARAMS
+	mariadb-upgrade $CREDENTIALS_PARAMS
 ) &
 
 # Start the actual database

--- a/tools/docker/docker-compose.yml
+++ b/tools/docker/docker-compose.yml
@@ -5,8 +5,8 @@ volumes:
   dockerdirectory:
 
 services:
-  ## A default mysql image
-  ## We map a local directory (data/mysql) so we can have the mysql data locally
+  ## A default mariadb image
+  ## We map a local directory (data/mysql) so we can have the data locally
   ## and reuse it if we need to remove containers and images for rebuilding from scratch.
   db:
     image: mariadb:lts
@@ -19,7 +19,7 @@ services:
       - default.env
       - .env
     entrypoint: [ '/bin/bash', '/var/scripts/docker-db-start-and-autoupgrade.sh' ]
-    command: [ 'mysqld' ]
+    command: [ 'mariadbd' ]
 
   ## - The container wordpress is a very basic but custom container with WordPress and all of the tools we need
   ##   for development.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It seems that MariaDB released a new lts, which dropped a bunch of the compatibility mysql-named symlinks from their docker image. This broke a bunch of our stuff.

* Change the health command passed to Docker.
* Use new names in the dev env db upgrade wrapper script.
* Pass the correct `command` to the dev env DB container.

Also I noticed our tests workflow was still using MySQL 5.6, while WordPress now requires either MySQL 8.0+ or MariaDB 10.4+. Updated to the latter there too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1717161929313609/1717160529.942769-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Do a `docker pull mariadb:lts`, then make sure that `jetpack docker down` and `jetpack docker up` still work.
* CI happy? Especially Tests and E2E Tests.
  * [x] https://github.com/Automattic/jetpack/actions/runs/9319590833/job/25654503380?pr=37659#step:2:80
  * [x] https://github.com/Automattic/jetpack/actions/runs/9319590815/job/25654738059#step:9:418
* We'll probably have to merge this to test whether it makes the Post-Build workflow happy.