### PR TITLE
Add/newsletter reply to comment

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -437,6 +437,14 @@ const EmailSettings = props => {
 						{
 							label: (
 								<span className="jp-form-toggle-explanation">
+									{ __( 'Replies will be a public comment on the post', 'jetpack' ) }
+								</span>
+							),
+							value: 'comment',
+						},
+						{
+							label: (
+								<span className="jp-form-toggle-explanation">
 									{ __( "Replies will be sent to the post author's email", 'jetpack' ) }
 								</span>
 							),

--- a/projects/plugins/jetpack/changelog/add-newsletter-reply-to-comment
+++ b/projects/plugins/jetpack/changelog/add-newsletter-reply-to-comment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter: now newsletter email replies can become comments on your blog


### PR DESCRIPTION
This PR adds the setting that allows for newsletter email replies to be comments on Jetpack sites. 


## Proposed changes:

See 
<img width="1111" alt="Screenshot 2024-06-21 at 4 14 35 PM" src="https://github.com/Automattic/jetpack/assets/115071/923610ba-29c1-49eb-8f25-144a2d94644f">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Go to jetpack / settings / newsletter. 
* Select the reply to setting to be comment.
* Create a new post that goes out to your subscribers. 
* Reply to the post. Notice a new pending comment on your blog.

