### PR TITLE
beta: Fix undefined variable reference

### DIFF
--- a/projects/plugins/beta/changelog/fix-beta-undefined-variable-ref
+++ b/projects/plugins/beta/changelog/fix-beta-undefined-variable-ref
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an undefined variable reference.

--- a/projects/plugins/beta/src/admin/plugin-select.template.php
+++ b/projects/plugins/beta/src/admin/plugin-select.template.php
@@ -18,6 +18,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $plugins = Plugin::get_all_plugins( true );
 
+// This needs to be defined for show-needed-updates.template.php.
+$plugin = null;
+
 ?>
 
 <?php require __DIR__ . '/header.template.php'; ?>

--- a/projects/plugins/beta/src/admin/show-needed-updates.template.php
+++ b/projects/plugins/beta/src/admin/show-needed-updates.template.php
@@ -3,7 +3,7 @@
  * Jetpack Beta wp-admin template to show needed updates.
  *
  * @html-template \Automattic\JetpackBeta\Admin::render -- Via plugin-select.template.php or plugin-manage.template.php
- * @html-template-var \Automattic\JetpackBeta\Plugin $plugin Plugin being managed (from render()).
+ * @html-template-var \Automattic\JetpackBeta\Plugin|null $plugin Plugin being managed.
  * @package automattic/jetpack-beta
  */
 
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Wrap in a function to avoid leaking all the variables we create to subsequent runs.
 ( function ( $plugin ) {
 	$updates = Utils::plugins_needing_update( true );
-	if ( isset( $plugin ) ) {
+	if ( $plugin ) {
 		$updates = array_intersect_key(
 			$updates,
 			array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`$plugin` wasn't defined when `show-needed-updates.template.php` was used from `plugin-select.template.php`. Define it as null.

Also remove an unnecessary `isset()`, by that point it is defined.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visit the plugin select page. Check for warnings.