### PR TITLE
Tooling: Add macOS support for changelogger-validate-all.sh

### DIFF
--- a/tools/changelogger-validate-all.sh
+++ b/tools/changelogger-validate-all.sh
@@ -114,7 +114,14 @@ function checkpkg {
 EXIT=0
 declare -A PIDS
 PIDS=()
-N=$( nproc || echo 1 )
+
+N=1
+if [[ $(uname) == 'Darwin' ]]; then
+	N=$( sysctl -n hw.physicalcpu )
+elif command -v nproc &>/dev/null; then
+	N=$( nproc )
+fi
+
 for FILE in projects/*/*/composer.json; do
 	spin
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #38074, changelogger validation was parallelized using `nproc`, which doesn't exist on macOS and thus returned errors. As the affected script is run by `fixup-project-versions.sh`, a common one to manually use, this PR adds support for the macOS equivalent: `sysctl -n hw.logicalcpu`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Run `tools/changelogger-validate-all.sh` on macOS and Linux and verify the output doesn't give any errors.