### PR TITLE
Update/notification style

### DIFF
--- a/projects/plugins/jetpack/changelog/update-notification-style
+++ b/projects/plugins/jetpack/changelog/update-notification-style
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: This just changes the default color of an active icon background in masterbar
+
+

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/_core-overrides.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/_core-overrides.scss
@@ -24,9 +24,7 @@
 		color: $text-color !important;
 	}
 
-	#wpadminbar:not(.mobile) .ab-top-menu > li:not(#wp-admin-bar-ab-new-post):hover > .ab-item,
-	#wpadminbar #wp-admin-bar-notes.hover > .ab-item,
-	#wpadminbar #wp-admin-bar-notes.wpnt-show > .ab-item {
+	#wpadminbar:not(.mobile) .ab-top-menu > li:not(#wp-admin-bar-ab-new-post):hover > .ab-item {
 		background: $menu-submenu-background !important;
 	}
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/_core-overrides.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/_core-overrides.scss
@@ -24,10 +24,6 @@
 		color: $text-color !important;
 	}
 
-	#wpadminbar:not(.mobile) .ab-top-menu > li:not(#wp-admin-bar-ab-new-post):hover > .ab-item {
-		background: $menu-submenu-background !important;
-	}
-
 	/**
 	 * Site Switcher - Browse Sites button text & arrow
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Follow up to https://github.com/Automattic/jetpack/pull/37625

We removed a rule in code-D150145 that set the default notification background to white (when active). This PR will remove the rule that is setting it to black on Jetpack/atomic.

## Before

https://github.com/Automattic/jetpack/assets/5560595/ffd41b5c-ac80-4e3a-b10b-c1175bd33b44

## After



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This removes the override CSS rule that forces the notification icon to a color

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

