### PR TITLE
Disable loading of Custom CSS for atomic sites in `jetpack-mu-wpcom`

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-use-jetpack-plugin-custom-css-for-atomic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-use-jetpack-plugin-custom-css-for-atomic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Disable loading of Custom CSS for atomic sites

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -61,7 +61,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.41.x-dev"
+			"dev-trunk": "5.42.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.41.1-alpha",
+	"version": "5.42.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -52,11 +52,6 @@ class Jetpack_Mu_Wpcom {
 			add_action( 'admin_menu', array( __CLASS__, 'load_wpcom_simple_odyssey_stats' ) );
 		}
 
-		// These features run only on atomic sites.
-		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-			add_action( 'plugins_loaded', array( __CLASS__, 'load_custom_css' ) );
-		}
-
 		// Unified navigation fix for changes in WordPress 6.2.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'unbind_focusout_on_wp_admin_bar_menu_toggle' ) );
 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.41.1-alpha';
+	const PACKAGE_VERSION = '5.42.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-use-jetpack-plugin-custom-css-for-atomic
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-use-jetpack-plugin-custom-css-for-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -937,7 +937,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "b26b9a925ced046e7ab18b4ed96fc559813b76b1"
+                "reference": "b0e59b4274535901640ddc2f61fa092bef3631fd"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -970,7 +970,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.41.x-dev"
+                    "dev-trunk": "5.42.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/changelog/fix-use-jetpack-plugin-custom-css-for-atomic
+++ b/projects/plugins/wpcomsh/changelog/fix-use-jetpack-plugin-custom-css-for-atomic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_27_0"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_27_1_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1074,7 +1074,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "b26b9a925ced046e7ab18b4ed96fc559813b76b1"
+                "reference": "b0e59b4274535901640ddc2f61fa092bef3631fd"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1107,7 +1107,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.41.x-dev"
+                    "dev-trunk": "5.42.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.27.0",
+	"version": "3.27.1-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.27.0
+ * Version: 3.27.1-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
@@ -10,7 +10,7 @@
  */
 
 // Increase version number if you change something in wpcomsh.
-define( 'WPCOMSH_VERSION', '3.27.0' );
+define( 'WPCOMSH_VERSION', '3.27.1-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
https://github.com/Automattic/jetpack/pull/37794 caused the wpcomsh plugin to throw the exception: `PHP Fatal error: Cannot redeclare jetpack_register_css_preprocessors()`.

This PR prevents the exception from being thrown by temporarily disabling the loading of the Custom CSS for atomic sites in the `jetpack-mu-wpcom` package (the Custom CSS will still be available in the Jetpack plugin for now). See conversation linked below for more details.
 
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1719591775246119-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a WoA developer site
- Install and activate a classic theme, such as Twenty-Eleven
- From `/wp-admin/admin.php?page=jetpack_modules`, activate the _Custom CSS_ module
- Install the [Jetpack Beta Tester plugin](https://github.com/Automattic/jetpack-beta/releases)
- In WPadmin, go to Jetpack > Beta Tester
- Select this branch for the WordPress.com Features
<img width="400" alt="Screenshot 2024-06-11 at 4 44 34 PM" src="https://github.com/Automattic/jetpack/assets/1620183/75e3bb0d-13d0-4bbd-b0a9-63773bfcb61c">

- In the admin, visit Appearance > Additional CSS
- Make sure you see the options above and that you can write additional CSS