### PR TITLE
Remove the WordPress Events and News Dashboard widget

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-wpcom-events-and-news-widget
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-wpcom-events-and-news-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Dashboard widgets: Remove WordPress Events and News feed widget

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -69,6 +69,10 @@ class Jetpack_Mu_Wpcom {
 		// Load the Newsletter category settings.
 		add_action( 'enqueue_block_assets', array( __CLASS__, 'load_newsletter_categories_settings' ), 999 );
 
+		// Remove WordPress Events and News feed widget from the dashboard.
+		add_action( 'wp_dashboard_setup', array( __CLASS__, 'remove_wp_dashboard_events_news' ) ); // Removes the widget from /wp-admin
+		add_action( 'wp_user_dashboard_setup', array( __CLASS__, 'remove_wp_dashboard_events_news' ) ); // Removes the widget from /wp-admin/user
+
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
 		 *
@@ -279,6 +283,17 @@ class Jetpack_Mu_Wpcom {
 
 		// Don't load any comment experience in the Reader, GlotPress, wp-admin, or P2.
 		return ( 1 === $blog_id || TRANSLATE_BLOG_ID === $blog_id || is_admin() || $is_p2 || $is_forums );
+	}
+
+	/**
+	 * Remove WordPress Events and News feed widget from the dashboard.
+	 *
+	 * We want to remove it for WPcom blogs since it's not relevant for them.
+	 *
+	 * @return void
+	 */
+	public static function remove_wp_dashboard_events_news() {
+		remove_meta_box( 'dashboard_primary', get_current_screen(), 'side' );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -69,10 +69,6 @@ class Jetpack_Mu_Wpcom {
 		// Load the Newsletter category settings.
 		add_action( 'enqueue_block_assets', array( __CLASS__, 'load_newsletter_categories_settings' ), 999 );
 
-		// Remove WordPress Events and News feed widget from the dashboard.
-		add_action( 'wp_dashboard_setup', array( __CLASS__, 'remove_wp_dashboard_events_news' ) ); // Removes the widget from /wp-admin
-		add_action( 'wp_user_dashboard_setup', array( __CLASS__, 'remove_wp_dashboard_events_news' ) ); // Removes the widget from /wp-admin/user
-
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
 		 *
@@ -106,6 +102,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';
 		require_once __DIR__ . '/features/site-editor-dashboard-link/site-editor-dashboard-link.php';
+		require_once __DIR__ . '/features/wpcom-admin-dashboard/wpcom-admin-dashboard.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';
 		require_once __DIR__ . '/features/wpcom-site-menu/wpcom-site-menu.php';
@@ -283,17 +280,6 @@ class Jetpack_Mu_Wpcom {
 
 		// Don't load any comment experience in the Reader, GlotPress, wp-admin, or P2.
 		return ( 1 === $blog_id || TRANSLATE_BLOG_ID === $blog_id || is_admin() || $is_p2 || $is_forums );
-	}
-
-	/**
-	 * Remove WordPress Events and News feed widget from the dashboard.
-	 *
-	 * We want to remove it for WPcom blogs since it's not relevant for them.
-	 *
-	 * @return void
-	 */
-	public static function remove_wp_dashboard_events_news() {
-		remove_meta_box( 'dashboard_primary', get_current_screen(), 'side' );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-dashboard/wpcom-admin-dashboard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-dashboard/wpcom-admin-dashboard.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * WordPress.com admin dashboard
+ *
+ * Modifies the WordPress admin dashboard with WordPress.com-specific stuff.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Remove WordPress Events and News feed widget from the dashboard.
+ *
+ * We want to remove it for WordPress.com blogs since it's not relevant for them.
+ */
+function remove_wp_dashboard_events_news() {
+	remove_meta_box( 'dashboard_primary', get_current_screen(), 'side' );
+}
+
+add_action( 'wp_dashboard_setup', 'remove_wp_dashboard_events_news' ); // Removes the widget from /wp-admin
+add_action( 'wp_user_dashboard_setup', 'remove_wp_dashboard_events_news' ); // Removes the widget from /wp-admin/user


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8060

## Proposed changes:

Remove WordPress Events and News feed in the Dashboard widget as it's not relevant to WordPress.com users for Simple Siters.

| - | Before | After |
| --- | --- | --- |
| Atomic | ![image](https://github.com/Automattic/jetpack/assets/402286/aa976a90-c999-4aff-a803-8a35e0e45690) | ![image](https://github.com/Automattic/jetpack/assets/402286/cd5deded-3816-4773-85d5-359ad2c667ef) |
| Simple | ![image](https://github.com/Automattic/jetpack/assets/402286/83bf8e95-1fb0-4cfc-a5df-7253cbfa9cdd) |![image](https://github.com/Automattic/jetpack/assets/402286/d6e0fcf4-816e-473b-b107-3f347efd5ea6) |


## Jetpack product discussion
Details here: pfsHM7-1fZ-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Follow the instructions in the first comment
* Check if the `WordPress Events and News feed` widget shows in Atomic & Simple sites