### PR TITLE
WPCOMSH: add plugin-dance CLI command

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-plugin-dance-command
+++ b/projects/plugins/wpcomsh/changelog/add-plugin-dance-command
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added plugin dance command

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -970,7 +970,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 		 */
 		public function plugin_dance( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			$plugins = WP_CLI::runcommand(
-				'--skip-plugins --skip-themes plugin list --format=json',
+				'--skip-plugins --skip-themes plugin list --status=active --format=json',
 				array(
 					'launch' => false,
 					'return' => true,
@@ -978,14 +978,6 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 			);
 
 			$plugins = json_decode( $plugins, true );
-
-			// filter plugins where status = active.
-			$active_plugins = array_filter(
-				$plugins,
-				function ( $plugin ) {
-					return 'active' === $plugin['status'];
-				}
-			);
 
 			// deactivate all active plugins.
 			WP_CLI::runcommand(
@@ -998,7 +990,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 			$breaking_plugins = array();
 
 			// loop through each active plugin and activate one by one.
-			foreach ( $active_plugins as $plugin ) {
+			foreach ( $plugins as $plugin ) {
 				WP_CLI::runcommand(
 					'--skip-themes plugin activate ' . $plugin['name'],
 					array(

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -962,8 +962,100 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 					WP_CLI::error( 'Invalid command' );
 			}
 		}
-	}
 
+		/**
+		 * Tries disabling all plugins & enabling them one by one to find the plugin causing the issue.
+		 *
+		 * @subcommand plugin-dance
+		 */
+		public function plugin_dance( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			$plugins = WP_CLI::runcommand(
+				'--skip-plugins --skip-themes plugin list --format=json',
+				array(
+					'launch' => false,
+					'return' => true,
+				)
+			);
+
+			$plugins = json_decode( $plugins, true );
+
+			// filter plugins where status = active.
+			$active_plugins = array_filter(
+				$plugins,
+				function ( $plugin ) {
+					return 'active' === $plugin['status'];
+				}
+			);
+
+			// deactivate all active plugins.
+			WP_CLI::runcommand(
+				'--skip-plugins --skip-themes wpcomsh deactivate-user-plugins',
+				array(
+					'launch' => false,
+				)
+			);
+
+			$breaking_plugins = array();
+
+			// loop through each active plugin and activate one by one.
+			foreach ( $active_plugins as $plugin ) {
+				WP_CLI::runcommand(
+					'--skip-themes plugin activate ' . $plugin['name'],
+					array(
+						'launch' => false,
+						'return' => true,
+					)
+				);
+
+				$result = WP_CLI::runcommand(
+					'--skip-themes= --skip-plugins= wpcomsh plugin-dance-health-check', // pass empty values to skip-themes and skip-plugins.
+					array(
+						'return'     => true,
+						'launch'     => true, // must run in a new process to avoid false positives.
+						'exit_error' => false,
+					)
+				);
+
+				if ( ! strpos( $result, 'Healthy' ) ) {
+					// deactivate the breaking plugin
+					WP_CLI::runcommand(
+						'--skip-themes plugin deactivate ' . $plugin['name'],
+						array(
+							'launch' => false,
+							'return' => true,
+						)
+					);
+					WP_CLI::log( '❌ Plugin activated, site health check failed and deactivated: ' . $plugin['name'] );
+
+					$breaking_plugins[] = array(
+						'name'    => $plugin['name'],
+						'version' => $plugin['version'],
+					);
+				} else {
+					WP_CLI::log( '✔ Plugin activated and site health check passed: ' . $plugin['name'] );
+				}
+			}
+
+			if ( ! empty( $breaking_plugins ) ) {
+				$formatter = new \WP_CLI\Formatter(
+					$assoc_args,
+					array( 'name', 'version' )
+				);
+				$formatter->display_items( $breaking_plugins );
+			} else {
+				WP_CLI::success( 'All plugins passed the site health check.' );
+			}
+		}
+
+		/**
+		 * This just outputs healthy. If there are errors this doesn't get outputted at all
+		 *
+		 * @subcommand plugin-dance-health-check
+		 */
+		public function plugin_dance_health_check( $args, $assoc_args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			WP_CLI::success( 'Healthy' );
+		}
+	}
 }
 
 if ( class_exists( 'Checksum_Plugin_Command' ) ) {

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_26_2_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_27_0_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.26.2-alpha",
+	"version": "3.27.0-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.26.2-alpha
+ * Version: 3.27.0-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
@@ -10,7 +10,7 @@
  */
 
 // Increase version number if you change something in wpcomsh.
-define( 'WPCOMSH_VERSION', '3.26.2-alpha' );
+define( 'WPCOMSH_VERSION', '3.27.0-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
## Proposed changes:
* Adds a `wpcomsh plugin-dance` command which:
- deactivated all user plugins
- activates them one by one and runs a site health check

* Adds a `wpcomsh plugin-dance-site-health` command which simply outputs "Healthy". This string is used to see if the site has broken down (The string `There has been a critical error on this website.` is localized, and a HTTP request doesn't work).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Build and rsync this to your sandbox: `jetpack build plugins/wpcomsh && jetpack rsync wpcomsh YOURSITE@sftp.wp.com:htdocs/wp-content/mu-plugins/wpcomsh`
2. Go to http://domain/_cli
3. Activate a plugin that breaks: `wp plugin activate xxxx`
4. Do the plugin dance:  `wp --skip-plugins --skip-themes wpcomsh plugin-dance`

A table will be outputted with the disabled plugins.
