### PR TITLE
Update/use connection notices to my jetpack connection wrapper

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -84,8 +84,7 @@ const MyJetpack = () => {
 								<Route path={ MyJetpackRoutes.AddLicense } element={ <AddLicenseScreen /> } />
 							) }
 							<Route path={ MyJetpackRoutes.RedeemToken } element={ <RedeemTokenScreen /> } />
-							<Route path="/redeem-token" element={ <RedeemTokenScreen /> } />
-							<Route path="/jetpack-ai" element={ <JetpackAiProductPage /> } />
+							<Route path={ MyJetpackRoutes.JetpackAI } element={ <JetpackAiProductPage /> } />
 						</Routes>
 					</HashRouter>
 				</QueryClientProvider>

--- a/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { AdminPage, Container, Col } from '@automattic/jetpack-components';
-import { useConnection } from '@automattic/jetpack-connection';
 import { ActivationScreen } from '@automattic/jetpack-licensing';
 import React, { useCallback, useState, useMemo } from 'react';
 /*
@@ -12,6 +11,7 @@ import { QUERY_LICENSES_KEY } from '../../data/constants';
 import useJetpackApiQuery from '../../data/use-jetpack-api-query';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../hooks/use-analytics';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import GoBackLink from '../go-back-link';
 
 /**
@@ -25,7 +25,7 @@ export default function AddLicenseScreen() {
 		name: QUERY_LICENSES_KEY,
 		queryFn: async api => ( await api.getUserLicenses() )?.items,
 	} );
-	const { userConnectionData } = useConnection();
+	const { userConnectionData } = useMyJetpackConnection();
 	const [ hasActivatedLicense, setHasActivatedLicense ] = useState( false );
 
 	// They might not have a display name set in wpcom, so fall back to wpcom login or local username.

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { Text } from '@automattic/jetpack-components';
-import { useConnection } from '@automattic/jetpack-connection';
 import PropTypes from 'prop-types';
 import { useCallback } from 'react';
 /**
@@ -12,6 +11,7 @@ import { MyJetpackRoutes } from '../../constants';
 import useActivate from '../../data/products/use-activate';
 import useInstallStandalonePlugin from '../../data/products/use-install-standalone-plugin';
 import useProduct from '../../data/products/use-product';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import ProductCard from '../product-card';
 
@@ -28,7 +28,7 @@ const ConnectedProductCard = ( {
 	onMouseEnter,
 	onMouseLeave,
 } ) => {
-	const { isRegistered, isUserConnected } = useConnection();
+	const { isRegistered, isUserConnected } = useMyJetpackConnection();
 
 	const { install: installStandalonePlugin, isPending: isInstalling } =
 		useInstallStandalonePlugin( slug );

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -1,9 +1,5 @@
 import { Button, getRedirectUrl, H3, Text } from '@automattic/jetpack-components';
-import {
-	ManageConnectionDialog,
-	useConnection,
-	CONNECTION_STORE_ID,
-} from '@automattic/jetpack-connection';
+import { ManageConnectionDialog, CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
 import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, info, check, lockOutline } from '@wordpress/icons';
@@ -13,6 +9,7 @@ import { useAllProducts } from '../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
 import useAnalytics from '../../hooks/use-analytics';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import cloud from './cloud.svg';
 import emptyAvatar from './empty-avatar.svg';
 import jetpackGray from './jetpack-gray.svg';
@@ -159,8 +156,6 @@ const getUserConnectionLineData: getUserConnectionLineDataType = ( {
 };
 
 const ConnectionStatusCard: ConnectionStatusCardType = ( {
-	apiRoot,
-	apiNonce,
 	redirectUri = null,
 	title = __( 'Connection', 'jetpack-my-jetpack' ),
 	connectionInfoText = __(
@@ -173,14 +168,13 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	context,
 	onConnectUser = null,
 } ) => {
-	const { isRegistered, isUserConnected, userConnectionData } = useConnection( {
-		apiRoot,
-		apiNonce,
-		redirectUri,
-		skipUserConnection: false,
-		autoTrigger: false,
-		from: 'my-jetpack',
-	} );
+	const { apiRoot, apiNonce, isRegistered, isUserConnected, userConnectionData } =
+		useMyJetpackConnection( {
+			redirectUri,
+			skipUserConnection: false,
+			autoTrigger: false,
+			from: 'my-jetpack',
+		} );
 
 	const { recordEvent } = useAnalytics();
 	const [ isManageConnectionDialogOpen, setIsManageConnectionDialogOpen ] = useState( false );

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -156,6 +156,8 @@ const getUserConnectionLineData: getUserConnectionLineDataType = ( {
 };
 
 const ConnectionStatusCard: ConnectionStatusCardType = ( {
+	apiNonce,
+	apiRoot,
 	redirectUri = null,
 	title = __( 'Connection', 'jetpack-my-jetpack' ),
 	connectionInfoText = __(
@@ -168,13 +170,12 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	context,
 	onConnectUser = null,
 } ) => {
-	const { apiRoot, apiNonce, isRegistered, isUserConnected, userConnectionData } =
-		useMyJetpackConnection( {
-			redirectUri,
-			skipUserConnection: false,
-			autoTrigger: false,
-			from: 'my-jetpack',
-		} );
+	const { isRegistered, isUserConnected, userConnectionData } = useMyJetpackConnection( {
+		redirectUri,
+		skipUserConnection: false,
+		autoTrigger: false,
+		from: 'my-jetpack',
+	} );
 
 	const { recordEvent } = useAnalytics();
 	const [ isManageConnectionDialogOpen, setIsManageConnectionDialogOpen ] = useState( false );

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -1,12 +1,12 @@
-import { useConnection } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { useRef } from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import ProductCard from '../connected-product-card';
 
 const AiCard = ( { admin } ) => {
-	const { userConnectionData } = useConnection();
+	const { userConnectionData } = useMyJetpackConnection();
 	const { currentUser } = userConnectionData;
 	const { wpcomUser } = currentUser;
 	const userId = currentUser?.id || 0;

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -9,7 +9,6 @@ import {
 	Text,
 	TermsOfService,
 } from '@automattic/jetpack-components';
-import { useConnection } from '@automattic/jetpack-connection';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -23,6 +22,7 @@ import useProduct from '../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../hooks/use-analytics';
 import { useGoBack } from '../../hooks/use-go-back';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import GoBackLink from '../go-back-link';
 import ProductDetailCard from '../product-detail-card';
@@ -80,7 +80,7 @@ export default function ProductInterstitial( {
 	const { recordEvent } = useAnalytics();
 	const { onClickGoBack } = useGoBack( { slug } );
 	const { myJetpackCheckoutUri = '' } = getMyJetpackWindowInitialState();
-	const { siteIsRegistering, handleRegisterSite } = useConnection( {
+	const { siteIsRegistering, handleRegisterSite } = useMyJetpackConnection( {
 		skipUserConnection: true,
 		redirectUri: detail.postActivationUrl ? detail.postActivationUrl : null,
 	} );

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { useConnection } from '@automattic/jetpack-connection';
 import debugFactory from 'debug';
 import { useCallback } from 'react';
 /**
@@ -9,6 +8,7 @@ import { useCallback } from 'react';
  */
 import ProductInterstitial from '../';
 import useProduct from '../../../data/products/use-product';
