### PR TITLE
Update/purchase plan url if site is not connected

### DIFF
--- a/projects/packages/my-jetpack/_inc/constants.ts
+++ b/projects/packages/my-jetpack/_inc/constants.ts
@@ -1,5 +1,6 @@
 export const MY_JETPACK_MY_PLANS_MANAGE_SOURCE = 'my-jetpack-my-plans-manage';
 export const MY_JETPACK_MY_PLANS_PURCHASE_SOURCE = 'my-jetpack-my-plans-purchase';
+export const MY_JETPACK_MY_PLANS_PURCHASE_NO_SITE_SOURCE = 'my-jetpack-my-plans-purchase-no-site';
 export const MY_JETPACK_PRODUCT_CHECKOUT = 'my-jetpack-product-checkout';
 
 export const MyJetpackRoutes = {

--- a/projects/packages/my-jetpack/_inc/utils/get-purchase-plan-url.ts
+++ b/projects/packages/my-jetpack/_inc/utils/get-purchase-plan-url.ts
@@ -18,16 +18,17 @@ const getPurchasePlanUrl = () => {
 		lifecycleStats,
 	} = getMyJetpackWindowInitialState();
 
-	const { isSiteConnected } = lifecycleStats;
+	const { isSiteConnected, isUserConnected } = lifecycleStats;
 
-	// If site is not connected, we will send the user to the purchase page without a site in context.
-	const redirectID = isSiteConnected
-		? MY_JETPACK_MY_PLANS_PURCHASE_SOURCE
-		: MY_JETPACK_MY_PLANS_PURCHASE_NO_SITE_SOURCE;
+	// If site or user is not connected, we will send the user to the purchase page without a site in context.
+	const redirectID =
+		isSiteConnected && isUserConnected
+			? MY_JETPACK_MY_PLANS_PURCHASE_SOURCE
+			: MY_JETPACK_MY_PLANS_PURCHASE_NO_SITE_SOURCE;
 
 	const getUrlArgs = () => {
 		const query = myJetpackCheckoutUri ? `redirect_to=${ myJetpackCheckoutUri }` : null;
-		if ( ! isSiteConnected ) {
+		if ( ! isSiteConnected || ! isUserConnected ) {
 			return {
 				query,
 			};

--- a/projects/packages/my-jetpack/_inc/utils/get-purchase-plan-url.ts
+++ b/projects/packages/my-jetpack/_inc/utils/get-purchase-plan-url.ts
@@ -1,16 +1,45 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { MY_JETPACK_MY_PLANS_PURCHASE_SOURCE } from '../constants';
+import {
+	MY_JETPACK_MY_PLANS_PURCHASE_SOURCE,
+	MY_JETPACK_MY_PLANS_PURCHASE_NO_SITE_SOURCE,
+} from '../constants';
 import { getMyJetpackWindowInitialState } from '../data/utils/get-my-jetpack-window-state';
+
 /**
  * Return the redurect URL for purchasing a plan, according to the Jetpack redurects source.
  *
  * @returns {string}            the redirect URL
  */
 const getPurchasePlanUrl = () => {
-	const { siteSuffix: site = '', blogID, myJetpackCheckoutUri } = getMyJetpackWindowInitialState();
+	const {
+		siteSuffix: site = '',
+		blogID,
+		myJetpackCheckoutUri,
+		lifecycleStats,
+	} = getMyJetpackWindowInitialState();
 
-	const query = myJetpackCheckoutUri ? `redirect_to=${ myJetpackCheckoutUri }` : null;
-	return getRedirectUrl( MY_JETPACK_MY_PLANS_PURCHASE_SOURCE, { site: blogID ?? site, query } );
+	const { isSiteConnected } = lifecycleStats;
+
+	// If site is not connected, we will send the user to the purchase page without a site in context.
+	const redirectID = isSiteConnected
+		? MY_JETPACK_MY_PLANS_PURCHASE_SOURCE
+		: MY_JETPACK_MY_PLANS_PURCHASE_NO_SITE_SOURCE;
+
+	const getUrlArgs = () => {
+		const query = myJetpackCheckoutUri ? `redirect_to=${ myJetpackCheckoutUri }` : null;
+		if ( ! isSiteConnected ) {
+			return {
+				query,
+			};
+		}
+
+		return {
+			site: blogID ?? site,
+			query,
+		};
+	};
+
+	return getRedirectUrl( redirectID, getUrlArgs() );
 };
 
 export default getPurchasePlanUrl;

--- a/projects/packages/my-jetpack/changelog/update-purchase-plan-url-if-site-is-not-connected
+++ b/projects/packages/my-jetpack/changelog/update-purchase-plan-url-if-site-is-not-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Send user to siteless pricing page if site is not connected

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.24.3",
+	"version": "4.24.4-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.24.3';
+	const PACKAGE_VERSION = '4.24.4-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
## Proposed changes:

Currently, if the user or site is not connected, the user will be sent to a page to "pick their site" when they select a plan from the pricing page with a site in context. This leads to needing to click through 4 pages to reach checkout. This change sends the user to a siteless pricing page if the site or user is not connected so they'll be sent straight to checkout from the pricing page if they don't have a connected site

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack
3. With your site not connected, in the footer, click Purchase a Plan
4. Confirm you are sent to a siteless pricing page
![Screenshot 2024-05-31 at 12 42 07 PM](https://github.com/Automattic/jetpack/assets/65001528/c8ba3e1f-c8f5-4706-8f3b-31125f2b2073)
5. Select a product and confirm you are sent straight to a siteless checkout
![image](https://github.com/Automattic/jetpack/assets/65001528/d0136039-eba0-4c4f-9324-724f34750590)
6. Now go back to My Jetpack and connect your site/user and click on Purchase Plan again. Make sure you are sent to the pricing page with the site in context
![Screenshot 2024-05-31 at 12 46 41 PM](https://github.com/Automattic/jetpack/assets/65001528/408c9e0b-896f-4617-982b-8d60bf001f54)
7. Click on a product and make sure you are sent to a site-full checkout
![image](https://github.com/Automattic/jetpack/assets/65001528/3a90f9c6-8a04-470e-ab94-7a96a3e6235e)




