### PR TITLE
 AI Assistant: Disable extensions when AI Assistant block is hidden

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-extensions-disable
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-extensions-disable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Disable extensions when AI Assistant block is hidden

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-contact-form/index.tsx
@@ -93,7 +93,7 @@ export function useIsPossibleToExtendJetpackFormBlock(
 	 */
 	const { getHiddenBlockTypes } = select( 'core/edit-post' ) || {};
 	const hiddenBlocks = getHiddenBlockTypes?.() || []; // It will extend the block if the function is undefined.
-	if ( hiddenBlocks.includes( blockName ) ) {
+	if ( hiddenBlocks.includes( 'jetpack/ai-assistant' ) ) {
 		return false;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/lib/is-possible-to-extend-block.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/lib/is-possible-to-extend-block.ts
@@ -33,13 +33,13 @@ export function isPossibleToExtendBlock( blockName: string ): boolean {
 
 	/*
 	 * Do not extend if the AI Assistant block is hidden
-	 * Todo: Do we want to make the extension depend on the block visibility?
 	 * ToDo: the `editPostStore` is undefined for P2 sites.
 	 * Let's find a way to check if the block is hidden.
 	 */
 	const { getHiddenBlockTypes } = select( 'core/edit-post' ) || {};
-	const hiddenBlocks = getHiddenBlockTypes?.() || []; // It will extend the block if the function is undefined.
-	if ( hiddenBlocks.includes( blockName ) ) {
+	const hiddenBlocks = getHiddenBlockTypes?.() || []; // It will extend the block if the function is undefined
+
+	if ( hiddenBlocks.includes( 'jetpack/ai-assistant' ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38104

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes the block name to check against hidden blocks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Check that the extensions are visible as normal
* Go to Preferences > Block and deselect "AI Assistant"
* Reload the page
* Check that the extensions are not registered anymore
* Re-enable the AI Assistant block and reload
* Check that the extensions are visible again
