### PR TITLE
Backport mu-wpcom-plugin 2.3.3, jetpack 13.7-a.1, wpcomsh 3.27.3 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.5] - 2024-07-08
+### Changed
+- Updated package dependencies. [#38132]
+
 ## [0.14.4] - 2024-06-17
 ### Changed
 - Updated package dependencies. [#37779]
@@ -343,6 +347,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.14.5]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.4...v0.14.5
 [0.14.4]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.1...v0.14.2

--- a/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/ai-client/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.14.5-alpha",
+	"version": "0.14.5",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.82 - 2024-07-08
+### Changed
+- Updated package dependencies. [#38132]
+
 ## 0.2.81 - 2024-06-24
 ### Changed
 - Update dependencies. [#37979]

--- a/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
+++ b/projects/js-packages/partner-coupon/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.82-alpha",
+	"version": "0.2.82",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.56.0] - 2024-07-08
+### Added
+- Updated the connections cofirmation logic to preselect the reconnecting account by default on confirmation screen [#38193]
+
+### Changed
+- Changed `Manage connections` to a link with at least 1 connection [#38220]
+
 ## [0.55.1] - 2024-07-03
 ### Changed
 - Updated package dependencies. [#38132]
@@ -769,6 +776,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.56.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.55.1...v0.56.0
 [0.55.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.55.0...v0.55.1
 [0.55.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.54.6...v0.55.0
 [0.54.6]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.54.5...v0.54.6

--- a/projects/js-packages/publicize-components/changelog/change-social-manage-connection-link
+++ b/projects/js-packages/publicize-components/changelog/change-social-manage-connection-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Changed `Manage connections` to a link with at least 1 connection

--- a/projects/js-packages/publicize-components/changelog/update-social-select-the-reconnecting-account-by-default-on-confirmation-screen
+++ b/projects/js-packages/publicize-components/changelog/update-social-select-the-reconnecting-account-by-default-on-confirmation-screen
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Updated the connections cofirmation logic to preselect the reconnecting account by default on confirmation screen

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.56.0-alpha",
+	"version": "0.56.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.1] - 2024-07-08
+### Changed
+- Updated package dependencies. [#38132]
+
 ## [3.4.0] - 2024-06-27
 ### Added
 - Add on-demand backups feature in the backup package [#37998]
@@ -652,6 +656,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[3.4.1]: https://github.com/Automattic/jetpack-backup/compare/v3.4.0...v3.4.1
 [3.4.0]: https://github.com/Automattic/jetpack-backup/compare/v3.3.17...v3.4.0
 [3.3.17]: https://github.com/Automattic/jetpack-backup/compare/v3.3.16...v3.3.17
 [3.3.16]: https://github.com/Automattic/jetpack-backup/compare/v3.3.15...v3.3.16

--- a/projects/packages/backup/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/backup/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.4.1-alpha';
+	const PACKAGE_VERSION = '3.4.1';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] - 2024-07-08
+### Changed
+- As we've launched untangling & nav redesign, the wpcom_is_nav_redesign_enabled() function name is not relevant anymore and can be confusing for future developers, so we replace it with the equivalent get_option call. [#38197]
+- Updated package dependencies. [#38132]
+
+### Fixed
+- Fixes a bug in the Blaze endpoint blaze/posts that happens when we get a non-200 from WPCOM [#38070]
+
 ## [0.21.10] - 2024-06-28
 ### Changed
 - Eligibility checks: when a request to the WordPress.com API fails, store the response for an hour to avoid spamming the API. [#38066]
@@ -396,6 +404,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.22.0]: https://github.com/automattic/jetpack-blaze/compare/v0.21.10...v0.22.0
 [0.21.10]: https://github.com/automattic/jetpack-blaze/compare/v0.21.9...v0.21.10
 [0.21.9]: https://github.com/automattic/jetpack-blaze/compare/v0.21.8...v0.21.9
 [0.21.8]: https://github.com/automattic/jetpack-blaze/compare/v0.21.7...v0.21.8

--- a/projects/packages/blaze/changelog/fix-blaze-posts-error-handling
+++ b/projects/packages/blaze/changelog/fix-blaze-posts-error-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixes a bug in the Blaze endpoint blaze/posts that happens when we get a non-200 from WPCOM

--- a/projects/packages/blaze/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/blaze/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/blaze/changelog/update-rename-wpcom_is_nav_redesign_enabled
+++ b/projects/packages/blaze/changelog/update-rename-wpcom_is_nav_redesign_enabled
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-As we've launched untangling & nav redesign, the wpcom_is_nav_redesign_enabled() function name is not relevant anymore and can be confusing for future developers, so we replace it with the equivalent get_option call.

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.22.0-alpha",
+	"version": "0.22.0",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.22.0-alpha';
+	const PACKAGE_VERSION = '0.22.0';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/calypsoify/CHANGELOG.md
+++ b/projects/packages/calypsoify/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2024-07-08
+### Changed
+- Updated package dependencies. [#38132]
+
 ## [0.1.1] - 2024-06-06
 ### Added
 - Calypsoify: Deprecating functions no longer in use [#37453]
@@ -21,4 +25,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calypsoify: Load feature from the Calypsoify package. [#37375]
 - Updated package dependencies. [#37379]
 
+[0.1.2]: https://github.com/Automattic/jetpack-calypsoify/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/Automattic/jetpack-calypsoify/compare/v0.1.0...v0.1.1

--- a/projects/packages/calypsoify/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/calypsoify/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/calypsoify/package.json
+++ b/projects/packages/calypsoify/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-calypsoify",
-	"version": "0.1.2-alpha",
+	"version": "0.1.2",
 	"description": "Calypsoify is designed to make sure specific wp-admin pages include navigation that prioritizes the Calypso navigation experience.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/calypsoify/#readme",
 	"bugs": {

--- a/projects/packages/calypsoify/src/class-jetpack-calypsoify.php
+++ b/projects/packages/calypsoify/src/class-jetpack-calypsoify.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Status;
  */
 class Jetpack_Calypsoify {
 
-	const PACKAGE_VERSION = '0.1.2-alpha';
+	const PACKAGE_VERSION = '0.1.2';
 
 	/**
 	 * Singleton instance of `Jetpack_Calypsoify`.

--- a/projects/packages/classic-theme-helper/CHANGELOG.md
+++ b/projects/packages/classic-theme-helper/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2024-07-08
+### Changed
+- Classic Theme Helper - Featured Content: Moved check for plugins page to init since setup is used now externally [#38215]
+- Classic Theme Helper - Requiring Responsive Videos and Featured Content files. [#37969]
+- Updated package dependencies. [#38132]
+
+### Removed
+- Classic Theme Helper: Remove wpcom only code for featured content [#38154]
+
 ## [0.3.1] - 2024-06-13
 ### Changed
 - Updated package dependencies. [#37796]
@@ -33,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add wordpress folder on gitignore. [#37177]
 
+[0.4.0]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.2.0...v0.2.1

--- a/projects/packages/classic-theme-helper/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/classic-theme-helper/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/classic-theme-helper/changelog/update-featured-content-remove-wpcom-only-code
+++ b/projects/packages/classic-theme-helper/changelog/update-featured-content-remove-wpcom-only-code
@@ -1,4 +1,0 @@
-Significance: minor
-Type: removed
-
-Classic Theme Helper: Remove wpcom only code for featured content

--- a/projects/packages/classic-theme-helper/changelog/update-featured-content-update-loading
+++ b/projects/packages/classic-theme-helper/changelog/update-featured-content-update-loading
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Classic Theme Helper - Featured Content: Moved check for plugins page to init since setup is used now externally

--- a/projects/packages/classic-theme-helper/changelog/update-require-classic-theme-helper-package
+++ b/projects/packages/classic-theme-helper/changelog/update-require-classic-theme-helper-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Classic Theme Helper - Requiring Responsive Videos and Featured Content files.

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-classic-theme-helper",
-	"version": "0.4.0-alpha",
+	"version": "0.4.0",
 	"description": "Features used with classic themes",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/classic-theme-helper/#readme",
 	"bugs": {

--- a/projects/packages/classic-theme-helper/src/class-main.php
+++ b/projects/packages/classic-theme-helper/src/class-main.php
@@ -14,7 +14,7 @@ use WP_Error;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.4.0-alpha';
+	const PACKAGE_VERSION = '0.4.0';
 
 	/**
 	 * Modules to include.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.3] - 2024-07-08
+### Changed
+- Updated package dependencies. [#38132]
+
 ## [0.32.2] - 2024-06-24
 ### Changed
 - Update dependencies. [#37979]
@@ -598,6 +602,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.32.3]: https://github.com/automattic/jetpack-forms/compare/v0.32.2...v0.32.3
 [0.32.2]: https://github.com/automattic/jetpack-forms/compare/v0.32.1...v0.32.2
 [0.32.1]: https://github.com/automattic/jetpack-forms/compare/v0.32.0...v0.32.1
 [0.32.0]: https://github.com/automattic/jetpack-forms/compare/v0.31.4...v0.32.0

--- a/projects/packages/forms/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/forms/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.32.3-alpha",
+	"version": "0.32.3",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.32.3-alpha';
+	const PACKAGE_VERSION = '0.32.3';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.43.0] - 2024-07-08
+### Added
+- Added Help Center (migration from ETK) [#38093]
+- Custom CSS: Add the loading mechanism back after it was reverted. [#38173]
+- Jetpack Mu Wpcom: Added call for Featured Content [#38215]
+- MU WPCOM: Allow simple sites to upload the heif images [#38188]
+- MU WPCOM: Port font-smoothing-antialiased feature from ETK [#38195]
+- MU WPCOM: Port override-preview-button-url feature from ETK [#38196]
+- MU WPCOM: Port paragraph block feature from ETK [#38213]
+- MU WPCOM: Port tags-education feature from ETK. [#38210]
+- MU WPCOM: Port the hide-homepage-title feature from ETK [#38190]
+
+### Changed
+- As we've launched untangling & nav redesign, the wpcom_is_nav_redesign_enabled() function name is not relevant anymore and can be confusing for future developers, so we replace it with the equivalent get_option call. [#38197]
+- Classic Theme Helper - initialize Featured Content from the mu-wpcom package [#37969]
+- Load ETK features with a higher priority to avoid the ETK plugin taking precedence. [#38230]
+- Updated package dependencies. [#38132]
+- Updated package dependencies. [#38235]
+- Update Verbum Comments accessibility. [#38116]
+
+### Removed
+- Jetpack Mu Wpcom: Removed call to Featured Content class for initial release. [#38205]
+
 ## [5.42.1] - 2024-07-01
 ### Changed
 - Redirect to Default settings page after Admin Interface has been updated to Default. [#38107]
@@ -942,6 +965,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.43.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.42.1...v5.43.0
 [5.42.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.42.0...v5.42.1
 [5.42.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.41.0...v5.42.0
 [5.41.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.40.0...v5.41.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-mu-wpcom-load-etk-features
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-mu-wpcom-load-etk-features
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Load ETK features with a higher priority to avoid the ETK plugin taking precedence. 

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-plugins-scheduled-updates-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-plugins-scheduled-updates-menu
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Adds back missing menu to WP.com sites using the classic interface
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/move-help-center
+++ b/projects/packages/jetpack-mu-wpcom/changelog/move-help-center
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added Help Center (migration from ETK)

--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-font-smoothing
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-font-smoothing
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-MU WPCOM: Port font-smoothing-antialiased feature from ETK

--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-heif-support
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-heif-support
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-MU WPCOM: Allow simple sites to upload the heif images

--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-hide-homepage-title
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-hide-homepage-title
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-MU WPCOM: Port the hide-homepage-title feature from ETK

--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-override-preview-button-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-override-preview-button-url
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-MU WPCOM: Port override-preview-button-url feature from ETK

--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-port-paragraph-block
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-port-paragraph-block
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-MU WPCOM: Port paragraph block feature from ETK

--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-tags-education
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-tags-education
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-MU WPCOM: Port tags-education feature from ETK.

--- a/projects/packages/jetpack-mu-wpcom/changelog/renovate-playwright-monorepo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/renovate-playwright-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/jetpack-mu-wpcom/changelog/revert-custom-css-removal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/revert-custom-css-removal
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Custom CSS: Add the loading mechanism back after it was reverted.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-featured-content-update-loading
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-featured-content-update-loading
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Jetpack Mu Wpcom: Added call for Featured Content

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-featured-content-setup-call
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-mu-wpcom-featured-content-setup-call
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Jetpack Mu Wpcom: Removed call to Featured Content class for initial release.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-rename-wpcom_is_nav_redesign_enabled
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-rename-wpcom_is_nav_redesign_enabled
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-As we've launched untangling & nav redesign, the wpcom_is_nav_redesign_enabled() function name is not relevant anymore and can be confusing for future developers, so we replace it with the equivalent get_option call.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-require-classic-theme-helper-package
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-require-classic-theme-helper-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Classic Theme Helper - initialize Featured Content from the mu-wpcom package

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-verbum-comments-accessibility
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-verbum-comments-accessibility
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update Verbum Comments accessibility.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.43.0-alpha",
+	"version": "5.43.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.43.0-alpha';
+	const PACKAGE_VERSION = '5.43.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/masterbar/CHANGELOG.md
+++ b/projects/packages/masterbar/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2024-07-08
+### Changed
+- As we've launched untangling & nav redesign, the wpcom_is_nav_redesign_enabled() function name is not relevant anymore and can be confusing for future developers, so we replace it with the equivalent get_option call. [#38197]
+- Updated package dependencies. [#38132]
+
+### Fixed
+- Fixes scrollbar issue if upsell nudge is loaded in specific viewport. [#38170]
+
 ## [0.2.5] - 2024-06-28
 ### Changed
 - Internal updates.
@@ -50,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#37669]
 - Updated package dependencies. [#37706]
 
+[0.3.0]: https://github.com/Automattic/jetpack-masterbar/compare/v0.2.5...v0.3.0
 [0.2.5]: https://github.com/Automattic/jetpack-masterbar/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/Automattic/jetpack-masterbar/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/Automattic/jetpack-masterbar/compare/v0.2.2...v0.2.3

--- a/projects/packages/masterbar/changelog/fix-nav-classic-default--wp-admin
+++ b/projects/packages/masterbar/changelog/fix-nav-classic-default--wp-admin
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixes scrollbar issue if upsell nudge is loaded in specific viewport.

--- a/projects/packages/masterbar/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/masterbar/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/masterbar/changelog/update-rename-wpcom_is_nav_redesign_enabled
+++ b/projects/packages/masterbar/changelog/update-rename-wpcom_is_nav_redesign_enabled
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-As we've launched untangling & nav redesign, the wpcom_is_nav_redesign_enabled() function name is not relevant anymore and can be confusing for future developers, so we replace it with the equivalent get_option call.

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.3.0-alpha",
+	"version": "0.3.0",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.3.0-alpha';
+	const PACKAGE_VERSION = '0.3.0';
 
 	/**
 	 * Initializer.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.47.2] - 2024-07-08
+### Fixed
+- Social | Fixed the permissions for update and disconnection connections endpoints [#38187]
+
 ## [0.47.1] - 2024-07-03
 ### Changed
 - Updated package dependencies. [#38132]
@@ -614,6 +618,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.47.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.47.1...v0.47.2
 [0.47.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.47.0...v0.47.1
 [0.47.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.46.3...v0.47.0
 [0.46.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.46.2...v0.46.3

--- a/projects/packages/publicize/changelog/fix-social-update-permissions-for-the-disconnect-endpoint
+++ b/projects/packages/publicize/changelog/fix-social-update-permissions-for-the-disconnect-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Social | Fixed the permissions for update and disconnection connections endpoints

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.47.2-alpha",
+	"version": "0.47.2",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.12] - 2024-07-08
+### Changed
+- Updated package dependencies. [#38132] [#38133]
+
 ## [0.44.11] - 2024-06-24
 ### Changed
 - Update dependencies. [#37979]
@@ -984,6 +988,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.44.12]: https://github.com/Automattic/jetpack-search/compare/v0.44.11...v0.44.12
 [0.44.11]: https://github.com/Automattic/jetpack-search/compare/v0.44.10...v0.44.11
 [0.44.10]: https://github.com/Automattic/jetpack-search/compare/v0.44.9...v0.44.10
 [0.44.9]: https://github.com/Automattic/jetpack-search/compare/v0.44.8...v0.44.9

--- a/projects/packages/search/changelog/renovate-instant-search-dependency-updates
+++ b/projects/packages/search/changelog/renovate-instant-search-dependency-updates
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/search/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.12-alpha",
+	"version": "0.44.12",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.12-alpha';
+	const VERSION = '0.44.12';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.21.0 - 2024-07-08
+### Added
+- Stats: Add purchases endpoint [#38150]
+
 ## 0.20.0 - 2024-06-18
 ### Added
 - Check if Jetpack is integrated with the Complianz plugin to show the notice from blocking Stats. [#37870]

--- a/projects/packages/stats-admin/changelog/add-stats-purchases-endpoint
+++ b/projects/packages/stats-admin/changelog/add-stats-purchases-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Stats: Add purchases endpoint

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.21.0-alpha",
+	"version": "0.21.0",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.21.0-alpha';
+	const VERSION = '0.21.0';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2024-07-08
+### Changed
+- Jetpack Sync: Ensure we always sync heartbeat data and active plugins no matter the consumer config [#38135]
+
+### Fixed
+- Jetpack Sync: Fix HPOS checksum support for wc_order_operational_data [#38191]
+- Sync: Fix bug in WooCommerce_HPOS_Orders::get_objects_by_id method [#38192]
+
 ## [3.1.4] - 2024-07-01
 ### Fixed
 - Sync Checksum:Use postmeta table name from wpdb to compare so we don't filter by whitelist due to performance reasons. [#38084]
@@ -1192,6 +1200,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[3.2.0]: https://github.com/Automattic/jetpack-sync/compare/v3.1.4...v3.2.0
 [3.1.4]: https://github.com/Automattic/jetpack-sync/compare/v3.1.3...v3.1.4
 [3.1.3]: https://github.com/Automattic/jetpack-sync/compare/v3.1.2...v3.1.3
 [3.1.2]: https://github.com/Automattic/jetpack-sync/compare/v3.1.1...v3.1.2

--- a/projects/packages/sync/changelog/fix-sync-hpos-get_objects_by_id
+++ b/projects/packages/sync/changelog/fix-sync-hpos-get_objects_by_id
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Sync: Fix bug in WooCommerce_HPOS_Orders::get_objects_by_id method

--- a/projects/packages/sync/changelog/fix-sync-orders-_cart_hash
+++ b/projects/packages/sync/changelog/fix-sync-orders-_cart_hash
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack Sync: Fix HPOS checksum support for wc_order_operational_data

--- a/projects/packages/sync/changelog/update-sync-make-jetpack_connection_active_plugins-callable
+++ b/projects/packages/sync/changelog/update-sync-make-jetpack_connection_active_plugins-callable
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Jetpack Sync: Switch 'jetpack_connection_active_plugins' to a callable
-
-

--- a/projects/packages/sync/changelog/update-sync-must-sync-data-settings
+++ b/projects/packages/sync/changelog/update-sync-must-sync-data-settings
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Jetpack Sync: Ensure we always sync heartbeat data and active plugins no matter the consumer config

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.2.0-alpha';
+	const PACKAGE_VERSION = '3.2.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.27] - 2024-07-08
+### Changed
+- Updated package dependencies. [#38132]
+
 ## [0.23.26] - 2024-06-24
 ### Changed
 - Update dependencies. [#37979]
@@ -1365,6 +1369,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.27]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.26...v0.23.27
 [0.23.26]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.25...v0.23.26
 [0.23.25]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.24...v0.23.25
 [0.23.24]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.23...v0.23.24

--- a/projects/packages/videopress/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/videopress/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.27-alpha",
+	"version": "0.23.27",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.27-alpha';
+	const PACKAGE_VERSION = '0.23.27';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.23] - 2024-07-08
+### Changed
+- Updated package dependencies. [#38132] [#38133]
+
 ## [0.3.22] - 2024-06-24
 ### Changed
 - Update dependencies. [#37979]
@@ -367,6 +371,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.23]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.22...v0.3.23
 [0.3.22]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.21...v0.3.22
 [0.3.21]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.20...v0.3.21
 [0.3.20]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.19...v0.3.20

--- a/projects/packages/wordads/changelog/renovate-instant-search-dependency-updates
+++ b/projects/packages/wordads/changelog/renovate-instant-search-dependency-updates
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/wordads/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.23-alpha",
+	"version": "0.3.23",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.23-alpha';
+	const VERSION = '0.3.23';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.7-a.1 - 2024-07-08
+### Enhancements
+- AI Assistant: The general purpose image generator is now available to all users. [#38203]
+- Subscriptions: Add command palette commands for quickly changing post access. [#37716]
+- Subscriptions: Improve the Subscribe block loading animation. [#38174]
+
+### Bug fixes
+- Like block: Fix warning displayed when trying to load the Like block on unsupported pages. [#38199]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- AI Assistant: Add feature to tracks event. [#38207]
+- AI Assistant: Update Breve implementation to React. [#38125]
+- AI Assistant: Update Breve toggle location. [#38157]
+- AI Proofread: Change Breve request endpoint. [#38149]
+- AI Proofread: Move prompts to the backend. [#38182]
+- Carousel: Updating event listener to remove unnecessary default event prevention function call. [#38143]
+- Classic Theme Helper: Require Responsive Videos and Featured Content files. [#37969]
+- Featured Content: Don't call setup for wpcom platform since jetpack-mu-wpcom already takes care of that. [#38215]
+- Jetpack AI Breve: Fix popover font and css classnames. [#38161]
+- Jetpack AI Image: Include new entrypoint as a button on the image/gallery/slideshow block. [#38123]
+- Jetpack AI Image: Use better names when saving images. [#38179]
+- Masterbar: Deprecate module files. [#38109]
+- Newsletter settings: fix reply to example email when comment reply chosen. [#38151]
+- Search: Update search close button behaviour. [#38204]
+- Updated package dependencies. [#38132] [#38228] [#38235]
+
 ## 13.6 - 2024-07-02
 ### Enhancements
 - AI Assistant: Hide input when user types on extended block. [#37801]

--- a/projects/plugins/jetpack/changelog/add-stats-purchases-endpoint
+++ b/projects/plugins/jetpack/changelog/add-stats-purchases-endpoint
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-jetpack-search-clear-btn
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-search-clear-btn
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Update search close button behaviour

--- a/projects/plugins/jetpack/changelog/fix-like-block-undefined-postId-array-key
+++ b/projects/plugins/jetpack/changelog/fix-like-block-undefined-postId-array-key
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Like block: Fix warning displayed when trying to load the Like block on unsupported pages

--- a/projects/plugins/jetpack/changelog/fix-reply-to-example-email
+++ b/projects/plugins/jetpack/changelog/fix-reply-to-example-email
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Newsletter settings: fix reply to example email when comment reply chosen

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.7-a.2
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.7-a.0
-
-

--- a/projects/plugins/jetpack/changelog/remove-abandoned-packages
+++ b/projects/plugins/jetpack/changelog/remove-abandoned-packages
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Copy filter doc out of deleted package.
-
-

--- a/projects/plugins/jetpack/changelog/remove-references-to-packages-abtest
+++ b/projects/plugins/jetpack/changelog/remove-references-to-packages-abtest
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Remove unused dependency on `automattic/jetpack-abtest`.
-
-

--- a/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/jetpack/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-playwright-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-playwright-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
+++ b/projects/plugins/jetpack/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Updated package dependencies.

--- a/projects/plugins/jetpack/changelog/update-add-paywall-command-palette
+++ b/projects/plugins/jetpack/changelog/update-add-paywall-command-palette
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscriptions: added command palette commands for quickly changing post access.

--- a/projects/plugins/jetpack/changelog/update-carousel-interaction-handlers
+++ b/projects/plugins/jetpack/changelog/update-carousel-interaction-handlers
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Carousel: Updating event listener to remove unnecessary default event prevention function call

--- a/projects/plugins/jetpack/changelog/update-deprecate-masterbar-module
+++ b/projects/plugins/jetpack/changelog/update-deprecate-masterbar-module
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Masterbar: Deprecate module files

--- a/projects/plugins/jetpack/changelog/update-featured-content-remove-wpcom-only-code
+++ b/projects/plugins/jetpack/changelog/update-featured-content-remove-wpcom-only-code
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-featured-content-update-loading
+++ b/projects/plugins/jetpack/changelog/update-featured-content-update-loading
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Featured Content: Don't call setup for wpcom platform since jetpack-mu-wpcom already takes care of that.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-endpoint
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Proofread: Change Breve request endpoint

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-minor-style-fixes
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-minor-style-fixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI Breve: fix popover font and css classnames

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-prompts
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-prompts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Proofread: Move prompts to the backend

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-react
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-react
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Update Breve implementation to React

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-image-image-block-entrypoint
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-image-image-block-entrypoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack AI Image: include new entrypoint as a button on the image/gallery/slideshow block.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-image-improve-image-naming
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-image-improve-image-naming
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack AI Image: use better names when saving images.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-image-move-to-production
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-image-move-to-production
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Jetpack AI Image: move general purpose image generator to production.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-tracks-feature
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-inline-extension-tracks-feature
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Add feature to tracks event

--- a/projects/plugins/jetpack/changelog/update-jetpack-feedback-location-trigger
+++ b/projects/plugins/jetpack/changelog/update-jetpack-feedback-location-trigger
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Update Breve toggle location

--- a/projects/plugins/jetpack/changelog/update-rename-wpcom_is_nav_redesign_enabled#2
+++ b/projects/plugins/jetpack/changelog/update-rename-wpcom_is_nav_redesign_enabled#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/update-require-classic-theme-helper-package
+++ b/projects/plugins/jetpack/changelog/update-require-classic-theme-helper-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Classic Theme Helper - Requiring Responsive Videos and Featured Content files.

--- a/projects/plugins/jetpack/changelog/update-subscribe-modal-loading
+++ b/projects/plugins/jetpack/changelog/update-subscribe-modal-loading
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Subscribe block: improve loading animation

--- a/projects/plugins/jetpack/changelog/update-sync-make-jetpack_connection_active_plugins-callable
+++ b/projects/plugins/jetpack/changelog/update-sync-make-jetpack_connection_active_plugins-callable
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Jetpack: Update Sync related unit tests
-
-

--- a/projects/plugins/jetpack/changelog/update-sync-must-sync-data-settings
+++ b/projects/plugins/jetpack/changelog/update-sync-must-sync-data-settings
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -104,7 +104,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_7_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_7_a_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -104,7 +104,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_7_a_0",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_7_a_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.7-a.0
+ * Version: 13.7-a.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.7-a.0' );
+define( 'JETPACK__VERSION', '13.7-a.1' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.7-a.1
+ * Version: 13.7-a.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.7-a.1' );
+define( 'JETPACK__VERSION', '13.7-a.2' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/class-admin-color-schemes.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/class-admin-color-schemes.php
@@ -2,7 +2,7 @@
 /**
  * Unifies admin color scheme selection across WP.com sites.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\Admin_Color_Schemes instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\Admin_Color_Schemes instead.
  *
  * @package automattic/jetpack
  */
@@ -27,27 +27,27 @@ class Admin_Color_Schemes {
 	/**
 	 * Admin_Color_Schemes constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::__construct' );
 		$this->admin_cs_wrapper = new Masterbar_Admin_Color_Schemes();
 	}
 
 	/**
 	 * Makes admin_color available in users REST API endpoint.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function register_admin_color_meta() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::register_admin_color_meta' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::register_admin_color_meta' );
 		$this->admin_cs_wrapper->register_admin_color_meta();
 	}
 
 	/**
 	 * Permission callback to edit the `admin_color` user meta.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param bool   $allowed   Whether the given user is allowed to edit this meta value.
 	 * @param string $meta_key  Meta key. In this case `admin_color`.
@@ -55,40 +55,40 @@ class Admin_Color_Schemes {
 	 * @return bool
 	 */
 	public function update_admin_color_permissions_check( $allowed, $meta_key, $object_id ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::update_admin_color_permissions_check' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::update_admin_color_permissions_check' );
 		return $this->admin_cs_wrapper->update_admin_color_permissions_check( $allowed, $meta_key, $object_id );
 	}
 
 	/**
 	 * Get the admin color scheme URL based on the environment
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $color_scheme  The color scheme to get the URL for.
 	 * @return string
 	 */
 	public function get_admin_color_scheme_url( $color_scheme ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::get_admin_color_scheme_url' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::get_admin_color_scheme_url' );
 		return $this->admin_cs_wrapper->get_admin_color_scheme_url( $color_scheme );
 	}
 
 	/**
 	 * Registers new admin color schemes
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function register_admin_color_schemes() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::register_admin_color_schemes' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::register_admin_color_schemes' );
 		$this->admin_cs_wrapper->register_admin_color_schemes();
 	}
 
 	/**
 	 * Enqueues current color-scheme overrides for core color schemes
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function enqueue_core_color_schemes_overrides() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::enqueue_core_color_schemes_overrides' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Color_Schemes::enqueue_core_color_schemes_overrides' );
 		$this->admin_cs_wrapper->enqueue_core_color_schemes_overrides();
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-admin-menu.php
@@ -2,7 +2,7 @@
 /**
  * Admin Menu file.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\Admin_Menu instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\Admin_Menu instead.
  *
  * @package automattic/jetpack
  */
@@ -19,27 +19,27 @@ class Admin_Menu extends Masterbar_Admin_Menu {
 	/**
 	 * Ensure that instantiating this class will trigger a deprecation warning.
 	 *
-	 * @since $$next-version$$
+	 * @since 13.7
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::__construct' );
 		parent::__construct();
 	}
 
 	/**
 	 * Create the desired menu output.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function reregister_menu_items() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::reregister_menu_items' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::reregister_menu_items' );
 		parent::reregister_menu_items();
 	}
 
 	/**
 	 * Get the preferred view for the given screen.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $screen Screen identifier.
 	 * @param bool   $fallback_global_preference (Optional) Whether the global preference for all screens should be used
@@ -48,229 +48,229 @@ class Admin_Menu extends Masterbar_Admin_Menu {
 	 * @return string
 	 */
 	public function get_preferred_view( $screen, $fallback_global_preference = true ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::get_preferred_view' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::get_preferred_view' );
 		return parent::get_preferred_view( $screen, $fallback_global_preference );
 	}
 
 	/**
 	 * Check if Links Manager is being used.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function should_disable_links_manager() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::should_disable_links_manager' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::should_disable_links_manager' );
 		return parent::should_disable_links_manager();
 	}
 
 	/**
 	 * Adds My Home menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_my_home_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_my_home_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_my_home_menu' );
 		parent::add_my_home_menu();
 	}
 
 	/**
 	 * Adds My Mailboxes menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_my_mailboxes_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_my_mailboxes_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_my_mailboxes_menu' );
 		parent::add_my_mailboxes_menu();
 	}
 
 	/**
 	 * Adds Stats menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_stats_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_stats_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_stats_menu' );
 		parent::add_stats_menu();
 	}
 
 	/**
 	 * Adds Upgrades menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $plan The current WPCOM plan of the blog.
 	 */
 	public function add_upgrades_menu( $plan = null ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_upgrades_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_upgrades_menu' );
 		parent::add_upgrades_menu( $plan );
 	}
 
 	/**
 	 * Adds Posts menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_posts_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_posts_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_posts_menu' );
 		parent::add_posts_menu();
 	}
 
 	/**
 	 * Adds Media menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_media_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_media_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_media_menu' );
 		parent::add_media_menu();
 	}
 
 	/**
 	 * Adds Page menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_page_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_page_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_page_menu' );
 		parent::add_page_menu();
 	}
 
 	/**
 	 * Adds Testimonials menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_testimonials_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_testimonials_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_testimonials_menu' );
 		parent::add_testimonials_menu();
 	}
 
 	/**
 	 * Adds Portfolio menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_portfolio_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_portfolio_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_portfolio_menu' );
 		parent::add_portfolio_menu();
 	}
 
 	/**
 	 * Adds a custom post type menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $post_type Custom post type.
 	 */
 	public function add_custom_post_type_menu( $post_type ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_custom_post_type_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_custom_post_type_menu' );
 		parent::add_custom_post_type_menu( $post_type );
 	}
 
 	/**
 	 * Adds Comments menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_comments_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_comments_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_comments_menu' );
 		parent::add_comments_menu();
 	}
 
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return string The Customizer URL.
 	 */
 	public function add_appearance_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_appearance_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_appearance_menu' );
 		return parent::add_appearance_menu();
 	}
 
 	/**
 	 * Adds Plugins menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_plugins_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_plugins_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_plugins_menu' );
 		parent::add_plugins_menu();
 	}
 
 	/**
 	 * Adds Users menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_users_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_users_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_users_menu' );
 		parent::add_users_menu();
 	}
 
 	/**
 	 * Adds Tools menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_tools_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_tools_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_tools_menu' );
 		parent::add_tools_menu();
 	}
 
 	/**
 	 * Adds Settings menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_options_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_options_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_options_menu' );
 		parent::add_options_menu();
 	}
 
 	/**
 	 * Create Jetpack menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param int  $position  Menu position.
 	 * @param bool $separator Whether to add a separator before the menu.
 	 */
 	public function create_jetpack_menu( $position = 50, $separator = true ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::create_jetpack_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::create_jetpack_menu' );
 		parent::create_jetpack_menu( $position, $separator );
 	}
 
 	/**
 	 * Adds Jetpack menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_jetpack_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_jetpack_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_jetpack_menu' );
 		parent::add_jetpack_menu();
 	}
 
 	/**
 	 * Add the calypso /woocommerce-installation/ menu item.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array $current_plan The site's plan if they have one. This is passed from WPcom_Admin_Menu to prevent
 	 * redundant database queries.
 	 */
 	public function add_woocommerce_installation_menu( $current_plan = null ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_woocommerce_installation_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::add_woocommerce_installation_menu' );
 		parent::add_woocommerce_installation_menu( $current_plan );
 	}
 
 	/**
 	 * AJAX handler for retrieving the upsell nudge.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function wp_ajax_upsell_nudge_jitm() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::wp_ajax_upsell_nudge_jitm' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::wp_ajax_upsell_nudge_jitm' );
 		parent::wp_ajax_upsell_nudge_jitm();
 	}
 
@@ -279,12 +279,12 @@ class Admin_Menu extends Masterbar_Admin_Menu {
 	 * Needs to be implemented separately for each child menu class.
 	 * Empty by default.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return array
 	 */
 	public function get_upsell_nudge() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::get_upsell_nudge' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Admin_Menu::get_upsell_nudge' );
 		return parent::get_upsell_nudge();
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -2,7 +2,7 @@
 /**
  * Atomic Admin Menu file.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\Atomic_Admin_Menu instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\Atomic_Admin_Menu instead.
  *
  * @package automattic/jetpack
  */
@@ -19,20 +19,20 @@ class Atomic_Admin_Menu extends Masterbar_Atomic_Admin_Menu {
 	/**
 	 * Ensure that instantiating this class will trigger a deprecation warning.
 	 *
-	 * @since $$next-version$$
+	 * @since 13.7
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::__construct' );
 		parent::__construct();
 	}
 
 	/**
 	 * Dequeues unnecessary scripts.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function dequeue_scripts() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::dequeue_scripts' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::dequeue_scripts' );
 		parent::dequeue_scripts();
 	}
 
@@ -42,27 +42,27 @@ class Atomic_Admin_Menu extends Masterbar_Atomic_Admin_Menu {
 	 * Performs the check against the current locale set on the WordPress.com's account settings.
 	 * See `Masterbar::__construct` in `modules/masterbar/masterbar/class-masterbar.php`.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function is_rtl() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::is_rtl' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::is_rtl' );
 		return parent::is_rtl();
 	}
 
 	/**
 	 * Create the desired menu output.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function reregister_menu_items() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::reregister_menu_items' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::reregister_menu_items' );
 		parent::reregister_menu_items();
 	}
 
 	/**
 	 * Get the preferred view for the given screen.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $screen Screen identifier.
 	 * @param bool   $fallback_global_preference (Optional) Whether the global preference for all screens should be used
@@ -71,192 +71,192 @@ class Atomic_Admin_Menu extends Masterbar_Atomic_Admin_Menu {
 	 * @return string
 	 */
 	public function get_preferred_view( $screen, $fallback_global_preference = true ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::get_preferred_view' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::get_preferred_view' );
 		return parent::get_preferred_view( $screen, $fallback_global_preference );
 	}
 
 	/**
 	 * Adds Users menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_users_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_users_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_users_menu' );
 		parent::add_users_menu();
 	}
 
 	/**
 	 * Adds Plugins menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_plugins_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_plugins_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_plugins_menu' );
 		parent::add_plugins_menu();
 	}
 
 	/**
 	 * Adds the site switcher link if user has more than one site.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_browse_sites_link() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_browse_sites_link' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_browse_sites_link' );
 		parent::add_browse_sites_link();
 	}
 
 	/**
 	 * Adds a custom element class for Site Switcher menu item.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array $menu Associative array of administration menu items.
 	 *
 	 * @return array
 	 */
 	public function set_browse_sites_link_class( array $menu ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::set_browse_sites_link_class' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::set_browse_sites_link_class' );
 		return parent::set_browse_sites_link_class( $menu );
 	}
 
 	/**
 	 * Adds a link to the menu to create a new site.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_new_site_link() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_new_site_link' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_new_site_link' );
 		parent::add_new_site_link();
 	}
 
 	/**
 	 * Adds site card component.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_site_card_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_site_card_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_site_card_menu' );
 		parent::add_site_card_menu();
 	}
 
 	/**
 	 * Adds a custom element class and id for Site Card's menu item.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array $menu Associative array of administration menu items.
 	 *
 	 * @return array
 	 */
 	public function set_site_card_menu_class( array $menu ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::set_site_card_menu_class' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::set_site_card_menu_class' );
 		return parent::set_site_card_menu_class( $menu );
 	}
 
 	/**
 	 * Returns the first available upsell nudge.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return array
 	 */
 	public function get_upsell_nudge() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::get_upsell_nudge' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::get_upsell_nudge' );
 		return parent::get_upsell_nudge();
 	}
 
 	/**
 	 * Adds Jetpack menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_jetpack_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_jetpack_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_jetpack_menu' );
 		parent::add_jetpack_menu();
 	}
 
 	/**
 	 * Adds Stats menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_stats_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_stats_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_stats_menu' );
 		parent::add_stats_menu();
 	}
 
 	/**
 	 * Adds Upgrades menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $plan The current WPCOM plan of the blog.
 	 */
 	public function add_upgrades_menu( $plan = null ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_upgrades_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_upgrades_menu' );
 		parent::add_upgrades_menu( $plan );
 	}
 
 	/**
 	 * Adds Settings menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_options_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_options_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_options_menu' );
 		parent::add_options_menu();
 	}
 
 	/**
 	 * Adds Tools menu entries.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_tools_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_tools_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_tools_menu' );
 		parent::add_tools_menu();
 	}
 
 	/**
 	 * Override the global submenu_file for theme-install.php page so the WP Admin menu item gets highlighted correctly.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $submenu_file The current pages $submenu_file global variable value.
 	 * @return string | null
 	 */
 	public function override_the_theme_installer( $submenu_file ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::override_the_theme_installer' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::override_the_theme_installer' );
 		return parent::override_the_theme_installer( $submenu_file );
 	}
 
 	/**
 	 * Also remove the Gutenberg plugin menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function remove_gutenberg_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::remove_gutenberg_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::remove_gutenberg_menu' );
 		parent::remove_gutenberg_menu();
 	}
 
 	/**
 	 * Saves the sidebar state ( expanded / collapsed ) via an ajax request.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function ajax_sidebar_state() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::ajax_sidebar_state' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::ajax_sidebar_state' );
 		parent::ajax_sidebar_state();
 	}
 
 	/**
 	 * Handle ajax requests to dismiss a just-in-time-message
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function wp_ajax_jitm_dismiss() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::wp_ajax_jitm_dismiss' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::wp_ajax_jitm_dismiss' );
 		parent::wp_ajax_jitm_dismiss();
 	}
 
@@ -264,12 +264,12 @@ class Atomic_Admin_Menu extends Masterbar_Atomic_Admin_Menu {
 	 * Adds a notice above each settings page while using the Classic view to indicate
 	 * that the Default view offers more features. Links to the default view.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return void
 	 */
 	public function add_settings_page_notice() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_settings_page_notice' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_settings_page_notice' );
 		parent::add_settings_page_notice();
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-dashboard-switcher-tracking.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-dashboard-switcher-tracking.php
@@ -2,7 +2,7 @@
 /**
  * Quick switcher tracking file.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\Dashboard_Switcher_Tracking instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\Dashboard_Switcher_Tracking instead.
  *
  * @package automattic/jetpack
  */
@@ -35,53 +35,53 @@ class Dashboard_Switcher_Tracking {
 	/**
 	 * Dashboard_Switcher_Tracking constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param Tracking $tracking       Jetpack tracking object.
 	 * @param callable $wpcom_tracking A wrapper over wpcom event record.
 	 * @param string   $plan           The current site plan.
 	 */
 	public function __construct( Tracking $tracking, callable $wpcom_tracking, $plan ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::__construct' );
 		$this->dashboard_switcher_wrapper = new Masterbar_Dashboard_Switcher_Tracking( $tracking, $wpcom_tracking, $plan );
 	}
 
 	/**
 	 * Create an event for the Quick switcher when the user changes it's preferred view.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $screen The screen page.
 	 * @param string $view   The new preferred view.
 	 */
 	public function record_switch_event( $screen, $view ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::record_switch_event' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::record_switch_event' );
 		$this->dashboard_switcher_wrapper->record_switch_event( $screen, $view );
 	}
 
 	/**
 	 * Get the current site plan or 'N/A' when we cannot determine site's plan.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @todo: This method can be reused as a wrapper over WPCOM and Atomic as way to get site's current plan (display name).
 	 *
 	 * @return string
 	 */
 	public static function get_plan() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::get_plan' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::get_plan' );
 		return Masterbar_Dashboard_Switcher_Tracking::get_plan();
 	}
 
 	/**
 	 * Trigger the WPCOM tracks_record_event.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array $event_props Event props.
 	 */
 	public static function wpcom_tracks_record_event( $event_props ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::wpcom_tracks_record_event' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::wpcom_tracks_record_event' );
 		return Masterbar_Dashboard_Switcher_Tracking::wpcom_tracks_record_event( $event_props );
 	}
 
@@ -90,19 +90,19 @@ class Dashboard_Switcher_Tracking {
 	 *
 	 * The tracking product name is used by the Tracking as a prefix for the event name.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return string
 	 */
 	public static function get_jetpack_tracking_product() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::get_jetpack_tracking_product' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::get_jetpack_tracking_product' );
 		return Masterbar_Dashboard_Switcher_Tracking::get_jetpack_tracking_product();
 	}
 
 	/**
 	 * Mark the Jetpack ToS as read for Atomic Sites.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param mixed  $option_value The value of the Jetpack option.
 	 * @param string $option_name The name of the Jetpack option.
@@ -110,7 +110,7 @@ class Dashboard_Switcher_Tracking {
 	 * @return bool
 	 */
 	public static function mark_jetpack_tos_as_read( $option_value, $option_name ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::mark_jetpack_tos_as_read' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Dashboard_Switcher_Tracking::mark_jetpack_tos_as_read' );
 		return Masterbar_Dashboard_Switcher_Tracking::mark_jetpack_tos_as_read( $option_value, $option_name );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-domain-only-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-domain-only-admin-menu.php
@@ -2,7 +2,7 @@
 /**
  * Domain-only sites Admin Menu file.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\Domain_Only_Admin_Menu instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\Domain_Only_Admin_Menu instead.
  *
  * @package automattic/jetpack
  */
@@ -18,34 +18,34 @@ class Domain_Only_Admin_Menu extends Masterbar_Domain_Only_Admin_Menu {
 	/**
 	 * Ensure that instantiating this class will trigger a deprecation warning.
 	 *
-	 * @since $$next-version$$
+	 * @since 13.7
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Domain_Only_Admin_Menu::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Domain_Only_Admin_Menu::__construct' );
 		parent::__construct();
 	}
 
 	/**
 	 * This setter lets us inject an WPCOM_Email_Subscription_Checker instance.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param \Automattic\Jetpack\Masterbar\WPCOM_Email_Subscription_Checker $email_subscriptions_checker An WPCOM_Email_Subscription_Checker instance.
 	 *
 	 * @return void
 	 */
 	public function set_email_subscription_checker( $email_subscriptions_checker ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Domain_Only_Admin_Menu::set_email_subscription_checker' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Domain_Only_Admin_Menu::set_email_subscription_checker' );
 		parent::set_email_subscription_checker( $email_subscriptions_checker );
 	}
 
 	/**
 	 * Create the desired menu output.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function reregister_menu_items() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Domain_Only_Admin_Menu::reregister_menu_items' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Domain_Only_Admin_Menu::reregister_menu_items' );
 		parent::reregister_menu_items();
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-jetpack-admin-menu.php
@@ -2,7 +2,7 @@
 /**
  * Jetpack Admin Menu file.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\Jetpack_Admin_Menu instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\Jetpack_Admin_Menu instead.
  *
  * @package Jetpack
  */
@@ -19,10 +19,10 @@ class Jetpack_Admin_Menu extends Masterbar_Jetpack_Admin_Menu {
 	/**
 	 * Ensure that instantiating this class will trigger a deprecation warning.
 	 *
-	 * @since $$next-version$$
+	 * @since 13.7
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::__construct' );
 		parent::__construct();
 	}
 
@@ -32,27 +32,27 @@ class Jetpack_Admin_Menu extends Masterbar_Jetpack_Admin_Menu {
 	 * Performs the check against the current locale set on the WordPress.com's account settings.
 	 * See `Masterbar::__construct` in `modules/masterbar/masterbar/class-masterbar.php`.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function is_rtl() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::is_rtl' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::is_rtl' );
 		return parent::is_rtl();
 	}
 
 	/**
 	 * Create the desired menu output.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function reregister_menu_items() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::reregister_menu_items' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::reregister_menu_items' );
 		parent::reregister_menu_items();
 	}
 
 	/**
 	 * Get the preferred view for the given screen.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $screen Screen identifier.
 	 * @param bool   $fallback_global_preference (Optional) Whether the global preference for all screens should be used
@@ -61,166 +61,166 @@ class Jetpack_Admin_Menu extends Masterbar_Jetpack_Admin_Menu {
 	 * @return string
 	 */
 	public function get_preferred_view( $screen, $fallback_global_preference = true ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::get_preferred_view' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::get_preferred_view' );
 		return parent::get_preferred_view( $screen, $fallback_global_preference );
 	}
 
 	/**
 	 * Get the Calypso or wp-admin link to CPT page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param object $ptype_obj The post type object.
 	 * @return string The link to Calypso if SSO is enabled and the post_type
 	 * supports rest or to WP Admin if SSO is disabled.
 	 */
 	public function get_cpt_menu_link( $ptype_obj ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::get_cpt_menu_link' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::get_cpt_menu_link' );
 		return parent::get_cpt_menu_link( $ptype_obj );
 	}
 
 	/**
 	 * Adds Posts menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_posts_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_posts_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_posts_menu' );
 		parent::add_posts_menu();
 	}
 
 	/**
 	 * Adds Media menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_media_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_media_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_media_menu' );
 		parent::add_media_menu();
 	}
 
 	/**
 	 * Adds Page menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_page_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_page_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_page_menu' );
 		parent::add_page_menu();
 	}
 
 	/**
 	 * Adds a custom post type menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string   $post_type Custom post type.
 	 * @param int|null $position Optional. Position where to display the menu item. Default null.
 	 */
 	public function add_custom_post_type_menu( $post_type, $position = null ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_custom_post_type_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_custom_post_type_menu' );
 		parent::add_custom_post_type_menu( $post_type, $position );
 	}
 
 	/**
 	 * Adds Comments menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_comments_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_comments_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_comments_menu' );
 		parent::add_comments_menu();
 	}
 
 	/**
 	 * Adds Feedback menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_feedback_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_feedback_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_feedback_menu' );
 		parent::add_feedback_menu();
 	}
 
 	/**
 	 * Adds CPT menu items
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_cpt_menus() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_cpt_menus' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_cpt_menus' );
 		parent::add_cpt_menus();
 	}
 
 	/**
 	 * Adds Jetpack menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_jetpack_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_jetpack_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_jetpack_menu' );
 		parent::add_jetpack_menu();
 	}
 
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return string The Customizer URL.
 	 */
 	public function add_appearance_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_appearance_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_appearance_menu' );
 		return parent::add_appearance_menu();
 	}
 
 	/**
 	 * Adds Plugins menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_plugins_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_plugins_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_plugins_menu' );
 		parent::add_plugins_menu();
 	}
 
 	/**
 	 * Adds Users menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_users_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_users_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_users_menu' );
 		parent::add_users_menu();
 	}
 
 	/**
 	 * Adds Tools menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_tools_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_tools_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_tools_menu' );
 		parent::add_tools_menu();
 	}
 
 	/**
 	 * Adds Settings menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_options_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_options_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_options_menu' );
 		parent::add_options_menu();
 	}
 
 	/**
 	 * Adds WP Admin menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_wp_admin_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_wp_admin_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Jetpack_Admin_Menu::add_wp_admin_menu' );
 		parent::add_wp_admin_menu();
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-p2-admin-menu.php
@@ -2,7 +2,7 @@
 /**
  * P2 Admin Menu file.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\P2_Admin_Menu instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\P2_Admin_Menu instead.
  *
  * @package Jetpack
  */
@@ -19,32 +19,32 @@ class P2_Admin_Menu extends Masterbar_P2_Admin_Menu {
 	/**
 	 * Ensure that instantiating this class will trigger a deprecation warning.
 	 *
-	 * @since $$next-version$$
+	 * @since 13.7
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\P2_Admin_Menu::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\P2_Admin_Menu::__construct' );
 		parent::__construct();
 	}
 
 	/**
 	 * Create the desired menu output.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function reregister_menu_items() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\P2_Admin_Menu::reregister_menu_items' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\P2_Admin_Menu::reregister_menu_items' );
 		parent::reregister_menu_items();
 	}
 
 	/**
 	 * Override, don't add the woocommerce installation menu on any p2s.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array|null $current_plan The site's plan.
 	 */
 	public function add_woocommerce_installation_menu( $current_plan = null ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\P2_Admin_Menu::add_woocommerce_installation_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\P2_Admin_Menu::add_woocommerce_installation_menu' );
 		parent::add_woocommerce_installation_menu( $current_plan );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -2,7 +2,7 @@
 /**
  * WP.com Admin Menu file.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\WPcom_Admin_Menu instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\WPcom_Admin_Menu instead.
  *
  * @package automattic/jetpack
  */
@@ -19,27 +19,27 @@ class WPcom_Admin_Menu extends Masterbar_WPcom_Admin_Menu {
 	/**
 	 * Ensure that instantiating this class will trigger a deprecation warning.
 	 *
-	 * @since $$next-version$$
+	 * @since 13.7
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::__construct' );
 		parent::__construct();
 	}
 
 	/**
 	 * Create the desired menu output.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function reregister_menu_items() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::reregister_menu_items' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::reregister_menu_items' );
 		parent::reregister_menu_items();
 	}
 
 	/**
 	 * Get the preferred view for the given screen.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $screen Screen identifier.
 	 * @param bool   $fallback_global_preference (Optional) Whether the global preference for all screens should be used
@@ -48,203 +48,203 @@ class WPcom_Admin_Menu extends Masterbar_WPcom_Admin_Menu {
 	 * @return string
 	 */
 	public function get_preferred_view( $screen, $fallback_global_preference = true ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::get_preferred_view' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::get_preferred_view' );
 		return parent::get_preferred_view( $screen, $fallback_global_preference );
 	}
 
 	/**
 	 * Retrieve the number of blogs that the current user has.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return int
 	 */
 	public function get_current_user_blog_count() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::get_current_user_blog_count' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::get_current_user_blog_count' );
 		return parent::get_current_user_blog_count();
 	}
 
 	/**
 	 * Adds the site switcher link if user has more than one site.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_browse_sites_link() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_browse_sites_link' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_browse_sites_link' );
 		parent::add_browse_sites_link();
 	}
 
 	/**
 	 * Adds a custom element class for Site Switcher menu item.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array $menu Associative array of administration menu items.
 	 * @return array
 	 */
 	public function set_browse_sites_link_class( array $menu ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::set_browse_sites_link_class' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::set_browse_sites_link_class' );
 		return parent::set_browse_sites_link_class( $menu );
 	}
 
 	/**
 	 * Adds a link to the menu to create a new site.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_new_site_link() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_new_site_link' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_new_site_link' );
 		parent::add_new_site_link();
 	}
 
 	/**
 	 * Adds site card component.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_site_card_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_site_card_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_site_card_menu' );
 		parent::add_site_card_menu();
 	}
 
 	/**
 	 * Adds a custom element class and id for Site Card's menu item.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array $menu Associative array of administration menu items.
 	 * @return array
 	 */
 	public function set_site_card_menu_class( array $menu ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::set_site_card_menu_class' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::set_site_card_menu_class' );
 		return parent::set_site_card_menu_class( $menu );
 	}
 
 	/**
 	 * Returns the first available upsell nudge.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return array
 	 */
 	public function get_upsell_nudge() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::get_upsell_nudge' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::get_upsell_nudge' );
 		return parent::get_upsell_nudge();
 	}
 
 	/**
 	 * Adds Stats menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_stats_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_stats_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_stats_menu' );
 		parent::add_stats_menu();
 	}
 
 	/**
 	 * Adds Upgrades menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $plan The current WPCOM plan of the blog.
 	 */
 	public function add_upgrades_menu( $plan = null ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_upgrades_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_upgrades_menu' );
 		parent::add_upgrades_menu( $plan );
 	}
 
 	/**
 	 * Adds Appearance menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_appearance_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_appearance_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_appearance_menu' );
 		return parent::add_appearance_menu();
 	}
 
 	/**
 	 * Adds Users menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_users_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_users_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_users_menu' );
 		parent::add_users_menu();
 	}
 
 	/**
 	 * Adds Settings menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_options_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_options_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_options_menu' );
 		parent::add_options_menu();
 	}
 
 	/**
 	 * Adds My Home menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_my_home_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_my_home_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_my_home_menu' );
 		parent::add_my_home_menu();
 	}
 
 	/**
 	 * Also remove the Gutenberg plugin menu.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function remove_gutenberg_menu() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::remove_gutenberg_menu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::remove_gutenberg_menu' );
 		parent::remove_gutenberg_menu();
 	}
 
 	/**
 	 * Whether to use wp-admin pages rather than Calypso.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return bool
 	 */
 	public function should_link_to_wp_admin() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::should_link_to_wp_admin' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::should_link_to_wp_admin' );
 		return parent::should_link_to_wp_admin();
 	}
 
 	/**
 	 * Saves the sidebar state ( expanded / collapsed ) via an ajax request.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return never
 	 */
 	public function ajax_sidebar_state() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::ajax_sidebar_state' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::ajax_sidebar_state' );
 		parent::ajax_sidebar_state();
 	}
 
 	/**
 	 * Handle ajax requests to dismiss a just-in-time-message
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function wp_ajax_jitm_dismiss() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::wp_ajax_jitm_dismiss' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::wp_ajax_jitm_dismiss' );
 		parent::wp_ajax_jitm_dismiss();
 	}
 
 	/**
 	 * Syncs the sidebar collapsed state from Calypso Preferences.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function sync_sidebar_collapsed_state() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::sync_sidebar_collapsed_state' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::sync_sidebar_collapsed_state' );
 		parent::sync_sidebar_collapsed_state();
 	}
 
@@ -253,10 +253,10 @@ class WPcom_Admin_Menu extends Masterbar_WPcom_Admin_Menu {
 	 *
 	 * These submenus are added across wp-content and should be removed together with these function calls.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function remove_submenus() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::remove_submenus' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::remove_submenus' );
 		parent::remove_submenus();
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-email-subscription-checker.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-email-subscription-checker.php
@@ -2,7 +2,7 @@
 /**
  * A class that checks for the existence of email subscriptions for a user.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\WPCOM_Email_Subscription_Checker instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\WPCOM_Email_Subscription_Checker instead.
  *
  * @package automattic/jetpack
  */
