### PR TITLE
Subscriptions: added command palette commands for quickly changing post access.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add-paywall-command-palette
+++ b/projects/plugins/jetpack/changelog/update-add-paywall-command-palette
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Subscriptions: added command palette commands for quickly changing post access.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/command-palette.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/command-palette.js
@@ -1,3 +1,4 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useCommandLoader } from '@wordpress/commands';
@@ -22,6 +23,7 @@ function CommandPalette() {
 			<Path d="M11.471 6.37162C11.2294 6.55286 11.1538 6.74395 11.1538 6.88519C11.1538 7.02644 11.2294 7.21752 11.471 7.39877C11.7108 7.57865 12.0728 7.70953 12.5 7.70953C13.1349 7.70953 13.7344 7.90158 14.1907 8.24382C14.6451 8.5847 15 9.11491 15 9.77039C15 10.4259 14.6451 10.9561 14.1907 11.297C13.8758 11.5331 13.4928 11.6978 13.0769 11.7771V12.0373C13.0769 12.3788 12.8186 12.6556 12.5 12.6556C12.1814 12.6556 11.9231 12.3788 11.9231 12.0373V11.7771C11.5072 11.6978 11.1242 11.5331 10.8093 11.297C10.3549 10.9561 10 10.4259 10 9.77039C10 9.42893 10.2583 9.15213 10.5769 9.15213C10.8955 9.15213 11.1538 9.42893 11.1538 9.77039C11.1538 9.91163 11.2294 10.1027 11.471 10.284C11.7108 10.4638 12.0728 10.5947 12.5 10.5947C12.9272 10.5947 13.2892 10.4638 13.529 10.284C13.7706 10.1027 13.8462 9.91163 13.8462 9.77039C13.8462 9.62914 13.7706 9.43806 13.529 9.25681C13.2892 9.07693 12.9272 8.94605 12.5 8.94605C11.8651 8.94605 11.2656 8.754 10.8093 8.41176C10.3549 8.07089 10 7.54067 10 6.88519C10 6.22971 10.3549 5.6995 10.8093 5.35863C11.1242 5.12246 11.5072 4.95781 11.9231 4.87844V4.61826C11.9231 4.2768 12.1814 4 12.5 4C12.8186 4 13.0769 4.2768 13.0769 4.61826V4.87844C13.4928 4.95781 13.8758 5.12246 14.1907 5.35863C14.6451 5.6995 15 6.22971 15 6.88519C15 7.22665 14.7417 7.50345 14.4231 7.50345C14.1045 7.50345 13.8462 7.22665 13.8462 6.88519C13.8462 6.74395 13.7706 6.55286 13.529 6.37162C13.2892 6.19174 12.9272 6.06085 12.5 6.06085C12.0728 6.06085 11.7108 6.19174 11.471 6.37162Z" />
 		</SVG>
 	);
+	const { tracks } = useAnalytics();
 	const { createInfoNotice } = useDispatch( 'core/notices' );
 	const [ showDialog, setShowDialog ] = useState( false );
 	const closeDialog = () => setShowDialog( false );
