### PR TITLE
cli: Fix rsync of unpublished plugins to plugins dir

### DIFF
--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -61,10 +61,16 @@ export async function rsyncInit( argv ) {
 	let finalDest;
 	if ( argv.dest.match( /\/(?:mu-)?plugins\/?$/ ) ) {
 		// Pull the actual plugin slug from composer.json.
-		const pluginComposerJson = await fs.readFile(
-			projectDir( `plugins/${ argv.plugin }/composer.json` )
+		const pluginComposerJson = JSON.parse(
+			await fs.readFile( projectDir( `plugins/${ argv.plugin }/composer.json` ) )
 		);
-		const wpPluginSlug = JSON.parse( pluginComposerJson ).extra[ 'wp-plugin-slug' ];
+		const wpPluginSlug =
+			pluginComposerJson?.extra?.[ 'wp-plugin-slug' ] ??
+			pluginComposerJson?.extra?.[ 'beta-plugin-slug' ];
+		if ( ! wpPluginSlug ) {
+			console.error( chalk.red( `Failed to determine plugin slug for ${ argv.plugin }.` ) );
+			process.exit( 1 );
+		}
 		finalDest = path.join( argv.dest, wpPluginSlug + '/' );
 	} else {
 		finalDest = path.join( argv.dest, '/' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When running `jetpack rsync xxx host:/path/to/wp-content/plugins`, the command is supposed to look up the plugin slug so it can rsync to the correct subdirectory. This works for published plugins (that have `.extra.wp-plugin-slug` in composer.json), but for unpublished plugins it winds up rsyncing to `/path/to/wp-content/plugins/undefined/`.

The fix is twofold:

* If `.extra.wp-plugin-slug` is not set, check `.extra.beta-plugin-slug`.
* If both fail to give us a slug, raise an error.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1718291996950589/1718286769.962189-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try `jetpack rsync wpcomsh /some/path/ending/in/plugins`. It should write to `/some/path/ending/in/plugins/wpcomsh` now, not `/some/path/ending/in/plugins/undefined`.
* Temporarily delete the `beta-plugin-slug` from `projects/plugins/wpcomsh/composer.json` and try `jetpack rsync` again. It should now print an error message.