### PR TITLE
Social | Update the "Connect accounts" button on Social admin page

### DIFF
--- a/projects/plugins/social/changelog/update-fix-connect-accounts-button-on-social-admin-page
+++ b/projects/plugins/social/changelog/update-fix-connect-accounts-button-on-social-admin-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Updated the "Connect accounts" button to open connections modal

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -14,7 +14,6 @@ import {
 	ShareLimitsBar,
 	store as socialStore,
 	useShareLimits,
-	ManageConnectionsModalWithTrigger as ManageConnectionsModal,
 } from '@automattic/jetpack-publicize-components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -25,6 +24,7 @@ import styles from './styles.module.scss';
 const Header = () => {
 	const connectionData = window.jetpackSocialInitialState.connectionData ?? {};
 	const {
+		connectionsAdminUrl,
 		hasConnections,
 		isModuleEnabled,
 		newPostUrl,
@@ -38,6 +38,7 @@ const Header = () => {
 	} = useSelect( select => {
 		const store = select( socialStore );
 		return {
+			connectionsAdminUrl: connectionData.adminUrl,
 			hasConnections: Object.keys( connectionData.connections || {} ).length > 0,
 			isModuleEnabled: store.isModuleEnabled(),
 			newPostUrl: `${ store.getAdminUrl() }post-new.php`,
@@ -74,24 +75,18 @@ const Header = () => {
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 } className={ styles.container }>
 				<Col sm={ 4 } md={ 4 } lg={ 5 }>
 					<H3 mt={ 2 }>{ __( 'Write once, post everywhere', 'jetpack-social' ) }</H3>
-					<div className={ styles.actions }>
-						{ isModuleEnabled && ! hasConnections && (
-							<>
-								{ useAdminUiV1 ? (
-									<ManageConnectionsModal
-										trigger={ <Button>{ __( 'Connect accounts', 'jetpack-social' ) }</Button> }
-									/>
-								) : (
-									<Button href={ connectionData.adminUrl } isExternalLink={ true }>
-										{ __( 'Connect accounts', 'jetpack-social' ) }
-									</Button>
-								) }
-							</>
-						) }
-						<Button href={ newPostUrl } variant={ hasConnections ? 'primary' : 'secondary' }>
-							{ __( 'Write a post', 'jetpack-social' ) }
-						</Button>
-					</div>
+					{ ! useAdminUiV1 ? (
+						<div className={ styles.actions }>
+							{ isModuleEnabled && ! hasConnections && (
+								<Button href={ connectionsAdminUrl } isExternalLink={ true }>
+									{ __( 'Connect accounts', 'jetpack-social' ) }
+								</Button>
+							) }
+							<Button href={ newPostUrl } variant={ hasConnections ? 'primary' : 'secondary' }>
+								{ __( 'Write a post', 'jetpack-social' ) }
+							</Button>
+						</div>
+					) : null }
 				</Col>
 				<Col sm={ 4 } md={ 4 } lg={ { start: 7, end: 12 } }>
 					{ showShareLimits ? (

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -39,7 +39,7 @@ const Header = () => {
 		const store = select( socialStore );
 		return {
 			connectionsAdminUrl: connectionData.adminUrl,
-			hasConnections: Object.keys( connectionData.connections || {} ).length > 0,
+			hasConnections: store.getConnections().length > 0,
 			isModuleEnabled: store.isModuleEnabled(),
 			newPostUrl: `${ store.getAdminUrl() }post-new.php`,
 			postsCount: store.getSharedPostsCount(),
@@ -75,18 +75,16 @@ const Header = () => {
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 } className={ styles.container }>
 				<Col sm={ 4 } md={ 4 } lg={ 5 }>
 					<H3 mt={ 2 }>{ __( 'Write once, post everywhere', 'jetpack-social' ) }</H3>
-					{ ! useAdminUiV1 ? (
-						<div className={ styles.actions }>
-							{ isModuleEnabled && ! hasConnections && (
-								<Button href={ connectionsAdminUrl } isExternalLink={ true }>
-									{ __( 'Connect accounts', 'jetpack-social' ) }
-								</Button>
-							) }
-							<Button href={ newPostUrl } variant={ hasConnections ? 'primary' : 'secondary' }>
-								{ __( 'Write a post', 'jetpack-social' ) }
+					<div className={ styles.actions }>
+						{ ! useAdminUiV1 && isModuleEnabled && ! hasConnections && (
+							<Button href={ connectionsAdminUrl } isExternalLink={ true }>
+								{ __( 'Connect accounts', 'jetpack-social' ) }
 							</Button>
-						</div>
-					) : null }
+						) }
+						<Button href={ newPostUrl } variant={ hasConnections ? 'primary' : 'secondary' }>
+							{ __( 'Write a post', 'jetpack-social' ) }
+						</Button>
+					</div>
 				</Col>
 				<Col sm={ 4 } md={ 4 } lg={ { start: 7, end: 12 } }>
 					{ showShareLimits ? (

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -14,6 +14,7 @@ import {
 	ShareLimitsBar,
 	store as socialStore,
 	useShareLimits,
+	ManageConnectionsModalWithTrigger as ManageConnectionsModal,
 } from '@automattic/jetpack-publicize-components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -24,7 +25,6 @@ import styles from './styles.module.scss';
 const Header = () => {
 	const connectionData = window.jetpackSocialInitialState.connectionData ?? {};
 	const {
-		connectionsAdminUrl,
 		hasConnections,
 		isModuleEnabled,
 		newPostUrl,
@@ -34,10 +34,10 @@ const Header = () => {
 		blogID,
 		showShareLimits,
 		hasPaidFeatures,
+		useAdminUiV1,
 	} = useSelect( select => {
 		const store = select( socialStore );
 		return {
-			connectionsAdminUrl: connectionData.adminUrl,
 			hasConnections: Object.keys( connectionData.connections || {} ).length > 0,
 			isModuleEnabled: store.isModuleEnabled(),
 			newPostUrl: `${ store.getAdminUrl() }post-new.php`,
@@ -47,6 +47,7 @@ const Header = () => {
 			blogID: store.getBlogID(),
 			showShareLimits: store.showShareLimits(),
 			hasPaidFeatures: store.hasPaidFeatures() || store.hasPaidPlan(),
+			useAdminUiV1: store.useAdminUiV1(),
 		};
 	} );
 	const { hasConnectionError } = useConnectionErrorNotice();
@@ -75,9 +76,17 @@ const Header = () => {
 					<H3 mt={ 2 }>{ __( 'Write once, post everywhere', 'jetpack-social' ) }</H3>
 					<div className={ styles.actions }>
 						{ isModuleEnabled && ! hasConnections && (
-							<Button href={ connectionsAdminUrl } isExternalLink={ true }>
-								{ __( 'Connect accounts', 'jetpack-social' ) }
-							</Button>
+							<>
+								{ useAdminUiV1 ? (
+									<ManageConnectionsModal
+										trigger={ <Button>{ __( 'Connect accounts', 'jetpack-social' ) }</Button> }
+									/>
+								) : (
+									<Button href={ connectionData.adminUrl } isExternalLink={ true }>
+										{ __( 'Connect accounts', 'jetpack-social' ) }
+									</Button>
+								) }
+							</>
 						) }
 						<Button href={ newPostUrl } variant={ hasConnections ? 'primary' : 'secondary' }>
 							{ __( 'Write a post', 'jetpack-social' ) }


### PR DESCRIPTION
"Connect accounts" button points to Calypso instead of the new connections management UI


![Image](https://github.com/Automattic/jetpack-reach/assets/18226415/5d6e51b0-0321-4169-b874-5be9d64e68a7)



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the "Connect accounts" button on Social admin page to open the connections modal instead of a Calypso link

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ensure that feature flag is ON - `define( 'JETPACK_SOCIAL_USE_ADMIN_UI_V1', true );`
* Goto Social admin page
* Delete all the connections you have
* Confirm that you see the Connect accounts button as a non-external link
* Click on it
* Confirm that it opens the connections management modal
* Confirm that it works as expected
* Add a connection
* Confirm that the "Connect accounts" button is not visible when there is at least 1 connection

| BEFORE | AFTER |
|--------|--------|
|  <img width="1199" alt="Screenshot 2024-06-04 at 6 03 30 PM" src="https://github.com/Automattic/jetpack/assets/18226415/e7c9fe9c-1f90-469d-ae39-097d2d7fd81d"> | <img width="1198" alt="Screenshot 2024-06-04 at 6 06 09 PM" src="https://github.com/Automattic/jetpack/assets/18226415/dde0f308-69f3-413b-a88f-c957d7d3dfab"> | 

