### PR TITLE
Standardize wpcomsh cli post process messages

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-cli-post-process-messages
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-cli-post-process-messages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use wp-cli `success` function for messages

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -21,8 +21,6 @@ function wpcomsh_woa_post_process_job_cache_flush( $args, $assoc_args ) {
 			'exit_error' => false,
 		)
 	);
-
-	WP_CLI::log( 'Cache flushed' );
 }
 add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_process_job_cache_flush', 99, 2 );
 add_action( 'wpcomsh_woa_post_clone', 'wpcomsh_woa_post_process_job_cache_flush', 99, 2 );
@@ -96,7 +94,7 @@ function wpcomsh_woa_post_transfer_update_safecss_to_custom_css( $args, $assoc_a
 		);
 	}
 
-	WP_CLI::log( 'safecss posts updated to custom_css' );
+	WP_CLI::success( 'safecss posts updated to custom_css' );
 }
 add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_transfer_update_safecss_to_custom_css', 10, 2 );
 add_action( 'wpcomsh_woa_post_reset', 'wpcomsh_woa_post_transfer_update_safecss_to_custom_css', 10, 2 );
@@ -121,7 +119,7 @@ function wpcomsh_woa_post_transfer_woo_express_trial_deactivate_plugins( $args, 
 		)
 	);
 
-	WP_CLI::log( 'Woo Express plugins deactivated' );
+	WP_CLI::success( 'Woo Express plugins deactivated' );
 }
 add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_transfer_woo_express_trial_deactivate_plugins', 10, 2 );
 
@@ -145,6 +143,6 @@ function wpcomsh_woa_post_clone_set_staging_environment_type( $args, $assoc_args
 		)
 	);
 
-	WP_CLI::log( 'Staging environment set' );
+	WP_CLI::success( 'Staging environment set' );
 }
 add_action( 'wpcomsh_woa_post_clone', 'wpcomsh_woa_post_clone_set_staging_environment_type', 10, 2 );


### PR DESCRIPTION
Before:
```sh
$ wp wpcomsh post-transfer --woo-express-trial-deactivate-plugins
safecss posts updated to custom_css
Plugin 'crowdsignal-forms' deactivated.
Plugin 'polldaddy' deactivated.
Success: Deactivated 2 of 2 plugins.
Woo Express plugins deactivated
Success: The cache was flushed.
Cache flushed
Success: Post transfer completed successfully.
```

After:
```sh
$ wp wpcomsh post-transfer --woo-express-trial-deactivate-plugins
Success: safecss posts updated to custom_css
Warning: Plugin 'crowdsignal-forms' isn't active.
Warning: Plugin 'polldaddy' isn't active.
Success: Plugins already deactivated.
Success: Woo Express plugins deactivated
Success: The cache was flushed.
Success: Post transfer completed successfully.
```

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

