### PR TITLE
wpcomsh: Add WP-CLI commands with hooks for WoA post-transfer/reset/clone functionality

### DIFF
--- a/projects/plugins/wpcomsh/.phan/baseline.php
+++ b/projects/plugins/wpcomsh/.phan/baseline.php
@@ -47,7 +47,7 @@ return [
     'file_suppressions' => [
         'block-theme-footer-credits/class-wpcom-block-theme-footer-credits.php' => ['PhanUndeclaredFunction'],
         'class-jetpack-plugin-compatibility.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
-        'class-wpcomsh-cli-commands.php' => ['PhanTypeVoidAssignment', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunctionInCallable'],
+        'class-wpcomsh-cli-commands.php' => ['PhanTypeVoidAssignment', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredFunctionInCallable'],
         'custom-colors/class-palette.php' => ['PhanTypeArraySuspiciousNullable'],
         'custom-colors/colors-api.php' => ['PhanNoopNewNoSideEffects'],
         'custom-colors/colors.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredVariable'],
@@ -82,6 +82,7 @@ return [
         'widgets/class-jetpack-posts-i-like-widget.php' => ['PhanRedundantCondition'],
         'widgets/class-pd-top-rated.php' => ['PhanRedundantCondition'],
         'widgets/class-widget-top-clicks.php' => ['PhanUndeclaredFunction'],
+        'woa.php' => ['PhanUndeclaredClassMethod'],
         'wpcom-features/class-wpcom-features.php' => ['PhanPluginMixedKeyNoKey'],
         'wpcom-features/functions-wpcom-features.php' => ['PhanImpossibleCondition', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter'],
         'wpcomsh.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunctionInCallable'],

--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-cli-add-woa-post-actions
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-cli-add-woa-post-actions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+wpcomsh: Add WP-CLI commands with hooks for WoA post-transfer/reset/clone functionality

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -421,41 +421,51 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		}
 
 		/**
+		 * This is a post transfer command that is called after a site is transferred.
+		 *
+		 * This is necessary for some plugins that need to perform certain actions after
+		 * a site is transferred, such as WooCommerce Payments that needs to clear its cache.
+		 *
+		 * Note: This command should only be executed from WPCOM as part of a transfer.
+		 *
+		 * @subcommand post-transfer
+		 */
+		public function post_transfer( $args, $assoc_args = array() ) {
+			do_action( 'wpcomsh_woa_post_transfer', $args, $assoc_args );
+
+			WP_CLI::success( 'Post transfer completed successfully.' );
+		}
+
+		/**
+		 * This is a post reset command that is called after a site is reset.
+		 *
+		 * This is necessary for some plugins that need to perform certain actions after
+		 * a site is reset, such as WooCommerce Payments that needs to clear its cache.
+		 *
+		 * Note: This command should only be executed from WPCOM as part of a transfer.
+		 *
+		 * @subcommand post-reset
+		 */
+		public function post_reset( $args, $assoc_args = array() ) {
+			do_action( 'wpcomsh_woa_post_reset', $args, $assoc_args );
+
+			WP_CLI::success( 'Post reset completed successfully.' );
+		}
+
+		/**
 		 * This is a post clone command that is called after a site is cloned.
 		 *
 		 * This is necessary for some plugins that need to perform certain actions after
 		 * a site is cloned, such as WooCommerce Payments that needs to clear its cache.
 		 *
-		 * Note: This command should only be executed from WPCOM as part of an atomic transfer.
+		 * Note: This command should only be executed from WPCOM as part of a transfer.
 		 *
 		 * @subcommand post-clone
 		 */
-		public function post_clone( $args, $assoc_args = array() ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis
-				$plugins = array(
-					'woocommerce-payments' => function () {
-						$account = \WC_Payments::get_account_service();
-						$account->clear_cache();
-					},
-				);
+		public function post_clone( $args, $assoc_args = array() ) {
+			do_action( 'wpcomsh_woa_post_clone', $args, $assoc_args );
 
-				foreach ( $plugins as $plugin => $callback ) {
-					$result = WP_CLI::runcommand(
-						sprintf( '--skip-plugins --skip-themes plugin is-active %s', $plugin ),
-						array(
-							'launch'     => false,
-							'return'     => 'all',
-							'exit_error' => false,
-						)
-					);
-					if ( 0 !== $result->return_code ) {
-						WP_CLI::log( sprintf( 'Skipping inactive plugin: %s', $plugin ) );
-						continue;
-					}
-
-					$callback();
-					WP_CLI::log( sprintf( 'Callback executed for %s', $plugin ) );
-				}
-				WP_CLI::success( 'Post clone completed successfully.' );
+			WP_CLI::success( 'Post clone completed successfully.' );
 		}
 
 		/**

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_23_2_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_24_0_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_23_1_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_23_2_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.23.2-alpha",
+	"version": "3.24.0-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.23.1-alpha",
+	"version": "3.23.2-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * WPCOMSH functions file.
+ *
+ * @package wpcomsh
+ */
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+/**
+ * Clear WooCommerce plugin cache post clone.
+ *
+ * @param array $args       Arguments.
+ * @param array $assoc_args Associated arguments.
+ */
+function wpcomsh_woa_post_clone_woocommerce( $args, $assoc_args ) {
+	$plugins = array(
+		'woocommerce-payments' => function () {
+			$account = \WC_Payments::get_account_service();
+			$account->clear_cache();
+		},
+	);
+
+	foreach ( $plugins as $plugin => $callback ) {
+		$result = WP_CLI::runcommand(
+			sprintf( '--skip-plugins --skip-themes plugin is-active %s', $plugin ),
+			array(
+				'launch'     => false,
+				'return'     => 'all',
+				'exit_error' => false,
+			)
+		);
+		if ( 0 !== $result->return_code ) {
+			WP_CLI::log( sprintf( 'Skipping inactive plugin: %s', $plugin ) );
+			continue;
+		}
+
+		$callback();
+
+		WP_CLI::log( sprintf( 'Callback executed for %s', $plugin ) );
+	}
+}
+add_action( 'wpcomsh_woa_post_clone', 'wpcomsh_woa_post_clone_woocommerce', 10, 2 );
+
+/**
+ * Convert `safecss` WPCOM-specific post type to `custom_css`.
+ *
+ * @param array $args       Arguments.
+ * @param array $assoc_args Associated arguments.
+ */
+function wpcomsh_woa_post_transfer_update_safecss_to_custom_css( $args, $assoc_args ) {
+	$safecss_posts = get_posts(
+		array(
+			'numberposts' => 1,
+			'post_type'   => 'safecss',
+		)
+	);
+
+	foreach ( $safecss_posts as $safecss_post ) {
+		$safecss_post_id = $safecss_post->ID;
+
+		wp_update_post(
+			(object) array(
+				'ID'        => $safecss_post_id,
+				'post_type' => 'custom_css',
+			)
+		);
+
+		WP_CLI::runcommand(
+			"wp theme mod set custom_css_post_id {$safecss_post_id}",
+			array(
+				'launch'     => false,
+				'exit_error' => false,
+			)
+		);
+	}
+
+	WP_CLI::log( 'safecss posts updated to custom_css' );
+}
+add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_transfer_update_safecss_to_custom_css', 10, 2 );
+add_action( 'wpcomsh_woa_post_reset', 'wpcomsh_woa_post_transfer_update_safecss_to_custom_css', 10, 2 );

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.23.2-alpha
+ * Version: 3.24.0-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
@@ -10,7 +10,7 @@
  */
 
 // Increase version number if you change something in wpcomsh.
-define( 'WPCOMSH_VERSION', '3.23.2-alpha' );
+define( 'WPCOMSH_VERSION', '3.24.0-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );
@@ -26,8 +26,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/i18n.php';
 
 require_once __DIR__ . '/plugin-hotfixes.php';
-
-require_once __DIR__ . '/woa.php';
 
 require_once __DIR__ . '/footer-credit/footer-credit.php';
 require_once __DIR__ . '/block-theme-footer-credits/block-theme-footer-credits.php';
@@ -137,6 +135,7 @@ require_once __DIR__ . '/notices/feature-moved-to-jetpack-notices.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once __DIR__ . '/class-wpcomsh-cli-commands.php';
+	require_once __DIR__ . '/woa.php';
 }
 
 require_once __DIR__ . '/wpcom-migration-helpers/site-migration-helpers.php';

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -27,6 +27,8 @@ require_once __DIR__ . '/i18n.php';
 
 require_once __DIR__ . '/plugin-hotfixes.php';
 
+require_once __DIR__ . '/woa.php';
+
 require_once __DIR__ . '/footer-credit/footer-credit.php';
 require_once __DIR__ . '/block-theme-footer-credits/block-theme-footer-credits.php';
 require_once __DIR__ . '/storefront/storefront.php';

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.23.1-alpha
+ * Version: 3.23.2-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
@@ -10,7 +10,7 @@
  */
 
 // Increase version number if you change something in wpcomsh.
-define( 'WPCOMSH_VERSION', '3.23.1-alpha' );
+define( 'WPCOMSH_VERSION', '3.23.2-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
## Proposed changes:
We're in the process of moving SSH functionality from WPCOM post-transfer/reset/clone to the WoA sites to reduce the number of potential concurrent SSH requests to sites. This PR sets up the CLI commands and actions to be hooked into.

## Testing instructions:

* Go to '..'
*

## Does this pull request change what data or activity we track or use?
No


