### PR TITLE
tools: Fix colors in scripts

### DIFF
--- a/.github/files/lint-project-structure.sh
+++ b/.github/files/lint-project-structure.sh
@@ -9,12 +9,6 @@ BASE=$PWD
 . "$BASE/tools/includes/chalk-lite.sh"
 . "$BASE/.github/versions.sh"
 
-if [[ -n "$CI" ]]; then
-	function debug {
-		blue "$@"
-	}
-fi
-
 EXIT=0
 declare -A OKFILES
 for F in README.md .gitkeep .gitignore; do

--- a/tools/changelogger-validate-all.sh
+++ b/tools/changelogger-validate-all.sh
@@ -67,12 +67,6 @@ if ! $VERBOSE; then
 	}
 else
 	. "$BASE/tools/includes/nospin.sh"
-	if [[ -n "$CI" ]]; then
-		function debug {
-			# Grey doesn't work well in GH's output.
-			blue "$@"
-		}
-	fi
 fi
 
 init_changelogger

--- a/tools/check-changelogger-use.php
+++ b/tools/check-changelogger-use.php
@@ -105,11 +105,17 @@ function debug( $fmt, ...$args ) {
 		return;
 	}
 
-	if ( getenv( 'CI' ) ) {
-		$args[0] = "\e[34m{$args[0]}\e[0m\n";
-	} else {
-		$args[0] = "\e[1;30m{$args[0]}\e[0m\n";
+	static $color;
+	if ( $color === null ) {
+		$dim = shell_exec( 'tput dim 2>/dev/null' );
+		if ( is_string( $dim ) && substr( $dim, 0, 2 ) === "\e[" && substr( $dim, -1 ) === 'm' ) {
+			$color = substr( $dim, 2, -1 );
+		} else {
+			$color = '90';
+		}
 	}
+
+	$args[0] = "\e[{$color}m{$args[0]}\e[0m\n";
 	fprintf( STDERR, ...$args );
 }
 

--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -86,12 +86,6 @@ if ! $VERBOSE; then
 	}
 else
 	. "$BASE/tools/includes/nospin.sh"
-	if [[ -n "$CI" ]]; then
-		function debug {
-			# Grey doesn't work well in GH's output.
-			blue "$@"
-		}
-	fi
 fi
 
 declare -A SKIPSLUGS

--- a/tools/includes/chalk-lite.sh
+++ b/tools/includes/chalk-lite.sh
@@ -50,7 +50,7 @@ function chalk {
 #   Something went wrong!
 #   EOM
 
-TPUT_DIM="$(tput dim 2>/dev/null)"
+TPUT_DIM="$(tput dim 2>/dev/null)" || true
 if [[ "$TPUT_DIM" == $'\e['*m ]]; then
 	TPUT_DIM="${TPUT_DIM#$'\e['}"
 	TPUT_DIM="${TPUT_DIM%m}"

--- a/tools/includes/chalk-lite.sh
+++ b/tools/includes/chalk-lite.sh
@@ -4,7 +4,8 @@
 function color_supported {
 	[[ -n "$NO_COLOR" ]] && return 1
 	[[ -n "$FORCE_COLOR" ]] && return 0
-	[[ -t 1 ]]
+	[[ "$GITHUB_ACTIONS" == true ]] && return 0
+	[[ -n "$TERM" && -t 1 && $(tput colors 2>/dev/null) -ge 8 ]]
 }
 
 # Print possibly-colored text to standard output.
@@ -49,13 +50,20 @@ function chalk {
 #   Something went wrong!
 #   EOM
 
+TPUT_DIM="$(tput dim 2>/dev/null)"
+if [[ "$TPUT_DIM" == $'\e['*m ]]; then
+	TPUT_DIM="${TPUT_DIM#$'\e['}"
+	TPUT_DIM="${TPUT_DIM%m}"
+else
+	TPUT_DIM=90
+fi
 
 function debug {
-	chalk '1;30' "$@"
+	chalk "$TPUT_DIM" "$@"
 }
 
 function success {
-	if [[ $(tput colors 2>/dev/null) -gt 8 ]]; then
+	if [[ "$GITHUB_ACTIONS" == true || $(tput colors 2>/dev/null) -gt 8 ]]; then
 		chalk '1;38;5;41' "$@"
 	else
 		chalk '1;32' "$@"
@@ -92,7 +100,7 @@ function green {
 }
 
 function jetpackGreen {
-	if [[ $(tput colors 2>/dev/null) -gt 8 ]]; then
+	if [[ "$GITHUB_ACTIONS" == true || $(tput colors 2>/dev/null) -gt 8 ]]; then
 		chalk '38;5;41' "$@"
 	else
 		chalk '32' "$@"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
GitHub seems to have changed something since we wrote a lot of these. The `-t` test seems to no longer be true, so nothing outputs colors. Check for `GITHUB_ACTIONS` to be set to `true` and assume `-t` would be true in that case (hopefully we're not doing too much piping of script outputs).

Also, tests indicate that, despite not setting TERM or anything like that, Actions supports 24-bit color output. So check for `GITHUB_ACTIONS` in a few places where we use 256-color or 24-bit-color.

Also at least one person has the "bold is bright" setting in their terminal off, so setting "bold-black" for debug text isn't working for them. If `tput dim` returns something non-empty, use that, otherwise hope that 90 is supported.

On the plus side, Actions output seems to do ok now with `90` so no need to override `debug` in various scripts anymore.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/37967#pullrequestreview-2132937542

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try various things that have debug output in different terminals. Still look ok?
* Check GitHub Actions output where it runs scripts being touched here.
