### PR TITLE
All sites: Fix icon size in small screen sizes

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-all-sites-icon-size-mobile
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-all-sites-icon-size-mobile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Masterbar: Fix All sites icon size in small screen sizes

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.scss
@@ -35,6 +35,7 @@
 		width: 36px;
 		height: 36px;
 		margin: 0 8px;
+		mask-size: cover;
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7822

## Proposed changes:
Fix `All sites` icon size in small screens

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/jetpack/assets/402286/189c47fa-9af7-4aa6-9c3e-39f5ca6fcc3b) | ![image](https://github.com/Automattic/jetpack/assets/402286/b4860939-219a-4a1a-b752-b81a812a6fdd) |


## Jetpack product discussion
no

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:
* Check the All sites icon size in small screen sizes.
* Also check for no regressions in bigger screen sizes.
