### PR TITLE
Update/wpcom resize on jitm

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-resize-on-jitm
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-resize-on-jitm
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Triggers window resize event.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.js
@@ -51,6 +51,9 @@ const wpcomShowSidebarNotice = () => {
 		`
 	);
 
+	// Prevent sidebar being unscrollable by ensuring the sidebar recalculates it's height after the notice is added.
+	window.dispatchEvent( new Event( 'resize' ) );
+
 	// Record impression event in Tracks.
 	wpcomSidebarNoticeRecordEvent( wpcomSidebarNotice.tracks?.display );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7936

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Triggers window resize event when the upsell nudge jitm is inserted into the sidebar in wp-admin. At page heights where the sidebar content would be fully above the fold if it were not for the jitm, the sidebar isn't scrollable.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

```
apply pr:

bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/wpcom-resize-on-jitm

reset:

bin/jetpack-downloader reset jetpack-mu-wpcom-plugin
```

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

n/a

## Testing instructions:

* Apply the pr to your sandbox
* Sandbox a simple site
* Go to wp-admin for that simple site
* Resize your window height to the point the sidebar content only just fits on the screen before the jitm upsell loads in
* Refresh the page, once the jitm is inserted, ensure the sidebar content is scrollable


https://github.com/Automattic/jetpack/assets/811776/30774810-140a-49c2-a6ae-e177db3a91c2



