### PR TITLE
Boost: Fix removing WP_CACHE when advanced cache wasn't deleted

### DIFF
--- a/projects/plugins/boost/changelog/fix-boost-prevent-wp-cache-removal-if-advanced-cache-not-removed
+++ b/projects/plugins/boost/changelog/fix-boost-prevent-wp-cache-removal-if-advanced-cache-not-removed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+General: Fix instance where Boost can break caching for other caching plugins when getting deactivated.


### PR DESCRIPTION
Boost should only clean up after itself it it's the last thing that
enabled caching. If it cleans up, it might accidentally break caching
for other plugins.<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/38032

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevent Boost from breaking caching for other plugins;
* Add comment cleanup for `WP_CACHE` constant in `wp-config.php` (didn't break anything, it just seems odd having a boost related comment when boost might not even be present on a site).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test that deactivating Boost doesn't remove WP_CACHE from wp-config.php when it wasn't the last time that had cache enabled
1. Setup WP Super Cache and enable easy caching;
2. Setup Boost plugin and enable caching;
3. Check `wp-config.php` to make sure the WP_CACHE declaration got moved to the top of the file and there's a comment behind it (`// Boost Cache Plugin`);
4. Activate WP Super Cache (as it got deactivated in step 2);
5. Keep Boost plugin active, but disable caching;
6. Enable WP Super Cache caching;
7. Deactivate Boost plugin but don't visit WP Super Cache's settings (it will muddy the test, as it automatically adds constants to `wp-config.php`);
8. Check `wp-config.php` to make sure that `WP_CACHE` did not get removed (the comment from step 3 should be removed).