### PR TITLE
WP.com menu: Bring back "Plugins > Scheduled Updates" to classic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-plugins-scheduled-updates-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-plugins-scheduled-updates-menu
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Adds back missing menu to WP.com sites using the classic interface
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-menu/wpcom-site-menu.php
@@ -563,21 +563,23 @@ function wpcom_add_plugins_menu() {
 		}
 	}
 
-	if ( ! $uses_wp_admin_interface || $is_agency_managed_site ) {
+	if ( $is_agency_managed_site ) {
 		return;
 	}
 
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
-	add_submenu_page(
-		'plugins.php',
-		/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
-		__( 'Marketplace', 'jetpack-mu-wpcom' ),
-		/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
-		__( 'Marketplace', 'jetpack-mu-wpcom' ),
-		'manage_options', // Roughly means "is a site admin"
-		'https://wordpress.com/plugins/' . $domain,
-		null
-	);
+	if ( $uses_wp_admin_interface ) {
+		add_submenu_page(
+			'plugins.php',
+			/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
+				__( 'Marketplace', 'jetpack-mu-wpcom' ),
+			/* translators: Name of the Plugins submenu that links to the Plugins Marketplace */
+				__( 'Marketplace', 'jetpack-mu-wpcom' ),
+			'manage_options', // Roughly means "is a site admin"
+			'https://wordpress.com/plugins/' . $domain,
+			null
+		);
+	}
 
 	if ( $is_atomic_site ) {
 		if (


### PR DESCRIPTION
## Proposed changes:

The "Plugins > Scheduled Updates" menu was meant to be visible on sites with the default interface when it was [first introduced](https://github.com/Automattic/jetpack/pull/37070/files#diff-3f9389963ac0095c3c7b5517243fef9ecf971da9c6c59a7c5f4491d078071480), but we mistakenly added a "is classic interface" check in [a follow-up](https://github.com/Automattic/jetpack/pull/37521/files#diff-3f9389963ac0095c3c7b5517243fef9ecf971da9c6c59a7c5f4491d078071480R441) that prevented the menu from being visible on such sites.

This PR restores the original behavior and ensures that the "Plugins > Scheduled Updates" menu is visible on sites with both the default and the classic interface.

Before | After
--- | ---
<img width="283" alt="Screenshot 2024-07-08 at 09 52 28" src="https://github.com/Automattic/jetpack/assets/1233880/aff10795-8417-4b57-973e-0c6a118b0322"> | <img width="277" alt="Screenshot 2024-07-08 at 09 51 06" src="https://github.com/Automattic/jetpack/assets/1233880/fa4814d9-9093-4cf9-9b58-e475306a6bca">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to a WP.com site using the auto-generated instructions from the comment below
- On Simple sites:
  - Default (no changes): The Plugins menu doesn't have submenu
  - Classic (no changes): The Plugins menus has three submenus: Installed Plugins, Add New Plugin, and Marketplace
- On Atomic sites:
  - **Default: The "Plugins > Scheduled Updates" submenu is visible. Additionally, the previous submenus (Installed Plugins, and Add New Plugin) remain visible**
  - Classic (no changes): The Plugins menus has four submenus: Installed Plugins, Add New Plugin, Marketplace, and Scheduled Updates

