### PR TITLE
Jetpack AI: expose upgrade URL on ai-assistant-feature endpoint

### DIFF
--- a/.phan/stubs/wpcom-stubs.php
+++ b/.phan/stubs/wpcom-stubs.php
@@ -1435,6 +1435,12 @@ namespace WPCOM\Jetpack_AI\Usage {
         public static function get_costs()
         {
         }
+        /**
+         * @param int $blog_id
+         * @return string
+         */
+        public static function get_upgrade_url($blog_id){
+        }
     }
 }
 namespace WPForTeams {

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -377,6 +377,7 @@ class Jetpack_AI_Helper {
 				'usage-period'         => WPCOM\Jetpack_AI\Usage\Helper::get_period_data( $blog_id ),
 				'site-require-upgrade' => WPCOM\Jetpack_AI\Usage\Helper::site_requires_upgrade( $blog_id ),
 				'upgrade-type'         => $upgrade_type,
+				'upgrade-url'          => WPCOM\Jetpack_AI\Usage\Helper::get_upgrade_url( $blog_id ),
 				'current-tier'         => WPCOM\Jetpack_AI\Usage\Helper::get_current_tier( $blog_id ),
 				'next-tier'            => WPCOM\Jetpack_AI\Usage\Helper::get_next_tier( $blog_id ),
 				'tier-plans'           => WPCOM\Jetpack_AI\Usage\Helper::get_tier_plans_list(),

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-expose-upgrade-url-on-feature-endpoint
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-expose-upgrade-url-on-feature-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: expose the upgrade URL on the feature endpoint, considering current plan and site type.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use the Usage\Helper method added by D151093-code to expose the upgrade URL on the `ai-assistant-feature` endpoint

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run the Jetpack downloader command provided below on your sandbox and sandbox the `public-api` domain
* Go to https://developer.wordpress.com/docs/api/console/ and prepare a request to `wpcom/v2/sites/$wpcom_site/jetpack-ai/ai-assistant-feature`
* Execute the request for each test scenario provided below; on each scenario, confirm the `upgrade-url` field is present on the API response and contains the proper upgrade URL, considering site type and current plan of the site (check the test scenario description for details)

Test scenarios:

- a Jetpack site on the unlimited Jetpack AI tier
   - should return `null` since it's not possible to upgrade the site to any other tier
- a Jetpack site on any other tier (free or some limited one)
   - should return the My Jetpack Jetpack AI product interstitial URL
      - example: `https://the-site.jurassic.tube/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai`
- a Simple site with a paid WPCOM upgrade
   - should return `null` since the site will have the unlimited Jetpack AI tier, and it's not possible to upgrade the site to any other tier
- a free Simple site on any Jetpack AI tier (free or some limited one)
   - when the site is not on the biggest tier (1000 req/month), should return the Jetpack redirect URL that will lead to the checkout page, with the next tier set as the upgrade target (0 -> 100, 100 -> 200, and so on)
      - example: `https://jetpack.com/redirect/?source=jetpack-ai-yearly-tier-upgrade-nudge&site=the-site.wordpress.com&path=jetpack_ai_yearly%3A-q-100`
   - when the site is on the biggest tier (1000 req/month), should return the "Contact US" Jetpack redirect URL (currently a `mailto` link)
      - example: `https://jetpack.com/redirect/?source=jetpack-ai-tiers-more-requests-contact`

You can simulate the current tier of a site using filters on the `0-sandbox.php` file from your sandbox:

```
// return 0 for free plan, 1 for unlimited, 100, 200, 500, 750 and 1000 for tiers, being 1000 the last tier
add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 1; } );
```

---

<img width="600" alt="Screenshot 2024-06-05 at 15 20 25" src="https://github.com/Automattic/jetpack/assets/6760046/8ca609ed-aa0c-4178-8cca-da49d3824de2">