### PR TITLE
WP Super Cache: fix clearing the cache when scheduled posts are published

### DIFF
--- a/projects/plugins/super-cache/changelog/super-cache-fix-scheduled-posts
+++ b/projects/plugins/super-cache/changelog/super-cache-fix-scheduled-posts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WPSC: fix clearing the cache when scheduled posts are published

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -400,11 +400,6 @@ function wp_cache_postload() {
 		return true;
 	}
 
-	if ( wpsc_is_backend() ) {
-		wp_cache_debug( 'wp_cache_postload: backend detected, not running' );
-		return true;
-	}
-
 	if ( isset( $wp_super_cache_late_init ) && true == $wp_super_cache_late_init ) {
 		wp_cache_debug( 'Supercache Late Init: add wp_cache_serve_cache_file to init', 3 );
 		add_action( 'init', 'wp_cache_late_loader', 9999 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
A recent change added an "is backend" check to the code very early on in the "boot up" process of the request. One "is backend" URL is the website CRON function. This stopped the plugin hooking various functions that did maintenance of the cache. One of those was the transition action that fires when a post goes from scheduled to publish.
That stopped scheduled posts from clearing the cache as the caching system was disabled when CRON jobs ran.

Fixes #38257

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the is_backend check from wp_cache_postload()


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1720508923710769-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* This is possibly easier to debug if you disable the WP cron and call it from the system cron as it's more predictable, especially on a quiet website.
* Enable the debug log.
* Schedule a post for 2 minutes into the future.
* Keep an eye on the debug log.
* When the post is "published", the debug log will show something like this when the post is published: `wp_cache_post_edit: Clearing cache for post X on clean_post_cache`
* Reload the posts page and the new post should be there.