### PR TITLE
Fix/inefficient checks for broken modules

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-inefficient-checks-for-broken-modules
+++ b/projects/packages/my-jetpack/changelog/fix-inefficient-checks-for-broken-modules
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove the need for api requests in broken modules check

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.25.1",
+	"version": "4.25.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -166,6 +166,7 @@ class Initializer {
 	 */
 	public static function admin_init() {
 		self::$site_info = self::get_site_info();
+		self::update_historically_active_jetpack_modules();
 		add_filter( 'identity_crisis_container_id', array( static::class, 'get_idc_container_id' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
 		// Product statuses are constantly changing, so we never want to cache the page.
@@ -508,11 +509,7 @@ class Initializer {
 	 * @return void
 	 */
 	public static function setup_historically_active_jetpack_modules_sync() {
-		if ( wp_doing_ajax() ) {
-			return;
-		}
-
-		if ( get_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY ) ) {
+		if ( get_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY ) && ! wp_doing_ajax() ) {
 			self::update_historically_active_jetpack_modules();
 			delete_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY );
 		}
@@ -523,7 +520,6 @@ class Initializer {
 			'jetpack_user_authorized',
 			'jetpack_unlinked_user',
 			'activated_plugin',
-			'my_jetpack_init',
 		);
 
 		foreach ( $actions as $action ) {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -508,6 +508,10 @@ class Initializer {
 	 * @return void
 	 */
 	public static function setup_historically_active_jetpack_modules_sync() {
+		if ( wp_doing_ajax() ) {
+			return;
+		}
+
 		if ( get_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY ) ) {
 			self::update_historically_active_jetpack_modules();
 			delete_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY );

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -91,8 +91,6 @@ class Initializer {
 		// Initialize Boost Speed Score
 		new Speed_Score( array(), 'jetpack-my-jetpack' );
 
-		self::setup_historically_active_jetpack_modules_sync();
-
 		// Add custom WP REST API endoints.
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_endpoints' ) );
 

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -809,6 +809,24 @@ class Initializer {
 	 * @return array
 	 */
 	public static function alert_if_missing_connection( array $red_bubble_slugs ) {
+		$broken_modules = self::check_for_broken_modules();
+
+		if ( ! empty( $broken_modules['needs_user_connection'] ) ) {
+			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
+				'type'     => 'user',
+				'is_error' => true,
+			);
+			return $red_bubble_slugs;
+		}
+
+		if ( ! empty( $broken_modules['needs_site_connection'] ) ) {
+			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
+				'type'     => 'site',
+				'is_error' => true,
+			);
+			return $red_bubble_slugs;
+		}
+
 		if (
 			! ( new Connection_Manager() )->is_user_connected() &&
 			! ( new Connection_Manager() )->has_connected_owner()

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -515,10 +515,8 @@ class Initializer {
 		}
 
 		$actions = array(
-			'jetpack_site_before_disconnected',
 			'jetpack_site_registered',
 			'jetpack_user_authorized',
-			'jetpack_unlinked_user',
 			'activated_plugin',
 		);
 

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -91,6 +91,8 @@ class Initializer {
 		// Initialize Boost Speed Score
 		new Speed_Score( array(), 'jetpack-my-jetpack' );
 
+		self::setup_historically_active_jetpack_modules_sync();
+
 		// Add custom WP REST API endoints.
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_endpoints' ) );
 

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -91,6 +91,8 @@ class Initializer {
 		// Initialize Boost Speed Score
 		new Speed_Score( array(), 'jetpack-my-jetpack' );
 
+		self::setup_historically_active_jetpack_modules_sync();
+
 		// Add custom WP REST API endoints.
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_endpoints' ) );
 
@@ -208,7 +210,6 @@ class Initializer {
 			$previous_score = $speed_score_history->latest( 1 );
 		}
 		$latest_score['previousScores'] = $previous_score['scores'] ?? array();
-		self::update_historically_active_jetpack_modules();
 
 		wp_localize_script(
 			'my_jetpack_main_app',

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -743,8 +743,9 @@ class Initializer {
 	 * @return array
 	 */
 	public static function check_for_broken_modules() {
-		$is_user_connected = ( new Connection_Manager() )->is_user_connected() || ( new Connection_Manager() )->has_connected_owner();
-		$is_site_connected = ( new Connection_Manager() )->is_connected();
+		$connection        = new Connection_Manager();
+		$is_user_connected = $connection->is_user_connected() || $connection->has_connected_owner();
+		$is_site_connected = $connection->is_connected();
 		$broken_modules    = array(
 			'needs_site_connection' => array(),
 			'needs_user_connection' => array(),
@@ -804,6 +805,7 @@ class Initializer {
 	 */
 	public static function alert_if_missing_connection( array $red_bubble_slugs ) {
 		$broken_modules = self::check_for_broken_modules();
+		$connection     = new Connection_Manager();
 
 		if ( ! empty( $broken_modules['needs_user_connection'] ) ) {
 			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
@@ -821,10 +823,7 @@ class Initializer {
 			return $red_bubble_slugs;
 		}
 
-		if (
-			! ( new Connection_Manager() )->is_user_connected() &&
-			! ( new Connection_Manager() )->has_connected_owner()
-		) {
+		if ( ! $connection->is_user_connected() && ! $connection->has_connected_owner() ) {
 			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
 				'type'     => 'user',
 				'is_error' => false,
@@ -832,7 +831,7 @@ class Initializer {
 			return $red_bubble_slugs;
 		}
 
-		if ( ! ( new Connection_Manager() )->is_connected() ) {
+		if ( ! $connection->is_connected() ) {
 			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
 				'type'     => 'site',
 				'is_error' => false,

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -166,7 +166,6 @@ class Initializer {
 	 */
 	public static function admin_init() {
 		self::$site_info = self::get_site_info();
-		self::update_historically_active_jetpack_modules();
 		add_filter( 'identity_crisis_container_id', array( static::class, 'get_idc_container_id' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
 		// Product statuses are constantly changing, so we never want to cache the page.
@@ -211,6 +210,7 @@ class Initializer {
 			$previous_score = $speed_score_history->latest( 1 );
 		}
 		$latest_score['previousScores'] = $previous_score['scores'] ?? array();
+		self::update_historically_active_jetpack_modules();
 
 		wp_localize_script(
 			'my_jetpack_main_app',

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.25.1';
+	const PACKAGE_VERSION = '4.25.2-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
## Proposed changes:

* Calculate broken modules by checking manually if the product requires user/site connection and if the user is connected or not
* Remove the `get_products` function as it was causing many API requests unnecessarily
* Add usage of historically active modules sync to jetpack init

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1718632357913589-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
(In this case I would suggest Jetpack Beta so you can more easily start with a fresh site)
2. Go to My Jetpack and dismiss the welcome banner. Refresh the page. You should see a connection banner with a "info" display rather than an error
![image](https://github.com/Automattic/jetpack/assets/65001528/348da8f1-899f-4d03-ad4d-91469c868c83)
3. Connect your site (not the user)
4. Go back to My Jetpack and you should still see a user connection banner with an info banner rather than an error banner
![image](https://github.com/Automattic/jetpack/assets/65001528/7a456659-b6ae-4428-928b-3b790b71060d)
6. Disconnect your site from Jetpack Debugger
7. Go back to My Jetpack and you should now see the site connection banner with error styles
![image](https://github.com/Automattic/jetpack/assets/65001528/f39c08f7-5b35-4491-9867-04cac58b6acf)
8. Connect your site from the banner and refresh the page, you should see the user connection info banner again
9. Now connect your user account
10. Disconnect your site again and go back to My Jetpack. You should now see the *user* error connection banner instead of the site connection banner since you previously had a working plugin that requires a user connection (Jetpack AI)
![image](https://github.com/Automattic/jetpack/assets/65001528/bad2611e-0134-42cf-894d-90245e9afeda)
