### PR TITLE
wpcomsh: Update WooCommerce Calypso Bridge to 2.5.3

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wc-calypso-bridge-2.5.3
+++ b/projects/plugins/wpcomsh/changelog/update-wc-calypso-bridge-2.5.3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WooCommerce Calypso Bridge: Update version to 2.5.3

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.5.2",
+		"automattic/wc-calypso-bridge": "2.5.3",
 		"wordpress/classic-editor-plugin": "1.5",
 		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-post-list": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffe5ca5833543183c0d52b550b9ac02a",
+    "content-hash": "f7d0c73b28dfcf30b3571b3682fc9805",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -1794,16 +1794,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.5.2",
+            "version": "v2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "60e6bef4ddb7e4546852baa674dfdbb9f3f8e7eb"
+                "reference": "837f3e9bb7bc391192268343aeaa01f563515fbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/60e6bef4ddb7e4546852baa674dfdbb9f3f8e7eb",
-                "reference": "60e6bef4ddb7e4546852baa674dfdbb9f3f8e7eb",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/837f3e9bb7bc391192268343aeaa01f563515fbc",
+                "reference": "837f3e9bb7bc391192268343aeaa01f563515fbc",
                 "shasum": ""
             },
             "require": {
@@ -1844,7 +1844,7 @@
                     "phpcbf -p"
                 ]
             },
-            "time": "2024-06-14T14:44:22+00:00"
+            "time": "2024-07-11T14:54:19+00:00"
         },
         {
             "name": "composer/installers",


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR bumps the version of `wc-calypso-bridge` to 2.5.3, which includes the following change:

* https://github.com/Automattic/wc-calypso-bridge/pull/1489

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The changes related to the `wc-calypso-bridge` were already tested in the related PR (https://github.com/Automattic/wc-calypso-bridge/pull/1489).
