### PR TITLE
Offline mode: do not show any outbound SSL notice

### DIFF
--- a/projects/plugins/jetpack/changelog/update-outbound-ssl-notice-offline
+++ b/projects/plugins/jetpack/changelog/update-outbound-ssl-notice-offline
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Offline Mode: do not display Jetpack's outbound SSL notice when in Offline mode.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3238,7 +3238,11 @@ p {
 			Client::_wp_remote_request( self::connection()->api_url( 'test' ), $args, true );
 		}
 
-		if ( current_user_can( 'manage_options' ) && ! self::permit_ssl() ) {
+		if (
+			current_user_can( 'manage_options' )
+			&& ! self::permit_ssl()
+			&& ! $is_offline_mode
+		) {
 			add_action( 'jetpack_notices', array( $this, 'alert_auto_ssl_fail' ) );
 		}
 


### PR DESCRIPTION
## Proposed changes:

We do not need to care for communication with WordPress.com on sites running offline mode.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related conversation:
pdWQjU-Nt-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Create a new JN site using this branch.
* Go to Settings > Jetpack Constants and enable Offline mode.
* SSH into the site.
* Add a transient with `wp transient set jetpack_https_test 0`
* Go to the Jetpack Dashboard
    * You should not see any notice at the top of the page.
