### PR TITLE
MU WPCOM: Ensure that ETK features have higher priority than the ETK plugin

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-mu-wpcom-load-etk-features
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-mu-wpcom-load-etk-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Load ETK features with a higher priority to avoid the ETK plugin taking precedence. 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -32,6 +32,9 @@ class Jetpack_Mu_Wpcom {
 		// Load features that don't need any special loading considerations.
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_features' ) );
 
+		// Load ETK features that need higher priority than the ETK plugin.
+		add_action( 'plugins_loaded', array( __CLASS__, 'load_etk_features' ), 0 );
+
 		/*
 		 * Please double-check whether you really need to load your feature separately.
 		 * Chances are you can just add it to the `load_features` method.
@@ -95,14 +98,10 @@ class Jetpack_Mu_Wpcom {
 		if ( ! class_exists( 'A8C\FSE\Help_Center' ) ) {
 			require_once __DIR__ . '/features/help-center/class-help-center.php';
 		}
-		require_once __DIR__ . '/features/hide-homepage-title/hide-homepage-title.php';
 		require_once __DIR__ . '/features/import-customizations/import-customizations.php';
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';
-		require_once __DIR__ . '/features/override-preview-button-url/override-preview-button-url.php';
-		require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';
 		require_once __DIR__ . '/features/site-editor-dashboard-link/site-editor-dashboard-link.php';
-		require_once __DIR__ . '/features/tags-education/tags-education.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';
 		require_once __DIR__ . '/features/wpcom-site-menu/wpcom-site-menu.php';
@@ -122,6 +121,17 @@ class Jetpack_Mu_Wpcom {
 		if ( class_exists( 'Automattic\Jetpack\Scheduled_Updates' ) ) {
 			Scheduled_Updates::init();
 		}
+	}
+
+	/**
+	 * Laod ETK features that need higher priority than the ETK plugin.
+	 * Can be moved back to load_features() once the feature no longer exists in the ETK plugin.
+	 */
+	public static function load_etk_features() {
+		require_once __DIR__ . '/features/hide-homepage-title/hide-homepage-title.php';
+		require_once __DIR__ . '/features/override-preview-button-url/override-preview-button-url.php';
+		require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';
+		require_once __DIR__ . '/features/tags-education/tags-education.php';
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates how ETK features are loaded in order to ensure higher priority than the ETK plugin. This is necessary since these features contain code that disabled their counterparts in the ETK plugin.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Head to the Post Editor.
* Open the Settings panel, and expand the Tags section.
* Ensure that the link "[Build your audience with tags↗](https://wordpress.com/support/posts/tags/)" is only rendered once.
* Ensure that the event jetpack_mu_wpcom_tags_education_link_click triggers on link click.
