### PR TITLE
Boost: Backport changes from 3.4.2/ init new plugin cycle

### DIFF
--- a/projects/plugins/boost/CHANGELOG.md
+++ b/projects/plugins/boost/CHANGELOG.md
@@ -5,20 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.4.1-beta] - 2024-06-11
+## [3.4.2] - 2024-06-13
 ### Added
-- Page Cache: Added cache rebuild functionality. [#37151]
-- Page Cache: Remove the advanced-cache.php when the Cache module is disabled. [#37643]
-- Page Cache: Allow easy migration from WPSC to Boost Cache. [#36818]
 - Critical CSS: Add a friendly error if css gen library is broken or missing. [#37283]
+- Page Cache: Added cache rebuild functionality. [#37151]
+- Page Cache: Allow easy migration from WPSC to Boost Cache. [#36818]
+- Page Cache: Remove the advanced-cache.php when the Cache module is disabled. [#37643]
 
 ### Changed
 - Critical CSS: Improve source providers collecting logic. [#37095]
 - Critical CSS: Improve UI when errors are present. [#37658]
-- Minification: Change minification library. [#37700]
-- Minification: Skip files ending in `.min.js` and `.min.css` from minification. [#37700]
 - Dependency: Remove the explicit Plugin Install dependency. [#37430]
 - Dependency: Updated package dependencies. [#37348] [#37379] [#37380] [#37669]
+- Minification: Change minification library. [#37700]
+- Minification: Skip files ending in `.min.js` and `.min.css` from minification. [#37700]
 
 ## [3.3.1] - 2024-05-15
 ### Fixed
@@ -456,7 +456,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First public alpha release
 
-[3.4.1-beta]: https://github.com/Automattic/jetpack-boost-production/compare/3.3.1...3.4.1-beta
+[3.4.2]: https://github.com/Automattic/jetpack-boost-production/compare/3.3.1...3.4.2
 [3.3.1]: https://github.com/Automattic/jetpack-boost-production/compare/3.3.0...3.3.1
 [3.3.0]: https://github.com/Automattic/jetpack-boost-production/compare/3.2.2...3.3.0
 [3.2.2]: https://github.com/Automattic/jetpack-boost-production/compare/3.2.0...3.2.2

--- a/projects/plugins/boost/changelog/update-boost-portback-3.4.2-changes
+++ b/projects/plugins/boost/changelog/update-boost-portback-3.4.2-changes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Backport changes from 3.4.2 release.
+
+

--- a/projects/plugins/boost/changelog/update-boost-portback-3.4.2-changes#2
+++ b/projects/plugins/boost/changelog/update-boost-portback-3.4.2-changes#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/changelog/update-boost-update-tracks-update-pricing
+++ b/projects/plugins/boost/changelog/update-boost-update-tracks-update-pricing
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Add missing tracks event, fix incorrect tracks event, add LIAR to pricing table, add tracks event for learn more in c.css steps section.
-
-

--- a/projects/plugins/boost/changelog/update-include-matthiasmullie-minify-package
+++ b/projects/plugins/boost/changelog/update-include-matthiasmullie-minify-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fixed a missing vendor package from production build
-
-

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "3.4.2-alpha",
+	"version": "3.4.3-alpha",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -73,7 +73,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_4_2_alpha",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_4_3_alpha",
 		"allow-plugins": {
 			"roots/wordpress-core-installer": true,
 			"automattic/jetpack-autoloader": true,

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "271d98950b756f2429b4a5b7970127b3",
+    "content-hash": "f3385a1bfdd91858b9728ea8f4c28090",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 3.4.2-alpha
+ * Version: 3.4.3-alpha
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'JETPACK_BOOST_VERSION', '3.4.2-alpha' );
+define( 'JETPACK_BOOST_VERSION', '3.4.3-alpha' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-boost",
-	"version": "3.4.2-alpha",
+	"version": "3.4.3-alpha",
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"directories": {
 		"test": "tests"

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -5,7 +5,7 @@ Tags: performance, speed, web vitals, critical css, cache
 Requires at least: 5.5
 Tested up to: 6.5
 Requires PHP: 7.0
-Stable tag: 3.3.1
+Stable tag: 3.4.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -183,20 +183,20 @@ If you run into compatibility issues, please do let us know. You can drop us a l
 2. Jetpack Boost Speed Improvement
 
 == Changelog ==
-### 3.4.1-beta - 2024-06-11
+### 3.4.2 - 2024-06-13
 #### Added
-- Page Cache: Added cache rebuild functionality.
-- Page Cache: Remove the advanced-cache.php when the Cache module is disabled.
-- Page Cache: Allow easy migration from WPSC to Boost Cache.
 - Critical CSS: Add a friendly error if css gen library is broken or missing.
+- Page Cache: Added cache rebuild functionality.
+- Page Cache: Allow easy migration from WPSC to Boost Cache.
+- Page Cache: Remove the advanced-cache.php when the Cache module is disabled.
 
 #### Changed
 - Critical CSS: Improve source providers collecting logic.
 - Critical CSS: Improve UI when errors are present.
-- Minification: Change minification library.
-- Minification: Skip files ending in `.min.js` and `.min.css` from minification.
 - Dependency: Remove the explicit Plugin Install dependency.
 - Dependency: Updated package dependencies.
+- Minification: Change minification library.
+- Minification: Skip files ending in `.min.js` and `.min.css` from minification.
 
 --------
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Backport 3.4.2 changes;
* Init new plugin cycle.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

n/a