+import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
 import jetpackAiImage from '../jetpack-ai.png';
 import styles from './style.module.scss';
 
@@ -23,7 +23,7 @@ export default function JetpackAiInterstitial() {
 	const { detail } = useProduct( slug );
 	debug( detail );
 
-	const { userConnectionData } = useConnection();
+	const { userConnectionData } = useMyJetpackConnection();
 	const { currentUser } = userConnectionData;
 	const { wpcomUser } = currentUser;
 	const userId = currentUser?.id || 0;

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -10,7 +10,6 @@ import {
 	getRedirectUrl,
 	Notice,
 } from '@automattic/jetpack-components';
-import { useConnection } from '@automattic/jetpack-connection';
 import { Button, Card, ExternalLink } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, plus, help, check } from '@wordpress/icons';
@@ -23,6 +22,7 @@ import { useCallback, useState, useEffect } from 'react';
 import useProduct from '../../../data/products/use-product';
 import useAnalytics from '../../../hooks/use-analytics';
 import { useGoBack } from '../../../hooks/use-go-back';
+import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../../hooks/use-my-jetpack-navigate';
 import GoBackLink from '../../go-back-link';
 import styles from './style.module.scss';
@@ -38,7 +38,8 @@ export default function () {
 	const { detail } = useProduct( 'jetpack-ai' );
 	const { description, aiAssistantFeature } = detail;
 	const [ showNotice, setShowNotice ] = useState( false );
-	const { isRegistered } = useConnection();
+
+	const { isRegistered } = useMyJetpackConnection();
 
 	const videoTitleContentGeneration = __(
 		'Generate and edit content faster with Jetpack AI Assistant',

--- a/projects/packages/my-jetpack/_inc/components/redeem-token-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/redeem-token-screen/index.jsx
@@ -1,9 +1,8 @@
-import { useConnection } from '@automattic/jetpack-connection';
 import { GoldenTokenModal } from '@automattic/jetpack-licensing';
 import { __ } from '@wordpress/i18n';
-import React from 'react';
 import { QUERY_PURCHASES_KEY, REST_API_SITE_PURCHASES_ENDPOINT } from '../../data/constants';
 import useSimpleQuery from '../../data/use-simple-query';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import { includesLifetimePurchase } from '../../utils/is-lifetime-purchase';
 
 /**
@@ -12,7 +11,7 @@ import { includesLifetimePurchase } from '../../utils/is-lifetime-purchase';
  * @returns {object} The RedeemTokenScreen component.
  */
 export default function RedeemTokenScreen() {
-	const { userConnectionData } = useConnection();
+	const { userConnectionData } = useMyJetpackConnection();
 	// They might not have a display name set in wpcom, so fall back to wpcom login or local username.
 	const displayName =
 		userConnectionData?.currentUser?.wpcomUser?.display_name ||

--- a/projects/packages/my-jetpack/_inc/components/welcome-banner/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-banner/index.jsx
@@ -1,11 +1,11 @@
 import { Container, Col, Button, Text } from '@automattic/jetpack-components';
-import { useConnection } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { useEffect, useCallback, useState } from 'react';
 import { MyJetpackRoutes } from '../../constants';
 import useWelcomeBanner from '../../data/welcome-banner/use-welcome-banner';
 import useAnalytics from '../../hooks/use-analytics';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import { CardWrapper } from '../card';
 import styles from './style.module.scss';
@@ -18,7 +18,7 @@ import styles from './style.module.scss';
 const WelcomeBanner = () => {
 	const { recordEvent } = useAnalytics();
 	const { isWelcomeBannerVisible, dismissWelcomeBanner } = useWelcomeBanner();
-	const { isRegistered, isUserConnected } = useConnection();
+	const { isRegistered, isUserConnected } = useMyJetpackConnection();
 	const navigateToConnectionPage = useMyJetpackNavigate( MyJetpackRoutes.Connection );
 	const [ bannerVisible, setBannerVisible ] = useState( isWelcomeBannerVisible );
 	const shouldDisplayConnectionButton = ! isRegistered || ! isUserConnected;

--- a/projects/packages/my-jetpack/_inc/constants.ts
+++ b/projects/packages/my-jetpack/_inc/constants.ts
@@ -13,6 +13,7 @@ export const MyJetpackRoutes = {
 	AddCRM: '/add-crm',
 	AddCreator: '/add-creator',
 	AddJetpackAI: '/add-jetpack-ai',
+	JetpackAI: '/jetpack-ai',
 	AddExtras: '/add-extras',
 	AddProtect: '/add-protect',
 	AddScan: '/add-scan',

--- a/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-my-jetpack-connection/index.ts
@@ -20,13 +20,16 @@ interface MyJetpackConnection {
 	// The useConnection hook is not typed, so we don't know what other properties it returns.
 	// We could define the types here, but that hook returns a lot of data and it's not best practices
 	// to duplicate them here. The best approach would be to type the useConnection hook itself.
-	[ key: string ]: unknown;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	[ key: string ]: any;
 }
 
-const useMyJetpackConnection = (): MyJetpackConnection => {
+type useMyJetpackConnectionType = ( connectionProps?: object ) => MyJetpackConnection;
+
+const useMyJetpackConnection: useMyJetpackConnectionType = ( connectionProps = {} ) => {
 	const { apiRoot, apiNonce } = getMyJetpackWindowRestState();
 	const { topJetpackMenuItemUrl, blogID } = getMyJetpackWindowInitialState();
-	const connectionData = useConnection( { apiRoot, apiNonce } );
+	const connectionData = useConnection( { apiRoot, apiNonce, ...connectionProps } );
 	const { registrationNonce } = getMyJetpackWindowConnectionState();
 
 	// Alias: https://github.com/Automattic/jetpack/blob/trunk/projects/packages/connection/src/class-rest-connector.php/#L315

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -1,14 +1,13 @@
 import { Col, TermsOfService, Text } from '@automattic/jetpack-components';
-import { useConnection } from '@automattic/jetpack-connection';
 import { __, sprintf } from '@wordpress/i18n';
 import { useContext, useEffect } from 'react';
 import { MyJetpackRoutes } from '../../constants';
 import { NOTICE_PRIORITY_HIGH } from '../../context/constants';
 import { NoticeContext } from '../../context/notices/noticeContext';
 import { useAllProducts } from '../../data/products/use-product';
-import { getMyJetpackWindowRestState } from '../../data/utils/get-my-jetpack-window-state';
 import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
 import useAnalytics from '../use-analytics';
+import useMyJetpackConnection from '../use-my-jetpack-connection';
 import useMyJetpackNavigate from '../use-my-jetpack-navigate';
 import type { NoticeOptions } from '../../context/notices/types';
 
@@ -17,11 +16,8 @@ type RedBubbleAlerts = Window[ 'myJetpackInitialState' ][ 'redBubbleAlerts' ];
 const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 	const { recordEvent } = useAnalytics();
 	const { setNotice, resetNotice } = useContext( NoticeContext );
-	const { apiRoot, apiNonce } = getMyJetpackWindowRestState();
-	const { siteIsRegistering, handleRegisterSite } = useConnection( {
+	const { siteIsRegistering, handleRegisterSite } = useMyJetpackConnection( {
 		skipUserConnection: true,
-		apiRoot,
-		apiNonce,
 		from: 'my-jetpack',
 		redirectUri: null,
 		autoTrigger: false,

--- a/projects/packages/my-jetpack/changelog/update-use-connection-notices-to-my-jetpack-connection-wrapper
+++ b/projects/packages/my-jetpack/changelog/update-use-connection-notices-to-my-jetpack-connection-wrapper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace uses of useConnection with useMyJetpackConnection


### PR DESCRIPTION
## Proposed changes:

* Allow `useMyJetpackConnection` to accept additional props that get passed to `useConnection`
* Replace all uses of `useConnection` in My Jetpack to `useMyJetpackConnection`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
Note: A good way to test these changes is to run it locally and log out the values returned by `useMyJetpackConnection` to make sure they are correct
2. Go to the following pages in My Jetpack to ensure the information looks correct as it relates to the connection

- `/wp-admin/admin.php?page=my-jetpack#/add-license` (might want to have an unattached license for this one)

![image](https://github.com/user-attachments/assets/a6b566a4-6cae-4e99-980b-7cc7517dc0a1)

 - `/wp-admin/admin.php?page=my-jetpack#/`

![image](https://github.com/user-attachments/assets/f9c0e7ef-1268-4458-b52b-f5780988df13)

 - `/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai`

![image](https://github.com/user-attachments/assets/5c55556d-738f-4004-ae28-621b3d54128b)

 - `/wp-admin/admin.php?page=my-jetpack#/jetpack-ai`

![image](https://github.com/user-attachments/assets/2dcd3792-7a35-4326-af6d-0d3bfcb459e4)

 - Check out some other interstitials as the tables and cards use the hook
 - `/wp-admin/admin.php?page=my-jetpack#/redeem-token`
![image](https://github.com/user-attachments/assets/ecc3924f-770c-4bfa-8e52-40aab3472421)

