### PR TITLE
Subscribe overlay: use home URL in skip link

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-overlay-home-link
+++ b/projects/plugins/jetpack/changelog/update-subscribe-overlay-home-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Subscribe overlay: use home URL in skip link

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -109,6 +109,7 @@ class Jetpack_Subscribe_Overlay {
 	 * @return string
 	 */
 	public function get_subscribe_overlay_template_content() {
+		$home_url         = get_home_url();
 		$site_tagline     = get_bloginfo( 'description' );
 		$default_tagline  = __( 'Stay informed with curated content and the latest headlines, all delivered straight to your inbox. Subscribe now to stay ahead and never miss a beat!', 'jetpack' );
 		$tagline_block    = empty( $site_tagline )
@@ -129,7 +130,7 @@ class Jetpack_Subscribe_Overlay {
 		<!-- wp:jetpack/subscriptions /-->
 
 		<!-- wp:paragraph {"align":"center","className":"jetpack-subscribe-overlay__to-content"} -->
-		<p class="has-text-align-center jetpack-subscribe-overlay__to-content"><a href="#">$skip_to_content ↓</a></p>
+		<p class="has-text-align-center jetpack-subscribe-overlay__to-content"><a href="$home_url">$skip_to_content ↓</a></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Minor update to "skip" link in the overlay, mostly just for accessibility reasons. E.g. if someone is analysing their site with accessibility analyser, this would trip an error for them. (https://dequeuniversity.com/rules/axe/4.3/href-no-hash)

<img width="1057" alt="Screenshot 2024-06-05 at 12 11 27" src="https://github.com/Automattic/jetpack/assets/87168/bcf0e0e1-f011-44ee-b734-b80b4f6f9b02">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Instead of `#`, use the home URL in the link. Makes the URL accessible and possible to open the link in a new tab for example.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable overlay from newsletter settings
* Right click skip link to open in new tab

