### PR TITLE
Improve performance of `changelogger-validate-all.sh`

### DIFF
--- a/projects/packages/changelogger/changelog/update-improve-performance-of-check-intra-monorepo-deps
+++ b/projects/packages/changelogger/changelog/update-improve-performance-of-check-intra-monorepo-deps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Skip querying `git` in `changelogger version` command. We don't need the timestamp or PR number for that operation.

--- a/projects/packages/changelogger/src/Application.php
+++ b/projects/packages/changelogger/src/Application.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 class Application extends SymfonyApplication {
 
-	const VERSION = '4.2.4';
+	const VERSION = '4.2.5-alpha';
 
 	/**
 	 * Constructor.

--- a/projects/packages/changelogger/src/Utils.php
+++ b/projects/packages/changelogger/src/Utils.php
@@ -215,6 +215,7 @@ class Utils {
 	 * @param mixed           $files Output parameter. An array is written to this parameter, with
 	 *   keys being filenames in `$dir` and values being 0 for success, 1 for warnings, 2 for errors.
 	 * @param array|null      $input_options Options for the extraction.
+	 *   - skip-data: (bool) Set true to skip loading PR number and timestamp.
 	 *   - add-pr-num: (bool) Whether to try to read a `(#12345)`-like PR number from the git commit creating each change entry. Default false.
 	 * @return ChangeEntry[] Keys are filenames in `$dir`.
 	 */
@@ -249,7 +250,10 @@ class Utils {
 				}
 			}
 			try {
-				$repo_data    = self::getRepoData( $path, $output, $debugHelper );
+				$repo_data    = empty( $input_options['skip-data'] ) ? self::getRepoData( $path, $output, $debugHelper ) : array(
+					'pr-num'    => '',
+					'timestamp' => '1970-01-01T00:00:00Z',
+				);
 				$ret[ $name ] = $formatter->newChangeEntry(
 					array(
 						'significance' => $data['Significance'] ?? null,

--- a/projects/packages/changelogger/src/VersionCommand.php
+++ b/projects/packages/changelogger/src/VersionCommand.php
@@ -230,7 +230,8 @@ EOF
 		} else {
 			$dir = Config::changesDir();
 			if ( is_dir( $dir ) ) {
-				$changes = Utils::loadAllChanges( Config::changesDir(), Config::types(), $formatter, $output );
+				$dummy   = null;
+				$changes = Utils::loadAllChanges( Config::changesDir(), Config::types(), $formatter, $output, $dummy, array( 'skip-data' => true ) );
 			} else {
 				$output->writeln( '<warning>Changes directory does not exist</>' );
 				$changes = array();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`changelogger version` is unnecessarily calling `git` to fetch the timestamp and PR number for all the changelog entries, when all it's really using is the significance. Skip that.

Then, while validating each individual project is reasonably fast, when there's 117 of them it adds up. We can improve things somewhat by processing projects in parallel, matching the number of processors in the system.

On my laptop, the first takes the time from ~16.8s to ~10.7s, and the second (8 cores) takes it to ~2.3s.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try it?
