### PR TITLE
Update jetpack-abtest library to abandoned status

### DIFF
--- a/projects/packages/abtest/README.md
+++ b/projects/packages/abtest/README.md
@@ -1,4 +1,10 @@
-# Jetpack A/B Test
+# [Deprecated] Jetpack A/B Test
+
+**IMPORTANT NOTICE:**
+
+**This package is no longer maintained and currently broken. We do not recommend using it in any new projects.**
+
+---
 
 Provides an interface to the WP.com A/B tests.
 

--- a/projects/packages/abtest/changelog/update-abtest-library-to-abandoned-status
+++ b/projects/packages/abtest/changelog/update-abtest-library-to-abandoned-status
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+This package is no longer maintained and currently broken.

--- a/projects/packages/abtest/composer.json
+++ b/projects/packages/abtest/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "automattic/jetpack-abtest",
 	"description": "Provides an interface to the WP.com A/B tests.",
+	"abandoned": "automattic/jetpack-explat",
 	"type": "jetpack-library",
 	"license": "GPL-2.0-or-later",
 	"require": {

--- a/projects/packages/abtest/composer.json
+++ b/projects/packages/abtest/composer.json
@@ -50,7 +50,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-abtest/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "2.0.x-dev"
+			"dev-trunk": "2.1.x-dev"
 		}
 	},
 	"config": {

--- a/projects/plugins/jetpack/changelog/update-abtest-library-to-abandoned-status
+++ b/projects/plugins/jetpack/changelog/update-abtest-library-to-abandoned-status
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Deprecate jetpack-abtest

--- a/projects/plugins/jetpack/changelog/update-abtest-library-to-abandoned-status#2
+++ b/projects/plugins/jetpack/changelog/update-abtest-library-to-abandoned-status#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -62,7 +62,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/abtest",
-				"reference": "8d7ca6c2a61f73ba22831ca8eaab113ab7db09e0"
+				"reference": "d34ad925fc6dff1741b55aa33d1743080374938d"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -111,6 +111,7 @@
 				"GPL-2.0-or-later"
 			],
 			"description": "Provides an interface to the WP.com A/B tests.",
+			"abandoned": "automattic/jetpack-explat",
 			"transport-options": {
 				"relative": true
 			}

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -62,7 +62,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/abtest",
-				"reference": "d34ad925fc6dff1741b55aa33d1743080374938d"
+				"reference": "0bc2d4b9632a3f769675d66c6c4db976252670fd"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -85,7 +85,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-abtest/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "2.0.x-dev"
+					"dev-trunk": "2.1.x-dev"
 				}
 			},
 			"autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Since this library is not being maintained anymore and is possibly broken (see D60276-code), we decided to deprecate it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1718646751457569-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

N/a