### PR TITLE
Jetpack AI Image: save images with a better name, based on the user prompt

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-image-improve-image-naming
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-image-improve-image-naming
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI Image: use better names when saving images.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/hooks/use-save-to-media-library.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/hooks/use-save-to-media-library.ts
@@ -19,7 +19,10 @@ export default function useSaveToMediaLibrary() {
 		[]
 	) as BlockEditorStore[ 'selectors' ];
 
-	const saveToMediaLibrary = ( url: string ): Promise< { id: string; url: string } > => {
+	const saveToMediaLibrary = (
+		url: string,
+		name: string = null
+	): Promise< { id: string; url: string } > => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const settings = getSettings() as any;
 
@@ -36,8 +39,14 @@ export default function useSaveToMediaLibrary() {
 						.blob()
 						.then( ( blob: Blob ) => {
 							debug( 'Uploading blob to media library' );
+							const filesList = [];
 
-							const filesList = [ blob ];
+							if ( name ) {
+								filesList.push( new File( [ blob ], name ) );
+							} else {
+								filesList.push( blob );
+							}
+
 							settings.mediaUpload( {
 								allowedTypes: [ 'image' ],
 								filesList,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38178.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the `useSaveToMediaLibrary` hook to support a file name when saving the images
* Use the user prompt as the base to generate a name for the image, limiting it to a maximum of 10 words; fallback to the default `image.png`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable beta blocks and go to the block editor
* Add an image block and click the "Generate with AI" button
* Type a prompt to generate one image and then start the generation (example: "a frog using post-impressionist style")
* When the generation is done, go to the media library of your testing site (on the WP Admin panel, look for `Media > Library`)
* Look for the image that you just generated
* Click on it to open the "Attachment details" modal
* On the details modal, look for the "File name" property:

<img width="600" alt="Screenshot 2024-07-03 at 14 50 49" src="https://github.com/Automattic/jetpack/assets/6760046/49ee639a-a820-40ea-a3b1-cf746f2ccb33">

* Confirm the file name is an URL-friendly version of the prompt you typed when generating the image
* Generate two or more images with the exact same prompt
   * Confirm all the images are saved with a number suffix on the name, like `-1`, `-2`, `-3`
* Generate one image with a long prompt (more than 10 words)
   * Confirm the file name is truncated to have 10 words at maximum