### PR TITLE
Social: Fix connections UI for unsupported platforms

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-connections-ui-for-unsupported-platforms
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connections-ui-for-unsupported-platforms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed WSOD on connections UI when an old Twitter connection exists.

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-name.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-name.tsx
@@ -30,7 +30,7 @@ export function ConnectionName( { connection }: ConnectionNameProps ) {
 				<span className={ styles[ 'profile-link' ] }>{ connection.display_name }</span>
 			) : (
 				<ExternalLink className={ styles[ 'profile-link' ] } href={ connection.profile_link }>
-					{ connection.display_name }
+					{ connection.display_name || connection.external_display }
 				</ExternalLink>
 			) }
 			{ isUpdating ? (

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Connection } from '../../social-store/types';
 import { SupportedService } from '../services/use-supported-services';
 import { Disconnect } from './disconnect';
@@ -26,7 +26,7 @@ export function ConnectionStatus( { connection, service }: ConnectionStatusProps
 			<span className="description">
 				{ service
 					? __( 'There is an issue with this connection.', 'jetpack' )
-					: __( 'This platform is no longer supported.', 'jetpack' ) }
+					: _x( 'This platform is no longer supported.', '', 'jetpack' ) }
 			</span>
 			&nbsp;
 			{ service ? (

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-status.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { Connection } from '../../social-store/types';
 import { SupportedService } from '../services/use-supported-services';
+import { Disconnect } from './disconnect';
 import { Reconnect } from './reconnect';
 
 export type ConnectionStatusProps = {
@@ -23,10 +24,16 @@ export function ConnectionStatus( { connection, service }: ConnectionStatusProps
 	return (
 		<div>
 			<span className="description">
-				{ __( 'There is an issue with this connection.', 'jetpack' ) }
+				{ service
+					? __( 'There is an issue with this connection.', 'jetpack' )
+					: __( 'This platform is no longer supported.', 'jetpack' ) }
 			</span>
 			&nbsp;
-			<Reconnect connection={ connection } service={ service } />
+			{ service ? (
+				<Reconnect connection={ connection } service={ service } />
+			) : (
+				<Disconnect connection={ connection } variant="link" isDestructive={ false } />
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
A user reported that they see a WSOD on Sharing settings section in Jetpack Dashboard in the new connections UI. The reason for that was that the user had an old Twitter connection which is no longer supported - p1718102314427849-slack-C02JJ910CNL

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Display the notice that a platform is no longer supported
* Replace reconnect button with disconnect button for unsupported platforms
* <details>
    <summary>Fallback the connection name to <code>external_display</code> when <code>display_name</code> is not present in old connections to avoid showing a loading indicator or empty name</summary>
    <img width="622" alt="image" src="https://github.com/Automattic/jetpack/assets/18226415/ee7208f5-66f8-49b1-964e-ade390c209d0">
    </details>


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->



<details>
    <summary>To simulate a broken Twitter connection, you can make these changes (click to expand)</summary>

```diff
diff --git a/projects/packages/publicize/src/class-publicize.php b/projects/packages/publicize/src/class-publicize.php
index d23c38d358..df03785c82 100644
--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -239,6 +239,8 @@ class Publicize extends Publicize_Base {
                }
                $connections = $this->get_all_connections();

+               $count = 0;
+
                $connections_to_return = array();
                if ( ! empty( $connections ) ) {
                        foreach ( (array) $connections as $service_name => $connections_for_service ) {
@@ -250,7 +252,7 @@ class Publicize extends Publicize_Base {
                                                        $connections_to_return[] = array_merge(
                                                                $connection,
                                                                array(
-                                                                       'service_name'   => $service_name,
+                                                                       'service_name'   => ! ( $count++ ) ? 'twitter' : $service_name,
                                                                        'connection_id'  => $connection['connection_data']['id'],
                                                                        'can_disconnect' => self::can_manage_connection( $connection['connection_data'] ),
                                                                        'profile_link'   => $this->get_profile_link( $service_name, $connection ),
@@ -287,7 +289,7 @@ class Publicize extends Publicize_Base {
                $connection_results_map = array();

                foreach ( $connection_results as $connection_result ) {
-                       $connection_results_map[ $connection_result['connection_id'] ] = $connection_result['test_success'] ? 'ok' : 'broken';
+                       $connection_results_map[ $connection_result['connection_id'] ] = $connection_result['test_success'] ? 'broken' : 'broken';
                }
                foreach ( $connections as $key => $connection ) {
                        if ( isset( $connection_results_map[ $connection['connection_id'] ] ) ) {
```
</details>

* Ensure that you have at least one connection
* Goto Social admin or Jetpack Sharing section settings
* Confirm that there is no WSOD
* Confirm that you see the unsupported notice for Twitter

<img width="592" alt="image" src="https://github.com/Automattic/jetpack/assets/18226415/09ef5dd7-787b-45ac-8403-5ef8414dc6c6">