### PR TITLE
Fixes scrollbar issue if upsell nudge is loaded in sidebar

### DIFF
--- a/projects/packages/masterbar/changelog/fix-nav-classic-default--wp-admin
+++ b/projects/packages/masterbar/changelog/fix-nav-classic-default--wp-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes scrollbar issue if upsell nudge is loaded in specific viewport.

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Masterbar;
 
+use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Redirect;
 
@@ -519,14 +520,13 @@ class Admin_Menu extends Base_Admin_Menu {
 	 * https://github.com/Automattic/dotcom-forge/issues/7936
 	 */
 	public function wpcom_upsell_nudge_jitm_fix() {
-		wp_enqueue_script(
+		$assets_base_path = '../../dist/admin-menu/';
+		Assets::register_script(
 			'wpcom-upsell-nudge-jitm-fix',
-			plugins_url( 'wpcom-upsell-nudge-jitm-fix.js', __FILE__ ),
-			array(),
-			Main::PACKAGE_VERSION,
+			$assets_base_path . 'wpcom-upsell-nudge-jitm-fix.js',
+			__FILE__,
 			array(
-				'strategy'  => 'defer',
-				'in_footer' => true,
+				'enqueue' => true,
 			)
 		);
 	}

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -515,6 +515,23 @@ class Admin_Menu extends Base_Admin_Menu {
 	}
 
 	/**
+	 * Fixes scrollbar issue if upsell nudge is loaded.
+	 * https://github.com/Automattic/dotcom-forge/issues/7936
+	 */
+	public function wpcom_upsell_nudge_jitm_fix() {
+		wp_enqueue_script(
+			'wpcom-upsell-nudge-jitm-fix',
+			plugins_url( 'wpcom-upsell-nudge-jitm-fix.js', __FILE__ ),
+			array(),
+			Main::PACKAGE_VERSION,
+			array(
+				'strategy'  => 'defer',
+				'in_footer' => true,
+			)
+		);
+	}
+
+	/**
 	 * Returns the first available upsell nudge.
 	 * Needs to be implemented separately for each child menu class.
 	 * Empty by default.

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -33,6 +33,7 @@ class WPcom_Admin_Menu extends Admin_Menu {
 		add_action( 'wp_ajax_sidebar_state', array( $this, 'ajax_sidebar_state' ) );
 		add_action( 'wp_ajax_jitm_dismiss', array( $this, 'wp_ajax_jitm_dismiss' ) );
 		add_action( 'wp_ajax_upsell_nudge_jitm', array( $this, 'wp_ajax_upsell_nudge_jitm' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'wpcom_upsell_nudge_jitm_fix' ) );
 		add_action( 'admin_init', array( $this, 'sync_sidebar_collapsed_state' ) );
 		add_action( 'admin_menu', array( $this, 'remove_submenus' ), 140 ); // After hookpress hook at 130.
 	}

--- a/projects/packages/masterbar/src/admin-menu/wpcom-upsell-nudge-jitm-fix.js
+++ b/projects/packages/masterbar/src/admin-menu/wpcom-upsell-nudge-jitm-fix.js
@@ -1,0 +1,17 @@
+const wpcomFixSidebarScrolling = () => {
+	const observer = new MutationObserver( mutationList => {
+		mutationList.forEach( mutation => {
+			mutation.addedNodes.forEach( node => {
+				// The domain upsell nudge is added.
+				if ( node.id === 'toplevel_page_site-notices' ) {
+					window.dispatchEvent( new Event( 'resize' ) );
+				}
+			} );
+		} );
+	} );
+	observer.observe( document.querySelector( '#adminmenu' ), {
+		childList: true,
+	} );
+};
+
+document.addEventListener( 'DOMContentLoaded', wpcomFixSidebarScrolling );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7936
The bug details and reproduction video are in the original issue.

### Before

https://github.com/Automattic/jetpack/assets/6586048/abf2449a-8dc5-4f8a-9d08-9a42acef7c3b



### After

https://github.com/Automattic/jetpack/assets/6586048/788e5007-1f11-4393-8979-2f971a3e9381



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Trigger a resize event when the upsell nudge is loaded to make WP aware that the nav sidebar has to be scrollable.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the instructions in https://github.com/Automattic/jetpack/pull/38170#issuecomment-2205585049 for the environment your testing

What is being fixed with this PR:
* With a Simple Default site
* Go to `/wp-admin`
* After the upsell nudge shows, the nav bar is still scrollable

> [!NOTE]  
> Test for WoA and Jetpack sites to make sure nothing is broken due to this PR

