### PR TITLE
Remove the WordPress Events and News Dashboard widget

### DIFF
--- a/projects/plugins/wpcomsh/changelog/remove-wpcom-events-and-news-widget
+++ b/projects/plugins/wpcomsh/changelog/remove-wpcom-events-and-news-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Dashboard widgets: Remove WordPress Events and News feed widget

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_27_3_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_28_0_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/feature-plugins/wordpress-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/wordpress-mods.php
@@ -244,3 +244,17 @@ function wpcomsh_prevent_owner_removal( $allcaps, $caps, $args ) {
 	return $allcaps;
 }
 add_filter( 'user_has_cap', 'wpcomsh_prevent_owner_removal', 10, 3 );
+
+/**
+ * Remove WordPress Events and News feed widget from the dashboard.
+ *
+ * We want to remove it for WPcom blogs since it's not relevant for them.
+ *
+ * @return void
+ */
+function wpcomsh_remove_wp_dashboard_events_news() {
+	remove_meta_box( 'dashboard_primary', get_current_screen(), 'side' );
+}
+
+add_action( 'wp_dashboard_setup', 'wpcomsh_remove_wp_dashboard_events_news' ); // Removes the widget from /wp-admin
+add_action( 'wp_user_dashboard_setup', 'wpcomsh_remove_wp_dashboard_events_news' ); // Removes the widget from /wp-admin/user

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.27.3-alpha",
+	"version": "3.28.0-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.27.3-alpha
+ * Version: 3.28.0-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
@@ -10,7 +10,7 @@
  */
 
 // Increase version number if you change something in wpcomsh.
-define( 'WPCOMSH_VERSION', '3.27.3-alpha' );
+define( 'WPCOMSH_VERSION', '3.28.0-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8060

## Proposed changes:

Remove WordPress Events and News feed in the Dashboard widget as it's not relevant to WordPress.com users for Simple Siters.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/jetpack/assets/402286/aa976a90-c999-4aff-a803-8a35e0e45690) | ![image](https://github.com/Automattic/jetpack/assets/402286/cd5deded-3816-4773-85d5-359ad2c667ef) |

## Jetpack product discussion
Details here: pfsHM7-1fZ-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Build wpcomsh with `jetpack build plugins/wpcomsh`
* Sync with your Atomic Dev site: `jetpack rsync wpcomsh YOUR_SITE:htdocs/wp-content/mu-plugins/wpcomsh`
* Check if the `WordPress Events and News feed` widget shows