### PR TITLE
Simple Classic: Release it using wpcom function besides the option

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-condition-to-release-simple-classic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-condition-to-release-simple-classic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Simple Classic: Add condition to release it using a wpcom function

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.35.1",
+	"version": "5.35.2-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.35.1';
+	const PACKAGE_VERSION = '5.35.2-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -32,11 +32,10 @@ function wpcom_admin_interface_display() {
 	echo '</fieldset>';
 }
 
+// Display the admin interface settings on atomic sites or simple classic sites.
 if (
-	! empty( get_option( 'wpcom_classic_early_release' ) ) ||
-	// @phan-suppress-next-line PhanUndeclaredFunction -- Defined in wpcom, which Phan doesn't know about yet.
-	( function_exists( 'wpcom_is_simple_classic_released' ) && wpcom_is_simple_classic_released() ) ||
-	! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+	! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
+	( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) ) {
 	add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -34,6 +34,7 @@ function wpcom_admin_interface_display() {
 
 if (
 	! empty( get_option( 'wpcom_classic_early_release' ) ) ||
+	// @phan-suppress-next-line PhanUndeclaredFunction -- Defined in wpcom, which Phan doesn't know about yet.
 	( function_exists( 'wpcom_is_simple_classic_released' ) && wpcom_is_simple_classic_released() ) ||
 	! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 	add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -32,7 +32,10 @@ function wpcom_admin_interface_display() {
 	echo '</fieldset>';
 }
 
-if ( ! empty( get_option( 'wpcom_classic_early_release' ) ) || ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+if (
+	! empty( get_option( 'wpcom_classic_early_release' ) ) ||
+	( function_exists( 'wpcom_is_simple_classic_released' ) && wpcom_is_simple_classic_released() ) ||
+	! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 	add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -32,9 +32,10 @@ function wpcom_admin_interface_display() {
 	echo '</fieldset>';
 }
 
-// Display the admin interface settings on atomic sites or simple classic sites.
 if (
+	// The option should always be available on atomic sites.
 	! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
+	// The option will be shown if the simple site has already changed to Classic which means they should have already passed the experiment gate.
 	( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) ) {
 	add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/7718

## Proposed changes:

Update the condition to display the Admin Interface Styles setting as follows
* ALL atomic sites
* Simple sites with the classic view

See p1718315281445029-slack-C06DN6QQVAQ

## Jetpack product discussion
no

## Does this pull request change what data or activity we track or use?
We want an option to release Simple Classic option without waiting for a Jetpack release

## Testing instructions:
- Apply this Jetpack PR
- Go to `/wp-admin/options-general.php`
- Make sure you cannot see the Admin Interface Style option
- Change the admin interface style to the wp-admin
- Go to `/wp-admin/options-general.php`
- You should see the Admin Interface Style option