### PR TITLE
Disabled Two-Step checkbox when `jetpack_sso_require_two_step` is on

### DIFF
--- a/projects/plugins/jetpack/_inc/client/security/sso.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/sso.jsx
@@ -127,8 +127,11 @@ export const SSO = withModuleSettingsFormHelpers(
 		};
 
 		render() {
-			const isSSOActive = this.props.getOptionValue( 'sso' ),
-				unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'sso' );
+			const isSSOActive = this.props.getOptionValue( 'sso' );
+			const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'sso' );
+			const isTwoStepEnforced =
+				!! this.props.getModule( 'sso' )?.options?.jetpack_sso_require_two_step?.default;
+
 			return (
 				<>
 					<SettingsCard
@@ -194,12 +197,14 @@ export const SSO = withModuleSettingsFormHelpers(
 								/>
 								<ToggleControl
 									checked={
-										isSSOActive &&
-										this.props.getOptionValue( 'jetpack_sso_require_two_step', 'sso', false )
+										( isSSOActive &&
+											this.props.getOptionValue( 'jetpack_sso_require_two_step', 'sso', false ) ) ||
+										isTwoStepEnforced
 									}
 									disabled={
 										! isSSOActive ||
 										unavailableInOfflineMode ||
+										isTwoStepEnforced ||
 										this.props.isSavingAnyOption( [ 'sso' ] )
 									}
 									toggling={ this.props.isSavingAnyOption( [ 'jetpack_sso_require_two_step' ] ) }
@@ -211,6 +216,11 @@ export const SSO = withModuleSettingsFormHelpers(
 												'jetpack'
 											) }
 										</span>
+									}
+									help={
+										isTwoStepEnforced
+											? __( 'Two-Step Authentication is enforced on this site.', 'jetpack' )
+											: null
 									}
 								/>
 							</FormFieldset>

--- a/projects/plugins/jetpack/_inc/client/security/sso.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/sso.jsx
@@ -1,6 +1,7 @@
 import { getRedirectUrl, ToggleControl, Gridicon } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
-import { Button } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import ConnectUserBar from 'components/connect-user-bar';
 import { FormFieldset } from 'components/forms';
@@ -219,7 +220,19 @@ export const SSO = withModuleSettingsFormHelpers(
 									}
 									help={
 										isTwoStepEnforced
-											? __( 'Two-Step Authentication is enforced on this site.', 'jetpack' )
+											? createInterpolateElement(
+													__(
+														'Two-Step Authentication has been enabled by a site administrator. <link>Learn more</link>.',
+														'jetpack'
+													),
+													{
+														link: (
+															<ExternalLink
+																href={ getRedirectUrl( 'jetpack-support-force-2fa' ) }
+															/>
+														),
+													}
+											  )
 											: null
 									}
 								/>

--- a/projects/plugins/jetpack/_inc/client/security/sso.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/sso.jsx
@@ -222,7 +222,7 @@ export const SSO = withModuleSettingsFormHelpers(
 										isTwoStepEnforced
 											? createInterpolateElement(
 													__(
-														'Two-Step Authentication has been enabled by a site administrator. <link>Learn more</link>.',
+														'Two-Step Authentication is enforced because the <code>jetpack_sso_require_two_step</code> filter is active. <link>Learn more</link>.',
 														'jetpack'
 													),
 													{
@@ -231,6 +231,7 @@ export const SSO = withModuleSettingsFormHelpers(
 																href={ getRedirectUrl( 'jetpack-support-force-2fa' ) }
 															/>
 														),
+														code: <code />,
 													}
 											  )
 											: null

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -9,6 +9,7 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication;
 use Automattic\Jetpack\Connection\REST_Connector;
+use Automattic\Jetpack\Connection\SSO;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\Jetpack_CRM_Data;
 use Automattic\Jetpack\Plugins_Installer;
@@ -2590,7 +2591,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'jetpack_sso_require_two_step'          => array(
 				'description'       => esc_html__( 'Require Two-Step Authentication', 'jetpack' ),
 				'type'              => 'boolean',
-				'default'           => 0,
+				'default'           => SSO\Helpers::is_require_two_step_checkbox_disabled(),
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'sso',
 			),

--- a/projects/plugins/jetpack/changelog/fix-two-step-checkbox
+++ b/projects/plugins/jetpack/changelog/fix-two-step-checkbox
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+SSO: Disabled Two-Step checkbox when jetpack_sso_require_two_step filter is on


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/7868

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When the [jetpack_sso_require_two_step](https://developer.jetpack.com/hooks/jetpack_sso_require_two_step/) filter returns true in the backend, users shouldn't be able to update the value of the 
_Require accounts to use WordPress.com Two-Step Authentication_ toggle in the Jetpack settings UI.
<img width="450" alt="Screenshot 2024-06-17 at 3 16 42 PM" src="https://github.com/Automattic/jetpack/assets/1620183/af5bdcf4-e038-4876-83d1-7c45dff055bb">

This PR switches the toggle on and disables it when the filter is activated.
<img width="450" alt="Screenshot 2024-06-17 at 3 22 14 PM" src="https://github.com/Automattic/jetpack/assets/1620183/698a69da-6d70-4d07-a408-5d615d7536e5">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Regression Testing
- Spin up a test Jetpack self-hosted site with this branch
- Find the _WordPress.com Login_ section in the Jetpack settings (`wp-admin/admin.php?page=jetpack#/settings?term=WordPress.com`)
- Notice that all toggles are off
- Toggle the _Allow users to log in..._ option on
- You should be able to toggle the _Require accounts..._ on and off as you will

### Testing the Changes
- Toggle all options off
- By SSHing to your site or using one of the file editors, activate the filter: `add_filter( 'jetpack_sso_require_two_step', '__return_true' ); `
- You should now see the _Require accounts..._ option activated and the toggle disabled