### PR TITLE
Jetpack Sync: Fix HPOS checksum support for wc_order_operational_data

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-orders-_cart_hash
+++ b/projects/packages/sync/changelog/fix-sync-orders-_cart_hash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Sync: Fix HPOS checksum support for wc_order_operational_data

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -557,6 +557,7 @@ class WooCommerce extends Module {
 		'_download_permissions_granted',
 		// See https://github.com/woocommerce/woocommerce/blob/8ed6e7436ff87c2153ed30edd83c1ab8abbdd3e9/includes/data-stores/class-wc-order-data-store-cpt.php#L594 .
 		'_order_stock_reduced',
+		'_cart_hash',
 
 		// Woocommerce order refunds.
 		// See https://github.com/woocommerce/woocommerce/blob/b8a2815ae546c836467008739e7ff5150cb08e93/includes/data-stores/class-wc-order-refund-data-store-cpt.php#L20 .


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Sync HPOS checksum for `wc_order_operational_data` table relies on the `order_key` and `cart_hash` [checksum text fields](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/replicastore/class-table-checksum.php#L330).
However, the `_cart_hash` meta was never added to the corresponding WooCommerce meta whitelist, therefore [will not be available](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php#L231) when syncing an order via the `WooCommerce_HPOS_Orders` Sync module.

This PR fixes this bug by adding `_cart_hash` to Sync's WooCommerce post meta whitelist. 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\WooCommerce`: Add `_cart_hash` to Sync's WooCommerce post meta whitelist.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-8ec-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Pre-requisites: A JP connected site with WooCommerce and Jetpack plugins active.

- Try syncing an order with/without this PR applied
- Inspect the corresponding `wc_order_operational_data` table on WPCOM and confirm that with the PR applied the `cart_hash` column is populated