### PR TITLE
Featured Content: Update loading from different environments loading

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/update-featured-content-update-loading
+++ b/projects/packages/classic-theme-helper/changelog/update-featured-content-update-loading
@@ -1,4 +1,4 @@
 Significance: minor
-Type: other
+Type: changed
 
 Classic Theme Helper - Featured Content: Moved check for plugins page to init since setup is used now externally

--- a/projects/packages/classic-theme-helper/changelog/update-featured-content-update-loading
+++ b/projects/packages/classic-theme-helper/changelog/update-featured-content-update-loading
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Classic Theme Helper - Featured Content: Moved check for plugins page to init since setup is used now externally

--- a/projects/packages/classic-theme-helper/src/class-featured-content.php
+++ b/projects/packages/classic-theme-helper/src/class-featured-content.php
@@ -88,7 +88,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 		 */
 		public static function init() {
 
-			if ( isset( $GLOBALS['pagenow'] ) && 'plugins.php' !== $GLOBALS['pagenow'] ) {
+			if ( isset( $GLOBALS['pagenow'] ) && 'plugins.php' === $GLOBALS['pagenow'] ) {
 				return;
 			}
 			/**

--- a/projects/packages/classic-theme-helper/src/class-featured-content.php
+++ b/projects/packages/classic-theme-helper/src/class-featured-content.php
@@ -10,7 +10,7 @@ namespace Automattic\Jetpack\Classic_Theme_Helper;
 use Automattic\Jetpack\Assets;
 use WP_Customize_Manager;
 use WP_Query;
-if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'plugins.php' !== $GLOBALS['pagenow'] ) {
+if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 
 	/**
 	 * Featured Content.
@@ -88,6 +88,9 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) && isset( $GLOBALS['p
 		 */
 		public static function init() {
 
+			if ( isset( $GLOBALS['pagenow'] ) && 'plugins.php' !== $GLOBALS['pagenow'] ) {
+				return;
+			}
 			/**
 			 * Array variable to store theme support.
 			 *

--- a/projects/packages/classic-theme-helper/src/class-featured-content.php
+++ b/projects/packages/classic-theme-helper/src/class-featured-content.php
@@ -760,6 +760,4 @@ if ( ! class_exists( __NAMESPACE__ . '\Featured_Content' ) ) {
 			}
 		}
 	}
-
-	Featured_Content::setup();
 }

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-featured-content-update-loading
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-featured-content-update-loading
@@ -1,4 +1,4 @@
 Significance: minor
-Type: other
+Type: added
 
 Jetpack Mu Wpcom: Added call for Featured Content

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-featured-content-update-loading
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-featured-content-update-loading
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack Mu Wpcom: Added call for Featured Content

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -108,6 +108,7 @@ class Jetpack_Mu_Wpcom {
 
 		// Initializers, if needed.
 		\Marketplace_Products_Updater::init();
+		\Automattic\Jetpack\Classic_Theme_Helper\Featured_Content::setup();
 
 		// Only load the Calypsoify and Masterbar features on WoA sites.
 		if ( class_exists( '\Automattic\Jetpack\Status\Host' ) && ( new \Automattic\Jetpack\Status\Host() )->is_woa_site() ) {

--- a/projects/plugins/jetpack/changelog/update-featured-content-update-loading
+++ b/projects/plugins/jetpack/changelog/update-featured-content-update-loading
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Featured Content: Don't call setup for wpcom platform since jetpack-mu-wpcom already takes care of that.

--- a/projects/plugins/jetpack/modules/theme-tools/featured-content.php
+++ b/projects/plugins/jetpack/modules/theme-tools/featured-content.php
@@ -4,6 +4,7 @@
  *
  * @package automattic/jetpack
  */
+use Automattic\Jetpack\Status\Host;
 
 if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'plugins.php' !== $GLOBALS['pagenow'] ) {
 
@@ -357,5 +358,7 @@ if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'pl
 		}
 	}
 
-	Automattic\Jetpack\Classic_Theme_Helper\Featured_Content::setup();
+	if ( ! ( new Host() )->is_wpcom_platform() ) {
+		Automattic\Jetpack\Classic_Theme_Helper\Featured_Content::setup();
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
After the errors caused while deploying https://github.com/Automattic/jetpack/pull/37969 in WPCOM, this tries to give it another go.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moved the pagenow checks inside the init method
* Re-added the [reverted](https://github.com/Automattic/jetpack/pull/38205) setup call from jetpack-mu-wpcom package.
* Added a check for the jetpack plugin to only call setup method when in self-hosted.
* Removed the setup method at the end of the class in Classic Theme Helper Package so that it needs to be called explicitly

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1720119005687689-slack-C01U2KGS2PQ
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* See testing instructions relevant to Featured Content here: https://github.com/Automattic/jetpack/pull/37969
* In Atomic activate the Classic style in Settings -> Admin Interface Style and navigate to plugins. This will enter the `wp-admin/plugins.php` where featured-content init will return early. Check that it doesn't fatal now.