### PR TITLE
Jetpack AI Image: use error instead of warning on the upgrade notice

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-change-nudge-notice-level
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-change-nudge-notice-level
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI Image: use error notice instead of warning for the upgrade nudge.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/light-nudge.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/upgrade-prompt/light-nudge.tsx
@@ -17,7 +17,7 @@ export const LightNudge = ( {
 
 	return (
 		<div className="jetpack-upgrade-plan-banner-light">
-			<Notice status="warning" isDismissible={ false }>
+			<Notice status="error" isDismissible={ false }>
 				<p>
 					{ title && <strong>{ title }</strong> }
 					{ description }{ ' ' }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38049.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the upgrade nudge notice level, from warning to error

| Before | After |
| --- | --- |
| <img width="500" alt="Screenshot 2024-06-25 at 19 14 13" src="https://github.com/Automattic/jetpack/assets/6760046/9b72bec0-915f-4356-9ed0-57e1217180e8"> | <img width="500" alt="Screenshot 2024-06-25 at 19 16 30" src="https://github.com/Automattic/jetpack/assets/6760046/b7b8efa9-1b06-4ed8-891c-53031913a0da"> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin a new JN site
* Go to the block editor and use the AI Assistant to generate some content (example, "two paragraphs about wine production")
* Use the Featured Image generation tool to generate a featured image
* After the image is ready, you will probably not have enough requests for a new one, so you should see the upgrade prompt:

<img width="600" alt="Screenshot 2024-06-25 at 19 34 16" src="https://github.com/Automattic/jetpack/assets/6760046/ab1311f6-4c24-4e86-be1a-614fe4ca9699">

* Confirm the upgrade prompt is red (`error` level) instead of yellow (`warning` level)