### PR TITLE
Like Block: Fix styling conflicts and update editor styles

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-like-block-editor-styling
+++ b/projects/plugins/jetpack/changelog/fix-like-block-editor-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Like block: Fix editor styling

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -10,7 +10,7 @@
 	display: none;
 }
 
-/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-06-10T12:18:50.530Z */
+/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-06-11T11:31:33.631Z */
 .wpl-likebox {
 	container-type:inline-size;
 }
@@ -243,12 +243,21 @@ a.comment-like-link.loading:before {
 		}
 
 		.wpl-avatars {
-			margin: 0 0 4px 0;
+			margin: 0;
 			padding-left: 0;
+			align-content: unset;
+
+			li {
+				margin: 0;
+			}
 
 			li a:focus {
 				outline: none;
 				box-shadow: none;
+			}
+
+			li a img {
+				vertical-align: unset;
 			}
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -10,7 +10,7 @@
 	display: none;
 }
 
-/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-06-11T11:31:33.631Z */
+/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-06-11T14:41:11.500Z */
 .wpl-likebox {
 	container-type:inline-size;
 }
@@ -277,5 +277,16 @@ a.comment-like-link.loading:before {
 
 	.wpl-button.like a:hover:before {
 		background-image:url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m9.00081 2 1.95699 4.26814h4.3763l-3.6666 3.39117 1.2473 4.34069-3.91399-2.25-3.914 2.25 1.24734-4.34069-3.66667-3.39117h2.18817 2.18816z' stroke='%232c3338' stroke-linecap='round' stroke-width='1.5'/%3E%3C/svg%3E");
+	}
+}
+
+// Format buttons correctly when displayed in columns
+@container (max-width: 320px) {
+	.wpl-button {
+		min-width: auto;
+	}
+
+	.wpl-button a span {
+		display: none;
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -10,7 +10,7 @@
 	display: none;
 }
 
-/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-01-23T11:29:16.073Z */
+/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-06-05T15:01:45.045Z */
 .wpl-likebox {
 	container-type:inline-size;
 }
@@ -19,12 +19,13 @@
 	font-family:"Open Sans",sans-serif!important;
 }
 .wpl-button {
-	min-width:73px;
+	min-width:40px;
+	overflow:hidden;
 }
 .wpl-button a {
 	text-decoration:none;
 	display:flex;
-	margin:1px 7px 8px 1px;
+	margin:1px 6px 8px 1px;
 	font-size:13px;
 	font-family:"Open Sans",sans-serif;
 	font-weight:500;
@@ -34,7 +35,14 @@
 	box-shadow:0 1px 2px rgba(0,0,0,.12),0 0 0 1px rgba(0,0,0,.12);
 	text-shadow:none;
 	line-height:23px;
-	padding:4px 10px 3px;
+	padding:4px 10px 3px 9px;
+	min-height:30px;
+	min-width:33px;
+	box-sizing:border-box;
+}
+.rtl .wpl-button a {
+	margin:1px 1px 8px 6px;
+	padding:4px 9px 3px 10px;
 }
 .wpl-button a:hover {
 	box-shadow:0 1px 2px rgba(0,0,0,.22),0 0 0 1px rgba(0,0,0,.22);
@@ -49,8 +57,8 @@
 	height:16px;
 	text-align:center;
 	top:3px;
-	margin-left:-1px;
-	margin-right:1px;
+	margin-left:0;
+	margin-right:-1px;
 	content:"";
 	background-size:16px 16px;
 	min-width:16px;
@@ -74,22 +82,14 @@
 	background-image:url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m1 0h16v16h-16z' fill='%23fff'/%3E%3Cpath d='m16.0163 5.56587-1.4511-1.43412v8.99325c0 .7597-.6226 1.375-1.3913 1.375h-4.86955v-1.375h4.86955v-8.99325l-1.4511 1.43412-.9837-.97212 3.1305-3.09375 3.1304 3.09375zm-11.19021 6.30243v-8.9933h4.86956v-1.375h-4.86956c-.7687 0-1.39131.61531-1.39131 1.375v8.9933l-1.45113-1.4342-.98365.9721 3.13043 3.0938 3.13044-3.0938-.98365-.9721z' fill='%230675c4' stroke='%230675c4' stroke-width='.14'/%3E%3C/svg%3E");
 }
 .rtl .wpl-button.like a:before,.rtl .wpl-button.liked a:before {
-	margin-left:1px;
-	margin-right:-1px;
+	margin-right:0;
+	margin-left:-1px;
 }
 .wpl-button.like a span,.wpl-button.liked a span,.wpl-button.reblog a span {
-	margin-left:3px;
+	margin-left:5px;
 }
