### PR TITLE
Fix site management panel widget link

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-site-management-panel-widget-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-site-management-panel-widget-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix link to logs in Site management panel widget

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
@@ -203,7 +203,7 @@ class WPCOM_Site_Management_Widget {
 									),
 									array(
 										'name' => __( 'Logs', 'jetpack-mu-wpcom' ),
-										'href' => "/site-monitoring/$domain/php",
+										'href' => "/site-logs/$domain/php",
 									),
 									array(
 										'name' => __( 'Staging Site', 'jetpack-mu-wpcom' ),


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* this is currently pointing to a non-existent link
![smp](https://github.com/Automattic/jetpack/assets/6586048/5d35bddd-5482-4d7c-a5cb-4b2a78644316)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions https://github.com/Automattic/jetpack/pull/37868#issuecomment-2167264198
* Test for Simple/Atomic
* Go to /wp-admin
* Click on "Logs" in the "Site Management Panel" widget
* Simple: `wordpress.com/hosting-features/:site` upsell page
* Atomic: PHP Logs `wordpress.com/site-logs/:site/php`
