### PR TITLE
Newsletter settings: fix reply to example email when comment reply chosen

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -160,7 +160,7 @@ const EmailSettings = props => {
 		setFromNameState( { value: fromNameState.value, hasChanged: false } );
 	}, [ fromNameState, updateFormStateAndSaveOptionValue ] );
 
-	const getExampleEmail = ( replyTo ) => {
+	const getExampleEmail = replyTo => {
 		switch ( replyTo ) {
 			case 'author':
 				return 'author-name@example.com';

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -159,8 +159,17 @@ const EmailSettings = props => {
 		} );
 		setFromNameState( { value: fromNameState.value, hasChanged: false } );
 	}, [ fromNameState, updateFormStateAndSaveOptionValue ] );
-	const exampleEmail =
-		subscriptionReplyTo !== 'author' ? 'donotreply@wordpress.com' : 'author-name@example.com';
+
+	const getExampleEmail = ( replyTo ) => {
+		switch ( replyTo ) {
+			case 'author':
+				return 'author-name@example.com';
+			case 'comment':
+				return 'comment-reply@wordpress.com';
+			default:
+				return 'donotreply@wordpress.com';
+		}
+	};
 
 	return (
 		<SettingsCard
@@ -386,7 +395,7 @@ const EmailSettings = props => {
 							/* translators: 1. placeholder is the user entered value for From Name, 2. is the example email */
 							__( 'Example: %1$s <%2$s>', 'jetpack' ),
 							fromNameState.value || siteName,
-							exampleEmail
+							getExampleEmail( subscriptionReplyTo )
 						) }
 					</Col>
 				</Container>

--- a/projects/plugins/jetpack/changelog/fix-reply-to-example-email
+++ b/projects/plugins/jetpack/changelog/fix-reply-to-example-email
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter settings: fix reply to example email when comment reply chosen


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes "Example" address below name input when "reply to as comment" option is chosen. Previously it showed "donotreply" when it should show "comment-reply".

**Before**
![Screenshot 2024-07-02 at 10 47 02](https://github.com/Automattic/jetpack/assets/87168/6504348b-07f7-4922-86a6-ab12fa7891b8)

**After**
![Screenshot 2024-07-02 at 10 48 35](https://github.com/Automattic/jetpack/assets/87168/4361dc92-fa9d-4c72-9cf8-8f4ea9e31295)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

