### PR TITLE
MU WPCOM: Enable the custom-line-height feature for classic theme by default

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-custom-line-height
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-custom-line-height
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Enable the custom-line-height feature by default

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -132,6 +132,7 @@ class Jetpack_Mu_Wpcom {
 	 * Can be moved back to load_features() once the feature no longer exists in the ETK plugin.
 	 */
 	public static function load_etk_features() {
+		require_once __DIR__ . '/features/block-editor/custom-line-height.php';
 		require_once __DIR__ . '/features/block-inserter-modifications/block-inserter-modifications.php';
 		require_once __DIR__ . '/features/hide-homepage-title/hide-homepage-title.php';
 		require_once __DIR__ . '/features/jetpack-global-styles/class-global-styles.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-editor/custom-line-height.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-editor/custom-line-height.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Enable line-height settings for all themes with Gutenberg.
+ *
+ * @package jetpack-mu-wpcom
+ */
+
+define( 'MU_WPCOM_CUSTOM_LINE_HEIGHT', true );
+
+/**
+ * Prior to Gutenberg 8.6, line-height was always enabled, which meant that wpcom
+ * users had been utilizing the feature. With the 8.6 release, though, line-height
+ * was turned off by default unless the theme supported it. As a result, users
+ * suddenly were no longer able to access the settings they previously had access
+ * to. This turns the setting on for all wpcom users regardless of theme.
+ *
+ * @see https://github.com/WordPress/gutenberg/pull/23904
+ **/
+function jetpack_mu_wpcom_gutenberg_enable_custom_line_height() {
+	add_theme_support( 'custom-line-height' );
+}
+add_action( 'after_setup_theme', 'jetpack_mu_wpcom_gutenberg_enable_custom_line_height' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/8032, https://github.com/Automattic/dotcom-forge/issues/8034

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Port the custom-line-height feature by default from ETK

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Active Twenty Twenty theme on your site
* Go to page/post editor
* Edit the block setting
* Make sure you can control the line height
  ![image](https://github.com/user-attachments/assets/43a896bc-71db-429b-a623-a724b2ca5858)

