### PR TITLE
Hide wpcom items if `is_agency_managed_site`

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-is_agency_managed_site
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-is_agency_managed_site
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added is_agency_managed_site function used to hide wpcom items

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -60,7 +60,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.36.x-dev"
+			"dev-trunk": "5.37.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.36.0",
+	"version": "5.37.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -290,6 +290,9 @@ class Jetpack_Mu_Wpcom {
 	 * @return void
 	 */
 	public static function load_wpcom_command_palette() {
+		if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+			return;
+		}
 		require_once __DIR__ . '/features/wpcom-command-palette/wpcom-command-palette.php';
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -73,12 +73,13 @@ class Jetpack_Mu_Wpcom {
 	 * Load features that don't need any special loading considerations.
 	 */
 	public static function load_features() {
+		// Shared features.
+		require_once __DIR__ . '/features/agency-managed/agency-managed.php';
 
 		// Please keep the features in alphabetical order.
 		require_once __DIR__ . '/features/100-year-plan/enhanced-ownership.php';
 		require_once __DIR__ . '/features/100-year-plan/locked-mode.php';
 		require_once __DIR__ . '/features/admin-color-schemes/admin-color-schemes.php';
-		require_once __DIR__ . '/features/agency-managed/agency-managed.php';
 		require_once __DIR__ . '/features/block-patterns/block-patterns.php';
 		require_once __DIR__ . '/features/blog-privacy/blog-privacy.php';
 		require_once __DIR__ . '/features/cloudflare-analytics/cloudflare-analytics.php';
@@ -290,7 +291,7 @@ class Jetpack_Mu_Wpcom {
 	 * @return void
 	 */
 	public static function load_wpcom_command_palette() {
-		if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+		if ( is_agency_managed_site() ) {
 			return;
 		}
 		require_once __DIR__ . '/features/wpcom-command-palette/wpcom-command-palette.php';
@@ -318,7 +319,7 @@ class Jetpack_Mu_Wpcom {
 	 * Load WPCOM Site Management widget.
 	 */
 	public static function load_wpcom_site_management_widget() {
-		if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+		if ( is_agency_managed_site() ) {
 			return;
 		}
 		if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -315,6 +315,9 @@ class Jetpack_Mu_Wpcom {
 	 * Load WPCOM Site Management widget.
 	 */
 	public static function load_wpcom_site_management_widget() {
+		if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+			return;
+		}
 		if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
 			require_once __DIR__ . '/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php';
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.36.0';
+	const PACKAGE_VERSION = '5.37.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -78,6 +78,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/100-year-plan/enhanced-ownership.php';
 		require_once __DIR__ . '/features/100-year-plan/locked-mode.php';
 		require_once __DIR__ . '/features/admin-color-schemes/admin-color-schemes.php';
+		require_once __DIR__ . '/features/agency-managed/agency-managed.php';
 		require_once __DIR__ . '/features/block-patterns/block-patterns.php';
 		require_once __DIR__ . '/features/blog-privacy/blog-privacy.php';
 		require_once __DIR__ . '/features/cloudflare-analytics/cloudflare-analytics.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/agency-managed/agency-managed.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agency-managed/agency-managed.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Features related to fully managed agency sites.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Whether to enable "fully managed agency site" features.
+ *
+ * @return bool True if the site is "fully managed agency site", false otherwise.
+ */
+function is_agency_managed_site() {
+	return ! empty( get_option( 'is_fully_managed_agency_site' ) );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/agency-managed/agency-managed.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agency-managed/agency-managed.php
@@ -2,7 +2,7 @@
 /**
  * Features related to fully managed agency sites.
  *
- * @package wpcomsh
+ * @package jetpack-mu-wpcom
  */
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/agency-managed/agency-managed.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agency-managed/agency-managed.php
@@ -7,6 +7,7 @@
 
 /**
  * Whether to enable "fully managed agency site" features.
+ * This is primarily used to hide WPCOM links, upsells, and features.
  *
  * @return bool True if the site is "fully managed agency site", false otherwise.
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -550,16 +550,19 @@ function wpcom_add_plugins_menu() {
 	}
 
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
-	add_submenu_page(
-		'plugins.php',
-		/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
-		__( 'Marketplace', 'jetpack-mu-wpcom' ),
-		/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
-		__( 'Marketplace', 'jetpack-mu-wpcom' ),
-		'manage_options', // Roughly means "is a site admin"
-		'https://wordpress.com/plugins/' . $domain,
-		null
-	);
+
+	if ( ! function_exists( 'is_agency_managed_site' ) || ! is_agency_managed_site() ) {
+		add_submenu_page(
+			'plugins.php',
+			/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
+				__( 'Marketplace', 'jetpack-mu-wpcom' ),
+			/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
+				__( 'Marketplace', 'jetpack-mu-wpcom' ),
+			'manage_options', // Roughly means "is a site admin"
+			'https://wordpress.com/plugins/' . $domain,
+			null
+		);
+	}
 
 	if ( $is_atomic_site ) {
 		if (

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -584,3 +584,20 @@ function wpcom_add_plugins_menu() {
 	}
 }
 add_action( 'admin_menu', 'wpcom_add_plugins_menu' );
+
+/**
+ * Hide the 'Help Center' icon in WordPress admin.
+ */
+function hide_help_center_admin_bar() {
+	?>
+	<style>
+		#wp-admin-bar-help-center {
+			display: none !important;
+		}
+	</style>
+	<?php
+}
+
+if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+	add_action( 'admin_head', 'hide_help_center_admin_bar' );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -506,6 +506,7 @@ function wpcom_add_plugins_menu() {
 	$is_simple_site          = defined( 'IS_WPCOM' ) && IS_WPCOM;
 	$is_atomic_site          = ! $is_simple_site;
 	$is_nav_redesign_enabled = function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled();
+	$is_agency_managed_site  = function_exists( 'is_agency_managed_site' ) && is_agency_managed_site();
 
 	if ( $is_simple_site ) {
 		$has_plugins_menu = false;
@@ -545,24 +546,22 @@ function wpcom_add_plugins_menu() {
 		}
 	}
 
-	if ( ! $is_nav_redesign_enabled ) {
+	if ( ! $is_nav_redesign_enabled || $is_agency_managed_site ) {
 		return;
 	}
 
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 
-	if ( ! function_exists( 'is_agency_managed_site' ) || ! is_agency_managed_site() ) {
-		add_submenu_page(
-			'plugins.php',
-			/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
-				__( 'Marketplace', 'jetpack-mu-wpcom' ),
-			/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
-				__( 'Marketplace', 'jetpack-mu-wpcom' ),
-			'manage_options', // Roughly means "is a site admin"
-			'https://wordpress.com/plugins/' . $domain,
-			null
-		);
-	}
+	add_submenu_page(
+		'plugins.php',
+		/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
+			__( 'Marketplace', 'jetpack-mu-wpcom' ),
+		/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
+			__( 'Marketplace', 'jetpack-mu-wpcom' ),
+		'manage_options', // Roughly means "is a site admin"
+		'https://wordpress.com/plugins/' . $domain,
+		null
+	);
 
 	if ( $is_atomic_site ) {
 		if (

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -53,7 +53,7 @@ function wpcom_add_wpcom_menu_item() {
 	if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
 		return;
 	}
-	if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+	if ( is_agency_managed_site() ) {
 		return;
 	}
 
@@ -176,7 +176,7 @@ function add_all_sites_menu_to_masterbar( $wp_admin_bar ) {
 	if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
 		return;
 	}
-	if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+	if ( is_agency_managed_site() ) {
 		return;
 	}
 
@@ -314,7 +314,7 @@ add_action( 'admin_enqueue_scripts', 'wpcom_site_menu_enqueue_scripts' );
  * @return array | null
  */
 function wpcom_get_sidebar_notice() {
-	if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+	if ( is_agency_managed_site() ) {
 		return null;
 	}
 	$message_path = 'calypso:sites:sidebar_notice';
@@ -506,7 +506,7 @@ function wpcom_add_plugins_menu() {
 	$is_simple_site          = defined( 'IS_WPCOM' ) && IS_WPCOM;
 	$is_atomic_site          = ! $is_simple_site;
 	$is_nav_redesign_enabled = function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled();
-	$is_agency_managed_site  = function_exists( 'is_agency_managed_site' ) && is_agency_managed_site();
+	$is_agency_managed_site  = is_agency_managed_site();
 
 	if ( $is_simple_site ) {
 		$has_plugins_menu = false;
@@ -590,7 +590,7 @@ add_action( 'admin_menu', 'wpcom_add_plugins_menu' );
  * Hide the 'Help Center' icon in WordPress admin.
  */
 function hide_help_center_admin_bar() {
-	if ( ! function_exists( 'is_agency_managed_site' ) || ! is_agency_managed_site() ) {
+	if ( ! is_agency_managed_site() ) {
 		return;
 	}
 	?>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -53,6 +53,9 @@ function wpcom_add_wpcom_menu_item() {
 	if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
 		return;
 	}
+	if ( ! function_exists( 'is_agency_managed_site' ) || ! is_agency_managed_site() ) {
+		return;
+	}
 
 	/**
 	 * Don't show `Hosting` to administrators without a WordPress.com account being attached,

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -551,13 +551,12 @@ function wpcom_add_plugins_menu() {
 	}
 
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
-
 	add_submenu_page(
 		'plugins.php',
 		/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
-			__( 'Marketplace', 'jetpack-mu-wpcom' ),
+		__( 'Marketplace', 'jetpack-mu-wpcom' ),
 		/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
-			__( 'Marketplace', 'jetpack-mu-wpcom' ),
+		__( 'Marketplace', 'jetpack-mu-wpcom' ),
 		'manage_options', // Roughly means "is a site admin"
 		'https://wordpress.com/plugins/' . $domain,
 		null

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -592,6 +592,9 @@ add_action( 'admin_menu', 'wpcom_add_plugins_menu' );
  * Hide the 'Help Center' icon in WordPress admin.
  */
 function hide_help_center_admin_bar() {
+	if ( ! function_exists( 'is_agency_managed_site' ) || ! is_agency_managed_site() ) {
+		return;
+	}
 	?>
 	<style>
 		#wp-admin-bar-help-center {
@@ -600,7 +603,4 @@ function hide_help_center_admin_bar() {
 	</style>
 	<?php
 }
-
-if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
-	add_action( 'admin_head', 'hide_help_center_admin_bar' );
-}
+add_action( 'admin_head', 'hide_help_center_admin_bar' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -176,6 +176,9 @@ function add_all_sites_menu_to_masterbar( $wp_admin_bar ) {
 	if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
 		return;
 	}
+	if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+		return;
+	}
 
 	/**
 	 * Don't show `All Sites` to administrators without a WordPress.com account being attached,
@@ -311,6 +314,9 @@ add_action( 'admin_enqueue_scripts', 'wpcom_site_menu_enqueue_scripts' );
  * @return array | null
  */
 function wpcom_get_sidebar_notice() {
+	if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+		return null;
+	}
 	$message_path = 'calypso:sites:sidebar_notice';
 
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -53,7 +53,7 @@ function wpcom_add_wpcom_menu_item() {
 	if ( ! function_exists( 'wpcom_is_nav_redesign_enabled' ) || ! wpcom_is_nav_redesign_enabled() ) {
 		return;
 	}
-	if ( ! function_exists( 'is_agency_managed_site' ) || ! is_agency_managed_site() ) {
+	if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
@@ -13,6 +13,9 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
  * Displays a banner before the theme browser that links to the WP.com Theme Showcase.
  */
 function wpcom_themes_show_banner() {
+	if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+		return;
+	}
 	$site_slug        = wp_parse_url( home_url(), PHP_URL_HOST );
 	$wpcom_logo       = plugins_url( 'images/wpcom-logo.svg', __FILE__ );
 	$background_image = plugins_url( 'images/banner-background.webp', __FILE__ );
@@ -53,6 +56,9 @@ add_action( 'load-theme-install.php', 'wpcom_themes_show_banner' );
  */
 function wpcom_themes_add_theme_showcase_menu() {
 	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
+		return;
+	}
+	if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
@@ -13,7 +13,7 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
  * Displays a banner before the theme browser that links to the WP.com Theme Showcase.
  */
 function wpcom_themes_show_banner() {
-	if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+	if ( is_agency_managed_site() ) {
 		return;
 	}
 	$site_slug        = wp_parse_url( home_url(), PHP_URL_HOST );
@@ -58,7 +58,7 @@ function wpcom_themes_add_theme_showcase_menu() {
 	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
 		return;
 	}
-	if ( function_exists( 'is_agency_managed_site' ) && is_agency_managed_site() ) {
+	if ( is_agency_managed_site() ) {
 		return;
 	}
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/try-is_agency_managed_site
+++ b/projects/plugins/mu-wpcom-plugin/changelog/try-is_agency_managed_site
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -937,7 +937,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "7ff93b7e86792a3647a0defcdffa63cf5c8fa97f"
+                "reference": "4ab1da58a7fc1d1c874e023d3d6b0e32df54c1a2"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -969,7 +969,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.36.x-dev"
+                    "dev-trunk": "5.37.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/changelog/try-is_agency_managed_site
+++ b/projects/plugins/wpcomsh/changelog/try-is_agency_managed_site
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1070,7 +1070,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "7ff93b7e86792a3647a0defcdffa63cf5c8fa97f"
+                "reference": "4ab1da58a7fc1d1c874e023d3d6b0e32df54c1a2"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1102,7 +1102,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.36.x-dev"
+                    "dev-trunk": "5.37.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/wpcom-plugins/plugins.php
+++ b/projects/plugins/wpcomsh/wpcom-plugins/plugins.php
@@ -17,6 +17,11 @@ function wpcomsh_plugins_show_banner() {
 		return;
 	}
 
+	// No banner for agency-managed sites.
+	if ( ! empty( get_option( 'is_fully_managed_agency_site' ) ) ) {
+		return;
+	}
+
 	$site_slug        = wp_parse_url( home_url(), PHP_URL_HOST );
 	$wpcom_logo       = plugins_url( 'images/wpcom-logo.svg', __FILE__ );
 	$background_image = plugins_url( 'images/banner-background.webp', __FILE__ );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7889 & https://github.com/Automattic/dotcom-forge/issues/7890

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduces `is_agency_managed_site` function that checks for a `is_fully_managed_agency_site` site option.
* If `is_agency_managed_site` is true this PR hides:
  * "All Sites" in the masterbar
  * "Help Center" icon in the masterbar
  * "Hosting drawer"
  * "Site Management Panel" in home
  * Domain upsell in the sidebar
  * Command palette
  * Theme Showcase menu item
  * Theme Showcase banner
  * Marketplace menu item
* Images are included in the code comments

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to an Atomic test site using Jetpack Beta Plugin and the instructions in the [comment below.](https://github.com/Automattic/jetpack/pull/37993#issuecomment-2183397377)
* Use /_cli to add the option: `wp option add is_fully_managed_agency_site 1`
* View that all of the WPCOM items mentioned in the PR description are gone.
* Update the option using /_cli `wp option update is_fully_managed_agency_site 0` and view that the wpcom items have returned

