### PR TITLE
Update/redirect admin interface update

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-redirect-admin-interface-update
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-redirect-admin-interface-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Redirect to Default settings page after Admin Interface has been updated to Default.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.42.0",
+	"version": "5.42.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.42.0';
+	const PACKAGE_VERSION = '5.42.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -39,7 +39,6 @@ if (
 	// The option should always be available on atomic sites.
 	! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
 	// The option will be shown if the simple site has already changed to Classic which means they should have already passed the experiment gate.
-	// We can remove the redirection in wpcom_admin_interface_pre_update_option for simple sites after the experiment is finished.
 	( function_exists( 'wpcom_is_nav_redesign_enabled' ) && wpcom_is_nav_redesign_enabled() ) ) {
 	add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );
 }
@@ -87,8 +86,6 @@ function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 
 	if ( ( new Automattic\Jetpack\Status\Host() )->is_wpcom_simple() ) {
 		if ( 'calypso' === $new_value ) {
-			// Fixes https://github.com/Automattic/dotcom-forge/issues/7760.
-			// We can remove this code if the related code in wpcom_admin_interface_display is removed.
 			add_action(
 				'update_option_wpcom_admin_interface',
 				/**
@@ -97,7 +94,7 @@ function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 				 * @return never
 				*/
 				function () {
-					wp_safe_redirect( 'https://wordpress.com/home/' . wpcom_get_site_slug() );
+					wp_safe_redirect( 'https://wordpress.com/settings/general/' . wpcom_get_site_slug() );
 					exit;
 				}
 			);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7760

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Instead of redirecting to `/home`, we're redirecting to `/settings/general` for a more streamlined UX.

https://github.com/Automattic/jetpack/assets/6586048/84c0eac4-87ef-4a9f-9686-e816b66d15e8

I decided to remove the comments saying to remove these code changes after the experiment ends as I feel like this is a great UX instead of still stuck in the Classic General Settings.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a Simple Classic site
* Change the Admin interface to Classic and back to Default
* It should redirect to `/settings/general`

