### PR TITLE
Super Cache: add an admin notice to encourage migration to Jetpack Boost

### DIFF
--- a/projects/plugins/super-cache/.phan/baseline.php
+++ b/projects/plugins/super-cache/.phan/baseline.php
@@ -10,7 +10,7 @@
 return [
     // # Issue statistics:
     // PhanPluginSimplifyExpressionBool : 85+ occurrences
-    // PhanUndeclaredGlobalVariable : 55+ occurrences
+    // PhanUndeclaredGlobalVariable : 45+ occurrences
     // PhanTypeMismatchArgumentInternal : 30+ occurrences
     // PhanTypeMismatchArgumentNullableInternal : 25+ occurrences
     // PhanPossiblyUndeclaredVariable : 20+ occurrences
@@ -25,8 +25,8 @@ return [
     // PhanUndeclaredFunction : 8 occurrences
     // PhanTypeArraySuspiciousNull : 7 occurrences
     // PhanTypeArraySuspiciousNullable : 7 occurrences
-    // PhanUndeclaredVariableDim : 7 occurrences
     // PhanSuspiciousValueComparison : 6 occurrences
+    // PhanUndeclaredVariableDim : 6 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 5 occurrences
     // PhanTypeMismatchArgumentInternalProbablyReal : 4 occurrences
     // PhanTypeMismatchArgumentInternalReal : 4 occurrences
@@ -67,7 +67,6 @@ return [
         'partials/easy.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeArraySuspiciousNull', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredConstant', 'PhanUndeclaredGlobalVariable'],
         'partials/lockdown.php' => ['PhanUndeclaredGlobalVariable'],
         'partials/preload.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredGlobalVariable', 'PhanTypeMismatchDimAssignment', 'PhanUndeclaredGlobalVariable'],
-        'partials/rejected_user_agents.php' => ['PhanUndeclaredGlobalVariable'],
         'partials/tracking_parameters.php' => ['PhanUndeclaredGlobalVariable'],
         'plugins/badbehaviour.php' => ['PhanRedundantCondition'],
         'plugins/domain-mapping.php' => ['PhanRedundantCondition', 'PhanUndeclaredFunction'],
@@ -80,7 +79,6 @@ return [
         'rest/class.wp-super-cache-rest-update-settings.php' => ['PhanCommentParamWithoutRealParam', 'PhanPluginRedundantAssignment', 'PhanPluginSimplifyExpressionBool', 'PhanTypeMissingReturn'],
         'tests/e2e/tools/mu-test-helpers.php' => ['PhanTypeMismatchArgument'],
         'wp-cache-base.php' => ['PhanTypeMismatchArgumentNullableInternal'],
-        'wp-cache-config-sample.php' => ['PhanUndeclaredVariableDim'],
         'wp-cache-phase1.php' => ['PhanRedundantConditionInGlobalScope', 'PhanTypeNonVarPassByRef'],
         'wp-cache-phase2.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateIfCondition', 'PhanPluginRedundantAssignment', 'PhanPluginSimplifyExpressionBool', 'PhanPluginUnreachableCode', 'PhanPossiblyUndeclaredVariable', 'PhanRedefineFunctionInternal', 'PhanRedundantCondition', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNull', 'PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeNonVarPassByRef', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredConstant', 'PhanUndeclaredVariableDim'],
         'wp-cache.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateAdjacentStatement', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginNeverReturnFunction', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanRedundantConditionInLoop', 'PhanSuspiciousValueComparison', 'PhanTypeArraySuspicious', 'PhanTypeArraySuspiciousNullable', 'PhanTypeInvalidDimOffset', 'PhanTypeInvalidLeftOperandOfBitwiseOp', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeInvalidRightOperandOfAdd', 'PhanTypeInvalidRightOperandOfBitwiseOp', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentInternalReal', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeNonVarPassByRef', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction', 'PhanUndeclaredVariable', 'PhanUndeclaredVariableDim'],

--- a/projects/plugins/super-cache/changelog/add-super-cache-admin-notice-boost-age-check
+++ b/projects/plugins/super-cache/changelog/add-super-cache-admin-notice-boost-age-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Super Cache: add an admin notice to encourage migration to Jetpack Boost

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -45,10 +45,10 @@ function wpsc_jetpack_boost_notice() {
 	</p>
 
 	<p>
+		<div class="wpsc-boost-migration-error" style="display:none; color:red; margin-bottom: 20px;"></div>
 		<a data-source='notice' class='button button-primary <?php echo esc_attr( $button_class ); ?>' href="<?php echo esc_url( $button_url ); ?>">
-			<span>
-				<?php esc_html_e( 'Migrate now', 'wp-super-cache' ); ?>
-			</span>
+			<div class="spinner" style="display:none; margin-top: 8px"></div>
+			<label><?php esc_html_e( 'Migrate now', 'wp-super-cache' ); ?></label>
 		</a>
 	</p>
 	</div>

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -68,13 +68,34 @@ if ( isset( $_GET['page'] ) && $_GET['page'] === 'wpsupercache' ) { // phpcs:ign
 	add_action( 'admin_notices', 'wpsc_jetpack_boost_notice' );
 }
 
+/**
+ * Dismiss the migration admin notice by setting a user option flag.
+ */
 function wpsc_dismiss_boost_notice() {
-	check_ajax_referer( 'wpsc_dismiss_boost_notice', 'nonce' );
 	update_user_option( get_current_user_id(), 'wpsc_dismissed_boost_admin_notice', '1' );
+}
+
+/**
+ * Handler called by AJAX to dismiss the admin notice.
+ */
+function wpsc_dismiss_boost_notice_ajax_handler() {
+	check_ajax_referer( 'wpsc_dismiss_boost_notice', 'nonce' );
+	wpsc_dismiss_boost_notice();
 	wp_die();
 }
-add_action( 'wp_ajax_wpsc_dismiss_boost_notice', 'wpsc_dismiss_boost_notice' );
+add_action( 'wp_ajax_wpsc_dismiss_boost_notice', 'wpsc_dismiss_boost_notice_ajax_handler' );
 
+/**
+ * Dismiss the admin notice if the Jetpack Boost plugin is activated.
+ */
+function wpsc_dismiss_notice_on_activation() {
+	if ( ! current_user_can( 'activate_plugins' ) ) {
+		return;
+	}
+
+	wpsc_dismiss_boost_notice();
+}
+add_action( 'wp_ajax_wpsc_activate_boost', 'wpsc_dismiss_notice_on_activation' );
 /**
  * Add a notice to the settings page if the Jetpack Boost cache module is detected.
  * The notice contains instructions on how to disable the Boost Cache module.

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -56,7 +56,7 @@ function wpsc_jetpack_boost_notice() {
 
 	<p>
 		<div class="wpsc-boost-migration-error" style="display:none; color:red; margin-bottom: 20px;"></div>
-		<a data-source='notice' class='button button-primary <?php echo esc_attr( $button_class ); ?>' href="<?php echo esc_url( $button_url ); ?>">
+		<a data-source='notice' class='wpsc-boost-migration-button button button-primary <?php echo esc_attr( $button_class ); ?>' href="<?php echo esc_url( $button_url ); ?>">
 			<div class="spinner" style="display:none; margin-top: 8px"></div>
 			<label><?php esc_html_e( 'Migrate now', 'wp-super-cache' ); ?></label>
 		</a>

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -132,7 +132,7 @@ function wpsc_is_boost_compatible() {
 		return false;
 	}
 
-	if ( ! empty( $GLOBALS['wp_super_cache_late_init'] ) ) {
+	if ( isset( $GLOBALS['wp_super_cache_late_init'] ) && $GLOBALS['wp_super_cache_late_init'] === 1 ) {
 		return false;
 	}
 
@@ -144,7 +144,7 @@ function wpsc_is_boost_compatible() {
 		return false;
 	}
 
-	if ( ! empty( $GLOBALS['wp_cache_preload_on'] ) ) {
+	if ( isset( $GLOBALS['wp_cache_preload_on'] ) && $GLOBALS['wp_cache_preload_on'] === 1 ) {
 		return false;
 	}
 
@@ -156,7 +156,7 @@ function wpsc_is_boost_compatible() {
 		return false;
 	}
 
-	if ( ! empty( $GLOBALS['wp_cache_make_known_anon'] ) ) {
+	if ( isset( $GLOBALS['wp_cache_make_known_anon'] ) && $GLOBALS['wp_cache_make_known_anon'] === 1 ) {
 		return false;
 	}
 
@@ -164,7 +164,7 @@ function wpsc_is_boost_compatible() {
 		return false;
 	}
 
-	if ( ! empty( $GLOBALS['wp_cache_clear_on_post_edit'] ) ) {
+	if ( isset( $GLOBALS['wp_cache_clear_on_post_edit'] ) && $GLOBALS['wp_cache_clear_on_post_edit'] === 1 ) {
 		return false;
 	}
 
@@ -200,7 +200,7 @@ function wpsc_is_boost_compatible() {
  */
 function wpsc_is_boost_current() {
 	if ( defined( 'JETPACK_BOOST_VERSION' ) ) {
-		return version_compare( JETPACK_BOOST_VERSION, MINIMUM_BOOST_VERSION, '>=' );
+		return version_compare( (string) JETPACK_BOOST_VERSION, MINIMUM_BOOST_VERSION, '>=' );
 	} else {
 		return true; // don't care if Boost is not installed
 	}

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -25,6 +25,10 @@ function wpsc_get_boost_migration_config() {
  * Display an admin notice to install Jetpack Boost.
  */
 function wpsc_jetpack_boost_notice() {
+	if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wpsupercache' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return;
+	}
+
 	// Don't show the banner if the banner has been dismissed.
 	$is_dismissed = '1' === get_user_option( 'wpsc_dismissed_boost_admin_notice' );
 	if ( $is_dismissed ) {
@@ -64,9 +68,7 @@ function wpsc_jetpack_boost_notice() {
 	</div>
 	<?php
 }
-if ( isset( $_GET['page'] ) && $_GET['page'] === 'wpsupercache' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	add_action( 'admin_notices', 'wpsc_jetpack_boost_notice' );
-}
+add_action( 'admin_notices', 'wpsc_jetpack_boost_notice' );
 
 /**
  * Dismiss the migration admin notice by setting a user option flag.

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Code to handle migration from WP Super Cache to Jetpack Boost.
+ *
+ * @package WP_Super_Cache
+ */
+
+// Minimum version of Jetpack Boost required for compatibility.
+if ( ! defined( 'MINIMUM_BOOST_VERSION' ) ) {
+	define( 'MINIMUM_BOOST_VERSION', '3.4.0' );
+}
 
 /**
  * Get shared configuration for each migration button.
@@ -190,7 +200,7 @@ function wpsc_is_boost_compatible() {
  */
 function wpsc_is_boost_current() {
 	if ( defined( 'JETPACK_BOOST_VERSION' ) ) {
-		return version_compare( JETPACK_BOOST_VERSION, '3.4.0', '>=' );
+		return version_compare( JETPACK_BOOST_VERSION, MINIMUM_BOOST_VERSION, '>=' );
 	} else {
 		return true; // don't care if Boost is not installed
 	}

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -21,6 +21,11 @@ function wpsc_jetpack_boost_notice() {
 		return;
 	}
 
+	// Don't show the admin notice if Jetpack Boost is too old.
+	if ( ! wpsc_is_boost_current() ) {
+		return;
+	}
+
 	// Don't show the banner if Super Cache is using features that Boost doesn't support.
 	if ( ! wpsc_is_boost_compatible() ) {
 		return;
@@ -184,5 +189,9 @@ function wpsc_is_boost_compatible() {
  * @return bool True if Jetpack Boost is same as or newer than version 3.4.0
  */
 function wpsc_is_boost_current() {
-	return defined( 'JETPACK_BOOST_VERSION' ) && version_compare( JETPACK_BOOST_VERSION, '3.4.0', '>=' );
+	if ( defined( 'JETPACK_BOOST_VERSION' ) ) {
+		return version_compare( JETPACK_BOOST_VERSION, '3.4.0', '>=' );
+	} else {
+		return true; // don't care if Boost is not installed
+	}
 }

--- a/projects/plugins/super-cache/js/admin.js
+++ b/projects/plugins/super-cache/js/admin.js
@@ -9,9 +9,7 @@ jQuery( document ).ready( () => {
 	const ajaxurl = window.ajaxurl;
 	const wpscAdmin = window.wpscAdmin;
 
-	const link = jQuery( '.wpsc-install-action-button' );
-	const label = link.find( 'label' );
-	const spinner = link.find( '.spinner' );
+	let link, label, spinner, errorMessage, originalText;
 
 	// Dismiss Boost banner.
 	jQuery( '.wpsc-boost-dismiss' ).on( 'click', function () {
@@ -28,6 +26,11 @@ jQuery( document ).ready( () => {
 		const source = jQuery( event.currentTarget ).attr( 'data-source' );
 		event.preventDefault();
 		showBoostBannerBusy( __( 'Installing…', 'wp-super-cache' ) );
+		link = jQuery( event.currentTarget );
+		label = link.find( 'label' );
+		originalText = label.text();
+		spinner = link.find( '.spinner' );
+		errorMessage = link.prev( '.wpsc-boost-migration-error' );
 
 		jQuery
 			.post( ajaxurl, {
@@ -56,6 +59,11 @@ jQuery( document ).ready( () => {
 	// Handle activate button click.
 	jQuery( '.wpsc-activate-boost-button' ).on( 'click', event => {
 		const source = jQuery( event.currentTarget ).attr( 'data-source' );
+		link = jQuery( event.currentTarget );
+		label = link.find( 'label' );
+		originalText = label.text();
+		spinner = link.find( '.spinner' );
+		errorMessage = link.prev( '.wpsc-boost-migration-error' );
 		event.preventDefault();
 		activateBoost( source );
 	} );
@@ -70,12 +78,7 @@ jQuery( document ).ready( () => {
 	// Helper function to reset Boost Banner button.
 	const resetBoostBannerButton = () => {
 		link.attr( 'disabled', false );
-		jQuery( '#wpsc-activate-boost-button' )
-			.find( 'label' )
-			.text( __( 'Activate Jetpack Boost', 'wp-super-cache' ) );
-		jQuery( '#wpsc-install-boost-button' )
-			.find( 'label' )
-			.text( __( 'Install Jetpack Boost', 'wp-super-cache' ) );
+		label.text( originalText );
 		spinner.removeClass( 'is-active' ).hide();
 	};
 
@@ -83,7 +86,7 @@ jQuery( document ).ready( () => {
 	const showBoostBannerError = err => {
 		resetBoostBannerButton();
 
-		jQuery( '#wpsc-boost-banner-error' )
+		errorMessage
 			.text(
 				err || __( 'An error occurred while trying to activate Jetpack Boost', 'wp-super-cache' )
 			)

--- a/projects/plugins/super-cache/js/admin.js
+++ b/projects/plugins/super-cache/js/admin.js
@@ -1,4 +1,7 @@
-jQuery( document ).ready( () => {
+/**
+ * Handle the buttons for the Boost migration.
+ */
+function handleMigrationButtons() {
 	// Don't run on versions of WordPress too old for the block editor and the translation methods it brings.
 	// All the install / activate options are plain links with meaningful destinations anyway.
 	if ( ! window.wp || ! window.wp.i18n ) {
@@ -131,4 +134,8 @@ jQuery( document ).ready( () => {
 			_ajax_nonce: wpscAdmin.boostNoticeDismissNonce,
 		} );
 	} );
+}
+
+jQuery( document ).ready( () => {
+	handleMigrationButtons();
 } );

--- a/projects/plugins/super-cache/js/admin.js
+++ b/projects/plugins/super-cache/js/admin.js
@@ -1,7 +1,7 @@
 /**
  * Handle the buttons for the Boost migration.
  */
-function handleMigrationButtons() {
+jQuery( document ).ready( function () {
 	// Don't run on versions of WordPress too old for the block editor and the translation methods it brings.
 	// All the install / activate options are plain links with meaningful destinations anyway.
 	if ( ! window.wp || ! window.wp.i18n ) {
@@ -134,8 +134,4 @@ function handleMigrationButtons() {
 			_ajax_nonce: wpscAdmin.boostNoticeDismissNonce,
 		} );
 	} );
-}
-
-jQuery( document ).ready( () => {
-	handleMigrationButtons();
 } );

--- a/projects/plugins/super-cache/js/admin.js
+++ b/projects/plugins/super-cache/js/admin.js
@@ -1,137 +1,146 @@
 /**
  * Handle the buttons for the Boost migration.
+ * @param {jQuery} $ - jQuery
  */
-jQuery( document ).ready( function () {
-	// Don't run on versions of WordPress too old for the block editor and the translation methods it brings.
-	// All the install / activate options are plain links with meaningful destinations anyway.
-	if ( ! window.wp || ! window.wp.i18n ) {
-		return;
-	}
+( $ => {
+	$( document ).ready( function () {
+		// Don't run on versions of WordPress too old for the block editor and the translation methods it brings.
+		// All the install / activate options are plain links with meaningful destinations anyway.
+		if ( ! window.wp || ! window.wp.i18n ) {
+			return;
+		}
 
-	const { __, sprintf } = window.wp.i18n;
-	const ajaxurl = window.ajaxurl;
-	const wpscAdmin = window.wpscAdmin;
+		const { __, sprintf } = window.wp.i18n;
+		const ajaxurl = window.ajaxurl;
+		const wpscAdmin = window.wpscAdmin;
 
-	let link, label, spinner, errorMessage, originalText;
+		const setupBoostButton = $target => {
+			if ( ! $target.hasClass( 'wpsc-boost-migration-button' ) ) {
+				// eslint-disable-next-line no-console
+				console.warn( 'Unexpected button clicked for Boost migration.' );
+				return;
+			}
+			const $label = $target.find( 'label' );
+			const $spinner = $target.find( '.spinner' );
+			const $errorMessage = $target.prev( '.wpsc-boost-migration-error' );
+			const source = $target.attr( 'data-source' );
+			const originalText = $label.text();
 
-	// Dismiss Boost banner.
-	jQuery( '.wpsc-boost-dismiss' ).on( 'click', function () {
-		jQuery( '.wpsc-boost-banner' ).fadeOut( 'slow' );
+			// Helper function to show an error.
+			const showError = err => {
+				reset();
 
-		jQuery.post( ajaxurl, {
-			action: 'wpsc-hide-boost-banner',
-			nonce: wpscAdmin.boostDismissNonce,
+				$errorMessage
+					.text(
+						err ||
+							__( 'An error occurred while trying to activate Jetpack Boost', 'wp-super-cache' )
+					)
+					.show();
+			};
+			// Helper function to show Boost Banner work in progress.
+			const showBusy = action => {
+				$target.attr( 'disabled', true );
+				$label.text( action );
+				$spinner.addClass( 'is-active' ).show();
+			};
+
+			// Helper function to reset Boost Banner button.
+			const reset = () => {
+				$target.attr( 'disabled', false );
+				$label.text( originalText );
+				$spinner.removeClass( 'is-active' ).hide();
+			};
+
+			// Activate Jetpack Boost.
+			const activateBoost = () => {
+				showBusy( __( 'Activating…', 'wp-super-cache' ) );
+
+				$.post( ajaxurl, {
+					action: 'wpsc_activate_boost',
+					_ajax_nonce: wpscAdmin.boostActivateNonce,
+					source: source,
+				} )
+					.done( response => {
+						if ( response.success ) {
+							$label.text( 'Success! Sending you to Jetpack Boost...' );
+							$spinner.hide();
+							window.location.href = 'admin.php?page=jetpack-boost';
+						} else {
+							showError( response.data );
+						}
+					} )
+					.fail( response => {
+						showError(
+							sprintf(
+								/* translators: %d is an HTTP error code */
+								__( 'Failed to activate Jetpack Boost: HTTP %d error received', 'wp-super-cache' ),
+								response.status
+							)
+						);
+					} );
+			};
+
+			const installBoost = () => {
+				showBusy( __( 'Installing…', 'wp-super-cache' ) );
+				$.post( ajaxurl, {
+					action: 'wpsc_install_plugin',
+					_ajax_nonce: wpscAdmin.boostInstallNonce,
+					slug: 'jetpack-boost',
+				} )
+					.done( response => {
+						if ( response.success ) {
+							activateBoost();
+						} else {
+							showError( response.data );
+						}
+					} )
+					.fail( response => {
+						showError(
+							sprintf(
+								/* translators: %d is an HTTP error code */
+								__( 'Failed to install Jetpack Boost: HTTP %d error received', 'wp-super-cache' ),
+								response.status
+							)
+						);
+					} );
+			};
+
+			return {
+				installBoost,
+				activateBoost,
+			};
+		};
+
+		// One-click install for Boost.
+		$( '.wpsc-install-boost-button' ).on( 'click', event => {
+			event.preventDefault();
+			const boostActivation = setupBoostButton( $( event.currentTarget ) );
+			boostActivation.installBoost();
+		} );
+
+		// Handle activate button click.
+		$( '.wpsc-activate-boost-button' ).on( 'click', event => {
+			event.preventDefault();
+			const boostActivation = setupBoostButton( $( event.currentTarget ) );
+			boostActivation.activateBoost();
+		} );
+
+		// Dismiss Boost banner.
+		$( '.wpsc-boost-dismiss' ).on( 'click', () => {
+			$( '.wpsc-boost-banner' ).fadeOut( 'slow' );
+			$.post( ajaxurl, {
+				action: 'wpsc-hide-boost-banner',
+				nonce: wpscAdmin.boostDismissNonce,
+			} );
+		} );
+
+		// Dismiss admin notice
+		$( '.boost-notice' ).on( 'click', '.notice-dismiss', event => {
+			event.preventDefault();
+			$.post( ajaxurl, {
+				action: 'wpsc_dismiss_boost_notice',
+				_ajax_nonce: wpscAdmin.boostNoticeDismissNonce,
+			} );
 		} );
 	} );
-
-	// One-click install for Boost.
-	jQuery( '.wpsc-install-boost-button' ).on( 'click', event => {
-		const source = jQuery( event.currentTarget ).attr( 'data-source' );
-		event.preventDefault();
-		showBoostBannerBusy( __( 'Installing…', 'wp-super-cache' ) );
-		link = jQuery( event.currentTarget );
-		label = link.find( 'label' );
-		originalText = label.text();
-		spinner = link.find( '.spinner' );
-		errorMessage = link.prev( '.wpsc-boost-migration-error' );
-
-		jQuery
-			.post( ajaxurl, {
-				action: 'wpsc_install_plugin',
-				_ajax_nonce: wpscAdmin.boostInstallNonce,
-				slug: 'jetpack-boost',
-			} )
-			.done( response => {
-				if ( response.success ) {
-					activateBoost( source );
-				} else {
-					showBoostBannerError( response.data );
-				}
-			} )
-			.fail( response => {
-				showBoostBannerError(
-					sprintf(
-						/* translators: %d is an HTTP error code */
-						__( 'Failed to install Jetpack Boost: HTTP %d error received', 'wp-super-cache' ),
-						response.status
-					)
-				);
-			} );
-	} );
-
-	// Handle activate button click.
-	jQuery( '.wpsc-activate-boost-button' ).on( 'click', event => {
-		const source = jQuery( event.currentTarget ).attr( 'data-source' );
-		link = jQuery( event.currentTarget );
-		label = link.find( 'label' );
-		originalText = label.text();
-		spinner = link.find( '.spinner' );
-		errorMessage = link.prev( '.wpsc-boost-migration-error' );
-		event.preventDefault();
-		activateBoost( source );
-	} );
-
-	// Helper function to show Boost Banner work in progress.
-	const showBoostBannerBusy = action => {
-		link.attr( 'disabled', true );
-		label.text( action );
-		spinner.addClass( 'is-active' ).show();
-	};
-
-	// Helper function to reset Boost Banner button.
-	const resetBoostBannerButton = () => {
-		link.attr( 'disabled', false );
-		label.text( originalText );
-		spinner.removeClass( 'is-active' ).hide();
-	};
-
-	// Helper function to show an error.
-	const showBoostBannerError = err => {
-		resetBoostBannerButton();
-
-		errorMessage
-			.text(
-				err || __( 'An error occurred while trying to activate Jetpack Boost', 'wp-super-cache' )
-			)
-			.show();
-	};
-
-	// Activate Jetpack Boost.
-	const activateBoost = source => {
-		showBoostBannerBusy( __( 'Activating…', 'wp-super-cache' ) );
-
-		jQuery
-			.post( ajaxurl, {
-				action: 'wpsc_activate_boost',
-				_ajax_nonce: wpscAdmin.boostActivateNonce,
-				source: source,
-			} )
-			.done( response => {
-				if ( response.success ) {
-					label.text( 'Success! Sending you to Jetpack Boost...' );
-					spinner.hide();
-					window.location.href = 'admin.php?page=jetpack-boost';
-				} else {
-					showBoostBannerError( response.data );
-				}
-			} )
-			.fail( response => {
-				showBoostBannerError(
-					sprintf(
-						/* translators: %d is an HTTP error code */
-						__( 'Failed to activate Jetpack Boost: HTTP %d error received', 'wp-super-cache' ),
-						response.status
-					)
-				);
-			} );
-	};
-
-	// Dismiss admin notice
-	jQuery( '.boost-notice' ).on( 'click', '.notice-dismiss', event => {
-		event.preventDefault();
-		jQuery.post( ajaxurl, {
-			action: 'wpsc_dismiss_boost_notice',
-			_ajax_nonce: wpscAdmin.boostNoticeDismissNonce,
-		} );
-	} );
-} );
+} )( jQuery );

--- a/projects/plugins/super-cache/js/admin.js
+++ b/projects/plugins/super-cache/js/admin.js
@@ -119,4 +119,13 @@ jQuery( document ).ready( () => {
 				);
 			} );
 	};
+
+	// Dismiss admin notice
+	jQuery( '.boost-notice' ).on( 'click', '.notice-dismiss', event => {
+		event.preventDefault();
+		jQuery.post( ajaxurl, {
+			action: 'wpsc_dismiss_boost_notice',
+			_ajax_nonce: wpscAdmin.boostNoticeDismissNonce,
+		} );
+	} );
 } );

--- a/projects/plugins/super-cache/styling/dashboard.css
+++ b/projects/plugins/super-cache/styling/dashboard.css
@@ -173,3 +173,14 @@
 	width: 190px;
 	height: auto;
 }
+
+#wpsc-notice-boost-migrate {
+	width: 80%;
+	margin: 0 auto;
+	margin-top: 10px;
+
+	a.button.button-primary {
+		background-color: var(--jp-black);
+		color: var(--jp-white);
+	}
+}

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -319,9 +319,10 @@ function wp_super_cache_admin_enqueue_scripts( $hook ) {
 		'wp-super-cache-admin',
 		'wpscAdmin',
 		array(
-			'boostDismissNonce'  => wp_create_nonce( 'wpsc_dismiss_boost_banner' ),
-			'boostInstallNonce'  => wp_create_nonce( 'updates' ),
-			'boostActivateNonce' => wp_create_nonce( 'activate-boost' ),
+			'boostNoticeDismissNonce' => wp_create_nonce( 'wpsc_dismiss_boost_notice' ),
+			'boostDismissNonce'       => wp_create_nonce( 'wpsc_dismiss_boost_banner' ),
+			'boostInstallNonce'       => wp_create_nonce( 'updates' ),
+			'boostActivateNonce'      => wp_create_nonce( 'activate-boost' ),
 		)
 	);
 }

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -423,7 +423,7 @@ function wpsc_jetpack_boost_install_banner() {
 						?>
 					</p>
 
-					<div id="wpsc-boost-banner-error" style="display:none; color:red; margin-bottom: 20px;"></div>
+					<div class="wpsc-boost-migration-error" style="display:none; color:red; margin-bottom: 20px;"></div>
 
 					<a data-source='banner' href="<?php echo esc_url( $button_url ); ?>" class="button button-primary wpsc-install-action-button <?php echo esc_attr( $button_class ); ?>">
 						<div class="spinner" style="display:none; margin-top: 8px"></div>

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -425,7 +425,7 @@ function wpsc_jetpack_boost_install_banner() {
 
 					<div class="wpsc-boost-migration-error" style="display:none; color:red; margin-bottom: 20px;"></div>
 
-					<a data-source='banner' href="<?php echo esc_url( $button_url ); ?>" class="button button-primary wpsc-install-action-button <?php echo esc_attr( $button_class ); ?>">
+					<a data-source='banner' href="<?php echo esc_url( $button_url ); ?>" class="wpsc-boost-migration-button button button-primary wpsc-install-action-button <?php echo esc_attr( $button_class ); ?>">
 						<div class="spinner" style="display:none; margin-top: 8px"></div>
 						<label><?php echo esc_html( $button_label ); ?></label>
 					</a>

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -425,7 +425,7 @@ function wpsc_jetpack_boost_install_banner() {
 
 					<div class="wpsc-boost-migration-error" style="display:none; color:red; margin-bottom: 20px;"></div>
 
-					<a data-source='banner' href="<?php echo esc_url( $button_url ); ?>" class="wpsc-boost-migration-button button button-primary wpsc-install-action-button <?php echo esc_attr( $button_class ); ?>">
+					<a data-source='banner' href="<?php echo esc_url( $button_url ); ?>" class="wpsc-boost-migration-button button button-primary <?php echo esc_attr( $button_class ); ?>">
 						<div class="spinner" style="display:none; margin-top: 8px"></div>
 						<label><?php echo esc_html( $button_label ); ?></label>
 					</a>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
For site owners who are using the default settings of WP Super Cache they could use Jetpack Boost and see much the same caching results. This PR adds an admin notice with a "Migrate now" button that installs and activates Boost. It will set a flag that tells Boost to activate the Cache module.
This PR also adds a new function, `wpsc_is_boost_current()` that checks if the installed version of Boost is newer than or equal to 3.4.0. That fixes a different issue linked below.

Fixes #37743 #37932

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a function wpsc_jetpack_boost_notice() that displays the notice. It will only display on the WPSC settings page.
* Add a function wpsc_dismiss_boost_notice() that allows the notice to be hidden.
* Add a function wpsc_is_boost_compatible() that checks if WPSC is using only basic caching features.
* Add a function wpsc_is_boost_current() to check that Boost version is current.
* Add JavaScript that catches clicks on the dismiss button so that action is recorded by wpsc_dismiss_boost_notice()
* Style the admin notice
* Add a nonce for dismissing the admin notice.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-2QH-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Make sure your WPSC install has a default setting. Delete wp-content/wp-cache-config.php and visit the settings page, enable caching from Easy page.
* Delete Jetpack Boost plugin from your site and then reload WPSC settings page to see the admin notice.
* Clicking on the "Migrate Now" button will download, install and activate Boost and take you to the Boost settings page.
* Go to Plugins page and deactivate Jetpack Boost.
* Reload the WPSC settings page, click on the "Migrate Now" button again and it should activate Boost and take you there.
* Reload the WPSC settings page and the admin notice should be gone now.
* Delete or deactivate Boost and reload WPSC settings page to show admin notice again.
* Click the Dismiss button. It disappears, reload the page and it should stay gone.
* Delete the "wpsc_dismissed_boost_admin_notice" user option to show the admin notice again.
* `delete_user_option( get_current_user_id(), 'wpsc_dismissed_boost_admin_notice' );`