### PR TITLE
cli: For `jetpack release version`, only init next cycle when asked to

### DIFF
--- a/tools/cli/commands/release.js
+++ b/tools/cli/commands/release.js
@@ -46,6 +46,10 @@ export function releaseDefine( yargs ) {
 				.option( 'add-pr-num', {
 					describe: 'Append the GH PR number to each entry',
 					type: 'boolean',
+				} )
+				.option( 'init-next-cycle', {
+					describe: 'For `version`, init the next release cycle',
+					type: 'boolean',
 				} );
 		},
 		async argv => {
@@ -164,7 +168,7 @@ export async function scriptRouter( argv ) {
 			argv.version = await getReleaseVersion( argv );
 			argv = await promptForVersion( argv );
 			argv.script = 'tools/project-version.sh';
-			argv.scriptArgs = [ '-Cu', argv.version, argv.project ];
+			argv.scriptArgs = [ argv.initNextCycle ? '-Cu' : '-u', argv.version, argv.project ];
 			argv.next =
 				`Finished! Next, you will likely want to check the following project files to make sure versions were updated correctly:
 				 - The main php file

--- a/tools/release-plugin.sh
+++ b/tools/release-plugin.sh
@@ -296,7 +296,7 @@ git checkout prerelease
 # If we're releasing the Jetpack plugin, ask if we want to start a new cycle.
 if [[ -v PROJECTS["plugins/jetpack"] ]]; then
   if proceed_p "Do you want to start a new cycle for Jetpack?"; then
-    pnpm jetpack release plugins/jetpack version -a
+    pnpm jetpack release plugins/jetpack version -a --init-next-cycle
     git add --all
     git commit -am "Init new cycle"
   fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In #27641 we added code to init the next cycle to `jetpack release version`. It's not clear to me now whether that fixed one use case while breaking another, or whether the 'another' was added later.

Either way, we only want to start the next cycle in some cases. So add an `--init-next-cycle` option to use for those cases.

Note, post-merge we'll want to update docs in PCYsg-SU8-p2 and PCYsg-GRM-p2 to use the new flag.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1717596500913069-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack release plugins/starter-plugin version -s`. It should not create a file `projects/plugins/starter-plugin/changelog/init-release-cycle`.
* Run `jetpack release plugins/starter-plugin version -s --init-next-cycle`. It should create the file this time.