### PR TITLE
image-guide: Update `rollup-plugin-svelte-svg` dep

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -76,6 +76,12 @@ function fixDeps( pkg ) {
 		pkg.dependencies.cssnano = '^5.0.1 || ^6';
 	}
 
+	// Outdated dependency. And it doesn't really use it in our configuration anyway.
+	// No upstream bug link yet.
+	if ( pkg.name === 'rollup-plugin-svelte-svg' && pkg.dependencies.svgo === '^2.3.1' ) {
+		pkg.dependencies.svgo = '*';
+	}
+
 	// Missing dep or peer dep on @babel/runtime
 	// https://github.com/zillow/react-slider/issues/296
 	if (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: i2gupvr4pzna7cayhonamrk5iq
+pnpmfileChecksum: bjkzupj7mgxhpr4jv54264ts6e
 
 importers:
 
@@ -712,8 +712,8 @@ importers:
         specifier: 7.1.0
         version: 7.1.0(rollup@2.79.1)(svelte@3.58.0)
       rollup-plugin-svelte-svg:
-        specifier: 0.2.3
-        version: 0.2.3(svelte@3.58.0)
+        specifier: 1.0.0-beta.6
+        version: 1.0.0-beta.6(svelte@3.58.0)
       sass:
         specifier: 1.64.1
         version: 1.64.1
@@ -9706,9 +9706,6 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
-  estree-walker@0.2.1:
-    resolution: {integrity: sha512-6/I1dwNKk0N9iGOU3ydzAAurz4NPo/ttxZNCqgIVbWFvWyzWBSNonRrJ5CpjDuyBfmM7ENN7WCzUi9aT/UPXXQ==}
-
   estree-walker@0.6.1:
     resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
 
@@ -12982,10 +12979,10 @@ packages:
     peerDependencies:
       postcss: 8.x
 
-  rollup-plugin-svelte-svg@0.2.3:
-    resolution: {integrity: sha512-WH2KqihgVbcJT/PrjiJ/ipctrGueRdOLaaEuAIbXYqfsEzNb9krOVLyc5TL7to3cEKL6DiAa8IEe7IL1oqVolg==}
+  rollup-plugin-svelte-svg@1.0.0-beta.6:
+    resolution: {integrity: sha512-6uJb9kuaqK6p+DvkgphhGN18wvUzdT6h7MQC2B8P1omi9omC9lQC54pwaot21h6z9ibhGPLG9a1XFLeDQth/kg==}
     peerDependencies:
-      svelte: ^3.16.7
+      svelte: '*'
 
   rollup-plugin-svelte@7.1.0:
     resolution: {integrity: sha512-vopCUq3G+25sKjwF5VilIbiY6KCuMNHP1PFvx2Vr3REBNMDllKHFZN2B9jwwC+MqNc3UPKkjXnceLPEjTjXGXg==}
@@ -12993,9 +12990,6 @@ packages:
     peerDependencies:
       rollup: '>=2.0.0'
       svelte: '>=3.5.0'
-
-  rollup-pluginutils@1.5.2:
-    resolution: {integrity: sha512-SjdWWWO/CUoMpDy8RUbZ/pSpG68YHmhk5ROKNIoi2En9bJ8bTt3IhYi254RWiTclQmL7Awmrq+rZFOhZkJAHmQ==}
 
   rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
@@ -22141,8 +22135,6 @@ snapshots:
 
   estraverse@5.3.0: {}
 
-  estree-walker@0.2.1: {}
-
   estree-walker@0.6.1: {}
 
   estree-walker@1.0.1: {}
@@ -26047,10 +26039,11 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  rollup-plugin-svelte-svg@0.2.3(svelte@3.58.0):
+  rollup-plugin-svelte-svg@1.0.0-beta.6(svelte@3.58.0):
     dependencies:
-      rollup-pluginutils: 1.5.2
+      rollup-pluginutils: 2.8.2
       svelte: 3.58.0
+      svgo: 3.3.2
 
   rollup-plugin-svelte@7.1.0(rollup@2.79.1)(svelte@3.58.0):
     dependencies:
@@ -26058,11 +26051,6 @@ snapshots:
       rollup: 2.79.1
       rollup-pluginutils: 2.8.2
       svelte: 3.58.0
-
-  rollup-pluginutils@1.5.2:
-    dependencies:
-      estree-walker: 0.2.1
-      minimatch: 3.1.2
 
   rollup-pluginutils@2.8.2:
     dependencies:

--- a/projects/js-packages/image-guide/changelog/update-rollup-plugin-svelte-svg
+++ b/projects/js-packages/image-guide/changelog/update-rollup-plugin-svelte-svg
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update rollup-plugin-svelte-svg dependency. No change to functionality.
+
+

--- a/projects/js-packages/image-guide/package.json
+++ b/projects/js-packages/image-guide/package.json
@@ -50,7 +50,7 @@
 		"rollup": "2.79.1",
 		"rollup-plugin-postcss": "4.0.2",
 		"rollup-plugin-svelte": "7.1.0",
-		"rollup-plugin-svelte-svg": "0.2.3",
+		"rollup-plugin-svelte-svg": "1.0.0-beta.6",
 		"sass": "1.64.1",
 		"svelte": "3.58.0",
 		"svelte-preprocess": "5.0.4",

--- a/projects/js-packages/image-guide/rollup.config.js
+++ b/projects/js-packages/image-guide/rollup.config.js
@@ -8,7 +8,7 @@ import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import postcss from 'rollup-plugin-postcss';
 import svelte from 'rollup-plugin-svelte';
-import svelteSVG from 'rollup-plugin-svelte-svg';
+import { svelteSVG } from 'rollup-plugin-svelte-svg';
 import sveltePreprocess from 'svelte-preprocess';
 import tsconfig from './tsconfig.json';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Renovate won't do this one because the author never got around to releasing a 1.0.0 stable version, they stopped at 1.0.0-beta.6.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* There are no changes to the built artifact.