@@ -15,12 +15,12 @@ class WPCOM_Email_Subscription_Checker {
 	/**
 	 * Checks if a user's site has an email subscription
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return bool
 	 */
 	public function has_email() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPCOM_Email_Subscription_Checker::has_email' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPCOM_Email_Subscription_Checker::has_email' );
 
 		$email_subscriptions_checker_wrapper = new Masterbar_WPCOM_Email_Subscription_Checker();
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
@@ -2,7 +2,7 @@
 /**
  * Admin Menu loader.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  *
  * @package Jetpack
  *
@@ -11,7 +11,7 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
-_deprecated_file( __FILE__, 'jetpack-$$next-version$$' );
+_deprecated_file( __FILE__, 'jetpack-13.7' );
 
 use Automattic\Jetpack\Masterbar\Base_Admin_Menu;
 use Automattic\Jetpack\Status\Host;
@@ -20,14 +20,14 @@ use Automattic\Jetpack\Tracking;
 /**
  * Checks whether the navigation customizations should be performed for the given class.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  *
  * @param string $admin_menu_class Class name.
  *
  * @return bool
  */
 function should_customize_nav( $admin_menu_class ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\should_customize_nav' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\should_customize_nav' );
 	// Make sure the class extends the base admin menu class.
 	if ( ! is_subclass_of( $admin_menu_class, Base_Admin_Menu::class ) ) {
 		return false;
@@ -52,12 +52,12 @@ function should_customize_nav( $admin_menu_class ) {
  * Hides the Customizer menu items when the block theme is active by removing the dotcom-specific actions.
  * They are not needed for block themes.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  *
  * @see https://github.com/Automattic/jetpack/pull/36017
  */
 function hide_customizer_menu_on_block_theme() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\hide_customizer_menu_on_block_theme' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\hide_customizer_menu_on_block_theme' );
 	add_action(
 		'init',
 		function () {
@@ -85,12 +85,12 @@ function hide_customizer_menu_on_block_theme() {
 /**
  * Gets the name of the class that customizes the admin menu.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  *
  * @return string Class name.
  */
 function get_admin_menu_class() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\get_admin_menu_class' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\get_admin_menu_class' );
 	hide_customizer_menu_on_block_theme();
 
 	// WordPress.com Atomic sites.
@@ -164,13 +164,13 @@ if ( should_customize_nav( $admin_menu_class ) ) {
 	/**
 	 * Trigger an event when the user uses the dashboard quick switcher.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $screen The current screen.
 	 * @param string $view The view the user choosed to go to.
 	 */
 	function dashboard_quick_switcher_record_usage( $screen, $view ) {
-		_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\dashboard_quick_switcher_record_usage' );
+		_deprecated_function( __FUNCTION__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\dashboard_quick_switcher_record_usage' );
 
 		require_once __DIR__ . '/class-dashboard-switcher-tracking.php';
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/menu-mappings.php
@@ -2,11 +2,11 @@
 /**
  * Helper mapping between WP Admin pages and WordPress.com
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  *
  * @package automattic/jetpack
  */
 
-_deprecated_file( __FILE__, 'jetpack-$$next-version$$' );
+_deprecated_file( __FILE__, 'jetpack-13.7' );
 
 return require JETPACK__PLUGIN_DIR . 'jetpack_vendor/automattic/jetpack-masterbar/src/admin-menu/common-mappings.php';

--- a/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
+++ b/projects/plugins/jetpack/modules/masterbar/inline-help/class-inline-help.php
@@ -5,7 +5,7 @@
  * Handles providing a LiveChat icon within WPAdmin until such time
  * as the full live chat experience can be run in a non-Calypso environment.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\Inline_Help instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\Inline_Help instead.
  *
  * @package automattic/jetpack
  */
@@ -29,10 +29,10 @@ class Inline_Help {
 	/**
 	 * Inline_Help constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Inline_Help::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Inline_Help::__construct' );
 
 		$this->inline_help_wrapper = new Masterbar_Inline_Help();
 	}
@@ -40,37 +40,37 @@ class Inline_Help {
 	/**
 	 * Registers actions.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param object $current_screen Current screen object.
 	 * @return void
 	 */
 	public function register_actions( $current_screen ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Inline_Help::register_actions' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Inline_Help::register_actions' );
 		$this->inline_help_wrapper->register_actions( $current_screen );
 	}
 
 	/**
 	 * Outputs "FAB" icon markup and SVG.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return void|string the HTML markup for the FAB or early exit.
 	 */
 	public function add_fab_icon() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Inline_Help::add_fab_icon' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Inline_Help::add_fab_icon' );
 		$this->inline_help_wrapper->add_fab_icon();
 	}
 
 	/**
 	 * Enqueues FAB CSS styles.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return void
 	 */
 	public function add_fab_styles() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Inline_Help::add_fab_styles' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Inline_Help::add_fab_styles' );
 		$this->inline_help_wrapper->add_fab_styles();
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
+++ b/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php
@@ -2,7 +2,7 @@
 /**
  * Masterbar file.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\Masterbar instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\Masterbar instead.
  *
  * @package automattic/jetpack
  *
@@ -30,39 +30,39 @@ class Masterbar {
 	/**
 	 * Constructor
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::__construct' );
 		$this->masterbar_wrapper = new Jetpack_Masterbar();
 	}
 
 	/**
 	 * Initialize our masterbar.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function init() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::init' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::init' );
 		$this->masterbar_wrapper->init();
 	}
 
 	/**
 	 * Log out from WordPress.com when logging out of the local site.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $redirect_to The redirect destination URL.
 	 */
 	public function maybe_logout_user_from_wpcom( $redirect_to ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::maybe_logout_user_from_wpcom' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::maybe_logout_user_from_wpcom' );
 		return $this->masterbar_wrapper->maybe_logout_user_from_wpcom( $redirect_to );
 	}
 
 	/**
 	 * Adds CSS classes to admin body tag.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @since 5.1
 	 *
@@ -71,37 +71,37 @@ class Masterbar {
 	 * @return string
 	 */
 	public function admin_body_class( $admin_body_classes ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::admin_body_class' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::admin_body_class' );
 		return $this->masterbar_wrapper->admin_body_class( $admin_body_classes );
 	}
 
 	/**
 	 * Remove the default Admin Bar CSS.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function remove_core_styles() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::remove_core_styles' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::remove_core_styles' );
 		$this->masterbar_wrapper->remove_core_styles();
 	}
 
 	/**
 	 * Enqueue our own CSS and JS to display our custom admin bar.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_styles_and_scripts() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_styles_and_scripts' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_styles_and_scripts' );
 		$this->masterbar_wrapper->add_styles_and_scripts();
 	}
 
 	/**
 	 * Remove the default admin bar items and replace it with our own admin bar.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function replace_core_masterbar() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::replace_core_masterbar' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::replace_core_masterbar' );
 		$this->masterbar_wrapper->replace_core_masterbar();
 	}
 
@@ -113,14 +113,14 @@ class Masterbar {
 	 * to NOT use the wpcom master bar. We do need to adjust a couple of things
 	 * though.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param WP_Admin_Bar $bar The admin bar object.
 	 *
 	 * @return void
 	 */
 	protected function build_wp_admin_interface_bar( $bar ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::build_wp_admin_interface_bar' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::build_wp_admin_interface_bar' );
 		$nodes = array();
 
 		// First, lets gather all nodes and remove them.
@@ -163,14 +163,14 @@ class Masterbar {
 	/**
 	 * Add a link to the user` profile on WordPress.com
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param WP_Admin_Bar $bar The admin bar object.
 	 *
 	 * @return void
 	 */
 	protected function add_wpcom_profile_link( $bar ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_wpcom_profile_link' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_wpcom_profile_link' );
 		$custom_node = array(
 			'parent' => 'user-actions',
 			'id'     => 'wpcom-profile-link',
@@ -187,59 +187,59 @@ class Masterbar {
 	/**
 	 * Remove all existing toolbar entries from core Masterbar
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
 	 */
 	public function clear_core_masterbar( $wp_admin_bar ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::clear_core_masterbar' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::clear_core_masterbar' );
 		$this->masterbar_wrapper->clear_core_masterbar( $wp_admin_bar );
 	}
 
 	/**
 	 * Add entries corresponding to WordPress.com Masterbar
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
 	 */
 	public function build_wpcom_masterbar( $wp_admin_bar ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::build_wpcom_masterbar' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::build_wpcom_masterbar' );
 		$this->masterbar_wrapper->build_wpcom_masterbar( $wp_admin_bar );
 	}
 
 	/**
 	 * Get WordPress.com current locale name.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function get_locale() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::get_locale' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::get_locale' );
 		return $this->masterbar_wrapper->get_locale();
 	}
 
 	/**
 	 * Get Jetpack locale name.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param  string $slug Locale slug.
 	 * @return string Jetpack locale.
 	 */
 	public function get_jetpack_locale( $slug = '' ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::get_jetpack_locale' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::get_jetpack_locale' );
 		return $this->masterbar_wrapper->get_jetpack_locale( $slug );
 	}
 
 	/**
 	 * Install locale if not yet available.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $locale The new locale slug.
 	 */
 	public function install_locale( $locale = '' ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::install_locale' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::install_locale' );
 		return $this->masterbar_wrapper->install_locale( $locale );
 	}
 
