### PR TITLE
beta: Support testing mu-plugins

### DIFF
--- a/projects/plugins/beta/changelog/add-jetpack-beta-mu-plugin-support
+++ b/projects/plugins/beta/changelog/add-jetpack-beta-mu-plugin-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Support testing mu-plugins (i.e. wpcomsh).

--- a/projects/plugins/beta/composer.json
+++ b/projects/plugins/beta/composer.json
@@ -35,7 +35,7 @@
 	"prefer-stable": true,
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ4_0_1_alpha",
+		"autoloader-suffix": "567fa3f555de8fd218dfdc1688bb97b5_betaⓥ4_1_0_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true
 		}

--- a/projects/plugins/beta/docs/mu-plugin-info.md
+++ b/projects/plugins/beta/docs/mu-plugin-info.md
@@ -1,0 +1,30 @@
+## Mu-plugin support
+
+WordPress does not provide user interface for installing and uninstalling mu-plugins. Further, mu-plugins that aren't already a single file need a "loader" that is a single file placed in the mu-plugins directory (generally `wp-content/mu-plugins/`). While there are many ways this can be done, Jetpack Beta Tester makes some assumptions about how mu-plugins it supports are installed:
+
+* The directory of code for the mu-plugin is located in the mu-plugins directory and named after the plugin slug, similar to how plugins are installed. So, for example, a plugin with slug "wpcomsh" would be at `wp-content/mu-plugins/wpcomsh/`.
+* The corresponding loader file is named with the plugin slug with `-loader.php` appended. So, for example, a plugin with slug "wpcomsh" would have its loader named `wp-content/mu-plugins/wpcomsh-loader.php`.
+
+If your installation of the mu-plugin does not follow these conventions, attempting to use Jetpack Beta Tester to install development versions of the mu-plugin may result in multiple versions of the plugin being active simultaneously, which will very likely break your site.
+
+Also, be aware that Jetpack Beta Tester will not enable a stable version of a mu-plugin for you. You will have to follow the plugin's instructions for creating the loader to properly enable it.
+
+Jetpack Beta Tester will not auto-update mu-plugins, nor will it prompt when updates are available. WordPress core's plugin update infrastructure does not handle mu-plugins, so we can't hook into it like we do normal plugins.
+
+When a development version is active and no stable version directory exists, a "Deactivate" button will be provided in the UI to easily deactivate the development version.
+If a stable directory does exist, only the usual button to activate it will be provided; if you want to deactivate the mu-plugin in this situation, do so in the normal manner by removing the loader file.
+
+### How it works
+
+For those interested in the details of how Jetpack Beta Tester manages mu-plugins, read on.
+
+When installing mu-plugins, Jetpack Beta Tester will unpack them into the mu-plugins directory in the same manner that it unpacks normal plugins into the plugins directory. It even uses WordPress core's `Plugin_Upgrader` class to do most of the work, hooking the 'upgrader_package_options' filter to change the destination from WP_PLUGIN_DIR to WPMU_PLUGIN_DIR.
+
+Activation is done via the loader file:
+
+* If the loader file exists then Jetpack Beta Tester assumes that either a stable or dev version is active.
+  * While this may not be entirely accurate for something like wpcomsh where its standard loader checks the `IS_ATOMIC` constant before actually loading, it's good enough for our purposes.
+* To activate a dev version, Jetpack Beta Tester changes the opening `<?php` of the loader file to `<?php /* Load Jetpack Beta dev version: */ return require __DIR__ . '/plugin-dev/main.php';`. The presence of this snippet at the start of the loader file indicates that the dev version is active rather than any available stable version.
+  * If no loader file exists, Jetpack Beta Tester creates a stub loader to add the snippet to.
+* To deactivate a dev version (either to reactivate the stable version or to deactivate the mu-plugin entirely), Jetpack Beta Tester removes the snippet.
+  * If the loader file matches the stub that Jetpack Beta Tester creates, the loader file is then deleted.

--- a/projects/plugins/beta/jetpack-beta.php
+++ b/projects/plugins/beta/jetpack-beta.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Beta Tester
  * Plugin URI: https://jetpack.com/beta/
  * Description: Use the Beta plugin to get a sneak peek at new features and test them on your site.
- * Version: 4.0.1-alpha
+ * Version: 4.1.0-alpha
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * Update URI: https://jetpack.com/download-jetpack-beta/
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'JPBETA__PLUGIN_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
-define( 'JPBETA_VERSION', '4.0.1-alpha' );
+define( 'JPBETA_VERSION', '4.1.0-alpha' );
 
 define( 'JETPACK_BETA_PLUGINS_URL', 'https://betadownload.jetpack.me/plugins.json' );
 

