### PR TITLE
Enable jetpackedgephpold and jetpackedgenew

### DIFF
--- a/.github/files/jetpack-staging-sites/k6-shared.js
+++ b/.github/files/jetpack-staging-sites/k6-shared.js
@@ -14,18 +14,16 @@ export const sites = [
 		note: 'normal site',
 		blog_id: '215379549',
 	},
-	/* Comment out pending rename. p1720019588866209-slack-C05Q5HSS013
 	{
-		url: 'https://jetpackedgephp74.wpcomstaging.com',
-		note: 'php 7.4',
+		url: 'https://jetpackedgephpold.wpcomstaging.com',
+		note: 'php old',
 		blog_id: '215379848',
 	},
 	{
-		url: 'https://jetpackedgephp82.wpcomstaging.com',
-		note: 'php 8.2',
+		url: 'https://jetpackedgephpnew.wpcomstaging.com',
+		note: 'php new',
 		blog_id: '215380000',
 	},
-	*/
 	{
 		url: 'https://jetpackedgeecomm.wpcomstaging.com',
 		note: 'ecommerce plan',

--- a/.github/files/jetpack-staging-sites/update-jetpack-staging-sites.sh
+++ b/.github/files/jetpack-staging-sites/update-jetpack-staging-sites.sh
@@ -18,6 +18,18 @@ SITES='{
     "ssh_string": "jetpackedge.wordpress.com@sftp.wp.com",
     "blog_id": "215379549"
   },
+  "jetpackedgephpold.wpcomstaging.com": {
+    "url": "https://jetpackedgephpold.wpcomstaging.com/",
+    "note": "php old",
+    "ssh_string": "jetpackedgephpold.wordpress.com@sftp.wp.com",
+    "blog_id": "215379848"
+  },
+  "jetpackedgephpnew.wpcomstaging.com": {
+    "url": "https://jetpackedgephpnew.wpcomstaging.com/",
+    "note": "php new",
+    "ssh_string": "jetpackedgephpnew.wordpress.com@sftp.wp.com",
+    "blog_id": "215380000"
+  },
   "jetpackedgeecomm.wpcomstaging.com": {
     "url": "https://jetpackedgeecomm.wpcomstaging.com/",
     "note": "ecommerce plan",
@@ -43,19 +55,6 @@ SITES='{
     "blog_id": "215380213"
   }
 }'
-# Removed from the above pending a rename. p1720019588866209-slack-C05Q5HSS013
-#  "jetpackedgephp74.wpcomstaging.com": {
-#    "url": "https://jetpackedgephp74.wpcomstaging.com/",
-#    "note": "php 7.4",
-#    "ssh_string": "jetpackedgephp74.wordpress.com@sftp.wp.com",
-#    "blog_id": "215379848"
-#  },
-#  "jetpackedgephp82.wpcomstaging.com": {
-#    "url": "https://jetpackedgephp82.wpcomstaging.com/",
-#    "note": "php 8.2",
-#    "ssh_string": "jetpackedgephp82.wordpress.com@sftp.wp.com",
-#    "blog_id": "215380000"
-#  },
 
 ####################################################
 ## Fetch plugin data from the Jetpack Beta Builder.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Now that the sites have been renamed, re-enable them in the appropriate scripts.

This basically undoes #38176.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1720019588866209-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [x] https://github.com/Automattic/jetpack/actions/runs/9877471571
