### PR TITLE
Super Cache: don't show the migration notice if already using Boost Cache

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache-hide-migrate-notice
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-hide-migrate-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Super Cache: do not show migration notice if already using Boost Cache

--- a/projects/plugins/super-cache/inc/boost.php
+++ b/projects/plugins/super-cache/inc/boost.php
@@ -29,6 +29,11 @@ function wpsc_jetpack_boost_notice() {
 		return;
 	}
 
+	// hide the admin notice if Jetpack Boost Cache is already used.
+	if ( 'BOOST' === wpsc_identify_advanced_cache() ) {
+		return;
+	}
+
 	// Don't show the banner if the banner has been dismissed.
 	$is_dismissed = '1' === get_user_option( 'wpsc_dismissed_boost_admin_notice' );
 	if ( $is_dismissed ) {

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -2326,7 +2326,7 @@ function wp_cache_create_advanced_cache() {
 function wpsc_identify_advanced_cache() {
 	global $wpsc_advanced_cache_filename;
 	if ( ! file_exists( $wpsc_advanced_cache_filename ) ) {
-		return false;
+		return 'NONE';
 	}
 	$contents = file_get_contents( $wpsc_advanced_cache_filename ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
If the Cache module of Jetpack Boost is installed, then we don't want to show the migrate admin notice if the site owner installs WP Super Cache, and they are presented with the "Warning! Jetpack Boost Detected" message on the WPSC settings page.

Once they disable the Page Cache in Boost and refresh the settings page, the admin notice will appear again, if it hadn't already been dismissed.

Fixes #38002

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a function called wpsc_identify_advanced_cache() that identifies the kind of advanced-cache.php installed.
* Replace the code in wpsc_check_advanced_cache() that checked for those strings.
* Add a check for Boost Cache in wpsc_jetpack_boost_notice() and return immediately if found.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pc9hqz-2QH-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Configure WPSC with the default "easy" settings.
2. Migrate to Boost Cache and enable the Page Cache.
3. Activate WPSC again on the Plugins page.
4. Visit the WPSC settings page and confirm that the migrate admin notice does not show.
5. Disable Page Cache in Jetpack Boost.
6. Reload the WPSC settings page and confirm the migrate admin notice is now showing.
