### PR TITLE
Masterbar: Fix missing private badge on admin menu for private WoA sites

### DIFF
--- a/projects/packages/masterbar/changelog/fix-masterbar-atomic-menu-private-sites
+++ b/projects/packages/masterbar/changelog/fix-masterbar-atomic-menu-private-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Masterbar: Fix missing private badge on admin menu for private WoA sites

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.2.1",
+	"version": "0.2.2-alpha",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -257,6 +257,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$badge .= '<span class="site__badge site__badge-staging">' . esc_html__( 'Staging', 'jetpack-masterbar' ) . '</span>';
 		}
 
+		// @phan-suppress-next-line PhanUndeclaredFunction -- This is temp, pending pf4qpu-nc-p2
 		if ( ( function_exists( '\Private_Site\site_is_private' ) && \Private_Site\site_is_private() ) || $is_coming_soon ) {
 			$badge .= sprintf(
 				'<span class="site__badge site__badge-private">%s</span>',

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -257,8 +257,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			$badge .= '<span class="site__badge site__badge-staging">' . esc_html__( 'Staging', 'jetpack-masterbar' ) . '</span>';
 		}
 
-		// @phan-suppress-next-line PhanUndeclaredFunction -- This is temp, pending pf4qpu-nc-p2
-		if ( ( function_exists( 'site_is_private' ) && site_is_private() ) || $is_coming_soon ) {
+		if ( ( function_exists( '\Private_Site\site_is_private' ) && \Private_Site\site_is_private() ) || $is_coming_soon ) {
 			$badge .= sprintf(
 				'<span class="site__badge site__badge-private">%s</span>',
 				$is_coming_soon ? esc_html__( 'Coming Soon', 'jetpack-masterbar' ) : esc_html__( 'Private', 'jetpack-masterbar' )

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.2.1';
+	const PACKAGE_VERSION = '0.2.2-alpha';
 
 	/**
 	 * Initializer.

--- a/projects/packages/masterbar/tests/php/test-class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/tests/php/test-class-atomic-admin-menu.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Masterbar;
 
 use Automattic\Jetpack\Status;
+use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
@@ -194,6 +195,37 @@ class Test_Atomic_Admin_Menu extends TestCase {
 <div class="site__info">
 	<div class="site__title">' . get_option( 'blogname' ) . '</div>
 	<div class="site__domain">' . static::$domain . "</div>\n\t\n</div>",
+			'read',
+			$home_url,
+			'site-card',
+			'menu-top toplevel_page_' . $home_url,
+			'toplevel_page_' . $home_url,
+			plugins_url( 'src/admin-menu/globe-icon.svg', dirname( __DIR__ ) ),
+		);
+
+		$this->assertEquals( $site_card_menu_item, $menu[1] );
+	}
+
+	/**
+	 * Tests add_site_card_menu for Private sites
+	 *
+	 * @covers ::add_site_card_menu
+	 */
+	public function test_add_site_card_menu_private_site() {
+		global $menu;
+
+		Functions\expect( '\Private_Site\site_is_private' )
+				->andReturn( true );
+
+		static::$admin_menu->add_site_card_menu();
+
+		$home_url            = home_url();
+		$site_card_menu_item = array(
+			// phpcs:ignore Squiz.Strings.DoubleQuoteUsage.NotRequired
+			'
+<div class="site__info">
+	<div class="site__title">' . get_option( 'blogname' ) . '</div>
+	<div class="site__domain">' . static::$domain . "</div>\n\t<span class=\"site__badge site__badge-private\">Private</span>\n</div>",
 			'read',
 			$home_url,
 			'site-card',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a bug where the `Private` badge was missing from the admin menu in private WoA sites in `wp-admin`

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Atomic_Admin_Menu`: Use `\Private_Site\site_is_private()` instead of `site_is_private` in `add_site_card_menu` method
* Added a unit test

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/37342/files/61029c45d18b0d970796a08e0331e08c0216073d#r1651505588

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visit `wp-admin` in a WoA private site and ensure the `Private` badge is present in the admin menu under the site name, as displayed below:

<img width="228" alt="Screenshot 2024-06-25 at 13 15 38" src="https://github.com/Automattic/jetpack/assets/1758399/99bf6d94-60a5-4451-b97b-dee89ffcbe0a">
