### PR TITLE
Newsletter: Remove newsletter byline setting feature flag

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -162,10 +162,6 @@ const EmailSettings = props => {
 	const exampleEmail =
 		subscriptionReplyTo !== 'author' ? 'donotreply@wordpress.com' : 'author-name@example.com';
 
-	//Check for feature flag
-	const urlParams = new URLSearchParams( window.location.search );
-	const isBylineEnabled = urlParams.get( 'enable-byline' ) === 'true';
-
 	return (
 		<SettingsCard
 			{ ...props }
@@ -199,123 +195,121 @@ const EmailSettings = props => {
 					onChange={ handleEnableFeaturedImageInEmailToggleChange }
 				/>
 			</SettingsGroup>
-			{ isBylineEnabled && (
-				<SettingsGroup
-					hasChild
-					disableInOfflineMode
-					disableInSiteConnectionMode
-					module={ subscriptionsModule }
-					className="newsletter-group"
-				>
-					<FormLegend className="jp-form-label-wide">
-						{ __( 'Email byline', 'jetpack' ) }
-						<Chip type="new" text={ __( 'New', 'jetpack' ) } />
-					</FormLegend>
-					<p>
-						{ __(
-							'Customize the information you want to display below your post title in emails.',
-							'jetpack'
-						) }
-					</p>
-					<BylinePreview
-						isGravatarEnabled={ bylineState.isGravatarEnabled }
-						isAuthorEnabled={ bylineState.isAuthorEnabled }
-						isPostDateEnabled={ bylineState.isPostDateEnabled }
-						gravatar={ gravatar }
-						displayName={ displayName }
-						dateExample={ dateExample }
+			<SettingsGroup
+				hasChild
+				disableInOfflineMode
+				disableInSiteConnectionMode
+				module={ subscriptionsModule }
+				className="newsletter-group"
+			>
+				<FormLegend className="jp-form-label-wide">
+					{ __( 'Email byline', 'jetpack' ) }
+					<Chip type="new" text={ __( 'New', 'jetpack' ) } />
+				</FormLegend>
+				<p>
+					{ __(
+						'Customize the information you want to display below your post title in emails.',
+						'jetpack'
+					) }
+				</p>
+				<BylinePreview
+					isGravatarEnabled={ bylineState.isGravatarEnabled }
+					isAuthorEnabled={ bylineState.isAuthorEnabled }
+					isPostDateEnabled={ bylineState.isPostDateEnabled }
+					gravatar={ gravatar }
+					displayName={ displayName }
+					dateExample={ dateExample }
+				/>
+				<div className="email-settings__gravatar">
+					<ToggleControl
+						disabled={ gravatarInputDisabled }
+						checked={ isGravatarEnabled }
+						toogling={ isSavingAnyOption( [ GRAVATER_OPTION ] ) }
+						label={
+							<span className="jp-form-toggle-explanation">
+								{ __( 'Show author avatar on your emails', 'jetpack' ) }
+							</span>
+						}
+						onChange={ handleEnableGravatarToggleChange }
 					/>
-					<div className="email-settings__gravatar">
-						<ToggleControl
-							disabled={ gravatarInputDisabled }
-							checked={ isGravatarEnabled }
-							toogling={ isSavingAnyOption( [ GRAVATER_OPTION ] ) }
-							label={
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Show author avatar on your emails', 'jetpack' ) }
-								</span>
-							}
-							onChange={ handleEnableGravatarToggleChange }
-						/>
-						{ bylineState.isGravatarEnabled && (
-							<div className="email-settings__help-info">
-								<div className="email-settings__gravatar-help-info">
-									<img src={ gravatar } className="email-settings__gravatar-image" alt="" />
-									<div>
-										<div className="email-settings__gravatar-help-text">
-											{ __(
-												'We use Gravatar, a service that associates an avatar image with your primary email address.',
-												'jetpack'
-											) }
-										</div>
-										<JetpackButton
-											isExternalLink={ true }
-											href="https://gravatar.com/profile/avatars"
-											variant="secondary"
-											size="small"
-										>
-											{ __( 'Update your Gravatar', 'jetpack' ) }
-										</JetpackButton>
+					{ bylineState.isGravatarEnabled && (
+						<div className="email-settings__help-info">
+							<div className="email-settings__gravatar-help-info">
+								<img src={ gravatar } className="email-settings__gravatar-image" alt="" />
+								<div>
+									<div className="email-settings__gravatar-help-text">
+										{ __(
+											'We use Gravatar, a service that associates an avatar image with your primary email address.',
+											'jetpack'
+										) }
 									</div>
+									<JetpackButton
+										isExternalLink={ true }
+										href="https://gravatar.com/profile/avatars"
+										variant="secondary"
+										size="small"
+									>
+										{ __( 'Update your Gravatar', 'jetpack' ) }
+									</JetpackButton>
 								</div>
 							</div>
-						) }
-						<SupportInfo
-							text={ sprintf(
-								// translators: %s is the user's email address
-								__(
-									"The avatar comes from Gravatar, a universal avatar service. Your image may also appear on other sites using Gravatar when you're logged in with %s.",
-									'jetpack'
-								),
-								email
-							) }
-							privacyLink="https://support.gravatar.com/account/data-privacy/"
-						/>
-					</div>
-					<ToggleControl
-						disabled={ authorInputDisabled }
-						checked={ isAuthorEnabled }
-						toogling={ isSavingAnyOption( [ AUTHOR_OPTION ] ) }
-						label={
-							<span className="jp-form-toggle-explanation">
-								{ __( 'Show author display name', 'jetpack' ) }
-							</span>
-						}
-						onChange={ handleEnableAuthorToggleChange }
-					/>
-
-					<ToggleControl
-						disabled={ postDateInputDisabled }
-						checked={ isPostDateEnabled }
-						toogling={ isSavingAnyOption( [ POST_DATE_OPTION ] ) }
-						label={
-							<span className="jp-form-toggle-explanation">
-								{ __( 'Add the post date', 'jetpack' ) }
-							</span>
-						}
-						onChange={ handleEnablePostDateToggleChange }
-					/>
-					{ bylineState.isPostDateEnabled && (
-						<div className="email-settings__help-info">
-							{ createInterpolateElement(
-								__(
-									'You can customize the date format in your site’s <settingsLink>general settings</settingsLink>',
-									'jetpack'
-								),
-								{
-									settingsLink: (
-										<JetpackButton
-											variant="link"
-											isExternalLink={ true }
-											href={ adminUrl + 'options-general.php' }
-										/>
-									),
-								}
-							) }
 						</div>
 					) }
-				</SettingsGroup>
-			) }
+					<SupportInfo
+						text={ sprintf(
+							// translators: %s is the user's email address
+							__(
+								"The avatar comes from Gravatar, a universal avatar service. Your image may also appear on other sites using Gravatar when you're logged in with %s.",
+								'jetpack'
+							),
+							email
+						) }
+						privacyLink="https://support.gravatar.com/account/data-privacy/"
+					/>
+				</div>
+				<ToggleControl
+					disabled={ authorInputDisabled }
+					checked={ isAuthorEnabled }
+					toogling={ isSavingAnyOption( [ AUTHOR_OPTION ] ) }
+					label={
+						<span className="jp-form-toggle-explanation">
+							{ __( 'Show author display name', 'jetpack' ) }
+						</span>
+					}
+					onChange={ handleEnableAuthorToggleChange }
+				/>
+
+				<ToggleControl
+					disabled={ postDateInputDisabled }
+					checked={ isPostDateEnabled }
+					toogling={ isSavingAnyOption( [ POST_DATE_OPTION ] ) }
+					label={
+						<span className="jp-form-toggle-explanation">
+							{ __( 'Add the post date', 'jetpack' ) }
+						</span>
+					}
+					onChange={ handleEnablePostDateToggleChange }
+				/>
+				{ bylineState.isPostDateEnabled && (
+					<div className="email-settings__help-info">
+						{ createInterpolateElement(
+							__(
+								'You can customize the date format in your site’s <settingsLink>general settings</settingsLink>',
+								'jetpack'
+							),
+							{
+								settingsLink: (
+									<JetpackButton
+										variant="link"
+										isExternalLink={ true }
+										href={ adminUrl + 'options-general.php' }
+									/>
+								),
+							}
+						) }
+					</div>
+				) }
+			</SettingsGroup>
 			<SettingsGroup
 				hasChild
 				disableInOfflineMode

--- a/projects/plugins/jetpack/changelog/update-remove-newsletter-byline-setting-feature-flag
+++ b/projects/plugins/jetpack/changelog/update-remove-newsletter-byline-setting-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter: Now you can manage how your newsletter byline appears to your users


### PR DESCRIPTION
This PR removes the feature flag that was added in https://github.com/Automattic/jetpack/pull/37916 

## Proposed changes:

<img width="1111" alt="Screenshot 2024-06-21 at 4 46 35 PM" src="https://github.com/Automattic/jetpack/assets/115071/c78d1135-d092-4396-868e-3c6ea188f31c">

<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the newsletter setting. 
* Notice the new byline settings.
* They work as expected.

