### PR TITLE
WAF: Introduce separate toggles for the block and allow lists

### DIFF
--- a/projects/packages/waf/changelog/add-waf-ip-list-toggles
+++ b/projects/packages/waf/changelog/add-waf-ip-list-toggles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added the ability to toggle IP block and allow lists individually.

--- a/projects/packages/waf/composer.json
+++ b/projects/packages/waf/composer.json
@@ -61,7 +61,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.16.x-dev"
+			"dev-trunk": "0.17.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -14,6 +14,7 @@ use Automattic\Jetpack\IP\Utils as IP_Utils;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Waf\Waf_Compatibility;
 use Automattic\Jetpack\Waf\Waf_Constants;
+use Automattic\Jetpack\Waf\Waf_Rules_Manager;
 use Jetpack_IXR_Client;
 use Jetpack_Options;
 use WP_Error;
@@ -634,6 +635,15 @@ class Brute_Force_Protection {
 	}
 
 	/**
+	 * Whether or not the IP allow list is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function ip_allow_list_enabled() {
+		return get_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, true );
+	}
+
+	/**
 	 * Checks if the IP address is in the allow list.
 	 *
 	 * @deprecated 0.11.0 Use ip_is_allowed()
@@ -656,6 +666,11 @@ class Brute_Force_Protection {
 		// If we found an exact match in wp-config.
 		if ( defined( 'JETPACK_IP_ADDRESS_OK' ) && JETPACK_IP_ADDRESS_OK === $ip ) {
 			return true;
+		}
+
+		// Allow list must be enabled.
+		if ( ! $this->ip_allow_list_enabled() ) {
+			return false;
 		}
 
 		$allow_list = Brute_Force_Protection_Shared_Functions::get_local_allow_list();

--- a/projects/packages/waf/src/class-compatibility.php
+++ b/projects/packages/waf/src/class-compatibility.php
@@ -28,6 +28,8 @@ class Waf_Compatibility {
 		add_filter( 'default_option_' . Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, __CLASS__ . '::default_option_waf_needs_update', 10, 3 );
 		add_filter( 'default_option_' . Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME, __CLASS__ . '::default_option_waf_ip_allow_list', 10, 3 );
 		add_filter( 'option_' . Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME, __CLASS__ . '::filter_option_waf_ip_allow_list', 10, 1 );
+		add_filter( 'default_option_' . Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::default_option_waf_ip_allow_list_enabled', 10, 3 );
+		add_filter( 'default_option_' . Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::default_option_waf_ip_block_list_enabled', 10, 3 );
 	}
 
 	/**
@@ -228,5 +230,59 @@ class Waf_Compatibility {
 	 */
 	public static function is_brute_force_running_in_jetpack() {
 		return defined( 'JETPACK__VERSION' ) && version_compare( JETPACK__VERSION, '12', '<' );
+	}
+
+	/**
+	 * Default the allow list enabled option to the value of the generic IP lists enabled option it replaced.
+	 *
+	 * @since $next-version$
+	 *
+	 * @param mixed  $default         The default value to return if the option does not exist in the database.
+	 * @param string $option          Option name.
+	 * @param bool   $passed_default  Was get_option() passed a default value.
+	 *
+	 * @return mixed The default value to return if the option does not exist in the database.
+	 */
+	public static function default_option_waf_ip_allow_list_enabled( $default, $option, $passed_default ) {
+		// If the deprecated IP lists option was set to false, disable the allow list.
+		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
+		$deprecated_option = get_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, true );
+		if ( ! $deprecated_option ) {
+			return false;
+		}
+
+		// If the allow list is empty, disable the allow list.
+		if ( ! get_option( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME ) ) {
+			return false;
+		}
+
+		// Allow get_option() to override this default value
+		if ( $passed_default ) {
+			return $default;
+		}
+
+		// Default to enabling the allow list.
+		return true;
+	}
+
+	/**
+	 * Default the block list enabled option to the value of the generic IP lists enabled option it replaced.
+	 *
+	 * @since $next-version$
+	 *
+	 * @param mixed  $default         The default value to return if the option does not exist in the database.
+	 * @param string $option          Option name.
+	 * @param bool   $passed_default  Was get_option() passed a default value.
+	 *
+	 * @return mixed The default value to return if the option does not exist in the database.
+	 */
+	public static function default_option_waf_ip_block_list_enabled( $default, $option, $passed_default ) {
+		// Allow get_option() to override this default value
+		if ( $passed_default ) {
+			return $default;
+		}
+
+		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
+		return get_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, false );
 	}
 }

--- a/projects/packages/waf/src/class-rest-controller.php
+++ b/projects/packages/waf/src/class-rest-controller.php
@@ -107,7 +107,9 @@ class REST_Controller {
 		}
 
 		// IP Lists Enabled
