### PR TITLE
Newsletter: allow textarea to be autoexpending if browser supports it

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/style.scss
+++ b/projects/plugins/jetpack/_inc/client/newsletter/style.scss
@@ -136,3 +136,6 @@
 .email-settings__gravatar-help-text {
 	margin-bottom: 8px;
 }
+.jp-settings-card__email-settings .dops-textarea {
+	field-sizing: normal;
+}

--- a/projects/plugins/jetpack/_inc/client/newsletter/style.scss
+++ b/projects/plugins/jetpack/_inc/client/newsletter/style.scss
@@ -137,5 +137,5 @@
 	margin-bottom: 8px;
 }
 .jp-settings-card__email-settings .dops-textarea {
-	field-sizing: normal;
+	field-sizing: content;
 }

--- a/projects/plugins/jetpack/_inc/client/newsletter/style.scss
+++ b/projects/plugins/jetpack/_inc/client/newsletter/style.scss
@@ -136,6 +136,7 @@
 .email-settings__gravatar-help-text {
 	margin-bottom: 8px;
 }
-.jp-settings-card__email-settings .dops-textarea {
+
+#jp-settings-subscriptions .dops-textarea {
 	field-sizing: content;
 }

--- a/projects/plugins/jetpack/changelog/update-textarea-to-be-autoexpending
+++ b/projects/plugins/jetpack/changelog/update-textarea-to-be-autoexpending
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Newsletters: make the welcome form more editable


### PR DESCRIPTION
Currently when you are typing your welcome message the text area can be pretty small. 
This PR make it so that the textarea auto expands as you type in supported browser. 

## Proposed changes:

See 


https://github.com/Automattic/jetpack/assets/115071/ae36a7e8-774c-43c4-93e8-6e5981a97d29


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Newsletter setting. In Chrome type as you would expect and notice that the textarea expands. 

