### PR TITLE
Agency Managed: Hide the Site Visibility setting

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/hide-site-visibility-if-agency
+++ b/projects/packages/jetpack-mu-wpcom/changelog/hide-site-visibility-if-agency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Hide site visibility setting if is_agency_managed_site

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -60,7 +60,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.37.x-dev"
+			"dev-trunk": "5.38.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.37.0",
+	"version": "5.38.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.37.0';
+	const PACKAGE_VERSION = '5.38.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
@@ -55,3 +55,23 @@ function replace_site_visibility() {
 		<?php
 }
 add_action( 'blog_privacy_selector', 'replace_site_visibility' );
+
+/**
+ * Hide the "Site visibility" setting entirely if is_agency_managed_site is true.
+ */
+function wpcom_hide_site_visibility_setting() {
+	if ( ! is_agency_managed_site() ) {
+		return;
+	}
+	// Check if the current page is the reading settings page
+	$screen = get_current_screen();
+	if ( $screen->id === 'options-reading' ) {
+		echo '<style>
+            .option-site-visibility {
+                display: none;
+            }
+        </style>';
+	}
+}
+add_action( 'admin_head', 'wpcom_hide_site_visibility_setting' );
+

--- a/projects/plugins/mu-wpcom-plugin/changelog/try-hide-site-visibility
+++ b/projects/plugins/mu-wpcom-plugin/changelog/try-hide-site-visibility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_3_0"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_3_1_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -937,7 +937,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "4ab1da58a7fc1d1c874e023d3d6b0e32df54c1a2"
+                "reference": "96dc95c429a75a3c62911e5c8a23deb10d199740"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -969,7 +969,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.37.x-dev"
+                    "dev-trunk": "5.38.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.3.0
+ * Version: 2.3.1-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.3.0",
+	"version": "2.3.1-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/wpcomsh/changelog/try-hide-site-visibility
+++ b/projects/plugins/wpcomsh/changelog/try-hide-site-visibility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_24_0"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_24_1_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1070,7 +1070,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "4ab1da58a7fc1d1c874e023d3d6b0e32df54c1a2"
+                "reference": "96dc95c429a75a3c62911e5c8a23deb10d199740"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1102,7 +1102,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.37.x-dev"
+                    "dev-trunk": "5.38.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.24.0",
+	"version": "3.24.1-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.24.0
+ * Version: 3.24.1-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
@@ -10,7 +10,7 @@
  */
 
 // Increase version number if you change something in wpcomsh.
-define( 'WPCOMSH_VERSION', '3.24.0' );
+define( 'WPCOMSH_VERSION', '3.24.1-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7898

Before | After
--|--
<img width="1343" alt="Screenshot 2024-06-24 at 10 44 46 AM" src="https://github.com/Automattic/jetpack/assets/140841/a087a100-759d-4bd5-8368-389cafff2870"> | <img width="1340" alt="Screenshot 2024-06-24 at 10 45 11 AM" src="https://github.com/Automattic/jetpack/assets/140841/d8377c4c-b645-4b75-a7d0-c1d81d539388">



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hide the Site Visibility option in Settings > Reading if `is_agency_managed_site` is true.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

First, make sure that [the reasoning for hiding this setting makes sense](https://github.com/Automattic/dotcom-forge/issues/7898#issuecomment-2186822362).


* Apply this PR to an Atomic test site using Jetpack Beta Plugin and the instructions in the [comment below.](https://github.com/Automattic/jetpack/pull/38009#issuecomment-2186886794)
* Use /_cli to add the option: `wp option add is_fully_managed_agency_site 1`
* Go to /wp-admin/options-reading.php and view the Site Visibility setting is gone.
* Update the option using /_cli `wp option update is_fully_managed_agency_site 0` and view that the Site Visibility setting has returned.
* Apply this PR to a Simple test site using the instructions in the [comment below.](https://github.com/Automattic/jetpack/pull/38009#issuecomment-2186886794)
* Use wpsh then `switch_to_blog($blog_id);` and `add_option('is_fully_managed_agency_site', 1);` to add the option to your site.
* Go to /wp-admin/options-reading.php and view the Site Visibility setting is gone.
* Remove the `is_fully_managed_agency_site` option and view the Site Visibility setting has returned.

