### PR TITLE
Social: Fix admin pricing table not shown

### DIFF
--- a/projects/plugins/social/changelog/fix-social-admin-pricing-table-not-shown
+++ b/projects/plugins/social/changelog/fix-social-admin-pricing-table-not-shown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the admin page pricing table not shown

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -84,6 +84,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ4_5_0"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ4_5_1_alpha"
 	}
 }

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Social
  * Plugin URI: https://wordpress.org/plugins/jetpack-social
  * Description: Share your site’s posts on several social media networks automatically when you publish a new post.
- * Version: 4.5.0
+ * Version: 4.5.1-alpha
  * Author: Automattic - Jetpack Social team
  * Author URI: https://jetpack.com/social/
  * License: GPLv2 or later

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -38,8 +38,7 @@ const Admin = () => {
 	const {
 		isModuleEnabled,
 		showPricingPage,
-		hasPaidPlan,
-		isShareLimitEnabled,
+		hasPaidFeatures,
 		pluginVersion,
 		isSocialImageGeneratorAvailable,
 		isAutoConversionAvailable,
@@ -50,8 +49,7 @@ const Admin = () => {
 		return {
 			isModuleEnabled: store.isModuleEnabled(),
 			showPricingPage: store.showPricingPage(),
-			hasPaidPlan: store.hasPaidPlan(),
-			isShareLimitEnabled: store.isShareLimitEnabled(),
+			hasPaidFeatures: store.hasPaidFeatures(),
 			pluginVersion: store.getPluginVersion(),
 			isSocialImageGeneratorAvailable: store.isSocialImageGeneratorAvailable(),
 			isAutoConversionAvailable: store.isAutoConversionAvailable(),
@@ -95,7 +93,7 @@ const Admin = () => {
 	return (
 		<AdminPage moduleName={ moduleName } header={ <AdminPageHeader /> }>
 			<GlobalNotices />
-			{ ( isShareLimitEnabled && ! hasPaidPlan && showPricingPage ) || forceDisplayPricingPage ? (
+			{ ( ! hasPaidFeatures && showPricingPage ) || forceDisplayPricingPage ? (
 				<AdminSectionHero>
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 						<Col>


### PR DESCRIPTION
Our [E2E tests caught](https://github.com/Automattic/jetpack/actions/runs/9512885278/job/26222058342?pr=37869) a real bug/regression that we seem to have introduced after we removed the sharing limits.
The pricing page on Social admin page on the fresh install is no longer shown.

It’s because of this `isShareLimitEnabled` and `hasPaidPlan` checks [here](https://github.com/Automattic/jetpack/blob/7fd876ccbf6cc0b3df5baa2d7db6c02bffb8e043/projects/plugins/social/src/js/components/admin-page/index.jsx#L98).

Which means that the E2E tests cannot find the “Start for free” button and thus they fail.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix paid plan checks for admin pricing page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a fresh Jetpack site, activate Social
* Goto Social admin page
* Confirm that the pricing page is shown
* Click on Start for free
* Confirm that it works as expected.

