### PR TITLE
AI Assistant: Add feature to tracks event on extensions

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-tracks-feature
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-tracks-feature
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add feature to tracks event

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -28,6 +28,7 @@ export type AiAssistantInputProps = {
 	wrapperRef?: React.MutableRefObject< HTMLDivElement | null >;
 	action?: string;
 	blockType: ExtendedInlineBlockProp;
+	feature: string;
 	request: ( question: string ) => void;
 	stopSuggestion?: () => void;
 	close?: () => void;
@@ -48,6 +49,7 @@ export default function AiAssistantInput( {
 	wrapperRef,
 	action,
 	blockType,
+	feature,
 	request,
 	stopSuggestion,
 	close,
@@ -77,10 +79,11 @@ export default function AiAssistantInput( {
 	const handleSend = useCallback( () => {
 		tracks.recordEvent( 'jetpack_ai_assistant_extension_generate', {
 			block_type: blockType,
+			feature,
 		} );
 
 		request?.( value );
-	}, [ blockType, request, tracks, value ] );
+	}, [ blockType, feature, request, tracks, value ] );
 
 	const handleStopSuggestion = useCallback( () => {
 		tracks.recordEvent( 'jetpack_ai_assistant_extension_stop', {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -502,6 +502,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 						inputRef={ inputRef }
 						action={ action }
 						blockType={ blockName }
+						feature={ feature }
 						request={ handleUserRequest }
 						stopSuggestion={ handleStopSuggestion }
 						close={ handleClose }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38206

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Just adds the block handler's `feature` to the tracks call for the `jetpack_ai_assistant_extension_generate` event.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Add a form and make a request
* Check for the debug log (filter for `dops:analytics`)
* There should be a call for `jetpack_ai_assistant_extension_generate`  with `jetpack-form-ai-extension` as its feature
* Try any other extension (paragraph, heading, list or list item)
* There should be a call for the same event, but with `ai-assistant` as its feature

![2024-07-04_16-53-23](https://github.com/Automattic/jetpack/assets/8486249/cebcd6e7-67aa-4b8d-89cf-15cfc0d13252)
