### PR TITLE
tools: Don't try to close nonexistent req in await-packagist-updates

### DIFF
--- a/tools/js-tools/await-packagist-updates.mjs
+++ b/tools/js-tools/await-packagist-updates.mjs
@@ -180,7 +180,7 @@ function pollPackagist( name, versionRange ) {
 					} ).finally( () => {
 						// Make sure the request actually gets closed whenever the promise settles.
 						// We don't want hung connections waiting on us to read more data or something.
-						if ( ! req.closed && ! req.destroyed ) {
+						if ( req && ! req.closed && ! req.destroyed ) {
 							req.close( http2.constants.NGHTTP2_CANCEL );
 						}
 					} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If the attempt failed before ever creating a `req`, don't try to check for whether we need to close it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
This isn't what actually caused p1717566265906359-slack-C05Q5HSS013, but it's what made it say "Cannot read properties of undefined (reading 'closed') (will retry)" instead of whatever the real error message was.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷 Hack the code to randomly throw near the top of the promise body, before `req` gets set?