### PR TITLE
WP Super cache: make sure the debug log viewer isn't deleted by garbage collection

### DIFF
--- a/projects/plugins/super-cache/changelog/super-cache-fix-log-view-deleted
+++ b/projects/plugins/super-cache/changelog/super-cache-fix-log-view-deleted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WPSC: Don't delete the log viewer when doing garbage collection

--- a/projects/plugins/super-cache/wp-cache-phase2.php
+++ b/projects/plugins/super-cache/wp-cache-phase2.php
@@ -2775,7 +2775,7 @@ function wp_cache_rebuild_or_delete( $file ) {
 }
 
 function wp_cache_phase2_clean_expired( $file_prefix, $force = false ) {
-	global $cache_path, $cache_max_time, $blog_cache_dir, $wp_cache_preload_on;
+	global $cache_path, $cache_max_time, $blog_cache_dir, $wp_cache_preload_on, $wp_cache_debug_log;
 
 	if ( $cache_max_time == 0 ) {
 		wp_cache_debug( 'wp_cache_phase2_clean_expired: disabled because GC disabled.', 2 );
@@ -2786,6 +2786,14 @@ function wp_cache_phase2_clean_expired( $file_prefix, $force = false ) {
 	if ( ! wp_cache_writers_entry() ) {
 		return false;
 	}
+
+	// make sure we have a debug log viewer
+	if ( empty( $wp_cache_debug_log ) ) {
+		wpsc_create_debug_log();
+	} else {
+		touch( $cache_path . 'view_' . $wp_cache_debug_log ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_touch
+	}
+
 	$now = time();
 	wp_cache_debug( "Cleaning expired cache files in $blog_cache_dir", 2 );
 	$deleted = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
The debug log viewer may be deleted by garbage collection if the file is older than the garbage collection TTL. The only way to fix it is by deleting the log from the Debug log page.
This PR recreates the viewer if missing, or touches it so it's modification time is updated when garbage collection is run, so it's always seen as a new file.

Fixes #32626

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In wp_cache_phase2_clean_expired() recreate or touch the log viewer php script so it's always new and won't be deleted by garbage collection.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Set your garbage collection timeout to 90 seconds, and GC timer to 60 seconds.
* Enable debugging on the Debug page and load the debug viewer.
* Wait a few minutes.
* Try to reload the debug viewer page. Make sure that garbage collection has run more than 90 seconds after debugging was enabled. Look for "Cache garbage collection." in the logs.
