### PR TITLE
MU WPCOM: Support HEIF/HEIC on simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-heif-support
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-heif-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Allow simple sites to upload the heif images

--- a/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/media/heif-support.php
@@ -174,11 +174,12 @@ function jetpack_wpcom_add_heif_mimes_to_supported_upload_types( $mimes ) {
 	if ( ! class_exists( 'Photon_OpenCV' ) ) {
 		return $mimes;
 	}
-	// Only need to modify 'upload_mimes' on Atomic.
-	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-		$mimes['heif'] = 'image/heif';
-		$mimes['heic'] = 'image/heic';
-	}
+
+	$mimes['heif'] = 'image/heif';
+
+	// HEIC is supported by default, so maybe we don't need it anymore.
+	// See https://github.com/WordPress/wordpress-develop/blob/80b7747ef165dd5ed0150003a8c2f957f097609e/src/wp-includes/functions.php#L3416.
+	$mimes['heic'] = 'image/heic';
 	return $mimes;
 }
 add_filter( 'upload_mimes', 'jetpack_wpcom_add_heif_mimes_to_supported_upload_types' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/8034, https://github.com/Automattic/jetpack/pull/32900

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Allow people to upload HEIF images on simple sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Here's an image you can test with if needed: https://danielbachhuber.com/wp-content/uploads/2023/07/IMG_3634.heif_.zip

* Apply this change to your sandbox
* Go to the editor on your simple sites
* Insert an image block and upload the HEIF/HEIC image
* Make sure the image is uploaded successfully and is converted to JPG
  * Without this change, you're not able to upload the HEIF image as it's not supported by default
* Go to /wp-admin/media-new.php
* Upload the HEIF/HEIC image
* Make sure the image is uploaded successfully and is converted to JPG
* You may see the error notice when uploading HEIC image but [we didn't think it's worth trying to disable the error](https://github.com/Automattic/jetpack/pull/32900#issuecomment-1708858326)
  ![image](https://github.com/Automattic/jetpack/assets/13596067/ddaf03f3-a5fc-4601-95e9-2e90a36be02f)