### PR TITLE
Add an ID to the jetpack form EU cookie law form tag

### DIFF
--- a/projects/plugins/jetpack/changelog/jdv-eu-cookie-law-form-id
+++ b/projects/plugins/jetpack/changelog/jdv-eu-cookie-law-form-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+EU Cookie Law widget: add id attribute to consent form

--- a/projects/plugins/jetpack/modules/widgets/eu-cookie-law/widget.php
+++ b/projects/plugins/jetpack/modules/widgets/eu-cookie-law/widget.php
@@ -16,7 +16,7 @@
 	data-consent-expiration="<?php echo (int) $instance['consent-expiration']; ?>"
 	id="eu-cookie-law"
 >
-	<form method="post">
+	<form method="post" id="jetpack-eu-cookie-law-form">
 		<input type="submit" value="<?php echo esc_attr( $instance['button'] ); ?>" class="accept" />
 	</form>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

We use the Jetpack EU cookie law widget on WordCamp sites, but we need to be able to tie into this form easily with Google Tag Manager so we can adjust our form tracking on WordCamp sites. To do so, we need an `id` on the form tag, and it seems we might not be the only one to need that, so adding an `id` attribute to the form tag fixes this.

Fixes https://github.com/WordPress/wordcamp.org/issues/1334

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add an `id` attribute (with value `jetpack-eu-cookie-law-form`) to the form on EU cookie law widgets.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to any page that shows the cookie law widget.
* Check that the `id` has been added to the form.

