### PR TITLE
Boost: Add try again link for 404 errors

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/describe-critical-css-recommendations.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/describe-critical-css-recommendations.ts
@@ -131,6 +131,10 @@ function httpErrorSuggestion( code: number, count: number ): Suggestion {
 						'If you see an error only when not logged into your WordPress site (i.e.: in "Incognito Mode"), then check for plugins which might be enforcing access permissions on your pages. For example, a plugin which only allows authenticated users to view specific areas of your site.',
 						'jetpack-boost'
 					),
+					__(
+						'Once you have resolved the error, please <retry>try again</retry>.',
+						'jetpack-boost'
+					),
 				],
 				closingParagraph: __(
 					'If the page is only accessible to users who are logged in to your WordPress site, or should not be a part of your site then it is safe to ignore this error.',

--- a/projects/plugins/boost/changelog/add-try-again
+++ b/projects/plugins/boost/changelog/add-try-again
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+


### PR DESCRIPTION
## Proposed changes:
* There was no way to retry a 404 errors unlike other errors. I have added a retry step in the troubleshooting instructions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Use the following snippet to cause a 404:

```php
function mu_is_frontend() {
    return !is_admin() && !wp_doing_ajax() && strpos($_SERVER['REQUEST_URI'], '/wp-json/') === false;
}

function mu_showstopper() {
    if ( mu_is_frontend() ) {
        header('HTTP/1.0 404 Not Found' );
        die();
    }
}
add_action( 'init', 'mu_showstopper' );
```

- Try local C.CSS generation
- Ensure critical CSS generation can be retried from the instructions.
