### PR TITLE
Newsletter settings: add toggle for showing a subscribe modal after commenting

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -31,6 +31,7 @@ function SubscriptionsSettings( props ) {
 		isStbEnabled,
 		isStcEnabled,
 		isSmEnabled,
+		isCommentSubscribeModalEnabled,
 		isSubscribeOverlayEnabled,
 		isSubscribePostEndEnabled,
 		isLoginNavigationEnabled,
@@ -111,6 +112,10 @@ function SubscriptionsSettings( props ) {
 			SUBSCRIPTIONS_MODULE_NAME,
 			'jetpack_subscriptions_subscribe_navigation_enabled'
 		);
+	}, [ updateFormStateModuleOption ] );
+
+	const handleCommentsSubscribeModalToggleChange = useCallback( () => {
+		updateFormStateModuleOption( SUBSCRIPTIONS_MODULE_NAME, 'jetpack_verbum_subscription_modal' );
 	}, [ updateFormStateModuleOption ] );
 
 	const isDisabled = ! isSubscriptionsActive || unavailableInOfflineMode;
@@ -262,6 +267,17 @@ function SubscriptionsSettings( props ) {
 							</span>
 						}
 					/>
+					<ToggleControl
+						checked={ isSubscriptionsActive && isCommentSubscribeModalEnabled }
+						disabled={ isDisabled }
+						toggling={ isSavingAnyOption( [ 'jetpack_verbum_subscription_modal' ] ) }
+						onChange={ handleCommentsSubscribeModalToggleChange }
+						label={
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Show subscription pop-up after commenting on a post', 'jetpack' ) }
+							</span>
+						}
+					/>
 				</FormFieldset>
 			</SettingsGroup>
 		</SettingsCard>
@@ -280,6 +296,9 @@ export default withModuleSettingsFormHelpers(
 			isStcEnabled: ownProps.getOptionValue( 'stc_enabled' ),
 			isSmEnabled: ownProps.getOptionValue( 'sm_enabled' ),
 			isSubscribeOverlayEnabled: ownProps.getOptionValue( 'jetpack_subscribe_overlay_enabled' ),
+			isCommentSubscribeModalEnabled: ownProps.getOptionValue(
+				'jetpack_verbum_subscription_modal'
+			),
 			isSubscribePostEndEnabled: ownProps.getOptionValue(
 				'jetpack_subscriptions_subscribe_post_end_enabled'
 			),

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -54,6 +54,15 @@ function SubscriptionsSettings( props ) {
 			  } )
 			: null;
 
