### PR TITLE
Backport mu-wpcom-plugin 2.1.30 Changes

### DIFF
--- a/projects/packages/calypsoify/CHANGELOG.md
+++ b/projects/packages/calypsoify/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2024-06-06
+### Added
+- Calypsoify: Deprecating functions no longer in use [#37453]
+
+### Changed
+- Updated package dependencies. [#37669]
+
 ## 0.1.0 - 2024-05-27
 ### Added
 - Calypsoify: Copy the code from the Jetpack module into the package. [#37339]
@@ -13,3 +20,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Calypsoify: Load feature from the Calypsoify package. [#37375]
 - Updated package dependencies. [#37379]
+
+[0.1.1]: https://github.com/Automattic/jetpack-calypsoify/compare/v0.1.0...v0.1.1

--- a/projects/packages/calypsoify/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/calypsoify/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/calypsoify/changelog/update-deprecate-calypsoify-functions
+++ b/projects/packages/calypsoify/changelog/update-deprecate-calypsoify-functions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Calypsoify: Deprecating functions no longer in use

--- a/projects/packages/calypsoify/package.json
+++ b/projects/packages/calypsoify/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-calypsoify",
-	"version": "0.1.1-alpha",
+	"version": "0.1.1",
 	"description": "Calypsoify is designed to make sure specific wp-admin pages include navigation that prioritizes the Calypso navigation experience.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/calypsoify/#readme",
 	"bugs": {

--- a/projects/packages/calypsoify/src/class-jetpack-calypsoify.php
+++ b/projects/packages/calypsoify/src/class-jetpack-calypsoify.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Status;
  */
 class Jetpack_Calypsoify {
 
-	const PACKAGE_VERSION = '0.1.1-alpha';
+	const PACKAGE_VERSION = '0.1.1';
 
 	/**
 	 * Singleton instance of `Jetpack_Calypsoify`.

--- a/projects/packages/classic-theme-helper/CHANGELOG.md
+++ b/projects/packages/classic-theme-helper/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2024-06-06
+### Changed
+- Updated package dependencies. [#37669]
+
+### Fixed
+- Classic Theme Helper: Added dist folder to gitattributes so mirror repo picks it. [#37677]
+
 ## [0.2.0] - 2024-05-27
 ### Added
 - Classic Theme Helper: Add responsive videos. [#37406]
@@ -18,4 +25,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add wordpress folder on gitignore. [#37177]
 
+[0.2.1]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.1.0...v0.2.0

--- a/projects/packages/classic-theme-helper/changelog/renovate-glob-10.x
+++ b/projects/packages/classic-theme-helper/changelog/renovate-glob-10.x
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add missing dev-dep on `glob`. No change to functionality.
-
-

--- a/projects/packages/classic-theme-helper/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/classic-theme-helper/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/classic-theme-helper/changelog/update-classic-theme-helper-change-build-folder-to-dist
+++ b/projects/packages/classic-theme-helper/changelog/update-classic-theme-helper-change-build-folder-to-dist
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Classic Theme Helper: Added dist folder to gitattributes so mirror repo picks it.

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-classic-theme-helper",
-	"version": "0.2.1-alpha",
+	"version": "0.2.1",
 	"description": "Features used with classic themes",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/classic-theme-helper/#readme",
 	"bugs": {

--- a/projects/packages/classic-theme-helper/src/class-classic-theme-helper.php
+++ b/projects/packages/classic-theme-helper/src/class-classic-theme-helper.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack;
  */
 class Classic_Theme_Helper {
 
-	const PACKAGE_VERSION = '0.2.1-alpha';
+	const PACKAGE_VERSION = '0.2.1';
 
 	/**
 	 * Modules to include.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.3] - 2024-06-06
+### Added
+- Add mechanism to track previously working plugins [#37537]
+
 ## [2.9.2] - 2024-06-05
 ### Changed
 - Updated package dependencies. [#37669]
@@ -1100,6 +1104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[2.9.3]: https://github.com/Automattic/jetpack-connection/compare/v2.9.2...v2.9.3
 [2.9.2]: https://github.com/Automattic/jetpack-connection/compare/v2.9.1...v2.9.2
 [2.9.1]: https://github.com/Automattic/jetpack-connection/compare/v2.9.0...v2.9.1
 [2.9.0]: https://github.com/Automattic/jetpack-connection/compare/v2.8.6...v2.9.0

--- a/projects/packages/connection/changelog/add-mechanism-to-track-previously-working-plugins
+++ b/projects/packages/connection/changelog/add-mechanism-to-track-previously-working-plugins
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add mechanism to track previously working plugins

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.9.3-alpha';
+	const PACKAGE_VERSION = '2.9.3';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.34.0] - 2024-06-06
+### Added
+- Menu: Register plugin install page for default sites [#37686]
+
+### Changed
+- Updated links to site management panel [#37712]
+- Updated package dependencies. [#37669]
+
+### Fixed
+- Jetpack Cloud Simple > Monetize: Fix the link for "Set up an offer for your supporters" step [#37673]
+- Revert update_calypso_locale [#37740]
+
 ## [5.33.0] - 2024-06-03
 ### Added
 - New intro tour for classic admin interface. [#37533]
@@ -843,6 +855,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.34.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.33.0...v5.34.0
 [5.33.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.32.0...v5.33.0
 [5.32.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.31.1...v5.32.0
 [5.31.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.31.0...v5.31.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-monetize-payments
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launchpad-monetize-payments
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack Cloud Simple > Monetize: Fix the link for "Set up an offer for your supporters" step

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-site-management-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-site-management-link
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Link URL was incorrect
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jetpack-mu-wpcom/changelog/revert-sync_wp_admin_locale_to_calypso
+++ b/projects/packages/jetpack-mu-wpcom/changelog/revert-sync_wp_admin_locale_to_calypso
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Revert update_calypso_locale

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-plugins-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-plugins-menu
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Menu: Register plugin install page for default sites

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-site-management-widget-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-site-management-widget-links
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated links to site management panel

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.34.0-alpha",
+	"version": "5.34.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.34.0-alpha';
+	const PACKAGE_VERSION = '5.34.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.30 - 2024-06-06
+### Changed
+- Internal updates.
+
 ## 2.1.29 - 2024-06-03
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-plugins-menu
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-plugins-menu
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_30_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_30"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.30-alpha
+ * Version: 2.1.30
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.30-alpha",
+	"version": "2.1.30",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.30

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.