### PR TITLE
Tracking: Add blogid to blog details

### DIFF
--- a/projects/packages/connection/changelog/add-blog-id-to-tracks-events
+++ b/projects/packages/connection/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add blogid to tracks event data

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -70,7 +70,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.10.x-dev"
+			"dev-trunk": "2.11.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/connection/legacy/class-jetpack-tracks-client.php
+++ b/projects/packages/connection/legacy/class-jetpack-tracks-client.php
@@ -64,12 +64,16 @@ class Jetpack_Tracks_Client {
 	 * @return mixed         True on success, WP_Error on failure
 	 */
 	public static function record_event( $event ) {
+		error_log( 'Jetpack_Tracks_Client::record_event is deprecated. Use Jetpack_Tracks_Event::record_event instead.' );
+		error_log( print_r( $event, true ) );
+
 		if ( ! self::$terms_of_service ) {
 			self::$terms_of_service = new \Automattic\Jetpack\Terms_Of_Service();
 		}
 
 		// Don't track users who have opted out or not agreed to our TOS, or are not running an active Jetpack.
 		if ( ! self::$terms_of_service->has_agreed() || ! empty( $_COOKIE['tk_opt-out'] ) ) {
+			error_log( 'Jetpack_Tracks_Client::record_event: User has not agreed to TOS or has opted out.' );
 			return false;
 		}
 
@@ -77,15 +81,18 @@ class Jetpack_Tracks_Client {
 			$event = new Jetpack_Tracks_Event( $event );
 		}
 		if ( is_wp_error( $event ) ) {
+			error_log( 'Jetpack_Tracks_Client::record_event: Invalid event object.' );
 			return $event;
 		}
 
 		$pixel = $event->build_pixel_url( $event );
 
 		if ( ! $pixel ) {
+			error_log( 'Jetpack_Tracks_Client::record_event: Cannot generate tracks pixel for given input.' );
 			return new WP_Error( 'invalid_pixel', 'cannot generate tracks pixel for given input', 400 );
 		}
 
+		error_log( 'Jetpack_Tracks_Client::record_event: Sending pixel' );
 		return self::record_pixel( $pixel );
 	}
 
@@ -111,14 +118,18 @@ class Jetpack_Tracks_Client {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			error_log( 'Jetpack_Tracks_Client::record_pixel: ' . $response->get_error_message() );
 			return $response;
 		}
 
 		$code = isset( $response['response']['code'] ) ? $response['response']['code'] : 0;
 
 		if ( 200 !== $code ) {
+			error_log( 'Jetpack_Tracks_Client::record_pixel: Tracks pixel request failed with code ' . $code );
 			return new WP_Error( 'request_failed', 'Tracks pixel request failed', $code );
 		}
+
+		error_log( 'Jetpack_Tracks_Client::record_pixel: Tracks pixel request succeeded' );
 
 		return true;
 	}

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.10.1-alpha';
+	const PACKAGE_VERSION = '2.11.0-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,11 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-<<<<<<< add/blog-id-to-tracks-events
 	const PACKAGE_VERSION = '2.11.0-alpha';
-=======
-	const PACKAGE_VERSION = '2.10.1';
->>>>>>> trunk
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-tracking.php
+++ b/projects/packages/connection/src/class-tracking.php
@@ -252,6 +252,7 @@ class Tracking {
 
 		$blog_details = array(
 			'blog_lang' => isset( $properties['blog_lang'] ) ? $properties['blog_lang'] : get_bloginfo( 'language' ),
+			'blogid'    => (int) \Jetpack_Options::get_option( 'id' ),
 		);
 
 		$timestamp        = ( false !== $event_timestamp_millis ) ? $event_timestamp_millis : round( microtime( true ) * 1000 );

--- a/projects/plugins/automattic-for-agencies-client/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -384,7 +384,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+                "reference": "6d990be4aaded35f3ee203c976d16b9334419882"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -419,7 +419,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.10.x-dev"
+                    "dev-trunk": "2.11.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/backup/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/backup/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -666,7 +666,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+                "reference": "6d990be4aaded35f3ee203c976d16b9334419882"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -701,7 +701,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.10.x-dev"
+                    "dev-trunk": "2.11.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/boost/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/boost/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -522,7 +522,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+                "reference": "6d990be4aaded35f3ee203c976d16b9334419882"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -557,7 +557,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.10.x-dev"
+                    "dev-trunk": "2.11.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/inspect/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/inspect/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -384,7 +384,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+                "reference": "6d990be4aaded35f3ee203c976d16b9334419882"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -419,7 +419,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.10.x-dev"
+                    "dev-trunk": "2.11.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/jetpack/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/jetpack/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1029,7 +1029,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/connection",
-				"reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+				"reference": "6d990be4aaded35f3ee203c976d16b9334419882"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1064,7 +1064,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.10.x-dev"
+					"dev-trunk": "2.11.x-dev"
 				},
 				"dependencies": {
 					"test-only": [

--- a/projects/plugins/migration/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/migration/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -666,7 +666,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+                "reference": "6d990be4aaded35f3ee203c976d16b9334419882"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -701,7 +701,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.10.x-dev"
+                    "dev-trunk": "2.11.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -416,7 +416,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+                "reference": "6d990be4aaded35f3ee203c976d16b9334419882"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -451,7 +451,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.10.x-dev"
+                    "dev-trunk": "2.11.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/protect/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/protect/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -579,7 +579,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+                "reference": "6d990be4aaded35f3ee203c976d16b9334419882"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -614,7 +614,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.10.x-dev"
+                    "dev-trunk": "2.11.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/search/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/search/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -522,7 +522,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+                "reference": "6d990be4aaded35f3ee203c976d16b9334419882"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -557,7 +557,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.10.x-dev"
+                    "dev-trunk": "2.11.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/social/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/social/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -522,7 +522,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/connection",
-				"reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+				"reference": "6d990be4aaded35f3ee203c976d16b9334419882"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -557,7 +557,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.10.x-dev"
+					"dev-trunk": "2.11.x-dev"
 				},
 				"dependencies": {
 					"test-only": [

--- a/projects/plugins/starter-plugin/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/starter-plugin/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -522,7 +522,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+                "reference": "6d990be4aaded35f3ee203c976d16b9334419882"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -557,7 +557,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.10.x-dev"
+                    "dev-trunk": "2.11.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/videopress/changelog/add-blog-id-to-tracks-events
+++ b/projects/plugins/videopress/changelog/add-blog-id-to-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -522,7 +522,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "34b11d946a049dbd9f35f94b99f32b0410eafb8b"
+                "reference": "6d990be4aaded35f3ee203c976d16b9334419882"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -557,7 +557,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "2.10.x-dev"
+                    "dev-trunk": "2.11.x-dev"
                 },
                 "dependencies": {
                     "test-only": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to Automattic/wpcomsh#1904

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When recording Tracks events, include the `blogid` parameter if it exists.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes. This adds the site's `blogid` to our tracked data when a Tracks event fires.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your WoA test site following the instructions [in this comment](https://github.com/Automattic/jetpack/pull/37805#issuecomment-2161571621)
* Follow the testing instructions in this PR to get set up with AIOWPM on your WoA test site and run an import: Automattic/wpcomsh#1904
* Check Tracks Live to see if the `wpcom_site_migration_%` events fire as expected.
* The events should include the `blogid` property with the correct blog ID. 

