### PR TITLE
Jetpack 'admin-menu' endpoint: Load known dashicon list from 'jetpack-masterbar' package

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -380,7 +380,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	 */
 	private function prepare_dashicon( $icon ) {
 		if ( empty( $this->dashicon_set ) ) {
-			$this->dashicon_list = include JETPACK__PLUGIN_DIR . '/modules/masterbar/admin-menu/dashicon-set.php';
+			$this->dashicon_list = include JETPACK__PLUGIN_DIR . 'jetpack_vendor/automattic/jetpack-masterbar/src/admin-menu/dashicon-set.php';
 		}
 
 		if ( isset( $this->dashicon_list[ $icon ] ) && $this->dashicon_list[ $icon ] ) {

--- a/projects/plugins/jetpack/changelog/update-jetpack-admin-menu-load-dashicons-from-package
+++ b/projects/plugins/jetpack/changelog/update-jetpack-admin-menu-load-dashicons-from-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack 'admin-menu' endpoint: Load dashicon list from 'jetpack-masterbar' package


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Jetpack `admin-menu` endpoint: Load dashicon list from `jetpack-masterbar` package.
This work is done under the context of deprecating the Masterbar module code in the Jetpack plugin.
See Jetpack product discussion for full context.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `WPCOM_REST_API_V2_Endpoint_Admin_Menu`: Update `prepare_dashicon` method to load the known dashicon list from the  `jetpack-masterbar` package.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pfwV0U-3U-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using the https://developer.wordpress.com/docs/api/console/ fetch the `sites/YOUR_BLOG_ID/admin-menu` endpoint under `wpcom/v2/` as displayed below

<img width="637" alt="Screenshot 2024-06-25 at 12 37 14" src="https://github.com/Automattic/jetpack/assets/1758399/f3687451-0ffe-4619-9094-ddd2ce4f083d">

* Ensure that the returned `icon` for the `Stats` entry is `dashicons-chart-bar`