### PR TITLE
Jetpack Boost: Enhance Image and CSS Proxy with CDN and Caching

### DIFF
--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack_Boost\Modules\Image_Guide;
 
+use Automattic\Jetpack\Image_CDN\Image_CDN_Core;
+
 /**
  * Add an ajax endpoint to proxy external CSS files.
  */
@@ -34,7 +36,15 @@ class Image_Guide_Proxy {
 			wp_send_json_error( 'Invalid URL', 400 );
 		}
 
-		$response = wp_remote_get( $proxy_url );
+		$photon_url        = Image_CDN_Core::cdn_url( $proxy_url );
+		$photon_url_domain = wp_parse_url( $photon_url, PHP_URL_HOST );
+		$photon_domain     = wp_parse_url( apply_filters( 'jetpack_photon_domain', 'https://i0.wp.com', $image_url ), PHP_URL_HOST );
+		if ( $photon_url_domain !== $photon_domain ) {
+			wp_send_json_error( 'Failed to proxy the image.', 400 );
+			return;
+		}
+
+		$response = wp_remote_get( $photon_url );
 		if ( is_wp_error( $response ) ) {
 			wp_send_json_error( 'error', 400 );
 		}

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -41,7 +41,6 @@ class Image_Guide_Proxy {
 		$photon_domain     = wp_parse_url( apply_filters( 'jetpack_photon_domain', 'https://i0.wp.com' ), PHP_URL_HOST );
 		if ( $photon_url_domain !== $photon_domain ) {
 			wp_send_json_error( 'Failed to proxy the image.', 400 );
-			return;
 		}
 
 		$response = wp_remote_get( $photon_url );
@@ -50,6 +49,5 @@ class Image_Guide_Proxy {
 		}
 
 		wp_send_json_success( iterator_to_array( wp_remote_retrieve_headers( $response ) ) );
-		die();
 	}
 }

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -38,7 +38,7 @@ class Image_Guide_Proxy {
 
 		$photon_url        = Image_CDN_Core::cdn_url( $proxy_url );
 		$photon_url_domain = wp_parse_url( $photon_url, PHP_URL_HOST );
-		$photon_domain     = wp_parse_url( apply_filters( 'jetpack_photon_domain', 'https://i0.wp.com', $image_url ), PHP_URL_HOST );
+		$photon_domain     = wp_parse_url( apply_filters( 'jetpack_photon_domain', 'https://i0.wp.com' ), PHP_URL_HOST );
 		if ( $photon_url_domain !== $photon_domain ) {
 			wp_send_json_error( 'Failed to proxy the image.', 400 );
 			return;

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -43,7 +43,7 @@ class Image_Guide_Proxy {
 			wp_send_json_error( 'Failed to proxy the image.', 400 );
 		}
 
-		$response = wp_remote_get( $photon_url );
+		$response = wp_safe_remote_get( $photon_url );
 		if ( is_wp_error( $response ) ) {
 			wp_send_json_error( 'error', 400 );
 		}

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
@@ -55,7 +55,7 @@ class CSS_Proxy {
 		$response  = wp_cache_get( $cache_key );
 
 		if ( is_array( $response ) && isset( $response['error'] ) ) {
-			wp_die( $response['error'], 400 );
+			wp_die( esc_html( $response['error'] ), 400 );
 		}
 
 		if ( false === $response ) {

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
@@ -58,6 +58,7 @@ class CSS_Proxy {
 			wp_die( esc_html( $response['error'] ), 400 );
 		}
 
+		$css = '';
 		if ( false === $response ) {
 			$response     = wp_remote_get( $proxy_url );
 			$content_type = wp_remote_retrieve_header( $response, 'content-type' );
@@ -74,9 +75,8 @@ class CSS_Proxy {
 			die( 'error' );
 		}
 
-		header( 'Content-type: text/css' );
-
 		if ( $css ) {
+			header( 'Content-type: text/css' );
 			// Outputting proxied CSS contents unescaped.
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo wp_strip_all_tags( $css );

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
@@ -21,7 +21,7 @@ class CSS_Proxy {
 	/**
 	 * AJAX handler to handle proxying of external CSS resources.
 	 *
-	 * @return never
+	 * @return void
 	 */
 	public function handle_css_proxy() {
 

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
@@ -60,7 +60,7 @@ class CSS_Proxy {
 
 		$css = '';
 		if ( false === $response ) {
-			$response     = wp_remote_get( $proxy_url );
+			$response     = wp_safe_remote_get( $proxy_url );
 			$content_type = wp_remote_retrieve_header( $response, 'content-type' );
 			if ( strpos( $content_type, 'text/css' ) === false ) {
 				wp_cache_set( $cache_key, array( 'error' => 'Invalid content type. Expected CSS.' ), '', HOUR_IN_SECONDS );

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
@@ -46,7 +46,7 @@ class CSS_Proxy {
 			die( 'Invalid URL' );
 		}
 
-		$url_path = parse_url( $proxy_url, PHP_URL_PATH );
+		$url_path = wp_parse_url( $proxy_url, PHP_URL_PATH );
 		if ( ! $url_path || substr( strtolower( $url_path ), -4 ) !== '.css' ) {
 			wp_die( 'Invalid CSS file URL', 400 );
 		}

--- a/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
+++ b/projects/plugins/boost/app/modules/optimizations/critical-css/CSS_Proxy.php
@@ -25,7 +25,7 @@ class CSS_Proxy {
 	 */
 	public function handle_css_proxy() {
 
-		// Verify valid nonce .
+		// Verify valid nonce.
 		if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['nonce'] ), self::NONCE_ACTION ) ) {
 			wp_die( '', 400 );
 		}

--- a/projects/plugins/boost/changelog/fix-boost-proxy
+++ b/projects/plugins/boost/changelog/fix-boost-proxy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Jetpack Boost: Improved image and CSS proxy functionalities with CDN support, caching, and other enhancements.


### PR DESCRIPTION
## Proposed changes:
- Implement CDN URL handling for image proxy requests.
- Add content type validation and caching for CSS proxy requests.
- Escape error messages for security enhancements.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Use the image guide module to request an image and verify it's served through the Photon CDN.
- Request a CSS file through the CSS proxy and check that it's cached.
- Attempt to proxy a non-CSS file and confirm that they're not loaded