### PR TITLE
Jetpack AI Breve: edit popover styles

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-popover-styling
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-popover-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI Breve: tweak popover styles to fit better in the viewport

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/Highlight.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/Highlight.js
@@ -211,7 +211,7 @@ const Highlight = ( {
 				<Popover
 					anchor={ highlightContainerRef.current }
 					placement="bottom"
-					offset={ -3 }
+					offset={ 6 }
 					className="highlight-popover"
 					variant="tooltip"
 					animate={ false }
@@ -224,6 +224,7 @@ const Highlight = ( {
 						setIsVisible( false );
 						setIsHovering( false );
 					} }
+					noArrow={ false }
 				>
 					<div>{ popoverContents }</div>
 					{ isAIOn && (

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
@@ -83,8 +83,6 @@
 	font-style: normal;
 	font-weight: 400;
 	line-height: 18px;
-	padding: 8px;
-	width: auto;
 }
 
 .highlight-popover div.components-popover__content {
@@ -92,7 +90,7 @@
 	column-gap: 12px;
 	display: flex;
 	padding: 16px;
-	white-space: nowrap;
+	max-width: 230px;
 }
 
 .highlight-popover button{


### PR DESCRIPTION
WIP: waiting for some refactor before moving on with this

This PR tries to address an issue with popovers going outside the window
<img width="844" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/fe33a898-7d4d-4058-8b5c-008e92b1e216">


Fixes #38200 

## Proposed changes:
Restrict the width of the popover content to prevent most edge cases to go over the viewport edge
Allow for popover content to wrap the text
Force popover arrow for visual aid on the suggested fix

<img width="795" alt="image" src="https://github.com/Automattic/jetpack/assets/157240/d480038d-ffa7-413a-9815-c496f5328694">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test on an enabled Breve site
Once you have some content Breve can act upon, look for some edge suggestion (as seen on the example screenshots)
Verify the new styles lessen the chance the popover goes off the viewport edge