### PR TITLE
Add a command to disable error emails

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-disable-fatal-error-emails
+++ b/projects/plugins/wpcomsh/changelog/add-disable-fatal-error-emails
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a command to disable fatal error emails.

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -927,16 +927,27 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		 * ## OPTIONS
 		 *
 		 * <command>
-		 * : get/set
+		 * : The subcommand
+		 * ---
+		 * options:
+		 *  - get
+		 *  - set
+		 * ---
 		 *
-		 * [value]
+		 * [--value=<value>]
 		 * : The value (when setting)
+		 * ---
+		 * default: 1
+		 * options:
+		 *  - 0
+		 *  - 1
+		 * ---
 		 *
 		 * @subcommand disable-fatal-error-emails
 		 */
 		public function fatal_error_emails_disable( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			$command = $args[0];
-			$value   = (bool) $args[1];
+			$value   = (bool) $assoc_args['value'];
 
 			switch ( $command ) {
 				case 'get':

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -929,8 +929,8 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		 * <command>
 		 * : get/set
 		 *
-		 * <value>
-		 * : The plugin to patch.
+		 * [value]
+		 * : The value (when setting)
 		 *
 		 * @subcommand disable-fatal-error-emails
 		 */

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -920,7 +920,39 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 
 			WP_CLI::success( 'Success' );
 		}
+
+		/**
+		 * Enable or disable fatal error emails.
+		 *
+		 * ## OPTIONS
+		 *
+		 * <command>
+		 * : get/set
+		 *
+		 * <value>
+		 * : The plugin to patch.
+		 *
+		 * @subcommand disable-fatal-error-emails
+		 */
+		public function fatal_error_emails_disable( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$command = $args[0];
+			$value   = (bool) $args[1];
+
+			switch ( $command ) {
+				case 'get':
+					$option = get_option( 'wpcomsh_disable_fatal_error_emails', false );
+					WP_CLI::log( $option ? 'true' : 'false' );
+					break;
+				case 'set':
+					update_option( 'wpcomsh_disable_fatal_error_emails', $value );
+					WP_CLI::success( 'Success' );
+					break;
+				default:
+					WP_CLI::error( 'Invalid command' );
+			}
+		}
 	}
+
 }
 
 if ( class_exists( 'Checksum_Plugin_Command' ) ) {

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_24_1_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_25_0_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/functions.php
+++ b/projects/plugins/wpcomsh/functions.php
@@ -405,7 +405,7 @@ add_filter( 'wpcom_map_block_map_provider', 'wpcomsh_map_block_map_provider', 10
  */
 function wpcomsh_disable_fatal_error_emails( $email ) {
 	if ( get_option( 'wpcomsh_disable_fatal_error_emails', false ) ) {
-		$email['to'] = 'noreply@wordpress.com';
+		$email['to'] = '';
 	}
 	return $email;
 }

--- a/projects/plugins/wpcomsh/functions.php
+++ b/projects/plugins/wpcomsh/functions.php
@@ -397,6 +397,22 @@ function wpcomsh_map_block_map_provider() {
 add_filter( 'wpcom_map_block_map_provider', 'wpcomsh_map_block_map_provider', 10, 0 );
 
 /**
+ * Disabled fatal error emails if the option is set.
+ *
+ * @param array $email The email arguments.
+ *
+ * @return array The email arguments.
+ */
+function wpcomsh_disable_fatal_error_emails( $email ) {
+	if ( get_option( 'wpcomsh_disable_fatal_error_emails', false ) ) {
+		$email['to'] = 'noreply@wordpress.com';
+	}
+	return $email;
+}
+
+add_filter( 'recovery_mode_email', 'wpcomsh_disable_fatal_error_emails' );
+
+/**
  * Returns the location where newsletter categories should appear
  *
  * @return string

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.24.1-alpha",
+	"version": "3.25.0-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.24.1-alpha
+ * Version: 3.25.0-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
@@ -10,7 +10,7 @@
  */
 
 // Increase version number if you change something in wpcomsh.
-define( 'WPCOMSH_VERSION', '3.24.1-alpha' );
+define( 'WPCOMSH_VERSION', '3.25.0-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
Related to pfuQfP-gV-p2#comment-652 

## Proposed changes:
- Adds a WP CLI command to turn off error emails:

`wp wpcomsh disable-fatal-error-emails set --value=1`(disable emails)
`wp wpcomsh disable-fatal-error-emails set --value=0` (enable emails)
`wp wpcomsh disable-fatal-error-emails get`

- Adds a filter which checks for the value of the option set by the command

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

- Use a developer site
- Pull this branch
- `pnpm jetpack build plugins/wpcomsh && pnpm jetpack rsync wpcomsh`
- Select as destination `_USER_NAME_@sftp.wp.com:htdocs/wp-content/mu-plugins/wpcomsh`
- `Open https://YOUR_SITE.wpcomstaging.com/_cli`

### Test the command:
- `Open https://YOUR_SITE.wpcomstaging.com/_cli`
- - `wp wpcomsh disable-fatal-error-emails set --value=1`(disable emails)
- - `wp wpcomsh disable-fatal-error-emails get` (should output true)
- - `wp wpcomsh disable-fatal-error-emails set --value=0` (enable emails)
- - `wp wpcomsh disable-fatal-error-emails get` (should output false)

### Test the sending of emails

Install this plugin: [crash-test.zip](https://github.com/user-attachments/files/15966393/crash-test.zip)

This plugin will allow you to crash your website by appending `?crash=1` to any URL. Please note that emails only get sent on protected endpoints (wp-admin, wp-login.php, ...).

This plugin will also show you the current value of the setting:

![CleanShot 2024-06-25 at 09 08 40@2x](https://github.com/Automattic/jetpack/assets/528287/ed77d989-fc46-4613-b3d6-38e1c6fee32d)

Finally, the plugin lowers the rate limit of fatal error emails to 5 seconds (instead of a day).

- Disable sending error emails in _cli: `wp wpcomsh disable-fatal-error-emails set --value=1`
- Trigger a crash on a protected endpoint: `https://yoursite.com/wp-admin/?crash=1`
- You should not receive an email

Now, run:

- Enable sending error emails in _cli: `wp wpcomsh disable-fatal-error-emails set --value=0`
- Trigger a crash on a protected endpoint: `https://yoursite.com/wp-admin/?crash=1`
- You should receive an email


