### PR TITLE
Port wpcom-documentation-links from ETK

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/etk-documentation-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/etk-documentation-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Port wpcom-documentation-links feature from ETK

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -135,6 +135,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/override-preview-button-url/override-preview-button-url.php';
 		require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';
 		require_once __DIR__ . '/features/tags-education/tags-education.php';
+		require_once __DIR__ . '/features/wpcom-documentation-links/wpcom-documentation-links.php';
 		require_once __DIR__ . '/features/wpcom-whats-new/wpcom-whats-new.php';
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.css
@@ -1,0 +1,7 @@
+/*
+ For simple sites in "Customize Widgets" we override translations with empty strings.
+ This will result in empty link in that section shown without text and href. The CSS will hide those.
+ */
+.customize-widgets-welcome-guide__more-info a[href=""] {
+	display: none;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * WPCOM overrides to Core documentation links.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+define( 'MU_WPCOM_DOCUMENTATION_LINKS', true );
+
+/**
+ * Enqueue assets
+ */
+function wpcom_enqueue_documentation_links_assets() {
+	$asset_file          = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-documentation-links/wpcom-documentation-links.asset.php';
+	$script_dependencies = $asset_file['dependencies'] ?? array();
+	$script_version      = $asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-documentation-links/wpcom-documentation-links.js' );
+
+	wp_enqueue_script(
+		'wpcom-documentation-links-script',
+		plugins_url( 'build/wpcom-documentation-links/wpcom-documentation-links.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+		is_array( $script_dependencies ) ? $script_dependencies : array(),
+		$script_version,
+		true
+	);
+
+	wp_enqueue_style(
+		'wpcom-documentation-links-styles',
+		plugins_url( '/dist/wpcom-documentation-links.css', __FILE__ ),
+		array(),
+		$script_version
+	);
+
+	// This is a way to get the data from the customize-controls script and change the link to the wpcom support page.
+	global $wp_scripts;
+	$data = $wp_scripts->get_data( 'customize-controls', 'data' );
+
+	if ( $data ) {
+		$data = str_replace( 'https:\\/\\/wordpress.org\\/support\\/article\\/site-editor\\/\\', 'https:\\/\\/wordpress.com\\/support\\/site-editor\\/\\', $data );
+		$wp_scripts->registered['customize-controls']->extra['data'] = $data;
+	}
+
+	wp_set_script_translations( 'wpcom-documentation-links-script', 'jetpack-mu-wpcom' );
+}
+
+add_action( 'init', 'wpcom_enqueue_documentation_links_assets' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.php
@@ -35,7 +35,7 @@ function wpcom_enqueue_documentation_links_assets() {
 	$data = $wp_scripts->get_data( 'customize-controls', 'data' );
 
 	if ( $data ) {
-		$data = str_replace( 'https:\\/\\/wordpress.org\\/support\\/article\\/site-editor\\/\\', 'https:\\/\\/wordpress.com\\/support\\/site-editor\\/\\', $data );
+		$data = str_replace( 'https:\\/\\/wordpress.org\\/documentation\\/article\\/site-editor\\/\\', 'https:\\/\\/wordpress.com\\/support\\/site-editor\\/\\', $data );
 		$wp_scripts->registered['customize-controls']->extra['data'] = $data;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.php
@@ -13,23 +13,21 @@ define( 'MU_WPCOM_DOCUMENTATION_LINKS', true );
  * Enqueue assets
  */
 function wpcom_enqueue_documentation_links_assets() {
-	$asset_file          = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-documentation-links/wpcom-documentation-links.asset.php';
-	$script_dependencies = $asset_file['dependencies'] ?? array();
-	$script_version      = $asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-documentation-links/wpcom-documentation-links.js' );
+	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-documentation-links/wpcom-documentation-links.asset.php';
 
 	wp_enqueue_script(
 		'wpcom-documentation-links-script',
 		plugins_url( 'build/wpcom-documentation-links/wpcom-documentation-links.js', Jetpack_Mu_Wpcom::BASE_FILE ),
-		is_array( $script_dependencies ) ? $script_dependencies : array(),
-		$script_version,
+		$asset_file['dependencies'] ?? array(),
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-documentation-links/wpcom-documentation-links.js' ),
 		true
 	);
 
 	wp_enqueue_style(
 		'wpcom-documentation-links-styles',
-		plugins_url( '/dist/wpcom-documentation-links.css', __FILE__ ),
+		plugins_url( 'build/wpcom-documentation-links/wpcom-documentation-links.css', Jetpack_Mu_Wpcom::BASE_FILE ),
 		array(),
-		$script_version
+		filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-documentation-links/wpcom-documentation-links.css' )
 	);
 
 	// This is a way to get the data from the customize-controls script and change the link to the wpcom support page.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.php
@@ -42,4 +42,4 @@ function wpcom_enqueue_documentation_links_assets() {
 	wp_set_script_translations( 'wpcom-documentation-links-script', 'jetpack-mu-wpcom' );
 }
 
-add_action( 'init', 'wpcom_enqueue_documentation_links_assets' );
+add_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_documentation_links_assets', 100 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
@@ -1,0 +1,78 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { addFilter } from '@wordpress/hooks';
+import './wpcom-documentation-links.css';
+
+declare global {
+	interface Window {
+		_currentSiteId: number;
+		_currentSiteType: string;
+		wpcomDocumentationLinksLocale: string;
+	}
+}
+
+/**
+ * Override Core documentation that has matching WordPress.com documentation.
+ *
+ * @param translation - any    Callback function.
+ * @param text        - string Text to be translated.
+ */
+function overrideCoreDocumentationLinksToWpcom( translation: any, text: string ) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	switch ( text ) {
+		case 'https://wordpress.org/support/article/excerpt/':
+		case 'https://wordpress.org/support/article/settings-sidebar/#excerpt':
+		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt':
+			return 'https://wordpress.com/support/excerpts/';
+		case 'https://wordpress.org/support/article/writing-posts/#post-field-descriptions':
+		case 'https://wordpress.org/support/article/settings-sidebar/#permalink':
+		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink':
+			return 'https://wordpress.com/support/permalinks-and-slugs/';
+		case 'https://wordpress.org/support/article/wordpress-editor/':
+			return 'https://wordpress.com/support/wordpress-editor/';
+		case 'https://wordpress.org/support/article/site-editor/':
+			return 'https://wordpress.com/support/site-editor/';
+		case 'https://wordpress.org/support/article/block-based-widgets-editor/':
+			return 'https://wordpress.com/support/widgets/';
+		case 'https://wordpress.org/plugins/classic-widgets/':
+			return 'https://wordpress.com/plugins/classic-widgets';
+		case 'https://wordpress.org/support/article/styles-overview/':
+			return 'https://wordpress.com/support/using-styles/';
+	}
+
+	return translation;
+}
+
+/**
+ * Override Core documentation that doesn't have matching WordPress.com documentation.
+ *
+ * @param translation - any    Callback function.
+ * @param text        - string Text to be translated.
+ */
+function hideSimpleSiteTranslations( translation: any, text: string ) {
+	switch ( text ) {
+		case 'https://wordpress.org/plugins/classic-widgets/':
+			return '';
+		case 'Want to stick with the old widgets?':
+			return '';
+		case 'Get the Classic Widgets plugin.':
+			return '';
+	}
+
+	return translation;
+}
+
+addFilter(
+	'i18n.gettext_default',
+	'jetpack-mu-wpcom/override-core-docs-to-wpcom',
+	overrideCoreDocumentationLinksToWpcom,
+	9
+);
+
+if ( window?._currentSiteType === 'simple' ) {
+	addFilter(
+		'i18n.gettext_default',
+		'jetpack-mu-wpcom/override-core-docs-to-wpcom',
+		hideSimpleSiteTranslations,
+		10
+	);
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
@@ -16,23 +16,21 @@ declare global {
  */
 function overrideCoreDocumentationLinksToWpcom( translation: string, text: string ) {
 	switch ( text ) {
-		case 'https://wordpress.org/support/article/excerpt/':
-		case 'https://wordpress.org/support/article/settings-sidebar/#excerpt':
+		case 'https://wordpress.org/documentation/article/what-is-an-excerpt-classic-editor/':
 		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt':
 			return 'https://wordpress.com/support/excerpts/';
-		case 'https://wordpress.org/support/article/writing-posts/#post-field-descriptions':
-		case 'https://wordpress.org/support/article/settings-sidebar/#permalink':
+		case 'https://wordpress.org/documentation/article/write-posts-classic-editor/#post-field-descriptions':
 		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink':
 			return 'https://wordpress.com/support/permalinks-and-slugs/';
-		case 'https://wordpress.org/support/article/wordpress-editor/':
+		case 'https://wordpress.org/documentation/article/wordpress-block-editor/':
 			return 'https://wordpress.com/support/wordpress-editor/';
-		case 'https://wordpress.org/support/article/site-editor/':
+		case 'https://wordpress.org/documentation/article/site-editor/':
 			return 'https://wordpress.com/support/site-editor/';
-		case 'https://wordpress.org/support/article/block-based-widgets-editor/':
+		case 'https://wordpress.org/documentation/article/block-based-widgets-editor/':
 			return 'https://wordpress.com/support/widgets/';
 		case 'https://wordpress.org/plugins/classic-widgets/':
 			return 'https://wordpress.com/plugins/classic-widgets';
-		case 'https://wordpress.org/support/article/styles-overview/':
+		case 'https://wordpress.org/documentation/article/styles-overview/':
 			return 'https://wordpress.com/support/using-styles/';
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
@@ -6,7 +6,6 @@ declare global {
 	interface Window {
 		_currentSiteId: number;
 		_currentSiteType: string;
-		wpcomDocumentationLinksLocale: string;
 	}
 }
 
@@ -17,7 +16,6 @@ declare global {
  * @param text        - string Text to be translated.
  */
 function overrideCoreDocumentationLinksToWpcom( translation: any, text: string ) {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	switch ( text ) {
 		case 'https://wordpress.org/support/article/excerpt/':
 		case 'https://wordpress.org/support/article/settings-sidebar/#excerpt':

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { addFilter } from '@wordpress/hooks';
 import './wpcom-documentation-links.css';
 
@@ -12,10 +11,10 @@ declare global {
 /**
  * Override Core documentation that has matching WordPress.com documentation.
  *
- * @param translation - any    Callback function.
- * @param text        - string Text to be translated.
+ * @param translation - string Translated text.
+ * @param text        - string Original text.
  */
-function overrideCoreDocumentationLinksToWpcom( translation: any, text: string ) {
+function overrideCoreDocumentationLinksToWpcom( translation: string, text: string ) {
 	switch ( text ) {
 		case 'https://wordpress.org/support/article/excerpt/':
 		case 'https://wordpress.org/support/article/settings-sidebar/#excerpt':
@@ -43,10 +42,10 @@ function overrideCoreDocumentationLinksToWpcom( translation: any, text: string )
 /**
  * Override Core documentation that doesn't have matching WordPress.com documentation.
  *
- * @param translation - any    Callback function.
- * @param text        - string Text to be translated.
+ * @param translation - string Translated text.
+ * @param text        - string Original text.
  */
-function hideSimpleSiteTranslations( translation: any, text: string ) {
+function hideSimpleSiteTranslations( translation: string, text: string ) {
 	switch ( text ) {
 		case 'https://wordpress.org/plugins/classic-widgets/':
 			return '';

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -22,6 +22,8 @@ module.exports = [
 			'tags-education': './src/features/tags-education/tags-education.js',
 			'wpcom-admin-bar': './src/features/wpcom-admin-bar/wpcom-admin-bar.scss',
 			'wpcom-sidebar-notice': './src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.scss',
+			'wpcom-documentation-links':
+				'./src/features/wpcom-documentation-links/wpcom-documentation-links.ts',
 		},
 		mode: jetpackWebpackConfig.mode,
 		devtool: jetpackWebpackConfig.devtool,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/8037.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Port the wpcom-documentation-links feature from ETK, which replaces several wordpress.org links to their wordpress.com counterpart, if any. 

>[!NOTE]
>I did not port the use of localeUrl() since it was more complicated than I thought. As a result, the link URL will always link to the English version. This seems like an acceptible compromise since the support page already has links to other languages in it header.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR as instructed in https://github.com/Automattic/jetpack/pull/38249#issuecomment-2216241729.
* Head to the Post Editor.
* Open the Settings panel by clicking the Settings icon in the top bar.
* Click the Link slug in the Post tab.
![Screenshot 2024-07-09 at 2 02 39 PM](https://github.com/Automattic/jetpack/assets/797888/38256e3a-eae2-4ee0-a9fb-022e10d8d0c7)
* Ensure that the [Learn more.↗](https://wordpress.com/support/permalinks-and-slugs/) link in the Link pop-up is a link to wordpress.com instead of wordpress.org.
![Screenshot 2024-07-09 at 2 01 29 PM](https://github.com/Automattic/jetpack/assets/797888/63a11593-669a-40da-b9ac-344bf2fe6896)
* Ensure that Help is a link to wordpress.com instead of wordpress.org.
![Screenshot 2024-07-09 at 2 24 22 PM](https://github.com/Automattic/jetpack/assets/797888/b2671ab0-cd34-4501-8da3-92c2c49ec7bb)
 
