### PR TITLE
Social Previews: Fix Threads and Instagram previews

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,8 +897,8 @@ importers:
         specifier: 1.0.2
         version: 1.0.2
       '@automattic/social-previews':
-        specifier: 2.1.0-beta.5
-        version: 2.1.0-beta.5(@babel/runtime@7.24.7)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.1.0-beta.6
+        version: 2.1.0-beta.6(@babel/runtime@7.24.7)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/annotations':
         specifier: 3.0.0
         version: 3.0.0(react@18.3.1)
@@ -3640,8 +3640,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@automattic/social-previews':
-        specifier: 2.1.0-beta.5
-        version: 2.1.0-beta.5(@babel/runtime@7.24.7)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.1.0-beta.6
+        version: 2.1.0-beta.6(@babel/runtime@7.24.7)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@automattic/viewport':
         specifier: 1.0.0
         version: 1.0.0
@@ -4845,8 +4845,8 @@ packages:
   '@automattic/request-external-access@1.0.0':
     resolution: {integrity: sha512-vhN72lwPFzhCVMP1l2ODBqt7fI5jfeJz1JyBnq/AUCg9PpsJfdk4vZxhSOLhSSds8VMkU5WaNnaztkYfkkYOiA==}
 
-  '@automattic/social-previews@2.1.0-beta.5':
-    resolution: {integrity: sha512-PFDWkue9nMz4Vbze/egijz0YeEgKiwltOcT94zCUJWcn5wrlSuK5uks7sinYMDNMCq0ybYGJRiyW9NTEzmjoug==}
+  '@automattic/social-previews@2.1.0-beta.6':
+    resolution: {integrity: sha512-QSCzV+qm7v7ZssB8m54EZzvKl8YPFIN2hOxf5r/Jva5m8RN5pg3fIerE3lfTBQJlpChmRlqcxRvQc/1L4tnJrg==}
     peerDependencies:
       '@babel/runtime': ^7.24.5
       react: ^18.2.0
@@ -14549,7 +14549,7 @@ snapshots:
     dependencies:
       '@automattic/popup-monitor': 1.0.2
 
