### PR TITLE
Jetpack AI Breve minor style fixes

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-minor-style-fixes
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-minor-style-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI Breve: fix popover font and css classnames

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
@@ -276,17 +276,17 @@
 	color: rgb(117, 117, 117);
 }
 
-.gradeLevelContainer {
+.grade-level-container {
 	display: flex;
 	flex-direction: row;
 	align-items: flex-start;
 }
 
-.gradeLevelContainer p {
+.grade-level-container p {
 	margin-bottom: 0;
 }
 
-.gradeLevelContainer svg {
+.grade-level-container svg {
 	position: relative;
 	top: 2px;
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
@@ -79,7 +79,6 @@
 .highlight-popover	{
 	color: black;
 	cursor: default;
-	font-family: "SF Pro";
 	font-size: 13px;
 	font-style: normal;
 	font-weight: 400;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
@@ -145,7 +145,7 @@ const Controls = ( { blocks } ) => {
 					label="Reading level"
 					help="To make it easy to read, aim for level 8-12. Keep words simple and sentences short."
 				>
-					<div className="gradeLevelContainer">
+					<div className="grade-level-container">
 						{ gradeLevel !== null && gradeLevel <= 12 && (
 							<>
 								<SVG xmlns="http://www.w3.org/2000/svg" width={ 16 } height={ 15 } fill="none">


### PR DESCRIPTION
This PR addresses some minor issues with the popover font and css classnames

## Proposed changes:
Use kebab-case for CSS classnames
Let the popover inherit the font from its parent

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Enable Breve
- Add some content to the post
- Activate the Jetpack sidebar and hover some of the underlined suggestions

The popover font should be consistent with the rest of the editor UI:
<img width="436" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/7c4fa290-f4d3-4202-95af-8e11223ed237">
NOTE: the screenshot is using a Button with normal size, though that change is not included on this PR. May it serve to also check if we want it that way