### PR TITLE
Jetpack Blocks: Migrate the Timeline block from ETK

### DIFF
--- a/projects/plugins/jetpack/changelog/feat-jetpack-timeline-block
+++ b/projects/plugins/jetpack/changelog/feat-jetpack-timeline-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack Blocks: Migrate the Timeline block from ETK

--- a/projects/plugins/jetpack/extensions/blocks/timeline/block-appender.js
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/block-appender.js
@@ -1,0 +1,29 @@
+import { Path, SVG } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const BlockAppender = props => {
+	const { onClick } = props;
+	return (
+		<button
+			className="block-editor-inserter__toggle timeline-item-appender components-button"
+			type="button"
+			style={ { zIndex: 99999 } }
+			onClick={ onClick }
+		>
+			<SVG
+				width="24"
+				height="24"
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 24 24"
+				role="img"
+				aria-hidden="true"
+				focusable="false"
+			>
+				<Path d="M18 11.2h-5.2V6h-1.6v5.2H6v1.6h5.2V18h1.6v-5.2H18z"></Path>
+			</SVG>{ ' ' }
+			{ __( 'Add entry', 'jetpack' ) }
+		</button>
+	);
+};
+
+export default BlockAppender;

--- a/projects/plugins/jetpack/extensions/blocks/timeline/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/block.json
@@ -1,0 +1,22 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/timeline",
+	"title": "Timeline",
+	"description": "Create a timeline of events.",
+	"keywords": [ "events", "tickets" ],
+	"version": "12.5.0",
+	"textdomain": "jetpack",
+	"category": "widgets",
+	"icon": "<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'><path d='M15 13v1.2h-2.2V6h-1.6v2.2H9V7H4v4h5V9.8h2.2V18h1.6v-2.2H15V17h5v-4z' /></svg>",
+	"supports": {
+		"align": [ "wide", "full" ]
+	},
+	"attributes": {
+		"isAlternating": {
+			"type": "boolean",
+			"selector": "ul",
+			"attribute": "data-is-alternating"
+		}
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/timeline/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/edit.js
@@ -1,0 +1,46 @@
+import { InnerBlocks, InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { ToggleControl, PanelBody } from '@wordpress/components';
+import { dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import BlockAppender from './block-appender';
+
+const TimelineEdit = ( { clientId, attributes, setAttributes } ) => {
+	const { isAlternating } = attributes;
+	const className = clsx( 'wp-block-jetpack-timeline', {
+		'is-alternating': isAlternating,
+	} );
+
+	const blockProps = useBlockProps( { className } );
+
+	const addItem = () => {
+		const block = createBlock( 'jetpack/timeline-item' );
+		dispatch( 'core/block-editor' ).insertBlock( block, undefined, clientId );
+	};
+
+	const toggleAlternate = () => setAttributes( { isAlternating: ! isAlternating } );
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Timeline settings', 'jetpack' ) }>
+					<ToggleControl
+						label={ __( 'Alternate items', 'jetpack' ) }
+						onChange={ toggleAlternate }
+						checked={ isAlternating }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<ul { ...blockProps }>
+				<InnerBlocks
+					allowedBlocks={ [ 'jetpack/timeline-item' ] }
+					template={ [ [ 'jetpack/timeline-item' ] ] }
+					renderAppender={ () => <BlockAppender onClick={ addItem } /> }
+				/>
+			</ul>
+		</>
+	);
+};
+
+export default TimelineEdit;

--- a/projects/plugins/jetpack/extensions/blocks/timeline/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/editor.js
@@ -1,0 +1,18 @@
+import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
+import metadata from './block.json';
+import edit from './edit';
+import example from './example';
+import save from './save';
+import * as timelineItem from './timeline-item';
+import './editor.scss';
+import './style.scss';
+
+registerJetpackBlockFromMetadata(
+	metadata,
+	{
+		edit,
+		save,
+		example,
+	},
+	[ timelineItem ]
+);

--- a/projects/plugins/jetpack/extensions/blocks/timeline/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/editor.scss
@@ -1,0 +1,33 @@
+// Editor-only styles.
+[data-type="jetpack/timeline"] {
+
+	// Always show the Timeline appender, even when a child block is selected.
+	.block-list-appender {
+		display: none;
+	}
+
+	&.is-selected .block-list-appender,
+	&.has-child-selected .block-list-appender {
+		display: block;
+	}
+}
+
+// We replicate the appender look here.
+// @todo: once https://github.com/WordPress/gutenberg/issues/16659 we should replace the button with the actual appender.
+.components-button.timeline-item-appender {
+	background: #1e1e1e;
+	border-radius: 2px;
+	color: #fff;
+	min-width: 24px;
+	height: 24px;
+	margin-right: 12px;
+	padding-left: 0;
+	padding-right: 8px;
+
+	// Temporarily make this important. It can be retired once this custom appender is replaced with the real one.
+	animation: none !important;
+
+	&:hover {
+		color: #fff;
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/timeline/example.js
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/example.js
@@ -1,0 +1,52 @@
+import { __ } from '@wordpress/i18n';
+
+const example = {
+	innerBlocks: [
+		{
+			name: 'jetpack/timeline-item',
+			innerBlocks: [
+				{
+					name: 'core/heading',
+					attributes: {
+						content: __( 'Spring', 'jetpack' ),
+					},
+				},
+			],
+		},
+		{
+			name: 'jetpack/timeline-item',
+			innerBlocks: [
+				{
+					name: 'core/heading',
+					attributes: {
+						content: __( 'Summer', 'jetpack' ),
+					},
+				},
+			],
+		},
+		{
+			name: 'jetpack/timeline-item',
+			innerBlocks: [
+				{
+					name: 'core/heading',
+					attributes: {
+						content: __( 'Fall', 'jetpack' ),
+					},
+				},
+			],
+		},
+		{
+			name: 'jetpack/timeline-item',
+			innerBlocks: [
+				{
+					name: 'core/heading',
+					attributes: {
+						content: __( 'Winter', 'jetpack' ),
+					},
+				},
+			],
+		},
+	],
+};
+
+export default example;

--- a/projects/plugins/jetpack/extensions/blocks/timeline/icon.js
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/icon.js
@@ -1,0 +1,7 @@
+import { Path, SVG } from '@wordpress/components';
+
+export const TimelineIcon = () => (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M15 13v1.2h-2.2V6h-1.6v2.2H9V7H4v4h5V9.8h2.2V18h1.6v-2.2H15V17h5v-4z" />
+	</SVG>
+);

--- a/projects/plugins/jetpack/extensions/blocks/timeline/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/save.js
@@ -1,0 +1,23 @@
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import clsx from 'clsx';
+
+const save = ( { attributes } ) => {
+	const { isAlternating } = attributes;
+
+	const className = clsx( 'wp-block-jetpack-timeline', {
+		'is-alternating': isAlternating,
+	} );
+
+	const blockProps = useBlockProps.save( { className } );
+
+	const dataProps =
+		typeof isAlternating === 'boolean' ? { 'data-is-alternating': isAlternating } : null;
+
+	return (
+		<ul { ...blockProps } { ...dataProps }>
+			<InnerBlocks.Content />
+		</ul>
+	);
+};
+
+export default save;

--- a/projects/plugins/jetpack/extensions/blocks/timeline/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/style.scss
@@ -1,0 +1,109 @@
+/**
+ * Timeline Block styles.
+ */
+
+// Variables.
+$timeline-width: 36px;
+$timeline-gutter: 24px;
+$timeline-border-width: 4px;
+
+// Styles shared between editor and frontend.
+.wp-block-jetpack-timeline {
+
+	// This padding needs extra specificity.
+	&.wp-block-jetpack-timeline {
+		padding: 0;
+	}
+
+	li.wp-block-jetpack-timeline-item {
+		list-style-type: none;
+		position: relative;
+		padding: 1em 2em;
+
+		// Make the spacing between items consistent so we can connect the timeline
+		margin-bottom: $timeline-width;
+
+		// Make room for the timeline.
+		margin-left: $timeline-width;
+
+		// Draw the line connecting to the timeline.
+		.timeline-item__bubble {
+			display: block;
+			width: $timeline-width;
+			height: $timeline-border-width;
+			background-color: currentColor;
+			position: absolute;
+			top: 50%;
+			transform: translateY(-($timeline-border-width * 0.5));
+			left: -$timeline-width;
+		}
+
+		// Draw the vertical timeline line.
+		.timeline-item::after {
+			content: "";
+			display: block;
+			background: currentColor;
+			position: absolute;
+			left: -$timeline-width;
+			top: -$timeline-width;
+			bottom: -$timeline-width;
+			width: $timeline-border-width;
+		}
+	}
+
+	// Add special timeline starting point and end point.
+	[data-type="jetpack/timeline-item"]:first-child .timeline-item::after,
+	& > li.wp-block-jetpack-timeline-item:first-child .timeline-item::after { // Frontend
+		top: 50%;
+	}
+
+	[data-type="jetpack/timeline-item"]:nth-last-child(2)  .timeline-item::after,
+	& > li.wp-block-jetpack-timeline-item:last-child .timeline-item::after { // Frontend
+		bottom: 50%;
+	}
+
+}
+
+/**
+ * Alternating Bubbles
+ */
+@media only screen and (min-width: 640px) {
+	ul.wp-block-jetpack-timeline.is-alternating {
+		display: flex;
+		flex-direction: column;
+
+		// Bubbles.
+		.wp-block-jetpack-timeline-item {
+			width: calc(50% - #{ $timeline-width } + #{ $timeline-border-width * 0.5 });
+			box-sizing: border-box;
+		}
+
+		// Left aligned.
+		.wp-block-jetpack-timeline-item.is-left.is-left.is-left,
+		[data-type="jetpack/timeline-item"]:nth-child(odd) .wp-block-jetpack-timeline-item:not(.is-right),
+		& > .wp-block-jetpack-timeline-item:nth-child(odd):not(.is-right) { // Frontend
+			margin-left: 0;
+			margin-right: auto;
+
+			// Adjust the the line connecting to the timeline.
+			.timeline-item__bubble {
+				left: auto;
+				right: -$timeline-width;
+			}
+
+			// Adjust the vertical line.
+			.timeline-item::after {
+				left: auto;
+				right: -$timeline-width;
+			}
+		}
+
+		// Right aligned.
+		.wp-block-jetpack-timeline-item.is-right.is-right.is-right,
+		[data-type="jetpack/timeline-item"]:nth-child(even) .wp-block-jetpack-timeline-item:not(.is-left),
+		.wp-block-jetpack-timeline-item:nth-child(even):not(.is-left) { // Frontend
+			margin-left: auto;
+			margin-right: 0;
+		}
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/timeline/timeline-item/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/timeline-item/edit.js
@@ -1,0 +1,97 @@
+import {
+	InspectorControls,
+	InnerBlocks,
+	PanelColorSettings,
+	BlockControls,
+} from '@wordpress/block-editor';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { positionLeft, positionRight } from '@wordpress/icons';
+import clsx from 'clsx';
+
+export const DEFAULT_BACKGROUND = '#eeeeee';
+
+const Controls = ( { alignment, clientId, toggleAlignment } ) => {
+	const parentIsAlternating = useSelect( select => {
+		const parentIds = select( 'core/block-editor' ).getBlockParents( clientId );
+		const parent = select( 'core/block-editor' ).getBlock( parentIds[ 0 ] );
+		return parent?.attributes?.isAlternating;
+	} );
+
+	if ( parentIsAlternating === false ) {
+		return null;
+	}
+
+	return (
+		<BlockControls>
+			<ToolbarGroup>
+				<ToolbarButton
+					onClick={ () => toggleAlignment( 'left' ) }
+					isActive={ alignment === 'left' }
+					icon={ positionLeft }
+					title={ __( 'Left', 'jetpack' ) }
+				/>
+				<ToolbarButton
+					onClick={ () => toggleAlignment( 'right' ) }
+					isActive={ alignment === 'right' }
+					icon={ positionRight }
+					title={ __( 'Right', 'jetpack' ) }
+				/>
+			</ToolbarGroup>
+		</BlockControls>
+	);
+};
+
+const TimelineItemEdit = ( { attributes, clientId, setAttributes } ) => {
+	const style = {
+		backgroundColor: attributes.background,
+	};
+
+	const bubbleStyle = {
+		borderColor: attributes.background,
+	};
+
+	const toggleAlignment = alignment => {
+		const newAlignment = alignment === attributes.alignment ? 'auto' : alignment;
+		setAttributes( { alignment: newAlignment } );
+	};
+
+	const classes = clsx( 'wp-block-jetpack-timeline-item', {
+		'is-left': attributes.alignment === 'left',
+		'is-right': attributes.alignment === 'right',
+	} );
+
+	return (
+		<>
+			<Controls
+				alignment={ attributes.alignment }
+				clientId={ clientId }
+				toggleAlignment={ toggleAlignment }
+			/>
+			<li style={ style } className={ classes }>
+				<InspectorControls>
+					<PanelColorSettings
+						title={ __( 'Color Settings', 'jetpack' ) }
+						enableAlpha
+						colorSettings={ [
+							{
+								value: attributes.background,
+								onChange: background =>
+									setAttributes( { background: background || DEFAULT_BACKGROUND } ),
+								label: __( 'Background Color', 'jetpack' ),
+							},
+						] }
+					/>
+				</InspectorControls>
+				<div className="timeline-item">
+					<div className="timeline-item__bubble" style={ bubbleStyle } />
+					<div className="timeline-item__dot" style={ style } />
+					<InnerBlocks template={ [ [ 'core/paragraph' ] ] } />
+				</div>
+			</li>
+		</>
+	);
+};
+
+export default TimelineItemEdit;

--- a/projects/plugins/jetpack/extensions/blocks/timeline/timeline-item/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/timeline-item/index.js
@@ -1,0 +1,26 @@
+import { __ } from '@wordpress/i18n';
+import { TimelineIcon } from '../icon';
+import edit, { DEFAULT_BACKGROUND } from './edit';
+import save from './save';
+
+export const name = 'timeline-item';
+
+export const settings = {
+	title: __( 'Timeline Entry', 'jetpack' ),
+	description: __( 'An entry on the timeline', 'jetpack' ),
+	icon: TimelineIcon,
+	category: 'widgets',
+	parent: [ 'jetpack/timeline' ],
+	attributes: {
+		alignment: {
+			type: 'string',
+			default: 'auto',
+		},
+		background: {
+			type: 'string',
+			default: DEFAULT_BACKGROUND,
+		},
+	},
+	edit,
+	save,
+};

--- a/projects/plugins/jetpack/extensions/blocks/timeline/timeline-item/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/timeline-item/save.js
@@ -1,0 +1,29 @@
+import { InnerBlocks } from '@wordpress/block-editor';
+import clsx from 'clsx';
+
+const save = ( { attributes } ) => {
+	const classes = clsx( {
+		'is-left': attributes.alignment === 'left',
+		'is-right': attributes.alignment === 'right',
+	} );
+
+	const style = {
+		backgroundColor: attributes.background,
+	};
+
+	const bubbleStyle = {
+		borderColor: attributes.background,
+	};
+
+	return (
+		<li style={ style } className={ classes }>
+			<div className="timeline-item">
+				<div className="timeline-item__bubble" style={ bubbleStyle } />
+				<div className="timeline-item__dot" style={ style } />
+				<InnerBlocks.Content />
+			</div>
+		</li>
+	);
+};
+
+export default save;

--- a/projects/plugins/jetpack/extensions/blocks/timeline/timeline.php
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/timeline.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Timeline Block
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Timeline;
+
+use Automattic\Jetpack\Blocks;
+use Jetpack_Gutenberg;
+
+define( 'MU_WPCOM_JETPACK_TIMELINE_BLOCK', true );
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	Blocks::jetpack_register_block(
+		__DIR__,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Timeline block.
+ *
+ * @param array  $attr    Array containing the Timeline block attributes.
+ * @param string $content String containing the Timeline block content.
+ *
+ * @return string
+ */
+function load_assets( $attr, $content ) {
+	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
+	return $content;
+}

--- a/projects/plugins/jetpack/extensions/blocks/timeline/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/timeline/view.js
@@ -1,0 +1,1 @@
+import './style.scss';

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -45,6 +45,7 @@
 		"subscriber-login",
 		"subscriptions",
 		"tiled-gallery",
+		"timeline",
 		"tock",
 		"videopress",
 		"wordads",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/8032, https://github.com/Automattic/dotcom-forge/issues/8036

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Migrate the Timeline block to Jetpack Blocks

| Editor | Frontend |
| - | - |
| <img width="701" alt="image" src="https://github.com/Automattic/jetpack/assets/13596067/b59b21df-0387-4362-a292-8be1f098f96e"> | <img width="701" alt="image" src="https://github.com/Automattic/jetpack/assets/13596067/a8152001-d4c3-4910-b432-c10ece0961a1"> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site
* Go to the editor
* Insert the `Timeline` block
* Add any timeline entry
* Configure the `Alternative` setting of the `Timeline` block
  <img width="267" alt="image" src="https://github.com/Automattic/jetpack/assets/13596067/812b1ce5-e1f2-46c3-9bdc-70cbe050be06">
* Configure the left/right setting of the `Timeline Entry` block
  <img width="321" alt="image" src="https://github.com/Automattic/jetpack/assets/13596067/23e3867a-85ed-4d34-b5ff-6b5a26df2ea6">
* Configure the background color of the `Timeline Entry` block
  <img width="266" alt="image" src="https://github.com/Automattic/jetpack/assets/13596067/d9ff67ef-67d7-4a67-a1b0-259fb254933d">
* Make sure everything works as expected
* Preview your changes
* Make sure the `Timeline` block looks good on your frontend page
