### PR TITLE
Blaze: bail earlier when there are connection issues

### DIFF
--- a/projects/packages/blaze/changelog/fix-blaze-bail-earlier
+++ b/projects/packages/blaze/changelog/fix-blaze-bail-earlier
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Eligibility checks: shortcircuit Blaze feature earlier when a site is not properly connected to WordPress.com.

--- a/projects/packages/blaze/changelog/fix-blaze-bail-earlier#2
+++ b/projects/packages/blaze/changelog/fix-blaze-bail-earlier#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Eligibility checks: when a request to the WordPress.com API fails, store the response for an hour to avoid spamming the API.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.21.9",
+	"version": "0.21.10-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -210,12 +210,12 @@ class Blaze {
 				|| ! $connection->is_connected()
 				|| ! $connection->is_user_connected()
 			) {
-				$should_initialize = false;
+				return false;
 			}
 
 			// The whole thing is powered by Sync!
 			if ( ! Sync_Settings::is_sync_enabled() ) {
-				$should_initialize = false;
+				return false;
 			}
 		}
 

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -182,7 +182,7 @@ class Blaze {
 		$result = json_decode( wp_remote_retrieve_body( $response ), true );
 
 		// Bail if there were no results returned.
-		if ( ! is_array( $result ) || empty( $result['approved'] ) ) {
+		if ( ! is_array( $result ) || ! isset( $result['approved'] ) ) {
 			return false;
 		}
 

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -189,14 +189,25 @@ class Blaze {
 	 * @return bool
 	 */
 	public static function should_initialize() {
-		$should_initialize = true;
-		$is_wpcom          = defined( 'IS_WPCOM' ) && IS_WPCOM;
-		$connection        = new Jetpack_Connection();
-		$site_id           = Jetpack_Connection::get_site_id();
+		$is_wpcom   = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$connection = new Jetpack_Connection();
+		$site_id    = Jetpack_Connection::get_site_id();
 
 		// Only admins should be able to Blaze posts on a site.
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return false;
+		}
+
+		// Allow short-circuiting the Blaze initialization via a filter.
+		if ( has_filter( 'jetpack_blaze_enabled' ) ) {
+			/**
+			 * Filter to disable all Blaze functionality.
+			 *
+			 * @since 0.3.0
+			 *
+			 * @param bool $should_initialize Whether Blaze should be enabled. Default to true.
+			 */
+			return apply_filters( 'jetpack_blaze_enabled', true );
 		}
 
 		// On self-hosted sites, we must do some additional checks.
@@ -221,17 +232,11 @@ class Blaze {
 
 		// Check if the site supports Blaze.
 		if ( is_numeric( $site_id ) && ! self::site_supports_blaze( $site_id ) ) {
-			$should_initialize = false;
+			return false;
 		}
 
-		/**
-		 * Filter to disable all Blaze functionality.
-		 *
-		 * @since 0.3.0
-		 *
-		 * @param bool $should_initialize Whether Blaze should be enabled. Default to true.
-		 */
-		return apply_filters( 'jetpack_blaze_enabled', $should_initialize );
+		// Final fallback.
+		return true;
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -154,8 +154,8 @@ class Blaze {
 		}
 
 		$cached_result = get_transient( $transient_name );
-		if ( false !== $cached_result ) {
-			return $cached_result;
+		if ( false !== $cached_result && is_array( $cached_result ) ) {
+			return $cached_result['approved'];
 		}
 
 		// Make the API request.
@@ -170,7 +170,7 @@ class Blaze {
 
 		// If there was an error or malformed response, bail and save response for an hour.
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			set_transient( $transient_name, false, HOUR_IN_SECONDS );
+			set_transient( $transient_name, array( 'approved' => false ), HOUR_IN_SECONDS );
 			return false;
 		}
 
@@ -183,7 +183,7 @@ class Blaze {
 		}
 
 		// Cache the result for 24 hours.
-		set_transient( $transient_name, (bool) $result['approved'], DAY_IN_SECONDS );
+		set_transient( $transient_name, array( 'approved' => (bool) $result['approved'] ), DAY_IN_SECONDS );
 
 		return (bool) $result['approved'];
 	}

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -154,8 +154,12 @@ class Blaze {
 		}
 
 		$cached_result = get_transient( $transient_name );
-		if ( false !== $cached_result && is_array( $cached_result ) ) {
-			return $cached_result['approved'];
+		if ( false !== $cached_result ) {
+			if ( is_array( $cached_result ) ) {
+				return $cached_result['approved'];
+			}
+
+			return (bool) $cached_result;
 		}
 
 		// Make the API request.

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.21.9';
+	const PACKAGE_VERSION = '0.21.10-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -198,6 +198,54 @@ class Test_Blaze extends BaseTestCase {
 	}
 
 	/**
+	 * Test the different scenarios for Blaze eligibility.
+	 *
+	 * @dataProvider get_blaze_eligibility_responses
+	 *
+	 * @covers Automattic\Jetpack\Blaze::site_supports_blaze
+	 *
+	 * @param array $eligibility_details  Details about the site status and the expected response.
+	 * @param bool  $expected_eligibility The expected result of the Blaze eligibility check.
+	 */
+	public function test_site_supports_blaze( $eligibility_details, $expected_eligibility ) {
+		$remote_request_happened = false;
+		$has_transient           = ! empty( $eligibility_details['transient'] );
+
+		if ( $has_transient ) {
+			set_transient( 'jetpack_blaze_site_supports_blaze_0', $eligibility_details['transient'] );
+		} else {
+			if ( isset( $eligibility_details['body'] ) ) {
+				$eligibility_details['body'] = wp_json_encode( $eligibility_details['body'] );
+			}
+
+			$remote_request_happened = true;
+
+			add_filter(
+				'pre_http_request',
+				function () use ( $eligibility_details ) {
+					return $eligibility_details;
+				}
+			);
+		}
+
+		$site_supports_blaze = Blaze::site_supports_blaze( 0 );
+
+		if ( ! $has_transient ) {
+			remove_filter(
+				'pre_http_request',
+				function () use ( $eligibility_details ) {
+					return $eligibility_details;
+				}
+			);
+		}
+
+		$this->assertEquals( $expected_eligibility, $site_supports_blaze );
+		$this->assertEquals( $remote_request_happened, ! $has_transient );
+
+		delete_transient( 'jetpack_blaze_site_supports_blaze_0' );
+	}
+
+	/**
 	 * Different scenarios (pages, Blaze eligibility) to test if Blaze js is enqueued in the editor.
 	 *
 	 * @covers Automattic\Jetpack\Blaze::enqueue_block_editor_assets
@@ -234,6 +282,63 @@ class Test_Blaze extends BaseTestCase {
 				'post',
 				true,
 				false,
+				false,
+			),
+		);
+	}
+
+	/**
+	 * Different potential responses from the Blaze eligibility check.
+	 *
+	 * @return array[]
+	 */
+	public function get_blaze_eligibility_responses() {
+		return array(
+			'no cache, successful request, blog eligible' => array(
+				array(
+					'response'    => array( 'code' => 200 ),
+					'status_code' => 200,
+					'body'        => array( 'approved' => true ),
+				),
+				true,
+			),
+			'no cache, successful request, blog not eligible' => array(
+				array(
+					'response'    => array( 'code' => 200 ),
+					'status_code' => 200,
+					'body'        => array( 'approved' => false ),
+				),
+				false,
+			),
+			'no cache, unsuccessful request, 403'         => array(
+				array(
+					'response'    => array( 'code' => 403 ),
+					'status_code' => 403,
+				),
+				false,
+			),
+			'cache, boolean transient, blog eligible'     => array(
+				array(
+					'transient' => true,
+				),
+				true,
+			),
+			'cache, boolean transient, blog not eligible' => array(
+				array(
+					'transient' => false,
+				),
+				false,
+			),
+			'cache, array transient, blog eligible'       => array(
+				array(
+					'transient' => array( 'approved' => true ),
+				),
+				true,
+			),
+			'cache, array transient, blog not eligible'   => array(
+				array(
+					'transient' => array( 'approved' => false ),
+				),
 				false,
 			),
 		);

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -220,6 +220,9 @@ class Test_Blaze extends BaseTestCase {
 
 			$remote_request_happened = true;
 
+			Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = 'https://public-api.wordpress.com';
+			update_option( 'jetpack_private_options', array( 'blog_token' => 'blog.token' ) );
+
 			add_filter(
 				'pre_http_request',
 				function () use ( $eligibility_details ) {


### PR DESCRIPTION
Fixes #38068 

## Proposed changes:

When a site or user is not properly connected to WordPress.com, or when there are sync issues on the site, we can estimate that the site is not eligible to Blaze, since they won't be able to create Blaze campaigns when those things are not working properly.

Let's consequently bail earlier, consider Blaze as not ready to be initialized. That will save us a lot of failed remote requests later.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related discussion: p1719416484308139-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

This will be easier to test on a site with a broken Jetpack connection.

There, when the Blaze module is enabled in Jetpack > Settings > Traffic:

1. You should not see the navigation menu in Tools > Advertize.
2. You should not see any requests to WordPress.com being made.
