### PR TITLE
Image CDN: Add support for query string in image URLs.

### DIFF
--- a/projects/packages/image-cdn/changelog/fix-photon-querystring-url
+++ b/projects/packages/image-cdn/changelog/fix-photon-querystring-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Image CDN: Added support for query strings in image URLs

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Image_CDN;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.4.2';
+	const PACKAGE_VERSION = '0.4.3-alpha';
 
 	/**
 	 * Singleton.

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -310,7 +310,7 @@ final class Image_CDN {
 	public static function parse_dimensions_from_filename( $src ) {
 		$width_height_string = array();
 
-		if ( preg_match( '#-(\d+)x(\d+)\.(?:' . implode( '|', self::$extensions ) . '){1}$#i', $src, $width_height_string ) ) {
+		if ( preg_match( '#-(\d+)x(\d+)\.(?:' . implode( '|', self::$extensions ) . '){1}(?:\?.*)?$#i', $src, $width_height_string ) ) {
 			$width  = (int) $width_height_string[1];
 			$height = (int) $width_height_string[2];
 

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
@@ -410,6 +410,17 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	}
 
 	/**
+	 * Tests Photon will parse the dimensions from a filename that contains query parameters.
+	 *
+	 * @covers Image_CDN::parse_dimensions_from_filename
+	 */
+	public function test_image_cdn_parse_dimensions_from_filename_with_query_parameters() {
+		$image_url = 'http://' . WP_TESTS_DOMAIN . '/no-dimensions-here-148x148.jpg?foo=bar&baz=qux';
+
+		$this->assertEquals( array( 148, 148 ), Image_CDN::parse_dimensions_from_filename( $image_url ) );
+	}
+
+	/**
 	 * Tests Photon will parse the dimensions from a filename for a large value.
 	 *
 	 * @author scotchfield


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* If some other plugin added a query string in the image URLs, image CDN would fail to detect the dimensions because of a failed regex match. This expands the regex to add support for query string.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1718302129233919-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Add this snippet to your mu-plugins:
```php
<?php
add_filter('wp_calculate_image_srcset', function( $sources ) {
	foreach ( $sources as &$source ) {
		$source['url'] = add_query_arg( 'v', '1.0', $source['url'] );
	}

	return $sources;
}, 9 );
```

- Make sure photon still uses `resize` parameter for resizing the thumbnails rather than `w`