### PR TITLE
Backport mu-wpcom-plugin 2.1.32 Changes

### DIFF
--- a/projects/js-packages/social-logos/CHANGELOG.md
+++ b/projects/js-packages/social-logos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.1] - 2024-06-14
+### Changed
+- Internal updates.
+
 ## [3.1.0] - 2024-06-13
 ### Added
 - New icon: `deezer` [#37799]
@@ -121,6 +125,7 @@
 
 - Build: Refactored (aligned build system with Gridicons).
 
+[3.1.1]: https://github.com/Automattic/social-logos/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/Automattic/social-logos/compare/v3.0.2...v3.1.0
 [3.0.2]: https://github.com/Automattic/social-logos/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/Automattic/social-logos/compare/v3.0.0...v3.0.1

--- a/projects/js-packages/social-logos/changelog/update-social-logos-do_svg_optimize_with_js
+++ b/projects/js-packages/social-logos/changelog/update-social-logos-do_svg_optimize_with_js
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Rewrite svg-optimize in JS.
-
-

--- a/projects/js-packages/social-logos/package.json
+++ b/projects/js-packages/social-logos/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "social-logos",
-	"version": "3.1.1-alpha",
+	"version": "3.1.1",
 	"description": "A repository of all the social logos used on WordPress.com.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/social-logos/",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.35.2] - 2024-06-14
+### Added
+- Simple Classic: Add condition to release it using a wpcom function [#37867]
+
+### Fixed
+- Fix link to logs in Site management panel widget [#37868]
+
 ## [5.35.1] - 2024-06-13
 ### Changed
 - Move Verbum comments to clsx [#37789]
@@ -876,6 +883,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.35.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.35.1...v5.35.2
 [5.35.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.35.0...v5.35.1
 [5.35.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.34.0...v5.35.0
 [5.34.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.33.0...v5.34.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-condition-to-release-simple-classic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-condition-to-release-simple-classic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Simple Classic: Add condition to release it using a wpcom function

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-site-management-panel-widget-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-site-management-panel-widget-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix link to logs in Site management panel widget

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.35.2-alpha",
+	"version": "5.35.2",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.35.2-alpha';
+	const PACKAGE_VERSION = '5.35.2';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.32 - 2024-06-14
+### Changed
+- Updated package dependencies. [#37767]
+
 ## 2.1.31 - 2024-06-10
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_32_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_32"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.32-alpha
+ * Version: 2.1.32
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.32-alpha",
+	"version": "2.1.32",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.32

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.