### PR TITLE
Fix PHP Unit tests run using WP trunk

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-php-unit-tests-for-wp-trunk
+++ b/projects/plugins/jetpack/changelog/fix-php-unit-tests-for-wp-trunk
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed PHP Unit tests for WP trunk

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -791,6 +791,9 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 				$post_type_object->supports = array();
 			}
 			$synced_post_type = Functions::expand_synced_post_type( $synced[ $post_type ], $post_type );
+			if ( isset( $synced_post_type->labels->template_name ) ) {
+				$post_type_object->labels->template_name = $synced_post_type->labels->template_name;
+			}
 			$this->assertEqualsObject( $post_type_object, $synced_post_type, 'POST TYPE :' . $post_type . ' not equal' );
 		}
 	}


### PR DESCRIPTION
PHP Unit tests on WP trunk have been [failing](https://github.com/Automattic/jetpack/actions/runs/9459643543/job/26057530061?pr=37756) probably after [this commit](https://github.com/WordPress/wordpress-develop/commit/7d00db4009c10fda1e688b464a0049670410ead4) in WP Core.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix PHP Unit tests on WP trunk by accounting for `template_name` label for post types

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Just check that all the tests pass

