### PR TITLE
Admin search: update close button behaviour

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/search/clear-btn.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/search/clear-btn.jsx
@@ -1,0 +1,15 @@
+import { __ } from '@wordpress/i18n';
+
+const SearchClearButton = ( { onClick } ) => {
+	return (
+		<button
+			className="dops-search__clear-btn"
+			onClick={ onClick }
+			aria-label={ __( 'Clear search', 'jetpack' ) }
+		>
+			{ __( 'Clear', 'jetpack' ) }
+		</button>
+	);
+};
+
+export default SearchClearButton;

--- a/projects/plugins/jetpack/_inc/client/components/search/close-btn.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/search/close-btn.jsx
@@ -1,0 +1,19 @@
+import Gridicon from 'components/gridicon';
+
+const SearchCloseButton = ( { instanceId, closeSearch, closeListener } ) => {
+	return (
+		<div
+			role="button"
+			className="dops-search__icon-navigation"
+			onClick={ closeSearch }
+			tabIndex="0"
+			onKeyDown={ closeListener }
+			aria-controls={ 'dops-search-component-' + instanceId }
+			aria-label="Close Search"
+		>
+			<Gridicon icon="cross" className="dops-search__close-icon" />
+		</div>
+	);
+};
+
+export default SearchCloseButton;

--- a/projects/plugins/jetpack/_inc/client/components/search/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/search/style.scss
@@ -27,6 +27,31 @@
 		background-color: $white;
 		border-radius: inherit;
 		height: 100%;
+
+		&:focus-visible {
+			outline-offset: -2px;
+		}	
+	}
+
+	.dops-search__clear-btn {
+		min-width: 48px;
+		padding: 0.25em;
+		
+		background: none;
+		border: solid 1px currentColor;
+		border-radius: 4px;
+		color: var(--jp-gray-50);
+
+		&:focus-visible {
+			outline-offset: 2px;
+		}
+	}
+
+	.dops-search__icon-navigation,
+	.dops-search__clear-btn {
+		&:focus-visible {
+			outline: solid 2px var(--jp-green-50);
+		}
 	}
 
 	.dops-search__open-icon,
@@ -68,7 +93,9 @@
 	top: 0;
 	right: 0;
 	overflow: hidden;
-
+	gap: 0.25rem;	
+	background-color: var(--jp-white);
+		
 	.dops-search__input-fade {
 		position: relative;
 		flex: 1 1 auto;

--- a/projects/plugins/jetpack/changelog/fix-jetpack-search-clear-btn
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-search-clear-btn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update search close button behaviour

--- a/tools/eslint-excludelist.json
+++ b/tools/eslint-excludelist.json
@@ -10,7 +10,6 @@
 	"projects/plugins/jetpack/_inc/client/components/popover/index.jsx",
 	"projects/plugins/jetpack/_inc/client/components/popover/util.js",
 	"projects/plugins/jetpack/_inc/client/components/root-child/index.jsx",
-	"projects/plugins/jetpack/_inc/client/components/search/index.jsx",
 	"projects/plugins/jetpack/_inc/client/components/section-nav/index.jsx",
 	"projects/plugins/jetpack/_inc/client/components/section-nav/item.jsx",
 	"projects/plugins/jetpack/_inc/client/components/section-nav/tabs.jsx",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/6862

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The behavior of the search bar close button on the Jetpack Settings page is confusing. Clicking it once clears the search input, and clicking it twice collapses the search bar, but the button appearance stays the same. See the linked issue.

This PR adds a button to Clear the search input. In details, it:
- Moves the close button to its own file
- Updates the behavior of the close button to only close the search bar
- Adds a clear button that resets the search input
- Adds a visible focus state to both buttons
- Ensures the search can be used with a keyboard

_Updated search bar_
<img width="389" alt="Screenshot 2024-07-04 at 2 26 05 PM" src="https://github.com/Automattic/jetpack/assets/1620183/f8a73b3e-eea7-4248-b889-66153d87e296">

_Focus states_
<img width="128" alt="Screenshot 2024-07-04 at 2 41 12 PM" src="https://github.com/Automattic/jetpack/assets/1620183/5462ebe5-e8ee-4c98-8c96-c4cd1780adb9"><img width="134" alt="Screenshot 2024-07-04 at 2 41 14 PM" src="https://github.com/Automattic/jetpack/assets/1620183/2d98d501-187c-4e96-ae5c-9f8f481de89c">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jetpack site with this branch
- Visit the Jetpack Settings page at `/wp-admin/admin.php?page=jetpack#/settings`
- Test the search
  - The clear button should clear the input
  - The close button should collapse the search bar altogether
- Make sure it works when using a keyboard only


