### PR TITLE
Newsletters Settings: Fix Full text-Excerpt default value

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -2663,7 +2663,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'wpcom_subscription_emails_use_excerpt' => array(
 				'description'       => esc_html__( 'Whether to use the excerpt in the email or not', 'jetpack' ),
 				'type'              => 'boolean',
-				'default'           => 1,
+				'default'           => 0,
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),

--- a/projects/plugins/jetpack/changelog/fix-email-should-excerpt-default-value
+++ b/projects/plugins/jetpack/changelog/fix-email-should-excerpt-default-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter Settings: Fix default value for Full text vs Excerpt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

Even though the UI shows Excerpt as the selected value, the default in the backend is Full text.

![image](https://github.com/Automattic/jetpack/assets/104869/f53a013b-d65e-4a47-a7d3-f20d9cd85086)


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix API default value for `wpcom_subscription_emails_use_excerpt`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* On a brand new Jetpack site check Newsletter settings – Make sure "Full text" is selected.
* Write a long post – make sure subscribers receive the "Full text" email.

