### PR TITLE
MU WPCOM: Port paragraph-block feature from ETK

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-port-paragraph-block
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-port-paragraph-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Port paragraph block feature from ETK

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -100,6 +100,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';
 		require_once __DIR__ . '/features/override-preview-button-url/override-preview-button-url.php';
+		require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';
 		require_once __DIR__ . '/features/site-editor-dashboard-link/site-editor-dashboard-link.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/paragraph-block-placeholder/paragraph-block-placeholder.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/paragraph-block-placeholder/paragraph-block-placeholder.js
@@ -1,0 +1,22 @@
+import { addFilter } from '@wordpress/hooks';
+
+addFilter(
+	'blocks.registerBlockType',
+	'jetpack-mu-wpcom/paragraph-block-placeholder',
+	( settings, name ) => {
+		if ( name !== 'core/paragraph' || ! window.wpcomParagraphBlock ) {
+			return settings;
+		}
+
+		return {
+			...settings,
+			attributes: {
+				...settings.attributes,
+				placeholder: {
+					...settings.attributes.placeholder,
+					default: window.wpcomParagraphBlock.placeholder,
+				},
+			},
+		};
+	}
+);

--- a/projects/packages/jetpack-mu-wpcom/src/features/paragraph-block-placeholder/paragraph-block-placeholder.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/paragraph-block-placeholder/paragraph-block-placeholder.php
@@ -14,6 +14,12 @@ define( 'MU_WPCOM_PARAGRAPH_BLOCK', true );
  * Enqueue block editor assets.
  */
 function wpcom_enqueue_paragraph_block_placeholder_assets() {
+	global $post;
+
+	if ( ! is_post_with_write_intent( $post ) ) {
+		return;
+	}
+
 	$asset_file          = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/paragraph-block-placeholder/paragraph-block-placeholder.asset.php';
 	$script_dependencies = $asset_file['dependencies'] ?? array();
 	$version             = $asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/paragraph-block-placeholder/paragraph-block-placeholder.js' );
@@ -26,14 +32,11 @@ function wpcom_enqueue_paragraph_block_placeholder_assets() {
 		true
 	);
 
-	global $post;
-	if ( is_post_with_write_intent( $post ) ) {
-		wp_localize_script(
-			'paragraph-block-placeholder-script',
-			'wpcomParagraphBlock',
-			array( 'placeholder' => __( "Start writing or type '/' to insert a block", 'jetpack-mu-wpcom' ) )
-		);
-	}
+	wp_localize_script(
+		'paragraph-block-placeholder-script',
+		'wpcomParagraphBlock',
+		array( 'placeholder' => __( "Start writing or type '/' to insert a block", 'jetpack-mu-wpcom' ) )
+	);
 }
 add_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_paragraph_block_placeholder_assets' );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/paragraph-block-placeholder/paragraph-block-placeholder.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/paragraph-block-placeholder/paragraph-block-placeholder.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Overrides the paragraph block placeholder for sites with write intent.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+// Turn off the feature on ETK plugin.
+define( 'MU_WPCOM_PARAGRAPH_BLOCK', true );
+
+/**
+ * Enqueue block editor assets.
+ */
+function wpcom_enqueue_paragraph_block_placeholder_assets() {
+	$asset_file          = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/paragraph-block-placeholder/paragraph-block-placeholder.asset.php';
+	$script_dependencies = $asset_file['dependencies'] ?? array();
+	$version             = $asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/paragraph-block-placeholder/paragraph-block-placeholder.js' );
+
+	wp_enqueue_script(
+		'paragraph-block-placeholder-script',
+		plugins_url( 'build/paragraph-block-placeholder/paragraph-block-placeholder.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+		$script_dependencies,
+		$version,
+		true
+	);
+
+	global $post;
+	if ( is_post_with_write_intent( $post ) ) {
+		wp_localize_script(
+			'paragraph-block-placeholder-script',
+			'wpcomParagraphBlock',
+			array( 'placeholder' => __( "Start writing or type '/' to insert a block", 'jetpack-mu-wpcom' ) )
+		);
+	}
+}
+add_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_paragraph_block_placeholder_assets' );
+
+/**
+ * Check is it a post with “write” intent
+ *
+ * @param WP_Post|null $post Current post object. It would be null if the current post is not retrieved.
+ */
+function is_post_with_write_intent( $post ) {
+	return isset( $post ) && 'post' === $post->post_type && 'write' === get_option( 'site_intent', '' );
+}
+
+/**
+ * Replace the title placeholder if it's the post with “write” intent
+ *
+ * @param string       $text Text to shown.
+ * @param WP_Post|null $post Current post object. It would be null if the current post is not retrieved.
+ */
+function wpcom_enter_title_here( $text, $post ) {
+	if ( is_post_with_write_intent( $post ) ) {
+		return __( 'Add a post title', 'jetpack-mu-wpcom' );
+	}
+
+	return $text;
+}
+add_filter( 'enter_title_here', 'wpcom_enter_title_here', 0, 2 );
+
+/**
+ * Replace the body placeholder if it's the post with “write” intent
+ *
+ * @param string       $text Text to shown.
+ * @param WP_Post|null $post Current post object. It would be null if the current post is not retrieved.
+ */
+function wpcom_write_your_story( $text, $post ) {
+	if ( is_post_with_write_intent( $post ) ) {
+		return __( "Start writing or type '/' to insert a block", 'jetpack-mu-wpcom' );
+	}
+
+	return $text;
+}
+add_filter( 'write_your_story', 'wpcom_write_your_story', 0, 2 );

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -18,6 +18,8 @@ module.exports = [
 			'customizer-control': './src/features/custom-css/custom-css/css/customizer-control.css',
 			'override-preview-button-url':
 				'./src/features/override-preview-button-url/override-preview-button-url.js',
+			'paragraph-block-placeholder':
+				'./src/features/paragraph-block-placeholder/paragraph-block-placeholder.js',
 		},
 		mode: jetpackConfig.mode,
 		devtool: jetpackConfig.devtool,


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/8036

## Proposed changes:

This PR ports the `paragraph-block` feature from ETK.

This feature overrides the default placeholder in an empty post/page editor for sites with `write` intent:

|Default|Intent is `write`|
|-|-|
|<img width="631" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/bbe334ac-3c4e-4108-b892-72e5628dcf5c">|<img width="633" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/889ebc27-a47d-489e-938b-26ba134e008b">|

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Clear the `site_intent` option of your site (via `wpsh` / `_cli`).
2. Create a new post.
3. Verify that the placeholder is the default one (see the above screenshot).
4. Update the `site_intent` option of your site to `write` (via `wpsh` / `_cli`).
3. Verify that the placeholder is the right one (see the above screenshot).
5. Don't forget to test on Simple and Atomic.
6. When in Atomic, also test with ETK plugin disabled.