@@ -256,76 +256,76 @@ class Masterbar {
 	 * The default textdomain is not affected by this because it's always reloaded
 	 * after all plugins have been loaded, in wp-settings.php.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $wpcom_locale The user's detected WordPress.com locale.
 	 */
 	public function unload_non_default_textdomains_on_wpcom_user_locale_switch( $wpcom_locale ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::unload_non_default_textdomains_on_wpcom_user_locale_switch' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::unload_non_default_textdomains_on_wpcom_user_locale_switch' );
 		return $this->masterbar_wrapper->unload_non_default_textdomains_on_wpcom_user_locale_switch( $wpcom_locale );
 	}
 
 	/**
 	 * Hide language dropdown on user edit form.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function hide_language_dropdown() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::hide_language_dropdown' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::hide_language_dropdown' );
 		$this->masterbar_wrapper->hide_language_dropdown();
 	}
 
 	/**
 	 * Replace language dropdown with link to WordPress.com.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function replace_language_dropdown() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::replace_language_dropdown' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::replace_language_dropdown' );
 		return $this->masterbar_wrapper->replace_language_dropdown();
 	}
 
 	/**
 	 * Add the Notifications menu item.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
 	 */
 	public function add_notifications( $wp_admin_bar ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_notifications' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_notifications' );
 		$this->masterbar_wrapper->add_notifications( $wp_admin_bar );
 	}
 
 	/**
 	 * Add the "Reader" menu item in the root default group.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
 	 */
 	public function add_reader_submenu( $wp_admin_bar ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_reader_submenu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_reader_submenu' );
 		$this->masterbar_wrapper->add_reader_submenu( $wp_admin_bar );
 	}
 
 	/**
 	 * Merge 2 menu items together into 2 link tags.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array $primary   Array of menu information.
 	 * @param array $secondary Array of menu information.
 	 */
 	public function create_menu_item_pair( $primary, $secondary ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::create_menu_item_pair' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::create_menu_item_pair' );
 		return $this->masterbar_wrapper->create_menu_item_pair( $primary, $secondary );
 	}
 
 	/**
 	 * Create a link tag based on information about a menu item.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $class Menu item CSS class.
 	 * @param string $url   URL you go to when clicking on the menu item.
@@ -333,55 +333,55 @@ class Masterbar {
 	 * @param string $id    Menu item slug.
 	 */
 	public function create_menu_item_anchor( $class, $url, $label, $id ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::create_menu_item_anchor' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::create_menu_item_anchor' );
 		return $this->masterbar_wrapper->create_menu_item_anchor( $class, $url, $label, $id );
 	}
 
 	/**
 	 * Add Secondary groups for submenu items.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
 	 */
 	public function wpcom_adminbar_add_secondary_groups( $wp_admin_bar ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::wpcom_adminbar_add_secondary_groups' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::wpcom_adminbar_add_secondary_groups' );
 		$this->masterbar_wrapper->wpcom_adminbar_add_secondary_groups( $wp_admin_bar );
 	}
 
 	/**
 	 * Add User info menu item.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
 	 */
 	public function add_me_submenu( $wp_admin_bar ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_me_submenu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_me_submenu' );
 		$this->masterbar_wrapper->add_me_submenu( $wp_admin_bar );
 	}
 
 	/**
 	 * Add Write Menu item.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
 	 */
 	public function add_write_button( $wp_admin_bar ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_write_button' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_write_button' );
 		$this->masterbar_wrapper->add_write_button( $wp_admin_bar );
 	}
 
 	/**
 	 * Add the "My Site" menu item in the root default group.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
 	 */
 	public function add_my_sites_submenu( $wp_admin_bar ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_my_sites_submenu' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Masterbar::add_my_sites_submenu' );
 		$this->masterbar_wrapper->add_my_sites_submenu( $wp_admin_bar );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-atomic-additional-css-manager.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-atomic-additional-css-manager.php
