### PR TITLE
Super cache: don't log when there's no cache directory

### DIFF
--- a/projects/plugins/super-cache/changelog/super-cache-fix-no-cache-no-log
+++ b/projects/plugins/super-cache/changelog/super-cache-fix-no-cache-no-log
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Super Cache: don't log when cache directory is gone, to avoid PHP errors
+
+

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -728,7 +728,7 @@ function wp_cache_debug( $message, $level = 1 ) {
 	}
 
 	// if cache path is gone, then don't log anything
-	if ( ! is_dir( $cache_path ) ) {
+	if ( empty( $cache_path ) || ! is_dir( $cache_path ) ) {
 		return;
 	}
 

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -727,6 +727,11 @@ function wp_cache_debug( $message, $level = 1 ) {
 		return false;
 	}
 
+	// if cache path is gone, then don't log anything
+	if ( ! is_dir( $cache_path ) ) {
+		return;
+	}
+
 	// Log message: Date URI Message
 	$log_message = date( 'H:i:s' ) . ' ' . getmypid() . " {$_SERVER['REQUEST_URI']} {$message}" . PHP_EOL;
 	// path to the log file in the cache folder


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
When the plugin is deactivated and the debug log is enabled it will continue to log events even when the cache directory is deleted.
This PR checks if that directory is there before logging anything.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a check for $cache_path to the wp_cache_debug() function

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Enable debugging in the plugin.
* tail the PHP error log
* Go to the plugins page
* Deactivate WP Super Cache
* You shouldn't see attempts to open a file in the cache directory.


