### PR TITLE
Boost: don't cache pages with errors that exit very early

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -55,6 +55,11 @@ class Boost_Cache {
 	private static $cache_engine_loaded = false;
 
 	/**
+	 * @var bool - Indicates whether WordPress initialized correctly and we can cache the page.
+	 */
+	private $do_cache = false;
+
+	/**
 	 * @param ?Storage\Storage $storage - Optionally provide a Storage subclass to handle actually storing and retrieving cached content. Defaults to a new instance of File_Storage.
 	 */
 	public function __construct( $storage = null ) {
@@ -75,6 +80,7 @@ class Boost_Cache {
 		add_action( 'switch_theme', array( $this, 'invalidate_cache' ) );
 		add_action( 'wp_trash_post', array( $this, 'delete_on_post_trash' ), 10, 2 );
 		add_filter( 'wp_php_error_message', array( $this, 'disable_caching_on_error' ) );
+		add_filter( 'init', array( $this, 'init_do_cache' ) );
 	}
 
 	/**
@@ -175,6 +181,11 @@ class Boost_Cache {
 	 */
 	public function ob_callback( $buffer ) {
 		if ( strlen( $buffer ) > 0 && $this->request->is_cacheable() ) {
+
+			// Do not cache the page as WordPress did not initializeq correctly
+			if ( ! $this->do_cache ) {
+				return $buffer;
+			}
 
 			if ( false === stripos( $buffer, '</html>' ) ) {
 				Logger::debug( 'Closing HTML tag not found, not caching' );
@@ -467,5 +478,15 @@ class Boost_Cache {
 		}
 		Logger::debug( 'Fatal error detected, caching disabled' );
 		return $message;
+	}
+
+	/**
+	 * This function is called after WordPress is loaded, on "init".
+	 * It is used to indicate that it is safe to cache and that no
+	 * fatal errors occurred.
+	 */
+	public function init_do_cache() {
+		Logger::debug( 'postload: init succeeded' );
+		$this->do_cache = true;
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -182,7 +182,7 @@ class Boost_Cache {
 	public function ob_callback( $buffer ) {
 		if ( strlen( $buffer ) > 0 && $this->request->is_cacheable() ) {
 
-			// Do not cache the page as WordPress did not initializeq correctly
+			// Do not cache the page as WordPress did not initialize correctly.
 			if ( ! $this->do_cache ) {
 				return $buffer;
 			}

--- a/projects/plugins/boost/changelog/boost-update-init_check
+++ b/projects/plugins/boost/changelog/boost-update-init_check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Boost: ensure that "init" fires before allowing a page to be cached to avoid caching error pages

--- a/projects/plugins/boost/changelog/boost-update-init_check
+++ b/projects/plugins/boost/changelog/boost-update-init_check
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 Jetpack Boost: ensure that "init" fires before allowing a page to be cached to avoid caching error pages


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
We trap issues such as PHP errors to avoid caching error messages but we were still caching others, such as sites that displayed database connection warnings.

This PR fixes that by setting a flag on "init" and then checks that flag in the output buffer callback when creating the cache file. If the flag is false, then no cache file is created.

The one issue with how this works is that any page that exits before "init" will not be cached. I can't think of a good reason why a developer would do that, *and* want their page cached (when they should have their own caching system), but there might be one out there.

ref: https://wordpress.org/support/topic/error-page-cached/ (WP Super Cache report)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a private variable "do_cache", set to false, to the Boost Cache class.
* Add a function called "init_do_cache" to the Boost_Cache class. It sets "do_cache" to true.
* Modify the output buffer callback to check do_cache before creating the cache.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Apply patch and observe pages being cached correctly.
* Clear the cache.
* Edit wp-config.php and add "1" to the db password to break the site.
* Load the front page or any public page of the site.
* Confirm no cache files were created.
