### PR TITLE
Social: Change `Manage connections` button to a link with connections

### DIFF
--- a/projects/js-packages/publicize-components/changelog/change-social-manage-connection-link
+++ b/projects/js-packages/publicize-components/changelog/change-social-manage-connection-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Changed `Manage connections` to a link with at least 1 connection

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.55.2-alpha",
+	"version": "0.56.0-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
@@ -1,6 +1,7 @@
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import PublicizeConnection from '../connection';
+import { EnabledConnectionsNotice } from './enabled-connections-notice';
 import { SettingsButton } from './settings-button';
 import styles from './styles.module.scss';
 import { useConnectionState } from './use-connection-state';
@@ -33,6 +34,7 @@ export const ConnectionsList: React.FC = () => {
 					);
 				} ) }
 			</ul>
+			<EnabledConnectionsNotice />
 			{ ! needsUserConnection ? <SettingsButton variant="secondary" /> : null }
 		</div>
 	);

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -26,7 +26,6 @@ import { AdvancedPlanNudge } from './advanced-plan-nudge';
 import { AutoConversionNotice } from './auto-conversion-notice';
 import { BrokenConnectionsNotice } from './broken-connections-notice';
 import { ConnectionsList } from './connections-list';
-import { EnabledConnectionsNotice } from './enabled-connections-notice';
 import { InstagramNoMediaNotice } from './instagram-no-media-notice';
 import { SettingsButton } from './settings-button';
 import { ShareCountInfo } from './share-count-info';
@@ -108,7 +107,6 @@ export default function PublicizeForm() {
 					<PanelRow>
 						<ConnectionsList />
 					</PanelRow>
-					<EnabledConnectionsNotice />
 					<ShareCountInfo />
 					<BrokenConnectionsNotice />
 					<UnsupportedConnectionsNotice />

--- a/projects/js-packages/publicize-components/src/components/form/settings-button.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/settings-button.tsx
@@ -24,21 +24,23 @@ type SettingsButtonProps = {
  * @returns {import('react').ReactNode} The button/link component.
  */
 export function SettingsButton( { label, variant = 'primary' }: SettingsButtonProps ) {
-	const { useAdminUiV1 } = useSelect( select => {
+	const { useAdminUiV1, connections } = useSelect( select => {
 		return {
 			useAdminUiV1: select( store ).useAdminUiV1(),
+			connections: select( store ).getConnections(),
 		};
 	}, [] );
 	const { openConnectionsModal } = useDispatch( store );
 	const { connectionsAdminUrl } = usePublicizeConfig();
 
 	const text = label || __( 'Manage connections', 'jetpack' );
+	const hasConnections = connections.length > 0;
 
 	return useAdminUiV1 ? (
 		<Button
 			onClick={ openConnectionsModal }
-			variant={ variant }
-			size="small"
+			variant={ hasConnections ? 'link' : variant }
+			size={ hasConnections ? 'default' : 'small' }
 			className={ styles[ 'settings-button' ] }
 		>
 			{ text }

--- a/projects/js-packages/publicize-components/src/components/form/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/form/styles.module.scss
@@ -49,6 +49,7 @@
 
 .enabled-connections-notice {
 	color: var(--jp-gray-50);
+	margin-bottom: 0.5rem;
 }
 
 p.auto-share-title {
@@ -77,7 +78,7 @@ p.auto-share-title {
 	}
 }
 
-.settings-button {
+.settings-button.settings-button {
 	display: block;
-	margin-block: 0.5rem;
+	margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/442

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Eder suggested that we only use buttons for main actions, so the manage connection button is changed back to link if the number of connections is greater than 0.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/442
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor, and validate the states.
* You can mimic having no connections by returning `[]` in with `getConnections` in `projects/js-packages/publicize-components/src/social-store/selectors/connection-data.js`
* The link and button should have the same functionality which is opening the connections modal

| No connections | Having connections |
|--------|--------|
|  ![CleanShot 2024-07-05 at 14 52 13 png](https://github.com/Automattic/jetpack/assets/36671565/c7480bf2-873f-43f6-b341-2288923e4867) |  ![CleanShot 2024-07-05 at 14 52 49 png](https://github.com/Automattic/jetpack/assets/36671565/ed4d8a20-ea5a-416c-ac34-e719484be0a6) |


