### PR TITLE
autoloader: Avoid a deprecation notice in `Autoloader_Locator::find_latest_autoloader()`

### DIFF
--- a/projects/packages/autoloader/changelog/fix-autoloader-atomic-deprecated-notice
+++ b/projects/packages/autoloader/changelog/fix-autoloader-atomic-deprecated-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid a deprecation notice in `Autoloader_Locator::find_latest_autoloader()`.

--- a/projects/packages/autoloader/src/AutoloadGenerator.php
+++ b/projects/packages/autoloader/src/AutoloadGenerator.php
@@ -21,7 +21,7 @@ use Composer\Util\PackageSorter;
  */
 class AutoloadGenerator {
 
-	const VERSION = '3.0.8';
+	const VERSION = '3.0.9-alpha';
 
 	/**
 	 * IO object.

--- a/projects/packages/autoloader/src/class-autoloader-locator.php
+++ b/projects/packages/autoloader/src/class-autoloader-locator.php
@@ -37,7 +37,7 @@ class Autoloader_Locator {
 
 		foreach ( $plugin_paths as $plugin_path ) {
 			$version = $this->get_autoloader_version( $plugin_path );
-			if ( ! $this->version_selector->is_version_update_required( $latest_version, $version ) ) {
+			if ( ! $version || ! $this->version_selector->is_version_update_required( $latest_version, $version ) ) {
 				continue;
 			}
 

--- a/projects/packages/autoloader/tests/php/tests/unit/AutoloaderLocatorTest.php
+++ b/projects/packages/autoloader/tests/php/tests/unit/AutoloaderLocatorTest.php
@@ -63,15 +63,25 @@ class AutoloaderLocatorTest extends TestCase {
 		$this->assertNull( $latest );
 		$this->assertNull( $latest_version );
 
-		$latest = $this->autoloader_locator->find_latest_autoloader(
+		$latest_version = null;
+		$latest         = $this->autoloader_locator->find_latest_autoloader(
 			array( self::$older_plugin_dir ),
 			$latest_version
 		);
 		$this->assertEquals( self::$older_plugin_dir, $latest );
 		$this->assertEquals( self::OLDER_VERSION, $latest_version );
 
-		$latest = $this->autoloader_locator->find_latest_autoloader(
+		$latest_version = null;
+		$latest         = $this->autoloader_locator->find_latest_autoloader(
 			array( TEST_PLUGIN_DIR, self::$older_plugin_dir ),
+			$latest_version
+		);
+		$this->assertEquals( TEST_PLUGIN_DIR, $latest );
+		$this->assertEquals( Test_Plugin_Factory::VERSION_CURRENT, $latest_version );
+
+		$latest_version = null;
+		$latest         = $this->autoloader_locator->find_latest_autoloader(
+			array( TEST_PLUGIN_DIR, WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'this-does-not-exist' ),
 			$latest_version
 		);
 		$this->assertEquals( TEST_PLUGIN_DIR, $latest );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If one of the cached plugin paths has gone missing, `get_autoloader_version()` will return `null` when trying to check it. Avoid passing that `null` to `is_version_update_required()`.

This sort of thing happens weekly during Atomic upgrades, because there they have symlinks `wp-content/plugins/jetpack` →
`/wordpress/plugins/jetpack/latest` → `/wordpress/plugins/jetpack/<ver>` and the update process deletes the old `<ver>` at the same time as creating the new and updating the `latest` symlink.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1720462998876079/1720457892.196259-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Without this PR, this process should produce deprecation warnings about passing null to `substr` and `version_compare`. With it, it should no longer do so.

* Move `wp-content/plugins/jetpack` to `wp-content/plugins/jetpack-xxx`, then symlink `wp-content/plugins/jetpack` to that. Load a page.
* Move `wp-content/plugins/jetpack-xxx` to `wp-content/plugins/jetpack-yyy`, then symlink `wp-content/plugins/jetpack` to that. Load a page.

(if for some reason the PR doesn't seem to fix it, ensure that the PR's version of the autoloader is active rather than a trunk version from some other plugin)