-  '@automattic/social-previews@2.1.0-beta.5(@babel/runtime@7.24.7)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@automattic/social-previews@2.1.0-beta.6(@babel/runtime@7.24.7)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@emotion/react': 11.11.4(@types/react@18.3.1)(react@18.3.1)
       '@wordpress/components': 28.0.0(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/projects/js-packages/publicize-components/changelog/fix-social-preview-update-threads-and-instagram-previews
+++ b/projects/js-packages/publicize-components/changelog/fix-social-preview-update-threads-and-instagram-previews
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Threads and Instagram social previews

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -23,7 +23,7 @@
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/popup-monitor": "1.0.2",
-		"@automattic/social-previews": "2.1.0-beta.5",
+		"@automattic/social-previews": "2.1.0-beta.6",
 		"@wordpress/annotations": "3.0.0",
 		"@wordpress/api-fetch": "7.0.0",
 		"@wordpress/block-editor": "13.0.0",

--- a/projects/js-packages/publicize-components/src/components/social-previews/instagram.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/instagram.js
@@ -1,6 +1,10 @@
+import { Notice, getRedirectUrl } from '@automattic/jetpack-components';
 import { InstagramPreviews } from '@automattic/social-previews';
+import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { __, _x } from '@wordpress/i18n';
 import React from 'react';
+import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import { SOCIAL_STORE_ID, CONNECTION_SERVICE_INSTAGRAM_BUSINESS } from '../../social-store';
 
@@ -15,8 +19,39 @@ export function Instagram( props ) {
 	const { username: name, profileImage } = useSelect( select =>
 		select( SOCIAL_STORE_ID ).getConnectionProfileDetails( CONNECTION_SERVICE_INSTAGRAM_BUSINESS )
 	);
+	const { isEnhancedPublishingEnabled } = usePublicizeConfig();
 
 	const { message: text } = useSocialMediaMessage();
+
+	const hasMedia = media?.some(
+		( { type } ) => type.startsWith( 'image/' ) || type.startsWith( 'video/' )
+	);
+
+	const hasImage = Boolean( image );
+
+	if ( ! hasMedia && ! hasImage ) {
+		return (
+			<Notice
+				hideCloseButton
+				actions={ [
+					<ExternalLink href={ getRedirectUrl( 'jetpack-social-share-to-instagram' ) }>
+						{ __( 'Learn more', 'jetpack' ) }
+					</ExternalLink>,
+				] }
+			>
+				{ isEnhancedPublishingEnabled
+					? __(
+							'To share to Instagram, add an image/video, or enable Social Image Generator.',
+							'jetpack'
+					  )
+					: _x(
+							'You need a featured image to share to Instagram.',
+							'The message shown in the Instagram social preview',
+							'jetpack'
+					  ) }
+			</Notice>
+		);
+	}
 
 	const caption = text || title || description;
 

--- a/projects/js-packages/publicize-components/src/components/social-previews/modal.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/modal.js
@@ -13,7 +13,7 @@ import './modal.scss';
 
 const SocialPreviewsModal = function SocialPreviewsModal( { onClose, initialTabName } ) {
 	const availableServices = useAvailableSerivces();
-	const { image, media, title, description, url } = usePostData();
+	const { image, media, title, description, url, excerpt } = usePostData();
 
 	return (
 		<Modal
@@ -36,6 +36,7 @@ const SocialPreviewsModal = function SocialPreviewsModal( { onClose, initialTabN
 					<div>
 						<tab.preview
 							// pass only the props that are common to all previews
+							excerpt={ excerpt }
 							title={ title }
 							description={ description }
 							url={ url }

--- a/projects/js-packages/publicize-components/src/components/social-previews/use-post-data.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/use-post-data.js
@@ -70,6 +70,9 @@ export function usePostData() {
 					getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ] ||
 					__( 'Visit the post for more.', 'jetpack' ),
 				url: getEditedPostAttribute( 'link' ),
+				excerpt:
+					getEditedPostAttribute( 'excerpt' ) ||
+					getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ],
 				image,
 				media,
 				initialTabName: null,

--- a/projects/plugins/jetpack/changelog/fix-social-preview-update-threads-and-instagram-previews
+++ b/projects/plugins/jetpack/changelog/fix-social-preview-update-threads-and-instagram-previews
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated dependencies

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -59,7 +59,7 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/popup-monitor": "1.0.2",
 		"@automattic/request-external-access": "1.0.0",
-		"@automattic/social-previews": "2.1.0-beta.5",
+		"@automattic/social-previews": "2.1.0-beta.6",
 		"@automattic/viewport": "1.0.0",
 		"@microsoft/fetch-event-source": "2.0.1",
 		"@wordpress/base-styles": "5.0.0",


### PR DESCRIPTION
Our Threads social preview currently does not reflect what Jetpack Social sends out.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update Threads preview to fix the excerpt shown in the preview and make it match what publicize sends out
* Fix Instagram empty preview and display a warning when there is no media

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to post editor
* Open Jetpack/Social sidebar
* Open preview
* Confirm that the Threads preview works as expected - has title, excerpt and the URL.
* Remove the featured image and disable SIG for the post and remove any custom media
* Open Instagram preview
* Confirm that you see the notice about the need for an image/video
* Also test https://github.com/Automattic/wp-calypso/pull/92237

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <th colspan="2">Threads</th>
        </tr>
        <tr>
            <td>
<img width="942" alt="Screenshot 2024-07-01 at 6 04 59 PM" src="https://github.com/Automattic/jetpack/assets/18226415/2672ea40-6d63-4912-be38-92a3c429a9a5">

</td>
            <td>
<img width="943" alt="Screenshot 2024-07-01 at 5 52 46 PM" src="https://github.com/Automattic/jetpack/assets/18226415/aedc1f0a-7471-4201-91fa-5c2a3f95fd52">
</td>
        </tr>
        <tr>
            <th colspan="2">Instagram</th>
        </tr>
        <tr>
            <td>
<img width="926" alt="Screenshot 2024-07-01 at 5 54 46 PM" src="https://github.com/Automattic/jetpack/assets/18226415/d3aabe28-d7e2-45b4-b8b3-2f25a0cb4c3e">

</td>
            <td>

![image](https://github.com/Automattic/jetpack/assets/18226415/8844fd46-4a95-405a-b562-5c60f6f86f57)

</td>
        </tr>
    </tbody>
</table>

