### PR TITLE
Hide login banner for agency managed sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-hide-login-banner-for-agency
+++ b/projects/plugins/wpcomsh/changelog/update-hide-login-banner-for-agency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Hide login banner for agency-managed sites.

--- a/projects/plugins/wpcomsh/private-site/logged-in-banner.php
+++ b/projects/plugins/wpcomsh/private-site/logged-in-banner.php
@@ -48,6 +48,11 @@ function show_logged_in_banner() {
 		return;
 	}
 
+	// Hide banner for agency-managed sites.
+	if ( ! empty( get_option( 'is_fully_managed_agency_site' ) ) ) {
+		return;
+	}
+
 	/**
 	 * Filter to make it possible for the launch banner to be hidden.
 	 *


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7900

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Agency sites with `is_fully_managed_agency_site` option should stay in /wp-admin, the login banner points to WP.com (Calypso), so we will hide the banner for agency-managed sites as discussed in he original issue.

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/jetpack/assets/6586048/65509d7a-dfff-4083-b4fc-6f5b317c7f03">  | <img src="https://github.com/Automattic/jetpack/assets/6586048/82aa38f9-5902-4778-8717-3838392bb015">|

> [!NOTE]  
> The agency managing the site will still be able to set the site visibility settings from their dashboard.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With a WoA dev site, rsync the changes by following the Jetpack Rsync directions in pf4qpu-sv-p2
* The site currently will show the banner
* Run `wp option update is_fully_managed_agency_site 1` for the site
* The site should not show the banner