### PR TITLE
Restore Untangle Atomic Classic Users Profile fields

### DIFF
--- a/projects/packages/masterbar/changelog/restore-profile-fields-on-classic
+++ b/projects/packages/masterbar/changelog/restore-profile-fields-on-classic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Profile: Restore profile fields on Classic interface

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.2.0",
+	"version": "0.2.1-alpha",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.2.0';
+	const PACKAGE_VERSION = '0.2.1-alpha';
 
 	/**
 	 * Initializer.

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -29,6 +29,7 @@ class Main {
 
 		$host                    = new Host();
 		$should_use_nav_redesign = function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled();
+		$agency_managed_site     = function_exists( 'is_agency_managed_site' ) && is_agency_managed_site();
 
 		if ( ! $should_use_nav_redesign && ! $host->is_wpcom_simple() ) {
 			new Masterbar();
@@ -42,7 +43,7 @@ class Main {
 			require_once __DIR__ . '/nudges/bootstrap.php';
 		}
 
-		if ( $host->is_woa_site() ) {
+		if ( $host->is_woa_site() && ! ( $should_use_nav_redesign || $agency_managed_site ) ) {
 			require_once __DIR__ . '/profile-edit/bootstrap.php';
 		}
 

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -29,7 +29,6 @@ class Main {
 
 		$host                    = new Host();
 		$should_use_nav_redesign = function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled();
-		$agency_managed_site     = function_exists( 'is_agency_managed_site' ) && is_agency_managed_site();
 
 		if ( ! $should_use_nav_redesign && ! $host->is_wpcom_simple() ) {
 			new Masterbar();
@@ -43,7 +42,7 @@ class Main {
 			require_once __DIR__ . '/nudges/bootstrap.php';
 		}
 
-		if ( $host->is_woa_site() && ! ( $should_use_nav_redesign || $agency_managed_site ) ) {
+		if ( $host->is_woa_site() && ! $should_use_nav_redesign ) {
 			require_once __DIR__ . '/profile-edit/bootstrap.php';
 		}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7895

## Proposed changes:
In Classic sites, we used to show all the Core fields instead of the WPcom related admin notices:
We restore those fields for Classic sites

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/jetpack/assets/402286/bc0c9ed0-0e38-43c9-9334-ce63670586aa) | ![image](https://github.com/Automattic/jetpack/assets/402286/ece7a6fb-3a05-4c79-9be9-4115b1242477) |

## Jetpack product discussion
no

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Go to '/wp-admin/profile.php'
* The profile fields should be editable
* Check if the fields are saved