@@ -4,7 +4,7 @@
  *
  * Responsible with replacing the Core Additional CSS section with an upgrade nudge on Atomic.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\Atomic_Additional_CSS_Manager instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\Atomic_Additional_CSS_Manager instead.
  *
  * @package Jetpack
  */
@@ -31,24 +31,24 @@ class Atomic_Additional_CSS_Manager {
 	/**
 	 * Atomic_Additional_CSS_Manager constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $domain the Site domain.
 	 */
 	public function __construct( $domain ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Additional_CSS_Manager::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Additional_CSS_Manager::__construct' );
 		$this->additional_css_wrapper = new Masterbar_Atomic_Additional_CSS_Manager( $domain );
 	}
 
 	/**
 	 * Replace the Additional CSS section from Customiz¡er with an upgrade nudge.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param \WP_Customize_Manager $wp_customize_manager Core customize manager.
 	 */
 	public function register_nudge( \WP_Customize_Manager $wp_customize_manager ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Atomic_Additional_CSS_Manager::register_nudge' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Additional_CSS_Manager::register_nudge' );
 		$this->additional_css_wrapper->register_nudge( $wp_customize_manager );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-css-customizer-nudge.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-css-customizer-nudge.php
@@ -3,7 +3,7 @@
  * CSS_Customizer_Nudge file.
  * CSS Nudge implementation for Atomic and WPCOM.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\CSS_Customizer_Nudge instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\CSS_Customizer_Nudge instead.
  *
  * @package Jetpack
  */
@@ -29,64 +29,64 @@ class CSS_Customizer_Nudge {
 	/**
 	 * CSS_Customizer_Nudge constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $cta_url      The URL to the plans.
 	 * @param string $nudge_copy   The nudge text.
 	 * @param string $control_name The slug prefix of the nudge.
 	 */
 	public function __construct( $cta_url, $nudge_copy, $control_name = 'custom_css' ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\CSS_Customizer_Nudge::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\CSS_Customizer_Nudge::__construct' );
 		$this->css_customizer_nudge_wrapper = new Masterbar_CSS_Customizer_Nudge( $cta_url, $nudge_copy, $control_name );
 	}
 
 	/**
 	 * Register the assets required for the CSS nudge page from the Customizer.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function customize_controls_enqueue_scripts_nudge() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\CSS_Customizer_Nudge::customize_controls_enqueue_scripts_nudge' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\CSS_Customizer_Nudge::customize_controls_enqueue_scripts_nudge' );
 		$this->css_customizer_nudge_wrapper->customize_controls_enqueue_scripts_nudge();
 	}
 
 	/**
 	 * Register the CSS nudge in the Customizer.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param \WP_Customize_Manager $wp_customize The customize manager.
 	 */
 	public function customize_register_nudge( \WP_Customize_Manager $wp_customize ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\CSS_Customizer_Nudge::customize_register_nudge' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\CSS_Customizer_Nudge::customize_register_nudge' );
 		$this->css_customizer_nudge_wrapper->customize_register_nudge( $wp_customize );
 	}
 
 	/**
 	 * Create a nudge control object.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param \WP_Customize_Manager $wp_customize The Core Customize Manager.
 	 *
 	 * @return \Automattic\Jetpack\Masterbar\CSS_Nudge_Customize_Control
 	 */
 	public function create_css_nudge_control( \WP_Customize_Manager $wp_customize ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\CSS_Customizer_Nudge::create_css_nudge_control' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\CSS_Customizer_Nudge::create_css_nudge_control' );
 		return $this->css_customizer_nudge_wrapper->create_css_nudge_control( $wp_customize );
 	}
 
 	/**
 	 * Create the nudge section.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param \WP_Customize_Manager $wp_customize The core Customize Manager.
 	 *
 	 * @return \WP_Customize_Section
 	 */
 	public function create_css_nudge_section( \WP_Customize_Manager $wp_customize ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\CSS_Customizer_Nudge::create_css_nudge_section' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\CSS_Customizer_Nudge::create_css_nudge_section' );
 		return $this->css_customizer_nudge_wrapper->create_css_nudge_section( $wp_customize );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-css-nudge-customize-control.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-css-nudge-customize-control.php
