### PR TITLE
Sync: Fix bug in WooCommerce_HPOS_Orders::get_objects_by_id method

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-hpos-get_objects_by_id
+++ b/projects/packages/sync/changelog/fix-sync-hpos-get_objects_by_id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync: Fix bug in WooCommerce_HPOS_Orders::get_objects_by_id method

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -165,8 +165,8 @@ class WooCommerce_HPOS_Orders extends Module {
 		}
 		$orders      = wc_get_orders(
 			array(
-				'include' => $ids,
-				'type'    => $this->get_order_types_to_sync( true ),
+				'post__in' => $ids,
+				'type'     => $this->get_order_types_to_sync( true ),
 			)
 		);
 		$orders_data = array();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a bug in `WooCommerce_HPOS_Orders`'s `get_objects_by_id` method when querying orders via `wc_get_orders`.
We used to specify the order ids we need using `include` query argument, however this resulted in the later getting ignored and returning all orders instead.
This is fixed by replacing `include` with `post__in` as per the [corresponding WP_Query docs](https://developer.wordpress.org/reference/classes/wp_query/) that `wc_get_orders` [uses under the hood](https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders`: Replace `include` with `post__in` argument when fetching orders via `wc_get_orders` used in `get_objects_by_id` method.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-8ec-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Pre-requisites: 
- A JP connected site with WooCommerce and Jetpack plugins active.
- At least 2 orders

- Enter `wp shell`

```
$hpos = new Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders();
return $hpos->get_object_by_id( 'order', YOUR_ORDER_ID )
```

- With the PR applied confirm you get a single order. Without the patch all existing orders will be returned