### PR TITLE
Sync User Profile Data with WPCOM on Admin Interface Change

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-sync-user-profile
+++ b/projects/plugins/wpcomsh/changelog/add-sync-user-profile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Syncs the Atomic site user profile data with wpcom when the admin interface changes to Default

--- a/projects/plugins/wpcomsh/feature-plugins/classic-sync-profile.php
+++ b/projects/plugins/wpcomsh/feature-plugins/classic-sync-profile.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Synchronizes user profile data between WordPress.com and the local WordPress installation.
+ *
+ * @package wpcomsh
+ */
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Synchronize the current user's profile data from WordPress.com.
+ *
+ * Fetches the user profile data via WordPress.com's JSON API and updates the local user profile.
+ *
+ * @return void
+ */
+function wpcom_sync_user_profile_data() {
+	// Fetch the current user's profile data from wpcom.
+	$response = Client::wpcom_json_api_request_as_user(
+		'/me/profile',
+		'2',
+		array(
+			'method' => 'GET',
+		),
+		null,
+		'wpcom'
+	);
+
+	$response_code         = wp_remote_retrieve_response_code( $response );
+	$response_body_content = wp_remote_retrieve_body( $response );
+	$profile_data          = json_decode( $response_body_content, true );
+
+	// Check if the API call was successful.
+	if ( $response_code === 200 && is_array( $profile_data ) ) {
+		$user_id = get_current_user_id();
+		$user    = get_userdata( $user_id );
+
+		if ( $user ) {
+			// Update the user's profile with the fetched data.
+			$userdata = array(
+				'ID'                => $user_id,
+				'first_name'        => $profile_data['first_name'],
+				'last_name'         => $profile_data['last_name'],
+				'nickname'          => $profile_data['nickname'],
+				'display_name'      => $profile_data['display_name'],
+				'description'       => $profile_data['description'],
+				'user_url'          => $profile_data['user_url'],
+				'locale'            => $profile_data['locale'],
+				'admin_color'       => $profile_data['admin_color'],
+				'comment_shortcuts' => 'true',
+			);
+
+			update_user_option( $user_id, 'rich_editing', 'true' ); // Not working on my test site
+			update_user_option( $user_id, 'syntax_highlighting', 'true' ); // Not working on my test site
+			update_user_option( $user_id, 'show_admin_bar_front', 'true' );
+
+			wp_update_user( $userdata );
+		}
+	}
+}
+
+/**
+ * Trigger user profile data synchronization when the admin interface setting is updated.
+ *
+ * @param mixed $new_value The new value of the setting.
+ * @param mixed $old_value The old value of the setting.
+ * @return void
+ */
+function wpcom_admin_interface_updated( $new_value, $old_value ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	if ( $new_value === 'calypso' || empty( $new_value ) ) {
+		wpcom_sync_user_profile_data();
+	}
+}
+
+add_filter( 'pre_update_option_wpcom_admin_interface', 'wpcom_admin_interface_updated', 15, 2 );

