### PR TITLE
Remove/check for broken modules red bubble slug

### DIFF
--- a/projects/packages/my-jetpack/changelog/remove-check-for-broken-modules-red-bubble-slug
+++ b/projects/packages/my-jetpack/changelog/remove-check-for-broken-modules-red-bubble-slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove check for broken modules from red bubble connection check

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.25.0",
+	"version": "4.25.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -773,6 +773,10 @@ class Initializer {
 	 * @return array
 	 */
 	public static function add_red_bubble_alerts( array $red_bubble_slugs ) {
+		if ( wp_doing_ajax() ) {
+			return array();
+		}
+
 		$welcome_banner_dismissed = \Jetpack_Options::get_option( 'dismissed_welcome_banner', false );
 		if ( self::is_jetpack_user_new() && ! $welcome_banner_dismissed ) {
 			$red_bubble_slugs['welcome-banner-active'] = null;

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -789,24 +789,6 @@ class Initializer {
 	 * @return array
 	 */
 	public static function alert_if_missing_connection( array $red_bubble_slugs ) {
-		$broken_modules = self::check_for_broken_modules();
-
-		if ( ! empty( $broken_modules['needs_user_connection'] ) ) {
-			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
-				'type'     => 'user',
-				'is_error' => true,
-			);
-			return $red_bubble_slugs;
-		}
-
-		if ( ! empty( $broken_modules['needs_site_connection'] ) ) {
-			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
-				'type'     => 'site',
-				'is_error' => true,
-			);
-			return $red_bubble_slugs;
-		}
-
 		if (
 			! ( new Connection_Manager() )->is_user_connected() &&
 			! ( new Connection_Manager() )->has_connected_owner()

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.25.0';
+	const PACKAGE_VERSION = '4.25.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
## Proposed changes:

Remove the check for broken modules from connection red bubble slug check
This was causing too many dotcom requests

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1718632357913589-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack
3. Dismiss the welcome banner and refresh the page
4. With an unconnected site and you should see the user connection banner
![image](https://github.com/Automattic/jetpack/assets/65001528/88b1a536-05bc-4462-af82-5fc833003b49)

5. Connect your site and it should go away
![image](https://github.com/Automattic/jetpack/assets/65001528/479e4765-fecc-426c-8a7e-d0705ddf5f88)

