### PR TITLE
ci: In post-build job, use `wp db import/export`

### DIFF
--- a/.github/files/test-plugin-update/setup.sh
+++ b/.github/files/test-plugin-update/setup.sh
@@ -32,5 +32,5 @@ cp "$GITHUB_WORKSPACE/trunk/.github/files/test-plugin-update/mu-plugin.php" wp-c
 echo "::endgroup::"
 
 echo "::group::Backing up database"
-mysqldump --add-drop-database --add-drop-table --databases wordpress --column-statistics=0 > "$GITHUB_WORKSPACE/db.sql"
+wp --allow-root db export "$GITHUB_WORKSPACE/db.sql"
 echo "::endgroup::"

--- a/.github/files/test-plugin-update/test.sh
+++ b/.github/files/test-plugin-update/test.sh
@@ -41,7 +41,7 @@ for SLUG in "${SLUGS[@]}"; do
 			printf '\n\e[1mTest upgrade of %s from %s via %s\e[0m\n' "$SLUG" "$FROM" "$HOW"
 
 			echo "::group::Restoring database from backup"
-			mysql < "$GITHUB_WORKSPACE/db.sql"
+			wp --allow-root db import "$GITHUB_WORKSPACE/db.sql"
 			echo "::endgroup::"
 
 			ERRMSG=


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We had been using `mysqldump` and `mysql`. But since WP-CLI has its own export and import functionality, let's use that instead since it's more likely to handle any weird edge cases.

Saw `wp db` mentioned in pcShBQ-1OP-p2.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
None

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You'd probably have to fork, merge this, and set up a bunch of secrets to get it to run. 🤷