### PR TITLE
Update/redirect simple classic wpcom admin interface option update

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-redirect-simple-classic-wpcom_admin_interface-option-update
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-redirect-simple-classic-wpcom_admin_interface-option-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Simple Classic: Redirect to Default interface after switching wpcom_admin_interface

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -44,7 +44,7 @@ if (
 /**
  * Track the wpcom_admin_interface_changed event.
  *
- * @param array $value The new value.
+ * @param string $value The new value.
  * @return void
  */
 function wpcom_admin_interface_track_changed_event( $value ) {
@@ -65,9 +65,9 @@ function wpcom_admin_interface_track_changed_event( $value ) {
  * @access private
  * @since 4.20.0
  *
- * @param array $new_value The new settings value.
- * @param array $old_value The old settings value.
- * @return array The value to update.
+ * @param string $new_value The new settings value.
+ * @param string $old_value The old settings value.
+ * @return string The value to update.
  */
 function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 	if ( $new_value === $old_value ) {
@@ -89,6 +89,11 @@ function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 			// We can remove this code if the related code in wpcom_admin_interface_display is removed.
 			add_action(
 				'update_option_wpcom_admin_interface',
+				/**
+				 * Redirects to the WordPress.com home page when the admin interface is changed to Calypso.
+				 *
+				 * @return never
+				*/
 				function () {
 					wp_safe_redirect( 'https://wordpress.com/home/' . wpcom_get_site_slug() );
 					exit;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -36,6 +36,7 @@ if (
 	// The option should always be available on atomic sites.
 	! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
 	// The option will be shown if the simple site has already changed to Classic which means they should have already passed the experiment gate.
+	// We can remove the redirection in wpcom_admin_interface_pre_update_option for simple sites after the experiment is finished.
 	( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) ) {
 	add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );
 }
@@ -83,6 +84,17 @@ function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 	}
 
 	if ( ( new Automattic\Jetpack\Status\Host() )->is_wpcom_simple() ) {
+		if ( 'calypso' === $new_value ) {
+			// Fixes https://github.com/Automattic/dotcom-forge/issues/7760.
+			// We can remove this code if the related code in wpcom_admin_interface_display is removed.
+			add_action(
+				'update_option_wpcom_admin_interface',
+				function () {
+					wp_safe_redirect( 'https://wordpress.com/home/' . wpcom_get_site_slug() );
+					exit;
+				}
+			);
+		}
 		return $new_value;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related https://github.com/Automattic/dotcom-forge/issues/7760

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Redirect to /home/:site when changing Admin Interface from Classic to Default in /wp-admin for Simple Classic

https://github.com/Automattic/jetpack/assets/6586048/6b3f5d82-dac2-433a-86c6-f7d58cc294c6

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions to apply changes to Sandbox
* You can skip the Simple Classic release experiment by using wpsh in sandbox and run
```
update_blog_option( blogID, 'wpcom_admin_interface', 'wp-admin');
```
* Go to Settings > General
* Change Admin Interface to Default
* Should be redirected to Calypso home
