### PR TITLE
Remove references to deprecated packages/abtest

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-references-to-packages-abtest
+++ b/projects/plugins/jetpack/changelog/remove-references-to-packages-abtest
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Remove unused dependency on `automattic/jetpack-abtest`.
+
+

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -12,7 +12,6 @@
 		"ext-json": "*",
 		"ext-openssl": "*",
 		"automattic/jetpack-a8c-mc-stats": "@dev",
-		"automattic/jetpack-abtest": "@dev",
 		"automattic/jetpack-admin-ui": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-autoloader": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "2955ddfd68e522ba34797b7ded6b480f",
+	"content-hash": "8b707897257ea17c4df9995d01700551",
 	"packages": [
 		{
 			"name": "automattic/jetpack-a8c-mc-stats",
@@ -52,66 +52,6 @@
 				"GPL-2.0-or-later"
 			],
 			"description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
-			"transport-options": {
-				"relative": true
-			}
-		},
-		{
-			"name": "automattic/jetpack-abtest",
-			"version": "dev-trunk",
-			"dist": {
-				"type": "path",
-				"url": "../../packages/abtest",
-				"reference": "0bc2d4b9632a3f769675d66c6c4db976252670fd"
-			},
-			"require": {
-				"automattic/jetpack-connection": "@dev",
-				"automattic/jetpack-error": "@dev",
-				"php": ">=7.0"
-			},
-			"require-dev": {
-				"automattic/jetpack-changelogger": "@dev",
-				"automattic/wordbless": "dev-master",
-				"yoast/phpunit-polyfills": "1.1.0"
-			},
-			"suggest": {
-				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-			},
-			"type": "jetpack-library",
-			"extra": {
-				"autotagger": true,
-				"mirror-repo": "Automattic/jetpack-abtest",
-				"changelogger": {
-					"link-template": "https://github.com/Automattic/jetpack-abtest/compare/v${old}...v${new}"
-				},
-				"branch-alias": {
-					"dev-trunk": "2.1.x-dev"
-				}
-			},
-			"autoload": {
-				"classmap": [
-					"src/"
-				]
-			},
-			"scripts": {
-				"phpunit": [
-					"./vendor/phpunit/phpunit/phpunit --colors=always"
-				],
-				"post-install-cmd": [
-					"WorDBless\\Composer\\InstallDropin::copy"
-				],
-				"post-update-cmd": [
-					"WorDBless\\Composer\\InstallDropin::copy"
-				],
-				"test-php": [
-					"@composer phpunit"
-				]
-			},
-			"license": [
-				"GPL-2.0-or-later"
-			],
-			"description": "Provides an interface to the WP.com A/B tests.",
-			"abandoned": "automattic/jetpack-explat",
 			"transport-options": {
 				"relative": true
 			}
@@ -5946,7 +5886,6 @@
 	"minimum-stability": "dev",
 	"stability-flags": {
 		"automattic/jetpack-a8c-mc-stats": 20,
-		"automattic/jetpack-abtest": 20,
 		"automattic/jetpack-admin-ui": 20,
 		"automattic/jetpack-assets": 20,
 		"automattic/jetpack-autoloader": 20,

--- a/tools/cli/tests/unit/helpers/json.test.js
+++ b/tools/cli/tests/unit/helpers/json.test.js
@@ -24,7 +24,7 @@ describe( 'readPackageJson', () => {
 	test( 'plugins/jetpack should have data', () => {
 		expect( readPackageJson( 'plugins/jetpack', false ) ).toBeObject();
 	} );
-	test( 'packages/abtest should not have data', () => {
-		expect( readPackageJson( 'packages/abtest', false ) ).toBeUndefined();
+	test( 'packages/changelogger should not have data', () => {
+		expect( readPackageJson( 'packages/changelogger', false ) ).toBeUndefined();
 	} );
 } );

--- a/tools/cli/tests/unit/helpers/projectHelpers.test.js
+++ b/tools/cli/tests/unit/helpers/projectHelpers.test.js
@@ -56,7 +56,7 @@ describe( 'projectHelpers', () => {
 	} );
 	test( 'allProjects should contain prefixed packages', () => {
 		// Confirms the type/project style.
-		expect( allProjects() ).toContain( 'packages/abtest' );
+		expect( allProjects() ).toContain( 'packages/changelogger' );
 	} );
 	test( 'allProjects should contain prefixed github-actions', () => {
 		// Confirms the type/project style.
@@ -74,7 +74,7 @@ describe( 'projectHelpers', () => {
 		expect( allProjectsByType( 'plugins' ) ).toContain( 'plugins/jetpack' );
 	} );
 	test( 'allProjectsByType should include a known package', () => {
-		expect( allProjectsByType( 'packages' ) ).toContain( 'packages/abtest' );
+		expect( allProjectsByType( 'packages' ) ).toContain( 'packages/changelogger' );
 	} );
 	test( 'allProjectsByType should include a known GitHub action', () => {
 		expect( allProjectsByType( 'github-actions' ) ).toContain( 'github-actions/push-to-mirrors' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack still had it in composer.json. It was not being used.
* CLI tests were using it as an example (probably because it was first alphabetically). Swap that for changelogger.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See #37994

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Stuff still work?
