### PR TITLE
Boost: no need to log successful caching, only cache problems with early page exits

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/pre-wordpress/Boost_Cache.php
@@ -184,6 +184,7 @@ class Boost_Cache {
 
 			// Do not cache the page as WordPress did not initialize correctly.
 			if ( ! $this->do_cache ) {
+				Logger::debug( 'Page exited early. Do not cache.' );
 				return $buffer;
 			}
 
@@ -486,7 +487,6 @@ class Boost_Cache {
 	 * fatal errors occurred.
 	 */
 	public function init_do_cache() {
-		Logger::debug( 'postload: init succeeded' );
 		$this->do_cache = true;
 	}
 }

--- a/projects/plugins/boost/changelog/boost-fix-logging-too-much
+++ b/projects/plugins/boost/changelog/boost-fix-logging-too-much
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Boost: no need to log successful caching, done already. Only log early page exits.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
In #38054 I added code that checked if "init" fired and logged the event. That proves to be noisy so it makes more sense to log when the event fails.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move logging from a function hooked on init to a check that's run in the output buffer. That code checks if the init event fired.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Enable logging
* Visit a page on your site.
* Confirm there's no "postload: init succeeded" message in the log.