### PR TITLE
Jetpack AI Image: Automatically start generation of featured image when there is content on the post

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-featured-image-auto-start-generation
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-featured-image-auto-start-generation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI Image: trigger featured image auto generation when there is content on the post.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/featured-image.tsx
@@ -308,6 +308,8 @@ export default function FeaturedImage( {
 			) }
 			<AiImageModal
 				postContent={ postContent }
+				autoStart={ postContent !== '' }
+				autoStartAction={ handleGenerate }
 				images={ images }
 				currentIndex={ current }
 				title={ __( 'Generate a featured image with AI', 'jetpack' ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is reverting part of #38098 so we only trigger the generation automatically when there is content on the post. When there is no content, the user will see the modal open with the empty state on it.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enable featured image auto start when there is content on the post

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1720141077573849-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Let's test the first scenario: no content on the post.

* Run this branch on your testing site (or a fresh JN site)
* Go to the block editor and do not add any content
* Look for the featured image button on the Jetpack sidebar (Jetpack sidebar > AI Assistant section > AI Featured Image > Generate Image)
* Click the button and confirm the tool will open, the generation will not start and you see the proper empty state:

<img width="500" alt="Screenshot 2024-07-09 at 12 47 37" src="https://github.com/Automattic/jetpack/assets/6760046/ab4ac82b-24eb-4ac3-a4c9-289d3c49240a">

* Do the same test for the other 2 placements:
   * Settings sidebar > Post tab > AI Assistant section > AI Featured Image > Generate Image button
   * Settings sidebar > Post tab > Featured Image section (or summary section, depending on the Gutenberg version) > Set featured image button
   * Remember to not add content to the post while testing it and confirm you only see the modal showing the empty state, with no generation going on
* Confirm you still can type some prompt and generate images based on it

Now let's test the second scenario: a post with content.

* Add some content to the post (tip: use the AI Assistant to generate two paragraphs about some topic)
* Look for the featured image button on the Jetpack sidebar (Jetpack sidebar > AI Assistant section > AI Featured Image > Generate Image)
* Click the button and confirm the tool will open and the generation will start automatically
* You should see a loading state and then, after some time, the new generated image:

| The loading state | The generated image |
| --- | --- |
| <img width="500" alt="Screenshot 2024-07-09 at 12 49 10" src="https://github.com/Automattic/jetpack/assets/6760046/4e07c64b-0232-4dc1-8772-5cb59c1fecca"> | <img width="500" alt="Screenshot 2024-07-09 at 12 50 22" src="https://github.com/Automattic/jetpack/assets/6760046/8d53a704-4230-46cf-8c52-af5646b76fb5"> |

* Close the generation tool and do the same test for the other 2 placements:
   * Settings sidebar > Post tab > AI Assistant section > AI Featured Image > Generate Image button
   * Settings sidebar > Post tab > Featured Image section (or summary section, depending on the Gutenberg version) > Set featured image button
   * Confirm you see the modal with the loading state, followed by the new image being showed
* Confirm you still can type a custom prompt and generate images based on it, after the first one got generated