--- a/projects/plugins/beta/src/admin/admin.css
+++ b/projects/plugins/beta/src/admin/admin.css
@@ -65,6 +65,13 @@ html {
 	padding: 11px 0 6px;
 }
 
+#jetpack-beta-tester__is-mu-plugin.dops-card {
+	border-left: 3px solid #f0b849;
+	padding-top: 1px;
+	padding-bottom: 1px;
+	margin-top: 20px;
+}
+
 .jetpack-beta-container {
 	margin: 0 auto;
 	text-align: left;

--- a/projects/plugins/beta/src/admin/branch-card.template.php
+++ b/projects/plugins/beta/src/admin/branch-card.template.php
@@ -34,7 +34,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			esc_html( $branch->version ),
 			esc_attr( $branch->version )
 		);
-	} elseif ( 'rc' === $branch->source || 'trunk' === $branch->source || 'unknown' === $branch->source ) {
+	} elseif ( 'rc' === $branch->source || 'trunk' === $branch->source || 'unknown' === $branch->source && $branch->version ) {
 		$more_info[] = sprintf(
 			// translators: %s: Version number.
 			__( 'Version %s', 'jetpack-beta' ),
@@ -61,7 +61,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 		$classes[] = 'branch-card-active';
 	}
 	if ( 'unknown' === $branch->source ) {
-		$classes[] = 'existing-branch-for-' . $plugin->plugin_slug();
+		if ( $branch->id === 'deactivate' ) {
+			$classes[] = 'deactivate-mu-plugin';
+			$classes[] = 'deactivate-mu-plugin-' . $plugin->plugin_slug();
+		} else {
+			$classes[] = 'existing-branch-for-' . $plugin->plugin_slug();
+		}
 	}
 	if ( empty( $branch->is_last ) ) {
 		$classes[] = 'is-compact';
@@ -70,6 +75,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	// Needs to match what core's wp_ajax_update_plugin() will return.
 	// phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment, WordPress.WP.I18n.TextDomainMismatch
 	$updater_version = sprintf( __( 'Version %s', 'default' ), $branch->version );
+
+	if ( $branch->source === 'unknown' && $branch->id === 'deactivate' ) {
+		$active_text   = __( 'Inactive', 'jetpack-beta' );
+		$activate_text = __( 'Deactivate', 'jetpack-beta' );
+	} else {
+		$active_text   = __( 'Active', 'jetpack-beta' );
+		$activate_text = __( 'Activate', 'jetpack-beta' );
+	}
 
 	?>
 			<div <?php echo $data_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped above ?> class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>" data-slug="<?php echo esc_attr( $slug ); ?>" data-updater-version="<?php echo esc_attr( $updater_version ); ?>">
@@ -83,8 +96,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 						</div>
 					</span>
 					<span class="dops-foldable-card__secondary">
-						<span class="dops-foldable-card__summary" data-active="<?php echo esc_attr( __( 'Active', 'jetpack-beta' ) ); ?>">
-							<a href="<?php echo esc_html( $activate_url ); ?>" class="is-primary jp-form-button activate-branch dops-button is-compact jptracks" data-jptracks-name="jetpack_beta_activate_branch" data-jptracks-prop="<?php echo esc_attr( "{$branch->source}:{$branch->id}" ); ?>"><?php echo esc_html__( 'Activate', 'jetpack-beta' ); ?></a>
+						<span class="dops-foldable-card__summary" data-active="<?php echo esc_attr( $active_text ); ?>">
+							<a href="<?php echo esc_html( $activate_url ); ?>" class="is-primary jp-form-button activate-branch dops-button is-compact jptracks" data-jptracks-name="jetpack_beta_activate_branch" data-jptracks-prop="<?php echo esc_attr( "{$branch->source}:{$branch->id}" ); ?>"><?php echo esc_html( $activate_text ); ?></a>
 						</span>
 					</span>
 				</div>

--- a/projects/plugins/beta/src/admin/plugin-manage.template.php
+++ b/projects/plugins/beta/src/admin/plugin-manage.template.php
@@ -90,7 +90,7 @@ if ( $plugin->is_active( 'stable' ) ) {
 
 	<?php
 	if ( $plugin->is_mu_plugin() ) {
-		$url = sprintf( 'https://github.com/Automattic/jetpack-beta/blob/%s/docs/testing/mu-plugin-info.md', rawurlencode( str_ends_with( JPBETA_VERSION, '-alpha' ) ? 'HEAD' : JPBETA_VERSION ) );
+		$url = sprintf( 'https://github.com/Automattic/jetpack-beta/blob/%s/docs/mu-plugin-info.md', rawurlencode( str_ends_with( JPBETA_VERSION, '-alpha' ) ? 'HEAD' : JPBETA_VERSION ) );
 		?>
 		<div id="jetpack-beta-tester__is-mu-plugin" class="dops-card">
 			<p><?php echo esc_html( $plugin->get_name() ); ?> will be installed as a mu-plugin. See <a href="<?php echo esc_url( $url ); ?>">the documentation</a> for details on what this entails, particularly if you're newly installing a stable version.</p>

--- a/projects/plugins/beta/src/admin/plugin-manage.template.php
+++ b/projects/plugins/beta/src/admin/plugin-manage.template.php
@@ -22,8 +22,8 @@ $manifest   = $plugin->get_manifest( true );
 $wporg_data = $plugin->get_wporg_data( true );
 
 $existing_branch = null;
-if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin->plugin_file() ) ) {
-	$tmp             = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin->plugin_file(), false, false );
+if ( file_exists( $plugin->plugin_path() ) ) {
+	$tmp             = get_plugin_data( $plugin->plugin_path(), false, false );
 	$existing_branch = $plugin->source_info( 'release', $tmp['Version'] );
 	if ( ! $existing_branch || is_wp_error( $existing_branch ) ) {
 		$existing_branch = (object) array(
@@ -43,17 +43,17 @@ $active_branch = (object) array(
 );
 $version       = null;
 $verslug       = '';
-if ( is_plugin_active( $plugin->plugin_file() ) ) {
+if ( $plugin->is_active( 'stable' ) ) {
 	$active_branch = $existing_branch;
 	$verslug       = $plugin->plugin_slug();
 	$version       = $active_branch->pretty_version;
-} elseif ( is_plugin_active( $plugin->dev_plugin_file() ) ) {
+} elseif ( $plugin->is_active( 'dev' ) ) {
 	$active_branch = $plugin->dev_info();
 	if ( $active_branch ) {
 		$active_branch->which          = 'dev';
 		$active_branch->pretty_version = $plugin->dev_pretty_version();
 	} else {
-		$tmp           = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin->dev_plugin_file(), false, false );
+		$tmp           = get_plugin_data( $plugin->dev_plugin_path(), false, false );
 		$active_branch = (object) array(
 			'which'          => 'dev',
 			'source'         => 'unknown',
@@ -80,8 +80,22 @@ if ( is_plugin_active( $plugin->plugin_file() ) ) {
 		require __DIR__ . '/notice.template.php';
 	}
 	?>
-	<?php require __DIR__ . '/toggles.template.php'; ?>
+	<?php
+	// While the toggles apply globally rather than per-plugin, it might be confusing to show them on mu-plugins where they don't have any effect.
+	if ( ! $plugin->is_mu_plugin() ) {
+		require __DIR__ . '/toggles.template.php';
+	}
+	?>
 	<?php require __DIR__ . '/show-needed-updates.template.php'; ?>
+
+	<?php
+	if ( $plugin->is_mu_plugin() ) {
+		$url = sprintf( 'https://github.com/Automattic/jetpack-beta/blob/%s/docs/testing/mu-plugin-info.md', rawurlencode( str_ends_with( JPBETA_VERSION, '-alpha' ) ? 'HEAD' : JPBETA_VERSION ) );
+		?>
+		<div id="jetpack-beta-tester__is-mu-plugin" class="dops-card">
+			<p><?php echo esc_html( $plugin->get_name() ); ?> will be installed as a mu-plugin. See <a href="<?php echo esc_url( $url ); ?>">the documentation</a> for details on what this entails, particularly if you're newly installing a stable version.</p>
+		</div>
+	<?php } ?>
 
 	<?php if ( null !== $version ) { ?>
 	<div class="dops-foldable-card is-expanded has-expanded-summary dops-card is-compact">
@@ -122,6 +136,19 @@ if ( is_plugin_active( $plugin->plugin_file() ) ) {
 		if ( $existing_branch && 'unknown' === $existing_branch->source ) {
 			$branch                 = clone $existing_branch;
 			$branch->pretty_version = __( 'Existing Version', 'jetpack-beta' );
+			require __DIR__ . '/branch-card.template.php';
+		}
+		if ( $plugin->is_mu_plugin() && $active_branch && $active_branch->which === 'dev' && ! $existing_branch ) {
+			// This is a bit of a cheat. Telling it to activate an "unknown" existing stable version when there is no
+			// existing stable version has the effect of deactivating the plugin. This saves us having to write a special handler
+			// for mu-plugin deactivation.
+			$branch = (object) array(
+				'which'          => 'stable',
+				'source'         => 'unknown',
+				'id'             => 'deactivate', // Arbitrary, unused.
+				'version'        => '',
+				'pretty_version' => 'Deactivate mu-plugin',
+			);
 			require __DIR__ . '/branch-card.template.php';
 		}
 		?>

--- a/projects/plugins/beta/src/admin/plugin-select.template.php
+++ b/projects/plugins/beta/src/admin/plugin-select.template.php
@@ -34,11 +34,11 @@ $plugins = Plugin::get_all_plugins( true );
 	<?php
 	foreach ( $plugins as $slug => $plugin ) {
 		$classes = array( 'dops-foldable-card', 'has-expanded-summary', 'dops-card' );
-		if ( is_plugin_active( $plugin->plugin_file() ) ) {
+		if ( $plugin->is_active( 'stable' ) ) {
 			$classes[] = 'plugin-stable';
 			$verslug   = $plugin->plugin_slug();
 			$version   = $plugin->stable_pretty_version() ?? '';
-		} elseif ( is_plugin_active( $plugin->dev_plugin_file() ) ) {
+		} elseif ( $plugin->is_active( 'dev' ) ) {
 			$classes[] = 'plugin-dev';
 			$verslug   = $plugin->dev_plugin_slug();
 			$version   = $plugin->dev_pretty_version() ?? '';

--- a/projects/plugins/beta/src/class-admin.php
+++ b/projects/plugins/beta/src/class-admin.php
@@ -237,13 +237,13 @@ class Admin {
 	 * @return (string|null)[] HTML and diff summary.
 	 */
 	public static function to_test_content( Plugin $plugin ) {
-		if ( is_plugin_active( $plugin->plugin_file() ) ) {
-			$path = WP_PLUGIN_DIR . '/' . $plugin->plugin_slug();
+		if ( $plugin->is_active( 'stable' ) ) {
+			$path = dirname( $plugin->plugin_path() );
 			$info = (object) array(
 				'source' => 'stable',
 			);
-		} elseif ( is_plugin_active( $plugin->dev_plugin_file() ) ) {
-			$path = WP_PLUGIN_DIR . '/' . $plugin->dev_plugin_slug();
+		} elseif ( $plugin->is_active( 'dev' ) ) {
+			$path = dirname( $plugin->dev_plugin_path() );
 			$info = $plugin->dev_info();
 			if ( ! $info ) {
 				return array(

--- a/projects/plugins/beta/src/class-hooks.php
+++ b/projects/plugins/beta/src/class-hooks.php
@@ -90,6 +90,7 @@ class Hooks {
 			unset( $transient->no_update[ $dev ] );
 
 			// If the dev version is active, populate it into the transient.
+			// (no need to care about mu-plugins here, they can't be updated in the normal way)
 			if ( is_plugin_active( $dev ) ) {
 				list( $response, $no_update ) = Plugin::get_plugin( dirname( $nondev ) )->dev_upgrader_response();
 				if ( $response ) {
@@ -312,7 +313,7 @@ class Hooks {
 
 		// Delete dev plugin dirs.
 		foreach ( $plugins as $plugin ) {
-			$working_dir = WP_PLUGIN_DIR . '/' . $plugin->dev_plugin_slug();
+			$working_dir = dirname( $plugin->dev_plugin_path() );
 			if ( $wp_filesystem->is_dir( $working_dir ) ) {
 				$wp_filesystem->delete( $working_dir, true );
 			}
@@ -334,9 +335,11 @@ class Hooks {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		// If no managed plugins are active, we don't want to display anything.
+		// Assume any mu-plugins will have a corresponding <slug>-loader.php, and there isn't any weirdness about having a mu-plugin loader named the same as a non-mu-plugin.
+		// (We don't want to actually create Plugin objects here to avoid unnecessary network fetches, even though they're cached).
 		$any = array();
 		foreach ( Plugin::get_plugin_file_map() as $nondev => $dev ) {
-			if ( is_plugin_active( $nondev ) || is_plugin_active( $dev ) ) {
+			if ( is_plugin_active( $nondev ) || is_plugin_active( $dev ) || file_exists( WPMU_PLUGIN_DIR . '/' . dirname( $nondev ) . '-loader.php' ) ) {
 				$any = true;
 				break;
 			}
@@ -369,11 +372,11 @@ class Hooks {
 			$wp_admin_bar->add_node( $args );
 		}
 		foreach ( $plugins as $slug => $plugin ) {
-			if ( is_plugin_active( $plugin->plugin_file() ) ) {
+			if ( $plugin->is_active( 'stable' ) ) {
 				$is_dev   = false;
 				$version  = $plugin->stable_pretty_version();
 				$dev_info = null;
-			} elseif ( is_plugin_active( $plugin->dev_plugin_file() ) ) {
+			} elseif ( $plugin->is_active( 'dev' ) ) {
 				$is_dev   = true;
 				$any_dev  = true;
 				$version  = $plugin->dev_pretty_version();
@@ -545,7 +548,7 @@ class Hooks {
 				continue;
 			}
 
-			$file     = WP_PLUGIN_DIR . '/' . $plugin->dev_plugin_file();
+			$file     = $plugin->dev_plugin_path();
 			$tmp      = get_plugin_data( $file, false, false );
 			$message .= sprintf(
 				$fmt,

--- a/projects/plugins/beta/src/class-plugin.php
+++ b/projects/plugins/beta/src/class-plugin.php
@@ -19,6 +19,14 @@ use WP_Error;
 class Plugin {
 
 	/**
+	 * Regex for the loader added to a mu-plugin loader.
+	 *
+	 * @todo When we drop support for PHP <7.1.0, make this a private const.
+	 * @var string
+	 */
+	private static $mu_loader_regex = '#^<\?php\s+/\* Load Jetpack Beta dev version: \*/\s+return require\s*(?:\(\s*)?__DIR__\s*.\s*(?:\x27[^\x27]*\x27|"[^"]*")(?:\s*\))?\s*;#';
+
+	/**
 	 * Class instances.
 	 *
 	 * @var Plugin[]
@@ -94,6 +102,14 @@ class Plugin {
 	 * @var bool
 	 */
 	protected $unpublished = false;
+
+	/**
+	 * If the plugin is to be installed as a mu-plugin.
+	 *
+	 * @since $$next-version$$
+	 * @var bool
+	 */
+	protected $is_mu_plugin = false;
 
 	/**
 	 * Manifest data.
@@ -214,7 +230,8 @@ class Plugin {
 			$this->{$k} = $config[ $k ];
 		}
 
-		$this->unpublished = ! empty( $config['unpublished'] );
+		$this->unpublished  = ! empty( $config['unpublished'] );
+		$this->is_mu_plugin = ! empty( $config['is_mu_plugin'] );
 	}
 
 	/**
@@ -330,6 +347,36 @@ class Plugin {
 	}
 
 	/**
+	 * Get the plugin file path.
+	 *
+	 * @since $$next-version$$
+	 * @return string
+	 */
+	public function plugin_path() {
+		return ( $this->is_mu_plugin ? WPMU_PLUGIN_DIR : WP_PLUGIN_DIR ) . '/' . $this->plugin_file();
+	}
+
+	/**
+	 * Get the dev plugin file path.
+	 *
+	 * @since $$next-version$$
+	 * @return string
+	 */
+	public function dev_plugin_path() {
+		return ( $this->is_mu_plugin ? WPMU_PLUGIN_DIR : WP_PLUGIN_DIR ) . '/' . $this->dev_plugin_file();
+	}
+
+	/**
+	 * Is this a mu-plugin?
+	 *
+	 * @since $$next-version$$
+	 * @return bool
+	 */
+	public function is_mu_plugin() {
+		return $this->is_mu_plugin;
+	}
+
+	/**
 	 * Get the manifest data (i.e. branches) for the plugin.
 	 *
 	 * @param bool $no_cache Set true to bypass the transients cache.
@@ -387,7 +434,7 @@ class Plugin {
 	 * @return object|null
 	 */
 	public function dev_info() {
-		$file = WP_PLUGIN_DIR . "/{$this->dev_plugin_slug()}/.jpbeta.json";
+		$file = dirname( $this->dev_plugin_path() ) . '/.jpbeta.json';
 		if ( ! file_exists( $file ) ) {
 			return null;
 		}
@@ -405,6 +452,38 @@ class Plugin {
 			$info->source = 'trunk';
 		}
 		return is_object( $info ) ? $info : null;
+	}
+
+	/**
+	 * Determine if the plugin is active. Works for mu-plugins.
+	 *
+	 * @since $$next-version$$
+	 * @param string $which Which version to make active: "stable" or "dev".
+	 * @return bool Is active?
+	 * @throws InvalidArgumentException If `$which` is invalid.
+	 */
+	public function is_active( $which ) {
+		if ( $which === 'stable' ) {
+			$path = $this->plugin_file();
+		} elseif ( $which === 'dev' ) {
+			$path = $this->dev_plugin_file();
+		} else {
+			throw new InvalidArgumentException( __METHOD__ . ': $which must be "stable" or "dev".' );
+		}
+
+		if ( ! $this->is_mu_plugin ) {
+			return is_plugin_active( $path );
+		}
+
+		$file = WPMU_PLUGIN_DIR . '/' . $this->plugin_slug() . '-loader.php';
+		if ( ! file_exists( $file ) ) {
+			return false;
+		}
+
+		// If the loader snippet is present, dev is active. If not, assume stable is active (or there wouldn't be a loader).
+		// That assumption ignores things like how the usual wpcomsh-loader.php checks for IS_ATOMIC, but there's not much we can do about that and it's unlikely to matter anyway.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Not a remote URL.
+		return ( (bool) preg_match( self::$mu_loader_regex, (string) file_get_contents( $file ) ) ) === ( $which === 'dev' );
 	}
 
 	/**
@@ -427,6 +506,11 @@ class Plugin {
 			$to   = $this->dev_plugin_file();
 		} else {
 			throw new InvalidArgumentException( __METHOD__ . ': $which must be "stable" or "dev".' );
+		}
+
+		// If we're a mu-plugin, we have to fake it by manually adjusting the mu-plugin loader.
+		if ( $this->is_mu_plugin ) {
+			return $this->update_mu_plugin_loader( $which );
 		}
 
 		// If the target is already active, nothing to do.
@@ -462,9 +546,79 @@ class Plugin {
 	}
 
 	/**
+	 * Update the <slug>-loader.php file to activate/deactivate a mu-plugin.
+	 *
+	 * @param string $which Which version to make active: "stable" or "dev".
+	 * @return null|WP_Error
+	 */
+	private function update_mu_plugin_loader( $which ) {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		$creds = request_filesystem_credentials( site_url() . '/wp-admin/', '', false, '', array() );
+		if ( ! WP_Filesystem( $creds ) ) {
+			// Any problems and we exit.
+			return new WP_Error( 'fs_error', 'Filesystem Problem' );
+		}
+		global $wp_filesystem;
+		if ( ! $wp_filesystem ) {
+			return new WP_Error( 'fs_error', 'global $wp_filesystem is not set' );
+		}
+
+		$dir = $wp_filesystem->find_folder( WPMU_PLUGIN_DIR );
+
+		$file = $dir . '/' . $this->plugin_slug() . '-loader.php';
+		if ( ! $wp_filesystem->exists( $file ) ) {
+			if ( $which !== 'dev' || ! file_exists( $this->dev_plugin_path() ) ) {
+				return null;
+			}
+			$tmp      = get_plugin_data( $this->dev_plugin_path(), false, false );
+			$contents = "<?php\n/**\n * Loader generated by Jetpack Beta plugin\n\n";
+			if ( ! empty( $tmp['Name'] ) ) {
+				$value     = str_replace( '*/', '', $tmp['Name'] );
+				$contents .= " * Plugin Name: $value\n";
+			}
+			if ( ! empty( $tmp['Description'] ) ) {
+				$value     = str_replace( '*/', '', $tmp['Description'] );
+				$contents .= " * Description: $value\n";
+			}
+			$contents .= " */\n";
+		} else {
+			$contents = $wp_filesystem->get_contents( $file );
+			if ( $contents === false ) {
+				return is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ? $wp_filesystem->errors : new WP_Error( 'fs_error', "Unknown error while reading {$this->plugin_slug()}-loader.php" );
+			}
+			if ( ! str_starts_with( $contents, '<?php' ) ) {
+				return new WP_Error( 'bad_mu_loader', "Mu-plugin loader {$this->plugin_slug()}-loader.php is unparseable" );
+			}
+		}
+
+		// Strip our loader snippet, then re-add it if necessary.
+		$new_contents = preg_replace( self::$mu_loader_regex, '<?php', $contents );
+		if ( $which === 'dev' && file_exists( $this->dev_plugin_path() ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export -- Used for escaping, not output.
+			$new_contents = '<?php /* Load Jetpack Beta dev version: */ return require __DIR__ . ' . var_export( "/{$this->dev_plugin_file()}", true ) . ';' . substr( $new_contents, 5 );
+		}
+
+		// Write the file, or delete it if it's our auto-generated file and turns out to be empty.
+		if ( preg_match( '#^<\?php\s*/\*\*\n \* Loader generated by Jetpack Beta plugin\n\n(?: \* Plugin Name: .*\n)?(?: \* Description: .*\n)? \*/\s*$#', $new_contents ) ) {
+			$what = 'deleting';
+			$ok   = $wp_filesystem->delete( $file );
+		} elseif ( $contents !== $new_contents ) {
+			$what = 'updating';
+			$ok   = $wp_filesystem->put_contents( $file, $new_contents );
+		} else {
+			$what = 'nothing';
+			$ok   = true;
+		}
+		if ( ! $ok ) {
+			return is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ? $wp_filesystem->errors : new WP_Error( 'fs_error', "Unknown error while $what {$this->plugin_slug()}-loader.php" );
+		}
+		return null;
+	}
+
+	/**
 	 * Install & activate the plugin for the given branch.
 	 *
-	 * @param string $source Source of installation: "stable", "trunk", "rc", "pr", or "release".
+	 * @param string $source Source of installation: "stable", "trunk", "rc", "pr", "release", or "unknown".
 	 * @param string $id When `$source` is "pr", the PR branch name. When "release", the version.
 	 * @return null|WP_Error
 	 * @throws InvalidArgumentException If `$source` is invalid.
@@ -508,7 +662,7 @@ class Plugin {
 		if ( 'dev' === $which ) {
 			$fs_info = $this->dev_info();
 		} else {
-			$file = WP_PLUGIN_DIR . '/' . $this->plugin_file();
+			$file = $this->plugin_path();
 			if ( file_exists( $file ) ) {
 				$tmp     = get_plugin_data( $file, false, false );
 				$fs_info = (object) array(
@@ -629,14 +783,14 @@ class Plugin {
 		if ( ! $dev_info ) {
 			return $default;
 		}
-		$file = WP_PLUGIN_DIR . '/' . $this->dev_plugin_file();
+		$file = $this->dev_plugin_path();
 		if ( ! file_exists( $file ) ) {
 			return $default;
 		}
 		$tmp = get_plugin_data( $file, false, false );
 
 		// Read the plugin's to-test.md, or our generic testing tips should that not exist.
-		$file = WP_PLUGIN_DIR . '/' . $this->dev_plugin_slug() . '/to-test.md';
+		$file = dirname( $this->dev_plugin_path() ) . '/to-test.md';
 		if ( ! file_exists( $file ) ) {
 			$file = __DIR__ . '/../docs/testing/testing-tips.md';
 		}
@@ -667,7 +821,7 @@ class Plugin {
 	 * @return string|null
 	 */
 	public function stable_pretty_version() {
-		$file = WP_PLUGIN_DIR . '/' . $this->plugin_file();
+		$file = $this->plugin_path();
 		if ( ! file_exists( $file ) ) {
 			return null;
 		}
@@ -688,7 +842,7 @@ class Plugin {
 	public function dev_pretty_version() {
 		$dev_info = $this->dev_info();
 		if ( ! $dev_info ) {
-			$file = WP_PLUGIN_DIR . '/' . $this->dev_plugin_file();
+			$file = $this->dev_plugin_path();
 			if ( file_exists( $file ) ) {
 				$tmp = get_plugin_data( $file, false, false );
 				return $tmp['Version'];
@@ -845,12 +999,42 @@ class Plugin {
 		$skin     = new WP_Ajax_Upgrader_Skin();
 		$upgrader = new Plugin_Upgrader( $skin );
 		$upgrader->init();
+
+		// If this is a mu-plugin, overwrite the destination to put it into WPMU_PLUGIN_DIR.
+		$mu_fixers = array();
+		if ( $this->is_mu_plugin ) {
+			$destination                           = WPMU_PLUGIN_DIR . '/' . ( $which === 'dev' ? $this->dev_plugin_slug() : $this->plugin_slug() );
+			$mu_fixers['upgrader_package_options'] = static function ( $options ) use ( $destination ) {
+				$options['destination'] = $destination;
+				return $options;
+			};
+
+			// Also, WPMU_PLUGIN_DIR may not exist. Try to create it.
+			// We hook upgrader_clear_destination instead of doing it directly so Plugin_Upgrader will already have set up $wp_filesystem for us.
+			$mu_fixers['upgrader_clear_destination'] = static function ( $removed ) {
+				global $wp_filesystem;
+				$dir = $wp_filesystem->find_folder( WPMU_PLUGIN_DIR );
+				if ( $dir && ! $wp_filesystem->exists( $dir ) ) {
+					$wp_filesystem->mkdir( $dir, FS_CHMOD_DIR );
+				}
+				return $removed;
+			};
+
+			foreach ( $mu_fixers as $hook => $fixer ) {
+				add_filter( $hook, $fixer );
+			}
+		}
+
 		$result = $upgrader->install(
 			$info->download_url,
 			array(
 				'overwrite_package' => true,
 			)
 		);
+
+		foreach ( $mu_fixers as $hook => $fixer ) {
+			remove_filter( $hook, $fixer );
+		}
 
 		if ( is_wp_error( $result ) ) {
 			return $result;
@@ -866,7 +1050,7 @@ class Plugin {
 		// Record the source info, if it's a dev version.
 		if ( 'dev' === $which ) {
 			global $wp_filesystem; // Should have been set up by the upgrader already.
-			$wp_filesystem->put_contents( WP_PLUGIN_DIR . '/' . $this->dev_plugin_slug() . '/.jpbeta.json', wp_json_encode( $info, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+			$wp_filesystem->put_contents( dirname( $this->dev_plugin_path() ) . '/.jpbeta.json', wp_json_encode( $info, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
 		}
 
 		return null;

--- a/projects/plugins/beta/src/class-utils.php
+++ b/projects/plugins/beta/src/class-utils.php
@@ -133,7 +133,7 @@ class Utils {
 	 */
 	public static function has_been_used() {
 		foreach ( Plugin::get_plugin_file_map() as $dev ) {
-			if ( file_exists( WP_PLUGIN_DIR . "/$dev" ) ) {
+			if ( file_exists( WP_PLUGIN_DIR . "/$dev" ) || file_exists( WPMU_PLUGIN_DIR . "/$dev" ) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Now that we have wpcomsh in the monorepo, people want to test it using Jetpack Beta Tester. For that to work, we have to teach it how to handle mu-plugins.

It's more than just pointing it at `WPMU_PLUGIN_DIR`, since WordPress loads mu-plugins differently than it does normal plugins and has no built-in concept of deactivating them. Fortunately we can take advantage of how WordPress requires a "loader" file to load a mu-plugin to give us a way to "activate" either the stable or dev version on demand.

The diff here is a bit bigger than it would otherwise be because we have to replace a bunch of uses of `WP_PLUGIN_DIR` and `is_plugin_active()` outside of upgrading code with stuff that can handle mu-plugins too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1718725414586839/1718725079.178029-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

If you're testing on a JN site, you may want to add a mu-plugin or the like doing this
```php
add_action( 'muplugins_loaded', function () {
        remove_filter( 'map_meta_cap', 'wpcomsh_map_feature_cap', 10 );
} );
```
Otherwise enabling wpcomsh will screw up the permissions checks and you won't be able to access Jetpack Beta Tester.

Stuff to try:

* Proofread [docs/mu-plugin-info.md](https://github.com/Automattic/jetpack/blob/add/jetpack-beta-mu-plugin-support/projects/plugins/beta/docs/mu-plugin-info.md)
* Not having wpcomsh installed and using JPBeta to install bleeding edge. Then switch to the RC. Then use the "deactivate" button in JPBeta to deactivate it.
* Not having wpcomsh installed and using JPBeta to install bleeding edge. Then deactivate the Jetpack Beta plugin. Ensure wpcomsh got removed properly.
* Have wpcomsh stable installed already. Use JPBeta to install bleeding edge. Then switch to the RC. Then switch back to the existing stable version.
* Have wpcomsh stable installed already. Use JPBeta to install bleeding edge. Then deactivate the Jetpack Beta plugin. Ensure wpcomsh is switched back to stable, and the dev version was removed properly.
* Don't have a mu-plugins dir at all (e.g. `define( 'WPMU_PLUGIN_DIR', '/some/other/path' );` in wp-config.php), and use JPBeta to install wpcomsh bleeding edge.

Note the "See [the documentation](https://github.com/Automattic/jetpack/blob/add/jetpack-beta-mu-plugin-support/projects/plugins/beta/docs/mu-plugin-info.md) for details on what this entails" link in the UI won't work until this PR is merged.

P.S. Probably we should add functionality to either upgrade dev versions or at least allow re-installing them if the sha is different, since the existing normal-plugin updating doesn't work for mu-plugins. But let's leave that for a followup PR.