### PR TITLE
MU WPCOM: Port the a8c-posts-list block from ETK

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-a8c-posts-list
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-a8c-posts-list
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Port the a8c-posts-list block from ETK

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -140,6 +140,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';
 		require_once __DIR__ . '/features/tags-education/tags-education.php';
 		require_once __DIR__ . '/features/wpcom-block-description-links/wpcom-block-description-links.php';
+		require_once __DIR__ . '/features/wpcom-blocks/a8c-posts-list/a8c-posts-list.php';
 		require_once __DIR__ . '/features/wpcom-documentation-links/wpcom-documentation-links.php';
 		require_once __DIR__ . '/features/wpcom-whats-new/wpcom-whats-new.php';
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/a8c-posts-list.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/a8c-posts-list.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Posts list block file.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\A8C_Posts_List;
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+define( 'MU_WPCOM_POSTS_LIST_BLOCK', true );
+
+require_once __DIR__ . '/utils.php';
+
+/**
+ * Excerpt more string.
+ *
+ * @return string More string.
+ */
+function custom_excerpt_read_more() {
+	return sprintf(
+		'&hellip; <a href="%1$s" title="%2$s" class="a8c-posts-list-item__read-more">%3$s</a>',
+		esc_url( get_the_permalink() ),
+		sprintf(
+			/* translators: %s: Name of current post */
+			esc_attr__( 'Continue reading %s', 'jetpack-mu-wpcom' ),
+			the_title_attribute( array( 'echo' => false ) )
+		),
+		esc_html__( 'Read more', 'jetpack-mu-wpcom' )
+	);
+}
+
+/**
+ * Renders posts list.
+ *
+ * @param array  $attributes Block attributes.
+ * @param string $content    Block content.
+ * @return string
+ */
+function render_a8c_post_list_block( $attributes, $content ) {
+	static $rendering_block = false;
+
+	$posts_list = new \WP_Query(
+		array(
+			'post_type'        => 'post',
+			'posts_per_page'   => $attributes['postsPerPage'],
+			'post_status'      => 'publish',
+			'suppress_filters' => false,
+		)
+	);
+
+	add_filter( 'excerpt_more', __NAMESPACE__ . '\custom_excerpt_read_more' );
+
+	// Prevent situations when the block attempts rendering another a8c/posts-list block.
+	if ( true !== $rendering_block ) {
+		$rendering_block = true;
+
+		$content = render_template(
+			'posts-list',
+			array(
+				'posts_list' => $posts_list,
+			)
+		);
+
+		$rendering_block = false;
+	}
+
+	remove_filter( 'excerpt_more', __NAMESPACE__ . '\custom_excerpt_read_more' );
+
+	// Reset the custom query.
+	wp_reset_postdata();
+
+	return $content;
+}
+
+/**
+ * Register block.
+ */
+function register_blocks() {
+	register_block_type(
+		'a8c/posts-list',
+		array(
+			'attributes'      => array(
+				'postsPerPage' => array(
+					'type'    => 'number',
+					'default' => 10,
+				),
+			),
+			'render_callback' => __NAMESPACE__ . '\render_a8c_post_list_block',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_blocks', 100 );
+
+/**
+ * Enqueue block styles.
+ */
+function enqueue_styles() {
+	if ( ! has_block( 'a8c/posts-list' ) ) {
+		return;
+	}
+
+	$ext      = is_rtl()
+		? 'rtl.css'
+		: 'css';
+	$css_file = "build/a8c-posts-list/a8c-posts-list.$ext";
+	wp_enqueue_style(
+		'posts-list-block-style',
+		plugins_url( $css_file, Jetpack_Mu_Wpcom::BASE_FILE ),
+		array(),
+		filemtime( Jetpack_Mu_Wpcom::BASE_DIR . $css_file )
+	);
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_scripts', 100 );
+
+/**
+ * Enqueue block scripts.
+ */
+function enqueue_scripts() {
+	if ( ! has_block( 'a8c/posts-list' ) ) {
+		return;
+	}
+
+	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/a8c-posts-list/a8c-posts-list.asset.php';
+	$js_file    = 'build/a8c-posts-list/a8c-posts-list.js';
+	wp_enqueue_script(
+		'a8c-posts-list-script',
+		plugins_url( $js_file, Jetpack_Mu_Wpcom::BASE_FILE ),
+		$asset_file['dependencies'] ?? array(),
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . $js_file ),
+		true
+	);
+
+	wp_set_script_translations( 'a8c-posts-list-script', 'jetpack-mu-wpcom' );
+}
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\enqueue_styles', 100 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/editor.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/editor.scss
@@ -1,0 +1,19 @@
+div.a8c-posts-list__notice {
+	margin: 0 0 5px;
+
+	.components-notice__content {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.components-notice__action {
+		flex-shrink: 0;
+	}
+}
+
+.a8c-posts-list__placeholder {
+	.components-placeholder__fieldset:empty {
+		display: none;
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/index.js
@@ -1,0 +1,108 @@
+import { InspectorControls } from '@wordpress/block-editor';
+import {
+	registerBlockType,
+	switchToBlockType,
+	getPossibleBlockTransformations,
+} from '@wordpress/blocks';
+import { Placeholder, RangeControl, PanelBody, Notice } from '@wordpress/components';
+import { select, dispatch } from '@wordpress/data';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { transforms, isValidHomepagePostsBlockType } from './transforms';
+
+import './editor.scss';
+import './style.scss';
+
+const icon = (
+	<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<path opacity=".87" fill="none" d="M0 0h24v24H0V0z" />
+		<path d="M3 5v14h17V5H3zm4 2v2H5V7h2zm-2 6v-2h2v2H5zm0 2h2v2H5v-2zm13 2H9v-2h9v2zm0-4H9v-2h9v2zm0-4H9V7h9v2z" />
+	</svg>
+);
+
+registerBlockType( 'a8c/posts-list', {
+	title: __( 'Blog Posts Listing', 'jetpack-mu-wpcom' ),
+	description: __( 'Displays your latest Blog Posts.', 'jetpack-mu-wpcom' ),
+	keywords: [ 'posts' ],
+	icon,
+	category: 'layout',
+	supports: {
+		html: false,
+		multiple: false,
+		reusable: false,
+		inserter: false,
+	},
+	attributes: {
+		postsPerPage: {
+			type: 'number',
+			default: 10,
+		},
+	},
+	edit: ( { attributes, setAttributes, clientId, isSelected } ) => {
+		const block = select( 'core/block-editor' ).getBlock( clientId );
+
+		// Find if any of possible transformations is into the Homepage Posts block.
+		const possibleTransforms = getPossibleBlockTransformations( [ block ] );
+		const homepagePostsTransform = possibleTransforms.find(
+			transform => transform && isValidHomepagePostsBlockType( transform.name )
+		);
+		const canBeUpgraded = !! homepagePostsTransform;
+
+		const upgradeBlock = () => {
+			dispatch( 'core/block-editor' ).replaceBlocks(
+				block.clientId,
+				switchToBlockType( block, homepagePostsTransform.name )
+			);
+		};
+
+		return (
+			<Fragment>
+				{ canBeUpgraded && (
+					<Notice
+						actions={ [
+							{
+								label: __( 'Update Block', 'jetpack-mu-wpcom' ),
+								onClick: upgradeBlock,
+							},
+						] }
+						className="a8c-posts-list__notice"
+						isDismissible={ false }
+					>
+						{ __(
+							'An improved version of this block is available. Update for a better, more natural way to manage your blog post listings. There may be small visual changes.',
+							'jetpack-mu-wpcom'
+						) }
+					</Notice>
+				) }
+				<Placeholder
+					className="a8c-posts-list__placeholder"
+					icon={ icon }
+					label={ __( 'Your recent blog posts will be displayed here.', 'jetpack-mu-wpcom' ) }
+				>
+					{ isSelected ? (
+						<RangeControl
+							label={ __( 'Number of posts to show', 'jetpack-mu-wpcom' ) }
+							value={ attributes.postsPerPage }
+							onChange={ val => setAttributes( { postsPerPage: val } ) }
+							min={ 1 }
+							max={ 50 }
+						/>
+					) : null }
+				</Placeholder>
+				<InspectorControls>
+					<PanelBody>
+						<RangeControl
+							label={ __( 'Number of posts', 'jetpack-mu-wpcom' ) }
+							value={ attributes.postsPerPage }
+							onChange={ val => setAttributes( { postsPerPage: val } ) }
+							min={ 1 }
+							max={ 50 }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	},
+	save: () => null,
+	transforms,
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/style.scss
@@ -1,0 +1,9 @@
+.a8c-posts-list__listing {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.a8c-posts-list__item {
+	display: block;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/transforms.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/transforms.js
@@ -1,0 +1,27 @@
+import { createBlock } from '@wordpress/blocks';
+
+const HOMEPAGE_POSTS_BLOCK_TYPES = [ 'a8c/blog-posts', 'newspack-blocks/homepage-articles' ];
+
+const getTransformFunction =
+	type =>
+	( { postsPerPage } ) => {
+		// Configure the Newspack block to look as close as possible
+		// to the output of this one.
+		return createBlock( type, {
+			postsToShow: postsPerPage,
+			showAvatar: false,
+			displayPostDate: true,
+			displayPostContent: true,
+		} );
+	};
+
+export const isValidHomepagePostsBlockType = type =>
+	HOMEPAGE_POSTS_BLOCK_TYPES.indexOf( type ) > -1;
+
+export const transforms = {
+	to: HOMEPAGE_POSTS_BLOCK_TYPES.map( type => ( {
+		type: 'block',
+		blocks: [ type ],
+		transform: getTransformFunction( type ),
+	} ) ),
+};

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/templates/no-posts.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/templates/no-posts.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Template for displaying a message that posts cannot be found.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ */
+
+?>
+
+<p><?php esc_html_e( 'There are currently no posts to display.', 'jetpack-mu-wpcom' ); ?></p>
+<?php
+if ( current_user_can( 'publish_posts' ) ) :
+	printf(
+		'<p>' . wp_kses(
+			/* translators: 1: link to WP admin new post page. */
+			__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'jetpack-mu-wpcom' ),
+			array(
+				'a' => array(
+					'href' => array(),
+				),
+			)
+		) . '</p>',
+		esc_url( admin_url( 'post-new.php' ) )
+	);
+endif;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/templates/post-item.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/templates/post-item.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Post Item.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ *
+ * phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
+ */
+
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<?php if ( has_post_thumbnail() ) : ?>
+	<figure class="a8c-posts-list-item__post-thumbnail">
+		<a href="<?php the_permalink(); ?>">
+			<?php the_post_thumbnail( 'post-thumbnail' ); ?>
+		</a>
+	</figure>
+	<?php endif; // has_post_thumbnail. ?>
+
+	<?php if ( is_sticky() ) : ?>
+	<div class="a8c-posts-list-item__featured">
+		<span><?php esc_html_e( 'Featured', 'jetpack-mu-wpcom' ); ?></span>
+	</div>
+	<?php endif; // is_sticky. ?>
+
+	<?php the_title( sprintf( '<h2 class="a8c-posts-list-item__title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' ); ?>
+
+	<div class="a8c-posts-list-item__meta">
+		<span class="a8c-posts-list-item__datetime"><?php echo esc_html( get_the_time( get_option( 'date_format' ) ) ); ?></span>
+		<span class="a8c-posts-list-item__author"><?php echo esc_html_x( 'by', 'designating the post author (eg: by John Doe', 'jetpack-mu-wpcom' ); ?>
+			<?php the_author_posts_link(); ?>
+		</span>
+		<?php if ( current_user_can( 'edit_posts' ) ) : ?>	
+			<span class="a8c-posts-list-item__edit-link">
+				<a href="<?php echo esc_attr( get_edit_post_link() ); ?>"><?php esc_html_e( 'Edit', 'jetpack-mu-wpcom' ); ?></a>
+			</span>
+		<?php endif ?>
+	</div>
+
+	<div class="a8c-posts-list-item__excerpt">
+		<?php the_excerpt(); ?>
+	</div>
+</article>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/templates/posts-list.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/templates/posts-list.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Posts List
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Posts list.
+ *
+ * @global \WP_Query $posts_list
+ */
+global $posts_list;
+
+if ( $posts_list instanceof WP_Query && $posts_list->have_posts() ) :
+	?>
+	<div class="a8c-posts-list">
+		<ul class="a8c-posts-list__listing">
+			<?php
+			while ( $posts_list->have_posts() ) :
+				$posts_list->the_post();
+				?>
+				<li class="a8c-posts-list__item">
+					<?php require __DIR__ . '/post-item.php'; ?>
+				</li>
+			<?php endwhile; ?>
+		</ul>
+
+		<a href="<?php echo esc_url( get_post_type_archive_link( 'post' ) ); ?>" class="a8c-posts-list__view-all">
+			<?php esc_html_e( 'View all posts', 'jetpack-mu-wpcom' ); ?>
+		</a>
+	</div>
+	<?php
+else :
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo Automattic\Jetpack\Jetpack_Mu_Wpcom\A8C_Posts_List\render_template( 'no-posts' );
+endif;
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blocks/a8c-posts-list/utils.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Template functions.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\A8C_Posts_List;
+
+/**
+ * OUTPUT BUFFERED LOAD TEMPLATE PART.
+ *
+ * Loads a given template using output buffering.
+ * Optionally including $data to be passed into template.
+ *
+ * @param string $template_name Name of the template to be located.
+ * @param array  $data          Optional. Associative array of data to be passed into the template. Default empty array.
+ * @return string
+ */
+function render_template( $template_name, $data = array() ) {
+	if ( ! strpos( $template_name, '.php' ) ) {
+		$template_name .= '.php';
+	}
+
+	$template_file = __DIR__ . '/templates/' . $template_name;
+
+	if ( ! file_exists( $template_file ) ) {
+		return '';
+	}
+
+	// Optionally provided an assoc array of data to pass to template
+	// and it will be extracted into variables.
+	if ( is_array( $data ) ) {
+		foreach ( $data as $name => $value ) {
+			$GLOBALS[ $name ] = $value;
+		}
+	}
+
+	ob_start();
+	require_once $template_file;
+	$content = ob_get_contents();
+	ob_end_clean();
+
+	return $content;
+}

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = [
 	...verbumConfig,
 	{
 		entry: {
+			'a8c-posts-list': './src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/index.js',
 			'block-inserter-modifications': './src/features/block-inserter-modifications/index.js',
 			'block-theme-previews': './src/features/block-theme-previews/index.js',
 			'core-customizer-css':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/8036, https://github.com/Automattic/dotcom-forge/issues/8032

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Port the `a8c-posts-list` block from ETK. Note that the `a8c-posts-list` block is available only when it's already in the page/post, and we are not allowing people to insert this block from the editor for the new page/post. As a result, this feature is just for the backward compatibility.

| Editor | Editor (Selected) | Frontend |
| - | - | - |
| ![image](https://github.com/Automattic/jetpack/assets/13596067/15b70bc2-e22c-46ab-a40d-a2aa3e461074) | ![image](https://github.com/Automattic/jetpack/assets/13596067/a4f4eeb6-44a9-476a-bd3e-81d2c87e4f40) | ![image](https://github.com/Automattic/jetpack/assets/13596067/f652f308-69f1-4b57-8730-8382fe7a097d) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site
* Go to the editor
* Switch to Code Editor
* Enter the following code
  ```
  <!-- wp:a8c/posts-list /-->
  ```
* Switch back to Visual Editor
* Save changes because the block is registered only when it's saved in the post
* Refresh the page
* Make sure the block is rendered correctly
* Preview your changes
* Make sure the block is rendered correctly on frontend