### PR TITLE
 AI Assistant: Fix blocks content definition

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-content
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Fix blocks content definition

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { getBlockContent } from '@wordpress/blocks';
 import { BaseControl, PanelRow, SVG, Path } from '@wordpress/components';
 import { compose, useDebounce } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
@@ -17,6 +16,7 @@ import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import config from './dictionaries/dictionaries-config';
 import calculateFleschKincaid from './utils/FleschKincaidUtils';
 import './breve.scss';
+import { getPostText } from './utils/getPostText';
 
 export const useInit = init => {
 	const [ initialized, setInitialized ] = useState( false );
@@ -59,10 +59,7 @@ const Controls = ( { blocks, active } ) => {
 		}
 
 		// Get the text content from all blocks and inner blocks.
-		const allText = blocks
-			.map( block => getBlockContent( block ) )
-			.join( '' )
-			.replace( /<[^>]*>?/gm, ' ' );
+		const allText = getPostText( blocks );
 
 		const computedGradeLevel = calculateFleschKincaid( allText );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/getPostText.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/getPostText.ts
@@ -1,0 +1,31 @@
+/*
+ * External dependencies
+ */
+import * as Blocks from '@wordpress/blocks';
+/*
+ * Types
+ */
+import type { Block } from '@automattic/jetpack-ai-client';
+
+const { getBlockContent } = Blocks as unknown as {
+	getBlockContent: ( block: Block ) => string;
+};
+
+export function getHtmlText( html: string ): string {
+	const doc = document.implementation.createHTMLDocument( '' );
+	doc.body.innerHTML = html;
+
+	// Prevent table cells from merging into one long word
+	doc.body.querySelectorAll( 'td, th' ).forEach( node => {
+		node.innerHTML = ` ${ node.innerHTML }`;
+	} );
+
+	// innerText returns rendered text, excluding hidden content
+	return doc.body.innerText;
+}
+
+export function getPostText( blocks: Array< Block > ): string {
+	const html = blocks.map( block => getBlockContent( block ) ).join( '' );
+
+	return getHtmlText( html );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38268

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes the way the post text content is computed, ditching the regex replace and using the browser functionality
* Adds a tweak for forms, that otherwise return the cells' contents concatenated without a space between them

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The Breve implementation right now is in an unusable intermediary state, so to test this we need to run code manually.
I tried adding an unit test, but the `parse` function from `@wordpress/blocks` seems to be stubbed and always returns an empty array.

* Edit the new file, exposing the `getPostText` function to the window (`window.getPostText = getPostText`) 
* Go to the block editor
* Paste the following code:
```
<!-- wp:list -->
<ul><!-- wp:list-item -->
<li>D<strong>o</strong>g<!-- wp:list -->
<ul><!-- wp:list-item -->
<li>Cat</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>Fish<!-- wp:list -->
<ul><!-- wp:list-item -->
<li>Bird</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->

<!-- wp:paragraph -->
<p>Dog Cat Fish Bird</p>
<!-- /wp:paragraph -->

<!-- wp:table -->
<figure class="wp-block-table"><table><tbody><tr><td>Dog</td><td>Cat</td></tr><tr><td>Fish</td><td>B<s>ir</s>d</td></tr></tbody></table></figure>
<!-- /wp:table -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->
```
* Use `const blocks = wp.data.select('core/block-editor').getBlocks()` to get the post blocks
* Check the result of `getPostText( blocks )`

The words should all be correct and separated, regardless of formatting and if they are in table cells or not.

