### PR TITLE
Image CDN: Fix WooCommerce thumbnails

### DIFF
--- a/projects/packages/image-cdn/changelog/fix-photon-woocommerce-thumbnails
+++ b/projects/packages/image-cdn/changelog/fix-photon-woocommerce-thumbnails
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+More closely match core behaviour while downsizing images

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Image_CDN;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.4.2';
+	const PACKAGE_VERSION = '0.4.3-alpha';
 
 	/**
 	 * Singleton.

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
@@ -148,6 +148,7 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 
 		// add sizes that did not exist when the file was uploaded.
 		// These perfectly match the above and Photon should treat them the same.
+		add_image_size( 'jetpack_cropped_size', 165, 165, true );
 		add_image_size( 'jetpack_soft_defined_after_upload', 700, 500, false ); // Intentionally not a 1.33333 ratio.
 		add_image_size( 'jetpack_soft_undefined_after_upload', 700, 99999, false );
 		add_image_size( 'jetpack_soft_undefined_zero_after_upload', 700, 0, false );
@@ -786,6 +787,26 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 		$this->assertEquals(
 			'fit=400%2C300',
 			$this->helper_get_query( Image_CDN::instance()->filter_image_downsize( false, $test_image, array( 400, 400 ) ) )
+		);
+
+		wp_delete_attachment( $test_image );
+		$this->helper_remove_image_sizes();
+	}
+
+	/**
+	 * Tests Photon image_downsize will return a cropped image for custom size if the custom size matches a registered size.
+	 *
+	 * @author kraftbj
+	 * @covers Image_CDN::filter_image_downsize
+	 * @since $$next-version$$
+	 */
+	public function test_image_cdn_return_custom_size_array_uses_registered_crop() {
+		$test_image = $this->helper_get_image();
+
+		// Declaring the size array directly, registered size jetpack_cropped_size of 165 by 165, cropped.
+		$this->assertEquals(
+			'resize=165%2C165',
+			$this->helper_get_query( Image_CDN::instance()->filter_image_downsize( false, $test_image, array( 165, 165 ) ) )
 		);
 
 		wp_delete_attachment( $test_image );

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
@@ -813,6 +813,20 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	}
 
 	/**
+	 * Tests Photon image_downsize will return a cropped image for custom size if the custom size matches a registered size.
+	 *
+	 * @covers Image_CDN::filter_image_downsize
+	 * @since $$next-version$$
+	 */
+	public function test_image_cdn_return_false_for_image_with_null_size() {
+		$test_image = $this->helper_get_image();
+		$this->assertFalse( Image_CDN::instance()->filter_image_downsize( false, $test_image, array( null, null ) ) );
+
+		wp_delete_attachment( $test_image );
+		$this->helper_remove_image_sizes();
+	}
+
+	/**
 	 * Tests that Photon will not return an image larger than the original via image_downsize.
 	 *
 	 * @author kraftbj

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
@@ -796,7 +796,6 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	/**
 	 * Tests Photon image_downsize will return a cropped image for custom size if the custom size matches a registered size.
 	 *
-	 * @author kraftbj
 	 * @covers Image_CDN::filter_image_downsize
 	 * @since $$next-version$$
 	 */


### PR DESCRIPTION
## Proposed changes:
* While downscaling an image, providing dimensions instead of the size name, detect the registered size and use its settings. This solves woocommerce_gallery_thumbnails and possible other similar scenarios.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
8316746-zd-a8c

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Enable Image CDN
* Create a WooCommerce product and add non-square images to it's product image gallery
* Make sure the gallery thumbnails are still squared.