### PR TITLE
Custom CSS: prevent PHP warning

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-css-tidy-wraning
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-css-tidy-wraning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP warning
+
+

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.41.0",
+	"version": "5.41.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.41.0';
+	const PACKAGE_VERSION = '5.41.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/csstidy/class.csstidy-optimise.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/csstidy/class.csstidy-optimise.php
@@ -636,8 +636,8 @@ class csstidy_optimise { // phpcs:ignore
 		$shorthands = & $GLOBALS['csstidy']['shorthands'];
 
 		foreach ( $shorthands as $key => $value ) {
-			if ( is_array( $value ) && isset( $array[ $value[0] ] ) && isset( $array[ $value[1] ] )
-							&& isset( $array[ $value[2] ] ) && isset( $array[ $value[3] ] ) && $value !== 0 ) {
+			if ( $value !== 0 && isset( $array[ $value[0] ] ) && isset( $array[ $value[1] ] )
+							&& isset( $array[ $value[2] ] ) && isset( $array[ $value[3] ] ) ) {
 				$return[ $key ] = '';
 
 				$important = '';

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/csstidy/class.csstidy-optimise.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/csstidy/class.csstidy-optimise.php
@@ -632,11 +632,11 @@ class csstidy_optimise { // phpcs:ignore
 	 * @see dissolve_4value_shorthands()
 	 */
 	public static function merge_4value_shorthands( $array ) {
-		$return     = $array;
+		$return     = is_array( $array ) ? $array : array();
 		$shorthands = & $GLOBALS['csstidy']['shorthands'];
 
 		foreach ( $shorthands as $key => $value ) {
-			if ( isset( $array[ $value[0] ] ) && isset( $array[ $value[1] ] )
+			if ( is_array( $value ) && isset( $array[ $value[0] ] ) && isset( $array[ $value[1] ] )
 							&& isset( $array[ $value[2] ] ) && isset( $array[ $value[3] ] ) && $value !== 0 ) {
 				$return[ $key ] = '';
 

--- a/projects/plugins/jetpack/changelog/fix-css-tidy-wraning
+++ b/projects/plugins/jetpack/changelog/fix-css-tidy-wraning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Prevent PHP warning
+
+

--- a/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy-optimise.php
+++ b/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy-optimise.php
@@ -636,8 +636,8 @@ class csstidy_optimise { // phpcs:ignore
 		$shorthands = & $GLOBALS['csstidy']['shorthands'];
 
 		foreach ( $shorthands as $key => $value ) {
-			if ( is_array( $value ) && isset( $array[ $value[0] ] ) && isset( $array[ $value[1] ] )
-							&& isset( $array[ $value[2] ] ) && isset( $array[ $value[3] ] ) && $value !== 0 ) {
+			if ( $value !== 0 && isset( $array[ $value[0] ] ) && isset( $array[ $value[1] ] )
+							&& isset( $array[ $value[2] ] ) && isset( $array[ $value[3] ] ) ) {
 				$return[ $key ] = '';
 
 				$important = '';

--- a/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy-optimise.php
+++ b/projects/plugins/jetpack/modules/custom-css/csstidy/class.csstidy-optimise.php
@@ -632,11 +632,11 @@ class csstidy_optimise { // phpcs:ignore
 	 * @see dissolve_4value_shorthands()
 	 */
 	public static function merge_4value_shorthands( $array ) {
-		$return     = $array;
+		$return     = is_array( $array ) ? $array : array();
 		$shorthands = & $GLOBALS['csstidy']['shorthands'];
 
 		foreach ( $shorthands as $key => $value ) {
-			if ( isset( $array[ $value[0] ] ) && isset( $array[ $value[1] ] )
+			if ( is_array( $value ) && isset( $array[ $value[0] ] ) && isset( $array[ $value[1] ] )
 							&& isset( $array[ $value[2] ] ) && isset( $array[ $value[3] ] ) && $value !== 0 ) {
 				$return[ $key ] = '';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
On WordPress.com, the CSStidy library triggers a PHP warning: `Warning: Trying to access array offset on value of type`. This PR adds conditions in `class.csstidy-optimise.php` in the `jetpack-mu-wpcom` package to prevent the warning. This PR alone doesn't fix the issue for WordPress.com. We'll need to ensure it loads CSStidy from the `jetpack-mu-wpcom` package.

Note: the changes are reflected in the Jetpack plugin as well for good measure, though the Custom CSS will soon be removed from the plugin.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/vulcan/issues/362

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This one's hard to test. I don't know what path triggered a warning. Adding tests seems overkill as well, given the scope of the changes and that the method's not pure.

Code review should be sufficient.

