### PR TITLE
Super Cache: notify Boost that migration is in progress

### DIFF
--- a/projects/plugins/super-cache/changelog/update-super-cache-notify-boost-migration
+++ b/projects/plugins/super-cache/changelog/update-super-cache-notify-boost-migration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Super Cache: notify Boost of migration to that plugin

--- a/projects/plugins/super-cache/composer.json
+++ b/projects/plugins/super-cache/composer.json
@@ -51,6 +51,6 @@
 		"wp-svn-autopublish": true
 	},
 	"config": {
-		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_12_2_alpha"
+		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_13_0_alpha"
 	}
 }

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -41,5 +41,8 @@ add_action( 'wpsc_created_advanced_cache', 'wpsc_track_move_from_boost' );
  * @param string $source The source of the migration: 'notice', 'banner', 'try_button'.
  */
 function wpsc_notify_migration_to_boost( $source ) {
-	do_action( 'jb_cache_moved_to_boost', $source );
+	if ( ! in_array( $source, array( 'notice', 'banner', 'try_button' ), true ) ) {
+		return;
+	}
+	set_transient( 'jb_cache_moved_to_boost', $source, WEEK_IN_SECONDS );
 }

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -34,3 +34,12 @@ function wpsc_track_move_from_boost() {
 	do_action( 'jb_cache_moved_to_wpsc' );
 }
 add_action( 'wpsc_created_advanced_cache', 'wpsc_track_move_from_boost' );
+
+/**
+ * Notify Jetpack Boost that Boost Cache will be used instead of WP Super Cache.
+ *
+ * @param string $source The source of the migration: 'notice', 'banner', 'try_button'.
+ */
+function wpsc_notify_migration_to_boost( $source ) {
+	do_action( 'jb_cache_moved_to_boost', $source );
+}

--- a/projects/plugins/super-cache/package.json
+++ b/projects/plugins/super-cache/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-super-cache",
-	"version": "1.12.2-alpha",
+	"version": "1.13.0-alpha",
 	"description": "A very fast caching engine for WordPress that produces static html files.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Super Cache
  * Plugin URI: https://wordpress.org/plugins/wp-super-cache/
  * Description: Very fast caching plugin for WordPress.
- * Version: 1.12.2-alpha
+ * Version: 1.13.0-alpha
  * Author: Automattic
  * Author URI: https://automattic.com/
  * License: GPL2+

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -375,6 +375,7 @@ function wpsc_ajax_activate_boost() {
 	if ( is_wp_error( $result ) ) {
 		wp_send_json_error( $result->get_error_message() );
 	}
+	wpsc_notify_migration_to_boost( 'banner' );
 
 	wp_send_json_success();
 }

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -375,7 +375,6 @@ function wpsc_ajax_activate_boost() {
 	if ( is_wp_error( $result ) ) {
 		wp_send_json_error( $result->get_error_message() );
 	}
-	wpsc_notify_migration_to_boost( 'banner' );
 
 	wp_send_json_success();
 }


### PR DESCRIPTION
Fire an action "jb_cache_moved_to_boost" that lets Jetpack Boost know of a migration from WPSC to Boost.

Fixes #37742

## Proposed changes:
* Create a function "wpsc_notify_migration_to_boost" that creates a transient option called "jb_cache_moved_to_boost" with a $source as the value.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-2QH-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
No user visible changes as it sets a transient option.
Add this line to wpsc_ajax_activate_boost(), jsut above `wp_send_json_success();`
```
	wpsc_notify_migration_to_boost( 'banner' );
```
Add the following mu-plugin to hook on the action and log the source:
```
function test_jb_cache_moved_transient() {
    if ( get_transient( 'jb_cache_moved_to_boost' ) ) {
        error_log( 'transient: ' . get_transient( 'jb_cache_moved_to_boost' ) );
    }
}
add_action( 'admin_init', 'test_jb_cache_moved_transient' );
```
Make sure that Boost is entirely deleted from the plugins directory and reload the WPSC settings page. If you have previously dismissed the Boost banner you will need to delete the wpsc_dismissed_boost_banner user option for your user. 
Click the "Install Jetpack Boost" or "Activate Jetpack Boost" button and watch the error_log.