### PR TITLE
Social | Add optimistic connection data when adding one

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-add-optimistic-connection-data-when-adding-one
+++ b/projects/js-packages/publicize-components/changelog/update-social-add-optimistic-connection-data-when-adding-one
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social | Added optmistic response for connection creation

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.54.1",
+	"version": "0.54.2-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-name.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-name.tsx
@@ -1,5 +1,7 @@
 import { ExternalLink, Spinner } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { store as socialStore } from '../../social-store';
 import { Connection } from '../../social-store/types';
 import styles from './style.module.scss';
 
@@ -15,18 +17,25 @@ type ConnectionNameProps = {
  * @returns {import('react').ReactNode} - React element
  */
 export function ConnectionName( { connection }: ConnectionNameProps ) {
-	if ( connection.display_name ) {
-		return (
-			<div className={ styles[ 'connection-name' ] }>
-				{ ! connection.profile_link ? (
-					<span className={ styles[ 'profile-link' ] }>{ connection.display_name }</span>
-				) : (
-					<ExternalLink className={ styles[ 'profile-link' ] } href={ connection.profile_link }>
-						{ connection.display_name }
-					</ExternalLink>
-				) }
-			</div>
-		);
-	}
-	return <Spinner color="black" aria-label={ __( 'Loading account details', 'jetpack' ) } />;
+	const isUpdating = useSelect(
+		select => {
+			return select( socialStore ).getUpdatingConnections().includes( connection.connection_id );
+		},
+		[ connection.connection_id ]
+	);
+
+	return (
+		<div className={ styles[ 'connection-name' ] }>
+			{ ! connection.profile_link ? (
+				<span className={ styles[ 'profile-link' ] }>{ connection.display_name }</span>
+			) : (
+				<ExternalLink className={ styles[ 'profile-link' ] } href={ connection.profile_link }>
+					{ connection.display_name }
+				</ExternalLink>
+			) }
+			{ isUpdating ? (
+				<Spinner color="black" aria-label={ __( 'Updating account', 'jetpack' ) } />
+			) : null }
+		</div>
+	);
 }

--- a/projects/js-packages/publicize-components/src/components/connection-management/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/connection-management/style.module.scss
@@ -14,7 +14,12 @@
 }
 
 .connection-name {
-	display: inline-block;
+	display: flex;
+	align-items: center;
+
+	:global(.components-spinner) {
+		margin-top: 0px;
+	}
 
 	span.profile-link,
 	.profile-link:global(.components-external-link) {

--- a/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/index.test.js
+++ b/projects/js-packages/publicize-components/src/components/connection-management/tests/specs/index.test.js
@@ -20,20 +20,6 @@ describe( 'ConnectionManagement', () => {
 	} );
 
 	describe( 'With connections', () => {
-		test( 'renders the spinner without connection name', () => {
-			setup( {
-				connections: [
-					{ service_name: 'twitter', connection_id: '1' },
-					{ service_name: 'facebook', connection_id: '2' },
-				],
-			} );
-			const management = getManagementPageObject();
-
-			expect( management.header ).toBeInTheDocument();
-			expect( management.addConnectionButton ).toBeInTheDocument();
-			expect( management.spinners ).toHaveLength( 2 );
-		} );
-
 		test( 'renders the component with proper connections', () => {
 			setup();
 			const management = getManagementPageObject();

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/confirmation-form/index.tsx
@@ -146,7 +146,12 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 				shared: formData.get( 'shared' ) === '1' ? true : undefined,
 			};
 
-			await createConnection( data );
+			// Do not await the connection creation to unblock the UI
+			createConnection( data, {
+				display_name: formData.get( 'display_name' ),
+				profile_picture: formData.get( 'profile_picture' ),
+				service_name: service.ID,
+			} );
 
 			onComplete();
 		},
@@ -156,6 +161,7 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 			keyringResult.ID,
 			onComplete,
 			service.multiple_external_user_ID_support,
+			service.ID,
 		]
 	);
 
@@ -204,6 +210,12 @@ export function ConfirmationForm( { keyringResult, onComplete, isAdmin }: Confir
 											defaultChecked={ index === 0 }
 											className={ styles[ 'account-input' ] }
 											required
+										/>
+										<input type="hidden" name="display_name" value={ option.label } />
+										<input
+											type="hidden"
+											name="profile_picture"
+											value={ option.profile_picture || '' }
 										/>
 										<AccountInfo
 											label={ option.label }

--- a/projects/js-packages/publicize-components/src/components/manage-connections-modal/tests/confirmation-form.test.js
+++ b/projects/js-packages/publicize-components/src/components/manage-connections-modal/tests/confirmation-form.test.js
@@ -71,11 +71,18 @@ describe( 'ConfirmationForm', () => {
 		await userEvent.click( screen.getByText( 'Confirm' ) );
 
 		await waitFor( () =>
-			expect( stubCreateConnection ).toHaveBeenCalledWith( {
-				external_user_ID: 'additional-2',
-				keyring_connection_ID: 'service-1',
-				shared: undefined,
-			} )
+			expect( stubCreateConnection ).toHaveBeenCalledWith(
+				{
+					external_user_ID: 'additional-2',
+					keyring_connection_ID: 'service-1',
+					shared: undefined,
+				},
+				{
+					display_name: 'Additional User 1',
+					profile_picture: 'https://example.com/additional1.jpg',
+					service_name: 'service-1',
+				}
+			)
 		);
 	} );
 
@@ -86,11 +93,18 @@ describe( 'ConfirmationForm', () => {
 		await userEvent.click( screen.getByText( 'Confirm' ) );
 
 		await waitFor( () =>
-			expect( stubCreateConnection ).toHaveBeenCalledWith( {
-				external_user_ID: 'additional-1',
-				keyring_connection_ID: 'service-1',
-				shared: true,
-			} )
+			expect( stubCreateConnection ).toHaveBeenCalledWith(
+				{
+					external_user_ID: 'additional-1',
+					keyring_connection_ID: 'service-1',
+					shared: true,
+				},
+				{
+					display_name: 'Additional User 1',
+					profile_picture: 'https://example.com/additional1.jpg',
+					service_name: 'service-1',
+				}
+			)
 		);
 	} );
 


### PR DESCRIPTION
Right now we show a spinner on the confirm button in confirmation modal when creating a connection. This blocks the UI and the user from doing anything else, although it's unnecessary as the process can happen in the background.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add optimistic response for connection creation
* Immediately close the modal when clicking on "Confirm" button
* Show the new added connection in the list greyed out until the request is successful
* Show a loading indicator/spinner while a connection is being updated

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Ensure that feature flag is ON - `define( 'JETPACK_SOCIAL_USE_ADMIN_UI_V1', true );`
- Test the following for both Jetpack and Social plugin and the editor.
    - Goto connections management UI
    - Add a connection and click on "Confirm"
    - Confirm that the modal is immediately closed
    - Confirm that the newly added account is shown in the connections list but greyed out
    - Confirm that it is active after the connection creation request succeeds
    - Confirm that you see the loading indicator/spinner beside the account name
    - Confirm that the account is removed from the list if the request fails. You can simulate a failure by throwing early inside `create_publicize_connection` method in `projects/packages/publicize/src/class-rest-controller.php`


When creating a connection

https://github.com/Automattic/jetpack/assets/18226415/52d05aa0-85ea-426a-9302-72ea207e6ca4

When updating a connection

https://github.com/Automattic/jetpack/assets/18226415/e1982a00-800e-46db-8ace-07d0b5ce8c6f

When creating a connection fails

https://github.com/Automattic/jetpack/assets/18226415/c0d83e15-b73b-423e-960d-5bb87703b5fd




