### PR TITLE
Photon: avoid PHP deprecation warnings with bad URLs

### DIFF
--- a/projects/packages/image-cdn/changelog/fix-photon-warning-37783
+++ b/projects/packages/image-cdn/changelog/fix-photon-warning-37783
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add additional check to avoid PHP deprecation warnings.

--- a/projects/packages/image-cdn/src/class-image-cdn-core.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-core.php
@@ -345,6 +345,9 @@ class Image_CDN_Core {
 		);
 
 		$host = wp_parse_url( $image_url, PHP_URL_HOST );
+		if ( ! $host ) {
+			return $skip;
+		}
 
 		foreach ( $banned_host_patterns as $banned_host_pattern ) {
 			if ( 1 === preg_match( $banned_host_pattern, $host ) ) {

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Image_CDN;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.4.1';
+	const PACKAGE_VERSION = '0.4.2-alpha';
 
 	/**
 	 * Singleton.


### PR DESCRIPTION
Fixes #37783

## Proposed changes:

Being a bit more defensive should fix the deprecation warnings reported in #37783.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

I wasn't able to reproduce, so I'm afraid I can only recommend doing a code review for this change.