@@ -3,7 +3,7 @@
  * CSS_Nudge_Customize_Control file.
  * CSS Nudge implementation for Atomic and WPCOM.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\CSS_Nudge_Customize_Control instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\CSS_Nudge_Customize_Control instead.
  *
  * @package Jetpack
  */
@@ -21,10 +21,10 @@ class CSS_Nudge_Customize_Control extends Masterbar_CSS_Nudge_Customize_Control 
 	/**
 	 * Render the nudge on the page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function render_content() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\CSS_Nudge_Customize_Control::render_content' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\CSS_Nudge_Customize_Control::render_content' );
 		parent::render_content();
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-wpcom-additional-css-manager.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/additional-css/class-wpcom-additional-css-manager.php
@@ -4,7 +4,7 @@
  *
  * Is responsible with registering the Additional CSS section in WPCOM.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\WPCOM_Additional_CSS_Manager instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\WPCOM_Additional_CSS_Manager instead.
  *
  * @package Jetpack
  */
@@ -31,24 +31,24 @@ class WPCOM_Additional_CSS_Manager {
 	/**
 	 * WPCOM_Additional_CSS_Manager constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $domain the Site domain.
 	 */
 	public function __construct( $domain ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPCOM_Additional_CSS_Manager::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPCOM_Additional_CSS_Manager::__construct' );
 		$this->wpcom_additional_css_wrapper = new Masterbar_WPCOM_Additional_CSS_Manager( $domain );
 	}
 
 	/**
 	 * Register the Additional CSS nudge.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param \WP_Customize_Manager $wp_customize_manager The core customize manager.
 	 */
 	public function register_nudge( \WP_Customize_Manager $wp_customize_manager ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPCOM_Additional_CSS_Manager::register_nudge' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPCOM_Additional_CSS_Manager::register_nudge' );
 		$this->wpcom_additional_css_wrapper->register_nudge( $wp_customize_manager );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/nudges/bootstrap.php
+++ b/projects/plugins/jetpack/modules/masterbar/nudges/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * Bootstrap file for the nudges.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  *
  * @package Jetpack
  *
@@ -11,7 +11,7 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
-_deprecated_file( __FILE__, 'jetpack-$$next-version$$' );
+_deprecated_file( __FILE__, 'jetpack-13.7' );
 
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
@@ -19,12 +19,12 @@ use Automattic\Jetpack\Status\Host;
 /**
  * The WP_Customize_Control core class is loaded only on customize_register.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  *
  * @param \WP_Customize_Manager $customize_manager Core customize manager.
  */
 function register_css_nudge_control( \WP_Customize_Manager $customize_manager ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\register_css_nudge_control' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\register_css_nudge_control' );
 	require_once __DIR__ . '/additional-css/class-css-nudge-customize-control.php';
 	require_once __DIR__ . '/additional-css/class-css-customizer-nudge.php';
 
@@ -50,10 +50,10 @@ function register_css_nudge_control( \WP_Customize_Manager $customize_manager ) 
  *
  * We need to load on init because otherwise the filter will not be set to true in WPCOM (since the add_filter is set on init).
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  */
 function load_bootstrap_on_init() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\load_bootstrap_on_init' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\load_bootstrap_on_init' );
 	/**
 	 * Disable Additional CSS section from Customizer in WPCOM and Atomic and replace it with a nudge.
 	 *

--- a/projects/plugins/jetpack/modules/masterbar/profile-edit/bootstrap.php
+++ b/projects/plugins/jetpack/modules/masterbar/profile-edit/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * Bootstrap the WP.com User profile edit restriction.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  *
  * @package automattic\jetpack
  *
@@ -11,17 +11,17 @@
 
 namespace Automattic\Jetpack\Dashboard_Customizations;
 
-_deprecated_file( __FILE__, 'jetpack-$$next-version$$' );
+_deprecated_file( __FILE__, 'jetpack-13.7' );
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
 /**
  * Prevent WP.com user profile fields (first_name, last_name, display_name, description) to be updated.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  */
 function load_the_user_profile_info_revert() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\load_the_user_profile_info_revert' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\load_the_user_profile_info_revert' );
 	new WPCOM_User_Profile_Fields_Revert( new Connection_Manager( 'jetpack' ) );
 }
 

