### PR TITLE
Revert "Social: Update the Classic Editor nudge"

### DIFF
--- a/projects/packages/publicize/changelog/update-social-classic-editor-nudge
+++ b/projects/packages/publicize/changelog/update-social-classic-editor-nudge
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated the Classic Editor nudge

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -67,7 +67,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.46.x-dev"
+			"dev-trunk": "0.45.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.46.0-alpha",
+	"version": "0.45.1-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/plugins/jetpack/changelog/update-social-classic-editor-nudge
+++ b/projects/plugins/jetpack/changelog/update-social-classic-editor-nudge
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2102,7 +2102,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/publicize",
-				"reference": "c5a02ad97dc2231bc24d5196756cfc0e9d2ac70b"
+				"reference": "aa81259deff0daab3082228052b5d74002c75a5f"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -2130,7 +2130,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.46.x-dev"
+					"dev-trunk": "0.45.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/social/changelog/update-social-classic-editor-nudge
+++ b/projects/plugins/social/changelog/update-social-classic-editor-nudge
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1281,7 +1281,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/publicize",
-				"reference": "c5a02ad97dc2231bc24d5196756cfc0e9d2ac70b"
+				"reference": "aa81259deff0daab3082228052b5d74002c75a5f"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1309,7 +1309,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.46.x-dev"
+					"dev-trunk": "0.45.x-dev"
 				}
 			},
 			"autoload": {


### PR DESCRIPTION
Reverts Automattic/jetpack#37682

There is nothing to upgrade to in the classic editor when share limits aren't there

Test plan:

- Ensure we show the share counter and upgrade nudge for blogs on the free plan. 

