### PR TITLE
AI Inline Extensions: Move form to production

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-forms-inline-prod
+++ b/projects/plugins/jetpack/changelog/update-ai-forms-inline-prod
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Move ai form inline extensions version to production

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -56,10 +56,12 @@ const releasedInlineExtensions = [
 	'core/paragraph',
 	'core/list-item',
 	'core/list',
+	'jetpack/contact-form',
+	...JETPACK_FORM_CHILDREN_BLOCKS,
 ];
 
 // Temporarily keep track of inline extensions that are being worked on.
-const unreleasedInlineExtensions = [ 'jetpack/contact-form', ...JETPACK_FORM_CHILDREN_BLOCKS ];
+const unreleasedInlineExtensions = [];
 
 releasedInlineExtensions.forEach( block => {
 	// Add the released inline extension to the inline list...


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Move Form Inline Extension to production.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Release Form Inline Extension.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open editor.
* Add `Form`.
* Use AI Assistant Inline (it should be the new type).
* Check no conflicts with the deprecated version.

