### PR TITLE
Added new wpcomsh command for creating jetpack_connection_active_plugins blog option

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-update-jetpack-blog-option-command
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-update-jetpack-blog-option-command
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added new wpcomsh command for creating jetpack_connection_active_plugins blog option

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -564,6 +564,17 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		}
 
 		/**
+		 * Set up Jetpack active plugins blog option (jetpack_connection_active_plugins).
+		 *
+		 * @subcommand setup-jetpack-active-plugins
+		 */
+		public function setup_jetpack_active_plugins( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis
+			$jetpack_plugins = Automattic\Jetpack\Connection\Plugin_Storage::get_all();
+			update_option( 'jetpack_connection_active_plugins', $jetpack_plugins );
+			WP_CLI::log( wp_json_encode( $jetpack_plugins, JSON_PRETTY_PRINT ) );
+		}
+
+		/**
 		 * Import a backup .zip file.
 		 *
 		 * ## OPTIONS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Task-related: pet6gk-19m-p2

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adding a new command for being executed after site provision

## Does this pull request change what data or activity we track or use?
No. We're only anticipating the creation of a blog option that is already created when installing/removing any Jetpack plugin.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On an Atomic site, ensure you have the Jetpack and Jetpack protect plugins installed
* Delete your current `jetpack_connection_active_plugins` with the command `wp option delete jetpack_connection_active_plugins`
* Ensure you don't have it set with `wp option get jetpack_connection_active_plugins`
* Execute the new command for setting it: `wp wpcomsh setup-jetpack-active-plugins`
* You should receive a list of active plugins with that command:
<img width="1030" alt="image" src="https://github.com/Automattic/jetpack/assets/1044309/a28c18bf-829c-4bf7-b8c5-bab2fdf4f0d9">

* The `wp option get jetpack_connection_active_plugins` command should return the same values in an array.