### PR TITLE
Fix theme showcase button when there is only one theme left after deletion

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-theme-showcase-button
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-theme-showcase-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an edge case for theme showcase button rendering if only a single theme is left after deletion.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/js/theme-actions.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/js/theme-actions.js
@@ -18,7 +18,7 @@ const wpcomThemesRemoveWpcomActions = () => {
 		}
 	} );
 	observer.observe( themeOverlay, { childList: true } );
-	observer.observe( themeBrowser, { childList: true } );
+	observer.observe( themeBrowser, { childList: true, subtree: true } );
 };
 
 document.addEventListener( 'DOMContentLoaded', wpcomThemesRemoveWpcomActions );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7714

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the mutation observer to check for subtrees
Why: The mutation observer currently isn't triggered when there is only one theme left after deletion, so the broken t "Theme Showcase" button still renders.

Before

https://github.com/Automattic/jetpack/assets/6586048/c9ea45d8-7994-471b-83d9-df2d64385dc0

After

https://github.com/Automattic/jetpack/assets/6586048/c60ecc3d-6377-4e7c-a5f0-39521f3724de


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With an atomic site, have more than one theme installed.
* Go to Appearance > Themes and delete the other themes until there is one left
* The Theme Showcase button should not be rendered.
