### PR TITLE
MU WPCOM: Port MailerLite Widget

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-mailerlite
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-mailerlite
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Port MailerLite Widget

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -134,6 +134,7 @@ class Jetpack_Mu_Wpcom {
 	public static function load_etk_features() {
 		require_once __DIR__ . '/features/hide-homepage-title/hide-homepage-title.php';
 		require_once __DIR__ . '/features/jetpack-global-styles/class-global-styles.php';
+		require_once __DIR__ . '/features/mailerlite/subscriber-popup.php';
 		require_once __DIR__ . '/features/override-preview-button-url/override-preview-button-url.php';
 		require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';
 		require_once __DIR__ . '/features/tags-education/tags-education.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/mailerlite/subscriber-popup.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/mailerlite/subscriber-popup.js
@@ -1,0 +1,10 @@
+/* global ml,jetpackMailerliteSettings */
+
+( function () {
+	window.ml_account = ml(
+		'accounts',
+		jetpackMailerliteSettings.account,
+		jetpackMailerliteSettings.uuid,
+		'load'
+	);
+} )();

--- a/projects/packages/jetpack-mu-wpcom/src/features/mailerlite/subscriber-popup.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/mailerlite/subscriber-popup.php
@@ -116,16 +116,15 @@ class WPCOM_Widget_Mailerlite extends \WP_Widget {
 			)
 		);
 
-		echo '
-		<p><label for="' . esc_attr( $this->get_field_id( 'account' ) ) . '">';
-		/* translators: link to documentation */
-		printf( wp_kses_post( __( 'Account ID <a href="%s" target="_blank">(instructions)</a>:', 'jetpack-mu-wpcom' ) ), 'https://wordpress.com/support/widgets/mailerlite/' );
-		echo '<input class="widefat" id="' . esc_attr( $this->get_field_id( 'account' ) ) . '" name="' . esc_attr( $this->get_field_name( 'account' ) ) . '" type="text" value="' . esc_attr( $instance['account'] ) . '" />
-		</label></p>
-		<p><label for="' . esc_attr( $this->get_field_id( 'shelf' ) ) . '">' . esc_html__( 'UUID:', 'jetpack-mu-wpcom' );
-		echo '<input class="widefat" id="' . esc_attr( $this->get_field_id( 'uuid' ) ) . '" name="' . esc_attr( $this->get_field_name( 'uuid' ) ) . '" type="text" value="' . esc_attr( $instance['uuid'] ) . '" />';
-		echo '</label></p>
-		';
+    $html = '<p><label for="' . esc_attr( $this->get_field_id( 'account' ) ) . '">';
+    $html .= sprintf( wp_kses_post( __( 'Account ID <a href="%s" target="_blank">(instructions)</a>:', 'jetpack-mu-wpcom' ) ), 'https://wordpress.com/support/widgets/mailerlite/' );
+    $html .= '<input class="widefat" id="' . esc_attr( $this->get_field_id( 'account' ) ) . '" name="' . esc_attr( $this->get_field_name( 'account' ) ) . '" type="text" value="' . esc_attr( $instance['account'] ) . '" />
+    </label></p>
+    <p><label for="' . esc_attr( $this->get_field_id( 'shelf' ) ) . '">' . esc_html__( 'UUID:', 'jetpack-mu-wpcom' );
+    $html .= '<input class="widefat" id="' . esc_attr( $this->get_field_id( 'uuid' ) ) . '" name="' . esc_attr( $this->get_field_name( 'uuid' ) ) . '" type="text" value="' . esc_attr( $instance['uuid'] ) . '" />';
+    $html .= '</label></p>';
+
+		return $html;
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/mailerlite/subscriber-popup.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/mailerlite/subscriber-popup.php
@@ -5,6 +5,11 @@
 
 namespace A8C\FSE\Mailerlite;
 
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+// Turn off the feature on ETK plugin.
+define( 'MU_WPCOM_MAILERLITE_WIDGET', true );
+
 /**
  * Mailerlite widget class
  * Display a subscriber popup for Mailerlite.
@@ -64,11 +69,12 @@ class WPCOM_Widget_Mailerlite extends \WP_Widget {
 		}
 
 		wp_register_script( 'mailerlite-universal', 'https://static.mailerlite.com/js/universal.js', array(), '20200521', true );
+		$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/mailerlite-subscriber-popup/mailerlite-subscriber-popup.asset.php';
 		wp_enqueue_script(
 			'mailerlite-subscriber-popup',
-			plugins_url( 'subscriber-popup.js', __FILE__ ),
+			plugins_url( 'build/mailerlite-subscriber-popup/mailerlite-subscriber-popup.js', Jetpack_Mu_Wpcom::BASE_FILE ),
 			array( 'mailerlite-universal' ),
-			'20200521',
+			$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/mailerlite-subscriber-popup/mailerlite-subscriber-popup.js' ),
 			true
 		);
 		wp_localize_script(

--- a/projects/packages/jetpack-mu-wpcom/src/features/mailerlite/subscriber-popup.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/mailerlite/subscriber-popup.php
@@ -1,0 +1,132 @@
+<?php 
+//phpcs:ignoreFile WordPress.Files.FileName.InvalidClassFileName
+//phpcs:ignoreFile Universal.Files.SeparateFunctionsFromOO.Mixed
+
+
+namespace A8C\FSE\Mailerlite;
+
+/**
+ * Mailerlite widget class
+ * Display a subscriber popup for Mailerlite.
+ */
+class WPCOM_Widget_Mailerlite extends \WP_Widget {
+
+	/**
+	 * WPCOM_Widget_Mailerlite constructor.
+	 */
+	public function __construct() {
+		parent::__construct(
+			'wpcom-mailerlite',
+			/** This filter is documented in modules/widgets/facebook-likebox.php */
+			apply_filters( 'jetpack_widget_name', __( 'Mailerlite subscriber popup', 'jetpack-mu-wpcom' ) ),
+			array(
+				'classname'                   => 'widget_mailerlite',
+				'description'                 => __( 'Display Mailerlite subscriber popup', 'jetpack-mu-wpcom' ),
+				'customize_selective_refresh' => true,
+			)
+		);
+	}
+
+	/**
+	 * Output the widget.
+	 *
+	 * @param array $args Display arguments including 'before_title', 'after_title', 'before_widget', and 'after_widget'.
+	 * @param array $instance - The settings for the particular instance of the widget.
+	 */
+	public function widget( $args, $instance ) {
+		/** This action is documented in modules/widgets/gravatar-profile.php */
+		do_action( 'jetpack_stats_extra', 'widget_view', 'mailerlite' );
+
+		if ( empty( $instance['account'] ) || empty( $instance['uuid'] ) ) {
+			if ( current_user_can( 'edit_theme_options' ) ) {
+				echo $args['before_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo '<p>' . sprintf(
+					wp_kses(
+						/* translators: %1$s - URL to manage the widget, %2$s - documentation URL. */
+						__( 'You need to enter your numeric account ID and UUID for the <a href="%1$s">Mailerlite Widget</a> to work correctly. <a href="%2$s" target="_blank">Full instructions</a>.', 'jetpack-mu-wpcom' ),
+						array(
+							'a' => array(
+								'href'  => array(),
+								'title' => array(),
+							),
+						)
+					),
+					esc_url( admin_url( 'widgets.php' ) ),
+					'https://wordpress.com/support/widgets/mailerlite/'
+				) . '</p>';
+				echo $args['after_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+			return;
+		}
+
+		if ( wp_script_is( 'mailerlite-subscriber-popup', 'enqueued' ) ) {
+			return;
+		}
+
+		wp_register_script( 'mailerlite-universal', 'https://static.mailerlite.com/js/universal.js', array(), '20200521', true );
+		wp_enqueue_script(
+			'mailerlite-subscriber-popup',
+			plugins_url( 'subscriber-popup.js', __FILE__ ),
+			array( 'mailerlite-universal' ),
+			'20200521',
+			true
+		);
+		wp_localize_script(
+			'mailerlite-subscriber-popup',
+			'jetpackMailerliteSettings',
+			array(
+				'account' => esc_attr( $instance['account'] ),
+				'uuid'    => esc_attr( $instance['uuid'] ),
+			)
+		);
+	}
+
+	/**
+	 * Updates a particular instance of a widget.
+	 *
+	 * @param array $new_instance New settings for this instance as input by the user via WP_Widget::form().
+	 * @param array $old_instance   Old settings for this instance.
+	 *
+	 * @return mixed
+	 */
+	public function update( $new_instance, $old_instance ) { // @phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return array(
+			'account' => wp_kses( stripslashes( $new_instance['account'] ), array() ),
+			'uuid'    => wp_kses( stripslashes( $new_instance['uuid'] ), array() ),
+		);
+	}
+
+	/**
+	 * Editable form in WP-admin.
+	 *
+	 * @param array $instance - settings.
+	 */
+	public function form( $instance ) {
+		$instance = wp_parse_args(
+			(array) $instance,
+			array(
+				'account' => '',
+				'uuid'    => '',
+			)
+		);
+
+		echo '
+		<p><label for="' . esc_attr( $this->get_field_id( 'account' ) ) . '">';
+		/* translators: link to documentation */
+		printf( wp_kses_post( __( 'Account ID <a href="%s" target="_blank">(instructions)</a>:', 'jetpack-mu-wpcom' ) ), 'https://wordpress.com/support/widgets/mailerlite/' );
+		echo '<input class="widefat" id="' . esc_attr( $this->get_field_id( 'account' ) ) . '" name="' . esc_attr( $this->get_field_name( 'account' ) ) . '" type="text" value="' . esc_attr( $instance['account'] ) . '" />
+		</label></p>
+		<p><label for="' . esc_attr( $this->get_field_id( 'shelf' ) ) . '">' . esc_html__( 'UUID:', 'jetpack-mu-wpcom' );
+		echo '<input class="widefat" id="' . esc_attr( $this->get_field_id( 'uuid' ) ) . '" name="' . esc_attr( $this->get_field_name( 'uuid' ) ) . '" type="text" value="' . esc_attr( $instance['uuid'] ) . '" />';
+		echo '</label></p>
+		';
+	}
+}
+
+/**
+ * Registers the widget via widgets_init hook.
+ */
+function mailerlite_register_widget() {
+	register_widget( '\A8C\FSE\Mailerlite\WPCOM_Widget_Mailerlite' );
+}
+add_action( 'widgets_init', '\A8C\FSE\Mailerlite\mailerlite_register_widget' );

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = [
 			'jetpack-global-styles': './src/features/jetpack-global-styles/index.js',
 			'jetpack-global-styles-customizer-fonts':
 				'./src/features/jetpack-global-styles/customizer-fonts/index.js',
+			'mailerlite-subscriber-popup': './src/features/mailerlite/subscriber-popup.js',
 			'override-preview-button-url':
 				'./src/features/override-preview-button-url/override-preview-button-url.js',
 			'paragraph-block-placeholder':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR migrates MailerLite Widget to jetpack-mu-wpcom. 

Related to p1720664428594039/1720598146.501049-slack-CRWCHQGUB, pbxlJb-601-p2 (I'll wrap up the P2 post with the query result and this PR.), https://github.com/Automattic/wp-calypso/pull/42885 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

It is tricky to test this feature since you [can only use](https://www.mailerlite.com/help/discontinuation-of-free-plans-in-mailerlite-classic) MailerLite Classic if you previously had an account with it. 

* Activate a Classic theme
* Go to Appearance > Widgets
* Add "Mailerlite subscriber popup"
* Input arbitrary string for `account` and `uuid`
* Save your change
* Go to your site
* Ensure the following is in HTML

```html
<script src="https://static.mailerlite.com/js/universal.js" id="mailerlite-universal-js"></script>
<script id="mailerlite-subscriber-popup-js-extra">var jetpackMailerliteSettings = {"account":"<your-account>","uuid":"<your-uuid>"};</script>
<script src="https://<your-site>/wp-content/mu-plugins/jetpack-mu-wpcom-plugin/<path-to>/build/mailerlite-subscriber-popup/mailerlite-subscriber-popup.js" id="mailerlite-subscriber-popup-js"></script>
```

* Ensure `account` and `uuid` is stored in the `widget_wpcom-mailerlite` option (e.g., `echo print_r(get_option("widget_wpcom-mailerlite"))`)