### PR TITLE
Fix more phan undeclared issues

### DIFF
--- a/.phan/config.base.php
+++ b/.phan/config.base.php
@@ -31,6 +31,7 @@
  *      - woocommerce: Stubs from php-stubs/woocommerce.
  *      - woocommerce-internal: Stubs from .phan/stubs/woocommerce-internal-stubs.php.
  *      - woocommerce-packages: Stubs from php-stubs/woocommerce.
+ *      - woopayments: Stubs from .phan/stubs/woocommerce-payments-stubs.php.
  *      - wordpress: Stubs from php-stubs/wordpress-stubs, php-stubs/wordpress-tests-stubs, php-stubs/wp-cli-stubs, .phan/stubs/wordpress-constants.php, and .phan/stubs/wordpress-globals.jsonc.
  *      - wp-cli: Stubs from php-stubs/wp-cli-stubs.
  *      - wpcom: Stubs from .phan/stubs/wpcom-stubs.php, plus some stuff from wpcomsh.
@@ -84,6 +85,9 @@ function make_phan_config( $dir, $options = array() ) {
 				break;
 			case 'woocommerce-packages':
 				$stubs[] = "$root/vendor/php-stubs/woocommerce-stubs/woocommerce-packages-stubs.php";
+				break;
+			case 'woopayments':
+				$stubs[] = "$root/.phan/stubs/woocommerce-payments-stubs.php";
 				break;
 			case 'wordpress':
 				$stubs[]        = "$root/vendor/php-stubs/wordpress-stubs/wordpress-stubs.php";

--- a/.phan/stubs/woocommerce-payments-stubs.php
+++ b/.phan/stubs/woocommerce-payments-stubs.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Stubs automatically generated from WooPayments 7.8.0
+ * using the definition file `tools/stubs/woocommerce-payments-stub-defs.php` in the Jetpack monorepo.
+ *
+ * Do not edit this directly! Run tools/stubs/update-stubs.sh to regenerate it.
+ */
+
+/**
+ * Class handling any account connection functionality
+ */
+class WC_Payments_Account
+{
+    /**
+     * Wipes the account data option, forcing to re-fetch the account status from WP.com.
+     */
+    public function clear_cache()
+    {
+    }
+}
+/**
+ * Main class for the WooPayments extension. Its responsibility is to initialize the extension.
+ */
+class WC_Payments
+{
+    /**
+     * Returns the WC_Payments_Account instance
+     *
+     * @return WC_Payments_Account account service instance
+     */
+    public static function get_account_service()
+    {
+    }
+}

--- a/projects/packages/connection/.phan/baseline.php
+++ b/projects/packages/connection/.phan/baseline.php
@@ -9,16 +9,15 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 45+ occurrences
     // PhanParamTooMany : 40+ occurrences
+    // PhanTypeMismatchArgument : 40+ occurrences
     // PhanDeprecatedFunction : 15+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 15+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 15+ occurrences
     // PhanTypeMismatchReturn : 15+ occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 9 occurrences
     // PhanTypeMismatchPropertyProbablyReal : 9 occurrences
     // PhanNoopNew : 8 occurrences
     // PhanTypeMismatchReturnProbablyReal : 8 occurrences
-    // PhanUndeclaredProperty : 8 occurrences
     // PhanRedundantCondition : 5 occurrences
     // PhanTypeArraySuspiciousNullable : 5 occurrences
     // PhanTypeMismatchDefault : 5 occurrences
@@ -41,11 +40,10 @@ return [
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'legacy/class-jetpack-ixr-clientmulticall.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'legacy/class-jetpack-options.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal'],
         'legacy/class-jetpack-signature.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentInternal'],
         'legacy/class-jetpack-tracks-client.php' => ['PhanNonClassMethodCall', 'PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyProbablyReal'],
-        'legacy/class-jetpack-xmlrpc-server.php' => ['PhanAccessMethodInternal', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanUndeclaredProperty'],
+        'legacy/class-jetpack-xmlrpc-server.php' => ['PhanAccessMethodInternal', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn'],
         'src/class-error-handler.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-heartbeat.php' => ['PhanTypeMismatchPropertyDefault'],
         'src/class-manager.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal'],
@@ -58,8 +56,7 @@ return [
         'src/class-server-sandbox.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'src/class-tokens.php' => ['PhanImpossibleTypeComparison', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-tracking.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypePossiblyInvalidDimOffset'],
-        'src/sso/class-helpers.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'src/sso/class-sso.php' => ['PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
+        'src/sso/class-sso.php' => ['PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchArgument'],
         'src/sso/class-user-admin.php' => ['PhanPluginUnreachableCode', 'PhanTypeMismatchArgument'],
         'src/webhooks/class-authorize-redirect.php' => ['PhanUndeclaredClassMethod'],
         'tests/php/test-class-nonce-handler.php' => ['PhanPluginDuplicateAdjacentStatement', 'PhanTypeMismatchArgument'],

--- a/projects/packages/connection/changelog/fix-wpcomsh-phan-stuff
+++ b/projects/packages/connection/changelog/fix-wpcomsh-phan-stuff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix some phpdocs to make Phan happier.
+
+

--- a/projects/packages/connection/legacy/class-jetpack-ixr-client.php
+++ b/projects/packages/connection/legacy/class-jetpack-ixr-client.php
@@ -77,7 +77,7 @@ class Jetpack_IXR_Client extends IXR_Client {
 	/**
 	 * Perform the IXR request.
 	 *
-	 * @param string[] ...$args IXR args.
+	 * @param mixed ...$args IXR method and args.
 	 *
 	 * @return bool True if request succeeded, false otherwise.
 	 */

--- a/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -521,6 +521,7 @@ class Jetpack_XMLRPC_Server {
 	 * Getter for the local user to act as.
 	 *
 	 * @param array $request the current request data.
+	 * @return WP_User|IXR_Error|false IXR_Error if the request is missing a local_user field, WP_User object on success, or false on failure to find a user.
 	 */
 	private function fetch_and_verify_local_user( $request ) {
 		if ( empty( $request['local_user'] ) ) {
@@ -544,6 +545,7 @@ class Jetpack_XMLRPC_Server {
 	 * Gets the user object by its data.
 	 *
 	 * @param string $user_id can be any identifying user data.
+	 * @return WP_User|false WP_User object on success, false on failure.
 	 */
 	private function get_user_by_anything( $user_id ) {
 		$user = get_user_by( 'login', $user_id );

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.10.1';
+	const PACKAGE_VERSION = '2.10.2-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
@@ -13,9 +13,8 @@ return [
     // PhanTypeMismatchArgument : 15+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 8 occurrences
     // PhanTypeMismatchReturn : 6 occurrences
+    // PhanNoopNew : 4 occurrences
     // PhanTypeMismatchReturnProbablyReal : 4 occurrences
-    // PhanUndeclaredFunction : 4 occurrences
-    // PhanNoopNew : 3 occurrences
     // PhanTypePossiblyInvalidDimOffset : 3 occurrences
     // PhanUndeclaredClassMethod : 3 occurrences
     // PhanEmptyFQSENInCallable : 2 occurrences
@@ -25,6 +24,7 @@ return [
     // PhanTypeMismatchArgumentInternal : 2 occurrences
     // PhanTypeMismatchDefault : 2 occurrences
     // PhanTypeMissingReturn : 2 occurrences
+    // PhanUndeclaredFunction : 2 occurrences
     // PhanDeprecatedFunction : 1 occurrence
     // PhanImpossibleTypeComparison : 1 occurrence
     // PhanNonClassMethodCall : 1 occurrence
@@ -45,7 +45,7 @@ return [
         'src/features/100-year-plan/locked-mode.php' => ['PhanEmptyFQSENInCallable'],
         'src/features/admin-color-schemes/admin-color-schemes.php' => ['PhanNoopNew'],
         'src/features/block-patterns/class-wpcom-block-patterns-utils.php' => ['PhanTypeMismatchReturnNullable'],
-        'src/features/coming-soon/coming-soon.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal', 'PhanUndeclaredFunction'],
+        'src/features/coming-soon/coming-soon.php' => ['PhanTypeArraySuspicious', 'PhanTypeMismatchArgumentInternal'],
         'src/features/coming-soon/fallback-coming-soon-page.php' => ['PhanTypeMismatchArgument', 'PhanTypeVoidArgument'],
         'src/features/error-reporting/error-reporting.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/features/launchpad/class-launchpad-task-lists.php' => ['PhanNoopArrayAccess', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset'],
@@ -54,7 +54,6 @@ return [
         'src/features/marketplace-products-updater/class-marketplace-products-updater.php' => ['PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn'],
         'src/features/media/heif-support.php' => ['PhanPluginSimplifyExpressionBool'],
         'src/features/verbum-comments/class-verbum-comments.php' => ['PhanImpossibleTypeComparison', 'PhanNoopNew', 'PhanParamTooMany', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],
-        'src/features/wpcom-block-editor/functions.editor-type.php' => ['PhanUndeclaredFunction'],
         'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-migrate-guru-key.php' => ['PhanUndeclaredClassMethod'],
         'src/features/wpcom-site-menu/wpcom-site-menu.php' => ['PhanTypeMismatchArgumentProbablyReal'],

--- a/projects/packages/jetpack-mu-wpcom/.phan/config.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/config.php
@@ -26,6 +26,7 @@ return make_phan_config(
 			__DIR__ . '/../../../plugins/jetpack/modules/custom-css/custom-css.php',        // class Jetpack_Custom_CSS_Enhancements
 			__DIR__ . '/../../../plugins/jetpack/class-jetpack-stats-dashboard-widget.php', // class Jetpack_Stats_Dashboard_Widget
 			__DIR__ . '/../../../plugins/jetpack/modules/masterbar/nudges/bootstrap.php',   // function Automattic\Jetpack\Dashboard_Customizations\register_css_nudge_control  phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+			__DIR__ . '/../../../plugins/wpcomsh/wpcomsh.php',                              // function wpcomsh_record_tracks_event
 		),
 	)
 );

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcomsh-phan-stuff
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcomsh-phan-stuff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Phan: Add reference to a wpcom file for stubbing.
+
+

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcomsh-phan-stuff#2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcomsh-phan-stuff#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove use of `gutenberg_can_edit_post_type()`. Its replacement has been in WP Core since 6.1.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -51,7 +51,6 @@ function wpcom_admin_interface_track_changed_event( $value ) {
 	$event_name = 'wpcom_admin_interface_changed';
 	$properties = array( 'interface' => $value );
 	if ( function_exists( 'wpcomsh_record_tracks_event' ) ) {
-		// @phan-suppress-next-line PhanUndeclaredFunction -- Defined in wpcomsh, which Phan doesn't know about yet.
 		wpcomsh_record_tracks_event( $event_name, $properties );
 	} else {
 		require_lib( 'tracks/client' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
@@ -67,13 +67,5 @@ function remember_editor( $post_id, $editor ) {
  * @return bool              Whether the block editor can be used to edit the supplied post type.
  */
 function can_edit_post_type( $post_type ) {
-	$can_edit = false;
-
-	if ( function_exists( 'gutenberg_can_edit_post_type' ) ) {
-		$can_edit = gutenberg_can_edit_post_type( $post_type );
-	} elseif ( function_exists( 'use_block_editor_for_post_type' ) ) {
-		$can_edit = use_block_editor_for_post_type( $post_type );
-	}
-
-	return $can_edit;
+	return use_block_editor_for_post_type( $post_type );
 }

--- a/projects/packages/masterbar/.phan/baseline.php
+++ b/projects/packages/masterbar/.phan/baseline.php
@@ -10,14 +10,12 @@
 return [
     // # Issue statistics:
     // PhanNoopNew : 5 occurrences
-    // PhanPluginUnreachableCode : 1 occurrence
-    // PhanTypeInstantiateAbstract : 1 occurrence
     // PhanTypeMismatchArgument : 1 occurrence
-    // PhanTypeSuspiciousEcho : 1 occurrence
-    // PhanUndeclaredClassReference : 1 occurrence
+    // PhanUndeclaredFunction : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
+        'src/admin-menu/class-atomic-admin-menu.php' => ['PhanUndeclaredFunction'],
         'src/admin-menu/class-wpcom-admin-menu.php' => ['PhanTypeMismatchArgument'],
         'src/class-main.php' => ['PhanNoopNew'],
         'src/profile-edit/bootstrap.php' => ['PhanNoopNew'],

--- a/projects/packages/masterbar/.phan/baseline.php
+++ b/projects/packages/masterbar/.phan/baseline.php
@@ -11,11 +11,9 @@ return [
     // # Issue statistics:
     // PhanNoopNew : 5 occurrences
     // PhanTypeMismatchArgument : 1 occurrence
-    // PhanUndeclaredFunction : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/admin-menu/class-atomic-admin-menu.php' => ['PhanUndeclaredFunction'],
         'src/admin-menu/class-wpcom-admin-menu.php' => ['PhanTypeMismatchArgument'],
         'src/class-main.php' => ['PhanNoopNew'],
         'src/profile-edit/bootstrap.php' => ['PhanNoopNew'],

--- a/projects/packages/masterbar/.phan/config.php
+++ b/projects/packages/masterbar/.phan/config.php
@@ -31,6 +31,7 @@ return make_phan_config(
 			__DIR__ . '/../../../plugins/jetpack/modules/scan/class-admin-bar-notice.php',
 			__DIR__ . '/../../../plugins/jetpack/modules/stats.php',
 			__DIR__ . '/../../../plugins/wpcomsh/feature-plugins/masterbar.php',           // function wpcomsh_is_site_sticker_active
+			__DIR__ . '/../../../plugins/wpcomsh/private-site/private-site.php',           // function site_is_private
 		),
 	)
 );

--- a/projects/packages/masterbar/.phan/config.php
+++ b/projects/packages/masterbar/.phan/config.php
@@ -30,6 +30,7 @@ return make_phan_config(
 			__DIR__ . '/../../../plugins/jetpack/modules/notes.php',
 			__DIR__ . '/../../../plugins/jetpack/modules/scan/class-admin-bar-notice.php',
 			__DIR__ . '/../../../plugins/jetpack/modules/stats.php',
+			__DIR__ . '/../../../plugins/wpcomsh/feature-plugins/masterbar.php',           // function wpcomsh_is_site_sticker_active
 		),
 	)
 );

--- a/projects/packages/masterbar/changelog/fix-wpcomsh-phan-stuff
+++ b/projects/packages/masterbar/changelog/fix-wpcomsh-phan-stuff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Phan: Add reference to a wpcom file for stubbing.
+
+

--- a/projects/packages/masterbar/changelog/fix-wpcomsh-phan-stuff
+++ b/projects/packages/masterbar/changelog/fix-wpcomsh-phan-stuff
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Phan: Add reference to a wpcom file for stubbing.
+Comment: Phan: Add reference to some wpcom files for stubbing.
 
 

--- a/projects/packages/masterbar/changelog/fix-wpcomsh-phan-stuff#2
+++ b/projects/packages/masterbar/changelog/fix-wpcomsh-phan-stuff#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove Phan suppression for `site_is_private()`. The wpcomsh function is actually `\Private_Site\site_is_private()`, so the Phan issue is real.
+
+

--- a/projects/packages/masterbar/changelog/fix-wpcomsh-phan-stuff#2
+++ b/projects/packages/masterbar/changelog/fix-wpcomsh-phan-stuff#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Remove Phan suppression for `site_is_private()`. The wpcomsh function is actually `\Private_Site\site_is_private()`, so the Phan issue is real.
-
-

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.2.0",
+	"version": "0.2.1-alpha",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -40,7 +40,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		add_action(
 			'admin_menu',
 			function () {
-				// @phan-suppress-next-line PhanUndeclaredFunctionInCallable -- This is temp, pending pf4qpu-nc-p2
+				// @phan-suppress-next-line PhanUndeclaredFunctionInCallable -- Not worth bringing in a stub just for a callback in a remove_action call.
 				remove_action( 'admin_menu', 'gutenberg_menu', 9 );
 			},
 			0
@@ -257,7 +257,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$badge .= '<span class="site__badge site__badge-staging">' . esc_html__( 'Staging', 'jetpack-masterbar' ) . '</span>';
 		}
 
-		// @phan-suppress-next-line PhanUndeclaredFunction -- This is temp, pending pf4qpu-nc-p2
 		if ( ( function_exists( 'site_is_private' ) && site_is_private() ) || $is_coming_soon ) {
 			$badge .= sprintf(
 				'<span class="site__badge site__badge-private">%s</span>',

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -257,7 +257,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$badge .= '<span class="site__badge site__badge-staging">' . esc_html__( 'Staging', 'jetpack-masterbar' ) . '</span>';
 		}
 
-		// @phan-suppress-next-line PhanUndeclaredFunction -- This is temp, pending pf4qpu-nc-p2
 		if ( ( function_exists( '\Private_Site\site_is_private' ) && \Private_Site\site_is_private() ) || $is_coming_soon ) {
 			$badge .= sprintf(
 				'<span class="site__badge site__badge-private">%s</span>',

--- a/projects/packages/masterbar/src/admin-menu/load.php
+++ b/projects/packages/masterbar/src/admin-menu/load.php
@@ -83,7 +83,6 @@ function get_admin_menu_class() {
 
 		// DIFM Lite In Progress Atomic Sites. Uses the same menu used for domain-only sites.
 		// Ignore this check if we are in a support session.
-		// @phan-suppress-next-line PhanUndeclaredFunction -- This is temp, pending pf4qpu-nc-p2
 		$is_difm_lite_in_progress = wpcomsh_is_site_sticker_active( 'difm-lite-in-progress' );
 		$is_support_session       = defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION;
 		if ( $is_difm_lite_in_progress && ! $is_support_session ) {

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.2.0';
+	const PACKAGE_VERSION = '0.2.1-alpha';
 
 	/**
 	 * Initializer.

--- a/projects/packages/my-jetpack/.phan/baseline.php
+++ b/projects/packages/my-jetpack/.phan/baseline.php
@@ -25,7 +25,6 @@ return [
     // PhanRedundantCondition : 1 occurrence
     // PhanTypeMismatchArgumentInternal : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
-    // PhanUndeclaredStaticProperty : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
@@ -58,7 +57,6 @@ return [
         'src/products/class-videopress.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
         'tests/php/test-backup-product.php' => ['PhanTypeMismatchArgumentNullable'],
         'tests/php/test-hybrid-product.php' => ['PhanTypeMismatchArgumentNullable'],
-        'tests/php/test-module-product.php' => ['PhanUndeclaredStaticProperty'],
         'tests/php/test-product-multiple-filenames.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
         'tests/php/test-products.php' => ['PhanNonClassMethodCall'],
         'tests/php/test-search-product.php' => ['PhanTypeMismatchArgumentNullable'],

--- a/projects/packages/my-jetpack/changelog/fix-wpcomsh-phan-stuff
+++ b/projects/packages/my-jetpack/changelog/fix-wpcomsh-phan-stuff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Suppress a Phan false positive in a test.
+
+

--- a/projects/packages/my-jetpack/tests/php/test-module-product.php
+++ b/projects/packages/my-jetpack/tests/php/test-module-product.php
@@ -117,6 +117,7 @@ class Test_Module_Product extends TestCase {
 	 */
 	public function test_return_error_on_activation_failure() {
 		activate_plugins( 'jetpack/jetpack.php' );
+		// @phan-suppress-next-line PhanUndeclaredStaticProperty -- It's declared on the mock from ./assets/jetpack-mock-plugin.txt
 		\Jetpack::$return_false = true;
 		$this->assertTrue( is_wp_error( Sample_Module_Product::activate() ) );
 

--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -9,10 +9,9 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 10+ occurrences
     // PhanDeprecatedFunction : 9 occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 9 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 7 occurrences
+    // PhanTypeMismatchArgument : 7 occurrences
     // PhanTypeMismatchArgumentNullable : 3 occurrences
     // PhanPluginMixedKeyNoKey : 2 occurrences
     // PhanPossiblyUndeclaredVariable : 2 occurrences
@@ -24,6 +23,7 @@ return [
     // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanSuspiciousMagicConstant : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
+    // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
     // PhanTypeMismatchDefault : 1 occurrence
     // PhanTypeMismatchDimFetch : 1 occurrence
     // PhanTypeMismatchReturn : 1 occurrence
@@ -32,11 +32,11 @@ return [
     'file_suppressions' => [
         'src/auto-conversion-settings/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/class-connections-post-field.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
-        'src/class-keyring-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault'],
+        'src/class-keyring-helper.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault'],
         'src/class-publicize-base.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn'],
         'src/class-publicize-setup.php' => ['PhanTypeMismatchArgument'],
         'src/class-publicize-ui.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn'],
+        'src/class-publicize.php' => ['PhanParamSignatureMismatch', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMissingReturn'],
         'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'src/social-image-generator/class-post-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/social-image-generator/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],

--- a/projects/packages/publicize/changelog/fix-wpcomsh-phan-stuff
+++ b/projects/packages/publicize/changelog/fix-wpcomsh-phan-stuff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update Phan stubs. No change to functionality.
+
+

--- a/projects/packages/sync/.phan/baseline.php
+++ b/projects/packages/sync/.phan/baseline.php
@@ -9,13 +9,13 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 40+ occurrences
+    // PhanTypeMismatchArgument : 35+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 35+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 30+ occurrences
     // PhanTypeMismatchReturn : 20+ occurrences
     // PhanUndeclaredProperty : 20+ occurrences
     // PhanParamSignatureMismatch : 15+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 15+ occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 10+ occurrences
     // PhanPluginSimplifyExpressionBool : 9 occurrences
     // PhanPossiblyUndeclaredVariable : 8 occurrences
     // PhanPluginDuplicateSwitchCaseLooseEquality : 6 occurrences
@@ -47,7 +47,7 @@ return [
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-actions.php' => ['PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal'],
+        'src/class-actions.php' => ['PhanPluginSimplifyExpressionBool', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentInternal'],
         'src/class-data-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-dedicated-sender.php' => ['PhanTypeInvalidLeftOperandOfNumericOp'],
         'src/class-functions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset'],

--- a/projects/packages/sync/changelog/fix-wpcomsh-phan-stuff
+++ b/projects/packages/sync/changelog/fix-wpcomsh-phan-stuff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update Phan stubs. No change to functionality.
+
+

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.1.2';
+	const PACKAGE_VERSION = '3.1.3-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/waf/.phan/baseline.php
+++ b/projects/packages/waf/.phan/baseline.php
@@ -9,10 +9,9 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 10+ occurrences
     // PhanDeprecatedFunction : 9 occurrences
+    // PhanTypeMismatchArgument : 9 occurrences
     // PhanNoopNew : 6 occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 5 occurrences
     // PhanTypeMismatchDefault : 5 occurrences
     // PhanTypeMismatchReturn : 5 occurrences
     // PhanTypeMismatchReturnProbablyReal : 5 occurrences
@@ -20,6 +19,7 @@ return [
     // PhanPluginDuplicateConditionalNullCoalescing : 4 occurrences
     // PhanRedefineFunction : 4 occurrences
     // PhanTypeMismatchArgumentInternal : 4 occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 4 occurrences
     // PhanPluginRedundantAssignment : 2 occurrences
     // PhanStaticCallToNonStatic : 2 occurrences
     // PhanTypeArraySuspiciousNullable : 2 occurrences
@@ -40,7 +40,7 @@ return [
         'src/brute-force-protection/class-blocked-login-page.php' => ['PhanNonClassMethodCall', 'PhanTypeExpectedObjectPropAccess', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault'],
         'src/brute-force-protection/class-math-fallback.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturnProbablyReal'],
         'src/brute-force-protection/class-shared-functions.php' => ['PhanTypeComparisonToArray', 'PhanTypeMismatchReturnProbablyReal'],
-        'src/class-brute-force-protection.php' => ['PhanNoopNew', 'PhanStaticCallToNonStatic', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn'],
+        'src/class-brute-force-protection.php' => ['PhanNoopNew', 'PhanStaticCallToNonStatic', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturn'],
         'src/class-compatibility.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullableInternal'],
         'src/class-waf-constants.php' => ['PhanCoalescingNeverNull', 'PhanUndeclaredConstant'],
         'src/class-waf-operators.php' => ['PhanTypeMismatchReturn'],

--- a/projects/packages/waf/changelog/fix-wpcomsh-phan-stuff
+++ b/projects/packages/waf/changelog/fix-wpcomsh-phan-stuff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update Phan stubs. No change to functionality.
+
+

--- a/projects/packages/woocommerce-analytics/.phan/baseline.php
+++ b/projects/packages/woocommerce-analytics/.phan/baseline.php
@@ -10,7 +10,6 @@
 return [
     // # Issue statistics:
     // PhanPluginRedundantAssignment : 4 occurrences
-    // PhanUndeclaredFunction : 4 occurrences
     // PhanTypeSuspiciousNonTraversableForeach : 1 occurrence
     // PhanUndeclaredMethod : 1 occurrence
     // PhanUndeclaredMethodInCallable : 1 occurrence
@@ -19,7 +18,7 @@ return [
     'file_suppressions' => [
         'src/class-checkout-flow.php' => ['PhanPluginRedundantAssignment'],
         'src/class-universal.php' => ['PhanPluginRedundantAssignment', 'PhanUndeclaredMethodInCallable'],
-        'src/class-woo-analytics-trait.php' => ['PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod'],
+        'src/class-woo-analytics-trait.php' => ['PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredMethod'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/woocommerce-analytics/changelog/fix-wpcomsh-phan-stuff
+++ b/projects/packages/woocommerce-analytics/changelog/fix-wpcomsh-phan-stuff
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove use of `gutenberg_get_block_template()`. Its replacement has been in WP Core since 5.8.

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -204,19 +204,6 @@ trait Woo_Analytics_Trait {
 			}
 		}
 
-		if ( function_exists( 'gutenberg_get_block_template' ) ) {
-			$checkout_template = gutenberg_get_block_template( 'woocommerce/woocommerce//page-checkout' );
-			$cart_template     = gutenberg_get_block_template( 'woocommerce/woocommerce//page-cart' );
-
-			if ( ! $checkout_template ) {
-				$checkout_template = gutenberg_get_block_template( 'woocommerce/woocommerce//checkout' );
-			}
-
-			if ( ! $cart_template ) {
-				$cart_template = gutenberg_get_block_template( 'woocommerce/woocommerce//cart' );
-			}
-		}
-
 		if ( ! empty( $checkout_template->content ) ) {
 			// Checkout template is in use, but we need to see if the page-content-wrapper is in use, or if the template is being used directly.
 			$this->checkout_content_source = $checkout_template->content;

--- a/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
+++ b/projects/packages/woocommerce-analytics/src/class-woocommerce-analytics.php
@@ -20,7 +20,7 @@ class Woocommerce_Analytics {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.1.6';
+	const PACKAGE_VERSION = '0.1.7-alpha';
 
 	/**
 	 * Initializer.

--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -9,9 +9,9 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 480+ occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 290+ occurrences
+    // PhanTypeMismatchArgument : 470+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 280+ occurrences
+    // PhanTypeMismatchArgumentProbablyReal : 270+ occurrences
     // PhanNoopNew : 200+ occurrences
     // PhanTypeMismatchReturn : 150+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 140+ occurrences
@@ -36,7 +36,6 @@ return [
     // PhanDeprecatedProperty : 20+ occurrences
     // PhanTypeArraySuspicious : 20+ occurrences
     // PhanTypeMismatchDimFetch : 20+ occurrences
-    // PhanUndeclaredFunction : 20+ occurrences
     // PhanPluginDuplicateExpressionAssignmentOperation : 15+ occurrences
     // PhanPluginMixedKeyNoKey : 15+ occurrences
     // PhanRedefineFunction : 15+ occurrences
@@ -50,6 +49,7 @@ return [
     // PhanTypeInvalidLeftOperandOfNumericOp : 10+ occurrences
     // PhanTypeMismatchProperty : 10+ occurrences
     // PhanTypeMismatchReturnNullable : 10+ occurrences
+    // PhanUndeclaredFunction : 10+ occurrences
     // PhanTypeComparisonToArray : 9 occurrences
     // PhanDeprecatedClass : 8 occurrences
     // PhanPluginRedundantAssignment : 8 occurrences
@@ -126,8 +126,8 @@ return [
         '_inc/lib/class-jetpack-recommendations.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition'],
         '_inc/lib/class-jetpack-top-posts-helper.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         '_inc/lib/class.color.php' => ['PhanImpossibleTypeComparison', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanPluginSimplifyExpressionBool', 'PhanPossiblyUndeclaredVariable', 'PhanTypeInvalidDimOffset', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeInvalidRightOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDefault'],
-        '_inc/lib/class.core-rest-api-endpoints.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod'],
-        '_inc/lib/class.jetpack-keyring-service-helper.php' => ['PhanEmptyForeach', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanUndeclaredMethod'],
+        '_inc/lib/class.core-rest-api-endpoints.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod'],
+        '_inc/lib/class.jetpack-keyring-service-helper.php' => ['PhanEmptyForeach', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanUndeclaredMethod'],
         '_inc/lib/class.jetpack-password-checker.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal'],
         '_inc/lib/class.media-extractor.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateExpressionAssignmentOperation', 'PhanTypeMismatchDefault', 'PhanTypePossiblyInvalidDimOffset'],
         '_inc/lib/class.media-summary.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanRedundantCondition', 'PhanTypeArraySuspiciousNull', 'PhanTypeMismatchArgument'],
@@ -136,7 +136,6 @@ return [
         '_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php' => ['PhanNonClassMethodCall', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchDimFetch', 'PhanTypeMismatchReturn', 'PhanUndeclaredConstant'],
         '_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php' => ['PhanTypeMismatchReturn'],
         '_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php' => ['PhanTypeMismatchReturn'],
-        '_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php' => ['PhanPluginMixedKeyNoKey', 'PhanPluginSimplifyExpressionBool'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgument'],
         '_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-blog-stats.php' => ['PhanTypeMismatchReturnProbablyReal'],
@@ -171,9 +170,9 @@ return [
         'class-jetpack-gallery-settings.php' => ['PhanNoopNew'],
         'class-jetpack-pre-connection-jitms.php' => ['PhanTypeMismatchArgument'],
         'class-jetpack-xmlrpc-methods.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition'],
-        'class.frame-nonce-preview.php' => ['PhanParamTooMany', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
+        'class.frame-nonce-preview.php' => ['PhanParamTooMany'],
         'class.jetpack-admin.php' => ['PhanPluginMixedKeyNoKey', 'PhanTypeMismatchArgumentProbablyReal'],
-        'class.jetpack-autoupdate.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
+        'class.jetpack-autoupdate.php' => ['PhanTypeMismatchArgument'],
         'class.jetpack-cli.php' => ['PhanAccessMethodInternal', 'PhanParamTooMany', 'PhanParamTooManyCallable', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn'],
         'class.jetpack-gutenberg.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeSuspiciousStringExpression'],
         'class.jetpack-heartbeat.php' => ['PhanTypeMismatchPropertyDefault'],
@@ -217,7 +216,7 @@ return [
         'extensions/blocks/simple-payments/simple-payments.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/slideshow/slideshow.php' => ['PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/story/story.php' => ['PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable'],
-        'extensions/blocks/subscriptions/subscriptions.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],
+        'extensions/blocks/subscriptions/subscriptions.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/top-posts/top-posts.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/wordads/wordads.php' => ['PhanNonClassMethodCall', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeMismatchArgument'],
         'extensions/plugins/sharing/sharing.php' => ['PhanRedundantCondition'],
@@ -364,16 +363,15 @@ return [
         'modules/masterbar/admin-menu/class-jetpack-admin-menu.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'modules/masterbar/admin-menu/class-p2-admin-menu.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'modules/masterbar/admin-menu/class-wpcom-admin-menu.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn'],
-        'modules/masterbar/admin-menu/load.php' => ['PhanUndeclaredFunction'],
         'modules/masterbar/inline-help/class-inline-help.php' => ['PhanTypeSuspiciousEcho'],
         'modules/masterbar/masterbar/class-masterbar.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'modules/masterbar/profile-edit/bootstrap.php' => ['PhanNoopNew'],
         'modules/memberships/class-jetpack-memberships.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
         'modules/module-headings.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
-        'modules/monitor.php' => ['PhanNoopNew', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
+        'modules/monitor.php' => ['PhanNoopNew', 'PhanTypeMismatchReturnProbablyReal'],
         'modules/photon-cdn.php' => ['PhanTypeMismatchArgument'],
         'modules/plugin-search.php' => ['PhanTypePossiblyInvalidDimOffset'],
-        'modules/post-by-email/class-jetpack-post-by-email.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethodInCallable'],
+        'modules/post-by-email/class-jetpack-post-by-email.php' => ['PhanUndeclaredMethodInCallable'],
         'modules/publicize.php' => ['PhanNoopNew', 'PhanPluginSimplifyExpressionBool', 'PhanRedefineFunction'],
         'modules/related-posts/class.related-posts-customize.php' => ['PhanNoopNew', 'PhanPluginDuplicateConditionalNullCoalescing'],
         'modules/related-posts/jetpack-related-posts.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginSimplifyExpressionBool', 'PhanTypeInvalidLeftOperandOfNumericOp', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousStringExpression', 'PhanUndeclaredFunction'],
@@ -440,7 +438,7 @@ return [
         'modules/stats.php' => ['PhanDeprecatedFunction', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanSuspiciousMagicConstant', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn'],
         'modules/subscriptions.php' => ['PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach'],
         'modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php' => ['PhanTypeMismatchReturnNullable'],
-        'modules/subscriptions/views.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMissingReturn', 'PhanTypePossiblyInvalidDimOffset'],
+        'modules/subscriptions/views.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanPossiblyUndeclaredVariable', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMissingReturn', 'PhanTypePossiblyInvalidDimOffset'],
         'modules/theme-tools/compat/twentyfifteen.php' => ['PhanRedefineFunction'],
         'modules/theme-tools/compat/twentyfourteen.php' => ['PhanRedefineFunction'],
         'modules/theme-tools/compat/twentynineteen.php' => ['PhanRedefineFunction'],
@@ -508,7 +506,7 @@ return [
         'modules/woocommerce-analytics/class-jetpack-woocommerce-analytics.php' => ['PhanDeprecatedClass', 'PhanDeprecatedFunction', 'PhanStaticPropIsStaticType', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal'],
         'modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-checkout-flow.php' => ['PhanDeprecatedFunction', 'PhanDeprecatedTrait', 'PhanPluginRedundantAssignment'],
         'modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-my-account.php' => ['PhanDeprecatedFunction', 'PhanDeprecatedTrait'],
-        'modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php' => ['PhanDeprecatedFunction', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod'],
+        'modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php' => ['PhanDeprecatedFunction', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredMethod'],
         'modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-universal.php' => ['PhanDeprecatedFunction', 'PhanDeprecatedTrait', 'PhanPluginRedundantAssignment'],
         'modules/wordads/class-wordads.php' => ['PhanNonClassMethodCall', 'PhanPluginRedundantAssignment', 'PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyProbablyReal'],
         'modules/wordads/php/class-wordads-admin.php' => ['PhanTypeMismatchArgumentProbablyReal'],
@@ -516,11 +514,10 @@ return [
         'modules/wordads/php/class-wordads-params.php' => ['PhanTypeMismatchReturn'],
         'modules/wordads/php/class-wordads-sidebar-widget.php' => ['PhanTypeExpectedObjectPropAccessButGotNull', 'PhanTypeMismatchArgument'],
         'modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php' => ['PhanDeprecatedClass', 'PhanDeprecatedFunction', 'PhanPluginUseReturnValueInternalKnown'],
-        'modules/wpcom-block-editor/functions.editor-type.php' => ['PhanUndeclaredFunction'],
         'sal/class.json-api-date.php' => ['PhanPluginDuplicateExpressionAssignmentOperation', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentInternalProbablyReal'],
         'sal/class.json-api-links.php' => ['PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'sal/class.json-api-post-base.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnNullable', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypePossiblyInvalidDimOffset', 'PhanTypeSuspiciousNonTraversableForeach'],
-        'sal/class.json-api-site-base.php' => ['PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredFunction'],
+        'sal/class.json-api-site-base.php' => ['PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchReturnProbablyReal'],
         'sal/class.json-api-site-jetpack-base.php' => ['PhanRedundantCondition', 'PhanTypeMismatchReturnProbablyReal'],
         'sal/class.json-api-site-jetpack.php' => ['PhanParamSignatureMismatch'],
         'sal/class.json-api-token.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgumentProbablyReal'],

--- a/projects/plugins/jetpack/.phan/config.php
+++ b/projects/plugins/jetpack/.phan/config.php
@@ -36,6 +36,7 @@ return make_phan_config(
 			// DO NOT add references to files in packages like this! Packages should be listed in composer.json 'require',
 			// or 'require-dev' if they're only needed in tests or build scripts.
 			__DIR__ . '/../../../plugins/vaultpress/vaultpress.php',                  // class VaultPress
+			__DIR__ . '/../../../plugins/wpcomsh/feature-plugins/masterbar.php',      // function wpcomsh_is_site_sticker_active
 			__DIR__ . '/../../../plugins/crm/includes/ZeroBSCRM.Core.Extensions.php', // functions zeroBSCRM_isExtensionInstalled, zeroBSCRM_extension_install_jetpackforms
 
 			// Make an exception to the above for packages/jetpack-mu-wpcom. Pulling in that whole package here seems more risky than beneficial.

--- a/projects/plugins/jetpack/changelog/fix-wpcomsh-phan-stuff
+++ b/projects/plugins/jetpack/changelog/fix-wpcomsh-phan-stuff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Phan: Add reference to a wpcom file for stubbing.
+
+

--- a/projects/plugins/jetpack/changelog/fix-wpcomsh-phan-stuff#2
+++ b/projects/plugins/jetpack/changelog/fix-wpcomsh-phan-stuff#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove use of `gutenberg_get_block_template()`. Its replacement has been in WP Core since 5.8.

--- a/projects/plugins/jetpack/changelog/fix-wpcomsh-phan-stuff#3
+++ b/projects/plugins/jetpack/changelog/fix-wpcomsh-phan-stuff#3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove use of `gutenberg_can_edit_post_type()`. Its replacement has been in WP Core since 6.1.

--- a/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
+++ b/projects/plugins/jetpack/modules/woocommerce-analytics/classes/class-jetpack-woocommerce-analytics-trait.php
@@ -214,19 +214,6 @@ trait Jetpack_WooCommerce_Analytics_Trait {
 			}
 		}
 
-		if ( function_exists( 'gutenberg_get_block_template' ) ) {
-			$checkout_template = gutenberg_get_block_template( 'woocommerce/woocommerce//page-checkout' );
-			$cart_template     = gutenberg_get_block_template( 'woocommerce/woocommerce//page-cart' );
-
-			if ( ! $checkout_template ) {
-				$checkout_template = gutenberg_get_block_template( 'woocommerce/woocommerce//checkout' );
-			}
-
-			if ( ! $cart_template ) {
-				$cart_template = gutenberg_get_block_template( 'woocommerce/woocommerce//cart' );
-			}
-		}
-
 		if ( ! empty( $checkout_template->content ) ) {
 			// Checkout template is in use, but we need to see if the page-content-wrapper is in use, or if the template is being used directly.
 			$this->checkout_content_source = $checkout_template->content;

--- a/projects/plugins/jetpack/modules/wpcom-block-editor/functions.editor-type.php
+++ b/projects/plugins/jetpack/modules/wpcom-block-editor/functions.editor-type.php
@@ -68,13 +68,5 @@ function remember_editor( $post_id, $editor ) {
  * @return bool              Whether the block editor can be used to edit the supplied post type.
  */
 function can_edit_post_type( $post_type ) {
-	$can_edit = false;
-
-	if ( function_exists( 'gutenberg_can_edit_post_type' ) ) {
-		$can_edit = gutenberg_can_edit_post_type( $post_type );
-	} elseif ( function_exists( 'use_block_editor_for_post_type' ) ) {
-		$can_edit = use_block_editor_for_post_type( $post_type );
-	}
-
-	return $can_edit;
+	return use_block_editor_for_post_type( $post_type );
 }

--- a/projects/plugins/wpcomsh/.phan/baseline.php
+++ b/projects/plugins/wpcomsh/.phan/baseline.php
@@ -10,34 +10,29 @@
 return [
     // # Issue statistics:
     // PhanPluginMixedKeyNoKey : 25+ occurrences
-    // PhanUndeclaredFunction : 20+ occurrences
-    // PhanUndeclaredClassMethod : 15+ occurrences
     // PhanUndeclaredStaticMethod : 15+ occurrences
-    // PhanUndeclaredFunctionInCallable : 10+ occurrences
     // PhanTypeVoidAssignment : 8 occurrences
-    // PhanUndeclaredClassProperty : 7 occurrences
     // PhanRedundantCondition : 6 occurrences
     // PhanTypeMismatchArgument : 6 occurrences
     // PhanTypeMismatchArgumentNullable : 5 occurrences
     // PhanUndeclaredConstant : 5 occurrences
     // PhanTypeSuspiciousEcho : 4 occurrences
-    // PhanUndeclaredClassInCallable : 4 occurrences
-    // PhanUndeclaredTypeParameter : 4 occurrences
     // PhanImpossibleCondition : 3 occurrences
     // PhanTypeArraySuspiciousNullable : 3 occurrences
+    // PhanUndeclaredClassMethod : 3 occurrences
+    // PhanUndeclaredFunctionInCallable : 3 occurrences
     // PhanNoopNew : 2 occurrences
-    // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
     // PhanTypeVoidArgument : 2 occurrences
-    // PhanUndeclaredClassInstanceof : 2 occurrences
-    // PhanUndeclaredClassReference : 2 occurrences
-    // PhanUndeclaredVariable : 2 occurrences
+    // PhanUndeclaredProperty : 2 occurrences
     // PhanContextNotObject : 1 occurrence
+    // PhanDeprecatedFunction : 1 occurrence
     // PhanDeprecatedProperty : 1 occurrence
     // PhanNoopNewNoSideEffects : 1 occurrence
     // PhanPluginRedundantAssignment : 1 occurrence
     // PhanPluginUseReturnValueInternalKnown : 1 occurrence
     // PhanPossiblyUndeclaredVariable : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
+    // PhanTypeMismatchArgumentProbablyReal : 1 occurrence
     // PhanTypeObjectUnsetDeclaredProperty : 1 occurrence
     // PhanUndeclaredClassConstant : 1 occurrence
     // PhanUndeclaredClassStaticProperty : 1 occurrence
@@ -45,13 +40,11 @@ return [
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'block-theme-footer-credits/class-wpcom-block-theme-footer-credits.php' => ['PhanUndeclaredFunction'],
-        'class-jetpack-plugin-compatibility.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference'],
-        'class-wpcomsh-cli-commands.php' => ['PhanTypeVoidAssignment', 'PhanUndeclaredClassInCallable', 'PhanUndeclaredFunctionInCallable'],
+        'class-wpcomsh-cli-commands.php' => ['PhanTypeVoidAssignment'],
         'custom-colors/class-palette.php' => ['PhanTypeArraySuspiciousNullable'],
         'custom-colors/colors-api.php' => ['PhanNoopNewNoSideEffects'],
-        'custom-colors/colors.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredVariable'],
-        'custom-colors/core-bg-admin-notice.php' => ['PhanContextNotObject', 'PhanUndeclaredClassMethod'],
+        'custom-colors/colors.php' => ['PhanTypeMismatchArgumentNullable'],
+        'custom-colors/core-bg-admin-notice.php' => ['PhanContextNotObject'],
         'endpoints/class-marketplace-webhook-response.php' => ['PhanPluginMixedKeyNoKey'],
         'endpoints/rest-api-export.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'feature-plugins/autosave-revision.php' => ['PhanPluginRedundantAssignment', 'PhanTypeMismatchArgumentNullable'],
@@ -59,14 +52,11 @@ return [
         'feature-plugins/gutenberg-mods.php' => ['PhanUndeclaredFunctionInCallable'],
         'feature-plugins/managed-plugins.php' => ['PhanRedundantCondition', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunctionInCallable'],
         'feature-plugins/sensei-pro-mods.php' => ['PhanUndeclaredClassMethod'],
-        'footer-credit/theme-optimizations.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredConstant', 'PhanUndeclaredFunction'],
-        'frontend-notices/gifting-banner/gifting-banner.php' => ['PhanUndeclaredFunction'],
+        'footer-credit/theme-optimizations.php' => ['PhanUndeclaredConstant', 'PhanUndeclaredStaticMethod'],
         'functions.php' => ['PhanImpossibleCondition', 'PhanUndeclaredClassStaticProperty'],
-        'i18n.php' => ['PhanUndeclaredFunction'],
         'imports/playground/class-sql-importer.php' => ['PhanUndeclaredConstant'],
-        'logo-tool/logo-tool.php' => ['PhanTypeMismatchArgumentNullableInternal', 'PhanUndeclaredFunction'],
+        'logo-tool/logo-tool.php' => ['PhanTypeMismatchArgumentNullableInternal'],
         'notices/plan-notices.php' => ['PhanImpossibleCondition'],
-        'plugin-hotfixes.php' => ['PhanUndeclaredFunctionInCallable'],
         'private-site/access-denied-coming-soon-template.php' => ['PhanTypeSuspiciousEcho'],
         'private-site/access-denied-preview-login-template.php' => ['PhanTypeSuspiciousEcho'],
         'private-site/access-denied-private-site-template.php' => ['PhanTypeSuspiciousEcho'],
@@ -81,11 +71,9 @@ return [
         'tests/test-wpcom-features.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredStaticMethod'],
         'widgets/class-jetpack-posts-i-like-widget.php' => ['PhanRedundantCondition'],
         'widgets/class-pd-top-rated.php' => ['PhanRedundantCondition'],
-        'widgets/class-widget-top-clicks.php' => ['PhanUndeclaredFunction'],
-        'woa.php' => ['PhanUndeclaredClassMethod'],
+        'widgets/class-widget-top-clicks.php' => ['PhanDeprecatedFunction'],
         'wpcom-features/class-wpcom-features.php' => ['PhanPluginMixedKeyNoKey'],
-        'wpcom-features/functions-wpcom-features.php' => ['PhanImpossibleCondition', 'PhanTypeMismatchArgument', 'PhanUndeclaredClassInstanceof', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassProperty', 'PhanUndeclaredFunction', 'PhanUndeclaredMethod', 'PhanUndeclaredTypeParameter'],
-        'wpcomsh.php' => ['PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredFunctionInCallable'],
+        'wpcom-features/functions-wpcom-features.php' => ['PhanImpossibleCondition', 'PhanTypeMismatchArgument', 'PhanUndeclaredMethod', 'PhanUndeclaredProperty'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/plugins/wpcomsh/.phan/config.php
+++ b/projects/plugins/wpcomsh/.phan/config.php
@@ -32,8 +32,11 @@ return make_phan_config(
 			__DIR__ . '/../../../plugins/jetpack/jetpack.php',
 			// photon-cdn.php provides the definition of the Jetpack_Photon_Static_Assets_CDN.
 			__DIR__ . '/../../../plugins/jetpack/modules/photon-cdn.php',
+			__DIR__ . '/../../../plugins/jetpack/functions.is-mobile.php',  // function jetpack_is_mobile
+			__DIR__ . '/../../../plugins/jetpack/modules/stats.php',        // function stats_get_from_restapi
+			__DIR__ . '/../../../plugins/jetpack/functions.compat.php',     // function wp_startswith
 		),
 		'php_extensions_needed' => array( 'sqlite3', 'zip' ),
-		'+stubs'                => array( 'woocommerce' ),
+		'+stubs'                => array( 'woocommerce', 'woopayments', 'wpcom' ),
 	)
 );

--- a/projects/plugins/wpcomsh/.phan/stubs/atomic.php
+++ b/projects/plugins/wpcomsh/.phan/stubs/atomic.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Stubs for Atomic platform custom code
+ *
+ * Manually updated.
+ */
+
+final class Atomic_Platform_Mu_Plugin {
+	function __construct() {
+	}
+	/**
+	 * @return array<string,string>
+	 */
+	function get_disallowed_plugins() {
+	}
+	/**
+	 * @param string $plugin_file
+	 * @return bool
+	 */
+	static function is_managed_plugin( $plugin_file ) {
+	}
+}
+class Atomic_Platform_Managed_Software_Commands {
+	public static function use_managed_plugin( $args, $assoc_args = array() ) {
+	}
+	public static function use_unmanaged_plugin( $args, $assoc_args = array() ) {
+	}
+	public static function use_managed_theme( $args, $assoc_args = array() ) {
+	}
+	public static function use_unmanaged_theme( $args, $assoc_args = array() ) {
+	}
+}

--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-phan-stuff
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-phan-stuff
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Phan: Add stubs for WooPayments and some Atomic classes. Use wpcom stubs. Add some Jetpack files for stubbing too.
+
+

--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-phan-stuff#2
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-phan-stuff#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Custom Colors: Remove a use of `extract()`.

--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-phan-stuff#3
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-phan-stuff#3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Plugin hotfixes: Remove a hotfix for an issue fixed in Gutenberg 15.3.0.

--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-phan-stuff#4
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-phan-stuff#4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Switch from Jetpack-the-plugin's `Jetpack_WPCOM_Block_Editor` class to jetpack-mu-wpcom's namespaced version.

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -1176,7 +1176,9 @@ WP_CLI::add_wp_hook(
 add_action( 'deactivated_plugin', 'wpcomsh_cli_remember_plugin_deactivation' );
 add_action( 'activated_plugin', 'wpcomsh_cli_forget_plugin_deactivation' );
 
+// @phan-suppress-next-line PhanUndeclaredFunctionInCallable -- https://github.com/phan/phan/issues/4763
 WP_CLI::add_command( 'wpcomsh', 'WPCOMSH_CLI_Commands' );
+// @phan-suppress-next-line PhanUndeclaredFunctionInCallable -- https://github.com/phan/phan/issues/4763
 WP_CLI::add_command( 'wpcomsh plugin verify-checksums', 'Checksum_Plugin_Command_WPCOMSH' );
 WP_CLI::add_command( 'plugin symlink', 'wpcomsh_cli_plugin_symlink' );
 WP_CLI::add_command( 'theme symlink', 'wpcomsh_cli_theme_symlink' );

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -964,14 +964,14 @@ class Colors_Manager_Common {
 			'image' => false,
 		);
 
-		$args = wp_parse_args( $args, $defaults );
-		extract( $args, EXTR_SKIP ); // phpcs:ignore
+		$args  = wp_parse_args( $args, $defaults );
+		$image = $args['image'] ?? '';
 
-		if ( ! $image ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- extract adds this to the scope.
+		if ( ! $image ) {
 			return array();
 		}
 
-		$tonesque = new Tonesque( $image ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+		$tonesque = new Tonesque( $image );
 		$points   = $tonesque->grab_points( 'hex' );
 
 		$roles = self::get_color_slots();

--- a/projects/plugins/wpcomsh/plugin-hotfixes.php
+++ b/projects/plugins/wpcomsh/plugin-hotfixes.php
@@ -101,18 +101,3 @@ add_action(
 		</style>';
 	}
 );
-
-/**
- * Fixes an infinite redirect bug when trying to access the Site Editor
- * Gutenberg already removed it: https://github.com/WordPress/gutenberg/pull/48283
- *
- * @see https://github.com/Automattic/wp-calypso/issues/74072
- *
- * @todo: remove after Gutenberg 15.3.x lands on WoA
- */
-function wpcomsh_maybe_remove_gutenberg_site_editor_redirect() {
-	if ( has_filter( 'wp_redirect', 'gutenberg_prevent_site_editor_redirection' ) ) {
-		remove_filter( 'wp_redirect', 'gutenberg_prevent_site_editor_redirection', 1 );
-	}
-}
-add_action( 'plugins_loaded', 'wpcomsh_maybe_remove_gutenberg_site_editor_redirect' );

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -515,12 +515,10 @@ function wpcomsh_footer_rum_js() {
 	if ( 'admin_footer' === current_action() ) {
 		$service = 'atomic-wpadmin';
 
-		if ( method_exists( 'Jetpack_WPCOM_Block_Editor', 'init' ) ) {
-			$block_editor = Jetpack_WPCOM_Block_Editor::init();
-			if ( $block_editor->is_iframed_block_editor() ) {
-				$service      = 'atomic-gutenframe';
-				$allow_iframe = 'data-allow-iframe="true"';
-			}
+		$block_editor = \Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Block_Editor\Jetpack_WPCOM_Block_Editor::init();
+		if ( $block_editor->is_iframed_block_editor() ) {
+			$service      = 'atomic-gutenframe';
+			$allow_iframe = 'data-allow-iframe="true"';
 		}
 	}
 
@@ -582,6 +580,7 @@ function wpcomsh_jetpack_filter_tos_for_tracking( $value, $name ) {
  * Avoid proxied v2 banner
  *
  * @return void
+ * @phan-suppress PhanUndeclaredFunctionInCallable -- No point in stubbing `atomic_proxy_bar` just for remove_action().
  */
 function wpcomsh_avoid_proxied_v2_banner() {
 	$priority = has_action( 'wp_footer', 'atomic_proxy_bar' );

--- a/tools/stubs/update-stubs.sh
+++ b/tools/stubs/update-stubs.sh
@@ -107,6 +107,14 @@ info 'Extracting WordPress.com Editing Toolkit stubs'
 "$BASE/projects/packages/stub-generator/bin/jetpack-stub-generator" --output "$BASE/.phan/stubs/full-site-editing-stubs.php" "$BASE/tools/stubs/full-site-editing-stub-defs.php"
 
 echo
+info 'Downloading WooPayments'
+fetch_plugin woocommerce-payments
+
+echo
+info 'Extracting WooPayments stubs'
+"$BASE/projects/packages/stub-generator/bin/jetpack-stub-generator" --output "$BASE/.phan/stubs/woocommerce-payments-stubs.php" "$BASE/tools/stubs/woocommerce-payments-stub-defs.php"
+
+echo
 info 'Downloading WooCommerce'
 fetch_repo woocommerce/woocommerce
 

--- a/tools/stubs/woocommerce-payments-stub-defs.php
+++ b/tools/stubs/woocommerce-payments-stub-defs.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Stub config for WooPayments classes and such needed in the Jetpack monorepo.
+ *
+ * @package automattic/jetpack-monorepo
+ */
+
+// phpcs:disable PHPCompatibility.Syntax.NewFlexibleHeredocNowdoc.ClosingMarkerNoNewLine -- https://github.com/PHPCompatibility/PHPCompatibility/issues/1696
+
+$work_dir = getenv( 'WORK_DIR' );
+if ( ! is_dir( $work_dir ) ) {
+	throw new RuntimeException( 'WORK_DIR is not set or does not refer to a directory' );
+}
+
+$data = file_get_contents( "$work_dir/woocommerce-payments/woocommerce-payments.php" );
+if ( ! preg_match( '/^ \* Version: (\d+\.\d+.*)/m', (string) $data, $m ) ) {
+	throw new RuntimeException( "Failed to extract version from $work_dir/woocommerce-payments/woocommerce-payments.php" );
+}
+$version = $m[1];
+
+return array(
+	'header'  => <<<HEAD
+	/**
+	 * Stubs automatically generated from WooPayments $version
+	 * using the definition file `tools/stubs/woocommerce-payments-stub-defs.php` in the Jetpack monorepo.
+	 *
+	 * Do not edit this directly! Run tools/stubs/update-stubs.sh to regenerate it.
+	 */
+	HEAD,
+	'basedir' => "$work_dir/woocommerce-payments/",
+	'files'   => array(
+		'includes/class-wc-payments-account.php' => array(
+			'class' => array(
+				'WC_Payments_Account' => array(
+					'method' => array( 'clear_cache' ),
+				),
+			),
+		),
+		'includes/class-wc-payments.php'         => array(
+			'class' => array(
+				'WC_Payments' => array(
+					'method' => array(
+						'get_account_service',
+					),
+				),
+			),
+		),
+	),
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Mostly wpcomsh-related stuff this time.

* Fix some phpdocs and suppress some false positives.
* Add a stub file for woocommerce-payments plugin.
* Add a few Phan config 'parse_file_list' for wpcomsh functions.
* Remove some no-longer-needed suppressions.
* Remove some bogus suppressions:
  * ~~Looks like `\site_is_private()` never existed, even in 4237ebca it was `\Private_Site\site_is_private()`.~~ fixed in trunk now
  * Same for `\site_is_coming_soon()` and 263cf530.
* Remove references to some long-gone Gutenberg plugin functions.
  * `gutenberg_can_edit_post_type`, removed in 5.3.0 (2019) and core has had `use_block_editor_for_post_type` in `wp-includes/post.php` since 6.1.
  * `gutenberg_get_block_template`, removed in 15.8.0 (May 2023) and core has had `get_block_template` since 5.8.
* Use 'wpcom' stubs in wpcomsh, and add a manually-curated stub file for some Atomic stuff too.
* wpcomsh: Remove a use of `extract()`.
* wpcomsh: Remove a plugin hotfix that said "remove after Gutenberg 15.3.x lands on WoA", which happened a while ago now.
* wpcomsh: Switch from Jetpack's `Jetpack_WPCOM_Block_Editor` class to jetpack-mu-wpcom's namespaced version.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Stuff still works?