### PR TITLE
Tiled Gallery: Ensure accessibility related event listeners target parent Tiled Gallery classes 

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-event-listener-space-issue
+++ b/projects/plugins/jetpack/changelog/fix-carousel-event-listener-space-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: Ensure event listeners target relevant Tiled Gallery classes for accessibility fixes.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1587,7 +1587,11 @@
 			}
 
 			if ( e.type === 'keydown' ) {
-				if ( e.key === ' ' || e.key === 'Enter' ) {
+				const parentElement = document.activeElement.parentElement;
+				const isParentCarouselContainer =
+					parentElement && parentElement.classList.contains( 'tiled-gallery__item' );
+
+				if ( ( e.key === ' ' || e.key === 'Enter' ) && isParentCarouselContainer ) {
 					handleClick( e );
 					e.preventDefault(); // Prevent scrolling on space
 					return;


### PR DESCRIPTION
## Proposed changes:

* This PR fixes an issue introduced in https://github.com/Automattic/jetpack/pull/37792 related to preventing the default spacebar (and enter) behaviour anywhere where the affected carousel code would be running. The effect of that would be the inability to press space or enter on a comment on a relevant post / page (self hosted site with a Tiled Gallery in the post / page), or press space when creating a front-end P2 post.
* The fix was to ensure that event default behaviour prevention was targeted only to Tiled Gallery images.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack discussion: p1718920129635049-slack-C02FMH4G8

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

**Self-hosted/Atomic:**

To replicate the issue:
* On a Jurassic Ninja or Atomic site using 'Bleeding Edge', or testing locally on trunk, enable the 'Display images in a full-screen carousel gallery' feature - `/wp-admin/admin.php?page=jetpack#/writing`.
* Ensure you have comments enabled for posts.
* Create a post and add a Tiled Gallery, set to link to 'None' from the settings sidebar.
* Publish the post and view it on the front-end. Use a keyboard to navigate to the images (clicking to tab for example), and you should be able to navigate to the gallery images.
* Click Save and notice the carousel will open.
* Then attempt to add a comment on the post - notice that pressing the spacebar does not create a space, and clicking Enter does not create a newline. Note on an Atomic test site comments worked, but I could replicate the issue commenting on the Tiled Gallery carousel images directly.

To test the fix:
* Apply the PR, and follow the above steps. 
* Images in the Tiled Gallery should still be accessible, however when adding a comment you should also be able to add spaces.

**P2:**

To replicate the issue:
* Sandbox an internal P2 and apply this patch - D152915-code.
* Start a new post on the front-end. Notice you cannot add a space with the spacebar.

To test the fix:
* Follow the steps in the generated comment below to apply the changes on WordPress.com.
* With the same sandboxed internal P2, start a new post on the front-end. You should now be able to add spaces with the spacebar.

**Simple:**

To replicate the issue:
* Sandbox a simple site and apply this patch - D152915-code.
* Ensure Carousel is enabled from Media Settings: https://wordpress.com/support/settings/media-settings/
* Follow the subsequent steps under Self-hosted / Atomic above (noting that on WordPress.com for me the best way to replicate the issue was on comments of the Tiled Gallery itself)

To test the fix:
* Follow the steps in the generated comment below to apply the changes on WordPress.com.
* Images in the Tiled Gallery should still be accessible, however when adding a comment you should also be able to add spaces.