+		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
 		if ( isset( $request[ Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME ] ) ) {
+			// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
 			update_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, (bool) $request->get_param( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME ) );
 		}
 
@@ -115,10 +117,16 @@ class REST_Controller {
 		if ( isset( $request[ Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME ] ) ) {
 			update_option( Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME, $request[ Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME ] );
 		}
+		if ( isset( $request[ Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME ] ) ) {
+			update_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, $request[ Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME ] );
+		}
 
 		// IP Allow List
 		if ( isset( $request[ Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME ] ) ) {
 			update_option( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME, $request[ Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME ] );
+		}
+		if ( isset( $request[ Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME ] ) ) {
+			update_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, $request[ Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME ] );
 		}
 
 		// Share Data

--- a/projects/packages/waf/src/class-waf-rules-manager.php
+++ b/projects/packages/waf/src/class-waf-rules-manager.php
@@ -24,11 +24,19 @@ class Waf_Rules_Manager {
 	// WAF Options
 	const VERSION_OPTION_NAME                      = 'jetpack_waf_rules_version';
 	const AUTOMATIC_RULES_ENABLED_OPTION_NAME      = 'jetpack_waf_automatic_rules';
-	const IP_LISTS_ENABLED_OPTION_NAME             = 'jetpack_waf_ip_list';
 	const IP_ALLOW_LIST_OPTION_NAME                = 'jetpack_waf_ip_allow_list';
+	const IP_ALLOW_LIST_ENABLED_OPTION_NAME        = 'jetpack_waf_ip_allow_list_enabled';
 	const IP_BLOCK_LIST_OPTION_NAME                = 'jetpack_waf_ip_block_list';
+	const IP_BLOCK_LIST_ENABLED_OPTION_NAME        = 'jetpack_waf_ip_block_list_enabled';
 	const RULE_LAST_UPDATED_OPTION_NAME            = 'jetpack_waf_last_updated_timestamp';
 	const AUTOMATIC_RULES_LAST_UPDATED_OPTION_NAME = 'jetpack_waf_automatic_rules_last_updated_timestamp';
+
+	/**
+	 * IP Lists Enabled Option Name
+	 *
+	 * @deprecated $next-version$ Use Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME and Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME instead.
+	 */
+	const IP_LISTS_ENABLED_OPTION_NAME = 'jetpack_waf_ip_list';
 
 	// Rule Files
 	const RULES_ENTRYPOINT_FILE = '/rules/rules.php';
@@ -45,11 +53,15 @@ class Waf_Rules_Manager {
 		// Re-activate the WAF any time an option is added or updated.
 		add_action( 'add_option_' . self::AUTOMATIC_RULES_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		add_action( 'update_option_' . self::AUTOMATIC_RULES_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
+		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
 		add_action( 'add_option_' . self::IP_LISTS_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
+		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
 		add_action( 'update_option_' . self::IP_LISTS_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		add_action( 'add_option_' . self::IP_ALLOW_LIST_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
+		add_action( 'add_option_' . self::IP_ALLOW_LIST_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		add_action( 'update_option_' . self::IP_ALLOW_LIST_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		add_action( 'add_option_' . self::IP_BLOCK_LIST_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
+		add_action( 'add_option_' . self::IP_BLOCK_LIST_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		add_action( 'update_option_' . self::IP_BLOCK_LIST_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		// Register the cron job.
 		add_action( 'jetpack_waf_rules_update_cron', array( static::class, 'update_rules_cron' ) );
@@ -213,9 +225,13 @@ class Waf_Rules_Manager {
 			}
 		}
 
-		// Add manual rules
-		if ( get_option( self::IP_LISTS_ENABLED_OPTION_NAME ) ) {
+		// Add IP allow list
+		if ( get_option( self::IP_ALLOW_LIST_ENABLED_OPTION_NAME ) ) {
 			$rules .= self::wrap_require( Waf_Runner::get_waf_file_path( self::IP_ALLOW_RULES_FILE ) ) . "\n";
+		}
+
+		// Add IP block list
+		if ( get_option( self::IP_BLOCK_LIST_ENABLED_OPTION_NAME ) ) {
 			$rules .= self::wrap_require( Waf_Runner::get_waf_file_path( self::IP_BLOCK_RULES_FILE ), "return \$waf->block( 'block', -1, 'ip block list' );" ) . "\n";
 		}
 

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -161,15 +161,25 @@ class Waf_Runner {
 	public static function get_config() {
 		return array(
 			Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME => get_option( Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME ),
-			Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME => get_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME ),
 			Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME => get_option( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME ),
+			Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME => get_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME ),
 			Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME => get_option( Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME ),
+			Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME => get_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME ),
 			self::SHARE_DATA_OPTION_NAME                 => get_option( self::SHARE_DATA_OPTION_NAME ),
 			self::SHARE_DEBUG_DATA_OPTION_NAME           => get_option( self::SHARE_DEBUG_DATA_OPTION_NAME ),
 			'bootstrap_path'                             => self::get_bootstrap_file_path(),
 			'standalone_mode'                            => self::get_standalone_mode_status(),
 			'automatic_rules_available'                  => (bool) self::automatic_rules_available(),
 			'brute_force_protection'                     => (bool) Brute_Force_Protection::is_enabled(),
+
+			/**
+			 * Provide the deprecated IP lists options for backwards compatibility with older versions of the Jetpack and Protect plugins.
+			 * i.e. If one plugin is updated and the other is not, the latest version of this package will be used by both plugins.
+			 *
+			 * @deprecated $next-version$
+			 */
+			// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
+			Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME => get_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME ),
 		);
 	}
 

--- a/projects/packages/waf/tests/php/integration/test-waf-compatibility.php
+++ b/projects/packages/waf/tests/php/integration/test-waf-compatibility.php
@@ -189,4 +189,40 @@ final class WafCompatibilityIntegrationTest extends WorDBless\BaseTestCase {
 		// Check that the automatic rules option is enabled by default.
 		$this->assertTrue( Waf_Runner::is_enabled() );
 	}
+
+	/**
+	 * Test the default options for the IP allow and block lists.
+	 */
+	public function testIpListsDefaultOptions() {
+		// Enable the WAF module.
+		Waf_Runner::enable();
+
+		// Validate default options on fresh installs.
+		$this->assertFalse( get_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME ) );
+		$this->assertFalse( get_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME ) );
+
+		// Add content to the allow list.
+		update_option( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME, '1.2.3.4' );
+
+		$this->assertTrue( get_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME ) );
+		$this->assertFalse( get_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME ) );
+
+		// Toggle the old generic option from true to false.
+		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
+		update_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, true );
+		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
+		update_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, false );
+
+		// Options default to false when the old generic option is set to false.
+		$this->assertFalse( get_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME ) );
+		$this->assertFalse( get_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME ) );
+
+		// Set the old generic option to true.
+		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
+		update_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, true );
+
+		// Options default to true when the old generic option is set to true.
+		$this->assertTrue( get_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME ) );
+		$this->assertTrue( get_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME ) );
+	}
 }

