### PR TITLE
Boost: Add tracking to retry and fix css regen notice showing with show stopper

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/cloud-css-meta/cloud-css-meta.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import Status from '../status/status';
 import { useCriticalCssState } from '../lib/stores/critical-css-state';
 import { useRetryRegenerate } from '../lib/use-retry-regenerate';
+import { isFatalError } from '../lib/critical-css-errors';
 
 export default function CloudCssMetaProps() {
 	const [ cssState ] = useCriticalCssState();
@@ -27,6 +28,7 @@ export default function CloudCssMetaProps() {
 		<Status
 			cssState={ cssState }
 			isCloud={ true }
+			showFatalError={ isFatalError( cssState ) }
 			hasRetried={ hasRetried }
 			retry={ retry }
 			extraText={ extraText || undefined }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
@@ -6,6 +6,7 @@ import { useCriticalCssState } from '../lib/stores/critical-css-state';
 import { RegenerateCriticalCssSuggestion, useRegenerationReason } from '..';
 import { useLocalCriticalCssGenerator } from '../local-generator/local-generator-provider';
 import { useRetryRegenerate } from '../lib/use-retry-regenerate';
+import { isFatalError } from '../lib/critical-css-errors';
 
 /**
  * Critical CSS Meta - the information and options displayed under the Critical CSS toggle on the
@@ -16,6 +17,7 @@ export default function CriticalCssMeta() {
 	const [ hasRetried, retry ] = useRetryRegenerate();
 	const [ regenerateReason ] = useRegenerationReason();
 	const { progress } = useLocalCriticalCssGenerator();
+	const showFatalError = isFatalError( cssState );
 
 	if ( cssState.status === 'pending' ) {
 		return (
@@ -36,6 +38,7 @@ export default function CriticalCssMeta() {
 			<Status
 				cssState={ cssState }
 				isCloud={ false }
+				showFatalError={ showFatalError }
 				hasRetried={ hasRetried }
 				retry={ retry }
 				highlightRegenerateButton={ !! regenerateReason }
@@ -45,7 +48,9 @@ export default function CriticalCssMeta() {
 				) }
 			/>
 
-			<RegenerateCriticalCssSuggestion regenerateReason={ regenerateReason } />
+			{ ! showFatalError && (
+				<RegenerateCriticalCssSuggestion regenerateReason={ regenerateReason } />
+			) }
 		</>
 	);
 }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
@@ -160,7 +160,13 @@ const OtherErrors = ( { cssState, retry, showRetry, supportLink }: ShowStopperEr
 								'jetpack-boost'
 							),
 							{
-								...actionLinkInterpolateVar( retry, 'retry' ),
+								...actionLinkInterpolateVar( () => {
+									recordBoostEvent( 'critical_css_retry', {
+										errorType: 'CssGenLibraryFailure',
+									} );
+
+									retry();
+								}, 'retry' ),
 							}
 						) }
 					</p>
@@ -176,7 +182,16 @@ const OtherErrors = ( { cssState, retry, showRetry, supportLink }: ShowStopperEr
 						) }
 					</p>
 					{ showRetry ? (
-						<button className="secondary" onClick={ retry }>
+						<button
+							className="secondary"
+							onClick={ () => {
+								recordBoostEvent( 'critical_css_retry', {
+									errorType: 'UnknownError',
+								} );
+
+								retry();
+							} }
+						>
 							{ __( 'Refresh', 'jetpack-boost' ) }
 						</button>
 					) : (

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
@@ -7,7 +7,7 @@ import RefreshIcon from '$svg/refresh';
 import { createInterpolateElement } from '@wordpress/element';
 import { Link } from 'react-router-dom';
 import { useRegenerateCriticalCssAction } from '../lib/stores/critical-css-state';
-import { getProvidersWithErrors, isFatalError } from '../lib/critical-css-errors';
+import { getProvidersWithErrors } from '../lib/critical-css-errors';
 import ShowStopperError from '../show-stopper-error/show-stopper-error';
 import { Button } from '@automattic/jetpack-components';
 import styles from './status.module.scss';
@@ -15,6 +15,7 @@ import styles from './status.module.scss';
 type StatusTypes = {
 	cssState: CriticalCssState;
 	isCloud?: boolean;
+	showFatalError: boolean;
 	hasRetried: boolean;
 	retry: () => void;
 	highlightRegenerateButton?: boolean;
@@ -25,6 +26,7 @@ type StatusTypes = {
 const Status: React.FC< StatusTypes > = ( {
 	cssState,
 	isCloud = false,
+	showFatalError,
 	hasRetried,
 	retry,
 	highlightRegenerateButton = false,
@@ -37,7 +39,7 @@ const Status: React.FC< StatusTypes > = ( {
 	const providersWithErrors = getProvidersWithErrors( cssState );
 
 	// If there has been a fatal error, show it.
-	if ( isFatalError( cssState ) ) {
+	if ( showFatalError ) {
 		return (
 			<ShowStopperError
 				supportLink={ ( isCloud && 'https://jetpack.com/contact-support/' ) || undefined }

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/get-critical-css-error-set-interpolate-vars.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/get-critical-css-error-set-interpolate-vars.tsx
@@ -5,6 +5,7 @@ import supportLinkInterpolateVar from '$lib/utils/support-link-interpolate-var';
 import { useRegenerateCriticalCssAction } from '$features/critical-css/lib/stores/critical-css-state';
 import { suggestion } from '$features/critical-css/lib/describe-critical-css-recommendations';
 import { ErrorSet } from '$features/critical-css/lib/critical-css-errors';
+import { recordBoostEvent } from './analytics';
 
 function getCriticalCssErrorSetInterpolateVars( errorSet: ErrorSet ) {
 	const regenerateAction = useRegenerateCriticalCssAction();
@@ -16,7 +17,13 @@ function getCriticalCssErrorSetInterpolateVars( errorSet: ErrorSet ) {
 	}
 
 	const interpolateVars: InterpolateVars = {
-		...actionLinkInterpolateVar( retry, 'retry' ),
+		...actionLinkInterpolateVar( () => {
+			recordBoostEvent( 'critical_css_retry', {
+				errorType: errorSet.type,
+			} );
+
+			retry();
+		}, 'retry' ),
 		...supportLinkInterpolateVar(),
 		b: <b />,
 	};

--- a/projects/plugins/boost/changelog/update-boost-tracking-and-regen-prompt-fix
+++ b/projects/plugins/boost/changelog/update-boost-tracking-and-regen-prompt-fix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add tracking events when using retry from the show stopper section. Fix show stopper and regen notice showing together.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add tracking to retry link in show stopper section;
* Fix "Regenerate Critical CSS" notice showing at the same time as the show stopper section (image of old/buggy behavior below);

![image](https://github.com/Automattic/jetpack/assets/11799079/53affb72-0a67-41d9-a26f-fc8ec159408e)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost (free);
* Break the front-end of the site by using the provided snippet (this will make the show stopper error show up after generation);
* Try generating critical css;
* Make sure the show stopper error is showing up;
* Edit a page and make sure the "Regenerate Critical CSS" notice doesn't show up;
* Remove the snippet and generate critical css (show stopper shouldn't be visible);
* Edit a page and make sure the notice shows up.

```php
<?php

add_action( 'template_redirect', function () {
	exit;
} );
```
