### PR TITLE
Sakura scheme: Fix color issues on masterbar

### DIFF
--- a/projects/packages/masterbar/changelog/fix-sakura-scheme-issues-masterbar
+++ b/projects/packages/masterbar/changelog/fix-sakura-scheme-issues-masterbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Color Schemes: Fix Sakura color issues on masterbar

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/sakura/_variables.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/sakura/_variables.scss
@@ -14,7 +14,7 @@ $body-background: $studio-gray-0; // Calypso --color-surface-backdrop
 // admin menu & admin-bar (core _variables.scss)
 $menu-text: $studio-pink-80; // Calypso --color-sidebar-text
 $menu-background: $studio-pink-5; // Calypso --color-sidebar-background
-$menu-highlight-text: $studio-pink-90; // Calypso --color-sidebar-menu-hover-text
+$menu-highlight-text: $studio-pink-0; // Calypso --color-sidebar-menu-hover-text
 $menu-highlight-icon: $menu-highlight-text;
 $menu-highlight-background: $studio-pink-10; // Calypso --color-sidebar-menu-hover-background
 $menu-current-text: $studio-white; // Calypso --color-sidebar-menu-selected-text
@@ -22,9 +22,9 @@ $menu-current-icon: $menu-current-text;
 $menu-current-background: $studio-blue-50; // Calypso --color-sidebar-menu-selected-background
 $menu-submenu-text: $studio-pink-0; // Calypso --color-sidebar-submenu-text
 $menu-submenu-background: $studio-pink-90; // Calypso --color-sidebar-submenu-background
-$menu-submenu-focus-text: $studio-blue-20; // Calypso --color-sidebar-submenu-hover-text
+$menu-submenu-background-alt: $studio-pink-70; // Calypso --color-sidebar-submenu-background-alt
+$menu-submenu-focus-text: $studio-pink-0; // Calypso --color-sidebar-submenu-hover-text
 $menu-submenu-current-text: $studio-pink-0; // Calypso --color-sidebar-submenu-selected-text
-
 // masterbar overrides
 $masterbar-background: $studio-celadon-70; // Calypso --color-masterbar-background
 $masterbar-highlight-background: $studio-celadon-80; // Calypso --color-masterbar-item-hover-background

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/sakura/_variables.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/sakura/_variables.scss
@@ -14,7 +14,7 @@ $body-background: $studio-gray-0; // Calypso --color-surface-backdrop
 // admin menu & admin-bar (core _variables.scss)
 $menu-text: $studio-pink-80; // Calypso --color-sidebar-text
 $menu-background: $studio-pink-5; // Calypso --color-sidebar-background
-$menu-highlight-text: $studio-pink-0; // Calypso --color-sidebar-menu-hover-text
+$menu-highlight-text: $studio-pink-90; // Calypso --color-sidebar-menu-hover-text
 $menu-highlight-icon: $menu-highlight-text;
 $menu-highlight-background: $studio-pink-10; // Calypso --color-sidebar-menu-hover-background
 $menu-current-text: $studio-white; // Calypso --color-sidebar-menu-selected-text

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/sakura/_variables.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/sakura/_variables.scss
@@ -23,8 +23,9 @@ $menu-current-background: $studio-blue-50; // Calypso --color-sidebar-menu-selec
 $menu-submenu-text: $studio-pink-0; // Calypso --color-sidebar-submenu-text
 $menu-submenu-background: $studio-pink-90; // Calypso --color-sidebar-submenu-background
 $menu-submenu-background-alt: $studio-pink-70; // Calypso --color-sidebar-submenu-background-alt
-$menu-submenu-focus-text: $studio-pink-0; // Calypso --color-sidebar-submenu-hover-text
+$menu-submenu-focus-text: $studio-blue-20; // Calypso --color-sidebar-submenu-hover-text
 $menu-submenu-current-text: $studio-pink-0; // Calypso --color-sidebar-submenu-selected-text
+
 // masterbar overrides
 $masterbar-background: $studio-celadon-70; // Calypso --color-masterbar-background
 $masterbar-highlight-background: $studio-celadon-80; // Calypso --color-masterbar-item-hover-background

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/sakura/colors.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/sakura/colors.scss
@@ -1,3 +1,12 @@
 @import "variables";
 @import "../admin";
 @import "sidebar-notice";
+
+#wpadminbar:not(.mobile) li:hover .ab-icon:before,
+#wpadminbar:not(.mobile) li:hover .ab-item:before {
+    color: $menu-submenu-current-text;
+}
+
+#wpadminbar #wp-admin-bar-user-info .display-name {
+	color: $menu-submenu-text;
+}

