### PR TITLE
jetpack: Fix undefined array warnings in Donations block

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-currencies.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-currencies.php
@@ -161,7 +161,7 @@ class Jetpack_Currencies {
 		// Fall back to unspecified currency symbol like `¤1,234.05`.
 		// @link https://en.wikipedia.org/wiki/Currency_sign_(typography).
 		if ( ! array_key_exists( $currency, self::CURRENCIES ) ) {
-			return '¤' . number_format_i18n( $price, 2 );
+			return ( $symbol ? '¤' : '' ) . number_format_i18n( $price, 2 );
 		}
 
 		$currency_details = self::CURRENCIES[ $currency ];

--- a/projects/plugins/jetpack/changelog/fix-jetpack-donations-block-missing-array-keys
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-donations-block-missing-array-keys
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Donations Block: Fix undefined array key warnings with old/malformed blocks.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-donations-block-missing-array-keys#2
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-donations-block-missing-array-keys#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack_Currencies: Honor the `$symbol` arg when passed an unknown currency.

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -58,6 +58,7 @@ function render_block( $attr, $content ) {
 	$donations = array(
 		'one-time' => array_merge(
 			array(
+				'planId'     => null,
 				'title'      => __( 'One-Time', 'jetpack' ),
 				'class'      => 'donations__one-time-item',
 				'heading'    => $default_texts['oneTimeDonation']['heading'],
@@ -69,6 +70,7 @@ function render_block( $attr, $content ) {
 	if ( $attr['monthlyDonation']['show'] ) {
 		$donations['1 month'] = array_merge(
 			array(
+				'planId'     => null,
 				'title'      => __( 'Monthly', 'jetpack' ),
 				'class'      => 'donations__monthly-item',
 				'heading'    => $default_texts['monthlyDonation']['heading'],
@@ -80,6 +82,7 @@ function render_block( $attr, $content ) {
 	if ( $attr['annualDonation']['show'] ) {
 		$donations['1 year'] = array_merge(
 			array(
+				'planId'     => null,
 				'title'      => __( 'Yearly', 'jetpack' ),
 				'class'      => 'donations__annual-item',
 				'heading'    => $default_texts['annualDonation']['heading'],
@@ -153,14 +156,14 @@ function render_block( $attr, $content ) {
 			'<p>%s</p>',
 			wp_kses_post( $custom_amount_text )
 		);
-		$default_custom_amount = \Jetpack_Memberships::SUPPORTED_CURRENCIES[ $currency ] * 100;
+		$default_custom_amount = ( \Jetpack_Memberships::SUPPORTED_CURRENCIES[ $currency ] ?? 1 ) * 100;
 		$custom_amount        .= sprintf(
 			'<div class="donations__amount donations__custom-amount">
 				%1$s
 				<div class="donations__amount-value" data-currency="%2$s" data-empty-text="%3$s"></div>
 			</div>',
-			esc_html( \Jetpack_Currencies::CURRENCIES[ $attr['currency'] ]['symbol'] ),
-			esc_attr( $attr['currency'] ),
+			esc_html( \Jetpack_Currencies::CURRENCIES[ $currency ]['symbol'] ?? '¤' ),
+			esc_attr( $currency ),
 			esc_attr( \Jetpack_Currencies::format_price( $default_custom_amount, $currency, false ) )
 		);
 	}

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-currencies.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test-class-jetpack-currencies.php
@@ -53,7 +53,15 @@ class WP_Test_Jetpack_Currencies extends WP_UnitTestCase {
 	 * Test that the unspecified currency symbol is displayed when the currency is not found.
 	 */
 	public function test_format_price_unspecified_currency_symbol() {
-		$formatted_price = Jetpack_Currencies::format_price( '12345.67890', 'TEST', false );
+		$formatted_price = Jetpack_Currencies::format_price( '12345.67890', 'TEST' );
 		$this->assertEquals( '¤12,345.68', $formatted_price );
+	}
+
+	/**
+	 * Test that the unspecified currency symbol is not displayed when the currency is not found but `$symbol` is false.
+	 */
+	public function test_format_price_unspecified_currency_symbol_no_symbol() {
+		$formatted_price = Jetpack_Currencies::format_price( '12345.67890', 'TEST', false );
+		$this->assertEquals( '12,345.68', $formatted_price );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If the donations block sets `oneTimeDonation`, `monthlyDonation`, and/or `annualDonation` without including a `planId` field, ensure the field is set by including the value used in the block.json in the defaults.

If the `currency` attribute is not set or is invalid, and `showCustomAmount` is true, fall back to the generic currency symbol `¤` like `Jetpack_Currencies::format_price()` already does and default to ¤100.

Also, `Jetpack_Currencies::format_price()` should honor its `$symbol` argument when doing that fallback.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1720547616141829/1720546514.458029-slack-C01U2KGS2PQ
p1HpG7-tpT-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect Stripe if necessary. Make sure normal donations blocks work.
* Create a post. Enable the code editor, paste in `<!-- wp:jetpack/donations {"oneTimeDonation":{"show":true,"amounts":[5,15,100]}} /-->` as a block, and save without going back to the visual editor.
* View the post. Check your PHP logs.