### PR TITLE
Update/subscription widget description

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscription-widget-description
+++ b/projects/plugins/jetpack/changelog/update-subscription-widget-description
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Minor copy change based on user feedback

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -190,7 +190,7 @@ class Jetpack_Subscription_Site {
 					) {
 						// translators: %s is the name of the site.
 						$discover_more_from_text = sprintf( __( 'Discover more from %s', 'jetpack' ), get_bloginfo( 'name' ) );
-						$subscribe_text          = __( 'Subscribe to get the latest posts to your email.', 'jetpack' );
+						$subscribe_text          = __( 'Subscribe to get the latest posts sent to your email.', 'jetpack' );
 
 						return $content . do_blocks(
 							<<<HTML
@@ -270,7 +270,7 @@ HTML
 
 					// translators: %s is the name of the site.
 					$discover_more_from_text = sprintf( __( 'Discover more from %s', 'jetpack' ), get_bloginfo( 'name' ) );
-					$subscribe_text          = __( 'Subscribe to get the latest posts to your email.', 'jetpack' );
+					$subscribe_text          = __( 'Subscribe to get the latest posts sent to your email.', 'jetpack' );
 					$inner_content_begin     = <<<HTML
 <div class="wp-block-group" style="margin-top:48px;margin-bottom:48px;padding-top:5px;padding-bottom:5px">
 	<!-- wp:separator {"style":{"spacing":{"margin":{"bottom":"36px"}}},"className":"is-style-wide"} -->


### PR DESCRIPTION
This PR updates the subscription block copy to sounds better. 
This change was based on user feedback in p1719342663378389-slack-C05PV073SG3



## Proposed changes:

* Update to copy.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p1719342663378389-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Still need to test this copy. 
