### PR TITLE
Add site onboarding segment

### DIFF
--- a/projects/plugins/jetpack/changelog/add-site-onboarding-segment
+++ b/projects/plugins/jetpack/changelog/add-site-onboarding-segment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add onboarding_segment to site endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -199,6 +199,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'videopress_storage_used',
 		'is_difm_lite_in_progress',
 		'site_intent',
+		'onboarding_segment',
 		'site_vertical_id',
 		'blogging_prompts_settings',
 		'launchpad_screen',
@@ -860,6 +861,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'site_intent':
 					$options[ $key ] = $site->get_site_intent();
+					break;
+				case 'onboarding_segment':
+					$options[ $key ] = $site->get_onboarding_segment();
 					break;
 				case 'site_vertical_id':
 					$options[ $key ] = $site->get_site_vertical_id();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1482,6 +1482,15 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Get the option onboarding_segment coming from the Guided Flow
+	 *
+	 * @return string
+	 */
+	public function get_onboarding_segment() {
+		return get_option( 'onboarding_segment', '' );
+	}
+
+	/**
 	 * Get site option for completed launchpad checklist tasks
 	 *
 	 * @return string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
7381-gh-Automattic/dotcom-forge

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The site option `onboarding_sement` needs to be exposed as it is needed for UI checks during onboarding

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this PR 
* While sandboxed visit wordpress.com/start/guided
* Choose "Create a site for me" and "Publish a blog" on the next screen
* Follow the onboarding and once the site is created verify that the `onboarding_screen` option for the site is `blogger` 