--- a/projects/plugins/jetpack/changelog/add-waf-ip-list-toggles
+++ b/projects/plugins/jetpack/changelog/add-waf-ip-list-toggles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2832,7 +2832,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/waf",
-				"reference": "7c30728a366806da71f9eb62fb015980ae79ebb2"
+				"reference": "8877a29b9be7e4ab5b3a13a9afdde2b65870cfe8"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2859,7 +2859,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.16.x-dev"
+					"dev-trunk": "0.17.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/protect/changelog/add-waf-ip-list-toggles
+++ b/projects/plugins/protect/changelog/add-waf-ip-list-toggles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1727,7 +1727,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/waf",
-                "reference": "7c30728a366806da71f9eb62fb015980ae79ebb2"
+                "reference": "8877a29b9be7e4ab5b3a13a9afdde2b65870cfe8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1754,7 +1754,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.16.x-dev"
+                    "dev-trunk": "0.17.x-dev"
                 }
             },
             "autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The purpose of this PR is to replace the singular "Enable IP block/allow lists" option in the `waf` package with individual controls to toggle the block and allow lists on and off independently.

This PR updates the package with the new functionality, in a backwards compatible way. Current and previous versions of Jetpack and Jetpack Protect, as well as the allow list in WordPress.com, should continue to work without regression.

Updated UI controls will be introduced to each related project in follow-up PRs.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Adds `Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME` and `Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME`.
* Deprecates `Waf_Rules_Manager::IP_LISTS_OPTION_NAME`.
* Backwards compatibility: Maintains support for getting and setting the now-deprecated `IP_LISTS_OPTION_NAME` value in the `waf` package's REST API endpoints.
* Backwards compatibility: When either of the new options have not been set yet, they will default to the value of the deprecated `IP_LISTS_OPTION_NAME` value.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

peb6dq-2wI-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Repeat tests across environments:

* Install production Jetpack, use Jetpack Beta to run this branch via Protect.
* Install production Protect, use Jetpack Beta to run this branch via Jetpack.

Test the firewall settings in both Jetpack and Protect:
* Enable and disable manual rules
* Update IP lists

Test the allow list setting in Calypso:
* Check out this branch in your local development environment.
* Run `jetpack build --production plugins/jetpack`
* Use `jetpack rsync` to push the built Jetpack on your WPCOM sandbox.
* Sandbox `public-api.wordpress.com`.
* Create and connect a JN site that is also running this branch of Jetpack.
* Test updating the IP allow list in Calypso security settings.