@@ -106,6 +108,7 @@ function CommandPalette() {
 					label: __( 'Limit post access to paid subscribers', 'jetpack' ),
 					icon: paywallIcon,
 					callback: ( { close } ) => {
+						tracks.recordEvent( 'editor_command_palette_access_paid_click' );
 						addPaywallBlock();
 						selectAccess( accessOptions.paid_subscribers.key );
 
@@ -122,6 +125,7 @@ function CommandPalette() {
 					label: __( 'Limit post access to free subscribers', 'jetpack' ),
 					icon: paywallIcon,
 					callback: ( { close } ) => {
+						tracks.recordEvent( 'editor_command_palette_access_subscribers_click' );
 						addPaywallBlock();
 						selectAccess( accessOptions.subscribers.key );
 
@@ -142,6 +146,7 @@ function CommandPalette() {
 					),
 					icon: people,
 					callback: ( { close } ) => {
+						tracks.recordEvent( 'editor_command_palette_access_everyone_click' );
 						removePaywallBlock();
 						selectAccess( accessOptions.everybody.key );
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/command-palette.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/command-palette.js
@@ -1,0 +1,133 @@
+import { JetpackLogo } from '@automattic/jetpack-components';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { useCommand } from '@wordpress/commands';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import PlansSetupDialog from '../../shared/components/plans-setup-dialog';
+import { accessOptions } from '../../shared/memberships/constants';
+import { useSetAccess } from '../../shared/memberships/settings';
+import paywallMeta from '../paywall/block.json';
+
+function CommandPalette() {
+	const icon = <JetpackLogo height={ 16 } logoColor="#1E1E1E" showText={ false } />;
+	const { createInfoNotice } = useDispatch( 'core/notices' );
+	const [ showDialog, setShowDialog ] = useState( false );
+	const closeDialog = () => setShowDialog( false );
+	const setAccess = useSetAccess();
+	const { removeBlock, insertBlocks } = useDispatch( blockEditorStore );
+	const { getBlocksByName, canRemoveBlock, canInsertBlockType, getBlockCount } =
+		useSelect( blockEditorStore );
+	const paywallBlockName = paywallMeta.name;
+
+	const { stripeConnectUrl, hasTierPlans } = useSelect( select => {
+		const { getNewsletterTierProducts, getConnectUrl } = select( 'jetpack/membership-products' );
+		return {
+			stripeConnectUrl: getConnectUrl(),
+			hasTierPlans: getNewsletterTierProducts()?.length !== 0,
+		};
+	} );
+
+	function selectAccess( value ) {
+		if ( accessOptions.paid_subscribers.key === value && ( stripeConnectUrl || ! hasTierPlans ) ) {
+			setShowDialog( true );
+			return;
+		}
+		setAccess( value );
+	}
+
+	function removePaywallBlock() {
+		const blocks = getBlocksByName( paywallBlockName );
+
+		if ( blocks.length ) {
+			const paywall = blocks[ 0 ];
+			if ( canRemoveBlock( paywall ) ) {
+				removeBlock( paywall );
+			}
+		}
+	}
+
+	function addPaywallBlock() {
+		// Check that paywall isn't already placed
+		const hasPaywallBlocks = getBlocksByName( paywallBlockName );
+		if ( hasPaywallBlocks.length ) {
+			return;
+		}
+
+		// Check that paywall can be inserted
+		if ( ! canInsertBlockType( paywallBlockName ) ) {
+			return;
+		}
+
+		const paywallBlock = createBlock( paywallBlockName );
+		const blocksCount = getBlockCount();
+
+		// When only one block, insert empty paragraph after paywall for easier editing
+		const blocks = [ paywallBlock ];
+		if ( blocksCount === 1 ) {
+			blocks.push( createBlock( 'core/paragraph' ) );
+		}
+
+		insertBlocks( blocks, 1 );
+	}
+
+	useCommand( {
+		name: 'jetpack/subscriptions-access-paid',
+		label: __( 'Limit post access to paid subscribers', 'jetpack' ),
+		icon,
+		// context: 'site-editor', // @TODO: post editor only
+		callback: ( { close } ) => {
+			addPaywallBlock();
+			selectAccess( accessOptions.paid_subscribers.key );
+
+			createInfoNotice( __( 'Post limited to paid subscribers only.', 'jetpack' ), {
+				id: 'jetpack/subscriptions-access-paid/notice',
+				type: 'snackbar',
+			} );
+
+			close();
+		},
+	} );
+
+	useCommand( {
+		name: 'jetpack/subscriptions-access-subscribers',
+		label: __( 'Limit post access to free subscribers', 'jetpack' ),
+		icon,
+		// context: 'site-editor', // @TODO: post editor only
+		callback: ( { close } ) => {
+			addPaywallBlock();
+			selectAccess( accessOptions.subscribers.key );
+
+			createInfoNotice( __( 'Post limited to subscribers only.', 'jetpack' ), {
+				id: 'jetpack/subscriptions-access-subscribers/notice',
+				type: 'snackbar',
+			} );
+
+			close();
+		},
+	} );
+
+	useCommand( {
+		name: 'jetpack/subscriptions-access-everyone',
+		label: __( 'Make post accessible to everyone', 'jetpack' ),
+		searchLabel: __( 'Make post accessible to everyone, free and paid subscribers', 'jetpack' ),
+		icon,
+		// context: 'site-editor', // @TODO: post editor only
+		callback: ( { close } ) => {
+			removePaywallBlock();
+			selectAccess( accessOptions.everybody.key );
+
+			createInfoNotice( __( 'Post made accesible to everyone.', 'jetpack' ), {
+				id: 'jetpack/subscriptions-access-everyone/notice',
+				type: 'snackbar',
+			} );
+
+			close();
+		},
+	} );
+
+	return <PlansSetupDialog closeDialog={ closeDialog } showDialog={ showDialog } />;
+}
+
+export default CommandPalette;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/command-palette.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/command-palette.js
@@ -1,18 +1,27 @@
-import { JetpackLogo } from '@automattic/jetpack-components';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useCommandLoader } from '@wordpress/commands';
+import { Path, SVG } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { people } from '@wordpress/icons';
 import PlansSetupDialog from '../../shared/components/plans-setup-dialog';
 import { accessOptions } from '../../shared/memberships/constants';
 import { useSetAccess } from '../../shared/memberships/settings';
 import paywallMeta from '../paywall/block.json';
 
 function CommandPalette() {
-	const icon = <JetpackLogo height={ 16 } logoColor="#1E1E1E" showText={ false } />;
+	const paywallIcon = (
+		<SVG viewBox="0 0 24 24" width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+			<Path d="M4 16.7134L20 16.7134V15.106H4V16.7134Z" />
+			<Path d="M16 21H20V19.3925H16V21Z" />
+			<Path d="M14 21H10V19.3925H14V21Z" />
+			<Path d="M4 21H8V19.3925H4V21Z" />
+			<Path d="M11.471 6.37162C11.2294 6.55286 11.1538 6.74395 11.1538 6.88519C11.1538 7.02644 11.2294 7.21752 11.471 7.39877C11.7108 7.57865 12.0728 7.70953 12.5 7.70953C13.1349 7.70953 13.7344 7.90158 14.1907 8.24382C14.6451 8.5847 15 9.11491 15 9.77039C15 10.4259 14.6451 10.9561 14.1907 11.297C13.8758 11.5331 13.4928 11.6978 13.0769 11.7771V12.0373C13.0769 12.3788 12.8186 12.6556 12.5 12.6556C12.1814 12.6556 11.9231 12.3788 11.9231 12.0373V11.7771C11.5072 11.6978 11.1242 11.5331 10.8093 11.297C10.3549 10.9561 10 10.4259 10 9.77039C10 9.42893 10.2583 9.15213 10.5769 9.15213C10.8955 9.15213 11.1538 9.42893 11.1538 9.77039C11.1538 9.91163 11.2294 10.1027 11.471 10.284C11.7108 10.4638 12.0728 10.5947 12.5 10.5947C12.9272 10.5947 13.2892 10.4638 13.529 10.284C13.7706 10.1027 13.8462 9.91163 13.8462 9.77039C13.8462 9.62914 13.7706 9.43806 13.529 9.25681C13.2892 9.07693 12.9272 8.94605 12.5 8.94605C11.8651 8.94605 11.2656 8.754 10.8093 8.41176C10.3549 8.07089 10 7.54067 10 6.88519C10 6.22971 10.3549 5.6995 10.8093 5.35863C11.1242 5.12246 11.5072 4.95781 11.9231 4.87844V4.61826C11.9231 4.2768 12.1814 4 12.5 4C12.8186 4 13.0769 4.2768 13.0769 4.61826V4.87844C13.4928 4.95781 13.8758 5.12246 14.1907 5.35863C14.6451 5.6995 15 6.22971 15 6.88519C15 7.22665 14.7417 7.50345 14.4231 7.50345C14.1045 7.50345 13.8462 7.22665 13.8462 6.88519C13.8462 6.74395 13.7706 6.55286 13.529 6.37162C13.2892 6.19174 12.9272 6.06085 12.5 6.06085C12.0728 6.06085 11.7108 6.19174 11.471 6.37162Z" />
+		</SVG>
+	);
 	const { createInfoNotice } = useDispatch( 'core/notices' );
 	const [ showDialog, setShowDialog ] = useState( false );
 	const closeDialog = () => setShowDialog( false );
@@ -95,7 +104,7 @@ function CommandPalette() {
 				{
 					name: 'jetpack/subscriptions-access-paid',
 					label: __( 'Limit post access to paid subscribers', 'jetpack' ),
-					icon,
+					icon: paywallIcon,
 					callback: ( { close } ) => {
 						addPaywallBlock();
 						selectAccess( accessOptions.paid_subscribers.key );
@@ -111,7 +120,7 @@ function CommandPalette() {
 				{
 					name: 'jetpack/subscriptions-access-subscribers',
 					label: __( 'Limit post access to free subscribers', 'jetpack' ),
-					icon,
+					icon: paywallIcon,
 					callback: ( { close } ) => {
 						addPaywallBlock();
 						selectAccess( accessOptions.subscribers.key );
@@ -131,7 +140,7 @@ function CommandPalette() {
 						'Make post accessible to everyone, free and paid subscribers',
 						'jetpack'
 					),
-					icon,
+					icon: people,
 					callback: ( { close } ) => {
 						removePaywallBlock();
 						selectAccess( accessOptions.everybody.key );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/command-palette.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/command-palette.js
@@ -108,7 +108,7 @@ function CommandPalette() {
 					label: __( 'Limit post access to paid subscribers', 'jetpack' ),
 					icon: paywallIcon,
 					callback: ( { close } ) => {
-						tracks.recordEvent( 'editor_command_palette_access_paid_click' );
+						tracks.recordEvent( 'jetpack_editor_command_palette_access_paid_click' );
 						addPaywallBlock();
 						selectAccess( accessOptions.paid_subscribers.key );
 
@@ -125,7 +125,7 @@ function CommandPalette() {
 					label: __( 'Limit post access to free subscribers', 'jetpack' ),
 					icon: paywallIcon,
 					callback: ( { close } ) => {
-						tracks.recordEvent( 'editor_command_palette_access_subscribers_click' );
+						tracks.recordEvent( 'jetpack_editor_command_palette_access_subscribers_click' );
 						addPaywallBlock();
 						selectAccess( accessOptions.subscribers.key );
 
@@ -146,7 +146,7 @@ function CommandPalette() {
 					),
 					icon: people,
 					callback: ( { close } ) => {
-						tracks.recordEvent( 'editor_command_palette_access_everyone_click' );
+						tracks.recordEvent( 'jetpack_editor_command_palette_access_everyone_click' );
 						removePaywallBlock();
 						selectAccess( accessOptions.everybody.key );
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/command-palette.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/command-palette.js
@@ -1,4 +1,4 @@
-import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { useAnalytics, useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useCommandLoader } from '@wordpress/commands';
@@ -24,6 +24,7 @@ function CommandPalette() {
 		</SVG>
 	);
 	const { tracks } = useAnalytics();
+	const { isLoadingModules, isModuleActive } = useModuleStatus( 'subscriptions' );
 	const { createInfoNotice } = useDispatch( 'core/notices' );
 	const [ showDialog, setShowDialog ] = useState( false );
 	const closeDialog = () => setShowDialog( false );
@@ -91,14 +92,15 @@ function CommandPalette() {
 
 			return {
 				postType: getCurrentPostType(),
-				isLoading: ! select( editorStore ).hasFinishedResolution( 'getCurrentPostType' ),
+				isLoading:
+					! select( editorStore ).hasFinishedResolution( 'getCurrentPostType' ) || isLoadingModules,
 			};
 		}, [] );
 
 		// Create the commands.
 		const commands = useMemo( () => {
-			// If postType is defined and not 'post', unregister the block.
-			if ( postType !== 'post' ) {
+			// Don't register commands
+			if ( postType !== 'post' || ! isModuleActive ) {
 				return [];
 			}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -3,6 +3,7 @@ import { createBlock } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
+import CommandPalette from './command-palette';
 import deprecated from './deprecated';
 import edit from './edit';
 import SubscribePanels from './panel';
@@ -61,11 +62,12 @@ registerJetpackBlockFromMetadata( metadata, {
 	deprecated,
 } );
 
-// Registers slot/fill panels defined via settings.render.
+// Registers slot/fill panels defined via settings.render and command palette commands
 registerJetpackPlugin( blockName, {
 	render: () => (
 		<>
-			<SubscribePanels />
+			<SubscribePanels />,
+			<CommandPalette />
 		</>
 	),
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

New command line commands to change posts into free, paid or subscribers-only. Commands show up only in the post editor, and not in page/site editors.

- When a post is made free, remove any paywall blocks from the content.

- When post is made paid, or subscribers-only, adds paywall block to the content after 1st block of the post.

- If the content is shorter than 2 blocks, add one empty block after the paywall block so that it's easier to continue writing paid content.

- If Stripe isn't connected, nudges to set up payments first.

- Has tracks events.

**Commands:**

<img width="427" alt="Screenshot 2024-06-10 at 12 38 00" src="https://github.com/Automattic/jetpack/assets/87168/e5cc03d6-4719-485e-b5a1-34cd7e456fc4">

**Video showing how paywall block gets inserted/removed:**

https://github.com/Automattic/jetpack/assets/87168/055e88b6-a094-44bc-99cb-baf331b8bc98

**Notices:**

<img width="885" alt="Screenshot 2024-06-07 at 15 51 59" src="https://github.com/Automattic/jetpack/assets/87168/13b9d809-f8d8-42ae-a5cb-29920b2c3f35">
<img width="706" alt="Screenshot 2024-06-07 at 15 51 38" src="https://github.com/Automattic/jetpack/assets/87168/a6ca1218-a341-406a-a706-078785c23ea6">



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In post editor with subscriptions module enabled, press `cmd+k`
* Type "access" or some other keyword, and try different commands.

