### PR TITLE
Update/conditionally hide connection banner

### DIFF
--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -920,6 +920,16 @@ class Manager {
 			return false;
 		}
 
+		/**
+		 * Fires before the current user has been unlinked from WordPress.com.
+		 *
+		 * @since 2.8.5
+		 * @since-jetpack 13.5.0
+		 *
+		 * @param int $user_id The current user's ID.
+		 */
+		do_action( 'jetpack_before_unlinking_user', $user_id );
+
 		// Attempt to disconnect the user from WordPress.com.
 		$is_disconnected_from_wpcom = $this->unlink_user_from_wpcom( $user_id );
 

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -920,16 +920,6 @@ class Manager {
 			return false;
 		}
 
-		/**
-		 * Fires before the current user has been unlinked from WordPress.com.
-		 *
-		 * @since 2.8.5
-		 * @since-jetpack 13.6.0
-		 *
-		 * @param int $user_id The current user's ID.
-		 */
-		do_action( 'jetpack_before_unlinking_user', $user_id );
-
 		// Attempt to disconnect the user from WordPress.com.
 		$is_disconnected_from_wpcom = $this->unlink_user_from_wpcom( $user_id );
 

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -924,7 +924,7 @@ class Manager {
 		 * Fires before the current user has been unlinked from WordPress.com.
 		 *
 		 * @since 2.8.5
-		 * @since-jetpack 13.5.0
+		 * @since-jetpack 13.6.0
 		 *
 		 * @param int $user_id The current user's ID.
 		 */

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -44,17 +44,15 @@ import styles from './styles.module.scss';
 
 const GlobalNotice = ( { message, title, options } ) => {
 	const { recordEvent } = useAnalytics();
-	const { redBubbleAlerts } = getMyJetpackWindowInitialState();
 
 	useEffect( () => {
-		// Record details of the red bubble alert if available.
-		const details = redBubbleAlerts[ options.id ] ?? [];
+		const tracksArgs = options?.tracksArgs || {};
 
 		recordEvent( 'jetpack_myjetpack_global_notice_view', {
 			noticeId: options.id,
-			...details,
+			...tracksArgs,
 		} );
-	}, [ options.id, recordEvent, redBubbleAlerts ] );
+	}, [ options.id, recordEvent, options?.tracksArgs ] );
 
 	const [ isBiggerThanMedium ] = useBreakpointMatch( [ 'md' ], [ '>' ] );
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -44,12 +44,17 @@ import styles from './styles.module.scss';
 
 const GlobalNotice = ( { message, title, options } ) => {
 	const { recordEvent } = useAnalytics();
+	const { redBubbleAlerts } = getMyJetpackWindowInitialState();
 
 	useEffect( () => {
+		// Record details of the red bubble alert if available.
+		const details = redBubbleAlerts[ options.id ] ?? [];
+
 		recordEvent( 'jetpack_myjetpack_global_notice_view', {
 			noticeId: options.id,
+			...details,
 		} );
-	}, [ options.id, recordEvent ] );
+	}, [ options.id, recordEvent, redBubbleAlerts ] );
 
 	const [ isBiggerThanMedium ] = useBreakpointMatch( [ 'md' ], [ '>' ] );
 

