### PR TITLE
a4a client: updates to readme

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/automattic-for-agencies-client.php
+++ b/projects/plugins/automattic-for-agencies-client/automattic-for-agencies-client.php
@@ -4,7 +4,7 @@
  * Plugin Name: Automattic for Agencies Client
  * Plugin URI: https://wordpress.org/plugins/automattic-for-agencies-client
  * Description: Securely connect your clients’ sites to the Automattic for Agencies Sites Dashboard. Manage your sites from one place and see what needs attention.
- * Version: 0.2.1
+ * Version: 0.2.2-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/projects/plugins/automattic-for-agencies-client/changelog/update-a4a-readme-2
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-a4a-readme-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Janitorial: changes to readme.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.json
+++ b/projects/plugins/automattic-for-agencies-client/composer.json
@@ -62,6 +62,7 @@
 		"release-branch-prefix": "automattic-for-agencies-client",
 		"beta-plugin-slug": "automattic-for-agencies-client",
 		"wp-plugin-slug": "automattic-for-agencies-client",
+		"wp-svn-autopublish": true,
 		"changelogger": {
 			"versioning": "semver"
 		}
@@ -72,6 +73,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_automattic_for_agencies_clientⓥ0_2_1"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_automattic_for_agencies_clientⓥ0_2_2_alpha"
 	}
 }

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c249536c1eb6830bdcff25bcf8d1b163",
+    "content-hash": "b332865f7ef4ee76b1633855d8257c0f",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/automattic-for-agencies-client/readme.txt
+++ b/projects/plugins/automattic-for-agencies-client/readme.txt
@@ -1,10 +1,10 @@
 === Automattic For Agencies Client ===
-Contributors: automattic
+Contributors: automattic, jeherve, njweller, rcanepa
 Tags: agency, dashboard, management, sites, monitoring
 Requires at least: 6.4
 Requires PHP: 7.0
 Tested up to: 6.5
-Stable tag: 0.1.0
+Stable tag: 0.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -49,5 +49,5 @@ Once connected, your site will display within Automattic for Agencies.
 - Dashboard: switch to a smaller and faster dependency (`clsx`) to handle class names.
 - Dashboard: update the connection screen's messaging to make our Terms of Service clearer.
 - Dependencies: remove the 'jetpack-identity-crisis' dependency.
-- Dependencies: update multiple dependencies. [#37669], [#37767], [#37776],
+- Dependencies: update multiple dependencies.
 


### PR DESCRIPTION
## Proposed changes:

Janitorial changes to ensure the plugin uses the right stable tag, is set to be automatically released when we release a new GitHub version, and a few minor tweaks to the readme as well (add some humans to the contributor list, remove useless PR numbers).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1718198708233069-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Not much to test this time around. Look that anything makes sense I suppose.
