### PR TITLE
Don't use masterbar package (except admin color schemes) for sites with Classic view

### DIFF
--- a/projects/packages/masterbar/changelog/untangle-masterbar
+++ b/projects/packages/masterbar/changelog/untangle-masterbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+For sites with Classic view, don't load the masterbar package except the admin color schemes functionality.

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.2.2",
+	"version": "0.2.3-alpha",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -27,14 +27,17 @@ class Main {
 			return;
 		}
 
-		$host                    = new Host();
-		$should_use_nav_redesign = function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled();
+		new Admin_Color_Schemes();
 
-		if ( ! $should_use_nav_redesign && ! $host->is_wpcom_simple() ) {
-			new Masterbar();
+		if ( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) {
+			return;
 		}
 
-		new Admin_Color_Schemes();
+		$host = new Host();
+
+		if ( ! $host->is_wpcom_simple() ) {
+			new Masterbar();
+		}
 
 		if ( $host->is_wpcom_platform() ) {
 			new Inline_Help();
@@ -42,7 +45,7 @@ class Main {
 			require_once __DIR__ . '/nudges/bootstrap.php';
 		}
 
-		if ( $host->is_woa_site() && ! $should_use_nav_redesign ) {
+		if ( $host->is_woa_site() ) {
 			require_once __DIR__ . '/profile-edit/bootstrap.php';
 		}
 
@@ -53,7 +56,7 @@ class Main {
 		 *
 		 * @param bool $load_admin_menu_class Load Jetpack's custom admin menu functionality. Default to false.
 		 */
-		if ( ! $should_use_nav_redesign && apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
+		if ( apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
 			require_once __DIR__ . '/admin-menu/load.php';
 		}
 

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.2.2';
+	const PACKAGE_VERSION = '0.2.3-alpha';
 
 	/**
 	 * Initializer.

--- a/projects/packages/masterbar/tests/php/test-class-admin-color-schemes.php
+++ b/projects/packages/masterbar/tests/php/test-class-admin-color-schemes.php
@@ -53,8 +53,7 @@ class Test_Admin_Color_Schemes extends BaseTestCase {
 		);
 
 		if ( 'test_enqueue_core_color_schemes_overrides_for_classic_sites' === $this->getName() ) {
-			Functions\expect( 'wpcom_is_nav_redesign_enabled' )
-				->andReturn( true );
+			Functions\when( 'wpcom_is_nav_redesign_enabled' )->justReturn( true );
 		}
 
 		new Admin_Color_Schemes();

--- a/projects/packages/masterbar/tests/php/test-class-main.php
+++ b/projects/packages/masterbar/tests/php/test-class-main.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Masterbar;
 
 use Automattic\Jetpack\Status\Cache;
+use Brain\Monkey\Functions;
 use WorDBless\BaseTestCase;
 
 /**
@@ -16,6 +17,15 @@ use WorDBless\BaseTestCase;
  * @covers Automattic\Jetpack\Masterbar\Main
  */
 class Test_Main extends BaseTestCase {
+	/**
+	 * Test setup.
+	 *
+	 * @before
+	 */
+	public function set_up() {
+		Functions\when( 'wpcom_is_nav_redesign_enabled' )->justReturn( false );
+	}
+
 	/**
 	 * Returning the environment into its initial state.
 	 *


### PR DESCRIPTION
Fixes (more robustly):

- https://github.com/Automattic/dotcom-forge/issues/7895

## Proposed changes:
We completely disabled Jetpack's masterbar module on Atomic Classic sites (ref: https://github.com/Automattic/wpcomsh/pull/1687).

Then somehow when we were refactoring the masterbar module into package, some masterbar functionalities got readded (maybe via: https://github.com/Automattic/jetpack/pull/37342).

This PR re-adds the `wpcom_is_nav_redesign_enabled()` guard, except for `Admin_Color_Schemes`, which got unified for Default and Classic sites into the same masterbar package.

Maybe in the future, we should extract the admin color scheme functionality into a separate package. cc: @fgiannar 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


1. Patch this PR to Beta Tester
2. Go to Users -> Profile, verify that all fields are visible.
4. Test that we don't load the `wp-posts-list` functionality:
    - Go to Settings -> Reading, set a page as Posts page.
    - Go to Pages, verify that we can delete the page that is set in the previous step.
5. I have no idea how to test the rest of functionalities (that they are removed), but if step (4) above is OK, I am confident (because that's how it was before the masterbar refactoring).
