### PR TITLE
Editor plugins: do not load post editor plugins in site editor

### DIFF
--- a/projects/plugins/jetpack/changelog/update-site-editor-plugins
+++ b/projects/plugins/jetpack/changelog/update-site-editor-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Editor functionality: ensure that features added by Jetpack to the block editor are compatible with site editor changes introduced in WordPres 6.6.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -4,7 +4,9 @@
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { PanelBody, PanelRow, BaseControl } from '@wordpress/components';
+import { select } from '@wordpress/data';
 import { PluginPrePublishPanel, PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import React from 'react';
@@ -95,6 +97,13 @@ export default function AiAssistantPluginSidebar() {
 		debug( placement );
 		tracks.recordEvent( 'jetpack_ai_panel_open', { placement } );
 	};
+
+	const postType = select( editorStore ).getCurrentPostType();
+
+	// If postType is still not available, simply return and wait for the next call.
+	if ( postType === null ) {
+		return;
+	}
 
 	return (
 		<>

--- a/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/post-publish-qr-post-panel/index.js
@@ -19,10 +19,17 @@ export const settings = {
 			initialOpen: false,
 		};
 
-		const isPostPublished = useSelect(
-			select => select( editorStore ).isCurrentPostPublished(),
-			[]
-		);
+		const { isPostPublished, postType } = useSelect( select => {
+			return {
+				isPostPublished: select( editorStore ).isCurrentPostPublished(),
+				postType: select( editorStore ).getCurrentPostType(),
+			};
+		}, [] );
+
+		// If postType is still not available, simply return and wait for the next call.
+		if ( postType === null ) {
+			return;
+		}
 
 		function QRPostPanelBodyContent() {
 			return (

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.js
@@ -6,7 +6,9 @@ import {
 	getRequiredPlan,
 } from '@automattic/jetpack-shared-extension-utils';
 import { PanelBody, PanelRow } from '@wordpress/components';
+import { select } from '@wordpress/data';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { store as editorStore } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
@@ -31,6 +33,14 @@ const Seo = () => {
 	const jetpackSeoPanelProps = {
 		title: __( 'SEO', 'jetpack' ),
 	};
+
+	// Those tools are only useful in the post editor.
+	const postType = select( editorStore ).getCurrentPostType();
+
+	// If postType is still not available, simply return and wait for the next call.
+	if ( postType === null ) {
+		return;
+	}
 
 	if ( canShowUpsell && requiredPlan !== false ) {
 		return (

--- a/projects/plugins/jetpack/extensions/plugins/social-previews/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/social-previews/index.js
@@ -1,7 +1,9 @@
 import { SocialPreviewsModal, SocialPreviewsPanel } from '@automattic/jetpack-publicize-components';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { PanelBody } from '@wordpress/components';
+import { select } from '@wordpress/data';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { store as editorStore } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
@@ -14,6 +16,13 @@ export const settings = {
 
 export const SocialPreviews = function SocialPreviews() {
 	const [ isOpened, setIsOpened ] = useState( false );
+
+	const postType = select( editorStore ).getCurrentPostType();
+
+	// If postType is still not available, simply return and wait for the next call.
+	if ( postType === null ) {
+		return;
+	}
 
 	return (
 		<>


### PR DESCRIPTION
## Proposed changes:

This is related to the changes mentioned in #37713.

Starting in WP 6.6, we need to explicitely ensure that editor plugins that can only be used in the post editor are only loaded there.

In this PR, we'll do this by checking for an existing post type.

- Internal reference: p1718201200111879-slack-C03EL5U0PS6

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

- Epic: #36721

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start by installing the WordPress Beta Tester plugin, and then switching your site to use the bleeding edge version of WP.
* Go to My Jetpack and connect your site to your WordPress.com account.
* Go to Appearance > Editor (if you use a classic theme that menu item will not be available ; switch to the Twenty Twenty Four theme to see the menu item)
* Ensure that the Jetpack plugin sidebar is not displayed.
