### PR TITLE
AI Assistant: Do not extend Form twice

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-form-double-extension
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-form-double-extension
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Do not extend Form twice

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/ai-assistant/index.ts
@@ -26,13 +26,6 @@ export const isAiAssistantExtensionsSupportEnabled = getFeatureAvailability(
 	AI_ASSISTANT_EXTENSIONS_SUPPORT_NAME
 );
 
-// The list of all extended blocks before the inline extensions were released. Does not include the list-item block.
-export const ALL_EXTENDED_BLOCKS = [ 'core/paragraph', 'core/list', 'core/heading' ];
-
-// The blocks will be converted one by one to inline blocks, so we update the lists accordingly, under the feature flag.
-export let EXTENDED_TRANSFORMATIVE_BLOCKS: string[] = [ ...ALL_EXTENDED_BLOCKS ];
-export const EXTENDED_INLINE_BLOCKS: string[] = [];
-
 // All Jetpack Form blocks to extend
 export const JETPACK_FORM_CHILDREN_BLOCKS = [
 	'jetpack/field-name',
@@ -49,6 +42,19 @@ export const JETPACK_FORM_CHILDREN_BLOCKS = [
 	'jetpack/field-consent',
 	'jetpack/button',
 ] as const;
+
+// The list of all extended blocks before the inline extensions were released. Does not include the list-item block.
+export const ALL_EXTENDED_BLOCKS = [
+	'core/paragraph',
+	'core/list',
+	'core/heading',
+	'jetpack/contact-form',
+	...JETPACK_FORM_CHILDREN_BLOCKS,
+];
+
+// The blocks will be converted one by one to inline blocks, so we update the lists accordingly, under the feature flag.
+export let EXTENDED_TRANSFORMATIVE_BLOCKS: string[] = [ ...ALL_EXTENDED_BLOCKS ];
+export const EXTENDED_INLINE_BLOCKS: string[] = [];
 
 // Temporarily keep track of inline extensions that have been released to production.
 const releasedInlineExtensions = [
@@ -152,6 +158,12 @@ function addJetpackAISupport(
 ): BlockSettingsProps {
 	// Only extend the blocks in the list.
 	if ( ! EXTENDED_TRANSFORMATIVE_BLOCKS.includes( name ) ) {
+		return settings;
+	}
+
+	// Do not extend Form blocks, as they are handled differently.
+	const formBlocks = [ 'jetpack/contact-form', ...JETPACK_FORM_CHILDREN_BLOCKS ];
+	if ( formBlocks.includes( name ) ) {
 		return settings;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -14,7 +14,10 @@ import React from 'react';
  * Internal dependencies
  */
 import { getFeatureAvailability } from '../../lib/utils/get-feature-availability';
-import { AI_ASSISTANT_EXTENSIONS_SUPPORT_NAME } from '../ai-assistant';
+import {
+	AI_ASSISTANT_EXTENSIONS_SUPPORT_NAME,
+	EXTENDED_TRANSFORMATIVE_BLOCKS,
+} from '../ai-assistant';
 import AiAssistantBar from './components/ai-assistant-bar';
 import AiAssistantToolbarButton from './components/ai-assistant-toolbar-button';
 import { isJetpackFromBlockAiCompositionAvailable } from './constants';
@@ -53,6 +56,11 @@ export function useIsPossibleToExtendJetpackFormBlock(
 
 	// Check if there is a block name.
 	if ( typeof blockName !== 'string' ) {
+		return false;
+	}
+
+	// Only extend the blocks in the allowed list.
+	if ( ! EXTENDED_TRANSFORMATIVE_BLOCKS.includes( blockName ) ) {
 		return false;
 	}
 
@@ -193,6 +201,11 @@ function jetpackFormWithAiSupport( settings, name: string ) {
 		return settings;
 	}
 
+	// Only extend the blocks in the allowed list.
+	if ( ! EXTENDED_TRANSFORMATIVE_BLOCKS.includes( name ) ) {
+		return settings;
+	}
+
 	// Disable if Inline Extension is enabled
 	if ( getFeatureAvailability( AI_ASSISTANT_EXTENSIONS_SUPPORT_NAME ) ) {
 		return settings;
@@ -264,6 +277,11 @@ const jetpackFormChildrenEditWithAiComponents = createHigherOrderComponent( Bloc
  * with the AI Assistant components.
  */
 function jetpackFormChildrenEditWithAiSupport( settings, name ) {
+	// Only extend the blocks in the allowed list.
+	if ( ! EXTENDED_TRANSFORMATIVE_BLOCKS.includes( name ) ) {
+		return settings;
+	}
+
 	// Only extend allowed blocks (Jetpack form and its children)
 	if ( ! JETPACK_FORM_CHILDREN_BLOCKS.includes( name ) ) {
 		return settings;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38064

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the same check used for the AI extensions to the Form extension, that was handled differently

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disable the feature flag
* Add a Form block
* Check that only the inline extension is displayed
* Test on a JN site and on a simple site

| Before | After |
| --------- | -------- |
| ![2024-06-26_12-38-02](https://github.com/Automattic/jetpack/assets/8486249/dac22c2b-2701-4722-ac16-704a5bc66e4b) | ![2024-06-26_13-44-59](https://github.com/Automattic/jetpack/assets/8486249/d3ca36d6-6d89-4724-9398-0f92131c92db) |
