### PR TITLE
Newsletters: Enhance Subscription Modal Display Logic

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-behaviour
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-behaviour
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Implemented a more dynamic approach to displaying the subscription modal

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -70,7 +70,7 @@ class Jetpack_Subscribe_Modal {
 			 *
 			 * @since 13.4
 			 *
-			 * @param int 300 Time in milliseconds for the Subscribe Modal to appear upon scrolling.
+			 * @param int 60000 Time in milliseconds for the Subscribe Modal to appear.
 			 */
 			$load_time = absint( apply_filters( 'jetpack_subscribe_modal_load_time', 60000 ) );
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -64,7 +64,7 @@ class Jetpack_Subscribe_Modal {
 			wp_enqueue_script( 'subscribe-modal-js', plugins_url( 'subscribe-modal.js', __FILE__ ), array( 'wp-dom-ready' ), JETPACK__VERSION, true );
 
 			/**
-			 * Filter how many milliseconds a user must scroll for until the Subscribe Modal appears.
+			 * Filter how many milliseconds until the Subscribe Modal appears.
 			 *
 			 * @module subscriptions
 			 *
@@ -72,9 +72,27 @@ class Jetpack_Subscribe_Modal {
 			 *
 			 * @param int 300 Time in milliseconds for the Subscribe Modal to appear upon scrolling.
 			 */
-			$load_time = absint( apply_filters( 'jetpack_subscribe_modal_load_time', 300 ) );
+			$load_time = absint( apply_filters( 'jetpack_subscribe_modal_load_time', 60000 ) );
 
-			wp_localize_script( 'subscribe-modal-js', 'Jetpack_Subscriptions', array( 'modalLoadTime' => $load_time ) );
+			/**
+			 * Filter how many percentage of the page should be scrolled before the Subscribe Modal appears.
+			 *
+			 * @module subscriptions
+			 *
+			 * @since 13.6
+			 *
+			 * @param int Percentage of the page scrolled before the Subscribe Modal appears.
+			 */
+			$scroll_threshold = absint( apply_filters( 'jetpack_subscribe_modal_scroll_threshold', 50 ) );
+
+			wp_localize_script(
+				'subscribe-modal-js',
+				'Jetpack_Subscriptions',
+				array(
+					'modalLoadTime'        => $load_time,
+					'modalScrollThreshold' => $scroll_threshold,
+				)
+			);
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1719421326241939/1719262060.786719-slack-C02NQ4HMJKV

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR introduces improvements to the logic controlling the display of the subscription modal.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*