--- a/projects/packages/my-jetpack/_inc/context/notices/types.ts
+++ b/projects/packages/my-jetpack/_inc/context/notices/types.ts
@@ -10,14 +10,17 @@ export type NoticeButtonAction = NoticeAction & {
 export type Notice = {
 	message: string | ReactNode;
 	title?: string;
-	options: {
-		id?: string;
-		level: string;
-		actions?: NoticeButtonAction[];
-		priority: number;
-		hideCloseButton?: boolean;
-		onClose?: () => void;
-	};
+	options: NoticeOptions;
+};
+
+export type NoticeOptions = {
+	id?: string;
+	level: 'error' | 'warning' | 'success' | 'info';
+	actions?: NoticeButtonAction[];
+	priority: number;
+	hideCloseButton?: boolean;
+	onClose?: () => void;
+	isRedBubble?: boolean;
 };
 
 export type NoticeContextType< T = Notice > = {

--- a/projects/packages/my-jetpack/_inc/context/notices/types.ts
+++ b/projects/packages/my-jetpack/_inc/context/notices/types.ts
@@ -21,6 +21,7 @@ export type NoticeOptions = {
 	hideCloseButton?: boolean;
 	onClose?: () => void;
 	isRedBubble?: boolean;
+	tracksArgs?: Record< string, unknown >;
 };
 
 export type NoticeContextType< T = Notice > = {

--- a/projects/packages/my-jetpack/_inc/data/utils/get-product-slugs-that-require-user-connection.ts
+++ b/projects/packages/my-jetpack/_inc/data/utils/get-product-slugs-that-require-user-connection.ts
@@ -8,7 +8,7 @@ const getProductSlugsThatRequireUserConnection = ( products: {
 		.filter(
 			( { requiresUserConnection, status } ) =>
 				requiresUserConnection &&
-				( status === PRODUCT_STATUSES.ACTIVE || status === PRODUCT_STATUSES.ERROR )
+				( status === PRODUCT_STATUSES.ACTIVE || PRODUCT_STATUSES.USER_CONNECTION_ERROR )
 		)
 		.map( ( { name } ) => name );
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-bad-install-notice.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-bad-install-notice.ts
@@ -3,6 +3,7 @@ import { useContext, useEffect } from 'react';
 import { NOTICE_PRIORITY_MEDIUM } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
 import useAnalytics from '../use-analytics';
+import type { NoticeOptions } from '../../context/notices/types';
 
 type RedBubbleAlerts = Window[ 'myJetpackInitialState' ][ 'redBubbleAlerts' ];
 
@@ -40,7 +41,7 @@ const useBadInstallNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			} );
 		};
 
-		const noticeOptions = {
+		const noticeOptions: NoticeOptions = {
 			id: 'bad-installation-notice',
 			level: 'error',
 			actions: [

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
@@ -5,6 +5,7 @@ import { useContext, useEffect } from 'react';
 import { NOTICE_PRIORITY_HIGH } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
 import useAnalytics from '../use-analytics';
+import type { NoticeOptions } from '../../context/notices/types';
 
 const useConnectionErrorsNotice = () => {
 	const { setNotice, resetNotice } = useContext( NoticeContext );
@@ -48,7 +49,7 @@ const useConnectionErrorsNotice = () => {
 		const loadingButtonLabel = __( 'Reconnecting Jetpack…', 'jetpack-my-jetpack' );
 		const restoreButtonLabel = __( 'Restore Connection', 'jetpack-my-jetpack' );
 
-		const noticeOptions = {
+		const noticeOptions: NoticeOptions = {
 			id: 'connection-error-notice',
 			level: 'error',
 			actions: [

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -10,6 +10,7 @@ import { getMyJetpackWindowRestState } from '../../data/utils/get-my-jetpack-win
 import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
 import useAnalytics from '../use-analytics';
 import useMyJetpackNavigate from '../use-my-jetpack-navigate';
+import type { NoticeOptions } from '../../context/notices/types';
 
 type RedBubbleAlerts = Window[ 'myJetpackInitialState' ][ 'redBubbleAlerts' ];
 
@@ -27,16 +28,16 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 	} );
 	const products = useAllProducts();
 	const navToConnection = useMyJetpackNavigate( MyJetpackRoutes.Connection );
-	const connectionErrorType = redBubbleAlerts[ 'missing-connection' ];
+	const connectionError = redBubbleAlerts[ 'missing-connection' ];
 
 	useEffect( () => {
-		if ( ! connectionErrorType ) {
+		if ( ! connectionError ) {
 			return;
 		}
 
 		const productSlugsThatRequireUserConnection =
 			getProductSlugsThatRequireUserConnection( products );
-		const requiresUserConnection = connectionErrorType === 'user';
+		const requiresUserConnection = connectionError.type === 'user';
 
 		const onActionButtonClick = () => {
 			if ( requiresUserConnection ) {
@@ -93,9 +94,9 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			title: __( 'Missing site connection', 'jetpack-my-jetpack' ),
 		};
 
-		const noticeOptions = {
+		const noticeOptions: NoticeOptions = {
 			id: requiresUserConnection ? 'user-connection-notice' : 'site-connection-notice',
-			level: 'error',
+			level: connectionError.is_error ? 'error' : 'info',
 			actions: [
 				{
 					label: requiresUserConnection
@@ -135,7 +136,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 		resetNotice,
 		setNotice,
 		siteIsRegistering,
-		connectionErrorType,
+		connectionError,
 	] );
 };
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -58,6 +58,8 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 						onClose: resetNotice,
 					},
 				} );
+				delete redBubbleAlerts[ 'missing-connection' ];
+				window.myJetpackInitialState.redBubbleAlerts = redBubbleAlerts;
 			} );
 		};
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -112,6 +112,10 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			// If this notice gets into a loading state, we want to show it above the rest
 			priority: NOTICE_PRIORITY_HIGH + ( siteIsRegistering ? 1 : 0 ),
 			isRedBubble: true,
+			tracksArgs: {
+				type: connectionError.type,
+				isError: connectionError.is_error,
+			},
 		};
 
 		const messageContent = requiresUserConnection ? (

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -28,7 +28,8 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 	} );
 	const products = useAllProducts();
 	const navToConnection = useMyJetpackNavigate( MyJetpackRoutes.Connection );
-	const connectionError = redBubbleAlerts[ 'missing-connection' ];
+	const redBubbleSlug = 'missing-connection';
+	const connectionError = redBubbleAlerts[ redBubbleSlug ];
 
 	useEffect( () => {
 		if ( ! connectionError ) {
@@ -59,7 +60,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 						onClose: resetNotice,
 					},
 				} );
-				delete redBubbleAlerts[ 'missing-connection' ];
+				delete redBubbleAlerts[ redBubbleSlug ];
 				window.myJetpackInitialState.redBubbleAlerts = redBubbleAlerts;
 			} );
 		};
@@ -95,7 +96,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 		};
 
 		const noticeOptions: NoticeOptions = {
-			id: requiresUserConnection ? 'user-connection-notice' : 'site-connection-notice',
+			id: redBubbleSlug,
 			level: connectionError.is_error ? 'error' : 'info',
 			actions: [
 				{

--- a/projects/packages/my-jetpack/changelog/update-conditionally-render-connection-banner
+++ b/projects/packages/my-jetpack/changelog/update-conditionally-render-connection-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Conditionally show connection banner as error or info

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -197,7 +197,10 @@ interface Window {
 			} >;
 		};
 		redBubbleAlerts: {
-			'missing-connection'?: 'site' | 'user';
+			'missing-connection'?: {
+				type: string;
+				is_error: boolean;
+			};
 			'welcome-banner-active'?: null;
 			[ key: `${ string }-bad-installation` ]: {
 				data: {

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -43,6 +43,8 @@ interface Window {
 			videoPressStats: boolean;
 		};
 		lifecycleStats: {
+			historicallyActiveModules: Array< string >;
+			brokenModules: Array< string >;
 			isSiteConnected: boolean;
 			isUserConnected: boolean;
 			jetpackPlugins: Array< string >;
@@ -195,7 +197,7 @@ interface Window {
 			} >;
 		};
 		redBubbleAlerts: {
-			'missing-site-connection'?: null;
+			'missing-connection'?: 'site' | 'user';
 			'welcome-banner-active'?: null;
 			[ key: `${ string }-bad-installation` ]: {
 				data: {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -78,8 +78,6 @@ class Initializer {
 			return;
 		}
 
-		self::setup_historically_active_jetpack_modules_sync();
-
 		// Extend jetpack plugins action links.
 		Products::extend_plugins_action_links();
 

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -78,6 +78,10 @@ class Initializer {
 			return;
 		}
 
+		add_action( 'jetpack_user_authorized', array( __CLASS__, 'update_historically_active_jetpack_modules' ), 1001 );
+		add_action( 'jetpack_site_before_disconnected', array( __CLASS__, 'update_historically_active_jetpack_modules' ), 1001 );
+		add_action( 'jetpack_before_unlinking_user', array( __CLASS__, 'update_historically_active_jetpack_modules' ), 1001 );
+
 		// Extend jetpack plugins action links.
 		Products::extend_plugins_action_links();
 

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -78,9 +78,7 @@ class Initializer {
 			return;
 		}
 
-		add_action( 'jetpack_user_authorized', array( __CLASS__, 'update_historically_active_jetpack_modules' ), 1001 );
-		add_action( 'jetpack_site_before_disconnected', array( __CLASS__, 'update_historically_active_jetpack_modules' ), 1001 );
-		add_action( 'jetpack_before_unlinking_user', array( __CLASS__, 'update_historically_active_jetpack_modules' ), 1001 );
+		self::setup_historically_active_jetpack_modules_sync();
 
 		// Extend jetpack plugins action links.
 		Products::extend_plugins_action_links();

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -812,21 +812,21 @@ class Initializer {
 	 * @return array
 	 */
 	public static function alert_if_missing_connection( array $red_bubble_slugs ) {
-		$broken_modules                         = self::check_for_broken_modules();
-		$is_modules_with_broken_site_connection = ! empty( $broken_modules['needs_site_connection'] );
-		$is_modules_with_broken_user_connection = ! empty( $broken_modules['needs_user_connection'] );
+		$broken_modules = self::check_for_broken_modules();
 
 		if (
 			! ( new Connection_Manager() )->is_user_connected() &&
-			! ( new Connection_Manager() )->has_connected_owner() &&
-			$is_modules_with_broken_user_connection
+			! ( new Connection_Manager() )->has_connected_owner()
 		) {
-			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = 'user';
-		} elseif (
-			! ( new Connection_Manager() )->is_connected() &&
-			$is_modules_with_broken_site_connection
-		) {
-			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = 'site';
+			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
+				'type'     => 'user',
+				'is_error' => ! empty( $broken_modules['needs_user_connection'] ),
+			);
+		} elseif ( ! ( new Connection_Manager() )->is_connected() ) {
+			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
+				'type'     => 'site',
+				'is_error' => ! empty( $broken_modules['needs_site_connection'] ),
+			);
 		}
 
 		return $red_bubble_slugs;

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -539,38 +539,19 @@ class Initializer {
 	public static function update_historically_active_jetpack_modules() {
 		$historically_active_modules = \Jetpack_Options::get_option( 'historically_active_modules', array() );
 		$products                    = Products::get_products();
-		$active_module_statuses      = array(
-			'active',
-			'can_upgrade',
-		);
-		$broken_module_statuses      = array(
-			'site_connection_error',
-			'user_connection_error',
-		);
-		// This is defined as the statuses in which the user willingly has the module disabled whether it be by
-		// default, uninstalling the plugin, disabling the module, or not renewing their plan.
-		$disabled_module_statuses = array(
-			'inactive',
-			'module_disabled',
-			'plugin_absent',
-			'plugin_absent_with_plan',
-			'needs_purchase',
-			'needs_purchase_or_free',
-			'needs_first_site_connection',
-		);
 
 		foreach ( $products as $product ) {
 			$status       = $product['status'];
 			$product_slug = $product['slug'];
 			// We want to leave modules in the array if they've been active in the past
 			// and were not manually disabled by the user.
-			if ( in_array( $status, $broken_module_statuses, true ) ) {
+			if ( in_array( $status, Products::$broken_module_statuses, true ) ) {
 				continue;
 			}
 
 			// If the module is active and not already in the array, add it
 			if (
-				in_array( $status, $active_module_statuses, true ) &&
+				in_array( $status, Products::$active_module_statuses, true ) &&
 				! in_array( $product_slug, $historically_active_modules, true )
 			) {
 					$historically_active_modules[] = $product_slug;
@@ -578,7 +559,7 @@ class Initializer {
 
 			// If the module has been disabled due to a manual user action,
 			// or because of a missing plan error, remove it from the array
-			if ( in_array( $status, $disabled_module_statuses, true ) ) {
+			if ( in_array( $status, Products::$disabled_module_statuses, true ) ) {
 				$historically_active_modules = array_values( array_diff( $historically_active_modules, array( $product_slug ) ) );
 			}
 		}
@@ -769,19 +750,15 @@ class Initializer {
 		);
 		$products                    = Products::get_products();
 		$historically_active_modules = \Jetpack_Options::get_option( 'historically_active_modules', array() );
-		$broken_connection_statuses  = array(
-			'user_connection_error',
-			'site_connection_error',
-		);
 
 		foreach ( $historically_active_modules as $module ) {
 			$product = $products[ $module ];
 
 			// If the site or user is disconnected, and the product requires a user connection
 			// mark the product as a broken module needing user connection
-			if ( in_array( $product['status'], $broken_connection_statuses, true ) && $product['requires_user_connection'] ) {
+			if ( in_array( $product['status'], Products::$broken_module_statuses, true ) && $product['requires_user_connection'] ) {
 				$broken_modules['needs_user_connection'][] = $module;
-			} elseif ( $product['status'] === 'site_connection_error' ) {
+			} elseif ( $product['status'] === Products::STATUS_SITE_CONNECTION_ERROR ) {
 				$broken_modules['needs_site_connection'][] = $module;
 			}
 		}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -650,7 +650,7 @@ class Initializer {
 	/**
 	 * Returns true if the site has file write access to the plugins folder, false otherwise.
 	 *
-	 * @return bool
+	 * @return string
 	 **/
 	public static function has_file_system_write_access() {
 
@@ -791,18 +791,28 @@ class Initializer {
 	public static function alert_if_missing_connection( array $red_bubble_slugs ) {
 		$broken_modules = self::check_for_broken_modules();
 
-		if (
+		if ( ! empty( $broken_modules['needs_user_connection'] ) ) {
+			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
+				'type'     => 'user',
+				'is_error' => true,
+			);
+		} elseif ( ! empty( $broken_modules['needs_site_connection'] ) ) {
+			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
+				'type'     => 'site',
+				'is_error' => true,
+			);
+		} elseif (
 			! ( new Connection_Manager() )->is_user_connected() &&
 			! ( new Connection_Manager() )->has_connected_owner()
 		) {
 			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
 				'type'     => 'user',
-				'is_error' => ! empty( $broken_modules['needs_user_connection'] ),
+				'is_error' => false,
 			);
 		} elseif ( ! ( new Connection_Manager() )->is_connected() ) {
 			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
 				'type'     => 'site',
-				'is_error' => ! empty( $broken_modules['needs_site_connection'] ),
+				'is_error' => false,
 			);
 		}
 

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -796,12 +796,18 @@ class Initializer {
 				'type'     => 'user',
 				'is_error' => true,
 			);
-		} elseif ( ! empty( $broken_modules['needs_site_connection'] ) ) {
+			return $red_bubble_slugs;
+		}
+
+		if ( ! empty( $broken_modules['needs_site_connection'] ) ) {
 			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
 				'type'     => 'site',
 				'is_error' => true,
 			);
-		} elseif (
+			return $red_bubble_slugs;
+		}
+
+		if (
 			! ( new Connection_Manager() )->is_user_connected() &&
 			! ( new Connection_Manager() )->has_connected_owner()
 		) {
@@ -809,11 +815,15 @@ class Initializer {
 				'type'     => 'user',
 				'is_error' => false,
 			);
-		} elseif ( ! ( new Connection_Manager() )->is_connected() ) {
+			return $red_bubble_slugs;
+		}
+
+		if ( ! ( new Connection_Manager() )->is_connected() ) {
 			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
 				'type'     => 'site',
 				'is_error' => false,
 			);
+			return $red_bubble_slugs;
 		}
 
 		return $red_bubble_slugs;

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -769,15 +769,20 @@ class Initializer {
 		);
 		$products                    = Products::get_products();
 		$historically_active_modules = \Jetpack_Options::get_option( 'historically_active_modules', array() );
+		$broken_connection_statuses  = array(
+			'user_connection_error',
+			'site_connection_error',
+		);
 
 		foreach ( $historically_active_modules as $module ) {
 			$product = $products[ $module ];
 
-			if ( $product['status'] === 'site_connection_error' ) {
-				$broken_modules['needs_site_connection'][] = $module;
-			}
-			if ( $product['status'] === 'user_connection_error' ) {
+			// If the site or user is disconnected, and the product requires a user connection
+			// mark the product as a broken module needing user connection
+			if ( in_array( $product['status'], $broken_connection_statuses, true ) && $product['requires_user_connection'] ) {
 				$broken_modules['needs_user_connection'][] = $module;
+			} elseif ( $product['status'] === 'site_connection_error' ) {
+				$broken_modules['needs_site_connection'][] = $module;
 			}
 		}
 

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -11,6 +11,59 @@ namespace Automattic\Jetpack\My_Jetpack;
  * A class for everything related to product handling in My Jetpack
  */
 class Products {
+	/**
+	 * Constants for the status of a product on a site
+	 *
+	 * @var string
+	 */
+	const STATUS_SITE_CONNECTION_ERROR       = 'site_connection_error';
+	const STATUS_USER_CONNECTION_ERROR       = 'user_connection_error';
+	const STATUS_ACTIVE                      = 'active';
+	const STATUS_CAN_UPGRADE                 = 'can_upgrade';
+	const STATUS_INACTIVE                    = 'inactive';
+	const STATUS_MODULE_DISABLED             = 'module_disabled';
+	const STATUS_PLUGIN_ABSENT               = 'plugin_absent';
+	const STATUS_PLUGIN_ABSENT_WITH_PLAN     = 'plugin_absent_with_plan';
+	const STATUS_NEEDS_PURCHASE              = 'needs_purchase';
+	const STATUS_NEEDS_PURCHASE_OR_FREE      = 'needs_purchase_or_free';
+	const STATUS_NEEDS_FIRST_SITE_CONNECTION = 'needs_first_site_connection';
+
+	/**
+	 * List of statuses that display the module as disabled
+	 * This is defined as the statuses in which the user willingly has the module disabled whether it be by
+	 * default, uninstalling the plugin, disabling the module, or not renewing their plan.
+	 *
+	 * @var array
+	 */
+	public static $disabled_module_statuses = array(
+		self::STATUS_INACTIVE,
+		self::STATUS_MODULE_DISABLED,
+		self::STATUS_PLUGIN_ABSENT,
+		self::STATUS_PLUGIN_ABSENT_WITH_PLAN,
+		self::STATUS_NEEDS_PURCHASE,
+		self::STATUS_NEEDS_PURCHASE_OR_FREE,
+		self::STATUS_NEEDS_FIRST_SITE_CONNECTION,
+	);
+
+	/**
+	 * List of statuses that display the module as broken
+	 *
+	 * @var array
+	 */
+	public static $broken_module_statuses = array(
+		self::STATUS_SITE_CONNECTION_ERROR,
+		self::STATUS_USER_CONNECTION_ERROR,
+	);
+
+	/**
+	 * List of statuses that display the module as active
+	 *
+	 * @var array
+	 */
+	public static $active_module_statuses = array(
+		self::STATUS_ACTIVE,
+		self::STATUS_CAN_UPGRADE,
+	);
 
 	/**
 	 * Get the list of Products classes
@@ -156,7 +209,7 @@ class Products {
 				'status'      => array(
 					'title' => 'The product status',
 					'type'  => 'string',
-					'enum'  => array( 'active', 'inactive', 'plugin_absent', 'needs_purchase', 'needs_purchase_or_free', 'needs_first_site_connection', 'user_connection_error', 'site_connection_error' ),
+					'enum'  => array( 'active', 'inactive', 'plugin_absent', 'plugin_absent_with_plan', 'needs_purchase', 'needs_purchase_or_free', 'needs_first_site_connection', 'user_connection_error', 'site_connection_error', 'can_upgrade', 'module_disabled' ),
 				),
 				'class'       => array(
 					'title' => 'The product class handler',

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -66,6 +66,25 @@ class Products {
 	);
 
 	/**
+	 * List of all statuses that a product can have
+	 *
+	 * @var array
+	 */
+	public static $all_statuses = array(
+		self::STATUS_SITE_CONNECTION_ERROR,
+		self::STATUS_USER_CONNECTION_ERROR,
+		self::STATUS_ACTIVE,
+		self::STATUS_CAN_UPGRADE,
+		self::STATUS_INACTIVE,
+		self::STATUS_MODULE_DISABLED,
+		self::STATUS_PLUGIN_ABSENT,
+		self::STATUS_PLUGIN_ABSENT_WITH_PLAN,
+		self::STATUS_NEEDS_PURCHASE,
+		self::STATUS_NEEDS_PURCHASE_OR_FREE,
+		self::STATUS_NEEDS_FIRST_SITE_CONNECTION,
+	);
+
+	/**
 	 * Get the list of Products classes
 	 *
 	 * Here's where all the existing Products are registered
@@ -209,7 +228,7 @@ class Products {
 				'status'      => array(
 					'title' => 'The product status',
 					'type'  => 'string',
-					'enum'  => array( 'active', 'inactive', 'plugin_absent', 'plugin_absent_with_plan', 'needs_purchase', 'needs_purchase_or_free', 'needs_first_site_connection', 'user_connection_error', 'site_connection_error', 'can_upgrade', 'module_disabled' ),
+					'enum'  => self::$all_statuses,
 				),
 				'class'       => array(
 					'title' => 'The product class handler',

--- a/projects/packages/my-jetpack/src/products/class-module-product.php
+++ b/projects/packages/my-jetpack/src/products/class-module-product.php
@@ -86,8 +86,8 @@ abstract class Module_Product extends Product {
 	 */
 	public static function get_status() {
 		$status = parent::get_status();
-		if ( 'inactive' === $status && ! static::is_module_active() ) {
-			$status = 'module_disabled';
+		if ( Products::STATUS_INACTIVE === $status && ! static::is_module_active() ) {
+			$status = Products::STATUS_MODULE_DISABLED;
 		}
 		return $status;
 	}

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -432,7 +432,7 @@ abstract class Product {
 	 * return all the products it contains.
 	 * Empty array by default.
 	 *
-	 * @return Array Product slugs
+	 * @return array Product slugs
 	 */
 	public static function get_supported_products() {
 		return array();
@@ -445,48 +445,48 @@ abstract class Product {
 	 */
 	public static function get_status() {
 		if ( ! static::is_plugin_installed() ) {
-			$status = 'plugin_absent';
+			$status = Products::STATUS_PLUGIN_ABSENT;
 			if ( static::has_paid_plan_for_product() ) {
-				$status = 'plugin_absent_with_plan';
+				$status = Products::STATUS_PLUGIN_ABSENT_WITH_PLAN;
 			}
 		} elseif ( static::is_active() ) {
-			$status = 'active';
+			$status = Products::STATUS_ACTIVE;
 			// We only consider missing site & user connection an error when the Product is active.
 			if ( static::$requires_site_connection && ! ( new Connection_Manager() )->is_connected() ) {
 				// Site has never been connected before
-				if ( ! \Jetpack_Options::get_option( 'id' ) ) {
-					$status = 'needs_first_site_connection';
+				if ( ! Jetpack_Options::get_option( 'id' ) ) {
+					$status = Products::STATUS_NEEDS_FIRST_SITE_CONNECTION;
 				} else {
-					$status = 'site_connection_error';
+					$status = Products::STATUS_SITE_CONNECTION_ERROR;
 				}
 			} elseif ( static::$requires_user_connection && ! ( new Connection_Manager() )->has_connected_owner() ) {
-				$status = 'user_connection_error';
+				$status = Products::STATUS_USER_CONNECTION_ERROR;
 			} elseif ( static::is_upgradable() ) {
-				$status = 'can_upgrade';
+				$status = Products::STATUS_CAN_UPGRADE;
 			}
 			// Check specifically for inactive modules, which will prevent a product from being active
 		} elseif ( static::$module_name && ! static::is_module_active() ) {
-			$status = 'module_disabled';
+			$status = Products::STATUS_MODULE_DISABLED;
 			// If there is not a plan associated with the disabled module, encourage a plan first
 			// Getting a plan set up should help resolve any connection issues
 			// However if the standalone plugin for this product is active, then we will defer to showing errors that prevent the module from being active
 			// This is because if a standalone plugin is installed, we expect the product to not show as "inactive" on My Jetpack
 			if ( static::$requires_plan || ( ! static::has_any_plan_for_product() && static::$has_standalone_plugin && ! self::is_plugin_active() ) ) {
-				$status = static::$has_free_offering ? 'needs_purchase_or_free' : 'needs_purchase';
+				$status = static::$has_free_offering ? Products::STATUS_NEEDS_PURCHASE_OR_FREE : Products::STATUS_NEEDS_PURCHASE;
 			} elseif ( static::$requires_site_connection && ! ( new Connection_Manager() )->is_connected() ) {
 				// Site has never been connected before
-				if ( ! \Jetpack_Options::get_option( 'id' ) ) {
-					$status = 'needs_first_site_connection';
+				if ( ! Jetpack_Options::get_option( 'id' ) ) {
+					$status = Products::STATUS_NEEDS_FIRST_SITE_CONNECTION;
 				} else {
-					$status = 'site_connection_error';
+					$status = Products::STATUS_SITE_CONNECTION_ERROR;
 				}
 			} elseif ( static::$requires_user_connection && ! ( new Connection_Manager() )->has_connected_owner() ) {
-				$status = 'user_connection_error';
+				$status = Products::STATUS_USER_CONNECTION_ERROR;
 			}
 		} elseif ( ! static::has_any_plan_for_product() ) {
-			$status = static::$has_free_offering ? 'needs_purchase_or_free' : 'needs_purchase';
+			$status = static::$has_free_offering ? Products::STATUS_NEEDS_PURCHASE_OR_FREE : Products::STATUS_NEEDS_PURCHASE;
 		} else {
-			$status = 'inactive';
+			$status = Products::STATUS_INACTIVE;
 		}
 		return $status;
 	}

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\My_Jetpack\Initializer;
 use Automattic\Jetpack\My_Jetpack\Module_Product;
+use Automattic\Jetpack\My_jetpack\Products;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Options;
@@ -169,10 +170,10 @@ class Stats extends Module_Product {
 	 */
 	public static function get_status() {
 		$status = parent::get_status();
-		if ( 'module_disabled' === $status && ! Initializer::is_registered() ) {
+		if ( Products::STATUS_MODULE_DISABLED === $status && ! Initializer::is_registered() ) {
 			// If the site has never been connected before, show the "Learn more" CTA,
 			// that points to the add Stats product interstitial.
-			$status = 'needs_purchase_or_free';
+			$status = Products::STATUS_NEEDS_PURCHASE_OR_FREE;
 		}
 		return $status;
 	}


### PR DESCRIPTION
## Proposed changes:

* Only show site connection banner if the site previously had working products that require the site connection but not the user connection
* Only show the user connection banner if the site previously had working products that require the user connection

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pbNhbs-akp-p2

## Does this pull request change what data or activity we track or use?

Yes, we are adding some tracks attributes to the `jetpack_myjetpack_global_notice_view` event such as the type of connection issue

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
(In this case I would suggest Jetpack Beta so you can more easily start with a fresh site)
2. Go to My Jetpack and dismiss the welcome banner. Refresh the page. You should see a connection banner with a "info" display rather than an error
![image](https://github.com/Automattic/jetpack/assets/65001528/348da8f1-899f-4d03-ad4d-91469c868c83)
3. Connect your site (not the user)
4. Go back to My Jetpack and you should still see a user connection banner with an info banner rather than an error banner
![image](https://github.com/Automattic/jetpack/assets/65001528/7a456659-b6ae-4428-928b-3b790b71060d)
6. Disconnect your site from Jetpack Debugger
7. Go back to My Jetpack and you should now see the site connection banner with error styles
![image](https://github.com/Automattic/jetpack/assets/65001528/f39c08f7-5b35-4491-9867-04cac58b6acf)
8. Connect your site from the banner and refresh the page, you should see the user connection info banner again
9. Now connect your user account
10. Disconnect your site again and go back to My Jetpack. You should now see the *user* error connection banner instead of the site connection banner since you previously had a working plugin that requires a user connection (Jetpack AI)
![image](https://github.com/Automattic/jetpack/assets/65001528/bad2611e-0134-42cf-894d-90245e9afeda)
