### PR TITLE
Update historically active modules activation condition

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-historically_active_modules_activation_condition
+++ b/projects/packages/my-jetpack/changelog/update-historically_active_modules_activation_condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Reduce amount of historically active modules updates by only triggering on activation of plugin is a jetpack plugin

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.26.0",
+	"version": "4.26.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -495,10 +495,21 @@ class Initializer {
 	/**
 	 * Set transient to queue an update to the historically active Jetpack modules on the next wp-admin load
 	 *
+	 * @param string $plugin The plugin that triggered the update. This will be present if the function was queued by a plugin activation.
+	 *
 	 * @return void
 	 */
-	public static function queue_historically_active_jetpack_modules_update() {
-		set_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY, true );
+	public static function queue_historically_active_jetpack_modules_update( $plugin = null ) {
+		$plugin_filenames = Products::get_all_plugin_filenames();
+
+		if ( ! $plugin ) {
+			set_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY, true );
+			return;
+		}
+
+		if ( in_array( $plugin, $plugin_filenames, true ) ) {
+			set_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY, true );
+		}
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -502,12 +502,7 @@ class Initializer {
 	public static function queue_historically_active_jetpack_modules_update( $plugin = null ) {
 		$plugin_filenames = Products::get_all_plugin_filenames();
 
-		if ( ! $plugin ) {
-			set_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY, true );
-			return;
-		}
-
-		if ( in_array( $plugin, $plugin_filenames, true ) ) {
+		if ( ! $plugin || in_array( $plugin, $plugin_filenames, true ) ) {
 			set_transient( self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY, true );
 		}
 	}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.26.0';
+	const PACKAGE_VERSION = '4.26.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -153,6 +153,27 @@ class Products {
 	}
 
 	/**
+	 * Get all plugin filenames associated with the products.
+	 *
+	 * @return array
+	 */
+	public static function get_all_plugin_filenames() {
+		$filenames = array();
+		foreach ( self::get_products_classes() as $class ) {
+			if ( ! isset( $class::$plugin_filename ) ) {
+				continue;
+			}
+
+			if ( is_array( $class::$plugin_filename ) ) {
+				$filenames = array_merge( $filenames, $class::$plugin_filename );
+			} else {
+				$filenames[] = $class::$plugin_filename;
+			}
+		}
+		return $filenames;
+	}
+
+	/**
 	 * Get one product data by its slug
 	 *
 	 * @param string $product_slug The product slug.

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -38,7 +38,7 @@ abstract class Product {
 	 *
 	 * @var string|string[]
 	 */
-	protected static $plugin_filename = null;
+	public static $plugin_filename = null;
 
 	/**
 	 * The slug of the plugin associated with this product. If not defined, it will default to the Jetpack plugin


### PR DESCRIPTION
## Proposed changes:

* Add new products function to get all plugin filenames
* Only trigger a historically active modules update if the plugin activation was from a Jetpack plugin

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1719343842667209-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

### Testing that historically active modules still works correctly

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
(In this case I would suggest Jetpack Beta so you can more easily start with a fresh site)
5. Go to My Jetpack and dismiss the welcome banner. Refresh the page. You should see a connection banner with a "info" display rather than an error
![image](https://github.com/Automattic/jetpack/assets/65001528/348da8f1-899f-4d03-ad4d-91469c868c83)
6. Connect your site (not the user)
7. Go back to My Jetpack and you should still see a user connection banner with an info banner rather than an error banner
![image](https://github.com/Automattic/jetpack/assets/65001528/7a456659-b6ae-4428-928b-3b790b71060d)
8. Disconnect your site from Jetpack Debugger
9. Go back to My Jetpack and you should now see the site connection banner with error styles
![image](https://github.com/Automattic/jetpack/assets/65001528/f39c08f7-5b35-4491-9867-04cac58b6acf)
10. Connect your site from the banner and refresh the page, you should see the user connection info banner again
11. Now connect your user account
12. Disconnect your site again and go back to My Jetpack. You should now see the *user* error connection banner instead of the site connection banner since you previously had a working plugin that requires a user connection (Jetpack AI)
![image](https://github.com/Automattic/jetpack/assets/65001528/bad2611e-0134-42cf-894d-90245e9afeda)

If you want to test to make sure the update is not triggered on a non-Jetpack plugin, you will have to 

1. checkout this branch on your local environment
2. log something to the error-log [here](https://github.com/Automattic/jetpack/pull/38065/files#diff-2be902912ee7edeeeed04156e4456f5966e480fea3067586ff451c63b2bf2624R511).
3. Activate a non-Jetpack plugin
4. Run the command `jetpack docker exec cat ./wp-content/debug.log`
5. Make sure your note did not get logged
6. You can also activate a Jetpack plugin and make sure that it does get logged