### PR TITLE
Boost: Updates for 3.4.2 release

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/lib/features.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/lib/features.tsx
@@ -179,7 +179,7 @@ export const boostFeatureList: FeatureItem[] = [
 			tooltipInfo: __( 'Fine-tune image quality settings to your liking.', 'jetpack-boost' ),
 			tooltipPlacement: 'bottom-start',
 		},
-		free: <PricingTableItem isIncluded={ true } />,
+		free: <PricingTableItem isIncluded={ false } />,
 		premium: <PricingTableItem isIncluded={ true } label={ __( 'Included', 'jetpack-boost' ) } />,
 	},
 	{

--- a/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/lib/features.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/lib/features.tsx
@@ -184,6 +184,18 @@ export const boostFeatureList: FeatureItem[] = [
 	},
 	{
 		description: {
+			name: __( 'Image CDN Auto-Resize Lazy Images', 'jetpack-boost' ),
+			tooltipInfo: __(
+				'Optimizes lazy-loaded images by dynamically serving perfectly sized images for each device.',
+				'jetpack-boost'
+			),
+			tooltipPlacement: 'bottom-start',
+		},
+		free: <PricingTableItem isIncluded={ false } />,
+		premium: <PricingTableItem isIncluded={ true } label={ __( 'Included', 'jetpack-boost' ) } />,
+	},
+	{
+		description: {
 			name: __( 'Image CDN', 'jetpack-boost' ),
 			tooltipInfo: imageCdnContext,
 			tooltipPlacement: 'bottom-start',

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
@@ -118,6 +118,9 @@ const DocumentationSection = ( {
 						href={ getSupportLinkCriticalCss( errorType ) }
 						target="_blank"
 						rel="noopener noreferrer"
+						onClick={ () => {
+							recordBoostEvent( 'critical_css_learn_more', {} );
+						} }
 					/>
 				),
 			} ) }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/show-stopper-error/show-stopper-error.tsx
@@ -162,7 +162,7 @@ const OtherErrors = ( { cssState, retry, showRetry, supportLink }: ShowStopperEr
 							{
 								...actionLinkInterpolateVar( () => {
 									recordBoostEvent( 'critical_css_retry', {
-										errorType: 'CssGenLibraryFailure',
+										error_type: 'CssGenLibraryFailure',
 									} );
 
 									retry();
@@ -186,7 +186,7 @@ const OtherErrors = ( { cssState, retry, showRetry, supportLink }: ShowStopperEr
 							className="secondary"
 							onClick={ () => {
 								recordBoostEvent( 'critical_css_retry', {
-									errorType: 'UnknownError',
+									error_type: 'UnknownError',
 								} );
 
 								retry();

--- a/projects/plugins/boost/app/assets/src/js/features/performance-history/performance-history.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/performance-history/performance-history.tsx
@@ -13,6 +13,7 @@ import { useNavigate } from 'react-router-dom';
 import { useSingleModuleState } from '$features/module/lib/stores';
 import styles from './performance-history.module.scss';
 import { useEffect } from 'react';
+import { recordBoostEvent } from '$lib/utils/analytics';
 
 const PerformanceHistoryBody = () => {
 	const [ performanceHistoryState ] = useSingleModuleState( 'performance_history' );
@@ -67,6 +68,7 @@ const PerformanceHistory = () => {
 					title={ __( 'Historical Performance', 'jetpack-boost' ) }
 					initialOpen={ isPanelOpen }
 					onToggle={ ( value: boolean ) => {
+						recordBoostEvent( 'performance_history_panel_toggle', {} );
 						setPanelOpen( value );
 					} }
 					className={ styles[ 'performance-history-body' ] }

--- a/projects/plugins/boost/app/assets/src/js/features/performance-history/performance-history.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/performance-history/performance-history.tsx
@@ -68,7 +68,7 @@ const PerformanceHistory = () => {
 					title={ __( 'Historical Performance', 'jetpack-boost' ) }
 					initialOpen={ isPanelOpen }
 					onToggle={ ( value: boolean ) => {
-						recordBoostEvent( 'performance_history_panel_toggle', {} );
+						recordBoostEvent( 'performance_history_panel_toggle', { status: value ? 'open' : 'close' } );
 						setPanelOpen( value );
 					} }
 					className={ styles[ 'performance-history-body' ] }

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/get-critical-css-error-set-interpolate-vars.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/get-critical-css-error-set-interpolate-vars.tsx
@@ -19,7 +19,7 @@ function getCriticalCssErrorSetInterpolateVars( errorSet: ErrorSet ) {
 	const interpolateVars: InterpolateVars = {
 		...actionLinkInterpolateVar( () => {
 			recordBoostEvent( 'critical_css_retry', {
-				errorType: errorSet.type,
+				error_type: errorSet.type,
 			} );
 
 			retry();

--- a/projects/plugins/boost/changelog/update-boost-update-tracks-update-pricing
+++ b/projects/plugins/boost/changelog/update-boost-update-tracks-update-pricing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add missing tracks event, fix incorrect tracks event, add LIAR to pricing table, add tracks event for learn more in c.css steps section.
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add tracks event for toggling performance history section `performance_history_panel_toggle`;
* Fix tracks events for retry in critical css show stopper steps UI `critical_css_retry`;
* Fix showing **Image CDN Quality Settings** as available for free;
* Add tracks event for learn more in show stopper steps UI `critical_css_learn_more`;
* Add **Image CDN Auto-Resize Lazy Images** to pricing table:

![image](https://github.com/Automattic/jetpack/assets/11799079/ea4c00c9-5c68-4c8c-8170-892194a5dbd8)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1718273406365169/1718268999.371939-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost;
* Check out the pricing table to make sure it shows `Image CDN Auto-Resize Lazy Images` correctly (and the description makes sense);
* Make sure tracks events listed above are showing up.