### PR TITLE
Super cache - fix tempnam system directory warning

### DIFF
--- a/projects/plugins/super-cache/changelog/super-cache-fix-tempnam-system-directory-warning
+++ b/projects/plugins/super-cache/changelog/super-cache-fix-tempnam-system-directory-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Super Cache: create the cache directory before creating the config file

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -260,9 +260,9 @@ function wpsupercache_activate() {
 	wpsc_init();
 
 	if (
+		! wp_cache_verify_cache_dir() ||
 		! wpsc_check_advanced_cache() ||
-		! wp_cache_verify_config_file() ||
-		! wp_cache_verify_cache_dir()
+		! wp_cache_verify_config_file()
 	) {
 		$text = ob_get_contents();
 		ob_end_clean();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
When WPSC is first installed it tries to create a temporary file when writing to the config file. As the cache directory hasn't been set up correctly yet, it can't, so it creates it in the system tmp directory. That results in a PHP warning. This PR fixes that by creating the cache directory first.

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Call wp_cache_verify_cache_dir() before writing to the config file so the cache directory is there already.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Activate the plugin and you will see a warning, "tempnam(): file created in the system's temporary directory in..."
* Apply this PR and deactivate and activate it and that warning won't show.

