### PR TITLE
Social: Fix plan slug in My-Jetpack

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-social-my-jetpack-plan-slug
+++ b/projects/packages/my-jetpack/changelog/fix-social-my-jetpack-plan-slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed plan slug

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.27.1",
+	"version": "4.27.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.27.1';
+	const PACKAGE_VERSION = '4.27.2-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Search product
+ * Jetpack Social product
  *
  * @package my-jetpack
  */

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -141,7 +141,7 @@ class Social extends Hybrid_Product {
 	 * @return string
 	 */
 	public static function get_wpcom_product_slug() {
-		return 'jetpack_social_basic_yearly';
+		return 'jetpack_social_v1_yearly';
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/443

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixed the purchase slug from My-Jetpack for Social

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/443
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new JN site, or delete jetpack options on your local site to reset the flows. `jetpack docker wp option delete jetpack_options`. You'll have to reconnect Jetpack after this.
* Ensure you do not have any social plans.
* Go to `/wp-admin/admin.php?page=my-jetpack`, scroll down and click `Learn more` at Social.  After clicking the CTA it should be the new Jetpack Social plan in your cart.


https://github.com/Automattic/jetpack/assets/36671565/73542d39-7a38-47aa-8d4a-f610cac340d9


Without this change the Basic plan will be added to the siteless checkout cart