--- a/projects/plugins/jetpack/modules/masterbar/profile-edit/class-wpcom-user-profile-fields-revert.php
+++ b/projects/plugins/jetpack/modules/masterbar/profile-edit/class-wpcom-user-profile-fields-revert.php
@@ -2,7 +2,7 @@
 /**
  * Manage User profile fields.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\WPCOM_User_Profile_Fields_Revert instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\WPCOM_User_Profile_Fields_Revert instead.
  *
  * @package automattic/jetpack
  */
@@ -30,19 +30,19 @@ class WPCOM_User_Profile_Fields_Revert {
 	/**
 	 * Profile_Edit_Filter_Fields constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param Connection_Manager $connection_manager The connection manager.
 	 */
 	public function __construct( Connection_Manager $connection_manager ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPCOM_User_Profile_Fields_Revert::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPCOM_User_Profile_Fields_Revert::__construct' );
 		$this->wpcom_user_profile_fields_revert_wrapper = new Masterbar_WPCOM_User_Profile_Fields_Revert( $connection_manager );
 	}
 
 	/**
 	 * Filter the built-in user profile fields.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array    $data            {
 	 *                                  Values and keys for the user.
@@ -63,14 +63,14 @@ class WPCOM_User_Profile_Fields_Revert {
 	 * @return array
 	 */
 	public function revert_user_data_on_wp_admin_profile_update( $data, $update, $id ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPCOM_User_Profile_Fields_Revert::revert_user_data_on_wp_admin_profile_update' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPCOM_User_Profile_Fields_Revert::revert_user_data_on_wp_admin_profile_update' );
 		return $this->wpcom_user_profile_fields_revert_wrapper->revert_user_data_on_wp_admin_profile_update( $data, $update, $id );
 	}
 
 	/**
 	 * Revert the first_name, last_name and description since this is managed by WP.com.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array    $meta {
 	 *        Default meta values and keys for the user.
@@ -95,20 +95,20 @@ class WPCOM_User_Profile_Fields_Revert {
 	 * @return array
 	 */
 	public function revert_user_meta_on_wp_admin_profile_change( $meta, $user, $update ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPCOM_User_Profile_Fields_Revert::revert_user_meta_on_wp_admin_profile_change' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPCOM_User_Profile_Fields_Revert::revert_user_meta_on_wp_admin_profile_change' );
 		return $this->wpcom_user_profile_fields_revert_wrapper->revert_user_meta_on_wp_admin_profile_change( $meta, $user, $update );
 	}
 
 	/**
 	 * Disable the e-mail notification.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param bool  $send     Whether to send or not the email.
 	 * @param array $user     User data.
 	 */
 	public function disable_send_email_change_email( $send, $user ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPCOM_User_Profile_Fields_Revert::disable_send_email_change_email' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPCOM_User_Profile_Fields_Revert::disable_send_email_change_email' );
 		return $this->wpcom_user_profile_fields_revert_wrapper->disable_send_email_change_email( $send, $user );
 	}
 
