### PR TITLE
Disable WP.com custom editor navigation bar

### DIFF
--- a/projects/plugins/wpcomsh/changelog/port-wpcomsh-1197
+++ b/projects/plugins/wpcomsh/changelog/port-wpcomsh-1197
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Disable WP.com custom editor navigation bar.

--- a/projects/plugins/wpcomsh/feature-plugins/full-site-editing.php
+++ b/projects/plugins/wpcomsh/feature-plugins/full-site-editing.php
@@ -16,9 +16,6 @@ function wpcomsh_maybe_disable_fse() {
 }
 add_filter( 'a8c_disable_full_site_editing', 'wpcomsh_maybe_disable_fse' );
 
-// Enable the navigation sidebar for all sites.
-add_filter( 'a8c_enable_nav_sidebar', '__return_true' );
-
 // Enable block patterns API.
 add_filter( 'a8c_enable_block_patterns_api', '__return_true' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Remove WP.com specific sidebar for Post and Page editor. See actual code removal in Calypso PR (WIP).

P2 p58i-dox-p2#comment-56472
Slack p1712659066418099-slack-C06DN6QQVAQ

### To test:

Open Page and Post editors, and confirm that the sidebar that appears when clicking W icon (or site icon when set) is gone:

<img width="756" alt="Screenshot 2022-12-12 at 13 01 32" src="https://user-images.githubusercontent.com/87168/207029345-b1b248d1-a183-4890-a9f8-0b1922bcb0c5.png">
<img width="928" alt="Screenshot 2022-12-12 at 13 01 23" src="https://user-images.githubusercontent.com/87168/207029353-305b2a26-2ab4-4e2f-ac50-85e9e2fb3bfd.png">