### PR TITLE
Boost: Add tracks events

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/performance-history/performance-history.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/performance-history/performance-history.tsx
@@ -46,12 +46,17 @@ const PerformanceHistoryBody = () => {
 		);
 	}
 
+	const handleUpgrade = () => {
+		recordBoostEvent( 'performance_history_upgrade_cta_click', {} );
+		navigate( '/upgrade' );
+	};
+
 	return (
 		<GraphComponent
 			{ ...( data as PerformanceHistoryData ) }
 			isFreshStart={ ! freshStartCompleted }
 			needsUpgrade={ needsUpgrade }
-			handleUpgrade={ () => navigate( '/upgrade' ) }
+			handleUpgrade={ handleUpgrade }
 			handleDismissFreshStart={ dismissFreshStart }
 			isLoading={ isFetching && ( ! data || data.periods.length === 0 ) }
 		/>
@@ -68,7 +73,9 @@ const PerformanceHistory = () => {
 					title={ __( 'Historical Performance', 'jetpack-boost' ) }
 					initialOpen={ isPanelOpen }
 					onToggle={ ( value: boolean ) => {
-						recordBoostEvent( 'performance_history_panel_toggle', { status: value ? 'open' : 'close' } );
+						recordBoostEvent( 'performance_history_panel_toggle', {
+							status: value ? 'open' : 'close',
+						} );
 						setPanelOpen( value );
 					} }
 					className={ styles[ 'performance-history-body' ] }

--- a/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/upgrade-cta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/upgrade-cta.tsx
@@ -8,13 +8,14 @@ import { useNavigate } from 'react-router-dom';
 
 type UpgradeCTAProps = {
 	description: string;
+	identifier: string;
 };
 
-const UpgradeCTA = ( { description }: UpgradeCTAProps ) => {
+const UpgradeCTA = ( { description, identifier }: UpgradeCTAProps ) => {
 	const navigate = useNavigate();
 
 	const showBenefits = () => {
-		recordBoostEvent( 'upsell_cta_from_settings_page_in_plugin', {} );
+		recordBoostEvent( 'upsell_cta_from_settings_page_in_plugin', { identifier } );
 		navigate( '/upgrade' );
 	};
 

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -76,6 +76,7 @@ const Index = () => {
 				<CriticalCssMeta />
 
 				<UpgradeCTA
+					identifier="critical-css"
 					description={ __(
 						'Save time by upgrading to Automatic Critical CSS generation.',
 						'jetpack-boost'
@@ -200,6 +201,7 @@ const Index = () => {
 			>
 				{ ! hasPremiumCdnFeatures && (
 					<UpgradeCTA
+						identifier="image-cdn"
 						description={ __(
 							'Auto-resize lazy images and adjust their quality.',
 							'jetpack-boost'
@@ -224,6 +226,7 @@ const Index = () => {
 							</p>
 							{ ! isaState?.available && (
 								<UpgradeCTA
+									identifier="image-guide"
 									description={ __(
 										'Upgrade to scan your site for issues - automatically!',
 										'jetpack-boost'

--- a/projects/plugins/boost/changelog/add-tracks-events
+++ b/projects/plugins/boost/changelog/add-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Added some tracks events
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/boost-cloud#493

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added identifiers for contextual triggers
* Added tracks event for performance history CTA

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Click upgrade CTA on performance history panel
* See if `jetpack_boost_performance_history_upgrade_cta_click` got recorded.
* Click the contextual triggers under, Critical CSS, Image CDN, Image Guide.
* Make sure `jetpack_boost_upsell_cta_from_settings_page_in_plugin` events are recorded with an identifier prop.