@@ -117,12 +117,12 @@ class WPCOM_User_Profile_Fields_Revert {
 	 *
 	 * We need this because WP.org uses a custom flow for E-mail changes.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param int $user_id The id of the user that's updated.
 	 */
 	public function disable_email_notification( $user_id ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\WPCOM_User_Profile_Fields_Revert::disable_email_notification' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPCOM_User_Profile_Fields_Revert::disable_email_notification' );
 		$this->wpcom_user_profile_fields_revert_wrapper->disable_email_notification( $user_id );
 	}
 }

--- a/projects/plugins/jetpack/modules/masterbar/profile-edit/profile-edit.php
+++ b/projects/plugins/jetpack/modules/masterbar/profile-edit/profile-edit.php
@@ -10,12 +10,12 @@ use Automattic\Jetpack\Masterbar;
 /**
  * Hides profile fields for WordPress.com connected users.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  *
  * @param WP_User $user The current WP_User object.
  */
 function jetpack_masterbar_hide_profile_fields( $user ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\jetpack_masterbar_hide_profile_fields' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\jetpack_masterbar_hide_profile_fields' );
 	Masterbar\jetpack_masterbar_hide_profile_fields( $user );
 }
 

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/bootstrap.php
@@ -2,22 +2,22 @@
 /**
  * WP-Admin Posts list bootstrap file.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  *
  * @package automattic\jetpack
  *
  * @phan-file-suppress PhanDeprecatedFunction -- Ok for deprecated code to call other deprecated code.
  */
 
