### PR TITLE
Forms: remove onSplit in favor of splitting feature

### DIFF
--- a/projects/packages/forms/changelog/fix-form-onSplit-deprecation
+++ b/projects/packages/forms/changelog/fix-form-onSplit-deprecation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Option field: remove onSplit prop in favor of splitting feature
+
+

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.32.3",
+	"version": "0.32.4-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -243,6 +243,7 @@ const OptionFieldDefaults = {
 	supports: {
 		reusable: false,
 		html: false,
+		splitting: true,
 	},
 };
 

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-multiple.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-multiple.js
@@ -62,7 +62,7 @@ function JetpackFieldMultiple( props ) {
 					<InnerBlocks
 						allowedBlocks={ ALLOWED_BLOCKS }
 						template={ [ [ `jetpack/field-option-${ type }`, {} ] ] }
-						templateInsertUpdatesSelection={ false }
+						templateInsertUpdatesSelection={ true }
 					/>
 				</div>
 			</div>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-option.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-option.js
@@ -1,18 +1,26 @@
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { first } from 'lodash';
+import { useEffect } from 'react';
+import { supportsParagraphSplitting } from '../util/block-support';
 import { useParentAttributes } from '../util/use-parent-attributes';
 import { useJetpackFieldStyles } from './use-jetpack-field-styles';
 
-export const JetpackFieldOptionEdit = props => {
-	const { attributes, clientId, name, onReplace, setAttributes } = props;
+export const JetpackFieldOptionEdit = ( {
+	isSelected,
+	attributes,
+	clientId,
+	name,
+	onReplace,
+	setAttributes,
+} ) => {
 	const { removeBlock } = useDispatch( 'core/block-editor' );
 	const parentAttributes = useParentAttributes( clientId );
 	const { optionStyle } = useJetpackFieldStyles( parentAttributes );
-
 	const siblingsCount = useSelect(
 		select => {
 			const blockEditor = select( 'core/block-editor' );
@@ -21,17 +29,16 @@ export const JetpackFieldOptionEdit = props => {
 		},
 		[ clientId ]
 	);
+	const blockProps = useBlockProps();
+	const labelRef = useRef( null );
 
-	const type = name.replace( 'jetpack/field-option-', '' );
-
-	const classes = clsx( 'jetpack-field-option', `field-option-${ type }` );
-
-	const handleSplit = label =>
-		createBlock( name, {
+	const handleSplit = label => {
+		return createBlock( name, {
 			...attributes,
 			clientId: label && attributes.label.indexOf( label ) === 0 ? attributes.clientId : undefined,
 			label,
 		} );
+	};
 
 	const handleDelete = () => {
 		if ( siblingsCount <= 1 ) {
@@ -41,21 +48,46 @@ export const JetpackFieldOptionEdit = props => {
 		removeBlock( clientId );
 	};
 
+	const onFocus = () => {
+		// TODO: move cursor to end
+	};
+
+	useEffect( () => {
+		const element = labelRef.current;
+
+		element?.addEventListener( 'focus', onFocus );
+
+		if ( isSelected ) {
+			// Timeout is necessary for the focus to be effective
+			setTimeout( () => element?.focus(), 0 );
+		}
+
+		return () => {
+			element?.removeEventListener( 'focus', onFocus );
+		};
+	}, [ isSelected, labelRef ] );
+
+	const supportsSplitting = supportsParagraphSplitting();
+	const type = name.replace( 'jetpack/field-option-', '' );
+	const classes = clsx( 'jetpack-field-option', `field-option-${ type }` );
+
 	return (
-		<div className={ classes } style={ optionStyle }>
+		<div { ...( supportsSplitting ? blockProps : {} ) } className={ classes } style={ optionStyle }>
 			<input type={ type } className="jetpack-option__type" tabIndex="-1" />
 			<RichText
-				allowedFormats={ [] }
-				onChange={ value => {
-					setAttributes( { label: value } );
-				} }
-				onRemove={ handleDelete }
-				onSplit={ handleSplit }
-				onReplace={ onReplace }
+				identifier="label"
+				tagName="p"
+				className="wp-block"
+				value={ attributes.label }
 				placeholder={ __( 'Add option…', 'jetpack-forms' ) }
+				allowedFormats={ [] }
+				onChange={ val => setAttributes( { label: val } ) }
+				onReplace={ onReplace }
+				onRemove={ handleDelete }
 				preserveWhiteSpace={ false }
 				withoutInteractiveFormatting
-				value={ attributes.label }
+				ref={ labelRef }
+				{ ...( supportsSplitting ? {} : { onSplit: handleSplit } ) }
 			/>
 		</div>
 	);

--- a/projects/packages/forms/src/blocks/contact-form/util/block-support.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/block-support.js
@@ -1,0 +1,10 @@
+import { hasBlockSupport } from '@wordpress/blocks';
+
+/**
+ * Check if Gutenberg supports splitting paragraphs.
+ *
+ * @returns {boolean} Whether Gutenberg supports splitting paragraphs.
+ */
+export function supportsParagraphSplitting() {
+	return hasBlockSupport( 'core/paragraph', 'splitting', false );
+}

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.32.3';
+	const PACKAGE_VERSION = '0.32.4-alpha';
 
 	/**
 	 * Load the contact form module.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/38031

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The `onSplit` prop of the [`RichText` component](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/rich-text/README.md) is [no longer supported](https://github.com/WordPress/gutenberg/pull/54543) in Gutenberg. The last remaining component that uses this property in the `forms` package is `JetpackFieldOptionEdit`, which is used by the _Multiple Choice (Checkbox)_ and _Single Choice (Radio)_ fields.

<img width="154" alt="Screenshot 2024-07-08 at 4 27 56 PM" src="https://github.com/Automattic/jetpack/assets/1620183/b340620e-fe04-4724-a2d3-438818efcfcd">
<img width="140" alt="Screenshot 2024-07-08 at 4 27 58 PM" src="https://github.com/Automattic/jetpack/assets/1620183/c6bbac7c-ee49-4cba-af6e-2307e1a58fc0">


This PR replaces the `onSplit` prop with the [`splitting` support feature](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#splitting). This [comment thread](https://github.com/WordPress/gutenberg/pull/54543#issuecomment-2197595603) explains the change in more detail.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Regression testing
- Spin up a Jetpack site
- Create a new post
- Add a form with the block inserter
- In the form, add both the _Multiple Choice (Checkbox)_ and _Single Choice (Radio)_ fields
<img width="357" alt="Screenshot 2024-07-08 at 4 30 38 PM" src="https://github.com/Automattic/jetpack/assets/1620183/bf7744f1-76d7-4070-b8f6-f54070d1cfbc">
<img width="364" alt="Screenshot 2024-07-08 at 4 30 44 PM" src="https://github.com/Automattic/jetpack/assets/1620183/09cbd676-88c2-4b26-b288-bf05314151cb">

- Ensure you can add a separate option when you hit the `Enter` key and that you can delete items with the keyboard
- Open the preview and verify the form renders and behaves as expected

### Update testing
- Install the Gutenberg plugin from the plugin repo and activate it. This version will take over the one shipped with WordPress.
<img width="410" alt="Screenshot 2024-07-11 at 11 38 56 AM" src="https://github.com/Automattic/jetpack/assets/1620183/40ceb2ce-99fb-4487-b530-225c888dab11">

- Refresh the post editor page in WPadmin
- Make sure there's no error message
- Test that the fields work as before

_Note: after removing an option with the `delete` key, the previous item gets the focus. but the caret doesn't move to the end. I haven't been able to fix this yet, but it doesn't break functionality, and we can ship this PR as is._

