### PR TITLE
Add/usage of historically active modules sync

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-usage-of-historically-active-modules-sync
+++ b/projects/packages/my-jetpack/changelog/add-usage-of-historically-active-modules-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add use of historically active modules sync

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -91,6 +91,8 @@ class Initializer {
 		// Initialize Boost Speed Score
 		new Speed_Score( array(), 'jetpack-my-jetpack' );
 
+		self::setup_historically_active_jetpack_modules_sync();
+
 		// Add custom WP REST API endoints.
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_endpoints' ) );
 
@@ -208,7 +210,6 @@ class Initializer {
 			$previous_score = $speed_score_history->latest( 1 );
 		}
 		$latest_score['previousScores'] = $previous_score['scores'] ?? array();
-		self::update_historically_active_jetpack_modules();
 
 		wp_localize_script(
 			'my_jetpack_main_app',


### PR DESCRIPTION
## Proposed changes:

* The sync function that handles syncing the historically active modules was not being used, this removes the direct use of the `update` function from the `enqueue_scripts` function and instead sets up the sync on the `init` of My Jetpack

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1718647795140269-slack-C02LK1W8T4Z

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
(If you want to do extensive testing, you'll probably want to set up your local dev environment and log the results of `$historically_active_modules` [here in this function](https://github.com/Automattic/jetpack/pull/37537/files#diff-2be902912ee7edeeeed04156e4456f5966e480fea3067586ff451c63b2bf2624R585) so you can see when it is being updated more clearly)
2. Connect your site and user account to the site
3. Make sure you do not have the Social sharing features active and the social plugin is not installed
![image](https://github.com/Automattic/jetpack/assets/65001528/8df2e178-9c26-42b7-9464-4451eeeeb347)
4. Go to My Jetpack, and in the console, log out `myJetpackInitialState.lifeCycleStats.historicallyActiveModules`. If you have not activated anything manually, the array should only be `[ 'creator', 'extras', 'stats' ]` as they are activated by a user connection only
5. Select `Activate` on the Social card and reload the page (the backend is updated in realtime, the frontend is not, so you'll need the page refresh)
6. Log out the historicallyActiveModules again and you should see that `social` has been added to the array
![image](https://github.com/Automattic/jetpack/assets/65001528/79071bbd-34c0-424e-92a6-683e4d5db82b)
(Note: AI had been active on my site when I was making these testing instructions, ignore that one)
7. Now disconnect your site and user account
8. Check `historicallyActiveModules` again and you should still see Social in the list even though it is now not working because of the connection issue
9. Now reconnect at least your user connection and go to `/admin.php?page=jetpack#/sharing` and disable the social modules
10. Go back to My Jetpack and check the `historicallyActiveModules` variable and it should now have "social" removed since it was disabled manually
![image](https://github.com/Automattic/jetpack/assets/65001528/5f371523-394c-4b5f-8af7-0491aad83f60)