### PR TITLE
Classic Theme Helper: Removing the setup call to the featured content class from the Jetpack Mu Wpcom package

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-featured-content-setup-call
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-featured-content-setup-call
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Jetpack Mu Wpcom: Removed call to Featured Content class for initial release.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -105,7 +105,6 @@ class Jetpack_Mu_Wpcom {
 
 		// Initializers, if needed.
 		\Marketplace_Products_Updater::init();
-		\Automattic\Jetpack\Classic_Theme_Helper\Featured_Content::setup();
 
 		// Only load the Calypsoify and Masterbar features on WoA sites.
 		if ( class_exists( '\Automattic\Jetpack\Status\Host' ) && ( new \Automattic\Jetpack\Status\Host() )->is_woa_site() ) {


### PR DESCRIPTION
## Proposed changes:

* Removing the setup call to the Featured_Content class in the Classic Theme Helper package will help prevent fatal errors caused when doing a WordPress.com deploy.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1720120931029749/1720119005.687689-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* See testing instructions relevant to Featured Content here: https://github.com/Automattic/jetpack/pull/37969