### PR TITLE
Sync: Adding 'editor-spacing-styles' to the default_theme_support_whitelist

### DIFF
--- a/projects/packages/sync/changelog/fix-default_theme_support_whitelist
+++ b/projects/packages/sync/changelog/fix-default_theme_support_whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Defaults: Add new item to default_theme_support_whitelist to prevent failing sync tests

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -850,6 +850,7 @@ class Defaults {
 		'editor-color-palette',
 		'editor-font-sizes',
 		'editor-gradient-presets',
+		'editor-spacing-sizes',
 		'editor-style', // deprecated.
 		'editor-styles',
 		'html5',

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.0.1';
+	const PACKAGE_VERSION = '3.0.2-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 


### PR DESCRIPTION
## Proposed changes:

* Adding 'editor-spacing-spaces' to `$default_theme_support_whitelist` to prevent failing sync tests.

The failing test (PHP 8.2 trunk) was:

```
  1) WP_Test_Jetpack_Sync_Themes::test_theme_callable_syncs_theme_supports_data
  Theme Sync Error. Please add the following editor-spacing-sizes to Defaults::$default_theme_support_whitelist
  Failed asserting that false is true.
  
  /tmp/wordpress-trunk/src/wp-content/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-themes.php:160
```

Example [here](https://github.com/Automattic/jetpack/actions/runs/9366825357/job/25786701354?pr=37453).

Related: https://github.com/WordPress/wordpress-develop/commit/782fb1f1a7128ff50ac1beccccd8de6e71918382

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See p1717505900578419-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* PHP 8.2 tests in the PR should pass.