### PR TITLE
Boost: Skip .min files from minification

### DIFF
--- a/projects/plugins/boost/app/lib/minify/functions-service.php
+++ b/projects/plugins/boost/app/lib/minify/functions-service.php
@@ -304,12 +304,19 @@ function jetpack_boost_page_optimize_build_output() {
 				);
 			}
 
-			// Minify CSS.
-			$buf     = Minify::css( $buf );
+			// If filename indicates it's already minified, don't minify it again.
+			if ( ! preg_match( '/\.min\.css$/', $fullpath ) ) {
+				// Minify CSS.
+				$buf = Minify::css( $buf );
+			}
 			$output .= "$buf";
 		} else {
-			// Minify JS
-			$buf     = Minify::js( $buf );
+			// If filename indicates it's already minified, don't minify it again.
+			if ( ! preg_match( '/\.min\.js$/', $fullpath ) ) {
+				// Minify JS
+				$buf = Minify::js( $buf );
+			}
+
 			$output .= "$buf;\n";
 		}
 	}

--- a/projects/plugins/boost/changelog/update-skip-dotmin-files
+++ b/projects/plugins/boost/changelog/update-skip-dotmin-files
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Minification: Skip files ending in `.min.js` and `.min.css` from minification


### PR DESCRIPTION
## Proposed changes:
* If a filename already contains `.min` in it's name, skip it from Boost's minification as that file's content is already minified.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1715767038971599-slack-C0299DMPG

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Enqueue files with names ending in `.min.js` and `.min.css`.
* Make sure they aren't minified in the concatenated results.

Snippet I used:
```php
<?php
add_action( 'wp_enqueue_scripts', function() {
	wp_enqueue_style( 'css1', WP_CONTENT_URL . '/mu-plugins/assets/file1.css', array(), '1.0', true );
	wp_enqueue_style( 'css2', WP_CONTENT_URL . '/mu-plugins/assets/file2.min.css', array(), '1.0', true );

	wp_enqueue_script( 'js1', WP_CONTENT_URL . '/mu-plugins/assets/file1.js', array(), '1.0', true );
	wp_enqueue_script( 'js2', WP_CONTENT_URL . '/mu-plugins/assets/file2.min.js', array(), '1.0', true );
} );
```