### PR TITLE
Classic theme helper | Remove wp-slug until plugin is approved

### DIFF
--- a/projects/plugins/classic-theme-helper-plugin/changelog/remove-classic-theme-helper-wp-plugin-slug
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/remove-classic-theme-helper-wp-plugin-slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed wp slug until plugin is approved

--- a/projects/plugins/classic-theme-helper-plugin/composer.json
+++ b/projects/plugins/classic-theme-helper-plugin/composer.json
@@ -57,7 +57,6 @@
 		"mirror-repo": "Automattic/classic-theme-plugin",
 		"release-branch-prefix": "classic-theme-plugin",
 		"beta-plugin-slug": "classic-theme-helper-plugin",
-		"wp-plugin-slug": "classic-theme-helper-plugin",
 		"changelogger": {
 			"versioning": "semver"
 		}

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37d376f477c972d17866ba617e05e65f",
+    "content-hash": "4cc54a7de0dd0b5f40570ba71b33fc96",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

p1720008114092869/1720007583.874379-slack-C01U2KGS2PQ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This change removes the wp slug until the plugin is approved so it's not blocking the release process

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
