### PR TITLE
Fix/newsletter popup tabs

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-popup-tabs
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-popup-tabs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Newsletter: Improvements the modal overlay

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -88,7 +88,7 @@ class Jetpack_Subscribe_Modal {
 			$scroll_threshold = absint( apply_filters( 'jetpack_subscribe_modal_scroll_threshold', 50 ) );
 
 			/**
-			 * Filter lets you control the interval how often a user gets to see the modal. Default is 24 hours.
+			 * Filter to control the interval at which the subscribe modal is shown to the same user.  The default interval is 24 hours.```
 			 *
 			 * @since 13.7
 			 *

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -51,6 +51,8 @@ class Jetpack_Subscribe_Modal {
 			add_action( 'wp_footer', array( $this, 'add_subscribe_modal_to_frontend' ) );
 		}
 		add_filter( 'get_block_template', array( $this, 'get_block_template_filter' ), 10, 3 );
+		// just for testing.
+		add_filter( 'jetpack_subscribe_modal_interval', '__return_zero' );
 	}
 
 	/**
@@ -85,12 +87,22 @@ class Jetpack_Subscribe_Modal {
 			 */
 			$scroll_threshold = absint( apply_filters( 'jetpack_subscribe_modal_scroll_threshold', 50 ) );
 
+			/**
+			 * Filter lets you control the interval how often a user gets to see the modal. Default is 24 hours.
+			 *
+			 * @since 13.7
+			 *
+			 * @param int 24 Hours before we show the same user the Subscribe Modal to again.
+			 */
+			$modal_interval = absint( apply_filters( 'jetpack_subscribe_modal_interval', 24 ) );
+
 			wp_localize_script(
 				'subscribe-modal-js',
 				'Jetpack_Subscriptions',
 				array(
 					'modalLoadTime'        => $load_time,
 					'modalScrollThreshold' => $scroll_threshold,
+					'modalInterval'        => ( $modal_interval * HOUR_IN_SECONDS * 1000 ),
 				)
 			);
 		}

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -88,7 +88,7 @@ class Jetpack_Subscribe_Modal {
 			$scroll_threshold = absint( apply_filters( 'jetpack_subscribe_modal_scroll_threshold', 50 ) );
 
 			/**
-			 * Filter to control the interval at which the subscribe modal is shown to the same user.  The default interval is 24 hours.```
+			 * Filter to control the interval at which the subscribe modal is shown to the same user.  The default interval is 24 hours.
 			 *
 			 * @since 13.7
 			 *

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -51,8 +51,6 @@ class Jetpack_Subscribe_Modal {
 			add_action( 'wp_footer', array( $this, 'add_subscribe_modal_to_frontend' ) );
 		}
 		add_filter( 'get_block_template', array( $this, 'get_block_template_filter' ), 10, 3 );
-		// just for testing.
-		add_filter( 'jetpack_subscribe_modal_interval', '__return_zero' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -1,6 +1,6 @@
 /* global Jetpack_Subscriptions */
 const { domReady } = wp;
-domReady( function () {
+domReady( () => {
 	const modal = document.getElementsByClassName( 'jetpack-subscribe-modal' )[ 0 ];
 	const modalDismissedCookie = 'jetpack_post_subscribe_modal_dismissed';
 
@@ -34,7 +34,7 @@ domReady( function () {
 	function onLocalStorage( event ) {
 		if ( event.key === modalDismissedCookie ) {
 			closeModal();
-			uninitialize();
+			removeEventListeners();
 		}
 	}
 	window.addEventListener( 'storage', onLocalStorage );
@@ -80,7 +80,7 @@ domReady( function () {
 		document.body.classList.add( 'jetpack-subscribe-modal-open' );
 		window.addEventListener( 'keydown', closeModalOnEscapeKeydown );
 		window.addEventListener( 'click', closeOnWindowClick );
-		uninitialize();
+		removeEventListeners();
 	}
 
 	function closeModal() {
@@ -93,7 +93,7 @@ domReady( function () {
 	}
 
 	// Remove all event listeners. That would add the modal again.
-	function uninitialize() {
+	function removeEventListeners() {
 		window.removeEventListener( 'scroll', onScroll );
 		window.clearInterval( modalInactiveInterval );
 	}

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -99,28 +99,13 @@ domReady( function () {
 	}
 
 	function storeCloseTimestamp() {
-		if ( window.localStorage ) {
-			localStorage.setItem( modalDismissedCookie, Date.now() );
-			return;
-		}
-		// Set a cookie.
-		const expires = new Date( Date.now() + Jetpack_Subscriptions.modalInterval ).toUTCString();
-		document.cookie = `${ modalDismissedCookie }=true; expires=${ expires };path=/;`;
+		localStorage.setItem( modalDismissedCookie, Date.now() );
 	}
 
 	function hasEnoughTimePassed() {
-		const hasModalDismissedCookie =
-			document.cookie && document.cookie.indexOf( modalDismissedCookie ) > -1;
-
-		if ( hasModalDismissedCookie ) {
-			return false;
-		}
-
-		if ( window.localStorage ) {
-			const timeSinceLastModal = localStorage.getItem( modalDismissedCookie );
-			return Date.now() - timeSinceLastModal > Jetpack_Subscriptions.modalInterval;
-		}
-
-		return true;
+		return (
+			Date.now() - localStorage.getItem( modalDismissedCookie ) >
+			Jetpack_Subscriptions.modalInterval
+		);
 	}
 } );

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -1,7 +1,7 @@
 /* global Jetpack_Subscriptions */
 const { domReady } = wp;
 domReady( () => {
-	const modal = document.getElementsByClassName( 'jetpack-subscribe-modal' )[ 0 ];
+	const modal = document.querySelector( '.jetpack-subscribe-modal' );
 	const modalDismissedCookie = 'jetpack_post_subscribe_modal_dismissed';
 
 	if ( ! modal || ! hasEnoughTimePassed() ) {
@@ -95,7 +95,7 @@ domReady( () => {
 	// Remove all event listeners. That would add the modal again.
 	function removeEventListeners() {
 		window.removeEventListener( 'scroll', onScroll );
-		window.clearInterval( modalInactiveInterval );
+		clearInterval( modalInactiveInterval );
 	}
 
 	function storeCloseTimestamp() {
@@ -103,9 +103,7 @@ domReady( () => {
 	}
 
 	function hasEnoughTimePassed() {
-		return (
-			Date.now() - localStorage.getItem( modalDismissedCookie ) >
-			Jetpack_Subscriptions.modalInterval
-		);
+		const lastDismissed = localStorage.getItem( modalDismissedCookie );
+		return lastDismissed ? Date.now() - lastDismissed > Jetpack_Subscriptions.modalInterval : true;
 	}
 } );

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -4,9 +4,16 @@ domReady( () => {
 	const modal = document.querySelector( '.jetpack-subscribe-modal' );
 	const modalDismissedCookie = 'jetpack_post_subscribe_modal_dismissed';
 
+	function hasEnoughTimePassed() {
+		const lastDismissed = localStorage.getItem( modalDismissedCookie );
+		return lastDismissed ? Date.now() - lastDismissed > Jetpack_Subscriptions.modalInterval : true;
+	}
+
 	if ( ! modal || ! hasEnoughTimePassed() ) {
 		return;
 	}
+
+	const modalLoadTimeout = setTimeout( openModal, Jetpack_Subscriptions.modalLoadTime );
 
 	const targetElement = (
 		document.querySelector( '.entry-content' ) || document.documentElement
@@ -38,9 +45,6 @@ domReady( () => {
 		}
 	}
 	window.addEventListener( 'storage', onLocalStorage );
-
-	// Check if the page is inactive
-	const modalInactiveInterval = setInterval( openModal, Jetpack_Subscriptions.modalLoadTime );
 
 	// When the form is submitted, and next modal loads, it'll fire "subscription-modal-loaded" signalling that this form can be hidden.
 	const form = modal.querySelector( 'form' );
@@ -95,15 +99,10 @@ domReady( () => {
 	// Remove all event listeners. That would add the modal again.
 	function removeEventListeners() {
 		window.removeEventListener( 'scroll', onScroll );
-		clearInterval( modalInactiveInterval );
+		clearTimeout( modalLoadTimeout );
 	}
 
 	function storeCloseTimestamp() {
 		localStorage.setItem( modalDismissedCookie, Date.now() );
-	}
-
-	function hasEnoughTimePassed() {
-		const lastDismissed = localStorage.getItem( modalDismissedCookie );
-		return lastDismissed ? Date.now() - lastDismissed > Jetpack_Subscriptions.modalInterval : true;
 	}
 } );

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -86,7 +86,6 @@ domReady( function () {
 		window.addEventListener( 'keydown', closeModalOnEscapeKeydown );
 		window.removeEventListener( 'scroll', onScroll );
 		window.removeEventListener( 'storage', onLocalStorage );
-		window.clearInterval( scrollThrottle );
 	}
 
 	function closeModal() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
* This PR has a few different changes. 
* We now use localstorage to presist the state. This also helps with the scroll tabs modal removal. 
* We don't add events directly but use addEventListeners this make sure that we allow other plugins to add their own even listeners (even if they are doing it wrong) 
* We remove events that we shouldn't need. So that they are not running any more once the modal is opened and closed. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Add the following code to ease of testing. 
```
// just for testing.
add_filter( 'jetpack_subscribe_modal_interval', '__return_zero' );

add_filter(
	'jetpack_subscribe_modal_load_time',
	function ( $item ) {
		return 4000;
	}
);
```

// The model should show up after 4seconds of inactivity on the page instead of 60. 
We also skip show the modal every time. ( since the interval is set to zero) 

To test. 
1. the modal still shows up after scrolling. 
2. After 4 seconds have passed.
3. Open the modal in two or more tabs.
 Do not dismiss the modal. 
 Note that after dismissing a modal in one tab that it is gone in other modals. 
4. Focus an input or link. 
 Notice that the modal doesn't show up. 
5. after the focus shifts to the window again the modal shows up again. 


