### PR TITLE
Return a custom error when the posts are not synced

### DIFF
--- a/projects/packages/blaze/changelog/add-jetpack-sync-check
+++ b/projects/packages/blaze/changelog/add-jetpack-sync-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added a Jetpack sync check when listing the posts.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.21.7",
+	"version": "0.21.8-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status\Host;
-use Automattic\Jetpack\Sync\Health;
+use Automattic\Jetpack\Sync\Modules;
 use WC_Product;
 use WP_Error;
 use WP_REST_Request;
@@ -19,7 +19,7 @@ use WP_REST_Server;
 
 /**
  * Registers the REST routes for Blaze Dashboard.
- * It bascially forwards the requests to the WordPress.com REST API.
+ * It basically forwards the requests to the WordPress.com REST API.
  */
 class Dashboard_REST_Controller {
 	/**
@@ -329,8 +329,8 @@ class Dashboard_REST_Controller {
 			return array();
 		}
 
-		if ( ! $this->is_jetpack_synced() ) {
-			return new WP_Error( 'jetpack_not_synced', 'Content not ready yet. Please try again later.' );
+		if ( ! $this->is_posts_synced() ) {
+			return new WP_Error( 'posts_not_synced', 'Content not ready yet. Please try again later.' );
 		}
 
 		// We don't use sub_path in the blaze posts, only query strings
@@ -391,8 +391,8 @@ class Dashboard_REST_Controller {
 			return array();
 		}
 
-		if ( ! $this->is_jetpack_synced() ) {
-			return new WP_Error( 'jetpack_not_synced', 'Content not ready yet. Please try again later.' );
+		if ( ! $this->is_posts_synced() ) {
+			return new WP_Error( 'posts_not_synced', 'Content not ready yet. Please try again later.' );
 		}
 
 		// We don't use sub_path in the blaze posts, only query strings
@@ -901,11 +901,19 @@ class Dashboard_REST_Controller {
 	}
 
 	/**
-	 * Check if the Jetpack is sync.
+	 * Check if the posts are synced.
 	 *
-	 * @return bool True if is sync false otherwise.
+	 * @return bool True if is sync, false otherwise.
 	 */
-	private function is_jetpack_synced(): bool {
-		return Health::STATUS_IN_SYNC === Health::get_status();
+	private function is_posts_synced(): bool {
+
+		/** The Full Sync Module.
+		 *
+		 * @var \Automattic\Jetpack\Sync\Modules\Full_Sync $full_sync_module
+		 */
+		$full_sync_module = Modules::get_module( 'full-sync' );
+		$posts_config     = (int) $full_sync_module->get_status()['config']['posts'] ?? 0;
+
+		return 1 === $posts_config;
 	}
 }

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -330,7 +330,7 @@ class Dashboard_REST_Controller {
 		}
 
 		if ( ! $this->are_posts_ready() ) {
-			return new WP_Error( 'posts_not_ready', 'Posts not ready yet. Please try again later.' );
+			return new WP_Error( 'posts_not_ready', 'Posts are not synced yet.' );
 		}
 
 		// We don't use sub_path in the blaze posts, only query strings
@@ -392,7 +392,7 @@ class Dashboard_REST_Controller {
 		}
 
 		if ( ! $this->are_posts_ready() ) {
-			return new WP_Error( 'posts_not_ready', 'Posts not ready yet. Please try again later.' );
+			return new WP_Error( 'posts_not_ready', 'Posts are not synced yet.' );
 		}
 
 		// We don't use sub_path in the blaze posts, only query strings

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status\Host;
-use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Health;
 use WC_Product;
 use WP_Error;
 use WP_REST_Request;
@@ -901,27 +901,16 @@ class Dashboard_REST_Controller {
 	}
 
 	/**
-	 * Check if a Full Sync of posts happened.
+	 * Check if the Health status code is sync.
 	 *
 	 * @return bool True if is sync, false otherwise.
 	 */
 	private function are_posts_ready(): bool {
-		// On WordPress.com Simple, Sync is not present, so we consider always synced.
+		// On WordPress.com Simple, Sync is not present, so we consider always ready.
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			return true;
 		}
 
-		$full_sync_module = Modules::get_module( 'full-sync' );
-		'@phan-var Modules\Full_Sync_Immediately|Modules\Full_Sync $full_sync_module';
-
-		// Is not synced if Full sync is in progress.
-		if ( ! $full_sync_module || ( $full_sync_module->is_started() && ! $full_sync_module->is_finished() ) ) {
-			return false;
-		}
-
-		// Check if the posts sync happened.
-		$posts_config = $full_sync_module->get_status()['config']['posts'] ?? 0;
-
-		return 1 === (int) $posts_config;
+		return Health::STATUS_IN_SYNC === Health::get_status();
 	}
 }

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -11,6 +11,7 @@ namespace Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Sync\Health;
 use WC_Product;
 use WP_Error;
 use WP_REST_Request;
