### PR TITLE
AI Forms: Fix check for inline extensions availability

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-old-form-availability
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-old-form-availability
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Use correct const to check for inline extensions availability

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -14,7 +14,7 @@ import React from 'react';
  * Internal dependencies
  */
 import { getFeatureAvailability } from '../../lib/utils/get-feature-availability';
-import { AI_ASSISTANT_SUPPORT_NAME } from '../ai-assistant';
+import { AI_ASSISTANT_EXTENSIONS_SUPPORT_NAME } from '../ai-assistant';
 import AiAssistantBar from './components/ai-assistant-bar';
 import AiAssistantToolbarButton from './components/ai-assistant-toolbar-button';
 import { isJetpackFromBlockAiCompositionAvailable } from './constants';
@@ -194,7 +194,7 @@ function jetpackFormWithAiSupport( settings, name: string ) {
 	}
 
 	// Disable if Inline Extension is enabled
-	if ( getFeatureAvailability( AI_ASSISTANT_SUPPORT_NAME ) ) {
+	if ( getFeatureAvailability( AI_ASSISTANT_EXTENSIONS_SUPPORT_NAME ) ) {
 		return settings;
 	}
 
@@ -270,7 +270,7 @@ function jetpackFormChildrenEditWithAiSupport( settings, name ) {
 	}
 
 	// Disable if Inline Extension is enabled
-	if ( getFeatureAvailability( AI_ASSISTANT_SUPPORT_NAME ) ) {
+	if ( getFeatureAvailability( AI_ASSISTANT_EXTENSIONS_SUPPORT_NAME ) ) {
 		return settings;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Ref: p1717766505948499-slack-C054LN8RNVA

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Look for `AI_ASSISTANT_EXTENSIONS_SUPPORT_NAME` instead `AI_ASSISTANT_SUPPORT_NAME`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open your editor.
* Make sure `inline extensions` is not enable through the filter ( `add_filter( 'jetpack_inline_extensions_enabled', '__return_true' )` )
* Add `Form` block.
* You should see the AI Assistant toolbar button.
* Click it, you'll see the old input.
* Add the filter back.
* It will now use the new input.