### PR TITLE
Backport mu-wpcom-plugin 2.1.33, jetpack 13.6-a.3, wpcomsh 3.22.15 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.4] - 2024-06-17
+### Changed
+- Updated package dependencies. [#37779]
+
 ## [0.14.3] - 2024-06-10
 ### Changed
 - AI Featured Image: export generic image generation request function. [#37668]
@@ -339,6 +343,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.14.4]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.0...v0.14.1

--- a/projects/js-packages/ai-client/changelog/renovate-storybook-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.14.4-alpha",
+	"version": "0.14.4",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/base-styles/CHANGELOG.md
+++ b/projects/js-packages/base-styles/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.27] - 2024-06-17
+### Added
+- Add color variable [#37802]
+
 ## [0.6.26] - 2024-06-05
 ### Changed
 - Updated package dependencies. [#37669]
@@ -289,6 +293,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Use Node 16.7.0 in tooling. This shouldn't change the behavior of the code itself.
 
+[0.6.27]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.26...0.6.27
 [0.6.26]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.25...0.6.26
 [0.6.25]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.24...0.6.25
 [0.6.24]: https://github.com/Automattic/jetpack-base-styles/compare/0.6.23...0.6.24

--- a/projects/js-packages/base-styles/changelog/update-coditionally-render-connection-footer-with-unlock
+++ b/projects/js-packages/base-styles/changelog/update-coditionally-render-connection-footer-with-unlock
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add color variable

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-base-styles",
-	"version": "0.6.27-alpha",
+	"version": "0.6.27",
 	"description": "Jetpack components base styles",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/base-styles/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.33.17] - 2024-06-17
+### Changed
+- Update type to enable JSX use [#37802]
+
 ## [0.33.16] - 2024-06-12
 ### Changed
 - Updated package dependencies. [#37796]
@@ -785,6 +789,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.33.17]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.16...v0.33.17
 [0.33.16]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.15...v0.33.16
 [0.33.15]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.14...v0.33.15
 [0.33.14]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.13...v0.33.14

--- a/projects/js-packages/connection/changelog/update-coditionally-render-connection-footer-with-unlock
+++ b/projects/js-packages/connection/changelog/update-coditionally-render-connection-footer-with-unlock
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update type to enable JSX use

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.33.17-alpha",
+	"version": "0.33.17",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.80 - 2024-06-17
+### Changed
+- Updated package dependencies. [#37796]
+
 ## 0.2.79 - 2024-06-10
 ### Changed
 - Change codebase to use clsx instead of classnames. [#37708]

--- a/projects/js-packages/partner-coupon/changelog/renovate-babel-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.80-alpha",
+	"version": "0.2.80",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.54.4] - 2024-06-17
+### Fixed
+- Social: Fixed broken connections reconnect link to point it to new connections UI [#37869]
+
 ## [0.54.3] - 2024-06-13
 ### Changed
 - Updated package dependencies. [#37795]
@@ -737,6 +741,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.54.4]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.54.3...v0.54.4
 [0.54.3]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.54.2...v0.54.3
 [0.54.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.54.1...v0.54.2
 [0.54.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.54.0...v0.54.1

--- a/projects/js-packages/publicize-components/changelog/fix-broken-connections-link-in-editor
+++ b/projects/js-packages/publicize-components/changelog/fix-broken-connections-link-in-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Social: Fixed broken connections reconnect link to point it to new connections UI

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.54.4-alpha",
+	"version": "0.54.4",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.16] - 2024-06-17
+### Changed
+- Updated package dependencies. [#37796]
+
 ## [3.3.15] - 2024-06-10
 ### Changed
 - Updated package dependencies. [#37669]
@@ -640,6 +644,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.3.16]: https://github.com/Automattic/jetpack-backup/compare/v3.3.15...v3.3.16
 [3.3.15]: https://github.com/Automattic/jetpack-backup/compare/v3.3.14...v3.3.15
 [3.3.14]: https://github.com/Automattic/jetpack-backup/compare/v3.3.13...v3.3.14
 [3.3.13]: https://github.com/Automattic/jetpack-backup/compare/v3.3.12...v3.3.13

--- a/projects/packages/backup/changelog/renovate-babel-monorepo
+++ b/projects/packages/backup/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.3.16-alpha';
+	const PACKAGE_VERSION = '3.3.16';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.7] - 2024-06-17
+### Changed
+- Updated package dependencies. [#37796]
+
 ## [0.21.6] - 2024-06-10
 ### Changed
 - Updated package dependencies. [#37669]
@@ -377,6 +381,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.21.7]: https://github.com/automattic/jetpack-blaze/compare/v0.21.6...v0.21.7
 [0.21.6]: https://github.com/automattic/jetpack-blaze/compare/v0.21.5...v0.21.6
 [0.21.5]: https://github.com/automattic/jetpack-blaze/compare/v0.21.4...v0.21.5
 [0.21.4]: https://github.com/automattic/jetpack-blaze/compare/v0.21.3...v0.21.4

--- a/projects/packages/blaze/changelog/renovate-babel-monorepo
+++ b/projects/packages/blaze/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.21.7-alpha",
+	"version": "0.21.7",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.21.7-alpha';
+	const PACKAGE_VERSION = '0.21.7';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.1] - 2024-06-17
+### Changed
+- Updated package dependencies. [#37796]
+
 ## [0.32.0] - 2024-06-10
 ### Changed
 - Change codebase to use clsx instead of classnames. [#37708]
@@ -590,6 +594,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.32.1]: https://github.com/automattic/jetpack-forms/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/automattic/jetpack-forms/compare/v0.31.4...v0.32.0
 [0.31.4]: https://github.com/automattic/jetpack-forms/compare/v0.31.3...v0.31.4
 [0.31.3]: https://github.com/automattic/jetpack-forms/compare/v0.31.2...v0.31.3

--- a/projects/packages/forms/changelog/cast_to_int
+++ b/projects/packages/forms/changelog/cast_to_int
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Cast to int for better PHP compatibility.
-
-

--- a/projects/packages/forms/changelog/renovate-babel-monorepo
+++ b/projects/packages/forms/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.32.1-alpha",
+	"version": "0.32.1",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.32.1-alpha';
+	const PACKAGE_VERSION = '0.32.1';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/masterbar/CHANGELOG.md
+++ b/projects/packages/masterbar/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2024-06-17
+### Changed
+- Updated package dependencies. [#37796]
+
+### Fixed
+- Color Schemes: Fix Sakura color issues on masterbar [#37806]
+
 ## 0.1.0 - 2024-06-10
 ### Added
 - Initial version. [#37277]
@@ -15,3 +22,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Notifications: Change Icon [#37676]
 - Updated package dependencies. [#37669]
 - Updated package dependencies. [#37706]
+
+[0.1.1]: https://github.com/Automattic/jetpack-masterbar/compare/v0.1.0...v0.1.1

--- a/projects/packages/masterbar/changelog/fix-sakura-scheme-issues-masterbar
+++ b/projects/packages/masterbar/changelog/fix-sakura-scheme-issues-masterbar
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Color Schemes: Fix Sakura color issues on masterbar

--- a/projects/packages/masterbar/changelog/renovate-babel-monorepo
+++ b/projects/packages/masterbar/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.1.1-alpha",
+	"version": "0.1.1",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.1.1-alpha';
+	const PACKAGE_VERSION = '0.1.1';
 
 	/**
 	 * Initializer.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.25.0] - 2024-06-17
+### Changed
+- Show tooltip on card hover instead of letter hover [#37858]
+- Update connection footer to conditionally render warnings or errors [#37802]
+- Update connection status card tests to TS [#37829]
+
 ## [4.24.7] - 2024-06-13
 ### Changed
 - Updated package dependencies. [#37796]
@@ -1516,6 +1522,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.25.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.24.7...4.25.0
 [4.24.7]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.24.6...4.24.7
 [4.24.6]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.24.5...4.24.6
 [4.24.5]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.24.4...4.24.5

--- a/projects/packages/my-jetpack/changelog/update-coditionally-render-connection-footer-with-unlock
+++ b/projects/packages/my-jetpack/changelog/update-coditionally-render-connection-footer-with-unlock
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update connection footer to conditionally render warnings or errors

--- a/projects/packages/my-jetpack/changelog/update-connection-status-tests-to-typescript
+++ b/projects/packages/my-jetpack/changelog/update-connection-status-tests-to-typescript
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update connection status card tests to TS

--- a/projects/packages/my-jetpack/changelog/update-show-tooltip-on-card-hover
+++ b/projects/packages/my-jetpack/changelog/update-show-tooltip-on-card-hover
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Show tooltip on card hover instead of letter hover

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.25.0-alpha",
+	"version": "4.25.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.25.0-alpha';
+	const PACKAGE_VERSION = '4.25.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.46.1] - 2024-06-17
+### Fixed
+- Fixed connections management links for classic editor [#37681]
+
 ## [0.46.0] - 2024-06-13
 ### Changed
 - Changed the social-product-info endpoint to return v1 plan [#36846]
@@ -585,6 +589,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.46.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.46.0...v0.46.1
 [0.46.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.45.2...v0.46.0
 [0.45.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.45.1...v0.45.2
 [0.45.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.45.0...v0.45.1

--- a/projects/packages/publicize/changelog/update-connections-management-links-for-classic-editor
+++ b/projects/packages/publicize/changelog/update-connections-management-links-for-classic-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed connections management links for classic editor

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.46.1-alpha",
+	"version": "0.46.1",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.10] - 2024-06-17
+### Changed
+- Updated package dependencies. [#37796] [#37860]
+
 ## [0.44.9] - 2024-06-10
 ### Changed
 - Change codebase to use clsx instead of classnames. [#37708]
@@ -976,6 +980,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.44.10]: https://github.com/Automattic/jetpack-search/compare/v0.44.9...v0.44.10
 [0.44.9]: https://github.com/Automattic/jetpack-search/compare/v0.44.8...v0.44.9
 [0.44.8]: https://github.com/Automattic/jetpack-search/compare/v0.44.7...v0.44.8
 [0.44.7]: https://github.com/Automattic/jetpack-search/compare/v0.44.6...v0.44.7

--- a/projects/packages/search/changelog/renovate-babel-monorepo
+++ b/projects/packages/search/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/renovate-major-size-limit
+++ b/projects/packages/search/changelog/renovate-major-size-limit
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.10-alpha",
+	"version": "0.44.10",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.10-alpha';
+	const VERSION = '0.44.10';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.25] - 2024-06-17
+### Changed
+- Updated package dependencies. [#37779] [#37796]
+
 ## [0.23.24] - 2024-06-10
 ### Changed
 - Change codebase to use clsx instead of classnames. [#37708]
@@ -1357,6 +1361,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.25]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.24...v0.23.25
 [0.23.24]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.23...v0.23.24
 [0.23.23]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.22...v0.23.23
 [0.23.22]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.21...v0.23.22

--- a/projects/packages/videopress/changelog/renovate-babel-monorepo
+++ b/projects/packages/videopress/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/changelog/renovate-storybook-monorepo
+++ b/projects/packages/videopress/changelog/renovate-storybook-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.25-alpha",
+	"version": "0.23.25",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.25-alpha';
+	const PACKAGE_VERSION = '0.23.25';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.21] - 2024-06-17
+### Changed
+- Updated package dependencies. [#37796]
+
 ## [0.3.20] - 2024-06-10
 ### Changed
 - Change codebase to use clsx instead of classnames. [#37708]
@@ -359,6 +363,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.21]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.20...v0.3.21
 [0.3.20]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.19...v0.3.20
 [0.3.19]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.18...v0.3.19
 [0.3.18]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.17...v0.3.18

--- a/projects/packages/wordads/changelog/renovate-babel-monorepo
+++ b/projects/packages/wordads/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.21-alpha",
+	"version": "0.3.21",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.21-alpha';
+	const VERSION = '0.3.21';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.6-a.3 - 2024-06-17
+### Enhancements
+- AI Assistant: Hide input when user types on extended block. [#37801]
+
+### Bug fixes
+- Like block: Fix editor styling. [#37719]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Added ability to test Jetpack together with wpcomsh. [#37737]
+- Color Schemes: Fix Sakura color issues on masterbar. [#37806]
+- EU Cookie Law widget: add id attribute to consent form. [#37839]
+- Fixed E2E tests navigating to block editor. [#37875]
+- Fixed PHP Unit tests for WP trunk. [#37785]
+- Fixed Uncaught TypeError in for recommendations CTA. [#37808]
+- Jetpack admin-menu endpoint: Require masterbar menu load file only on self-hosted sites. [#37891]
+- Jetpack AI: register ai-general-purpose-image-generator beta flag to control the changes we are doing to the image generation tool. [#37749]
+- Jetpack AI Image: create first draft of the General Purpose image generator. [#37782]
+- Jetpack AI Image: make the general purpose generator set the image on the image block. [#37834]
+- Return site_goals option for a site. [#37809]
+- Social: Fixed broken connections reconnect link to point it to new connections UI. [#37869]
+- Top Posts & Pages Block: Require that one content type is always set to display. [#36305]
+- Updated package dependencies. [#37767] [#37776] [#37795] [#37796]
+
 ## 13.6-a.1 - 2024-06-10
 ### Bug fixes
 - External media: Ensure connect URL has the correct blog ID and verification values. [#37689]

--- a/projects/plugins/jetpack/changelog/add-scan-team-contributors
+++ b/projects/plugins/jetpack/changelog/add-scan-team-contributors
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated contributors list in readme.txt
-
-

--- a/projects/plugins/jetpack/changelog/fix-broken-connections-link-in-editor
+++ b/projects/plugins/jetpack/changelog/fix-broken-connections-link-in-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Social: Fixed broken connections reconnect link to point it to new connections UI

--- a/projects/plugins/jetpack/changelog/fix-e2e-tests-navigating-to-block-editor
+++ b/projects/plugins/jetpack/changelog/fix-e2e-tests-navigating-to-block-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixed E2E tests navigating to block editor

--- a/projects/plugins/jetpack/changelog/fix-like-block-editor-styling
+++ b/projects/plugins/jetpack/changelog/fix-like-block-editor-styling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Like block: Fix editor styling

--- a/projects/plugins/jetpack/changelog/fix-php-unit-tests-for-wp-trunk
+++ b/projects/plugins/jetpack/changelog/fix-php-unit-tests-for-wp-trunk
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixed PHP Unit tests for WP trunk

--- a/projects/plugins/jetpack/changelog/fix-sakura-scheme-issues-masterbar
+++ b/projects/plugins/jetpack/changelog/fix-sakura-scheme-issues-masterbar
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Color Schemes: Fix Sakura color issues on masterbar

--- a/projects/plugins/jetpack/changelog/fix-site-goals-option
+++ b/projects/plugins/jetpack/changelog/fix-site-goals-option
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Return site_goals option for a site

--- a/projects/plugins/jetpack/changelog/fix-uncaught-type-error-for-recommendations-cta
+++ b/projects/plugins/jetpack/changelog/fix-uncaught-type-error-for-recommendations-cta
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixed Uncaught TypeError in for recommendations CTA

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.6-a.4
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.6-a.2
-
-

--- a/projects/plugins/jetpack/changelog/jdv-eu-cookie-law-form-id
+++ b/projects/plugins/jetpack/changelog/jdv-eu-cookie-law-form-id
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-EU Cookie Law widget: add id attribute to consent form

--- a/projects/plugins/jetpack/changelog/remove-social-basic-plan-admin-page
+++ b/projects/plugins/jetpack/changelog/remove-social-basic-plan-admin-page
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/renovate-automattic-social-previews-2.x
+++ b/projects/plugins/jetpack/changelog/renovate-automattic-social-previews-2.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-babel-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-babel-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-playwright-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-playwright-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/try-wpcomsh-skeleton-ci
+++ b/projects/plugins/jetpack/changelog/try-wpcomsh-skeleton-ci
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Added ability to test Jetpack together with wpcomsh.

--- a/projects/plugins/jetpack/changelog/update-coditionally-render-connection-footer-with-unlock
+++ b/projects/plugins/jetpack/changelog/update-coditionally-render-connection-footer-with-unlock
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-create-general-purpose-image-beta-flag
+++ b/projects/plugins/jetpack/changelog/update-create-general-purpose-image-beta-flag
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack AI: register ai-general-purpose-image-generator beta flag to control the changes we are doing to the image generation tool. 

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-image-create-general-purpose-generator-first-draft
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-image-create-general-purpose-generator-first-draft
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack AI Image: create first draft of the General Purpose image generator.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-image-use-image-action
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-image-use-image-action
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack AI Image: make the general purpose generator set the image on the image block.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-hide-control-when-typing
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-hide-control-when-typing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Hide input when user types on extended block

--- a/projects/plugins/jetpack/changelog/update-jp-admin-menu-endpoint
+++ b/projects/plugins/jetpack/changelog/update-jp-admin-menu-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack admin-menu endpoint: Require masterbar menu load file only on self-hosted sites

--- a/projects/plugins/jetpack/changelog/update-top-posts-toggle
+++ b/projects/plugins/jetpack/changelog/update-top-posts-toggle
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Top Posts & Pages Block: Require that one content type is always set to display. 

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -106,7 +106,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_6_a_3",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_6_a_4",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -106,7 +106,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_6_a_2",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_6_a_3",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.6-a.3
+ * Version: 13.6-a.4
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.6-a.3' );
+define( 'JETPACK__VERSION', '13.6-a.4' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.6-a.2
+ * Version: 13.6-a.3
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.6-a.2' );
+define( 'JETPACK__VERSION', '13.6-a.3' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.6.0-a.2",
+	"version": "13.6.0-a.3",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.6.0-a.3",
+	"version": "13.6.0-a.4",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,10 +326,12 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.6-a.1 - 2024-06-10
+### 13.6-a.3 - 2024-06-17
+#### Enhancements
+- AI Assistant: Hide input when user types on extended block.
+
 #### Bug fixes
-- External media: Ensure connect URL has the correct blog ID and verification values.
-- Slideshow: Ensure whole block is selectable in the editor.
+- Like block: Fix editor styling.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.33 - 2024-06-17
+### Changed
+- Internal updates.
+
 ## 2.1.32 - 2024-06-14
 ### Changed
 - Updated package dependencies. [#37767]

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_32"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_1_33"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.1.32
+ * Version: 2.1.33
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.1.32",
+	"version": "2.1.33",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/wpcomsh/CHANGELOG.md
+++ b/projects/plugins/wpcomsh/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.22.15 - 2024-06-17
+### Added
+- Added a prefix for wpcomsh weekly shipping. [#37857]
+
+### Changed
+- WooCommerce Calypso Brdige version update to 2.5.2 [#37883]
+
+### Removed
+- Disable WP.com custom editor navigation bar. [#37893]
+- Removed obsolete scripts and makefile targets. [#37880]
+
 ## 3.22.14 - 2024-06-14
 ### Changed
 - Changed the composer package slug to wpcomsh. [#37861]

--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-weekly-branch-prefix
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-weekly-branch-prefix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added a prefix for wpcomsh weekly shipping.

--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-weekly-branch-prefix#2
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-weekly-branch-prefix#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-weekly-branch-prefix#3
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-weekly-branch-prefix#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/fix-renovate-and-wpcomsh-weird-deps
+++ b/projects/plugins/wpcomsh/changelog/fix-renovate-and-wpcomsh-weird-deps
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Add names in composer.json `repositories` to make Renovate happy. No change to functionality.
-
-

--- a/projects/plugins/wpcomsh/changelog/port-wpcomsh-1197
+++ b/projects/plugins/wpcomsh/changelog/port-wpcomsh-1197
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Disable WP.com custom editor navigation bar.

--- a/projects/plugins/wpcomsh/changelog/remove-redundant-bin-scripts-wpcomsh
+++ b/projects/plugins/wpcomsh/changelog/remove-redundant-bin-scripts-wpcomsh
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Removed obsolete scripts and makefile targets.

--- a/projects/plugins/wpcomsh/changelog/update-wc-calypso-bridge-2.5.2
+++ b/projects/plugins/wpcomsh/changelog/update-wc-calypso-bridge-2.5.2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-WooCommerce Calypso Brdige version update to 2.5.2

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_22_15_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_22_15"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.22.15-alpha",
+	"version": "3.22.15",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.22.15-alpha
+ * Version: 3.22.15
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
@@ -10,7 +10,7 @@
  */
 
 // Increase version number if you change something in wpcomsh.
-define( 'WPCOMSH_VERSION', '3.22.15-alpha' );
+define( 'WPCOMSH_VERSION', '3.22.15' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.1.33, jetpack 13.6-a.3, wpcomsh 3.22.15

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.