### PR TITLE
Jetpack mu wpcom package: Fix typo in set cookie

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
@@ -14,10 +14,10 @@ return [
     // PhanPluginDuplicateConditionalNullCoalescing : 8 occurrences
     // PhanTypeMismatchReturn : 6 occurrences
     // PhanTypeMismatchReturnProbablyReal : 4 occurrences
+    // PhanUndeclaredFunction : 4 occurrences
     // PhanNoopNew : 3 occurrences
     // PhanTypePossiblyInvalidDimOffset : 3 occurrences
     // PhanUndeclaredClassMethod : 3 occurrences
-    // PhanUndeclaredFunction : 3 occurrences
     // PhanEmptyFQSENInCallable : 2 occurrences
     // PhanParamTooMany : 2 occurrences
     // PhanTypeArraySuspicious : 2 occurrences
@@ -25,7 +25,6 @@ return [
     // PhanTypeMismatchArgumentInternal : 2 occurrences
     // PhanTypeMismatchDefault : 2 occurrences
     // PhanTypeMissingReturn : 2 occurrences
-    // PhanUndeclaredFunctionInCallable : 2 occurrences
     // PhanDeprecatedFunction : 1 occurrence
     // PhanImpossibleTypeComparison : 1 occurrence
     // PhanNonClassMethodCall : 1 occurrence
@@ -54,7 +53,6 @@ return [
         'src/features/marketplace-products-updater/class-marketplace-products-updater.php' => ['PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn'],
         'src/features/media/heif-support.php' => ['PhanPluginSimplifyExpressionBool'],
         'src/features/verbum-comments/class-verbum-comments.php' => ['PhanImpossibleTypeComparison', 'PhanNoopNew', 'PhanParamTooMany', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],
-        'src/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php' => ['PhanUndeclaredFunctionInCallable'],
         'src/features/wpcom-block-editor/functions.editor-type.php' => ['PhanUndeclaredFunction'],
         'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-migrate-guru-key.php' => ['PhanUndeclaredClassMethod'],

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-rename-typo-in-set-cookie
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-rename-typo-in-set-cookie
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+mu-wpcom: Fixed typo in setcookie call

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -497,7 +497,7 @@ class Jetpack_WPCOM_Block_Editor {
 			array_walk(
 				$this->set_cookie_args,
 				function ( $cookie ) {
-					call_user_func_array( 'set_cookie', $cookie );
+					call_user_func_array( 'setcookie', $cookie );
 				}
 			);
 			$this->set_cookie_args = array();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fallback from #37324 as explained in https://github.com/Automattic/jetpack/pull/37324#discussion_r1633201875

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixed typo `set_cookie` vs `setcookie`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


