### PR TITLE
Map Block: React 19 compatibility - converting defaultProps usage on MapkitComponent

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-defaultProps-usage-react-19
+++ b/projects/plugins/jetpack/changelog/fix-defaultProps-usage-react-19
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Map block: Changed defaultProp usage to make use of default parameters, for React 19 compatibility.

--- a/projects/plugins/jetpack/extensions/blocks/map/component/mapkit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/component/mapkit.js
@@ -16,61 +16,95 @@ import {
 import { createCalloutElementCallback } from '../mapkit-utils';
 import InfoWindow from './info-window';
 
-const MapkitComponent = forwardRef( ( props, mapRef ) => {
-	const { admin, points, onError, onSetPoints } = props;
-	const { loaded, error, mapkit, currentDoc, currentWindow } = useMapkitSetup( mapRef );
-	const { map } = useMapkitInit( mapkit, loaded, mapRef );
-	const addPoint = Children.map( props.children, child => {
-		const tagName = get( child, 'props.tagName' );
-		if ( 'AddPoint' === tagName ) {
-			return child;
-		}
-	} );
+const MapkitComponent = forwardRef(
+	(
+		{
+			admin,
+			points = [],
+			mapStyle = 'default',
+			zoom = 13,
+			onSetZoom = () => {},
+			onSetMapCenter = () => {},
+			onMapLoaded = () => {},
+			onMarkerClick = () => {},
+			onError = () => {},
+			markerColor = 'red',
+			mapCenter = {},
+			mapHeight = 400,
+			address = null,
+			onSetPoints,
+			children,
+		},
+		mapRef
+	) => {
+		const { loaded, error, mapkit, currentDoc, currentWindow } = useMapkitSetup( mapRef );
+		const { map } = useMapkitInit( mapkit, loaded, mapRef );
+		const addPoint = Children.map( children, child => {
+			const tagName = get( child, 'props.tagName' );
+			if ( 'AddPoint' === tagName ) {
+				return child;
+			}
+		} );
 
-	useEffect( () => {
-		if ( error ) {
-			onError( 'mapkit_error', error );
-		}
-	}, [ error, onError ] );
+		useEffect( () => {
+			if ( error ) {
+				onError( 'mapkit_error', error );
+			}
+		}, [ error, onError ] );
 
-	return (
-		<MapkitProvider
-			value={ {
-				mapkit,
-				map,
-				loaded,
-				currentDoc,
-				currentWindow,
-				admin,
-				points,
-				setPoints: onSetPoints,
-			} }
-		>
-			{ loaded && mapkit && map ? <MapkitHelpers { ...props } /> : null }
-			<div
-				style={ { height: props.mapHeight ? `${ props.mapHeight }px` : '400px' } }
-				className="wp-block-jetpack-map__gm-container"
-				ref={ mapRef }
-			/>
-			{ addPoint }
-			<InfoWindow mapProvider="mapkit" />
-		</MapkitProvider>
-	);
-} );
+		return (
+			<MapkitProvider
+				value={ {
+					mapkit,
+					map,
+					loaded,
+					currentDoc,
+					currentWindow,
+					admin,
+					points,
+					setPoints: onSetPoints,
+				} }
+			>
+				{ loaded && mapkit && map ? (
+					<MapkitHelpers
+						address={ address }
+						mapCenter={ mapCenter }
+						mapStyle={ mapStyle }
+						zoom={ zoom }
+						onSetMapCenter={ onSetMapCenter }
+						onSetZoom={ onSetZoom }
+						onSetPoints={ onSetPoints }
+						points={ points }
+						markerColor={ markerColor }
+						onMarkerClick={ onMarkerClick }
+						onMapLoaded={ onMapLoaded }
+					/>
+				) : null }
+				<div
+					style={ { height: mapHeight ? `${ mapHeight }px` : '400px' } }
+					className="wp-block-jetpack-map__gm-container"
+					ref={ mapRef }
+				/>
+				{ addPoint }
+				<InfoWindow mapProvider="mapkit" />
+			</MapkitProvider>
+		);
+	}
+);
 
 const MapkitHelpers = memo(
 	( {
-		address,
-		mapCenter,
-		mapStyle,
-		zoom,
-		onSetMapCenter,
-		onSetZoom,
-		onSetPoints,
-		points,
-		markerColor,
-		onMarkerClick,
-		onMapLoaded,
+		address = null,
+		mapCenter = {},
+		mapStyle = 'default',
+		zoom = 13,
+		onSetMapCenter = () => {},
+		onSetZoom = () => {},
+		onSetPoints = () => {},
+		points = [],
+		markerColor = 'red',
+		onMarkerClick = () => {},
+		onMapLoaded = () => {},
 	} ) => {
 		const { map, mapkit, setActiveMarker, setPreviousCenter, setCalloutReference, currentDoc } =
 			useMapkit();
@@ -113,19 +147,5 @@ const MapkitHelpers = memo(
 		return null;
 	}
 );
-
-MapkitComponent.defaultProps = {
-	points: [],
-	mapStyle: 'default',
-	zoom: 13,
-	onSetZoom: () => {},
-	onSetMapCenter: () => {},
-	onMapLoaded: () => {},
-	onMarkerClick: () => {},
-	onError: () => {},
-	markerColor: 'red',
-	mapCenter: {},
-	address: null,
-};
 
 export default MapkitComponent;


### PR DESCRIPTION
Partial fix to https://github.com/Automattic/jetpack/issues/38271

## Proposed changes:

* This PR converts the defaultProps within the MapkitComponent to be default parameters passed in to the component, to prevent issues related to the deprecation of defaultProps in React 19.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/issues/38271

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Test that the Map block continues to work as expected - add the Map block on a post or page, check the editor and front-end, check there are no console errors.


