### PR TITLE
Agency Managed: Remove the admin interface option

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/hide-admin-interface-if-agency
+++ b/projects/packages/jetpack-mu-wpcom/changelog/hide-admin-interface-if-agency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Hide admin interface if is_agency_managed_site

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -14,6 +14,9 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
  * The setting is displayed only if the has the wp-admin interface selected.
  */
 function wpcomsh_wpcom_admin_interface_settings_field() {
+	if ( is_agency_managed_site() ) {
+		return;
+	}
 	add_settings_field( 'wpcom_admin_interface', '', 'wpcom_admin_interface_display', 'general', 'default' );
 
 	register_setting( 'general', 'wpcom_admin_interface', array( 'sanitize_callback' => 'esc_attr' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7897

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hide the "Admin Interface" option if `is_agency_managed_site` returns true.

Before | After
--|--
<img width="1399" alt="Screenshot 2024-06-24 at 9 47 42 AM" src="https://github.com/Automattic/jetpack/assets/140841/559c1a55-cb2a-4772-aa5e-a1b98b37df3d"> | <img width="1399" alt="Screenshot 2024-06-24 at 9 47 53 AM" src="https://github.com/Automattic/jetpack/assets/140841/5c4d8a8a-bfff-4903-8aed-53f4ea350438">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to an Atomic test site using Jetpack Beta Plugin and the instructions in the [comment below.](https://github.com/Automattic/jetpack/pull/38006#issuecomment-2186754653)
* Use /_cli to add the option: `wp option add is_fully_managed_agency_site 1`
* Go to /wp-admin/options-general.php and view the Admin Interface is gone
* Update the option using /_cli `wp option update is_fully_managed_agency_site 0` and view that the Admin Interface has returned
* Apply this PR to a Simple test site using the instructions in the [comment below.](https://github.com/Automattic/jetpack/pull/38006#issuecomment-2186754653)
* Use wpsh then `switch_to_blog($blog_id);` and `add_option('is_fully_managed_agency_site', 1);` to add the option to your site.
* Go to /wp-admin/options-general.php and view the Admin Interface is gone
* Remove the `is_fully_managed_agency_site` option and view the Admin Interface returns

