### PR TITLE
Update/usage of historically active modules sync

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-usage-of-historically-active-modules-sync
+++ b/projects/packages/my-jetpack/changelog/update-usage-of-historically-active-modules-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Move historically active modules sync to admin_init

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -91,8 +91,6 @@ class Initializer {
 		// Initialize Boost Speed Score
 		new Speed_Score( array(), 'jetpack-my-jetpack' );
 
-		self::setup_historically_active_jetpack_modules_sync();
-
 		// Add custom WP REST API endoints.
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_endpoints' ) );
 
@@ -108,6 +106,7 @@ class Initializer {
 		add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
 		// This is later than the admin-ui package, which runs on 1000
 		add_action( 'admin_init', array( __CLASS__, 'maybe_show_red_bubble' ), 1001 );
+		add_action( 'admin_init', array( __CLASS__, 'setup_historically_active_jetpack_modules_sync' ), 1002 );
 
 		// Sets up JITMS.
 		JITM::configure();

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -104,9 +104,9 @@ class Initializer {
 		);
 
 		add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
+		add_action( 'admin_init', array( __CLASS__, 'setup_historically_active_jetpack_modules_sync' ) );
 		// This is later than the admin-ui package, which runs on 1000
 		add_action( 'admin_init', array( __CLASS__, 'maybe_show_red_bubble' ), 1001 );
-		add_action( 'admin_init', array( __CLASS__, 'setup_historically_active_jetpack_modules_sync' ), 1002 );
 
 		// Sets up JITMS.
 		JITM::configure();


### PR DESCRIPTION
## Proposed changes:

1. Add failsafe that prevents My Jetpack from being called too early
2. Move call to sync historically active modules to the `admin_init` function

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1719343842667209-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

### Testing that bug is fixed

1. Start a JN site with only the Jetpack Beta plugin installed
2. Go to `https://clearly-narrow-tundra.jurassic.ninja/wp-admin/admin.php?page=jetpack-beta` and activate Jetpack VaultPress Backup with this branch `update/usage-of-historically-active-modules-sync`
3. Try to activate the plugin and ensure that it activates without errors
![image](https://github.com/Automattic/jetpack/assets/65001528/4d9c81a2-6e05-47fd-a19c-a3b35d16d5a0)

### Testing that historically active modules still works correctly

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
(In this case I would suggest Jetpack Beta so you can more easily start with a fresh site)
5. Go to My Jetpack and dismiss the welcome banner. Refresh the page. You should see a connection banner with a "info" display rather than an error
![image](https://github.com/Automattic/jetpack/assets/65001528/348da8f1-899f-4d03-ad4d-91469c868c83)
6. Connect your site (not the user)
7. Go back to My Jetpack and you should still see a user connection banner with an info banner rather than an error banner
![image](https://github.com/Automattic/jetpack/assets/65001528/7a456659-b6ae-4428-928b-3b790b71060d)
8. Disconnect your site from Jetpack Debugger
9. Go back to My Jetpack and you should now see the site connection banner with error styles
![image](https://github.com/Automattic/jetpack/assets/65001528/f39c08f7-5b35-4491-9867-04cac58b6acf)
10. Connect your site from the banner and refresh the page, you should see the user connection info banner again
11. Now connect your user account
12. Disconnect your site again and go back to My Jetpack. You should now see the *user* error connection banner instead of the site connection banner since you previously had a working plugin that requires a user connection (Jetpack AI)
![image](https://github.com/Automattic/jetpack/assets/65001528/bad2611e-0134-42cf-894d-90245e9afeda)