### PR TITLE
Social: Fix permissions for update/delete connections endpoints

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-update-permissions-for-the-disconnect-endpoint
+++ b/projects/packages/publicize/changelog/fix-social-update-permissions-for-the-disconnect-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social | Fixed the permissions for update and disconnection connections endpoints

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.47.1",
+	"version": "0.47.2-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -254,7 +254,7 @@ class Publicize extends Publicize_Base {
 									'connection_id'  => $connection['connection_data']['id'],
 									'can_disconnect' => self::can_manage_connection( $connection['connection_data'] ),
 									'profile_link'   => $this->get_profile_link( $service_name, $connection ),
-									'shared'         => $connection['connection_data']['user_id'] === '0',
+									'shared'         => '0' === $connection['connection_data']['user_id'],
 									'status'         => 'ok',
 								)
 							);
@@ -491,7 +491,7 @@ class Publicize extends Publicize_Base {
 		}
 
 		$connections = get_transient( self::JETPACK_SOCIAL_CONNECTIONS_TRANSIENT );
-		if ( $connections === false ) {
+		if ( false === $connections ) {
 			$xml = new Jetpack_IXR_Client();
 			$xml->query( 'jetpack.fetchPublicizeConnections' );
 			if ( ! $xml->isError() ) {
@@ -693,7 +693,7 @@ class Publicize extends Publicize_Base {
 	public function post_is_done_sharing( $post_id = null ) {
 		// Defaults to current post if $post_id is null.
 		$post = get_post( $post_id );
-		if ( $post === null ) {
+		if ( null === $post ) {
 			return false;
 		}
 
@@ -708,7 +708,7 @@ class Publicize extends Publicize_Base {
 	 * @param WP_Post $post Post object.
 	 */
 	public function save_publicized( $post_ID, $post = null ) {
-		if ( $post === null ) {
+		if ( null === $post ) {
 			return;
 		}
 		// Only do this when a post transitions to being published.

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -210,7 +210,7 @@ class REST_Controller {
 			return current_user_can( 'edit_others_posts' );
 		}
 
-		return true;
+		return $this->require_author_privilege_callback();
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -185,7 +185,7 @@ class REST_Controller {
 
 		$connection = $publicize->get_connection_for_user( $request->get_param( 'connection_id' ) );
 
-		$owns_connection = get_current_user_id() === (int) $connection['user_id'];
+		$owns_connection = isset( $connection['user_id'] ) && get_current_user_id() === (int) $connection['user_id'];
 
 		return $owns_connection;
 	}

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -82,7 +82,7 @@ class REST_Controller {
 
 		// Dismiss a notice.
 		// Flagged to be removed after deprecation.
-		// @deprecated $$next_version$$
+		// @deprecated $$next_version$$.
 		register_rest_route(
 			'jetpack/v4',
 			'/social/dismiss-notice',
@@ -146,7 +146,7 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_publicize_connection' ),
-				'permission_callback' => array( $this, 'require_author_privilege_callback' ),
+				'permission_callback' => array( $this, 'manage_connection_permission_check' ),
 				'schema'              => array( $this, 'get_jetpack_social_connections_update_schema' ),
 			)
 		);
@@ -158,9 +158,31 @@ class REST_Controller {
 			array(
 				'methods'             => WP_REST_Server::DELETABLE,
 				'callback'            => array( $this, 'delete_publicize_connection' ),
-				'permission_callback' => array( $this, 'require_author_privilege_callback' ),
+				'permission_callback' => array( $this, 'manage_connection_permission_check' ),
 			)
 		);
+	}
+
+	/**
+	 * Manage connection permission
+	 *
+	 * @param WP_REST_Request $request The request object, which includes the parameters.
+	 *
+	 * @return bool True if the user can manage connections, false otherwise.
+	 */
+	public function manage_connection_permission_check( WP_REST_Request $request ) {
+
+		if ( current_user_can( 'edit_others_posts' ) ) {
+			return true;
+		}
+
+		global $publicize;
+
+		$connection = $publicize->get_connection_for_user( $request->get_param( 'connection_id' ) );
+
+		$owns_connection = get_current_user_id() === (int) $connection['user_id'];
+
+		return $owns_connection;
 	}
 
 	/**


### PR DESCRIPTION
From the linked task:
> Currently we check if the current user ID matches the keyring connection user ID, and if they have permission to edit other's posts. However, it seems that anyone can disconnect shared connections. 

Actually WPCOM handles all these permissions but we should still handle these from inside Jetpack. It will:
- Prevent the unintended error messages from WPCOM being shown to non-admin authors
- Speed up the request by preventing an extra request to WPCOM

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the permissions for the update and disconnect connections endpoint.
* Ensure that non-editor authors are not able to mark connections as shared.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using an admin or an editor account, goto connections management on Social or Jetpack settings page or the editor.
* Confirm that you are able to add, disconnect and mark/unmark connections as shared.
* Mark a connection as shared
* Now login from a non-admin author account and goto the editor to manage connections
* Run `jetpack watch plugins/jetpack` or `jetpack watch plugins/social`
* Set `isAdmin` to `true` in `publicize-components/src/components/services/service-item-details.tsx` in order to see the "Mark as shared" checkbox for non-admins.
* Set `'can_disconnect'` to `true` in `get_all_connections_for_user` method in `packages/publicize/src/class-publicize.php` to allow non-admin author to see the disconnect button for shared connections.
* Try to disconnect a shared connection
* Confirm that you are not allowed to do that.
* Try to unmark a shared connection 
* Confirm that you are not allowed to do that.
* Try to mark the author connected account as shared.
* Confirm that you are not allowed to do that.
