### PR TITLE
Fix comment redirect and avoid loading likes for unapproved comments

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-at-comment-post-redirect
+++ b/projects/plugins/jetpack/changelog/fix-at-comment-post-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix redirect for comments pending approval

--- a/projects/plugins/jetpack/modules/comment-likes.php
+++ b/projects/plugins/jetpack/modules/comment-likes.php
@@ -209,6 +209,10 @@ class Jetpack_Comment_Likes {
 			return $content;
 		}
 
+		if ( empty( $comment->comment_approved ) ) {
+			return $content;
+		}
+
 		// In case master iframe hasn't been loaded. This could be the case when Post Likes module is disabled,
 		// or on pages on which we have comments but post likes are disabled.
 		if ( false === has_action( 'wp_footer', 'jetpack_likes_master_iframe' ) ) {

--- a/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
+++ b/projects/plugins/jetpack/modules/comments/subscription-modal-on-comment/subscription-modal.js
@@ -25,8 +25,8 @@ document.addEventListener( 'DOMContentLoaded', function () {
 			);
 			// eslint-disable-next-line no-empty
 		} catch ( e ) {}
-		// For avoiding Firefox reload, we need to force reload bypassing the cache.
-		window.location.reload( true );
+
+		window.location = destinationUrl.toString();
 	}
 
 	function JetpackSubscriptionModalOnCommentMessageListener( event ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
https://github.com/Automattic/jetpack/issues/38214

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure redirection happens after posting a comment awaiting moderation
* Ensure `comment-likes` ignores unapproved comments

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync this PR to atomic site
* In Settings/Discussion ensure that ` Comment must be manually approved` is enabled
* Open an incognito window and post a comment via email
* You should be redirected to the same page with the comment displayed with a notice `Your comment is awaiting moderation. This is a preview; your comment will be visible after it has been approved.`
* There should not be `Loading...` text displayed in the content of the unapproved comment. This was coming from the `comment-likes` module 
* **Note** the redirection happens only if the comment is not marked as spam. To avoid this maybe you can approve a comment with the same email and use the same email for testing


