### PR TITLE
MU WPCOM: Port tags-education feature from ETK

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2102,6 +2102,9 @@ importers:
 
   projects/packages/jetpack-mu-wpcom:
     dependencies:
+      '@automattic/jetpack-shared-extension-utils':
+        specifier: workspace:*
+        version: link:../../js-packages/shared-extension-utils
       '@automattic/typography':
         specifier: 1.0.0
         version: 1.0.0

--- a/projects/packages/jetpack-mu-wpcom/babel.config.js
+++ b/projects/packages/jetpack-mu-wpcom/babel.config.js
@@ -1,3 +1,10 @@
-module.exports = {
-	presets: [ [ '@automattic/jetpack-webpack-config/babel/preset' ] ],
+const config = {
+	presets: [
+		[
+			'@automattic/jetpack-webpack-config/babel/preset',
+			{ pluginReplaceTextdomain: { textdomain: 'jetpack-mu-wpcom' } },
+		],
+	],
 };
+
+module.exports = config;

--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-tags-education
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-tags-education
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Port tags-education feature from ETK.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -45,6 +45,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"dependencies": {
+		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/typography": "1.0.0",
 		"@preact/signals": "^1.2.2",
 		"@sentry/browser": "7.80.1",

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -102,6 +102,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/override-preview-button-url/override-preview-button-url.php';
 		require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';
 		require_once __DIR__ . '/features/site-editor-dashboard-link/site-editor-dashboard-link.php';
+		require_once __DIR__ . '/features/tags-education/tags-education.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';
 		require_once __DIR__ . '/features/wpcom-site-menu/wpcom-site-menu.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/tags-education/tags-education.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/tags-education/tags-education.js
@@ -17,7 +17,7 @@ const addTagsEducationLink = createHigherOrderComponent( PostTaxonomyType => {
 				<ExternalLink
 					href="https://wordpress.com/support/posts/tags/"
 					onClick={ () => {
-						tracks.recordEvent( 'wpcom_block_editor_tags_education_link_click' );
+						tracks.recordEvent( 'jetpack_mu_wpcom_tags_education_link_click' );
 					} }
 				>
 					{ window.wpcomTagsEducation.actionText }

--- a/projects/packages/jetpack-mu-wpcom/src/features/tags-education/tags-education.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/tags-education/tags-education.js
@@ -1,0 +1,34 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { ExternalLink } from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+
+const addTagsEducationLink = createHigherOrderComponent( PostTaxonomyType => {
+	return props => {
+		const { tracks } = useAnalytics();
+
+		if ( props.slug !== 'post_tag' || ! window.wpcomTagsEducation ) {
+			return <PostTaxonomyType { ...props } />;
+		}
+
+		return (
+			<>
+				<PostTaxonomyType { ...props } />
+				<ExternalLink
+					href="https://wordpress.com/support/posts/tags/"
+					onClick={ () => {
+						tracks.recordEvent( 'wpcom_block_editor_tags_education_link_click' );
+					} }
+				>
+					{ window.wpcomTagsEducation.actionText }
+				</ExternalLink>
+			</>
+		);
+	};
+}, 'addTagsEducationLink' );
+
+addFilter(
+	'editor.PostTaxonomyType',
+	'jetpack-mu-wpcom/add-tags-education-link',
+	addTagsEducationLink
+);

--- a/projects/packages/jetpack-mu-wpcom/src/features/tags-education/tags-education.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/tags-education/tags-education.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * WPCOM addition to Gutenberg post tags section.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Terms_Of_Service;
+use Automattic\Jetpack\Tracking;
+
+define( 'MU_WPCOM_TAGS_EDUCATION', true );
+
+/**
+ * Enqueue assets
+ */
+function wpcom_enqueue_tags_education_assets() {
+	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/tags-education/tags-education.asset.php';
+
+	wp_enqueue_script(
+		'wpcom-tags-education-script',
+		plugins_url( 'build/tags-education/tags-education.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+		$asset_file['dependencies'] ?? array(),
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/tags-education/tags-education.js' ),
+		true
+	);
+
+	wp_localize_script(
+		'wpcom-tags-education-script',
+		'wpcomTagsEducation',
+		array( 'actionText' => __( 'Build your audience with tags', 'jetpack-mu-wpcom' ) )
+	);
+
+	Connection_Initial_State::render_script( 'wpcom-tags-education-script' );
+
+	$status            = new Status();
+	$connection        = new Connection_Manager();
+	$tracking          = new Tracking( 'jetpack-mu-wpcom', $connection );
+	$can_use_analytics = $tracking->should_enable_tracking( new Terms_Of_Service(), $status );
+
+	if ( $can_use_analytics ) {
+		Tracking::register_tracks_functions_scripts( true );
+	}
+}
+
+add_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_tags_education_assets', 100 );

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require( 'path' );
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const jetpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
+const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
 const verbumConfig = require( './verbum.webpack.config.js' );
 
 module.exports = [
@@ -20,23 +20,24 @@ module.exports = [
 				'./src/features/override-preview-button-url/override-preview-button-url.js',
 			'paragraph-block-placeholder':
 				'./src/features/paragraph-block-placeholder/paragraph-block-placeholder.js',
+			'tags-education': './src/features/tags-education/tags-education.js',
 		},
-		mode: jetpackConfig.mode,
-		devtool: jetpackConfig.devtool,
+		mode: jetpackWebpackConfig.mode,
+		devtool: jetpackWebpackConfig.devtool,
 		output: {
-			...jetpackConfig.output,
+			...jetpackWebpackConfig.output,
 			filename: '[name]/[name].js',
 			path: path.resolve( __dirname, 'src/build' ),
 		},
 		optimization: {
-			...jetpackConfig.optimization,
+			...jetpackWebpackConfig.optimization,
 		},
 		resolve: {
-			...jetpackConfig.resolve,
+			...jetpackWebpackConfig.resolve,
 		},
 		node: false,
 		plugins: [
-			...jetpackConfig.StandardPlugins( {
+			...jetpackWebpackConfig.StandardPlugins( {
 				MiniCssExtractPlugin: { filename: '[name]/[name].css' },
 			} ),
 		],
@@ -44,24 +45,30 @@ module.exports = [
 			strictExportPresence: true,
 			rules: [
 				// Transpile JavaScript.
-				jetpackConfig.TranspileRule( {
+				jetpackWebpackConfig.TranspileRule( {
 					exclude: /node_modules\//,
 				} ),
 
 				// Transpile @automattic/jetpack-* in node_modules too.
-				jetpackConfig.TranspileRule( {
+				jetpackWebpackConfig.TranspileRule( {
 					includeNodeModules: [ '@automattic/jetpack-' ],
 				} ),
 
 				// Handle CSS.
-				jetpackConfig.CssRule( {
+				jetpackWebpackConfig.CssRule( {
 					extensions: [ 'css', 'scss' ],
 					extraLoaders: [ 'sass-loader' ],
 				} ),
 
 				// Handle images.
-				jetpackConfig.FileRule(),
+				jetpackWebpackConfig.FileRule(),
 			],
+		},
+		externals: {
+			...jetpackWebpackConfig.externals,
+			jetpackConfig: JSON.stringify( {
+				consumer_slug: 'jetpack-mu-wpcom',
+			} ),
 		},
 	},
 ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/8037.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Port the tags-education feature from ETK, which adds the link [Build your audience with tags↗](https://wordpress.com/support/posts/tags/) to the Tags section.

![Screenshot 2024-07-05 at 9 57 05 PM](https://github.com/Automattic/jetpack/assets/797888/51f268a2-e9ee-4c19-a8ed-2b74c55f0da2)

>[!NOTE]
>I did not port the use of `localeUrl()` since it was more complicated than I thought. As a result, the link URL will always link to the English version. This seems like an acceptible compromise since the support page already has links to other languages in it header.

![Screenshot 2024-07-05 at 10 12 55 PM](https://github.com/Automattic/jetpack/assets/797888/24731dad-cf5d-4b62-a771-4647ecd59ffb)


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Head to the Post Editor.
* Open the Settings panel, and expand the Tags section.
* Ensure that the link "[Build your audience with tags↗](https://wordpress.com/support/posts/tags/)" is available.
* Ensure that the event `jetpack_mu_wpcom_tags_education_link_click` triggers on link click.
* In Atomic sites, ensure that the ETK plugin is disabled. 

