### PR TITLE
My Jetpack: fix Stats Learn More link when site is disconnected

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -83,7 +83,7 @@ const ActionButton = ( {
 			case PRODUCT_STATUSES.NEEDS_FIRST_SITE_CONNECTION:
 				return {
 					...buttonState,
-					href: purchaseUrl || `#/add-${ slug }`,
+					href: slug !== 'stats' && purchaseUrl ? purchaseUrl : '#/add-stats',
 					size: 'small',
 					variant: 'primary',
 					weight: 'regular',

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.jsx
@@ -83,7 +83,7 @@ const ActionButton = ( {
 			case PRODUCT_STATUSES.NEEDS_FIRST_SITE_CONNECTION:
 				return {
 					...buttonState,
-					href: slug !== 'stats' && purchaseUrl ? purchaseUrl : '#/add-stats',
+					href: purchaseUrl || `#/add-${ slug }`,
 					size: 'small',
 					variant: 'primary',
 					weight: 'regular',

--- a/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
@@ -56,6 +56,9 @@ const StatsSection = () => {
 		[ PRODUCT_STATUSES.ERROR ]: {
 			label: __( 'Connect Jetpack to use Stats', 'jetpack-my-jetpack' ),
 		},
+		[ PRODUCT_STATUSES.NEEDS_FIRST_SITE_CONNECTION ]: {
+			href: `#/add-${ slug }`,
+		},
 	};
 
 	return (

--- a/projects/packages/my-jetpack/changelog/fix-learn-more-url-for-disconnected-stats
+++ b/projects/packages/my-jetpack/changelog/fix-learn-more-url-for-disconnected-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Learn More link destination when the site was never connected.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.27.2-alpha",
+	"version": "4.27.3-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.27.2",
+	"version": "4.27.2-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.27.2-alpha';
+	const PACKAGE_VERSION = '4.27.3-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -37,7 +37,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.27.2';
+	const PACKAGE_VERSION = '4.27.2-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See related issue for more context

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes the Learn More link specifically for Stats when the user has never been connected. It sends the user to the product interstitial instead of sending to a broken screen.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch
* Visit My Jetpack
* Scroll down to the Stats section and click on "Learn more" without connecting to Jetpack
<img width="1096" alt="image" src="https://github.com/Automattic/jetpack/assets/5714212/1607f892-5a78-4e23-ac5a-1bc2f848ccf7">
* Confirm that you are redirected to `/wp-admin/admin.php?page=my-jetpack#/add-stats`

