### PR TITLE
jetpack-mu-wpcom: Stabilize build

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/bin/download-help-center-languages.js
+++ b/projects/packages/jetpack-mu-wpcom/bin/download-help-center-languages.js
@@ -49,8 +49,10 @@ const path = require( 'path' );
 				dataParsed[ '' ][ 'plural-forms' ] = dataParsed[ '' ].plural_forms;
 				dataParsed[ '' ].lang = dataParsed[ '' ].language;
 
+				const date = new Date( response.headers[ 'last-modified' ] );
+
 				const JED = {
-					'translation-revision-date': new Date().toISOString(),
+					'translation-revision-date': date.toISOString(),
 					generator: 'Jetpack',
 					domain: 'jetpack-mu-wpcom',
 					locale_data: {

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-constant-changes-for-help-center-languages
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-constant-changes-for-help-center-languages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Help Center: Save Last-Modified date in downloaded language files instead of the current date.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
PR #38093 added downloading of translation data into the build for the package, and decided to store the current date in each file meaning that every file changes for every single build. This clutters up the history of the mirror repo, making it hard to see what the actual changes are since every trunk commit has these useless date changes.

We can improve the situation somewhat by saving the HTTP Last-Modified date into the files instead of the current date, so they should only be updated when the translations actually change. We'll still get updates attributed to whichever unrelated trunk commit happened to be the next after a change on the translation server, but at least we won't get it for every single commit.

Even better, IMO, would be if the translations could be downloaded to sites as needed like WordPress does with translations for plugins installed from wporg. But that would probably require a lot more refactoring.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. But have a look at https://github.com/Automattic/jetpack-mu-wpcom-plugin/commits/trunk/vendor/automattic/jetpack-mu-wpcom/src/features/help-center/languages

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Is the build happy?
* Check the dates in the files.