### PR TITLE
Like block: Fix PHP warning related to undefined `postId` array key coming from block context

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-like-block-undefined-postId-array-key
+++ b/projects/plugins/jetpack/changelog/fix-like-block-undefined-postId-array-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Like block: Fix warning displayed when trying to load the Like block on unsupported pages

--- a/projects/plugins/jetpack/extensions/blocks/like/like.php
+++ b/projects/plugins/jetpack/extensions/blocks/like/like.php
@@ -55,7 +55,7 @@ function render_block( $attr, $content, $block ) {
 	$html = '';
 
 	$uniqid  = uniqid();
-	$post_id = $block->context['postId'];
+	$post_id = $block->context['postId'] ?? null;
 	$title   = esc_html__( 'Like or Reblog', 'jetpack' );
 
 	if ( ! $post_id ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8098.

We have been receiving a number of PHP warnings. Please see the details, including Logstash here: 34f9c-pb/#plain.

The issue gets triggered when the Like block tries to render itself on a page / post that doesn't have a `postId`. This happens, for instance, when the Like block is added to the footer of a block theme and then we open a non-existing 404 page.

The proposed change will make sure that in those cases the `$post_id` will get set to `null` and as a result, the Like block won't render.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* if `$block->context['postId']` is undefined, make `$post_id` null

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

This is a bug fix. Related issue: https://github.com/Automattic/dotcom-forge/issues/8098.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. **Without** the proposed change applied, add the Like block to the Footer template in _Appearance → Editor:_

![Markup on 2024-07-04 at 17:07:04](https://github.com/Automattic/jetpack/assets/25105483/f39ccfdc-cc98-4237-af09-e0f3717a195a)

2. Open any non-existing page in the front-end. → The goal is to end up on a "Page Not Found" 404 page (or basically any other page that might not have any `postId`).
3. You should see the `Warning: Undefined array key "postId" in [...]` PHP warning on the top of the page.
4. Apply the changes from this PR and reload the same page with non-existing `postId`.
5. The warning should no longer be there.

The changes can be tested on any platform: Simple, WoA and self-hosted Jetpack by following the steps outlined in the comment below: https://github.com/Automattic/jetpack/pull/38199#issuecomment-2209153145.