### PR TITLE
Super Cache: check for the same Boost that the plugin later tries to install

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache-detect-boost
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-detect-boost
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Super Cache: Align detection of Boost installs with activation of that plugin

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -339,7 +339,7 @@ function wpsc_is_boost_installed() {
 	$plugins = array_keys( get_plugins() );
 
 	foreach ( $plugins as $plugin ) {
-		if ( str_contains( $plugin, 'jetpack-boost.php' ) ) {
+		if ( str_contains( $plugin, 'jetpack-boost/jetpack-boost.php' ) ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
The plugin would check for jetpack-boost.php and it might find it in a plugin directory other than "jetpack-boost" if used in a development environment. This would make it difficult to test installing Boost, but as well as that, the activation code uses the "jetpack-boost" directory. If Boost was installed in a different directory it wouldn't be activated, and the "Activate" button would return an error.
This PR fixes this by checking if Boost is installed in "jetpack-boost".
There is a `wpsc_is_boost_active` function that checks for the Jetpack Boost class, so if Boost is installed in a different directory, then the "Install/Activate Boost" button is hidden.

Props @haqadn.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added "jetpack-boost/" path to plugin check so it finds Boost in the public plugin directory.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Install in a dev environment, either Docker or with the Beta plugin.
* Make sure Boost is installed in a different directory, such as boost or jetpack-boost-dev
* Open the WP Super Cache settings page and note the banner button says "Activate Jetpack Boost".
* If you try to activate Boost, you will get an error saying, "Plugin file does not exist."
* Apply this PR.
* Refresh WP Super Cache settings page and the banner button should say "Install Jetpack Boost".

