### PR TITLE
Add Applebot-Extended to robots.txt disallow

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-applebot-extended-disallow
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-applebot-extended-disallow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack MU WPCOM: Added Applebot-Extended to robots.txt disallow.

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -53,6 +53,10 @@ function robots_txt( string $output, $public ): string {
 			$output .= "\nUser-agent: {$ai_bot}\n";
 			$output .= "Disallow: /\n";
 		}
+
+		// https://support.apple.com/en-us/119829#datausage
+		$output .= "\nUser-agent: Applebot-Extended\n";
+		$output .= "Disallow: /private/\n";
 	}
 
 	return $output;

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
@@ -67,6 +67,9 @@ Disallow: /
 User-agent: sentibot
 Disallow: /
 
+User-agent: Applebot-Extended
+Disallow: /private/
+
 AI_BLOCKS;
 
 		yield 'public, no discourage AI' => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Adds `Applebot-Extended` to robots.txt disallow. It tells Apple to not use the content in AI training. 

### Other information:

https://support.apple.com/en-us/119829#datausage

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1718736317699439-slack-C050S8KG677

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

rsync to your wpcom sandbox. Instructions here PCYsg-Osp-p2#simple-testing
- `jetpack build plugins/mu-wpcom-plugin`
- `jetpack rsync mu-wpcom-plugin {yoursandbox/to/mu-plugins/jetpack-mu-wpcom-plugin/production}`
- Point a simple site to your sandbox
- Comment out the `domo_arigato_mr_sandboxo` hook (in wpcom sandbox)
- Visit the site's `/robots.txt`