### PR TITLE
Fix/connection error notice reset incorrectly

### DIFF
--- a/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
+++ b/projects/packages/my-jetpack/_inc/context/notices/noticeContext.tsx
@@ -5,7 +5,7 @@ const defaultNotice: Notice = {
 	message: '',
 	title: null,
 	options: {
-		level: '',
+		level: 'info',
 		priority: 0,
 	},
 };
@@ -21,19 +21,20 @@ export const NoticeContext = createContext< NoticeContextType >( {
 const NoticeContextProvider = ( { children } ) => {
 	const [ currentNotice, setCurrentNotice ] = useState< Notice >( defaultNotice );
 
+	const resetNotice = useCallback( () => {
+		setCurrentNotice( defaultNotice );
+	}, [] );
+
 	const setNotice = useCallback(
 		( notice: Notice ) => {
 			// Only update notice if there is not already a notice or the new notice has a higher priority
 			if ( ! currentNotice.message || notice.options.priority > currentNotice.options.priority ) {
+				resetNotice();
 				setCurrentNotice( notice );
 			}
 		},
-		[ currentNotice.message, currentNotice.options.priority ]
+		[ currentNotice.message, currentNotice.options.priority, resetNotice ]
 	);
-
-	const resetNotice = useCallback( () => {
-		setCurrentNotice( defaultNotice );
-	}, [] );
 
 	return (
 		<NoticeContext.Provider

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-connection-errors-notice.tsx
@@ -8,16 +8,11 @@ import useAnalytics from '../use-analytics';
 import type { NoticeOptions } from '../../context/notices/types';
 
 const useConnectionErrorsNotice = () => {
-	const { setNotice, resetNotice } = useContext( NoticeContext );
+	const { setNotice, currentNotice } = useContext( NoticeContext );
 	const { hasConnectionError, connectionErrorMessage } = useConnectionErrorNotice();
 	const { restoreConnection, isRestoringConnection, restoreConnectionError } =
 		useRestoreConnection();
 	const { recordEvent } = useAnalytics();
-
-	useEffect( () => {
-		// Reset notice before showing the failed to restore connection notice
-		resetNotice();
-	}, [ resetNotice, restoreConnectionError ] );
 
 	useEffect( () => {
 		if ( ! hasConnectionError ) {
@@ -76,7 +71,7 @@ const useConnectionErrorsNotice = () => {
 		restoreConnection,
 		isRestoringConnection,
 		restoreConnectionError,
-		resetNotice,
+		currentNotice.options.priority,
 	] );
 };
 

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -48,7 +48,6 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 
 			recordEvent( 'jetpack_my_jetpack_site_connection_notice_cta_click' );
 			handleRegisterSite().then( () => {
-				resetNotice();
 				setNotice( {
 					message: __( 'Your site has been successfully connected.', 'jetpack-my-jetpack' ),
 					options: {

--- a/projects/packages/my-jetpack/changelog/fix-connection-error-notice-reset-incorrectly
+++ b/projects/packages/my-jetpack/changelog/fix-connection-error-notice-reset-incorrectly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an issue where the connection error hook was always resetting the notice

--- a/projects/plugins/protect/changelog/fix-connection-error-notice-reset-incorrectly
+++ b/projects/plugins/protect/changelog/fix-connection-error-notice-reset-incorrectly
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an issue where the connection error hook was always resetting the notice"


### PR DESCRIPTION
## Proposed changes:

* Remove uses of resetNotice from most of the hooks
* Left the use that resets the notice on dismissal

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Slack: p1719599178315809-slack-C01264051NE

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via your local environment
2. Go to `project/plugins/protect/jetpack-protect.php` and change line 47 to
```php
if ( ! is_readable( $jetpack_autoloader ) ) {
```
3. Go to My Jetpack and connect your user
4. Go back to My Jetpack and ensure you can see the bad installation notice
![image](https://github.com/Automattic/jetpack/assets/65001528/e4eafefe-d24a-48d5-82d0-ba028944b049)
