### PR TITLE
MU WPCOM: Port override-preview-button-url feature from ETK

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-override-preview-button-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-override-preview-button-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Port override-preview-button-url feature from ETK

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -92,6 +92,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/import-customizations/import-customizations.php';
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';
+		require_once __DIR__ . '/features/override-preview-button-url/override-preview-button-url.php';
 		require_once __DIR__ . '/features/site-editor-dashboard-link/site-editor-dashboard-link.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/override-preview-button-url/override-preview-button-url.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/override-preview-button-url/override-preview-button-url.js
@@ -1,0 +1,33 @@
+import { use } from '@wordpress/data';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * The gutenberg block editor preview button opens a new window to a simple site's mapped
+ * domain.
+ * Adds logmein query param to editor draft post preview url to add WordPress cookies in
+ * a first party context ( allowing us to avoid third party cookie issues )
+ */
+async function overridePreviewButtonUrl() {
+	use( registry => {
+		return {
+			dispatch: store => {
+				const namespace = store.name ?? store;
+				const actions = { ...registry.dispatch( namespace ) };
+
+				if ( namespace === 'core/editor' && actions.__unstableSaveForPreview ) {
+					const { __unstableSaveForPreview } = actions;
+					actions.__unstableSaveForPreview = async ( ...args ) => {
+						const link = await __unstableSaveForPreview( ...args );
+						return link.startsWith( window.location.origin )
+							? link
+							: addQueryArgs( link, { logmein: 'direct' } );
+					};
+				}
+
+				return actions;
+			},
+		};
+	} );
+}
+
+overridePreviewButtonUrl();

--- a/projects/packages/jetpack-mu-wpcom/src/features/override-preview-button-url/override-preview-button-url.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/override-preview-button-url/override-preview-button-url.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Apply the new font-smoothing styles.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+// Turn off the feature on ETK plugin.
+define( 'MU_WPCOM_OVERRIDE_PREVIEW_BUTTON_URL', true );
+
+/**
+ * Enqueue assets
+ */
+function wpcom_enqueue_override_preview_button_url_assets() {
+	$asset_file          = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/override-preview-button-url/override-preview-button-url.asset.php';
+	$script_dependencies = $asset_file['dependencies'] ?? array();
+	$script_version      = $asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/override-preview-button-url/override-preview-button-url.js' );
+	$script_id           = 'wpcom-override-preview-button-url-script';
+
+	wp_enqueue_script(
+		$script_id,
+		plugins_url( 'build/override-preview-button-url/override-preview-button-url.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+		$script_dependencies,
+		$script_version,
+		true
+	);
+}
+add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_override_preview_button_url_assets' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/override-preview-button-url/override-preview-button-url.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/override-preview-button-url/override-preview-button-url.php
@@ -11,9 +11,36 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 define( 'MU_WPCOM_OVERRIDE_PREVIEW_BUTTON_URL', true );
 
 /**
+ * Check if the feature should be loaded.
+ *
+ * @return bool
+ */
+function should_load_override_preview_button_url() {
+	if ( ! class_exists( 'Automattic\Jetpack\Status\Host' ) ) {
+		return false;
+	}
+
+	$host = new Automattic\Jetpack\Status\Host();
+	if ( ! $host->is_wpcom_simple() ) {
+		return false;
+	}
+
+	global $pagenow;
+	$allowed_pages = array(
+		'post.php',
+		'post-new.php',
+	);
+	return isset( $pagenow ) && in_array( $pagenow, $allowed_pages, true );
+}
+
+/**
  * Enqueue assets
  */
 function wpcom_enqueue_override_preview_button_url_assets() {
+	if ( ! should_load_override_preview_button_url() ) {
+		return;
+	}
+
 	$asset_file          = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/override-preview-button-url/override-preview-button-url.asset.php';
 	$script_dependencies = $asset_file['dependencies'] ?? array();
 	$script_version      = $asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/override-preview-button-url/override-preview-button-url.js' );

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -16,6 +16,8 @@ module.exports = [
 			'core-customizer-css-preview':
 				'./src/features/custom-css/custom-css/js/core-customizer-css-preview.js',
 			'customizer-control': './src/features/custom-css/custom-css/css/customizer-control.css',
+			'override-preview-button-url':
+				'./src/features/override-preview-button-url/override-preview-button-url.js',
 		},
 		mode: jetpackConfig.mode,
 		devtool: jetpackConfig.devtool,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/8034

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Port override-preview-button-url feature from ETK. However, the previous way didn't work...
* As a result, this PR made changes to override the `__unstableSaveForPreview` action to append the `logmein=direct` to the preview url to avoid the cookie issue

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the Incognito Window
* Go to https://wordpress.com/post/<your_custom_domain_site>
* Edit the post
* Preview
  * Without this patch, it will show the page is not found
  * With this patch, it will show the preview correctly