-_deprecated_file( __FILE__, 'jetpack-$$next-version$$' );
+_deprecated_file( __FILE__, 'jetpack-13.7' );
 
 /**
  * Load the Posts_List_Notification.
  *
- * @deprecated $$next-version$$
+ * @deprecated 13.7
  */
 function masterbar_init_wp_posts_list() {
-	_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\masterbar_init_wp_posts_list' );
+	_deprecated_function( __FUNCTION__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\masterbar_init_wp_posts_list' );
 
 	global $pagenow;
 

--- a/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
+++ b/projects/plugins/jetpack/modules/masterbar/wp-posts-list/class-posts-list-page-notification.php
@@ -3,7 +3,7 @@
  * Posts_List_Page_Notification file.
  * Disable edit_post and delete_post capabilities for Posts Pages in WP-Admin and display a notification icon.
  *
- * @deprecated $$next-version$$ Use Automattic\Jetpack\Masterbar\Posts_List_Page_Notification instead.
+ * @deprecated 13.7 Use Automattic\Jetpack\Masterbar\Posts_List_Page_Notification instead.
  *
  * @package Jetpack
  */
@@ -30,43 +30,43 @@ class Posts_List_Page_Notification {
 	/**
 	 * Posts_List_Page_Notification constructor.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param string $posts_page_id The Posts page configured in WordPress.
 	 * @param string $show_on_front The show_on_front site option.
 	 * @param string $page_on_front The page_on_front site_option.
 	 */
 	public function __construct( $posts_page_id, $show_on_front, $page_on_front ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::__construct' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::__construct' );
 		$this->post_list_page_notification_wrapper = new Masterbar_Posts_List_Page_Notification( $posts_page_id, $show_on_front, $page_on_front );
 	}
 
 	/**
 	 * Add in all hooks.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function init_actions() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::init_actions' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::init_actions' );
 		$this->post_list_page_notification_wrapper->init_actions();
 	}
 
 	/**
 	 * Creates instance.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @return \Automattic\Jetpack\Masterbar\Posts_List_Page_Notification
 	 */
 	public static function init() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::init' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::init' );
 		return Masterbar_Posts_List_Page_Notification::init();
 	}
 
 	/**
 	 * Disable editing and deleting for the page that is configured as a Posts Page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array  $caps Array of capabilities.
 	 * @param string $cap The current capability.
@@ -75,26 +75,26 @@ class Posts_List_Page_Notification {
 	 * @return array
 	 */
 	public function disable_posts_page( $caps, $cap, $user_id, $args ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::disable_posts_page' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::disable_posts_page' );
 		return $this->post_list_page_notification_wrapper->disable_posts_page( $caps, $cap, $user_id, $args );
 	}
 
 	/**
 	 * Load the CSS for the WP Posts List
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * We would probably need to move this elsewhere when new features are introduced to wp-posts-list.
 	 */
 	public function enqueue_css() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::enqueue_css' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::enqueue_css' );
 		$this->post_list_page_notification_wrapper->enqueue_css();
 	}
 
 	/**
 	 * Adds a CSS class on the page configured as a Posts Page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 *
 	 * @param array  $classes A list of CSS classes.
 	 * @param string $class A CSS class.
@@ -102,17 +102,17 @@ class Posts_List_Page_Notification {
 	 * @return array
 	 */
 	public function add_posts_page_css_class( $classes, $class, $post_id ) {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::add_posts_page_css_class' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::add_posts_page_css_class' );
 		return $this->post_list_page_notification_wrapper->add_posts_page_css_class( $classes, $class, $post_id );
 	}
 
 	/**
 	 * Add a info icon on the Posts Page letting the user know why they cannot delete and remove the page.
 	 *
-	 * @deprecated $$next-version$$
+	 * @deprecated 13.7
 	 */
 	public function add_notification_icon() {
-		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::add_notification_icon' );
+		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Posts_List_Page_Notification::add_notification_icon' );
 		$this->post_list_page_notification_wrapper->add_notification_icon();
 	}
 }

--- a/projects/plugins/jetpack/modules/theme-tools/responsive-videos.php
+++ b/projects/plugins/jetpack/modules/theme-tools/responsive-videos.php
@@ -11,10 +11,10 @@ if ( ! class_exists( '\Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 		/**
 		 * Load the Responsive videos plugin
 		 *
-		 * @deprecated $$next-version$$ Moved to Classic Theme Helper package.
+		 * @deprecated 13.7 Moved to Classic Theme Helper package.
 		 */
 	function jetpack_responsive_videos_init() {
-		_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 
 		/* If the doesn't theme support 'jetpack-responsive-videos', don't continue */
 		if ( ! current_theme_supports( 'jetpack-responsive-videos' ) ) {
@@ -45,13 +45,13 @@ if ( ! class_exists( '\Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 	/**
 	 * Adds a wrapper to videos and enqueue script
 	 *
-	 * @deprecated $$next-version$$ Moved to Classic Theme Helper package.
+	 * @deprecated 13.7 Moved to Classic Theme Helper package.
 	 *
 	 * @param string $html The video embed HTML.
 	 * @return string
 	 */
 	function jetpack_responsive_videos_embed_html( $html ) {
-		_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 
 		if ( empty( $html ) || ! is_string( $html ) ) {
 			return $html;
@@ -92,7 +92,7 @@ if ( ! class_exists( '\Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 	/**
 	 * Check if oEmbed is a `$video_patterns` provider video before wrapping.
 	 *
-	 * @deprecated $$next-version$$ Moved to Classic Theme Helper package.
+	 * @deprecated 13.7 Moved to Classic Theme Helper package.
 	 *
 	 * @param mixed  $html The cached HTML result, stored in post meta.
 	 * @param string $url  he attempted embed URL.
@@ -100,7 +100,7 @@ if ( ! class_exists( '\Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 	 * @return string
 	 */
 	function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url = null ) {
-		_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 
 		if ( empty( $html ) || ! is_string( $html ) || ! $url ) {
 			return $html;
@@ -167,7 +167,7 @@ if ( ! class_exists( '\Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @deprecated $$next-version$$ Moved to Classic Theme Helper package.
+	 * @deprecated 13.7 Moved to Classic Theme Helper package.
 	 *
 	 * @param string $block_content The block content about to be appended.
 	 * @param array  $block         The full block, including name and attributes.
@@ -175,7 +175,7 @@ if ( ! class_exists( '\Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 	 * @return string $block_content String of rendered HTML.
 	 */
 	function jetpack_responsive_videos_remove_wrap_oembed( $block_content, $block ) {
-		_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 
 		if (
 			isset( $block['blockName'] )

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.7.0-a.0",
+	"version": "13.7.0-a.1",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.7.0-a.1",
+	"version": "13.7.0-a.2",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,29 +326,14 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.6 - 2024-07-02
+### 13.7-a.1 - 2024-07-08
 #### Enhancements
-- AI Assistant: Hide input when user types on extended block.
-- Goodreads Block: provide support for additional profile URLs.
-- Newsletter: Add ability to manage the newsletter byline appearance.
-- Newsletter: Adding a new toggle to control the newsletter author line.
-- Newsletter: Email replies can become comments on your blog.
-- Social: Add Threads preview to Social Previews.
-- Tiled Gallery: Increase accessibility of Tiled Gallery carousel images.
-
-#### Improved compatibility
-- Block Editor: Ensure that no Jetpack features are displayed in the site editor's sidebar when not necessary.
-- General: indicate compatibility with the upcoming version of WordPress - 6.6.
-- Offline Mode: do not display Jetpack's outbound SSL notice when in Offline mode.
+- AI Assistant: The general purpose image generator is now available to all users.
+- Subscriptions: Add command palette commands for quickly changing post access.
+- Subscriptions: Improve the Subscribe block loading animation.
 
 #### Bug fixes
-- AI Assistant: Disable extensions when AI Assistant block is hidden.
-- External Media: Do not display External Media options in the Caption edit field.
-- External media: Ensure connect URL has the correct blog ID and verification values.
-- Like block: Fix editor styling.
-- Publicize: Fix a race condition with refreshing the active social connections.
-- Slideshow: Ensure whole block is selectable in the editor.
-- User Content Link Tracking: Check domain before redirecting to subscribe.wordpress.com.
+- Like block: Fix warning displayed when trying to load the Like block on unsupported pages.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.3.3 - 2024-07-08
+### Changed
+- Updated package dependencies. [#38228]
+
 ## 2.3.2 - 2024-07-01
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-stats-purchases-endpoint
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-stats-purchases-endpoint
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/move-help-center
+++ b/projects/plugins/mu-wpcom-plugin/changelog/move-help-center
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/mu-wpcom-plugin/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/mu-wpcom-plugin/changelog/revert-custom-css-removal
+++ b/projects/plugins/mu-wpcom-plugin/changelog/revert-custom-css-removal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-featured-content-remove-wpcom-only-code
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-featured-content-remove-wpcom-only-code
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-rename-wpcom_is_nav_redesign_enabled
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-rename-wpcom_is_nav_redesign_enabled
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-sync-must-sync-data-settings
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-sync-must-sync-data-settings
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-verbum-comments-accessibility
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-verbum-comments-accessibility
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated Verbum Comments accessibility
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_3_3_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_3_3"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.3.3-alpha
+ * Version: 2.3.3
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.3.3-alpha",
+	"version": "2.3.3",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/wpcomsh/CHANGELOG.md
+++ b/projects/plugins/wpcomsh/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.27.3 - 2024-07-08
+### Added
+- Add post transfer woo express deactivate plugins, post process cache flush, and post clone set staging environment [#38183]
+
+### Changed
+- Updated package dependencies. [#38228]
+- Use wp-cli `success` function for messages [#38201]
+
+### Fixed
+- Fix generate POT script to follow symlinks in vendor/* and update language files. [#38153]
+
 ## 3.27.2 - 2024-07-01
 ### Changed
 - Internal updates.

--- a/projects/plugins/wpcomsh/changelog/add-stats-purchases-endpoint
+++ b/projects/plugins/wpcomsh/changelog/add-stats-purchases-endpoint
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-cli-actions-for-woo-express-cache-flush-and-staging-env
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-cli-actions-for-woo-express-cache-flush-and-staging-env
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Add post transfer woo express deactivate plugins, post process cache flush, and post clone set staging environment

--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-cli-post-process-messages
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-cli-post-process-messages
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Use wp-cli `success` function for messages

--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-generate-pot
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-generate-pot
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix generate POT script to follow symlinks in vendor/* and update language files.

--- a/projects/plugins/wpcomsh/changelog/move-help-center
+++ b/projects/plugins/wpcomsh/changelog/move-help-center
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/renovate-lock-file-maintenance
+++ b/projects/plugins/wpcomsh/changelog/renovate-lock-file-maintenance
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/plugins/wpcomsh/changelog/revert-custom-css-removal
+++ b/projects/plugins/wpcomsh/changelog/revert-custom-css-removal
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/update-featured-content-remove-wpcom-only-code
+++ b/projects/plugins/wpcomsh/changelog/update-featured-content-remove-wpcom-only-code
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/update-rename-wpcom_is_nav_redesign_enabled#2
+++ b/projects/plugins/wpcomsh/changelog/update-rename-wpcom_is_nav_redesign_enabled#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/update-sync-must-sync-data-settings
+++ b/projects/plugins/wpcomsh/changelog/update-sync-must-sync-data-settings
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/update-verbum-comments-accessibility
+++ b/projects/plugins/wpcomsh/changelog/update-verbum-comments-accessibility
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated Verbum Comments accessibility
-
-

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_27_3_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_27_3"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.27.3-alpha",
+	"version": "3.27.3",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.27.3-alpha
+ * Version: 3.27.3
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
@@ -10,7 +10,7 @@
  */
 
 // Increase version number if you change something in wpcomsh.
-define( 'WPCOMSH_VERSION', '3.27.3-alpha' );
+define( 'WPCOMSH_VERSION', '3.27.3' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.3.3, jetpack 13.7-a.1, wpcomsh 3.27.3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.