### PR TITLE
Social: Update the Classic Editor nudge

### DIFF
--- a/projects/packages/publicize/changelog/update-social-classic-editor-nudge
+++ b/projects/packages/publicize/changelog/update-social-classic-editor-nudge
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated the Classic Editor nudge

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -67,7 +67,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.45.x-dev"
+			"dev-trunk": "0.46.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.45.1-alpha",
+	"version": "0.46.0-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use Automattic\Jetpack\Redirect;
+
 /**
  * The class to configure and initialize the publicize package.
  */
@@ -42,6 +44,7 @@ class Publicize_Setup {
 		add_action( 'rest_api_init', array( new Connections_Post_Field(), 'register_fields' ), 5 );
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 		add_action( 'current_screen', array( static::class, 'init_sharing_limits' ) );
+		add_action( 'publicize_classic_editor_form_after', array( static::class, 'render_classic_editor_nudge' ), 11 );
 
 		add_action( 'rest_api_init', array( static::class, 'register_core_options' ) );
 		add_action( 'admin_init', array( static::class, 'register_core_options' ) );
@@ -68,6 +71,19 @@ class Publicize_Setup {
 	 */
 	public static function get_blog_id() {
 		return defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : \Jetpack_Options::get_option( 'id' );
+	}
+
+	/**
+	 * Get current URL.
+	 *
+	 * @return string Current URL.
+	 */
+	public static function get_current_url() {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$host = ! empty( $_SERVER['HTTP_HOST'] ) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : wp_parse_url( home_url(), PHP_URL_HOST );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$path = ! empty( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '/';
+		return esc_url_raw( ( is_ssl() ? 'https' : 'http' ) . '://' . $host . $path );
 	}
 
 	/**
@@ -99,7 +115,44 @@ class Publicize_Setup {
 		$connections      = $publicize->get_filtered_connection_data();
 		$shares_remaining = $info['shares_remaining'];
 
-		$share_limits = new Share_Limits( $connections, $shares_remaining, ! $current_screen->is_block_editor() );
+		$share_limits = new Share_Limits( $connections, $shares_remaining, ! $current_screen->is_block_editor(), self::get_current_url() );
 		$share_limits->enforce_share_limits();
+	}
+
+	/**
+	 * Render the classic editor nudge.
+	 */
+	public static function render_classic_editor_nudge() {
+		global $publicize;
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return;
+		}
+
+		if ( $publicize->has_paid_features() ) {
+			return;
+		}
+
+		$current_url = self::get_current_url();
+
+		$link = sprintf(
+			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+			Redirect::get_url(
+				'jetpack-social-basic-plan-block-editor',
+				array(
+					'query' => 'redirect_to=' . rawurlencode( $current_url ),
+				)
+			),
+			__( 'Unlock enhanced media sharing features.', 'jetpack-publicize-pkg' )
+		);
+
+		$kses_allowed_tags = array(
+			'a' => array(
+				'href'   => array(),
+				'target' => array(),
+			),
+		);
+
+		echo '<p><em>' . wp_kses( $link, $kses_allowed_tags ) . ' </em></p>';
 	}
 }

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -105,7 +105,7 @@ class Publicize_Setup {
 	/**
 	 * Initialise share limits if they should be enabled.
 	 *
-	 * @param WP_Screen $current_screen The current screen object.
+	 * @param \WP_Screen $current_screen The current screen object.
 	 */
 	public static function init_sharing_limits( $current_screen ) {
 		global $publicize;

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * The class to configure and initialize the publicize package.
@@ -97,9 +98,14 @@ class Publicize_Setup {
 
 		self::init_sharing_limits( $current_screen );
 
-		if ( ! $current_screen->is_block_editor() ) {
-			add_action( 'publicize_classic_editor_form_after', array( static::class, 'render_classic_editor_nudge' ), 11 );
+		$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$is_atomic_site = ( new Host() )->is_woa_site();
+
+		if ( $current_screen->is_block_editor() || $is_simple_site || $is_atomic_site ) {
+			return;
 		}
+
+		add_action( 'publicize_classic_editor_form_after', array( static::class, 'render_classic_editor_nudge' ), 11 );
 	}
 
 	/**
@@ -136,10 +142,6 @@ class Publicize_Setup {
 	 */
 	public static function render_classic_editor_nudge() {
 		global $publicize;
-
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			return;
-		}
 
 		if ( $publicize->has_paid_features() ) {
 			return;

--- a/projects/packages/publicize/src/class-share-limits.php
+++ b/projects/packages/publicize/src/class-share-limits.php
@@ -36,16 +36,25 @@ class Share_Limits {
 	public $is_classic_editor;
 
 	/**
+	 * Current URL.
+	 *
+	 * @var string
+	 */
+	public $current_url;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param array $connections List of Publicize connections.
-	 * @param int   $shares_remaining Number of shares remaining for this period.
-	 * @param bool  $is_classic_editor Whether we're loading the classic editor.
+	 * @param array  $connections List of Publicize connections.
+	 * @param int    $shares_remaining Number of shares remaining for this period.
+	 * @param bool   $is_classic_editor Whether we're loading the classic editor.
+	 * @param string $current_url Current URL.
 	 */
-	public function __construct( $connections, $shares_remaining, $is_classic_editor ) {
+	public function __construct( $connections, $shares_remaining, $is_classic_editor, $current_url = '' ) {
 		$this->connections       = $connections;
 		$this->shares_remaining  = $shares_remaining;
 		$this->is_classic_editor = $is_classic_editor;
+		$this->current_url       = $current_url;
 	}
 
 	/**
@@ -79,24 +88,10 @@ class Share_Limits {
 	}
 
 	/**
-	 * Get current URL.
-	 *
-	 * @return string Current URL.
-	 */
-	public function get_current_url() {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$host = ! empty( $_SERVER['HTTP_HOST'] ) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : wp_parse_url( home_url(), PHP_URL_HOST );
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$path = ! empty( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '/';
-		return esc_url_raw( ( is_ssl() ? 'https' : 'http' ) . '://' . $host . $path );
-	}
-
-	/**
 	 * Render a notice with the share count in the classic editor.
 	 */
 	public function render_classic_editor_notice() {
-		$current_url = $this->get_current_url();
-		$notice      = sprintf(
+		$notice = sprintf(
 			/* translators: %1$d: number of shares remaining, %2$s: link to upgrade the plan. */
 			_n(
 				'You currently have %1$d share remaining. <a href="%2$s" target="_blank">Upgrade</a> to get more.',
@@ -108,19 +103,9 @@ class Share_Limits {
 			Redirect::get_url(
 				'jetpack-social-basic-plan-classic-editor',
 				array(
-					'query' => 'redirect_to=' . rawurlencode( $current_url ),
+					'query' => 'redirect_to=' . rawurlencode( $this->current_url ),
 				)
 			)
-		);
-		$more_link = sprintf(
-			'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
-			Redirect::get_url(
-				'jetpack-social-basic-plan-block-editor',
-				array(
-					'query' => 'redirect_to=' . rawurlencode( $current_url ),
-				)
-			),
-			__( 'More about Jetpack Social', 'jetpack-publicize-pkg' )
 		);
 
 		$kses_allowed_tags = array(
@@ -130,7 +115,7 @@ class Share_Limits {
 			),
 		);
 
-		echo '<p><em>' . wp_kses( $notice, $kses_allowed_tags ) . '<br />' . wp_kses( $more_link, $kses_allowed_tags ) . ' </em></p>';
+		echo '<p><em>' . wp_kses( $notice, $kses_allowed_tags ) . ' </em></p>';
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-social-classic-editor-nudge
+++ b/projects/plugins/jetpack/changelog/update-social-classic-editor-nudge
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2102,7 +2102,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/publicize",
-				"reference": "aa81259deff0daab3082228052b5d74002c75a5f"
+				"reference": "c5a02ad97dc2231bc24d5196756cfc0e9d2ac70b"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -2130,7 +2130,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.45.x-dev"
+					"dev-trunk": "0.46.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/social/changelog/update-social-classic-editor-nudge
+++ b/projects/plugins/social/changelog/update-social-classic-editor-nudge
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1281,7 +1281,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/publicize",
-				"reference": "aa81259deff0daab3082228052b5d74002c75a5f"
+				"reference": "c5a02ad97dc2231bc24d5196756cfc0e9d2ac70b"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1309,7 +1309,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.45.x-dev"
+					"dev-trunk": "0.46.x-dev"
 				}
 			},
 			"autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/376

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This change updates the Classic editor upgrade nudge, removing the share counter and updating the text.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/376
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate the Classic Editor plugin, then go to the post editor.

- With Advanced Plan
    - Confirm that you do not see the Share limit stats or the upgrade nudge
- With Basic Plan
    - Confirm that you do not see the Share limit stats, but see the upgrade nudge
- With the new Social plan
    - Confirm that you do not see the Share limit stats or the upgrade nudge
- Without any plan
    - Confirm that you see the Share limit stats and the nudge

Check that on WPCOM sites you do not see the notice


![CleanShot 2024-06-03 at 15 26 51 png](https://github.com/Automattic/jetpack/assets/36671565/883ec020-550e-4bb4-84fd-8a8cddf4521f)