--- a/projects/plugins/jetpack/changelog/fix-sakura-scheme-issues-masterbar
+++ b/projects/plugins/jetpack/changelog/fix-sakura-scheme-issues-masterbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Color Schemes: Fix Sakura color issues on masterbar

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/sakura/_variables.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/sakura/_variables.scss
@@ -14,7 +14,7 @@ $body-background: $studio-gray-0; // Calypso --color-surface-backdrop
 // admin menu & admin-bar (core _variables.scss)
 $menu-text: $studio-pink-80; // Calypso --color-sidebar-text
 $menu-background: $studio-pink-5; // Calypso --color-sidebar-background
-$menu-highlight-text: $studio-pink-90; // Calypso --color-sidebar-menu-hover-text
+$menu-highlight-text: $studio-pink-0; // Calypso --color-sidebar-menu-hover-text
 $menu-highlight-icon: $menu-highlight-text;
 $menu-highlight-background: $studio-pink-10; // Calypso --color-sidebar-menu-hover-background
 $menu-current-text: $studio-white; // Calypso --color-sidebar-menu-selected-text
@@ -22,7 +22,8 @@ $menu-current-icon: $menu-current-text;
 $menu-current-background: $studio-blue-50; // Calypso --color-sidebar-menu-selected-background
 $menu-submenu-text: $studio-pink-0; // Calypso --color-sidebar-submenu-text
 $menu-submenu-background: $studio-pink-90; // Calypso --color-sidebar-submenu-background
-$menu-submenu-focus-text: $studio-blue-20; // Calypso --color-sidebar-submenu-hover-text
+$menu-submenu-background-alt: $studio-pink-70; // Calypso --color-sidebar-submenu-background-alt
+$menu-submenu-focus-text: $studio-pink-0; // Calypso --color-sidebar-submenu-hover-text
 $menu-submenu-current-text: $studio-pink-0; // Calypso --color-sidebar-submenu-selected-text
 
 // masterbar overrides

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/sakura/_variables.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/sakura/_variables.scss
@@ -23,7 +23,7 @@ $menu-current-background: $studio-blue-50; // Calypso --color-sidebar-menu-selec
 $menu-submenu-text: $studio-pink-0; // Calypso --color-sidebar-submenu-text
 $menu-submenu-background: $studio-pink-90; // Calypso --color-sidebar-submenu-background
 $menu-submenu-background-alt: $studio-pink-70; // Calypso --color-sidebar-submenu-background-alt
-$menu-submenu-focus-text: $studio-pink-0; // Calypso --color-sidebar-submenu-hover-text
+$menu-submenu-focus-text: $studio-blue-20; // Calypso --color-sidebar-submenu-hover-text
 $menu-submenu-current-text: $studio-pink-0; // Calypso --color-sidebar-submenu-selected-text
 
 // masterbar overrides

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/sakura/_variables.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/sakura/_variables.scss
@@ -14,7 +14,7 @@ $body-background: $studio-gray-0; // Calypso --color-surface-backdrop
 // admin menu & admin-bar (core _variables.scss)
 $menu-text: $studio-pink-80; // Calypso --color-sidebar-text
 $menu-background: $studio-pink-5; // Calypso --color-sidebar-background
-$menu-highlight-text: $studio-pink-0; // Calypso --color-sidebar-menu-hover-text
+$menu-highlight-text: $studio-pink-90; // Calypso --color-sidebar-menu-hover-text
 $menu-highlight-icon: $menu-highlight-text;
 $menu-highlight-background: $studio-pink-10; // Calypso --color-sidebar-menu-hover-background
 $menu-current-text: $studio-white; // Calypso --color-sidebar-menu-selected-text

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/sakura/colors.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/sakura/colors.scss
@@ -1,3 +1,7 @@
 @import "variables";
 @import "../admin";
 @import "sidebar-notice";
+
+#wpadminbar #wp-admin-bar-user-info .display-name {
+	color: $menu-submenu-text;
+}

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/sakura/colors.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/sakura/colors.scss
@@ -2,6 +2,11 @@
 @import "../admin";
 @import "sidebar-notice";
 
+#wpadminbar:not(.mobile) li:hover .ab-icon:before,
+#wpadminbar:not(.mobile) li:hover .ab-item:before {
+    color: $menu-submenu-current-text;
+}
+
 #wpadminbar #wp-admin-bar-user-info .display-name {
 	color: $menu-submenu-text;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7063

## Proposed changes:

Fix Sakura scheme color issues on Masterbar when Classic Interface is selected.

Before:

https://github.com/Automattic/jetpack/assets/402286/eeb3fdee-063d-432a-a05a-27091d6c94b4

After:

https://github.com/Automattic/jetpack/assets/402286/c2a13154-6e00-4d7e-9e48-c68653d61477

> [!IMPORTANT]  
> If CSS won't reload, you have to disable the `EDGE CACHE` in Blog RC

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Using an Atomic site with Classic interface selected
* Select the `Sakura` color scheme in `/wp-admin/profile.php`
* Reload the page
* Check the W logo submenu and Profile submenu
