### PR TITLE
Renovate: update label used to flag Search updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -104,7 +104,7 @@
 				'uuid',
 				'@testing-library/preact',
 			],
-			reviewers: [ 'team:jetpack-search' ],
+			reviewers: [ 'team:red' ],
 			addLabels: [ '[Feature] Search', 'Instant Search' ],
 		},
 	],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -105,7 +105,7 @@
 				'@testing-library/preact',
 			],
 			reviewers: [ 'team:jetpack-search' ],
-			addLabels: [ 'Search', 'Instant Search' ],
+			addLabels: [ '[Feature] Search', 'Instant Search' ],
 		},
 	],
 


### PR DESCRIPTION
## Proposed changes:

We now prefix our feature labels with [Feature].

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Not much to test here. This will impact future PRs like this one: https://github.com/Automattic/jetpack/pull/38133
