### PR TITLE
MU WPCOM: Port hide-homepage-title feature from ETK

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-hide-homepage-title
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-hide-homepage-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+MU WPCOM: Port the hide-homepage-title feature from ETK

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -89,6 +89,7 @@ class Jetpack_Mu_Wpcom {
 		if ( ! class_exists( 'A8C\FSE\Help_Center' ) ) {
 			require_once __DIR__ . '/features/help-center/class-help-center.php';
 		}
+		require_once __DIR__ . '/features/hide-homepage-title/hide-homepage-title.php';
 		require_once __DIR__ . '/features/import-customizations/import-customizations.php';
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/hide-homepage-title/hide-homepage-title.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/hide-homepage-title/hide-homepage-title.css
@@ -1,0 +1,3 @@
+body.hide-homepage-title .editor-post-title {
+	opacity: 0.4;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/hide-homepage-title/hide-homepage-title.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/hide-homepage-title/hide-homepage-title.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Allow homepage title to be edited even when hidden Lighter color to signify not visible from front page
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+define( 'MU_WPCOM_HOMEPAGE_TITLE_HIDDEN', true );
+
+/**
+ * Can be used to determine if the current screen is the block editor.
+ *
+ * @return bool True if the current screen is a block editor screen. False otherwise.
+ */
+function wpcom_is_block_editor_screen() {
+	return is_callable( 'get_current_screen' ) && get_current_screen() && get_current_screen()->is_block_editor();
+}
+
+/**
+ * Detects if the current page is the homepage post editor, and if the homepage
+ * title is hidden.
+ *
+ * @return bool True if the homepage title features should be used. (See above.)
+ */
+function wpcom_is_homepage_title_hidden() {
+	global $post;
+
+	// Handle the case where we are not rendering a post.
+	if ( ! isset( $post ) ) {
+		return false;
+	}
+
+	$hide_homepage_title = (bool) get_theme_mod( 'hide_front_page_title', false );
+	$is_homepage         = ( (int) get_option( 'page_on_front' ) === $post->ID );
+	return (bool) wpcom_is_block_editor_screen() && $hide_homepage_title && $is_homepage;
+}
+
+/**
+ * Adds custom classes to the admin body classes.
+ *
+ * @param string $classes Classes for the body element.
+ * @return string
+ */
+function wpcom_add_hide_homepage_title_class_if_needed( $classes ) {
+	if ( wpcom_is_homepage_title_hidden() ) {
+		$classes .= ' hide-homepage-title ';
+	}
+
+	return $classes;
+}
+add_filter( 'admin_body_class', 'wpcom_add_hide_homepage_title_class_if_needed' );
+
+/**
+ * Enqueue assets
+ */
+function wpcom_enqueue_hide_homepage_title_assets() {
+	if ( ! wpcom_is_homepage_title_hidden() ) {
+		return;
+	}
+
+	wp_enqueue_style(
+		'wpcom-hide-homepage-title',
+		plugins_url( 'hide-homepage-title.css', __FILE__ ),
+		array(),
+		Jetpack_Mu_Wpcom::PACKAGE_VERSION
+	);
+}
+add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_hide_homepage_title_assets' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/8034, https://github.com/Automattic/wp-calypso/pull/40460

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Port hide-homepage-title feature from ETK

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site
* Activate the 2020 theme.
* Go to the customizer, under "Homepage settings" and check "Hide homepage". Publish the changes.
* Edit the homepage
* The post title should have the opacity
