### PR TITLE
Google Analytics: fix the 'missing array key' warning

### DIFF
--- a/projects/packages/google-analytics/changelog/fix-google-analytics-missing-key
+++ b/projects/packages/google-analytics/changelog/fix-google-analytics-missing-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the 'missing array key' notice.

--- a/projects/packages/google-analytics/package.json
+++ b/projects/packages/google-analytics/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-google-analytics",
-	"version": "0.2.1",
+	"version": "0.2.2-alpha",
 	"description": "Set up Google Analytics without touching a line of code.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/google-analytics/#readme",
 	"bugs": {

--- a/projects/packages/google-analytics/src/class-ga-manager.php
+++ b/projects/packages/google-analytics/src/class-ga-manager.php
@@ -18,7 +18,7 @@ use WP_Error;
  */
 class GA_Manager {
 
-	const PACKAGE_VERSION = '0.2.1';
+	const PACKAGE_VERSION = '0.2.2-alpha';
 
 	/**
 	 * Jetpack_Google_Analytics singleton instance.
@@ -211,7 +211,7 @@ class GA_Manager {
 		$wga       = get_option( $option_name, array() );
 		$is_active = ( new Modules() )->is_active( 'google-analytics', false );
 
-		if ( $is_active !== $wga['is_active'] ) {
+		if ( ! array_key_exists( 'is_active', $wga ) || $is_active !== $wga['is_active'] ) {
 			$wga['is_active'] = $is_active;
 		}
 


### PR DESCRIPTION
Reported in https://github.com/Automattic/vulcan/issues/313#issuecomment-2196524284.

## Proposed changes:
* Fix a PHP warning about a missing array key.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pfwV0U-4g-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Use a self-hosted Jetpack installation, connect Jetpack if not connected.
2. Deactivate Google Analytics if active, remove the `jetpack_wga` option if exists (`wp option delete jetpack_wga`).
3. Go to Calypso "Tools -> Marketing -> Traffic", activate Google Analytics.
4. Check the Jetpack site's `debug.log`, confirm there's no `Undefined array key "is_active"` PHP warning.