-@container (max-width:320px) {
-	.wpl-button {
-		min-width:auto;
-	}
-	.wpl-button a {
-		padding-bottom:10px;
-	}
-	.wpl-button a span {
-		display:none;
-	}
+.rtl .wpl-button.like a span,.rtl .wpl-button.liked a span,.rtl .wpl-button.reblog a span {
+	margin-right:5px;
 }
 .wpl-count {
 	clear:both;
@@ -99,7 +99,7 @@
 .wpl-count-text {
 	line-height:1.6;
 }
-.wpl-likebox.wpl-new-layout .wpl-count,.wpl-likebox.wpl-new-layout .wpl-count a,.wpl-likebox.wpl-new-layout .wpl-count-text,.wpl-likebox.wpl-new-layout .wpl-count-text a {
+.wpl-likebox .wpl-count,.wpl-likebox .wpl-count a,.wpl-likebox .wpl-count-text,.wpl-likebox .wpl-count-text a {
 	font-size:12px!important;
 }
 .wpl-button {
@@ -114,6 +114,9 @@
 	list-style:none;
 	overflow:hidden;
 	height:34px;
+}
+.wpl-avatars:empty {
+	display:none;
 }
 .wpl-avatars li {
 	margin:0;
@@ -167,11 +170,11 @@ a.comment-like-link.loading:before {
 	transition:opacity 2s;
 	opacity:0;
 }
-.wpl-likebox.wpl-new-layout {
+.wpl-likebox {
 	display:flex;
 	align-items:center;
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars {
+.wpl-likebox .wpl-avatars {
 	display:inline-flex;
 	flex-direction:row-reverse;
 	align-items:center;
@@ -179,56 +182,91 @@ a.comment-like-link.loading:before {
 	margin-bottom:4px;
 	flex-wrap:wrap;
 }
-.rtl .wpl-likebox.wpl-new-layout .wpl-avatars {
+.rtl .wpl-likebox .wpl-avatars {
 	justify-content:flex-end;
-	margin-right:8px;
 	overflow:initial;
 	flex-wrap:wrap;
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars li,.rtl .wpl-likebox.wpl-new-layout .wpl-avatars li {
+.wpl-likebox .wpl-avatars li,.rtl .wpl-likebox .wpl-avatars li {
 	margin-bottom:10px;
 	margin-top:1px;
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars li a {
+.wpl-likebox .wpl-avatars li a {
 	position:relative;
 	margin:0;
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars li:not(:first-child) a {
+.wpl-likebox .wpl-avatars li:not(:first-child) a {
 	margin-right:-4px;
 }
-.rtl .wpl-likebox.wpl-new-layout .wpl-avatars li:not(:first-child) a {
+.rtl .wpl-likebox .wpl-avatars li:not(:first-child) a {
 	margin-left:-4px;
 }
-.wpl-likebox.wpl-new-layout .wpl-avatars li a img {
+.wpl-likebox .wpl-avatars li a img {
 	border:solid 1.5px rgba(255,255,255,.5);
 	border-radius:50%;
 	width:26px;
 	height:26px;
 }
-.wpl-likebox.wpl-new-layout .wpl-count {
-	margin-left:8px;
+.wpl-likebox .wpl-count {
+	margin-left:4px;
 	margin-bottom:4px;
 	clear:none;
 	white-space:nowrap;
 }
-.rtl .wpl-likebox.wpl-new-layout .wpl-count {
+.rtl .wpl-likebox .wpl-count {
 	margin-left:0;
-	margin-right:12px;
+	margin-right:4px;
 	white-space:nowrap;
 }
 
 /* Overrides to fix CSS conflicts within editor. */
 .wpl-likebox {
-	// Prevents color conflict by
+	// Prevents color and outline conflict by
 	// .wp-block-post-content a:where(:not(.wp-element-button))
 	a {
 		color: #2C3338 !important;
 		text-decoration: none !important;
+		outline: none !important;
 	}
 
 	// Prevents focus state conflict by
 	// a:where(:not(.wp-element-button)):focus
 	a:focus {
 		text-decoration: none !important;
+		outline: none !important;
+	}
+
+	// Prevent a number of editor and theme conflicts
+	&.wpl-new-layout {
+		* {
+			cursor: default;
+		}
+
+		.wpl-avatars {
+			margin: 0 0 4px 0;
+			padding-left: 0;
+
+			li a:focus {
+				outline: none;
+				box-shadow: none;
+			}
+		}
+
+		.wpl-count:focus,
+		.wpl-count a:focus,
+		.wpl-count-text:focus,
+		.wpl-count-text a:focus {
+			outline: none;
+			box-shadow: none;
+		}
+	}
+
+	// Prevents hover state conflicts on the button element.
+	.wpl-button a:hover {
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.12);
+	}
+
+	.wpl-button.like a:hover:before {
+		background-image:url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m9.00081 2 1.95699 4.26814h4.3763l-3.6666 3.39117 1.2473 4.34069-3.91399-2.25-3.914 2.25 1.24734-4.34069-3.66667-3.39117h2.18817 2.18816z' stroke='%232c3338' stroke-linecap='round' stroke-width='1.5'/%3E%3C/svg%3E");
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/like/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/like/editor.scss
@@ -10,7 +10,7 @@
 	display: none;
 }
 
-/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-06-05T15:01:45.045Z */
+/* Fetched below from https://widgets.wp.com/likes/style.css at 2024-06-10T12:18:50.530Z */
 .wpl-likebox {
 	container-type:inline-size;
 }
@@ -39,6 +39,7 @@
 	min-height:30px;
 	min-width:33px;
 	box-sizing:border-box;
+	align-items:center;
 }
 .rtl .wpl-button a {
 	margin:1px 1px 8px 6px;
@@ -56,7 +57,6 @@
 	width:16px;
 	height:16px;
 	text-align:center;
-	top:3px;
 	margin-left:0;
 	margin-right:-1px;
 	content:"";
@@ -87,6 +87,7 @@
 }
 .wpl-button.like a span,.wpl-button.liked a span,.wpl-button.reblog a span {
 	margin-left:5px;
+	text-wrap:nowrap;
 }
 .rtl .wpl-button.like a span,.rtl .wpl-button.liked a span,.rtl .wpl-button.reblog a span {
 	margin-right:5px;
@@ -181,14 +182,11 @@ a.comment-like-link.loading:before {
 	justify-content:center;
 	margin-bottom:4px;
 	flex-wrap:wrap;
-}
-.rtl .wpl-likebox .wpl-avatars {
-	justify-content:flex-end;
-	overflow:initial;
-	flex-wrap:wrap;
+	align-content:end;
+	min-width:30px;
 }
 .wpl-likebox .wpl-avatars li,.rtl .wpl-likebox .wpl-avatars li {
-	margin-bottom:10px;
+	margin-bottom:1px;
 	margin-top:1px;
 }
 .wpl-likebox .wpl-avatars li a {
@@ -200,6 +198,7 @@ a.comment-like-link.loading:before {
 }
 .rtl .wpl-likebox .wpl-avatars li:not(:first-child) a {
 	margin-left:-4px;
+	margin-right:0;
 }
 .wpl-likebox .wpl-avatars li a img {
 	border:solid 1.5px rgba(255,255,255,.5);
@@ -214,8 +213,9 @@ a.comment-like-link.loading:before {
 	white-space:nowrap;
 }
 .rtl .wpl-likebox .wpl-count {
-	margin-left:0;
 	margin-right:4px;
+	margin-bottom:4px;
+	clear:none;
 	white-space:nowrap;
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
@@ -115,6 +115,17 @@ function processCSS( css ) {
 		background-image:url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m9.00081 2 1.95699 4.26814h4.3763l-3.6666 3.39117 1.2473 4.34069-3.91399-2.25-3.914 2.25 1.24734-4.34069-3.66667-3.39117h2.18817 2.18816z' stroke='%232c3338' stroke-linecap='round' stroke-width='1.5'/%3E%3C/svg%3E");
 	}
 }
+
+// Format buttons correctly when displayed in columns
+@container (max-width: 320px) {
+	.wpl-button {
+		min-width: auto;
+	}
+
+	.wpl-button a span {
+		display: none;
+	}
+}
 `;
 
 	// Get current date and time

--- a/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
@@ -57,17 +57,53 @@ function processCSS( css ) {
 	const customRule2 = `
 	/* Overrides to fix CSS conflicts within editor. */
 .wpl-likebox {
-	// Prevents color conflict by
+	// Prevents color and outline conflict by
 	// .wp-block-post-content a:where(:not(.wp-element-button))
 	a {
 		color: #2C3338 !important;
 		text-decoration: none !important;
+		outline: none !important;
 	}
 
 	// Prevents focus state conflict by
 	// a:where(:not(.wp-element-button)):focus
 	a:focus {
 		text-decoration: none !important;
+		outline: none !important;
+	}
+
+	// Prevent a number of editor and theme conflicts
+	&.wpl-new-layout {
+		* {
+			cursor: default;
+		}
+
+		.wpl-avatars {
+			margin: 0 0 4px 0;
+			padding-left: 0;
+
+			li a:focus {
+				outline: none;
+				box-shadow: none;
+			}
+		}
+
+		.wpl-count:focus,
+		.wpl-count a:focus,
+		.wpl-count-text:focus,
+		.wpl-count-text a:focus {
+			outline: none;
+			box-shadow: none;
+		}
+	}
+
+	// Prevents hover state conflicts on the button element.
+	.wpl-button a:hover {
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(0, 0, 0, 0.12);
+	}
+
+	.wpl-button.like a:hover:before {
+		background-image:url("data:image/svg+xml,%3Csvg fill='none' height='16' viewBox='0 0 18 16' width='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='m9.00081 2 1.95699 4.26814h4.3763l-3.6666 3.39117 1.2473 4.34069-3.91399-2.25-3.914 2.25 1.24734-4.34069-3.66667-3.39117h2.18817 2.18816z' stroke='%232c3338' stroke-linecap='round' stroke-width='1.5'/%3E%3C/svg%3E");
 	}
 }
 `;

--- a/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js
@@ -79,12 +79,21 @@ function processCSS( css ) {
 		}
 
 		.wpl-avatars {
-			margin: 0 0 4px 0;
+			margin: 0;
 			padding-left: 0;
+			align-content: unset;
+
+			li {
+				margin: 0;
+			}
 
 			li a:focus {
 				outline: none;
 				box-shadow: none;
+			}
+
+			li a img {
+				vertical-align: unset;
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87082.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* fix Like block editor and theme styling conflicts (changes in `projects/plugins/jetpack/extensions/blocks/like/tools/update-editor-styles.js`); when it comes to the code review, these are the changes that are worth looking at. The rest (`editor.scss`) is generated by the script that loads the latest style changes from WPCOM
* update Like block's `editor.scss` with the latest styles

| Before | After |
|--------|--------|
| ![Markup on 2024-06-06 at 14:22:45](https://github.com/Automattic/jetpack/assets/25105483/03eba576-b19b-4d94-81bf-0b97f2fdddae) | ![Markup on 2024-06-06 at 14:27:27](https://github.com/Automattic/jetpack/assets/25105483/5a9e0fb1-80df-4c82-a673-3e83e773f07d) | 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

- related issue: https://github.com/Automattic/wp-calypso/issues/87082

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:

1. Sync the changes to your Simple test site with rsync (https://github.com/Automattic/jetpack/pull/37719#issuecomment-2150363482) and sandbox the site.
2. Add the Like block to a post / page.
3. The Like block formatting in the **editor** should be correct. Try clicking on the avatars, buttons and number of likes. There should be no overlays, nor hover effects (as in the _After_ screenshot).
4. Please try several different themes; I have observed the original issues with `Twenty Twenty-One` and `Twenty Twenty`, but you don't need to feel limited to these two themes.
5. Feel free to test with self-hosted and WoA sites. Taking into account the scope of changes in this PR, testing with Simple sites should be sufficient. 