### PR TITLE
Super Cache: rename WPSC_VERSION to avoid conflicts with other plugins

### DIFF
--- a/projects/plugins/super-cache/changelog/fix-super-cache-rename_wpsc_version
+++ b/projects/plugins/super-cache/changelog/fix-super-cache-rename_wpsc_version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Super Cache: renamed WPSC_VERSION because it conflicted with other plugins

--- a/projects/plugins/super-cache/inc/preload-notification.php
+++ b/projects/plugins/super-cache/inc/preload-notification.php
@@ -11,7 +11,7 @@ function wpsc_preload_notification_scripts() {
 			'preload-notification',
 			plugins_url( '/js/preload-notification.js', __DIR__ ),
 			array( 'jquery', 'wp-i18n' ),
-			WPSC_VERSION,
+			WPSC_VERSION_ID,
 			true
 		);
 

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -29,7 +29,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-define( 'WPSC_VERSION', '1.9.1-alpha' );
+define( 'WPSC_VERSION_ID', '1.9.1-alpha' );
 
 require_once( __DIR__. '/inc/delete-cache-button.php');
 require_once( __DIR__. '/inc/preload-notification.php');
@@ -311,7 +311,7 @@ function wp_super_cache_admin_enqueue_scripts( $hook ) {
 		'wp-super-cache-admin',
 		trailingslashit( plugin_dir_url( __FILE__ ) ) . 'js/admin.js',
 		array( 'jquery' ),
-		WPSC_VERSION,
+		WPSC_VERSION_ID,
 		false
 	);
 

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -29,7 +29,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-define( 'WPSC_VERSION_ID', '1.9.1-alpha' );
+define( 'WPSC_VERSION_ID', '1.12.1' );
 
 require_once( __DIR__. '/inc/delete-cache-button.php');
 require_once( __DIR__. '/inc/preload-notification.php');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
At least two other plugins use the WPSC prefix and have a constant WPSC_VERSION. This PR renames the constant we use to avoid conflicting with the other plugins.

Since we're modifying this line, I'm going to take the opportunity to bump. the version number too because admin.js was modified since the last release.

Fixes #37692

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Rename WPSC_VERSION to WPSC_VERSION_ID
* bump version from 1.9.1-alpha to 1.12.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Apply PR and load the plugin settings page
* View source and look for admin.js?ver=1.12.1