@@ -328,6 +329,10 @@ class Dashboard_REST_Controller {
 			return array();
 		}
 
+		if ( ! $this->is_jetpack_synced() ) {
+			return new WP_Error( 'jetpack_not_synced', 'Content not ready yet. Please try again later.' );
+		}
+
 		// We don't use sub_path in the blaze posts, only query strings
 		if ( isset( $req['sub_path'] ) ) {
 			unset( $req['sub_path'] );
@@ -384,6 +389,10 @@ class Dashboard_REST_Controller {
 		$site_id = $this->get_site_id();
 		if ( is_wp_error( $site_id ) ) {
 			return array();
+		}
+
+		if ( ! $this->is_jetpack_synced() ) {
+			return new WP_Error( 'jetpack_not_synced', 'Content not ready yet. Please try again later.' );
 		}
 
 		// We don't use sub_path in the blaze posts, only query strings
@@ -889,5 +898,14 @@ class Dashboard_REST_Controller {
 	 */
 	private function get_site_id() {
 		return Connection_Manager::get_site_id();
+	}
+
+	/**
+	 * Check if the Jetpack is sync.
+	 *
+	 * @return bool True if is sync false otherwise.
+	 */
+	private function is_jetpack_synced(): bool {
+		return Health::STATUS_IN_SYNC === Health::get_status();
 	}
 }

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -329,8 +329,8 @@ class Dashboard_REST_Controller {
 			return array();
 		}
 
-		if ( ! $this->is_posts_synced() ) {
-			return new WP_Error( 'posts_not_synced', 'Content not ready yet. Please try again later.' );
+		if ( ! $this->are_posts_ready() ) {
+			return new WP_Error( 'posts_not_ready', 'Posts not ready yet. Please try again later.' );
 		}
 
 		// We don't use sub_path in the blaze posts, only query strings
@@ -391,8 +391,8 @@ class Dashboard_REST_Controller {
 			return array();
 		}
 
-		if ( ! $this->is_posts_synced() ) {
-			return new WP_Error( 'posts_not_synced', 'Content not ready yet. Please try again later.' );
+		if ( ! $this->are_posts_ready() ) {
+			return new WP_Error( 'posts_not_ready', 'Posts not ready yet. Please try again later.' );
 		}
 
 		// We don't use sub_path in the blaze posts, only query strings
@@ -905,7 +905,7 @@ class Dashboard_REST_Controller {
 	 *
 	 * @return bool True if is sync, false otherwise.
 	 */
-	private function is_posts_synced(): bool {
+	private function are_posts_ready(): bool {
 		// On WordPress.com Simple, Sync is not present, so we consider always synced.
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			return true;

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.21.7';
+	const PACKAGE_VERSION = '0.21.8-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.


### PR DESCRIPTION
This PR adds a custom error message in the endpoints below when the posts are not synced:
* `/wp-json/jetpack/v4/blaze-app/sites/<blog_id>/blaze/posts`
* `/wp-json/jetpack/v4/blaze-app/sites/<blog_id>/wordads/dsp/api/v1/wpcom/sites/<blog_id>/blaze/posts`

This is necessary because of the delay in syncing the blog posts for more than 10 minutes. The DSP side, where the ads are created, needs the full sync to consume the post data when creating the campaign.


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When listing the eligible posts to be promoted, return a custom error when the site is not synced.
* This new error code will be handled on the [Blaze Dashboard](https://github.com/Automattic/wp-calypso/tree/trunk/apps/blaze-dashboard) to show a custom message to the user. ([PR](https://github.com/Automattic/wp-calypso/pull/91888))

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch
* Create a new jurassic.tube domain, never connected to Jetpack before
* [Set up](https://github.com/Automattic/jetpack/blob/trunk/tools/docker/README.md) your environment and create a domain on jurassic.tube
* Via CLI, build the Jetpack plugin without dependencies
* In the WP Dashboard, activate and connect Jetpack
* Open the dev console, go to the Network tab
* Go to "Tools > Advertising"
* Filter out the request for "blaze/posts" and ensure that the response showing is the below:
````JSON
{
    "code": "posts_not_ready",
    "message": "Posts are not synced yet.",
    "data": null
}
````
* Refresh the page after 10 minutes, you should be able to see your post lists because it is when post sync happens
* You may also try with an old site already connected with Jetpack previously

