### PR TITLE
Add/default tracks to my jetpack events

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -196,12 +196,10 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	const hasSiteConnectionBrokenModules = brokenModules?.needs_site_connection.length > 0;
 	const tracksEventData = useMemo( () => {
 		return {
-			isUserConnected: isUserConnected,
-			isRegistered: isRegistered,
 			userConnectionBrokenModules: brokenModules?.needs_user_connection.join( ', ' ),
 			siteConnectionBrokenModules: brokenModules?.needs_site_connection.join( ', ' ),
 		};
-	}, [ isUserConnected, isRegistered, brokenModules ] );
+	}, [ brokenModules ] );
 
 	/**
 	 * Open the Manage Connection Dialog, and register the connection type as part of the Tracks event recorded

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -219,15 +219,6 @@ const ProductDetailCard = ( {
 			/* dummy arg to avoid bad minification */ 0
 		);
 	}
-	const clickHandler = useCallback( () => {
-		trackButtonClick();
-		onClick?.( mainCheckoutRedirect, detail );
-	}, [ onClick, trackButtonClick, mainCheckoutRedirect, detail ] );
-
-	const trialClickHandler = useCallback( () => {
-		trackButtonClick( true, wpcomFreeProductSlug, detail );
-		onClick?.( trialCheckoutRedirect, detail );
-	}, [ onClick, trackButtonClick, trialCheckoutRedirect, wpcomFreeProductSlug, detail ] );
 
 	const disclaimerClickHandler = useCallback(
 		id => {
@@ -279,6 +270,16 @@ const ProductDetailCard = ( {
 					productMoniker
 			  );
 	const ctaLabel = ctaButtonLabel || defaultCtaLabel;
+
+	const clickHandler = useCallback( () => {
+		trackButtonClick( false, null, ctaLabel );
+		onClick?.( mainCheckoutRedirect, detail );
+	}, [ onClick, trackButtonClick, mainCheckoutRedirect, detail, ctaLabel ] );
+
+	const trialClickHandler = useCallback( () => {
+		trackButtonClick( true, wpcomFreeProductSlug, 'Start for free' );
+		onClick?.( trialCheckoutRedirect, detail );
+	}, [ onClick, trackButtonClick, trialCheckoutRedirect, wpcomFreeProductSlug, detail ] );
 
 	return (
 		<div

--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -272,12 +272,12 @@ const ProductDetailCard = ( {
 	const ctaLabel = ctaButtonLabel || defaultCtaLabel;
 
 	const clickHandler = useCallback( () => {
-		trackButtonClick( false, null, ctaLabel );
+		trackButtonClick( { ctaText: ctaLabel } );
 		onClick?.( mainCheckoutRedirect, detail );
 	}, [ onClick, trackButtonClick, mainCheckoutRedirect, detail, ctaLabel ] );
 
 	const trialClickHandler = useCallback( () => {
-		trackButtonClick( true, wpcomFreeProductSlug, 'Start for free' );
+		trackButtonClick( { customSlug: wpcomFreeProductSlug, ctaText: 'Start for free' } );
 		onClick?.( trialCheckoutRedirect, detail );
 	}, [ onClick, trackButtonClick, trialCheckoutRedirect, wpcomFreeProductSlug, detail ] );
 

--- a/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
@@ -138,7 +138,7 @@ const ProductDetailTableColumn = ( {
 
 	// Register the click handler for the product button.
 	const onClick = useCallback( () => {
-		trackProductButtonClick( isFree, null, callToAction );
+		trackProductButtonClick( { isFreePlan: isFree, ctaText: callToAction } );
 		onProductButtonClick?.( runCheckout, detail, tier );
 	}, [
 		trackProductButtonClick,

--- a/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
@@ -98,12 +98,6 @@ const ProductDetailTableColumn = ( {
 		quantity,
 	} );
 
-	// Register the click handler for the product button.
-	const onClick = useCallback( () => {
-		trackProductButtonClick( isFree );
-		onProductButtonClick?.( runCheckout, detail, tier );
-	}, [ trackProductButtonClick, onProductButtonClick, runCheckout, detail, tier, isFree ] );
-
 	// Compute the price per month.
 	const price = fullPrice ? Math.round( ( fullPrice / 12 ) * 100 ) / 100 : null;
 	const offPrice = introductoryOffer?.costPerInterval
@@ -141,6 +135,20 @@ const ProductDetailTableColumn = ( {
 	const callToAction =
 		customCallToAction ||
 		( isFree ? __( 'Start for Free', 'jetpack-my-jetpack' ) : defaultCtaLabel );
+
+	// Register the click handler for the product button.
+	const onClick = useCallback( () => {
+		trackProductButtonClick( isFree, null, callToAction );
+		onProductButtonClick?.( runCheckout, detail, tier );
+	}, [
+		trackProductButtonClick,
+		onProductButtonClick,
+		runCheckout,
+		detail,
+		tier,
+		isFree,
+		callToAction,
+	] );
 
 	return (
 		<PricingTableColumn primary={ ! isFree }>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -115,10 +115,11 @@ export default function ProductInterstitial( {
 	);
 
 	const trackProductClick = useCallback(
-		( isFreePlan = false, customSlug = null ) => {
+		( isFreePlan = false, customSlug = null, ctaText ) => {
 			recordEvent( 'jetpack_myjetpack_product_interstitial_add_link_click', {
 				product: customSlug ?? slug,
 				product_slug: getProductSlugForTrackEvent( isFreePlan ),
+				ctaText,
 			} );
 		},
 		[ recordEvent, slug, getProductSlugForTrackEvent ]

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -117,7 +117,7 @@ export default function ProductInterstitial( {
 	const trackProductOrBundleClick = useCallback(
 		options => {
 			const { customSlug = null, isFreePlan = false, ctaText = null } = options || {};
-			const productSlug = bundle ? bundle : customSlug ?? slug;
+			const productSlug = customSlug ? customSlug : bundle ?? slug;
 			recordEvent( 'jetpack_myjetpack_product_interstitial_add_link_click', {
 				product: productSlug,
 				product_slug: getProductSlugForTrackEvent( isFreePlan ),

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -114,25 +114,17 @@ export default function ProductInterstitial( {
 		[ slug, pricingForUi ]
 	);
 
-	const trackProductClick = useCallback(
-		( isFreePlan = false, customSlug = null, ctaText ) => {
+	const trackProductOrBundleClick = useCallback(
+		options => {
+			const { customSlug = null, isFreePlan = false, ctaText = null } = options || {};
+			const productSlug = bundle ? bundle : customSlug ?? slug;
 			recordEvent( 'jetpack_myjetpack_product_interstitial_add_link_click', {
-				product: customSlug ?? slug,
+				product: productSlug,
 				product_slug: getProductSlugForTrackEvent( isFreePlan ),
 				ctaText,
 			} );
 		},
-		[ recordEvent, slug, getProductSlugForTrackEvent ]
-	);
-
-	const trackBundleClick = useCallback(
-		( isFreePlan = false ) => {
-			recordEvent( 'jetpack_myjetpack_product_interstitial_add_link_click', {
-				product: bundle,
-				product_slug: getProductSlugForTrackEvent( isFreePlan ),
-			} );
-		},
-		[ recordEvent, bundle, getProductSlugForTrackEvent ]
+		[ recordEvent, slug, getProductSlugForTrackEvent, bundle ]
 	);
 
 	const navigateToMyJetpackOverviewPage = useMyJetpackNavigate( MyJetpackRoutes.Home );
@@ -236,7 +228,7 @@ export default function ProductInterstitial( {
 							slug={ slug }
 							clickHandler={ clickHandler }
 							onProductButtonClick={ clickHandler }
-							trackProductButtonClick={ trackProductClick }
+							trackProductButtonClick={ trackProductOrBundleClick }
 							preferProductName={ preferProductName }
 							isFetching={ isActivating || siteIsRegistering }
 						/>
@@ -250,7 +242,7 @@ export default function ProductInterstitial( {
 							<Col sm={ 4 } md={ 4 } lg={ 7 }>
 								<ProductDetailCard
 									slug={ slug }
-									trackButtonClick={ trackProductClick }
+									trackButtonClick={ trackProductOrBundleClick }
 									onClick={ installsPlugin ? clickHandler : undefined }
 									className={ isUpgradableByBundle ? styles.container : null }
 									supportingInfo={ supportingInfo }
@@ -271,7 +263,7 @@ export default function ProductInterstitial( {
 								{ bundle ? (
 									<ProductDetailCard
 										slug={ bundle }
-										trackButtonClick={ trackBundleClick }
+										trackButtonClick={ trackProductOrBundleClick }
 										onClick={ clickHandler }
 										className={ isUpgradableByBundle ? styles.container : null }
 										hideTOS={ hideTOS || showBundledTOS }

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
@@ -16,7 +16,7 @@ const useAnalytics = () => {
 		userConnectionData = {},
 	} = useMyJetpackConnection();
 	const { login, ID } = userConnectionData.currentUser?.wpcomUser || {};
-	const { myJetpackVersion = '', jetpackVersion = '' } = getMyJetpackWindowInitialState();
+	const { myJetpackVersion = '' } = getMyJetpackWindowInitialState();
 
 	/**
 	 * Initialize tracks with user data.
@@ -44,7 +44,6 @@ const useAnalytics = () => {
 		jetpackAnalytics.tracks.recordEvent( event, {
 			...properties,
 			version: myJetpackVersion,
-			jetpackVersion,
 			isSiteConnected,
 			isUserConnected,
 			referring_plugins: connectedPluginsSlugs,

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
@@ -9,9 +9,14 @@ type TracksRecordEvent = (
 ) => void;
 
 const useAnalytics = () => {
-	const { isUserConnected, connectedPlugins, userConnectionData = {} } = useMyJetpackConnection();
+	const {
+		isUserConnected,
+		isSiteConnected,
+		connectedPlugins,
+		userConnectionData = {},
+	} = useMyJetpackConnection();
 	const { login, ID } = userConnectionData.currentUser?.wpcomUser || {};
-	const { myJetpackVersion = '' } = getMyJetpackWindowInitialState();
+	const { myJetpackVersion = '', jetpackVersion = '' } = getMyJetpackWindowInitialState();
 
 	/**
 	 * Initialize tracks with user data.
@@ -39,6 +44,9 @@ const useAnalytics = () => {
 		jetpackAnalytics.tracks.recordEvent( event, {
 			...properties,
 			version: myJetpackVersion,
+			jetpackVersion,
+			isSiteConnected,
+			isUserConnected,
 			referring_plugins: connectedPluginsSlugs,
 		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/projects/packages/my-jetpack/changelog/add-default-tracks-to-my-jetpack-events
+++ b/projects/packages/my-jetpack/changelog/add-default-tracks-to-my-jetpack-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add more default args for tracks events

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -73,6 +73,7 @@ interface Window {
 			purchases: Array< string >;
 		};
 		myJetpackUrl: string;
+		jetpackVersion: string;
 		myJetpackVersion: string;
 		plugins: {
 			[ key: string ]: {

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -73,7 +73,6 @@ interface Window {
 			purchases: Array< string >;
 		};
 		myJetpackUrl: string;
-		jetpackVersion: string;
 		myJetpackVersion: string;
 		plugins: {
 			[ key: string ]: {

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.25.2",
+	"version": "4.25.3-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.25.2';
+	const PACKAGE_VERSION = '4.25.3-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -229,6 +229,7 @@ class Initializer {
 				'siteSuffix'             => ( new Status() )->get_site_suffix(),
 				'siteUrl'                => esc_url( get_site_url() ),
 				'blogID'                 => Connection_Manager::get_site_id( true ),
+				'jetpackVersion'         => JETPACK__VERSION,
 				'myJetpackVersion'       => self::PACKAGE_VERSION,
 				'myJetpackFlags'         => self::get_my_jetpack_flags(),
 				'fileSystemWriteAccess'  => self::has_file_system_write_access(),

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -229,7 +229,6 @@ class Initializer {
 				'siteSuffix'             => ( new Status() )->get_site_suffix(),
 				'siteUrl'                => esc_url( get_site_url() ),
 				'blogID'                 => Connection_Manager::get_site_id( true ),
-				'jetpackVersion'         => JETPACK__VERSION,
 				'myJetpackVersion'       => self::PACKAGE_VERSION,
 				'myJetpackFlags'         => self::get_my_jetpack_flags(),
 				'fileSystemWriteAccess'  => self::has_file_system_write_access(),


### PR DESCRIPTION
## Proposed changes:

* Add site connection status and user connection status to default tracks args
* Add CTA text to the tracks args of the product interstitial tracks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-8dz-p2#comment-19727

## Does this pull request change what data or activity we track or use?

Yes, we are adding new default tracks to the My Jetpack tracks, as well as adding CTA text to the interstitial tracks

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect your site and ensure site connection status and user connection status are both being tracked on every event
![image](https://github.com/Automattic/jetpack/assets/65001528/f38a7080-5afb-4711-8331-4b399c313752)
3. Go to `/wp-admin/admin.php?page=my-jetpack#/add-search` and click on each of the CTA's, make sure both of the CTA text are recorded in tracks
![image](https://github.com/Automattic/jetpack/assets/65001528/41201231-a629-4a40-a1d1-6477c1f4b229)
![image](https://github.com/Automattic/jetpack/assets/65001528/e37b968c-d56e-4d8b-84e7-4d8503c55637)
4. Now go to `/wp-admin/admin.php?page=my-jetpack#/add-boost` and do the same thing
![image](https://github.com/Automattic/jetpack/assets/65001528/087b6cfd-d6c4-4524-9913-932dc8767d11)
![image](https://github.com/Automattic/jetpack/assets/65001528/a88b89d7-bc5f-4c4d-a9e2-fe4107ca5950)
