### PR TITLE
Sync checksum: ensure postmeta table does not filter by whitelist when getting range edges

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-checksum-ensure-postmeta-table-does-not-filter-by-whitelist-when-getting-range-edges
+++ b/projects/packages/sync/changelog/fix-sync-checksum-ensure-postmeta-table-does-not-filter-by-whitelist-when-getting-range-edges
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync Checksum:Use postmeta table name from wpdb to compare so we don't filter by whitelist due to performance reasons.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.1.3';
+	const PACKAGE_VERSION = '3.1.4-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -701,7 +701,7 @@ class Table_Checksum {
 		// The reason for this is that it leads to a non-performant query that can timeout.
 		// Instead lets get the range based on posts regardless of meta.
 		$filter_values = $this->filter_values;
-		if ( 'postmeta' === $this->table ) {
+		if ( $wpdb->postmeta === $this->table ) {
 			$this->filter_values = null;
 		}
 
@@ -709,7 +709,7 @@ class Table_Checksum {
 		$filters = trim( $this->build_filter_statement( $range_from, $range_to ) );
 
 		// Reset Post meta filter.
-		if ( 'postmeta' === $this->table ) {
+		if ( $wpdb->postmeta === $this->table ) {
 			$this->filter_values = $filter_values;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
While working on https://github.com/Automattic/jpop-issues/issues/9085 I found many sites were failing on the WPCOM side due to a SQL error like the following. `WordPress database error MySQL server has gone away for query` which will show a PHP error with `error_text Uncaught Exception: Unable to get range edges` (Check for an example in the [issue](https://github.com/Automattic/jpop-issues/issues/9085)).

I was able to find that https://github.com/Automattic/jetpack/pull/19453 tried actually to tackle the same issue. Seems that the check in the fix there needed to be against  `$wpdb->postmeta` instead of `postmeta` [here](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/replicastore/class-table-checksum.php#L712).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes the check to remove the filter for `postmeta` ranges. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
### In your local instance of Jetpack
First try without the PR applied.
1 Enter wp shell. `jetpack docker shell`
2 `$rs = new Automattic\Jetpack\Sync\Replicastore();`
3 `$rs->checksum_histogram( 'postmeta' );`
4 Record the checksum results
5 Exit wp shell
6 Apply Patch
7 Enter wp shell
8 `$rs = new Automattic\Jetpack\Sync\Replicastore();`
9 `$rs->checksum_histogram( 'postmeta' );`
10 Verify the checksum matches the prepatch value **Note that the ranges will probably differ, which makes sense since we are not filtering some posts**.

Example 
```
PRE PATCH
> $rs->checksum_histogram( 'postmeta' );
= [
    "555-3015" => "2594727997867",
  ]
POST PATCH
> $rs->checksum_histogram( 'postmeta' );
= [
    "555-3020" => "2594727997867",
  ]
```

### In WPCOM
Do the same thing for a cached site after switching to your blog_id while not patched and patched in your sandbox.