--- a/projects/plugins/wpcomsh/feature-plugins/classic-sync-profile.php
+++ b/projects/plugins/wpcomsh/feature-plugins/classic-sync-profile.php
@@ -38,21 +38,20 @@ function wpcom_sync_user_profile_data() {
 		if ( $user ) {
 			// Update the user's profile with the fetched data.
 			$userdata = array(
-				'ID'                => $user_id,
-				'first_name'        => $profile_data['first_name'],
-				'last_name'         => $profile_data['last_name'],
-				'nickname'          => $profile_data['nickname'],
-				'display_name'      => $profile_data['display_name'],
-				'description'       => $profile_data['description'],
-				'user_url'          => $profile_data['user_url'],
-				'locale'            => $profile_data['locale'],
-				'admin_color'       => $profile_data['admin_color'],
-				'comment_shortcuts' => 'true',
+				'ID'                   => $user_id,
+				'first_name'           => $profile_data['first_name'],
+				'last_name'            => $profile_data['last_name'],
+				'nickname'             => $profile_data['nickname'],
+				'display_name'         => $profile_data['display_name'],
+				'description'          => $profile_data['description'],
+				'user_url'             => $profile_data['user_url'],
+				'locale'               => $profile_data['locale'],
+				'admin_color'          => $profile_data['admin_color'],
+				'comment_shortcuts'    => 'true',
+				'rich_editing'         => 'true',
+				'syntax_highlighting'  => 'true',
+				'show_admin_bar_front' => 'true',
 			);
-
-			update_user_option( $user_id, 'rich_editing', 'true' ); // Not working on my test site
-			update_user_option( $user_id, 'syntax_highlighting', 'true' ); // Not working on my test site
-			update_user_option( $user_id, 'show_admin_bar_front', 'true' );
 
 			wp_update_user( $userdata );
 		}

--- a/projects/plugins/wpcomsh/feature-plugins/classic-sync-profile.php
+++ b/projects/plugins/wpcomsh/feature-plugins/classic-sync-profile.php
@@ -61,14 +61,14 @@ function wpcom_sync_user_profile_data() {
 /**
  * Trigger user profile data synchronization when the admin interface setting is updated.
  *
- * @param mixed $new_value The new value of the setting.
  * @param mixed $old_value The old value of the setting.
+ * @param mixed $new_value The new value of the setting.
  * @return void
  */
-function wpcom_admin_interface_updated( $new_value, $old_value ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+function wpcom_admin_interface_updated( $old_value, $new_value ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 	if ( $new_value === 'calypso' || empty( $new_value ) ) {
 		wpcom_sync_user_profile_data();
 	}
 }
 
-add_filter( 'pre_update_option_wpcom_admin_interface', 'wpcom_admin_interface_updated', 15, 2 );
+add_action( 'update_option_wpcom_admin_interface', 'wpcom_admin_interface_updated', 15, 2 );

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -86,6 +86,7 @@ require_once __DIR__ . '/endpoints/rest-api.php';
 require_once __DIR__ . '/feature-plugins/additional-css.php';
 require_once __DIR__ . '/feature-plugins/autosave-revision.php';
 require_once __DIR__ . '/feature-plugins/blaze.php';
+require_once __DIR__ . '/feature-plugins/classic-sync-profile.php';
 require_once __DIR__ . '/feature-plugins/coblocks-mods.php';
 require_once __DIR__ . '/feature-plugins/full-site-editing.php';
 require_once __DIR__ . '/feature-plugins/google-fonts.php';
@@ -107,7 +108,6 @@ require_once __DIR__ . '/feature-plugins/stats.php';
 require_once __DIR__ . '/feature-plugins/theme-homepage-switch.php';
 require_once __DIR__ . '/feature-plugins/woocommerce.php';
 require_once __DIR__ . '/feature-plugins/wordpress-mods.php';
-require_once __DIR__ . '/feature-plugins/classic-sync-profile.php';
 
 /**
  * Conditionally load the jetpack-mu-wpcom package.

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -107,6 +107,7 @@ require_once __DIR__ . '/feature-plugins/stats.php';
 require_once __DIR__ . '/feature-plugins/theme-homepage-switch.php';
 require_once __DIR__ . '/feature-plugins/woocommerce.php';
 require_once __DIR__ . '/feature-plugins/wordpress-mods.php';
+require_once __DIR__ . '/feature-plugins/classic-sync-profile.php';
 
 /**
  * Conditionally load the jetpack-mu-wpcom package.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7758

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Syncs Atomic site's user profile data with WPCOM when the site admin interface changes from wp-admin to Default.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load the /me/profile endpoint on your sandbox with D152947-code
* Apply this PR to wpcomsh on your Atomic test site
* Point your Atomic test site to the API on your sandbox by SSHing into your Atomic site and adding `define( 'JETPACK__SANDBOX_DOMAIN', '<your_sandbox>' );` to your wp-config.php.
* Make your site Classic and head to /wp-admin/profile.php
* Customize [these profile options](https://github.com/Automattic/jetpack/blob/a2fd9d972329bbf8a3bfa2395fa3832522420dbe/projects/plugins/wpcomsh/feature-plugins/classic-sync-profile.php#L42-L53) and save them. Observe that your profile options only apply to your Atomic site.
* Head to /wp-admin/options-general.php and change your interface to Default and then back to Classic. Switching from Classic to Default triggers the sync callback, makes the API call, and resets the Atomic data.
* Go back to /wp-admin/profile.php and observe that all of the profile options have been reset to match the values on wpcom /me