### PR TITLE
MU WPCOM: Port block-inserter-modifications feature from ETK

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/etk-block-inserter-modifications
+++ b/projects/packages/jetpack-mu-wpcom/changelog/etk-block-inserter-modifications
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Port block-inserter-modifications from ETK

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -132,6 +132,7 @@ class Jetpack_Mu_Wpcom {
 	 * Can be moved back to load_features() once the feature no longer exists in the ETK plugin.
 	 */
 	public static function load_etk_features() {
+		require_once __DIR__ . '/features/block-inserter-modifications/block-inserter-modifications.php';
 		require_once __DIR__ . '/features/hide-homepage-title/hide-homepage-title.php';
 		require_once __DIR__ . '/features/jetpack-global-styles/class-global-styles.php';
 		require_once __DIR__ . '/features/override-preview-button-url/override-preview-button-url.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/README.md
@@ -1,0 +1,5 @@
+# Block Inserter Modifications
+
+## Contextual Tips
+
+- [contextual-tips](./contextual-tips.js) add Tips to the searcher box when the term matches with some of the keywords defined by the component.

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/block-inserter-modifications.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/block-inserter-modifications.php
@@ -13,26 +13,26 @@ define( 'MU_WPCOM_BLOCK_INSERTER_MODIFICATIONS', true );
  * Enqueue script for the Block Inserter modifications.
  */
 function wpcom_enqueue_block_inserter_modifications_assets() {
-	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/block-inserter-modications/block-inserter-modications.asset.php';
+	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/block-inserter-modifications/block-inserter-modifications.asset.php';
 
 	wp_enqueue_script(
-		'block-inserter-modications-script',
-		plugins_url( 'build/block-inserter-modications/block-inserter-modications.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+		'block-inserter-modifications-script',
+		plugins_url( 'build/block-inserter-modifications/block-inserter-modifications.js', Jetpack_Mu_Wpcom::BASE_FILE ),
 		$asset_file['dependencies'] ?? array(),
-		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/block-inserter-modications/block-inserter-modications.js' ),
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/block-inserter-modifications/block-inserter-modifications.js' ),
 		true
 	);
 
-	wp_set_script_translations( 'block-inserter-modications-script', 'jetpack-mu-wpcom' );
+	wp_set_script_translations( 'block-inserter-modifications-script', 'jetpack-mu-wpcom' );
 
-	$style_name = 'block-inserter-modications';
+	$style_name = 'block-inserter-modifications';
 	$style_file = is_rtl() ? $style_name . '.rtl.css' : $style_name . '.css';
 
 	wp_enqueue_style(
-		'block-inserter-modications-styles',
-		plugins_url( 'build/block-inserter-modications/' . $style_file, Jetpack_Mu_Wpcom::BASE_FILE ),
+		'block-inserter-modifications-styles',
+		plugins_url( 'build/block-inserter-modifications/' . $style_file, Jetpack_Mu_Wpcom::BASE_FILE ),
 		array(),
-		filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-documentation-links/' . $style_file . '.css' )
+		filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/block-inserter-modifications/' . $style_file )
 	);
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/block-inserter-modifications.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/block-inserter-modifications.php
@@ -20,7 +20,7 @@ function wpcom_enqueue_block_inserter_modifications_assets() {
 		plugins_url( 'build/block-inserter-modications/block-inserter-modications.js', Jetpack_Mu_Wpcom::BASE_FILE ),
 		$asset_file['dependencies'] ?? array(),
 		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/block-inserter-modications/block-inserter-modications.js' ),
-		true,
+		true
 	);
 
 	wp_set_script_translations( 'block-inserter-modications-script', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/block-inserter-modifications.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/block-inserter-modifications.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * WPCOM Block Inserter Modifications
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+define( 'MU_WPCOM_BLOCK_INSERTER_MODIFICATIONS', true );
+
+/**
+ * Enqueue script for the Block Inserter modifications.
+ */
+function wpcom_enqueue_block_inserter_modifications_assets() {
+	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/block-inserter-modications/block-inserter-modications.asset.php';
+
+	wp_enqueue_script(
+		'block-inserter-modications-script',
+		plugins_url( 'build/block-inserter-modications/block-inserter-modications.js', Jetpack_Mu_Wpcom::BASE_FILE ),
+		$asset_file['dependencies'] ?? array(),
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/block-inserter-modications/block-inserter-modications.js' ),
+		true,
+	);
+
+	wp_set_script_translations( 'block-inserter-modications-script', 'jetpack-mu-wpcom' );
+
+	$style_name = 'block-inserter-modications';
+	$style_file = is_rtl() ? $style_name . '.rtl.css' : $style_name . '.css';
+
+	wp_enqueue_style(
+		'block-inserter-modications-styles',
+		plugins_url( 'build/block-inserter-modications/' . $style_file, Jetpack_Mu_Wpcom::BASE_FILE ),
+		array(),
+		filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-documentation-links/' . $style_file . '.css' )
+	);
+}
+
+add_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_block_inserter_modifications_assets', 0 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/index.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
 import { __unstableInserterMenuExtension as InserterMenuExtension } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/index.js
@@ -1,0 +1,38 @@
+import { __unstableInserterMenuExtension as InserterMenuExtension } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
+import { registerPlugin } from '@wordpress/plugins';
+import { debounce } from 'lodash';
+import ContextualTip from './src/contextual-tip';
+
+import './src/style.scss';
+
+const ContextualTips = function () {
+	const [ debouncedFilterValue, setFilterValue ] = useState( '' );
+
+	const debouncedSetFilterValue = debounce( setFilterValue, 400 );
+
+	return (
+		<InserterMenuExtension>
+			{ ( { filterValue, hasItems } ) => {
+				if ( hasItems || ! filterValue ) {
+					return null;
+				}
+
+				if ( debouncedFilterValue !== filterValue ) {
+					debouncedSetFilterValue( filterValue );
+				}
+
+				return <ContextualTip searchTerm={ filterValue } />;
+			} }
+		</InserterMenuExtension>
+	);
+};
+
+// Check if the experimental slot is available before to register plugin.
+if ( typeof InserterMenuExtension !== 'undefined' ) {
+	registerPlugin( 'block-inserter-contextual-tips', {
+		render() {
+			return <ContextualTips />;
+		},
+	} );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/contextual-tip.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/contextual-tip.js
@@ -5,11 +5,12 @@ import { get, filter, deburr, lowerCase, includes } from 'lodash';
 import tipsList from './list';
 
 /**
+ * Create the contextual tip.
  *
- * @param root0
- * @param root0.searchTerm
- * @param root0.random
- * @param root0.canUserCreate
+ * @param {object} props                 - The function props.
+ * @param {string} props.searchTerm      - Search term text.
+ * @param {boolean} props.random         - Whether to choose a random tooltip on multiple matches.
+ * @param {Function} props.canUserCreate - Function to check user permission.
  */
 function ContextualTip( { searchTerm, random = false, canUserCreate } ) {
 	if ( ! searchTerm ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/contextual-tip.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/contextual-tip.js
@@ -1,0 +1,52 @@
+import { Tip } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+import { get, filter, deburr, lowerCase, includes } from 'lodash';
+import tipsList from './list';
+
+/**
+ *
+ * @param root0
+ * @param root0.searchTerm
+ * @param root0.random
+ * @param root0.canUserCreate
+ */
+function ContextualTip( { searchTerm, random = false, canUserCreate } ) {
+	if ( ! searchTerm ) {
+		return null;
+	}
+
+	if ( ! tipsList.length ) {
+		return null;
+	}
+
+	const normalizedSearchTerm = deburr( lowerCase( searchTerm ) ).replace( /^\//, '' );
+
+	const foundTips = filter(
+		tipsList,
+		( { keywords, permission } ) =>
+			canUserCreate( permission ) &&
+			filter( [ ...new Set( keywords ) ], keyword => includes( normalizedSearchTerm, keyword ) )
+				.length
+	);
+
+	if ( ! foundTips.length ) {
+		return null;
+	}
+
+	const index = random ? Math.floor( Math.random() * foundTips.length ) : 0;
+
+	return (
+		<div className="contextual-tip">
+			<Tip>{ get( foundTips, [ index, 'description' ] ) }</Tip>
+		</div>
+	);
+}
+
+export default compose(
+	withSelect( select => {
+		return {
+			canUserCreate: type => select( 'core' ).canUser( 'create', type ),
+		};
+	} )
+)( ContextualTip );

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/list.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/list.js
@@ -1,0 +1,108 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import TipLink from './tip-link';
+
+/**
+ *
+ * @param text
+ * @param conversion
+ * @param textFallback
+ */
+function getTipDescription( text, conversion, textFallback ) {
+	if ( typeof createInterpolateElement !== 'undefined' ) {
+		return createInterpolateElement( text, conversion );
+	}
+
+	return textFallback;
+}
+
+const tips = [
+	{
+		context: 'theme',
+		keywords: [ 'theme', __( 'theme', 'jetpack-mu-wpcom' ) ],
+		description: getTipDescription(
+			__(
+				'You can visit the <a>theme directory</a> to select a different design for your site.',
+				'jetpack-mu-wpcom'
+			),
+			{
+				a: <TipLink section="themes" />,
+			},
+			__(
+				'You can visit the theme directory to select a different design for your site.',
+				'jetpack-mu-wpcom'
+			)
+		),
+		permission: 'settings',
+	},
+	{
+		context: 'css',
+		keywords: [
+			'css',
+			__( 'css', 'jetpack-mu-wpcom' ),
+			'style',
+			__( 'style', 'jetpack-mu-wpcom' ),
+		],
+		description: getTipDescription(
+			__(
+				'You can visit the the <a>Customizer</a> to edit the CSS on your site.',
+				'jetpack-mu-wpcom'
+			),
+			{
+				a: <TipLink section="customizer" subsection="custom_css" />,
+			},
+			__( 'You can visit the the Customizer to edit the CSS on your site.', 'jetpack-mu-wpcom' )
+		),
+		permission: 'settings',
+	},
+	{
+		context: 'plugin',
+		keywords: [ 'plugin', __( 'plugin', 'jetpack-mu-wpcom' ) ],
+		description: getTipDescription(
+			__(
+				'You can visit the <a>plugin directory</a> to get started with installing new plugins.',
+				'jetpack-mu-wpcom'
+			),
+			{
+				a: <TipLink section="plugins" />,
+			},
+			__(
+				'You can visit the plugin directory to get started with installing new plugins.',
+				'jetpack-mu-wpcom'
+			)
+		),
+		permission: 'settings',
+	},
+	{
+		context: 'header',
+		keywords: [ 'header', __( 'header', 'jetpack-mu-wpcom' ) ],
+		description: getTipDescription(
+			__(
+				'You can visit the the <a>Customizer</a> to edit your logo and site title.',
+				'jetpack-mu-wpcom'
+			),
+			{
+				a: <TipLink section="customizer" subsection="title_tagline" />,
+			},
+			__( 'You can visit the the Customizer to edit your logo and site title.', 'jetpack-mu-wpcom' )
+		),
+		permission: 'settings',
+	},
+	{
+		context: 'color',
+		keywords: [ 'color', __( 'color', 'jetpack-mu-wpcom' ) ],
+		description: getTipDescription(
+			__(
+				'You can visit the the <a>Customizer</a> to edit the colors on your site.',
+				'jetpack-mu-wpcom'
+			),
+			{
+				a: <TipLink section="customizer" subsection="colors" />,
+			},
+			__( 'You can visit the the Customizer to edit the colors on your site.', 'jetpack-mu-wpcom' )
+		),
+		permission: 'settings',
+	},
+];
+
+export default tips;

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/list.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/list.js
@@ -3,10 +3,11 @@ import { __ } from '@wordpress/i18n';
 import TipLink from './tip-link';
 
 /**
+ * Creates the tip content as an React element or text.
  *
- * @param text
- * @param conversion
- * @param textFallback
+ * @param text         - The tip description text string.
+ * @param conversion   - The map used to convert the string to an element.
+ * @param textFallback - The fallback text for the tip description.
  */
 function getTipDescription( text, conversion, textFallback ) {
 	if ( typeof createInterpolateElement !== 'undefined' ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/list.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/list.js
@@ -37,26 +37,6 @@ const tips = [
 		permission: 'settings',
 	},
 	{
-		context: 'css',
-		keywords: [
-			'css',
-			__( 'css', 'jetpack-mu-wpcom' ),
-			'style',
-			__( 'style', 'jetpack-mu-wpcom' ),
-		],
-		description: getTipDescription(
-			__(
-				'You can visit the the <a>Customizer</a> to edit the CSS on your site.',
-				'jetpack-mu-wpcom'
-			),
-			{
-				a: <TipLink section="customizer" subsection="custom_css" />,
-			},
-			__( 'You can visit the the Customizer to edit the CSS on your site.', 'jetpack-mu-wpcom' )
-		),
-		permission: 'settings',
-	},
-	{
 		context: 'plugin',
 		keywords: [ 'plugin', __( 'plugin', 'jetpack-mu-wpcom' ) ],
 		description: getTipDescription(
@@ -71,36 +51,6 @@ const tips = [
 				'You can visit the plugin directory to get started with installing new plugins.',
 				'jetpack-mu-wpcom'
 			)
-		),
-		permission: 'settings',
-	},
-	{
-		context: 'header',
-		keywords: [ 'header', __( 'header', 'jetpack-mu-wpcom' ) ],
-		description: getTipDescription(
-			__(
-				'You can visit the the <a>Customizer</a> to edit your logo and site title.',
-				'jetpack-mu-wpcom'
-			),
-			{
-				a: <TipLink section="customizer" subsection="title_tagline" />,
-			},
-			__( 'You can visit the the Customizer to edit your logo and site title.', 'jetpack-mu-wpcom' )
-		),
-		permission: 'settings',
-	},
-	{
-		context: 'color',
-		keywords: [ 'color', __( 'color', 'jetpack-mu-wpcom' ) ],
-		description: getTipDescription(
-			__(
-				'You can visit the the <a>Customizer</a> to edit the colors on your site.',
-				'jetpack-mu-wpcom'
-			),
-			{
-				a: <TipLink section="customizer" subsection="colors" />,
-			},
-			__( 'You can visit the the Customizer to edit the colors on your site.', 'jetpack-mu-wpcom' )
 		),
 		permission: 'settings',
 	},

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/style.scss
@@ -1,0 +1,3 @@
+.contextual-tip {
+	margin: 16px;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/tip-link.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/tip-link.js
@@ -4,13 +4,14 @@ import { inIframe, isSimpleSite } from './utils';
 const isEditorIFramed = inIframe();
 
 /**
+ * Create the link for the contextual tip.
  *
- * @param root0
- * @param root0.section
- * @param root0.children
- * @param root0.subsection
+ * @param {object} props            - The function props.
+ * @param {string} props.children   - The tip content.
+ * @param {string} props.section    - The tip context section.
+ * @param {string} props.subsection - The tip context subsection.
  */
-export default function ( { section, children, subsection } ) {
+export default function ( { children, section, subsection } ) {
 	const { hostname } = window.location;
 	const editorSelector = select( 'core/editor' );
 	const postId = editorSelector.getCurrentPostId();

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/tip-link.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/tip-link.js
@@ -1,0 +1,52 @@
+import { select } from '@wordpress/data';
+import { inIframe, isSimpleSite } from './utils';
+
+const isEditorIFramed = inIframe();
+
+/**
+ *
+ * @param root0
+ * @param root0.section
+ * @param root0.children
+ * @param root0.subsection
+ */
+export default function ( { section, children, subsection } ) {
+	const { hostname } = window.location;
+	const editorSelector = select( 'core/editor' );
+	const postId = editorSelector.getCurrentPostId();
+	const postType = editorSelector.getCurrentPostType();
+	const returnLink =
+		isEditorIFramed && ! isSimpleSite
+			? '&' +
+			  encodeURIComponent( `return=https://wordpress.com/${ postType }/${ hostname }/${ postId }` )
+			: '';
+	const autofocus = `autofocus[section]=${ subsection }`;
+
+	let href = '#';
+
+	switch ( section ) {
+		case 'themes':
+			href = isEditorIFramed ? `https://wordpress.com/themes/${ hostname }` : './themes.php';
+			break;
+
+		case 'plugins':
+			href =
+				isEditorIFramed || isSimpleSite
+					? `https://wordpress.com/plugins/${ hostname }`
+					: './plugin-install.php';
+			break;
+
+		case 'customizer':
+			href =
+				isEditorIFramed && isSimpleSite
+					? `https://wordpress.com/customize/${ hostname }?${ autofocus }`
+					: `./customize.php?${ autofocus }${ returnLink }`;
+			break;
+	}
+
+	return (
+		<a href={ href } target="_blank" rel="noreferrer noopener">
+			{ children }
+		</a>
+	);
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/tip-link.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/tip-link.js
@@ -1,4 +1,3 @@
-import { select } from '@wordpress/data';
 import { inIframe, isSimpleSite } from './utils';
 
 const isEditorIFramed = inIframe();
@@ -9,20 +8,9 @@ const isEditorIFramed = inIframe();
  * @param {object} props            - The function props.
  * @param {string} props.children   - The tip content.
  * @param {string} props.section    - The tip context section.
- * @param {string} props.subsection - The tip context subsection.
  */
-export default function ( { children, section, subsection } ) {
+export default function ( { children, section } ) {
 	const { hostname } = window.location;
-	const editorSelector = select( 'core/editor' );
-	const postId = editorSelector.getCurrentPostId();
-	const postType = editorSelector.getCurrentPostType();
-	const returnLink =
-		isEditorIFramed && ! isSimpleSite
-			? '&' +
-			  encodeURIComponent( `return=https://wordpress.com/${ postType }/${ hostname }/${ postId }` )
-			: '';
-	const autofocus = `autofocus[section]=${ subsection }`;
-
 	let href = '#';
 
 	switch ( section ) {
@@ -35,13 +23,6 @@ export default function ( { children, section, subsection } ) {
 				isEditorIFramed || isSimpleSite
 					? `https://wordpress.com/plugins/${ hostname }`
 					: './plugin-install.php';
-			break;
-
-		case 'customizer':
-			href =
-				isEditorIFramed && isSimpleSite
-					? `https://wordpress.com/customize/${ hostname }?${ autofocus }`
-					: `./customize.php?${ autofocus }${ returnLink }`;
 			break;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/utils.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-inserter-modifications/src/utils.js
@@ -1,0 +1,17 @@
+/**
+ * Detect if the editor is already iFramed.
+ * @returns {boolean} `True` is the editor is iFramed. Otherwise, `False`.
+ */
+export const inIframe = () => {
+	try {
+		return window.self !== window.top;
+	} catch ( e ) {
+		return true;
+	}
+};
+
+export const isSimpleSite = !! (
+	window &&
+	window._currentSiteType &&
+	window._currentSiteType === 'simple'
+);

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = [
 	...verbumConfig,
 	{
 		entry: {
+			'block-inserter-modifications': './src/features/block-inserter-modifications/index.js',
 			'block-theme-previews': './src/features/block-theme-previews/index.js',
 			'core-customizer-css':
 				'./src/features/custom-css/custom-css/js/core-customizer-css.core-4.9.js',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/8037.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR ports the block-inserter-modifications feature from ETK. This feature adds contextual tips to the editor's block inserter and currently supports the following keywords:
 
![Screenshot 2024-07-11 at 9 28 38 AM](https://github.com/Automattic/jetpack/assets/797888/d8c63421-9e75-45fb-99eb-3b83bf128f1a)

![Screenshot 2024-07-11 at 9 29 01 AM](https://github.com/Automattic/jetpack/assets/797888/ff1d0e23-ad70-415f-b7b4-260484525c72)

>[!NOTE]
> I removed the keywords below since it seems outdated that we send users to the Customizer from the Editor.

![Screenshot 2024-07-11 at 9 28 52 AM](https://github.com/Automattic/jetpack/assets/797888/d804a1db-0e9e-4854-93b1-fee28cc5ff2c)


![Screenshot 2024-07-11 at 9 29 22 AM](https://github.com/Automattic/jetpack/assets/797888/1c3ccd05-4431-4350-bbd0-32e4113c08b9)

![Screenshot 2024-07-11 at 9 29 32 AM](https://github.com/Automattic/jetpack/assets/797888/4d053485-01ff-4dee-b9ec-c3c634d15483)


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR as instructed in https://github.com/Automattic/jetpack/pull/38277#issuecomment-2220142413.
* Head to the Site Editor.
* Open the block inserter.
* Enter any of the keywords above and ensure you see the contextual tip.
