### PR TITLE
ci: Handle multiple artifacts in post-build workflow

### DIFF
--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -120,7 +120,7 @@ jobs:
             )"
             echo "$JSON"
             echo "::endgroup::"
-            ZIPURL="$(jq -r '.artifacts | map( select( .name == "jetpack-build" ) ) | sort_by( .created_at ) | last | .archive_download_url' <<<"$JSON")"
+            ZIPURL="$(jq -r '.artifacts | map( select( .name == "jetpack-build" ) ) | sort_by( .created_at ) | last | .archive_download_url // empty' <<<"$JSON")"
             PLUGINS="$(jq -r '.artifacts[] | select( .name == "plugins.tsv" )' <<<"$JSON")"
             if [[ -n "$ZIPURL" ]]; then
               break

--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -120,7 +120,7 @@ jobs:
             )"
             echo "$JSON"
             echo "::endgroup::"
-            ZIPURL="$(jq -r '.artifacts[] | select( .name == "jetpack-build" ) | .archive_download_url' <<<"$JSON")"
+            ZIPURL="$(jq -r '.artifacts | map( select( .name == "jetpack-build" ) ) | sort_by( .created_at ) | last | .archive_download_url' <<<"$JSON")"
             PLUGINS="$(jq -r '.artifacts[] | select( .name == "plugins.tsv" )' <<<"$JSON")"
             if [[ -n "$ZIPURL" ]]; then
               break


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Not sure how common it is, but [a recent job][1] failed because the build workflow was re-run and so GitHub's API was returning multiple build zips, so the action was concatenating the URLs. Adjust the script to take the last URL when there are more than one.

[1]: https://github.com/Automattic/jetpack/actions/runs/9518168268/job/26241262598

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No idea how to reproduce the problem. At the least you might copy the JSON from https://github.com/Automattic/jetpack/actions/runs/9518168268/job/26241262598#step:3:159 and feed it to the `jq` command being modified here to see that it does the right thing. And then do the same with some other representative JSONs as well.
