### PR TITLE
Jetpack admin-menu endpoint: Require masterbar menu load file only on self-hosted sites

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -83,9 +83,8 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$is_wpcom                = defined( 'IS_WPCOM' ) && IS_WPCOM;
 		$should_use_nav_redesign = function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled();
-		if ( ! $is_wpcom && ! $should_use_nav_redesign ) {
+		if ( ! ( new Host() )->is_wpcom_platform() && ! $should_use_nav_redesign ) {
 			require_once JETPACK__PLUGIN_DIR . 'jetpack_vendor/automattic/jetpack-masterbar/src/admin-menu/load.php';
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -6,6 +6,8 @@
  * @since 9.1.0
  */
 
+use Automattic\Jetpack\Status\Host;
+
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Admin_Menu
  */

--- a/projects/plugins/jetpack/changelog/update-jp-admin-menu-endpoint
+++ b/projects/plugins/jetpack/changelog/update-jp-admin-menu-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack admin-menu endpoint: Require masterbar menu load file only on self-hosted sites


### PR DESCRIPTION
Pre-requisite for https://github.com/Automattic/jetpack/pull/37812

This PR ensures that the Jetpack admin-menu endpoint will only require the masterbar menu load file, only on self-hosted sites.

This is needed to [prevent a Fatal](https://github.com/Automattic/jetpack/pull/37812#issuecomment-2172322573) during the transitory period for WoA sites, while we move the `masterbar` feature outside of the Jetpack plugin when the `jetpack-masterbar/src/admin-menu/load.php` ends up being loaded twice from two different plugins ( Jetpack on `13.6-a.1` and wpcomsh).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* WPCOM_REST_API_V2_Endpoint_Admin_Menu: Only load `jetpack-masterbar/src/admin-menu/load.php` on self-hosted envs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See https://github.com/Automattic/jetpack/pull/37812

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### nav-unification: Testing the admin menu in WoA and self-hosted:
You can test this in the [WPCOM REST API Dev console](https://developer.wordpress.com/docs/api/console/) for the `wpcom/v2/sites/YOUR_BLOG_ID/admin-menu` endpoint. 

- Ensure the same response on self-hosted sites with/without PR
- Ensure the same response on WoA classic and default sites with/without PR

<img width="727" alt="Screenshot 2024-06-13 at 14 29 19" src="https://github.com/Automattic/jetpack/assets/1758399/0d45e728-f6c8-468d-a397-7d531bd1f79c">

