### PR TITLE
Update/wpcom site visibility copy update

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-site-visibility-copy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-site-visibility-copy
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Site Visibility: Update link copy"
+Site Visibility: Update link copy

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-site-visibility-copy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-site-visibility-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Site Visibility: Update link copy"

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -59,7 +59,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.35.x-dev"
+			"dev-trunk": "5.36.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.35.4",
+	"version": "5.36.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.35.4';
+	const PACKAGE_VERSION = '5.36.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
@@ -34,7 +34,7 @@ function replace_site_visibility() {
 		return;
 	} else {
 		$settings_url = esc_url_raw( sprintf( 'https://wordpress.com/settings/general/%s#site-privacy-settings', $site_slug ) );
-		$manage_label = __( 'Manage your site visibility settings', 'jetpack-mu-wpcom' );
+		$manage_label = __( 'Manage your privacy settings', 'jetpack-mu-wpcom' );
 	}
 
 	$escaped_content = '<a href="' . esc_url( $settings_url ) . '">' . esc_html( $manage_label ) . '</a>';

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-wpcom-site-visibility-copy
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-wpcom-site-visibility-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Site Visibility: Update link copy

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_2_0"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_2_0_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_2_0_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_3_0_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -780,7 +780,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "572557dc75d57d3d1a24aed00fc6cfbbf784f618"
+                "reference": "7080bba6447f9bd0815793ded78e5e5fb681be0e"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -811,7 +811,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.35.x-dev"
+                    "dev-trunk": "5.36.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.2.0-alpha
+ * Version: 2.3.0-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.2.0
+ * Version: 2.2.0-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.2.0-alpha",
+	"version": "2.3.0-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.2.0",
+	"version": "2.2.0-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/wpcomsh/changelog/update-wpcom-site-visibility-copy
+++ b/projects/plugins/wpcomsh/changelog/update-wpcom-site-visibility-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Site Visibility: Update link copy

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -914,7 +914,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "572557dc75d57d3d1a24aed00fc6cfbbf784f618"
+                "reference": "7080bba6447f9bd0815793ded78e5e5fb681be0e"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -945,7 +945,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.35.x-dev"
+                    "dev-trunk": "5.36.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7547

## Proposed changes:

Update the WPCOM site-visibility link copy

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/jetpack/assets/402286/793d83ca-f5c2-48b8-b6b0-d5f66cbcd842) | ![image](https://github.com/Automattic/jetpack/assets/402286/e1b7d817-fa1f-4552-ab70-046c9ad629ec) |

## Jetpack product discussion
no

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Go to `/wp-admin/options-reading.php`
* Check the copy of the Site Visibility link.
