### PR TITLE
ci: Fix second fetch in monorepo autotagger

### DIFF
--- a/.github/workflows/autotagger.yml
+++ b/.github/workflows/autotagger.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Fetch tags, shallowly and blobless
         if: steps.get-tags.outputs.any == 'true'
         run: |
-          git fetch --depth=1 --filter=blob:none origin 'refs/tags/*:refs/tags/*'
+          git fetch --force --depth=1 --filter=blob:none origin 'refs/tags/*:refs/tags/*'
 
       - name: Tag projects
         if: steps.get-tags.outputs.any == 'true'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The monorepo autotagger fetches tags, determines if it needs to create any tags, then if so it waits for any competing runs to complete and then fetches tags again in case the competing run created some.

The problem happens if existing tags were _changed_, for example by the PR is up-to-date workflow updatinng its own tags. In that case the second fetch chokes with errors like
```
 ! [rejected]            pr-update-to-projects/js-packages/components -> pr-update-to-projects/js-packages/components  (would clobber existing tag)
```

To avoid this, pass `--force` to the second tag fetch.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1717103617272869-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