### PR TITLE
wpcomsh: Translate managed plugin auto update label

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-translate-plugin-auto-update-label
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-translate-plugin-auto-update-label
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add `atomic_managed_theme_template_auto_update_label` filter to translate the managed plugin auto update label
+Add `atomic_managed_plugin_row_auto_update_label` filter to translate the managed plugin auto update label

--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-translate-plugin-auto-update-label
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-translate-plugin-auto-update-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add `atomic_managed_theme_template_auto_update_label` filter to translate the managed plugin auto update label

--- a/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
+++ b/projects/plugins/wpcomsh/feature-plugins/managed-plugins.php
@@ -497,6 +497,17 @@ function wpcomsh_symlinked_plugins_url( $url, $path, $plugin ) {
 add_filter( 'plugins_url', 'wpcomsh_symlinked_plugins_url', 0, 3 );
 
 /**
+ * Get atomic managed plugin row auto update label
+ *
+ * @return string
+ */
+function wpcomsh_atomic_managed_plugin_row_auto_update_label() {
+	/* translators: Message about how a managed plugin is updated. */
+	return __( 'Updates managed by WordPress.com', 'wpcomsh' );
+}
+add_filter( 'atomic_managed_plugin_row_auto_update_label', 'wpcomsh_atomic_managed_plugin_row_auto_update_label' );
+
+/**
  * Get atomic managed theme template auto update label
  *
  * @return string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 818-gh-Automattic/i18n-issues

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `atomic_managed_theme_template_auto_update_label` filter to translate the managed plugin auto update label

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync changes to a WoA test site that has plugins that are managed by WordPress.com. I used a WoA site with **Enterprenuer** plan, which had WooCommerce and some WooCommerce extension plugins pre-installed that are managed by WordPress.com.
* Switch to a Mag-16 language.
* Visit `/wp-admin/plugins.php` and confirm the `Managed by host` label is now translated.

