### PR TITLE
Avoid showing help center for woocommerce admin homepage

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-hide-hc-wc-admin
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-hide-hc-wc-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hide help-center for wc-admin home page

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -297,6 +297,14 @@ class Help_Center {
 	}
 
 	/**
+	 * Returns true if the current screen is the woo commerce admin home page.
+	 */
+	public function is_wc_admin_home_page() {
+		global $current_screen;
+		return $current_screen->id === 'woocommerce_page_wc-admin';
+	}
+
+	/**
 	 * Returns true if the current user is connected through Jetpack
 	 */
 	public function is_jetpack_disconnected() {
@@ -359,6 +367,10 @@ class Help_Center {
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 
 		if ( ! is_admin() ) {
+			return;
+		}
+
+		if ( $this->is_wc_admin_home_page() ) {
 			return;
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -299,7 +299,7 @@ class Help_Center {
 	/**
 	 * Returns true if the current screen is the woo commerce admin home page.
 	 */
-	public function is_wc_admin_home_page() {
+	private function is_wc_admin_home_page() {
 		global $current_screen;
 		return $current_screen->id === 'woocommerce_page_wc-admin';
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
We should hide the help center for the WooCommerce admin home page.
There is already an implementation similar to the help center in this case. This leads to two help center icons being shown, which might confuse the user.

| WooCommerce Documentation  | Help Center |
| ------------- | ------------- |
| <img width="449" alt="Screenshot 2024-07-09 at 11 57 26" src="https://github.com/Automattic/jetpack/assets/7000684/6647c5d2-0e03-417d-b77d-ca3261ac7893"> | <img width="498" alt="Screenshot 2024-07-09 at 11 57 10" src="https://github.com/Automattic/jetpack/assets/7000684/eb3dbf10-a6fc-4ed6-98b4-75dd761e7279"> |



| Before  | After |
| ------------- | ------------- |
| <img width="1727" alt="Screenshot 2024-07-09 at 11 55 51" src="https://github.com/Automattic/jetpack/assets/7000684/24ec0afb-9633-4bf5-b559-ac7825198c87">  |  <img width="1728" alt="Screenshot 2024-07-09 at 11 54 47" src="https://github.com/Automattic/jetpack/assets/7000684/30235287-624a-4781-a25c-b176c9898929"> |

Fixes #
8125-gh-Automattic/dotcom-forge

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Avoid enqueuing the help center for this page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test this PR with site for which you have the Entrepreneur plan. Sync `jetpack-mu-wpcom` to it
* Navigate to https://{your-site}/wp-admin/admin.php?page=wc-admin
* Ensure that the help center is not shown there
* Ensure that the help center is shown for the other pages as before