### PR TITLE
SSO: Remove tabindex on tooltip modal

### DIFF
--- a/projects/packages/connection/changelog/fix-sso-tooltip_tweaks_on_user_page
+++ b/projects/packages/connection/changelog/fix-sso-tooltip_tweaks_on_user_page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove tabindex from tooltip modal.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.9.0';
+	const PACKAGE_VERSION = '2.9.1-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/sso/class-user-admin.php
+++ b/projects/packages/connection/src/sso/class-user-admin.php
@@ -1203,7 +1203,7 @@ class User_Admin {
 					'<span tabindex="0" role="tooltip" aria-label="%4$s: %3$s" class="jetpack-sso-invitation-tooltip-icon sso-disconnected-user">
 						<a href="%1$s" class="jetpack-sso-invitation sso-disconnected-user">%2$s</a>
 						<span class="sso-disconnected-user-icon dashicons dashicons-warning">
-							<span class="jetpack-sso-invitation-tooltip jetpack-sso-td-tooltip" tabindex="0">%3$s</span>
+							<span class="jetpack-sso-invitation-tooltip jetpack-sso-td-tooltip">%3$s</span>
 						</span>
 					</span>',
 					add_query_arg(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

SSO: Remove tabindex on tooltip modal

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Tab navigation is broken by the tooltip modal. Presumably this is because moving the tooltip modal out of the flow resets the tabindex. There's no reason for the modal to have a tabindex.

This removes an unneeded tabindex that interferes with accessibility in Firefox.

Reported in p8oabR-1wt-p2#comment-8039.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This only affects Firefox, but feel free to test in Chrome as well to ensure no regressions.

1. Ensure the SSO feature is enabled: `/wp-admin/admin.php?page=jetpack_modules`
2. Navigate to Users > All Users: `/wp-admin/users.php`
3. Add a few additional users who does not have SSO enabled. Ensure "Invite user to WordPress.com" is unticked or you won’t see the "Sent Invite" link and tooltip.
4. Press tab until "Send Invite" is selected. The tooltip should show.
5. Press tab again.

In `trunk` on Firefox, the tab index will be reset. There's no way to tab-navigate to the next "Send Invite" link.

In the `fix/sso/tooltip_tweaks_on_user_page`, one can tab to each "Send Invite" link.