### PR TITLE
Add Profile -> My Account menu to admin bar

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/wpcom-admin-bar-profile
+++ b/projects/packages/jetpack-mu-wpcom/changelog/wpcom-admin-bar-profile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Profile -> My Account menu to admin bar

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -83,6 +83,37 @@ function wpcom_add_reader_menu( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'wpcom_add_reader_menu', 15 );
 
 /**
+ * Adds (Profile) -> My Account menu pointing to /me/account.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
+ */
+function wpcom_add_my_account_item_to_profile_menu( $wp_admin_bar ) {
+	if ( is_agency_managed_site() || ! current_user_has_wpcom_account() ) {
+		return;
+	}
+
+	$logout_node = $wp_admin_bar->get_node( 'logout' );
+	if ( $logout_node ) {
+		// Adds the 'My Account' menu item before 'Log Out'.
+		$wp_admin_bar->remove_node( 'logout' );
+	}
+
+	$wp_admin_bar->add_node(
+		array(
+			'id'     => 'wpcom-profile',
+			'parent' => 'user-actions',
+			'title'  => __( 'My Account', 'jetpack-mu-wpcom' ),
+			'href'   => 'https://wordpress.com/me/account',
+		)
+	);
+
+	if ( $logout_node ) {
+		$wp_admin_bar->add_node( (array) $logout_node );
+	}
+}
+add_action( 'admin_bar_menu', 'wpcom_add_my_account_item_to_profile_menu' );
+
+/**
  * Hides the Help Center menu.
  */
 function wpcom_hide_help_center_menu() {


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/8144

## Proposed changes:

This PR adds "My Account" to the profile menu, linking to `/me/account`. This is so that classic-view sites can also have a link to their WordPress.com account.

|Before|After|
|-|-|
|<img width="272" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/dfd0f0c8-67b7-42a0-8e98-6319dedd994c">|<img width="274" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/4006d33f-bc85-4dcd-a19c-9f415322302e">|

## Note

This is a temporary solution. See discussion: p1720675904667349/1720546443.113669-slack-C06DN6QQVAQ

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this to your Atomic Classic site.
2. Observe the new link as shown in the screenshot above.
3. Test also in your Simple Classic site.
    - Note that on Simple, somehow to order of items in the top-right corner is reversed; it is a regression not related to this PR
        <img width="237" alt="image" src="https://github.com/Automattic/jetpack/assets/1525580/b306d0b2-067f-4d2e-8d26-8abb5b05234c">
