### PR TITLE
Stats: Add stats purchases endpoint

### DIFF
--- a/projects/packages/stats-admin/changelog/add-stats-purchases-endpoint
+++ b/projects/packages/stats-admin/changelog/add-stats-purchases-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add purchases endpoint

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -52,7 +52,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.20.x-dev"
+			"dev-trunk": "0.21.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.20.0",
+	"version": "0.21.0-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.20.0';
+	const VERSION = '0.21.0-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -1114,7 +1114,8 @@ class REST_Controller {
 	}
 
 	/**
-	 * Get module settings on dashboard.
+	 * Get purchases array; I don't see anything sensetive in there, so didn't sentinizie it.
+	 * Plus it is the same case as Jetpack.
 	 *
 	 * @param WP_REST_Request $req The request object.
 	 * @return array

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -409,7 +409,7 @@ class REST_Controller {
 			static::$namespace,
 			sprintf( '/sites/%d/purchases', Jetpack_Options::get_option( 'id' ) ),
 			array(
-				'methods'             => WP_REST_Server::EDITABLE,
+				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_site_purchases' ),
 				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -403,6 +403,17 @@ class REST_Controller {
 				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
 			)
 		);
+
+		// Purchases endpoint.
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/purchases', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'get_site_purchases' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+			)
+		);
 	}
 
 	/**
@@ -1099,6 +1110,24 @@ class REST_Controller {
 			),
 			null,
 			'wpcom'
+		);
+	}
+
+	/**
+	 * Get module settings on dashboard.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array
+	 */
+	public function get_site_purchases( $req ) {
+		return WPCOM_Client::request_as_blog_cached(
+			sprintf(
+				'/sites/%d/purchases?%s',
+				Jetpack_Options::get_option( 'id' ),
+				$this->filter_and_build_query_string(
+					$req->get_query_params()
+				)
+			)
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/add-stats-purchases-endpoint
+++ b/projects/plugins/jetpack/changelog/add-stats-purchases-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2467,7 +2467,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/stats-admin",
-				"reference": "f188536acdc40d4d174907d96875313f111fbdb7"
+				"reference": "ff4b8867ed6377bbbef67e778b08eac0ccbe635c"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2491,7 +2491,7 @@
 				"autotagger": true,
 				"mirror-repo": "Automattic/jetpack-stats-admin",
 				"branch-alias": {
-					"dev-trunk": "0.20.x-dev"
+					"dev-trunk": "0.21.x-dev"
 				},
 				"textdomain": "jetpack-stats-admin",
 				"version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-stats-purchases-endpoint
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-stats-purchases-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1306,7 +1306,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "f188536acdc40d4d174907d96875313f111fbdb7"
+                "reference": "ff4b8867ed6377bbbef67e778b08eac0ccbe635c"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1330,7 +1330,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.20.x-dev"
+                    "dev-trunk": "0.21.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/changelog/add-stats-purchases-endpoint
+++ b/projects/plugins/wpcomsh/changelog/add-stats-purchases-endpoint
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1505,7 +1505,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "f188536acdc40d4d174907d96875313f111fbdb7"
+                "reference": "ff4b8867ed6377bbbef67e778b08eac0ccbe635c"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1529,7 +1529,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.20.x-dev"
+                    "dev-trunk": "0.21.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {


### PR DESCRIPTION
Partially Fixes https://github.com/Automattic/red-team/issues/58

## Proposed changes:

* Adds endpoint for purchases which is proxied to wpcom

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Please follow instructions in https://github.com/Automattic/wp-calypso/pull/92305
