### PR TITLE
Change the wpcomsh project composer slug.

### DIFF
--- a/projects/plugins/wpcomsh/changelog/change-wpcomsh-composer-name
+++ b/projects/plugins/wpcomsh/changelog/change-wpcomsh-composer-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Changed the composer package slug to wpcomsh.

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "automattic/jetpack-wpcomsh",
+	"name": "automattic/wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8abc07542e2835541aedabf0e46efce",
+    "content-hash": "4437b03befd1d10fbfd87f388d358501",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes the release archive name and generally makes the name more logical.

## Proposed changes:
* Change the composer `.name` property to "wpcomsh".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

