### PR TITLE
Jetpack AI Image: show snackbar notice when the image is saved to the library

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-image-saved-notification
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-image-saved-notification
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI Image: show notice when image gets saved to media library.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
@@ -237,7 +237,7 @@ export default function GeneralPurposeImage( {
 			autoStart={ false }
 			images={ images }
 			currentIndex={ current }
-			title={ __( 'Generate a image with AI', 'jetpack' ) }
+			title={ __( 'Generate an image with AI', 'jetpack' ) }
 			cost={ generalImageCost }
 			open={ isFeaturedImageModalVisible }
 			placement={ placement }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useImageGenerator } from '@automattic/jetpack-ai-client';
+import { useDispatch } from '@wordpress/data';
 import { useCallback, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
@@ -32,6 +33,7 @@ export default function useAiImage( {
 	const { generateImageWithParameters } = useImageGenerator();
 	const { increaseRequestsCount } = useAiFeature();
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
+	const { createNotice } = useDispatch( 'core/notices' );
 
 	/* Images Control */
 	const pointer = useRef( 0 );
@@ -49,6 +51,19 @@ export default function useAiImage( {
 			return newImages;
 		} );
 	}, [] );
+
+	/*
+	 * Function to show a snackbar notice on the editor.
+	 */
+	const showSnackbarNotice = useCallback(
+		( message: string ) => {
+			createNotice( 'success', message, {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
+		},
+		[ createNotice ]
+	);
 
 	/*
 	 * Function to update the requests count after a featured image generation.
@@ -134,6 +149,7 @@ export default function useAiImage( {
 							updateRequestsCount();
 							saveToMediaLibrary( image )
 								.then( savedImage => {
+									showSnackbarNotice( __( 'Image saved to media library.', 'jetpack' ) );
 									updateImages(
 										{ libraryId: savedImage?.id, libraryUrl: savedImage?.url, generating: false },
 										pointer.current
@@ -165,6 +181,7 @@ export default function useAiImage( {
 			type,
 			updateRequestsCount,
 			saveToMediaLibrary,
+			showSnackbarNotice,
 		]
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38076.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Show "Image saved to media library" on a snackbar notice after the image is saved to the media library (happens automatically after it gets generated)
* Fix typo on general purpose image generator modal title

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you have the beta extensions enabled
* Go to the block editor, add an image block and then click "Select Image" > "Generate with AI" to trigger the general purpose image generator
* Confirm the heading of the modal says "Generate an image with AI" (there was a typo there before):

<img width="300" alt="Screenshot 2024-06-26 at 18 38 16" src="https://github.com/Automattic/jetpack/assets/6760046/b285ab16-72c2-4cf8-bf97-01a620c0b792">

* Type some prompt and ask for an image
* As soon as the image is ready, notice that a message is showed at the bottom left corner of the editor, using the snackbar component:

<img width="600" alt="Screenshot 2024-06-26 at 18 39 00" src="https://github.com/Automattic/jetpack/assets/6760046/d409e011-598d-40c8-9334-5a1c3fa69fa7">

* You can also test it using the featured image generator; the snackbar notice should be triggered there as well