+	const commentSubscribeModalEditorUrl =
+		siteAdminUrl && themeStylesheet
+			? addQueryArgs( `${ siteAdminUrl }site-editor.php`, {
+					postType: 'wp_template_part',
+					postId: `${ themeStylesheet }//jetpack-subscription-modal`,
+					canvas: 'edit',
+			  } )
+			: null;
+
 	const subscribeOverlayEditorUrl =
 		siteAdminUrl && themeStylesheet
 			? addQueryArgs( `${ siteAdminUrl }site-editor.php`, {
@@ -275,6 +284,14 @@ function SubscriptionsSettings( props ) {
 						label={
 							<span className="jp-form-toggle-explanation">
 								{ __( 'Show subscription pop-up after commenting on a post', 'jetpack' ) }
+								{ isSubscriptionSiteEditSupported && commentSubscribeModalEditorUrl && (
+									<>
+										{ '. ' }
+										<ExternalLink href={ commentSubscribeModalEditorUrl }>
+											{ __( 'Preview and edit', 'jetpack' ) }
+										</ExternalLink>
+									</>
+								) }
 							</span>
 						}
 					/>

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2719,7 +2719,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'jetpack_verbum_subscription_modal'     => array(
 				'description'       => esc_html__( 'Show subscription pop-up after commenting on a post', 'jetpack' ),
 				'type'              => 'boolean',
-				'default'           => 0,
+				'default'           => 1,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2716,6 +2716,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
+			'jetpack_verbum_subscription_modal'     => array(
+				'description'       => esc_html__( 'Show subscription pop-up after commenting on a post', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'subscriptions',
+			),
 			'social_notifications_subscribe'        => array(
 				'description'       => esc_html__( 'Send email notification when someone subscribes to my blog', 'jetpack' ),
 				'type'              => 'boolean',

--- a/projects/plugins/jetpack/changelog/update-subscribe-toggle-comment-form
+++ b/projects/plugins/jetpack/changelog/update-subscribe-toggle-comment-form
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter settings: add toggle for showing a subscribe modal after commenting.

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -720,8 +720,7 @@ HTML;
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		$is_current_user_subscribed = (bool) isset( $_POST['is_current_user_subscribed'] ) ? filter_var( wp_unslash( $_POST['is_current_user_subscribed'] ) ) : null;
 
-		// Atomic sites with jetpack_verbum_subscription_modal option enabled
-		$modal_enabled = ( new Host() )->is_woa_site() && get_option( 'jetpack_verbum_subscription_modal', true );
+		$modal_enabled = get_option( 'jetpack_verbum_subscription_modal', true );
 
 		return $modal_enabled && ! $is_current_user_subscribed;
 	}

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -713,10 +713,17 @@ HTML;
 	public function should_show_subscription_modal() {
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		$is_current_user_subscribed = (bool) isset( $_POST['is_current_user_subscribed'] ) ? filter_var( wp_unslash( $_POST['is_current_user_subscribed'] ) ) : null;
+		if ( $is_current_user_subscribed ) {
+			return false;
+		}
 
-		$modal_enabled = get_option( 'jetpack_verbum_subscription_modal', true );
+		// Are subscriptions disabled? They're always enabled on simple sites.
+		if ( ! ( new Host() )->is_wpcom_simple() || ! \Jetpack::is_module_active( 'subscriptions' ) ) {
+			return false;
+		}
 
-		return $modal_enabled && ! $is_current_user_subscribed;
+		// Is the modal enabled (by default it is)
+		return get_option( 'jetpack_verbum_subscription_modal', true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -711,12 +711,6 @@ HTML;
 	 * @return boolean
 	 */
 	public function should_show_subscription_modal() {
-
-		// Not allow it to run on self-hosted or simple sites
-		if ( ! ( new Host() )->is_wpcom_platform() || ( new Host() )->is_wpcom_simple() ) {
-			return false;
-		}
-
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		$is_current_user_subscribed = (bool) isset( $_POST['is_current_user_subscribed'] ) ? filter_var( wp_unslash( $_POST['is_current_user_subscribed'] ) ) : null;
 
@@ -752,10 +746,8 @@ HTML;
 	 */
 	public function subscription_modal_status_track_event() {
 		$tracking_event = 'hidden_disabled';
-		// Not allow it to run on self-hosted or simple sites
-		if ( ! ( new Host() )->is_wpcom_platform() || ( new Host() )->is_wpcom_simple() ) {
-			$tracking_event = 'hidden_self_hosted';
-		}
+
+		$platform = ( new Host() )->is_wpcom_platform() ? 'wpcom' : 'jetpack';
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		$is_current_user_subscribed = (bool) isset( $_POST['is_current_user_subscribed'] ) ? filter_var( wp_unslash( $_POST['is_current_user_subscribed'] ) ) : null;
@@ -767,6 +759,7 @@ HTML;
 		$jetpack = Jetpack::init();
 		// $jetpack->stat automatically prepends the stat group with 'jetpack-'
 		$jetpack->stat( 'subscribe-modal-comm', $tracking_event );
+		$jetpack->stat( 'subscribe-modal-comm-platform', $tracking_event . '-' . $platform );
 		$jetpack->do_stats( 'server_side' );
 	}
 

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
@@ -46,10 +46,9 @@ class Jetpack_Subscription_Modal_On_Comment {
 
 	/**
 	 * Jetpack_Subscription_Modal_On_Comment class constructor.
-	 * Limited to Atomic sites.
 	 */
 	public function __construct() {
-		if ( ( new Host() )->is_woa_site() && get_option( 'jetpack_verbum_subscription_modal', true ) ) {
+		if ( get_option( 'jetpack_verbum_subscription_modal', true ) ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 			add_action( 'wp_footer', array( $this, 'add_subscription_modal_to_frontend' ) );
 			add_filter( 'get_block_template', array( $this, 'get_block_template_filter' ), 10, 3 );
@@ -137,6 +136,7 @@ class Jetpack_Subscription_Modal_On_Comment {
 		$discover_more_from = sprintf( __( 'Discover more from %s', 'jetpack' ), get_bloginfo( 'name' ) );
 		$subscribe_text     = __( 'Subscribe now to keep reading and get access to the full archive.', 'jetpack' );
 		$continue_reading   = __( 'Continue reading', 'jetpack' );
+		$source             = ( new Host() )->is_woa_site() ? 'atomic-subscription-modal-lo' : 'jetpack-subscription-modal-lo';
 
 		return <<<HTML
 	<!-- wp:group {"style":{"spacing":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
@@ -150,7 +150,7 @@ class Jetpack_Subscription_Modal_On_Comment {
 		<p class='has-text-align-center' style='margin-top:4px;margin-bottom:0px;font-size:15px'>$subscribe_text</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:jetpack/subscriptions {"borderRadius":50,"className":"is-style-compact","appSource":"atomic-subscription-modal-lo"} /-->
+		<!-- wp:jetpack/subscriptions {"borderRadius":50,"className":"is-style-compact","appSource":$source"} /-->
 
 		<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"20px"}},"typography":{"fontSize":"14px"}},"className":"jetpack-subscription-modal__close"} -->
 		<p class="has-text-align-center jetpack-subscription-modal__close" style="margin-top:20px;font-size:14px"><a href="#">$continue_reading</a></p>

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/class-jetpack-subscription-modal-on-comment.php
@@ -8,7 +8,6 @@
  */
 
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
-use Automattic\Jetpack\Status\Host;
 use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
 
 /**
@@ -136,7 +135,6 @@ class Jetpack_Subscription_Modal_On_Comment {
 		$discover_more_from = sprintf( __( 'Discover more from %s', 'jetpack' ), get_bloginfo( 'name' ) );
 		$subscribe_text     = __( 'Subscribe now to keep reading and get access to the full archive.', 'jetpack' );
 		$continue_reading   = __( 'Continue reading', 'jetpack' );
-		$source             = ( new Host() )->is_woa_site() ? 'atomic-subscription-modal-lo' : 'jetpack-subscription-modal-lo';
 
 		return <<<HTML
 	<!-- wp:group {"style":{"spacing":{"top":"32px","bottom":"32px","left":"32px","right":"32px"},"margin":{"top":"0","bottom":"0"}},"border":{"color":"#dddddd","width":"1px"}},"layout":{"type":"constrained","contentSize":"450px"}} -->
@@ -150,7 +148,7 @@ class Jetpack_Subscription_Modal_On_Comment {
 		<p class='has-text-align-center' style='margin-top:4px;margin-bottom:0px;font-size:15px'>$subscribe_text</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:jetpack/subscriptions {"borderRadius":50,"className":"is-style-compact","appSource":$source"} /-->
+		<!-- wp:jetpack/subscriptions {"borderRadius":50,"className":"is-style-compact","appSource":"atomic-subscription-modal-lo"} /-->
 
 		<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"20px"}},"typography":{"fontSize":"14px"}},"className":"jetpack-subscription-modal__close"} -->
 		<p class="has-text-align-center jetpack-subscription-modal__close" style="margin-top:20px;font-size:14px"><a href="#">$continue_reading</a></p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Adds a missing toggle to Jetpack settings.

The toggle and feature is already available on WP.com sites and Calypso settings. The Dotcom team implementing this originally just didn't get to add the Jetpack side ([convo](https://github.com/Automattic/wp-calypso/pull/86246#issuecomment-1885789955)), so this is a follow up to that.

**Calypso newsletter settings:**

<img width="359" alt="image" src="https://github.com/Automattic/jetpack/assets/87168/84df8ecb-742c-49e7-922c-33e5487e0552">

**Jetpack newsletter settings:**

<img width="1075" alt="Screenshot 2024-06-20 at 13 55 01" src="https://github.com/Automattic/jetpack/assets/87168/624e59c8-cefd-4a02-8f84-235030861ca8">

After filling commenting field and submitting a comment:

<img width="645" alt="Screenshot 2024-06-20 at 13 53 03" src="https://github.com/Automattic/jetpack/assets/87168/b89979a2-3ad8-4994-8005-1a55f598ab6b">

You will see a modal pop-up prefilled with the email you used for commenting:

<img width="994" alt="Screenshot 2024-06-20 at 13 52 23" src="https://github.com/Automattic/jetpack/assets/87168/3a1c4073-cf5a-469d-ba59-10442409c530">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Release "show subscribe modal after commenting" feature to Jetpack sites; previously it was available only for WP.com sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See PR description

