### PR TITLE
Map Block: Fix Mapbox maps and markers in React's Strict Mode

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-map-block-in-react-strict-mode
+++ b/projects/plugins/jetpack/changelog/fix-map-block-in-react-strict-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Map Block: Handle React's Strict Mode correctly for Mapbox maps

--- a/projects/plugins/jetpack/extensions/blocks/map/component/map-marker/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/component/map-marker/index.js
@@ -11,6 +11,7 @@ export class MapMarker extends Component {
 	componentWillUnmount() {
 		if ( this.marker ) {
 			this.marker.remove();
+			this.marker = null;
 		}
 	}
 	componentDidUpdate() {

--- a/projects/plugins/jetpack/extensions/blocks/map/component/mapbox.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/component/mapbox.js
@@ -352,21 +352,32 @@ export class MapBoxComponent extends Component {
 		} );
 		/* Listen for clicks on the Map background, which hides the current popup. */
 		map.getCanvas().addEventListener( 'click', this.onMapClick );
-		this.setState( { map, zoomControl, fullscreenControl }, () => {
-			this.debouncedSizeMap();
-			map.addControl( zoomControl );
-			if ( showFullscreenButton ) {
-				map.addControl( fullscreenControl );
-				if ( admin && fullscreenControl._fullscreenButton ) {
-					fullscreenControl._fullscreenButton.disabled = true;
+		this.setState(
+			( { map: prevMap } ) => {
+				try {
+					// If there's an old map instance hanging around, try to
+					// clean it up.
+					prevMap?.remove();
+				} catch ( error ) {}
+
+				return { map, zoomControl, fullscreenControl };
+			},
+			() => {
+				this.debouncedSizeMap();
+				map.addControl( zoomControl );
+				if ( showFullscreenButton ) {
+					map.addControl( fullscreenControl );
+					if ( admin && fullscreenControl._fullscreenButton ) {
+						fullscreenControl._fullscreenButton.disabled = true;
+					}
 				}
+				this.mapRef.current.addEventListener( 'alignmentChanged', this.debouncedSizeMap );
+				map.resize();
+				onMapLoaded();
+				this.setState( { loaded: true } );
+				window.addEventListener( 'resize', this.debouncedSizeMap );
 			}
-			this.mapRef.current.addEventListener( 'alignmentChanged', this.debouncedSizeMap );
-			map.resize();
-			onMapLoaded();
-			this.setState( { loaded: true } );
-			window.addEventListener( 'resize', this.debouncedSizeMap );
-		} );
+		);
 	}
 }
 


### PR DESCRIPTION
Fixes #37888.

## Proposed changes:
In React's Strict Mode, React will mount, unmount, then remount each component to make sure components handle unmounting correctly. Currently, Mapbox maps do not unmount correctly:
* In strict mode, markers do not appear on the map. When unmounting, the markers are removed from the map, but we hold on to a reference to them. Seeing that reference, we don't recreate or readd the markers when remounting.
* In strict mode, we end up initializing two maps. You can see this by inspecting the block in the editor: you'll see two `<canvas>` elements. This happens because the initialization is asynchronous, and we don't catch when that asynchronous initialization happens after an unmount.

This PR:
* Gets rid of the reference to unmounted Markers. On remount, new markers are created and added to the map.
* When initializing the map, checks to see if there is already an existing initialized map. If so, remove it. Ideally, we'd do a more careful refactor of the block to properly handle an unmount prior to the asynchronous initialization. This was simpler :( :)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Install **Gutenberg trunk**.
2. Checkout current Jetpack trunk.
3. Create a new post.
4. Add a map block, and add a marker.
5. See that no markers appear.
6. Inspect the block with your browser's dev tools. See two `<canvas>` elements.
7. Publish the post.
8. See that the marker **does** appear on the frontend.
9. Checkout this branch.
10. Edit the post.
11. See that the marker now appears in the editor.
12. See that there is only one `<canvas>` element. (Probably, there may still be a race condition here. Even so, a double `<canvas>` is not a huge issue… I don't think?)
13. (You can create a new post and map block now as well: you see the markers in the editor.)