### PR TITLE
Jetpack: Fix Uncaught TypeError for recommendations CTA

### DIFF
--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/resource-prompt/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/resource-prompt/index.jsx
@@ -119,7 +119,7 @@ const ResourcePromptComponent = props => {
 		return null;
 	}, [ stepProgressValue, progressValue ] );
 
-	const ctaLinkIsExternal = ctaLink.match( /^https:\/\/jetpack.com\/redirect/ );
+	const ctaLinkIsExternal = ctaLink?.match( /^https:\/\/jetpack.com\/redirect/ );
 
 	return (
 		<PromptLayout

--- a/projects/plugins/jetpack/changelog/fix-uncaught-type-error-for-recommendations-cta
+++ b/projects/plugins/jetpack/changelog/fix-uncaught-type-error-for-recommendations-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed Uncaught TypeError in for recommendations CTA


### PR DESCRIPTION
#37693 introduced a regression that resulted in Uncaught TypeError on `/wp-admin/admin.php?page=jetpack#/recommendations/welcome-security` reported here p1718139510797719-slack-CBG1CP4EN

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix Uncaught TypeError for recommendations CTA

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack#/recommendations/welcome-security`
* Confirm that there is no error like the one on `trunk`