### PR TITLE
Backport mu-wpcom-plugin 2.3.0, jetpack 13.6-a.7, wpcomsh 3.24.0 Changes

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.54.1] - 2024-06-24
+### Fixed
+- Updated threads icon color [#37977]
+
 ## [0.54.0] - 2024-06-21
 ### Added
 - Added Chip component [#37916]
@@ -1071,6 +1075,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.54.1]: https://github.com/Automattic/jetpack-components/compare/0.54.0...0.54.1
 [0.54.0]: https://github.com/Automattic/jetpack-components/compare/0.53.10...0.54.0
 [0.53.10]: https://github.com/Automattic/jetpack-components/compare/0.53.9...0.53.10
 [0.53.9]: https://github.com/Automattic/jetpack-components/compare/0.53.8...0.53.9

--- a/projects/js-packages/components/changelog/add-social-threads-connection-ui
+++ b/projects/js-packages/components/changelog/add-social-threads-connection-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Updated threads icon color

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.54.1-alpha",
+	"version": "0.54.1",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.81 - 2024-06-24
+### Changed
+- Update dependencies. [#37979]
+
 ## 0.2.80 - 2024-06-17
 ### Changed
 - Updated package dependencies. [#37796]

--- a/projects/js-packages/partner-coupon/changelog/force-a-release
+++ b/projects/js-packages/partner-coupon/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.81-alpha",
+	"version": "0.2.81",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.54.5] - 2024-06-24
+### Added
+- Added Threads to the social connections services [#37977]
+
+### Fixed
+- Fixed skipped connections id [#37810]
+- Social | Replaced + icon with connections management link in the post editor [#37961]
+
 ## [0.54.4] - 2024-06-17
 ### Fixed
 - Social: Fixed broken connections reconnect link to point it to new connections UI [#37869]
@@ -741,6 +749,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.54.5]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.54.4...v0.54.5
 [0.54.4]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.54.3...v0.54.4
 [0.54.3]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.54.2...v0.54.3
 [0.54.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.54.1...v0.54.2

--- a/projects/js-packages/publicize-components/changelog/add-social-resharing-for-classic-editor
+++ b/projects/js-packages/publicize-components/changelog/add-social-resharing-for-classic-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed skipped connections id

--- a/projects/js-packages/publicize-components/changelog/add-social-threads-connection-ui
+++ b/projects/js-packages/publicize-components/changelog/add-social-threads-connection-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added Threads to the social connections services

--- a/projects/js-packages/publicize-components/changelog/update-social-replace-plus-icon-with-manage-connections-button-in-editor
+++ b/projects/js-packages/publicize-components/changelog/update-social-replace-plus-icon-with-manage-connections-button-in-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Social | Replaced + icon with connections management link in the post editor

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.54.5-alpha",
+	"version": "0.54.5",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/social-logos/CHANGELOG.md
+++ b/projects/js-packages/social-logos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.2] - 2024-06-24
+### Fixed
+- Update logo color for Threads [#37977]
+
 ## [3.1.1] - 2024-06-14
 ### Changed
 - Internal updates.
@@ -125,6 +129,7 @@
 
 - Build: Refactored (aligned build system with Gridicons).
 
+[3.1.2]: https://github.com/Automattic/social-logos/compare/v3.1.1...v3.1.2
 [3.1.1]: https://github.com/Automattic/social-logos/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/Automattic/social-logos/compare/v3.0.2...v3.1.0
 [3.0.2]: https://github.com/Automattic/social-logos/compare/v3.0.1...v3.0.2

--- a/projects/js-packages/social-logos/changelog/add-social-threads-connection-ui
+++ b/projects/js-packages/social-logos/changelog/add-social-threads-connection-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Update logo color for Threads

--- a/projects/js-packages/social-logos/package.json
+++ b/projects/js-packages/social-logos/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "social-logos",
-	"version": "3.1.2-alpha",
+	"version": "3.1.2",
 	"description": "A repository of all the social logos used on WordPress.com.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/social-logos/",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.17] - 2024-06-24
+### Changed
+- Update backup header cards layout for responsive design [#37944]
+
 ## [3.3.16] - 2024-06-17
 ### Changed
 - Updated package dependencies. [#37796]
@@ -644,6 +648,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.3.17]: https://github.com/Automattic/jetpack-backup/compare/v3.3.16...v3.3.17
 [3.3.16]: https://github.com/Automattic/jetpack-backup/compare/v3.3.15...v3.3.16
 [3.3.15]: https://github.com/Automattic/jetpack-backup/compare/v3.3.14...v3.3.15
 [3.3.14]: https://github.com/Automattic/jetpack-backup/compare/v3.3.13...v3.3.14

--- a/projects/packages/backup/changelog/update-backup-admin-cards
+++ b/projects/packages/backup/changelog/update-backup-admin-cards
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update backup header cards layout for responsive design

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.3.17-alpha';
+	const PACKAGE_VERSION = '3.3.17';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/config/CHANGELOG.md
+++ b/projects/packages/config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2024-06-24
+### Changed
+- Internal updates.
+
 ## [2.0.3] - 2024-06-03
 ### Removed
 - Remove the Identity Crisis package dev dependency. [#37654]
@@ -204,6 +208,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Trying to add deterministic initialization.
 
+[2.0.4]: https://github.com/Automattic/jetpack-config/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/Automattic/jetpack-config/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/Automattic/jetpack-config/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-config/compare/v2.0.0...v2.0.1

--- a/projects/packages/config/changelog/remove-ref-to-removed-idc-package
+++ b/projects/packages/config/changelog/remove-ref-to-removed-idc-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove reference to removed identity-crisis package from composer.json `.extra.dependencies.test-only`. No change to functionality.
-
-

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.2] - 2024-06-24
+### Changed
+- Update dependencies. [#37979]
+
 ## [0.32.1] - 2024-06-17
 ### Changed
 - Updated package dependencies. [#37796]
@@ -594,6 +598,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.32.2]: https://github.com/automattic/jetpack-forms/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/automattic/jetpack-forms/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/automattic/jetpack-forms/compare/v0.31.4...v0.32.0
 [0.31.4]: https://github.com/automattic/jetpack-forms/compare/v0.31.3...v0.31.4

--- a/projects/packages/forms/changelog/force-a-release
+++ b/projects/packages/forms/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.32.2-alpha",
+	"version": "0.32.2",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.32.2-alpha';
+	const PACKAGE_VERSION = '0.32.2';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/google-analytics/CHANGELOG.md
+++ b/projects/packages/google-analytics/CHANGELOG.md
@@ -5,8 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2024-06-24
+### Added
+- Add the GA API handling moved from Jetpack. [#37358]
+
 ## 0.1.0 - 2024-05-13
 ### Added
 - Initial version. [#37137]
 - Copy the code from the Jetpack module into the package. [#37184]
 - Migrate unit tests from the Jetpack module. [#37246]
+
+[0.2.0]: https://github.com/Automattic/jetpack-google-analytics/compare/v0.1.0...v0.2.0

--- a/projects/packages/google-analytics/changelog/update-move-google-analytics-apis
+++ b/projects/packages/google-analytics/changelog/update-move-google-analytics-apis
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the GA API handling moved from Jetpack.

--- a/projects/packages/google-analytics/package.json
+++ b/projects/packages/google-analytics/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-google-analytics",
-	"version": "0.2.0-alpha",
+	"version": "0.2.0",
 	"description": "Set up Google Analytics without touching a line of code.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/google-analytics/#readme",
 	"bugs": {

--- a/projects/packages/google-analytics/src/class-ga-manager.php
+++ b/projects/packages/google-analytics/src/class-ga-manager.php
@@ -18,7 +18,7 @@ use WP_Error;
  */
 class GA_Manager {
 
-	const PACKAGE_VERSION = '0.2.0-alpha';
+	const PACKAGE_VERSION = '0.2.0';
 
 	/**
 	 * Jetpack_Google_Analytics singleton instance.
@@ -155,7 +155,7 @@ class GA_Manager {
 		 * Allow newer versions of this endpoint to filter in additional fields for Google Analytics
 		 *
 		 * @since Jetpack 5.4.0
-		 * @since $$next-version$$
+		 * @since 0.2.0
 		 *
 		 * @param array $wga Associative array of existing Google Analytics settings.
 		 * @param array $value Associative array of new Google Analytics settings passed to the endpoint.
@@ -186,7 +186,7 @@ class GA_Manager {
 		 * Fires for each settings update.
 		 *
 		 * @since Jetpack 3.6.0
-		 * @since $$next-version$$
+		 * @since 0.2.0
 		 *
 		 * @param string $action_type Type of settings to track.
 		 * @param string $val The settings value.
@@ -224,7 +224,7 @@ class GA_Manager {
 		 * Filter whether the current site is a Jetpack site.
 		 *
 		 * @since Jetpack 3.3.0
-		 * @since $$next-version$$
+		 * @since 0.2.0
 		 *
 		 * @param bool $is_jetpack Is the current site a Jetpack site. Default to false.
 		 * @param int $blog_id Blog ID.

--- a/projects/packages/google-analytics/src/class-utils.php
+++ b/projects/packages/google-analytics/src/class-utils.php
@@ -99,7 +99,7 @@ class Utils {
 	 * Determine if a string is truthy. If it's not a string, which can happen with
 	 * not well-formed data coming from Jetpack sites, we still consider it a truthy value.
 	 *
-	 * @since $$next-version$$
+	 * @since 0.2.0
 	 *
 	 * @param mixed $value true, 1, "1", "t", and "true" (case insensitive) are truthy, everything else isn't.
 	 * @return bool

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.37.0] - 2024-06-24
+### Added
+- Added is_agency_managed_site function used to hide wpcom items [#37993]
+
 ## [5.36.0] - 2024-06-21
 ### Changed
 - Jetpack MU WPCOM: Added Applebot-Extended to robots.txt disallow. [#37954]
@@ -906,6 +910,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.37.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.36.0...v5.37.0
 [5.36.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.35.4...v5.36.0
 [5.35.4]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.35.3...v5.35.4
 [5.35.3]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.35.2...v5.35.3

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-is_agency_managed_site
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-is_agency_managed_site
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added is_agency_managed_site function used to hide wpcom items

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.37.0-alpha",
+	"version": "5.37.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.37.0-alpha';
+	const PACKAGE_VERSION = '5.37.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.25.3] - 2024-06-24
+### Added
+- Add more default args for tracks events [#37974]
+
 ## [4.25.2] - 2024-06-21
 ### Fixed
 - Remove the need for api requests in broken modules check [#37908]
@@ -1530,6 +1534,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.25.3]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.25.2...4.25.3
 [4.25.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.25.1...4.25.2
 [4.25.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.25.0...4.25.1
 [4.25.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.24.7...4.25.0

--- a/projects/packages/my-jetpack/changelog/add-default-tracks-to-my-jetpack-events
+++ b/projects/packages/my-jetpack/changelog/add-default-tracks-to-my-jetpack-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add more default args for tracks events

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.25.3-alpha",
+	"version": "4.25.3",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.25.3-alpha';
+	const PACKAGE_VERSION = '4.25.3';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.46.2] - 2024-06-24
+### Added
+- Added Social resharing for classic editor [#37810]
+
+### Changed
+- Removed unneeded check for connection management wpcom [#37899]
+
+### Fixed
+- Added support for Threads for Social connections [#37977]
+
 ## [0.46.1] - 2024-06-17
 ### Fixed
 - Fixed connections management links for classic editor [#37681]
@@ -589,6 +599,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.46.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.46.1...v0.46.2
 [0.46.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.46.0...v0.46.1
 [0.46.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.45.2...v0.46.0
 [0.45.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.45.1...v0.45.2

--- a/projects/packages/publicize/changelog/add-social-resharing-for-classic-editor
+++ b/projects/packages/publicize/changelog/add-social-resharing-for-classic-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added Social resharing for classic editor

--- a/projects/packages/publicize/changelog/add-social-threads-connection-ui
+++ b/projects/packages/publicize/changelog/add-social-threads-connection-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Added support for Threads for Social connections

--- a/projects/packages/publicize/changelog/remove-social-connection-managemet-unneeded-wpcom-check
+++ b/projects/packages/publicize/changelog/remove-social-connection-managemet-unneeded-wpcom-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Removed unneeded check for connection management wpcom

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.46.2-alpha",
+	"version": "0.46.2",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.11] - 2024-06-24
+### Changed
+- Update dependencies. [#37979]
+
 ## [0.44.10] - 2024-06-17
 ### Changed
 - Updated package dependencies. [#37796] [#37860]
@@ -980,6 +984,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.44.11]: https://github.com/Automattic/jetpack-search/compare/v0.44.10...v0.44.11
 [0.44.10]: https://github.com/Automattic/jetpack-search/compare/v0.44.9...v0.44.10
 [0.44.9]: https://github.com/Automattic/jetpack-search/compare/v0.44.8...v0.44.9
 [0.44.8]: https://github.com/Automattic/jetpack-search/compare/v0.44.7...v0.44.8

--- a/projects/packages/search/changelog/force-a-release
+++ b/projects/packages/search/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.11-alpha",
+	"version": "0.44.11",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.11-alpha';
+	const VERSION = '0.44.11';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - 2024-06-24
+### Changed
+- Internal updates.
+
 ## [3.3.1] - 2024-06-21
 ### Added
 - Check for active modules among the unavailable ones. [#37358]
@@ -377,6 +381,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[3.3.2]: https://github.com/Automattic/jetpack-status/compare/v3.3.1...v3.3.2
 [3.3.1]: https://github.com/Automattic/jetpack-status/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/Automattic/jetpack-status/compare/v3.2.3...v3.3.0
 [3.2.3]: https://github.com/Automattic/jetpack-status/compare/v3.2.2...v3.2.3

--- a/projects/packages/status/changelog/remove-ref-to-removed-idc-package
+++ b/projects/packages/status/changelog/remove-ref-to-removed-idc-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Remove reference to removed identity-crisis package from composer.json `.extra.dependencies.test-only`. No change to functionality.
-
-

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.26] - 2024-06-24
+### Changed
+- Update dependencies. [#37979]
+
 ## [0.23.25] - 2024-06-17
 ### Changed
 - Updated package dependencies. [#37779] [#37796]
@@ -1361,6 +1365,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.26]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.25...v0.23.26
 [0.23.25]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.24...v0.23.25
 [0.23.24]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.23...v0.23.24
 [0.23.23]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.22...v0.23.23

--- a/projects/packages/videopress/changelog/force-a-release
+++ b/projects/packages/videopress/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.26-alpha",
+	"version": "0.23.26",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.26-alpha';
+	const PACKAGE_VERSION = '0.23.26';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.22] - 2024-06-24
+### Changed
+- Update dependencies. [#37979]
+
 ## [0.3.21] - 2024-06-17
 ### Changed
 - Updated package dependencies. [#37796]
@@ -363,6 +367,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.22]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.21...v0.3.22
 [0.3.21]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.20...v0.3.21
 [0.3.20]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.19...v0.3.20
 [0.3.19]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.18...v0.3.19

--- a/projects/packages/wordads/changelog/force-a-release
+++ b/projects/packages/wordads/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.22-alpha",
+	"version": "0.3.22",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.22-alpha';
+	const VERSION = '0.3.22';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.6-a.7 - 2024-06-24
+### Enhancements
+- Goodreads Block: provide support for additional profile URLs. [#37939]
+- Newsletter: Adding a new toggle to control the newsletter author line. [#37916]
+- Newsletter: Email replies can become comments on your blog. [#37995]
+- Tiled Gallery: Increase accessibility of Tiled Gallery carousel images. [#37792]
+
+### Improved compatibility
+- General: indicate compatibility with the upcoming version of WordPress - 6.6. [#37962]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- AI Assistant: Add Breve proofread feature flag. [#37986]
+- AI Assistant: Extract AI Image logic to its own hook. [#37956]
+- AI Assistant: Extract the Google Analytics API into a package. [#37358]
+- AI Assistant: Introduce AI Image Modal. [#37959]
+- AI Assistant: Specific placeholder instruction for featured and general image. [#38008]
+- AI Assistant: Update General Image to reuse modal and hooks with expected behavior. [#37991]
+- Carousel: Ensure event listeners target relevant Tiled Gallery classes for accessibility fixes. [#37978]
+- Carousel: Add empty state for AI Image carousel. [#38004]
+- Map Block: Handle React's Strict Mode correctly for Mapbox maps. [#37918]
+- Masterbar: Remove the old fly panel. [#37764]
+- Newsletters: Make the welcome form more editable. [#37996]
+
 ## 13.6-a.5 - 2024-06-18
 ### Bug fixes
 - User Content Link Tracking: Check domain before redirecting to subscribe.wordpress.com. [#37798]

--- a/projects/plugins/jetpack/changelog/add-ai-general-image-hook-modal-usage
+++ b/projects/plugins/jetpack/changelog/add-ai-general-image-hook-modal-usage
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Update General Image to reuse modal and hooks with expected behavior

--- a/projects/plugins/jetpack/changelog/add-ai-image-generation-hook
+++ b/projects/plugins/jetpack/changelog/add-ai-image-generation-hook
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Extract AI Image logic to own hook

--- a/projects/plugins/jetpack/changelog/add-ai-image-modal
+++ b/projects/plugins/jetpack/changelog/add-ai-image-modal
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Introduce AI Image Modal

--- a/projects/plugins/jetpack/changelog/add-ai-image-modal-instructions-placeholder
+++ b/projects/plugins/jetpack/changelog/add-ai-image-modal-instructions-placeholder
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Specific placeholder instruction for featured and general image

--- a/projects/plugins/jetpack/changelog/add-ai-proofread-beta-flag
+++ b/projects/plugins/jetpack/changelog/add-ai-proofread-beta-flag
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Add Breve proofread feature flag

--- a/projects/plugins/jetpack/changelog/add-masterbar-package-to-jetpack-mu-wpcom
+++ b/projects/plugins/jetpack/changelog/add-masterbar-package-to-jetpack-mu-wpcom
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-newsletter-reply-to-comment
+++ b/projects/plugins/jetpack/changelog/add-newsletter-reply-to-comment
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Newsletter: now newsletter email replies can become comments on your blog

--- a/projects/plugins/jetpack/changelog/add-remove-gravatar-toggle
+++ b/projects/plugins/jetpack/changelog/add-remove-gravatar-toggle
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
- Adding a new toggles to control the newsletter byline

--- a/projects/plugins/jetpack/changelog/add-to-test-13-6
+++ b/projects/plugins/jetpack/changelog/add-to-test-13-6
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Testing instructions added, no changelog necessary.
-
-

--- a/projects/plugins/jetpack/changelog/fix-carousel-event-listener-space-issue
+++ b/projects/plugins/jetpack/changelog/fix-carousel-event-listener-space-issue
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Carousel: Ensure event listeners target relevant Tiled Gallery classes for accessibility fixes.

--- a/projects/plugins/jetpack/changelog/fix-eslint-e2e
+++ b/projects/plugins/jetpack/changelog/fix-eslint-e2e
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Fix eslint issues in tests/e2e. No change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/fix-map-block-in-react-strict-mode
+++ b/projects/plugins/jetpack/changelog/fix-map-block-in-react-strict-mode
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Map Block: Handle React's Strict Mode correctly for Mapbox maps

--- a/projects/plugins/jetpack/changelog/fix-subscription-modal-ls-errors
+++ b/projects/plugins/jetpack/changelog/fix-subscription-modal-ls-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
- 

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.6-a.6
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.6-a.8
+
+

--- a/projects/plugins/jetpack/changelog/remove-old-flyout-panel
+++ b/projects/plugins/jetpack/changelog/remove-old-flyout-panel
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Masterbar: Remove old fly panel

--- a/projects/plugins/jetpack/changelog/remove-ref-to-removed-idc-package
+++ b/projects/plugins/jetpack/changelog/remove-ref-to-removed-idc-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-ai-general-image-empty
+++ b/projects/plugins/jetpack/changelog/update-ai-general-image-empty
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Empty state for AI Image carrousel

--- a/projects/plugins/jetpack/changelog/update-goodreads-links
+++ b/projects/plugins/jetpack/changelog/update-goodreads-links
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Goodreads Block: provide support for additional profile URLs.

--- a/projects/plugins/jetpack/changelog/update-move-google-analytics-apis
+++ b/projects/plugins/jetpack/changelog/update-move-google-analytics-apis
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Extract the Google Analytics API into the package.

--- a/projects/plugins/jetpack/changelog/update-tested-to-6-6
+++ b/projects/plugins/jetpack/changelog/update-tested-to-6-6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: compat
-
-General: indicate compatibility with the upcoming version of WordPress - 6.6.

--- a/projects/plugins/jetpack/changelog/update-textarea-to-be-autoexpending
+++ b/projects/plugins/jetpack/changelog/update-textarea-to-be-autoexpending
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Newsletters: make the welcome form more editable

--- a/projects/plugins/jetpack/changelog/update-tiled-gallery-carousel-accessibility
+++ b/projects/plugins/jetpack/changelog/update-tiled-gallery-carousel-accessibility
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Tiled Gallery: Increase accessibility of Tiled Gallery carousel images.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -106,7 +106,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_6_a_7",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_6_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -106,7 +106,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_6_a_6",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_6_a_7",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.6-a.6
+ * Version: 13.6-a.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.6-a.6' );
+define( 'JETPACK__VERSION', '13.6-a.7' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.6-a.7
+ * Version: 13.6-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.6-a.7' );
+define( 'JETPACK__VERSION', '13.6-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -515,7 +515,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					 * @module json-api
 					 *
 					 * @since 3.9.3
-					 * @since $$next-version$$ Added the API object parameter.
+					 * @since 13.6 Added the API object parameter.
 					 *
 					 * @param mixed $response_item A single site setting.
 					 * @param WPCOM_JSON_API_Site_Settings_Endpoint $this The API object.
@@ -598,7 +598,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	/**
 	 * Get GA tracking code.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.6
 	 */
 	protected function get_google_analytics() {
 		if ( class_exists( GA_Manager::class ) ) {
@@ -613,7 +613,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	/**
 	 * Get GA tracking code option name.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.6
 	 */
 	protected function get_google_analytics_option_name() {
 		if ( class_exists( GA_Manager::class ) ) {
@@ -1195,7 +1195,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						 * @module json-api
 						 *
 						 * @since 3.9.3
-						 * @since $$next-version$$ Added the API object parameter.
+						 * @since 13.6 Added the API object parameter.
 						 *
 						 * @param mixed $response_item A single site setting value.
 						 * @param WPCOM_JSON_API_Site_Settings_Endpoint The API object parameter.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -142,7 +142,7 @@ class WPCOM_JSON_API_Site_Settings_V1_3_Endpoint extends WPCOM_JSON_API_Site_Set
 	 * Filter the parent's response to include the fields
 	 * added to 1.3 (and their defaults)
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.6
 	 *
 	 * @param array $settings - the settings array.
 	 *
@@ -167,7 +167,7 @@ class WPCOM_JSON_API_Site_Settings_V1_3_Endpoint extends WPCOM_JSON_API_Site_Set
 	 * @param array $wga - Array of existing Google Analytics settings.
 	 * @param array $new_values - the new values we're adding.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.6
 	 *
 	 * @return array
 	 */

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.6.0-a.7",
+	"version": "13.6.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.6.0-a.6",
+	"version": "13.6.0-a.7",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,9 +326,15 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.6-a.5 - 2024-06-18
-#### Bug fixes
-- User Content Link Tracking: Check domain before redirecting to subscribe.wordpress.com.
+### 13.6-a.7 - 2024-06-24
+#### Enhancements
+- Goodreads Block: provide support for additional profile URLs.
+- Newsletter: Adding a new toggle to control the newsletter author line.
+- Newsletter: Email replies can become comments on your blog.
+- Tiled Gallery: Increase accessibility of Tiled Gallery carousel images.
+
+#### Improved compatibility
+- General: indicate compatibility with the upcoming version of WordPress - 6.6.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.3.0 - 2024-06-24
+### Changed
+- Site Visibility: Update link copy [#37909]
+
 ## 2.2.0 - 2024-06-18
 ### Changed
 - Bump lock files. [#37870]

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-masterbar-package-to-jetpack-mu-wpcom
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-masterbar-package-to-jetpack-mu-wpcom
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-masterbar-package-to-jetpack-mu-wpcom#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-masterbar-package-to-jetpack-mu-wpcom#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/remove-ref-to-removed-idc-package
+++ b/projects/plugins/mu-wpcom-plugin/changelog/remove-ref-to-removed-idc-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/try-is_agency_managed_site
+++ b/projects/plugins/mu-wpcom-plugin/changelog/try-is_agency_managed_site
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-wpcom-site-visibility-copy
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-wpcom-site-visibility-copy
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Site Visibility: Update link copy

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_3_0_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_3_0"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.3.0-alpha
+ * Version: 2.3.0
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.3.0-alpha",
+	"version": "2.3.0",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/wpcomsh/CHANGELOG.md
+++ b/projects/plugins/wpcomsh/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.24.0 - 2024-06-24
+### Added
+- Added featrue flag checks for the Threads Social Connection. [#38001]
+- wpcomsh: Add WP-CLI commands with hooks for WoA post-transfer/reset/clone functionality [#37972]
+
 ## 3.23.0 - 2024-06-21
 ### Added
 - New wpcomsh CLI command to fix PHP 7.4 plugin [#37966]

--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-cli-add-woa-post-actions
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-cli-add-woa-post-actions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-wpcomsh: Add WP-CLI commands with hooks for WoA post-transfer/reset/clone functionality

--- a/projects/plugins/wpcomsh/changelog/remove-ref-to-removed-idc-package
+++ b/projects/plugins/wpcomsh/changelog/remove-ref-to-removed-idc-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/sync-class-wpcom-features
+++ b/projects/plugins/wpcomsh/changelog/sync-class-wpcom-features
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added featrue flag checks for the Threads Social Connection.

--- a/projects/plugins/wpcomsh/changelog/try-is_agency_managed_site
+++ b/projects/plugins/wpcomsh/changelog/try-is_agency_managed_site
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/update-phan-wpcom-stubs
+++ b/projects/plugins/wpcomsh/changelog/update-phan-wpcom-stubs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Move `require_lib` function into a separate file, to facilitate it being used as a stub elsewhere. No change to functionality.
-
-

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_24_0_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_24_0"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.24.0-alpha",
+	"version": "3.24.0",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.24.0-alpha
+ * Version: 3.24.0
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
@@ -10,7 +10,7 @@
  */
 
 // Increase version number if you change something in wpcomsh.
-define( 'WPCOMSH_VERSION', '3.24.0-alpha' );
+define( 'WPCOMSH_VERSION', '3.24.0' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.3.0, jetpack 13.6-a.7, wpcomsh 3.24.0

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.