### PR TITLE
actions: Upload wpcomsh to jetpackedge sites

### DIFF
--- a/.github/files/jetpack-staging-sites/update-jetpack-staging-sites.sh
+++ b/.github/files/jetpack-staging-sites/update-jetpack-staging-sites.sh
@@ -8,7 +8,7 @@
 
 TMP_DIR=$(mktemp -d) # Temp dir where the plugin .zip files are downloaded and unpacked.
 REMOTE_DIR='/srv/htdocs/jetpack-staging' # Remote dir where the unpacked plugin files are synced to.
-PLUGINS=( "jetpack" "jetpack-mu-wpcom-plugin" ); # Plugins to update.
+PLUGINS=( "jetpack" "jetpack-mu-wpcom-plugin" "wpcomsh" ); # Plugins to update.
 declare -A PLUGIN_DOWNLOAD_URLS # Array used to hold fetched plugin download URLs.
 
 SITES='{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It will probably improve testing if we have the jetpackedge sites run wpcomsh trunk instead of using `JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN` to test only the jetpack-mu-wpcom package.

In order to do that, first we need to start uploading wpcomsh to the sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1718902328224339-slack-C05Q5HSS013
See also https://github.com/Automattic/jetpack-builder/pull/38

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [x] https://github.com/Automattic/jetpack/actions/runs/9765679784/job/26956913073