### PR TITLE
Remove "Update Services" section in Writing Settings if `is_agency_managed_site`

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/hide-writing-update-services
+++ b/projects/packages/jetpack-mu-wpcom/changelog/hide-writing-update-services
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Remove Update Services section in Writing Setting if is_agency_managed_site

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -60,7 +60,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.38.x-dev"
+			"dev-trunk": "5.39.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.39.1-alpha",
+	"version": "5.39.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.38.1-alpha",
+	"version": "5.39.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.38.1-alpha';
+	const PACKAGE_VERSION = '5.39.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.39.1-alpha';
+	const PACKAGE_VERSION = '5.39.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
@@ -57,21 +57,28 @@ function replace_site_visibility() {
 add_action( 'blog_privacy_selector', 'replace_site_visibility' );
 
 /**
- * Hide the "Site visibility" setting entirely if is_agency_managed_site is true.
+ * Hide the "Site visibility" setting in Reading Settings if is_agency_managed_site is true.
  */
 function wpcom_hide_site_visibility_setting() {
 	if ( ! is_agency_managed_site() ) {
 		return;
 	}
-	// Check if the current page is the reading settings page
+	// Check if the current page is the Reading Settings page.
 	$screen = get_current_screen();
 	if ( $screen->id === 'options-reading' ) {
 		echo '<style>
             .option-site-visibility {
-                display: none;
+                display: none !important;
             }
         </style>';
 	}
 }
 add_action( 'admin_head', 'wpcom_hide_site_visibility_setting' );
 
+/**
+ * Remove the "Update Services" section in Writing Settings if is_agency_managed_site is true.
+ */
+function wpcom_remove_update_services_section() {
+	return ! is_agency_managed_site();
+}
+add_filter( 'enable_update_services_configuration', 'wpcom_remove_update_services_section' );

--- a/projects/plugins/mu-wpcom-plugin/changelog/hide-writing-update-services
+++ b/projects/plugins/mu-wpcom-plugin/changelog/hide-writing-update-services
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -937,7 +937,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "96dc95c429a75a3c62911e5c8a23deb10d199740"
+                "reference": "53c0f7ac4139b96bf0063a7f9937e19d16448475"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -969,7 +969,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.38.x-dev"
+                    "dev-trunk": "5.39.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/changelog/hide-writing-update-services
+++ b/projects/plugins/wpcomsh/changelog/hide-writing-update-services
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_25_1"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_25_2_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1070,7 +1070,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "96dc95c429a75a3c62911e5c8a23deb10d199740"
+                "reference": "53c0f7ac4139b96bf0063a7f9937e19d16448475"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1102,7 +1102,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.38.x-dev"
+                    "dev-trunk": "5.39.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.25.1",
+	"version": "3.25.2-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.25.1
+ * Version: 3.25.2-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
@@ -10,7 +10,7 @@
  */
 
 // Increase version number if you change something in wpcomsh.
-define( 'WPCOMSH_VERSION', '3.25.1' );
+define( 'WPCOMSH_VERSION', '3.25.2-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7916

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `enable_update_services_configuration` filter to remove the "Update Services" section in Writing Settings if is_agency_managed_site is true.

Before | After
--|--
<img width="1378" alt="Screenshot 2024-06-25 at 10 15 38 AM" src="https://github.com/Automattic/jetpack/assets/140841/508b85bc-417d-4e14-b4b7-0aa0b683ee1d"> | <img width="1378" alt="Screenshot 2024-06-25 at 10 15 24 AM" src="https://github.com/Automattic/jetpack/assets/140841/d13cdc8c-798d-4ede-931d-d3aef6d340c1">





### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Apply this PR to an Atomic test site using Jetpack Beta Plugin and the instructions in the [comment below.](https://github.com/Automattic/jetpack/pull/38038#issuecomment-2189249617)
* Use /_cli to add the option: `wp option add is_fully_managed_agency_site 1`
* Go to /wp-admin/options-writing.php and view the "Update Services" section is gone.
* Update the option using /_cli `wp option update is_fully_managed_agency_site 0` and view that the "Update Services" section has returned.
* Apply this PR to a Simple test site using the instructions in the [comment below.](https://github.com/Automattic/jetpack/pull/38038#issuecomment-2189249617)
* Use wpsh then `switch_to_blog($blog_id);` and `add_option('is_fully_managed_agency_site', 1);` to add the option to your site.
* Go to /wp-admin/options-writing.php and view the "Update Services" section is gone.
* Remove the `is_fully_managed_agency_site` option and view the "Update Services" section has returned.
