### PR TITLE
MU WPCOM: Support localizeUrl

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2102,9 +2102,15 @@ importers:
 
   projects/packages/jetpack-mu-wpcom:
     dependencies:
+      '@automattic/i18n-utils':
+        specifier: 1.2.1
+        version: 1.2.1
       '@automattic/jetpack-base-styles':
         specifier: workspace:*
         version: link:../../js-packages/base-styles
+      '@automattic/jetpack-components':
+        specifier: workspace:*
+        version: link:../../js-packages/components
       '@automattic/jetpack-shared-extension-utils':
         specifier: workspace:*
         version: link:../../js-packages/shared-extension-utils
@@ -2153,6 +2159,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      i18n-calypso:
+        specifier: 7.0.0
+        version: 7.0.0(@types/react@18.3.1)(react@18.3.1)
       preact:
         specifier: ^10.13.1
         version: 10.22.1
@@ -2194,6 +2203,12 @@ importers:
       babel-plugin-transform-rename-properties:
         specifier: 0.1.0
         version: 0.1.0(@babel/core@7.24.7)
+      events:
+        specifier: 3.3.0
+        version: 3.3.0
+      pkg-dir:
+        specifier: ^5.0.0
+        version: 5.0.0
       sass:
         specifier: 1.64.1
         version: 1.64.1
@@ -4849,6 +4864,12 @@ packages:
   '@automattic/calypso-color-schemes@3.1.3':
     resolution: {integrity: sha512-nzs36yfxUOcsD3HvB72IHgdUfIzTRnT7QmF78CBXEREawTEs0uDyELdx/rAOtW/PauxRYRGQ4zeK5c67FWqLxw==}
 
+  '@automattic/calypso-config@1.2.0':
+    resolution: {integrity: sha512-7NE5oVOEyQ4KRz1VNnPIHgW+mcwxnkcs/+Cymba7OA7SYKARiTg3ETGlZGX19S0F7gjYZMq+IeLHeAZSrNjz/Q==}
+
+  '@automattic/calypso-url@1.1.0':
+    resolution: {integrity: sha512-oA6pzfrp538gq5JEjE0ARDjvR8Efhw+jrK15TJPjAq5Q+vhPSJhH8sYKEsMAoYZV3d5nnyUcmI5Evge+yq4zeg==}
+
   '@automattic/color-studio@2.6.0':
     resolution: {integrity: sha512-2LzB6bbQw1vayZxZy5Y+DnCYU7x8tPu+rZhNkWD7V8QZTSJMJO65XKZhYaCByC+C5OegXyGyZzcqEOHHdj5iiQ==}
 
@@ -4860,6 +4881,21 @@ packages:
 
   '@automattic/format-currency@1.0.1':
     resolution: {integrity: sha512-RY2eiUlDiqNSHiJzz2YmH/mw4IjAUO5hkxbwcVGHJkBZowdq/WcSG2yhXc8N9cV9N1fTO/ryCuJvGnpHUe+mAg==}
+
+  '@automattic/i18n-utils@1.2.1':
+    resolution: {integrity: sha512-QckbuwNRIoaj3Dkf0jRYRCOWsKk9bTkkFzHA5uU+n12RkgNsM5EhVfq+2/dmdpwux9aFtz/hc35VJhJGgUOtww==}
+
+  '@automattic/interpolate-components@1.2.1':
+    resolution: {integrity: sha512-YNQtJsrs9KQ3lkBdtLyDheVRijoBA3y/PuHdgJ0eB4AX9JyjkDX7jd79Inh79+01CGNLbMQGrEJby2zvbJr17A==}
+    peerDependencies:
+      '@types/react': '>=16.14.23'
+      react: '>=16.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@automattic/languages@1.0.0':
+    resolution: {integrity: sha512-froTyDbTmLitHkvY9WLCpFdjUo6moOLkDKw63J2fLiB2gBApy2thkBV+LRx4Z0kIF5iXVkQF4yYOPYkT9Sr13Q==}
 
   '@automattic/popup-monitor@1.0.2':
     resolution: {integrity: sha512-Y4LMfdkV8iDmezu/7Ov/18JaFJ0QAy5vCntiP0S5AhLt4R/kjLtBt4ifNXNbdKTthGxlL17+LJ1bNtHBVCzPwg==}
@@ -7132,6 +7168,9 @@ packages:
   '@tannin/postfix@1.1.0':
     resolution: {integrity: sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==}
 
+  '@tannin/sprintf@1.2.0':
+    resolution: {integrity: sha512-T0ORaQrH6kNFGzTg285RVPK+NCYZxOoA+r0QfKgHqK+yk5RuYPSKDa18XCLtycCNq+VWKpfyDpzGUGhYgCV+kw==}
+
   '@tanstack/query-core@4.35.3':
     resolution: {integrity: sha512-PS+WEjd9wzKTyNjjQymvcOe1yg8f3wYc6mD+vb6CKyZAKvu4sIJwryfqfBULITKCla7P9C4l5e9RXePHvZOZeQ==}
 
@@ -7752,6 +7791,12 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@wordpress/compose@6.35.0':
+    resolution: {integrity: sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/compose@7.2.0':
     resolution: {integrity: sha512-J2OGEatXXTgRJmXZHYcstL5GyQgQcoeSJ9dQ2wVFHJLnWoIX3hlvi5oRy10lpl1yntfm6NLkWDBuSTIbAYJzww==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -7788,6 +7833,10 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
 
+  '@wordpress/deprecated@3.58.0':
+    resolution: {integrity: sha512-knweE2lLEUxWRr6A48sHiO0ww5pPybGe2NVIZVq/y7EaYCMdpy6gYA0ZdVqMKZvtxKKqicJfwigcn+hinsTvUQ==}
+    engines: {node: '>=12'}
+
   '@wordpress/deprecated@4.2.0':
     resolution: {integrity: sha512-grD/IBGEvXzTLaNB45QZv8jDQYK6bMhCSa7obRahZDpyrM2lwKwa8p1oack5R+81YWkBL02gl9V5G9BrpNfBJg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -7795,6 +7844,10 @@ packages:
   '@wordpress/dom-ready@4.2.0':
     resolution: {integrity: sha512-1rD9vcwVy7s+yGbe8DuDkBpjvA/PJtY2DnUgyHIedC/YonlswalBSiFWGZuTX5QyocdffBAWiUlvebyN4TNtOw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/dom@3.58.0':
+    resolution: {integrity: sha512-t3xSr/nqekj2qwUGRAqSeGx6116JOBxzI+VBiUfZrjGEnuyKdLelXDEeYtcwbb7etMkj/6F60/NB7GTl5IwizQ==}
+    engines: {node: '>=12'}
 
   '@wordpress/dom@4.2.0':
     resolution: {integrity: sha512-vkeIsFdoKWl6lZJM+E49b+HocePP8gSPiDeUaa3P82JPTLTNAAfQMGWbAG0dbQCOZa7pmF4Sh0T1iVYmznm6eA==}
@@ -7814,9 +7867,17 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@wordpress/element@5.35.0':
+    resolution: {integrity: sha512-puswpGcIdS+0A2g28uHriMkZqqRCmzFczue5Tk99VNtzBdehyk7Ae+DZ4xw5yT6GqYai8NTqv6MRwCB78uh5Mw==}
+    engines: {node: '>=12'}
+
   '@wordpress/element@6.2.0':
     resolution: {integrity: sha512-pRCchhYoH7eN0bxL4iUMBm82psqSUozlmk4B5IhQiqzYoOWn7OjvkGqejAnt81iDZUNZ8hIY2gLpRplgwwiZlQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/escape-html@2.58.0':
+    resolution: {integrity: sha512-9YJXMNfzkrhHEVP1jFEhgijbZqW8Mt3NHIMZjIQoWtBf7QE86umpYpGGBXzYC0YlpGTRGzZTBwYaqFKxjeaSgA==}
+    engines: {node: '>=12'}
 
   '@wordpress/escape-html@3.2.0':
     resolution: {integrity: sha512-GFJ91lrs46zN3bgRGBHREaZ4jegwUA+2Gx+P6f11VDLhihNGKyg67uNf0lXqLoLj6iQQCBDP+15k/0k2ccr3YA==}
@@ -7853,6 +7914,10 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@wordpress/hooks@3.58.0':
+    resolution: {integrity: sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==}
+    engines: {node: '>=12'}
+
   '@wordpress/hooks@4.2.0':
     resolution: {integrity: sha512-N2dRMIb3F6y2dXlcT6m2CH/jDi9/Fe0gaM6ev7DrvwJ8+kX1CRzwAydemmPw34EnhQKvYKQYgGqttrfzvzgKJw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -7860,6 +7925,11 @@ packages:
   '@wordpress/html-entities@4.2.0':
     resolution: {integrity: sha512-NwYv/VSxASrhIqjcgVkKS9s9kAseTJ6NYVpqCm8owz81GqYcpOe2XVCKQxOKHcU8x9Gm99uHR10jztXXJr1Z2Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/i18n@4.58.0':
+    resolution: {integrity: sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   '@wordpress/i18n@5.2.0':
     resolution: {integrity: sha512-G8z3/o1gm158XHANzthMBLsInQ/iWBFFIUoThiOP8C+VtpVozVpmWpgdayldPoTYolhCdaW6dicNUfdX8fOBTQ==}
@@ -7887,6 +7957,10 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@wordpress/is-shallow-equal@4.58.0':
+    resolution: {integrity: sha512-NH2lbXo/6ix1t4Zu9UBXpXNtoLwSaYmIRSyDH34XNb0ic8a7yjEOhYWVW3LTfSCv9dJVyxlM5TJPtL85q7LdeQ==}
+    engines: {node: '>=12'}
+
   '@wordpress/is-shallow-equal@5.2.0':
     resolution: {integrity: sha512-WIsaAu+vDoAwnfGSWqyOMZiJeKXMXHNj6SzuESieASbL1VcbWgpg8FjDRjCNCEBgu7oe2VQrDOpDfajI1fgVvw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -7902,6 +7976,10 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
+
+  '@wordpress/keycodes@3.58.0':
+    resolution: {integrity: sha512-Q/LRKpx8ndzuHlkxSQ2BD+NTYYKQPIneNNMng8hTAfyU7RFwXpqj06HpeOFGh4XIdPKCs/8hmucoLJRmmLmZJA==}
+    engines: {node: '>=12'}
 
   '@wordpress/keycodes@4.2.0':
     resolution: {integrity: sha512-FJMR+KLfltcfmd0GhpI2C+zohFaGwPwZTYx9e0+cnIDJ5c5Jw1KTToZ+gkWPoSi++U/dlqkxkKYLD4AnGg7L5Q==}
@@ -7955,6 +8033,10 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18
+
+  '@wordpress/priority-queue@2.58.0':
+    resolution: {integrity: sha512-W+qCS8HJWsXG8gE6yK/H/IObowcghPrQMM3cQHtfd/U05yFNU1Bd/fbj3AO1fVRztktS47lIpi9m3ll1evPEHA==}
+    engines: {node: '>=12'}
 
   '@wordpress/priority-queue@3.2.0':
     resolution: {integrity: sha512-Kz/Zv+/TzgsKi5M3/iE2w4sMSi0f2Q3KnmU6taS5bEiiKRHvuC1U629YBsXCvBfi+7QWe2L7J7OVcLRwdEzAkg==}
@@ -8011,6 +8093,10 @@ packages:
   '@wordpress/token-list@3.2.0':
     resolution: {integrity: sha512-4CDvT2x+NmP255E4JSowpHiZUK2wqVOvfrcuY884mm149+ZmPp2OyGuRnn4aqFEs3+Bcxjg5NEz0o4KH0CXt5Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/undo-manager@0.18.0':
+    resolution: {integrity: sha512-upbzPEToa095XG+2JXLHaolF1LfXEMFS0lNMYV37myoUS+eZ7/tl9Gx+yU2+OqWy57TMwx33NlWUX/n+ynzPRw==}
+    engines: {node: '>=12'}
 
   '@wordpress/undo-manager@1.2.0':
     resolution: {integrity: sha512-xOjyl2hRro5I3pBuDYvrF+cLe0617KlPiuJok9YPofjUvfDvgf6gPLSBOAPj2GzYkiGASz0fnsPcE4UxS14ApQ==}
@@ -10359,6 +10445,9 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
   hasha@5.2.2:
     resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
     engines: {node: '>=8'}
@@ -10484,6 +10573,11 @@ packages:
     resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
     engines: {node: '>=14'}
     hasBin: true
+
+  i18n-calypso@7.0.0:
+    resolution: {integrity: sha512-GQesQzd/VYXiJOrjMixJNFOqNOcp43kKGKZTimYu70RabvcObpjfAOqtrQganszXqXWxZ7fAXOnhCTd8NVtf/Q==}
+    peerDependencies:
+      react: ^18.2.0
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -11393,6 +11487,10 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  lru@3.1.0:
+    resolution: {integrity: sha512-5OUtoiVIGU4VXBOshidmtOsvBIvcQR6FD/RzWSvaeHyxCGB+PCUCu+52lqMfdc0h/2CLvHhZS4TwUmMQrrMbBQ==}
+    engines: {node: '>= 0.4.0'}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -11643,6 +11741,9 @@ packages:
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -14151,6 +14252,11 @@ packages:
       '@types/react':
         optional: true
 
+  use-subscription@1.6.0:
+    resolution: {integrity: sha512-0Y/cTLlZfw547tJhJMoRA16OUbVqRm6DmvGpiGbmLST6BIA5KU5cKlvlz8DVMrACnWpyEjCkgmhLatthP4jUbA==}
+    peerDependencies:
+      react: ^18.0.0
+
   use-sync-external-store@1.2.2:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
     peerDependencies:
@@ -14600,6 +14706,14 @@ snapshots:
 
   '@automattic/calypso-color-schemes@3.1.3': {}
 
+  '@automattic/calypso-config@1.2.0': {}
+
+  '@automattic/calypso-url@1.1.0':
+    dependencies:
+      photon: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@automattic/color-studio@2.6.0': {}
 
   '@automattic/explat-client-react-helpers@0.1.0':
@@ -14613,6 +14727,28 @@ snapshots:
       tslib: 2.5.0
 
   '@automattic/format-currency@1.0.1':
+    dependencies:
+      tslib: 2.5.0
+
+  '@automattic/i18n-utils@1.2.1':
+    dependencies:
+      '@automattic/calypso-config': 1.2.0
+      '@automattic/calypso-url': 1.1.0
+      '@automattic/languages': 1.0.0
+      '@wordpress/compose': 6.35.0(react@18.3.1)
+      '@wordpress/i18n': 4.58.0
+      react: 18.3.1
+      tslib: 2.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@automattic/interpolate-components@1.2.1(@types/react@18.3.1)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.1
+
+  '@automattic/languages@1.0.0':
     dependencies:
       tslib: 2.5.0
 
@@ -18143,6 +18279,8 @@ snapshots:
 
   '@tannin/postfix@1.1.0': {}
 
+  '@tannin/sprintf@1.2.0': {}
+
   '@tanstack/query-core@4.35.3': {}
 
   '@tanstack/query-core@5.0.5': {}
@@ -19289,6 +19427,23 @@ snapshots:
       - '@types/react'
       - supports-color
 
+  '@wordpress/compose@6.35.0(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@types/mousetrap': 1.6.15
+      '@wordpress/deprecated': 3.58.0
+      '@wordpress/dom': 3.58.0
+      '@wordpress/element': 5.35.0
+      '@wordpress/is-shallow-equal': 4.58.0
+      '@wordpress/keycodes': 3.58.0
+      '@wordpress/priority-queue': 2.58.0
+      '@wordpress/undo-manager': 0.18.0
+      change-case: 4.1.2
+      clipboard: 2.0.11
+      mousetrap: 1.6.5
+      react: 18.3.1
+      use-memo-one: 1.1.3(react@18.3.1)
+
   '@wordpress/compose@7.2.0(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -19483,6 +19638,11 @@ snapshots:
       json2php: 0.0.7
       webpack: 5.76.0(webpack-cli@4.9.1)
 
+  '@wordpress/deprecated@3.58.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@wordpress/hooks': 3.58.0
+
   '@wordpress/deprecated@4.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -19491,6 +19651,11 @@ snapshots:
   '@wordpress/dom-ready@4.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
+
+  '@wordpress/dom@3.58.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@wordpress/deprecated': 3.58.0
 
   '@wordpress/dom@4.2.0':
     dependencies:
@@ -19697,6 +19862,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@wordpress/element@5.35.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@types/react': 18.3.1
+      '@types/react-dom': 18.3.0
+      '@wordpress/escape-html': 2.58.0
+      change-case: 4.1.2
+      is-plain-object: 5.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@wordpress/element@6.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -19707,6 +19883,10 @@ snapshots:
       is-plain-object: 5.0.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@wordpress/escape-html@2.58.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
 
   '@wordpress/escape-html@3.2.0':
     dependencies:
@@ -19761,6 +19941,10 @@ snapshots:
       - '@types/react'
       - supports-color
 
+  '@wordpress/hooks@3.58.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+
   '@wordpress/hooks@4.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -19768,6 +19952,15 @@ snapshots:
   '@wordpress/html-entities@4.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
+
+  '@wordpress/i18n@4.58.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@wordpress/hooks': 3.58.0
+      gettext-parser: 1.4.0
+      memize: 2.1.0
+      sprintf-js: 1.1.2
+      tannin: 1.2.0
 
   '@wordpress/i18n@5.2.0':
     dependencies:
@@ -19847,6 +20040,10 @@ snapshots:
       - '@types/react'
       - supports-color
 
+  '@wordpress/is-shallow-equal@4.58.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+
   '@wordpress/is-shallow-equal@5.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -19864,6 +20061,11 @@ snapshots:
       '@wordpress/element': 6.2.0
       '@wordpress/keycodes': 4.2.0
       react: 18.3.1
+
+  '@wordpress/keycodes@3.58.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@wordpress/i18n': 4.58.0
 
   '@wordpress/keycodes@4.2.0':
     dependencies:
@@ -20028,6 +20230,11 @@ snapshots:
       clsx: 2.1.1
       react: 18.3.1
 
+  '@wordpress/priority-queue@2.58.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      requestidlecallback: 0.3.0
+
   '@wordpress/priority-queue@3.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -20184,6 +20391,11 @@ snapshots:
   '@wordpress/token-list@3.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
+
+  '@wordpress/undo-manager@0.18.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@wordpress/is-shallow-equal': 4.58.0
 
   '@wordpress/undo-manager@1.2.0':
     dependencies:
@@ -23016,6 +23228,11 @@ snapshots:
     dependencies:
       has-symbols: 1.0.3
 
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   hasha@5.2.2:
     dependencies:
       is-stream: 2.0.1
@@ -23170,6 +23387,24 @@ snapshots:
   humps@2.0.1: {}
 
   husky@8.0.3: {}
+
+  i18n-calypso@7.0.0(@types/react@18.3.1)(react@18.3.1):
+    dependencies:
+      '@automattic/interpolate-components': 1.2.1(@types/react@18.3.1)(react@18.3.1)
+      '@babel/runtime': 7.24.7
+      '@tannin/sprintf': 1.2.0
+      '@wordpress/compose': 6.35.0(react@18.3.1)
+      debug: 4.3.4
+      events: 3.3.0
+      hash.js: 1.1.7
+      lodash: 4.17.21
+      lru: 3.1.0
+      react: 18.3.1
+      tannin: 1.2.0
+      use-subscription: 1.6.0(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
 
   iconv-lite@0.4.24:
     dependencies:
@@ -24388,6 +24623,10 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
+  lru@3.1.0:
+    dependencies:
+      inherits: 2.0.4
+
   lz-string@1.5.0: {}
 
   magic-string@0.27.0:
@@ -24809,6 +25048,8 @@ snapshots:
     dependencies:
       schema-utils: 4.2.0
       webpack: 5.76.0(webpack-cli@4.9.1)
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -27450,6 +27691,10 @@ snapshots:
       detect-node-es: 1.1.0
       react: 18.3.1
       tslib: 2.5.0
+
+  use-subscription@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   use-sync-external-store@1.2.2(react@18.3.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2103,14 +2103,11 @@ importers:
   projects/packages/jetpack-mu-wpcom:
     dependencies:
       '@automattic/i18n-utils':
-        specifier: 1.2.1
-        version: 1.2.1
+        specifier: 1.2.3
+        version: 1.2.3
       '@automattic/jetpack-base-styles':
         specifier: workspace:*
         version: link:../../js-packages/base-styles
-      '@automattic/jetpack-components':
-        specifier: workspace:*
-        version: link:../../js-packages/components
       '@automattic/jetpack-shared-extension-utils':
         specifier: workspace:*
         version: link:../../js-packages/shared-extension-utils
@@ -2159,9 +2156,6 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
-      i18n-calypso:
-        specifier: 7.0.0
-        version: 7.0.0(@types/react@18.3.1)(react@18.3.1)
       preact:
         specifier: ^10.13.1
         version: 10.22.1
@@ -2206,9 +2200,6 @@ importers:
       events:
         specifier: 3.3.0
         version: 3.3.0
-      pkg-dir:
-        specifier: ^5.0.0
-        version: 5.0.0
       sass:
         specifier: 1.64.1
         version: 1.64.1
@@ -4882,17 +4873,8 @@ packages:
   '@automattic/format-currency@1.0.1':
     resolution: {integrity: sha512-RY2eiUlDiqNSHiJzz2YmH/mw4IjAUO5hkxbwcVGHJkBZowdq/WcSG2yhXc8N9cV9N1fTO/ryCuJvGnpHUe+mAg==}
 
-  '@automattic/i18n-utils@1.2.1':
-    resolution: {integrity: sha512-QckbuwNRIoaj3Dkf0jRYRCOWsKk9bTkkFzHA5uU+n12RkgNsM5EhVfq+2/dmdpwux9aFtz/hc35VJhJGgUOtww==}
-
-  '@automattic/interpolate-components@1.2.1':
-    resolution: {integrity: sha512-YNQtJsrs9KQ3lkBdtLyDheVRijoBA3y/PuHdgJ0eB4AX9JyjkDX7jd79Inh79+01CGNLbMQGrEJby2zvbJr17A==}
-    peerDependencies:
-      '@types/react': '>=16.14.23'
-      react: '>=16.2.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
+  '@automattic/i18n-utils@1.2.3':
+    resolution: {integrity: sha512-zvZlazUoEasLATrta3ljfxu2uaZWgHRNKWf56KKBlrPiIxNQvx9D7YyN2MhiV27e/PuAhB0gI4ghqp3gzurKmA==}
 
   '@automattic/languages@1.0.0':
     resolution: {integrity: sha512-froTyDbTmLitHkvY9WLCpFdjUo6moOLkDKw63J2fLiB2gBApy2thkBV+LRx4Z0kIF5iXVkQF4yYOPYkT9Sr13Q==}
@@ -7168,9 +7150,6 @@ packages:
   '@tannin/postfix@1.1.0':
     resolution: {integrity: sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==}
 
-  '@tannin/sprintf@1.2.0':
-    resolution: {integrity: sha512-T0ORaQrH6kNFGzTg285RVPK+NCYZxOoA+r0QfKgHqK+yk5RuYPSKDa18XCLtycCNq+VWKpfyDpzGUGhYgCV+kw==}
-
   '@tanstack/query-core@4.35.3':
     resolution: {integrity: sha512-PS+WEjd9wzKTyNjjQymvcOe1yg8f3wYc6mD+vb6CKyZAKvu4sIJwryfqfBULITKCla7P9C4l5e9RXePHvZOZeQ==}
 
@@ -7791,12 +7770,6 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@wordpress/compose@6.35.0':
-    resolution: {integrity: sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/compose@7.2.0':
     resolution: {integrity: sha512-J2OGEatXXTgRJmXZHYcstL5GyQgQcoeSJ9dQ2wVFHJLnWoIX3hlvi5oRy10lpl1yntfm6NLkWDBuSTIbAYJzww==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -7833,10 +7806,6 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
 
-  '@wordpress/deprecated@3.58.0':
-    resolution: {integrity: sha512-knweE2lLEUxWRr6A48sHiO0ww5pPybGe2NVIZVq/y7EaYCMdpy6gYA0ZdVqMKZvtxKKqicJfwigcn+hinsTvUQ==}
-    engines: {node: '>=12'}
-
   '@wordpress/deprecated@4.2.0':
     resolution: {integrity: sha512-grD/IBGEvXzTLaNB45QZv8jDQYK6bMhCSa7obRahZDpyrM2lwKwa8p1oack5R+81YWkBL02gl9V5G9BrpNfBJg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -7844,10 +7813,6 @@ packages:
   '@wordpress/dom-ready@4.2.0':
     resolution: {integrity: sha512-1rD9vcwVy7s+yGbe8DuDkBpjvA/PJtY2DnUgyHIedC/YonlswalBSiFWGZuTX5QyocdffBAWiUlvebyN4TNtOw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/dom@3.58.0':
-    resolution: {integrity: sha512-t3xSr/nqekj2qwUGRAqSeGx6116JOBxzI+VBiUfZrjGEnuyKdLelXDEeYtcwbb7etMkj/6F60/NB7GTl5IwizQ==}
-    engines: {node: '>=12'}
 
   '@wordpress/dom@4.2.0':
     resolution: {integrity: sha512-vkeIsFdoKWl6lZJM+E49b+HocePP8gSPiDeUaa3P82JPTLTNAAfQMGWbAG0dbQCOZa7pmF4Sh0T1iVYmznm6eA==}
@@ -7867,17 +7832,9 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@wordpress/element@5.35.0':
-    resolution: {integrity: sha512-puswpGcIdS+0A2g28uHriMkZqqRCmzFczue5Tk99VNtzBdehyk7Ae+DZ4xw5yT6GqYai8NTqv6MRwCB78uh5Mw==}
-    engines: {node: '>=12'}
-
   '@wordpress/element@6.2.0':
     resolution: {integrity: sha512-pRCchhYoH7eN0bxL4iUMBm82psqSUozlmk4B5IhQiqzYoOWn7OjvkGqejAnt81iDZUNZ8hIY2gLpRplgwwiZlQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/escape-html@2.58.0':
-    resolution: {integrity: sha512-9YJXMNfzkrhHEVP1jFEhgijbZqW8Mt3NHIMZjIQoWtBf7QE86umpYpGGBXzYC0YlpGTRGzZTBwYaqFKxjeaSgA==}
-    engines: {node: '>=12'}
 
   '@wordpress/escape-html@3.2.0':
     resolution: {integrity: sha512-GFJ91lrs46zN3bgRGBHREaZ4jegwUA+2Gx+P6f11VDLhihNGKyg67uNf0lXqLoLj6iQQCBDP+15k/0k2ccr3YA==}
@@ -7914,10 +7871,6 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@wordpress/hooks@3.58.0':
-    resolution: {integrity: sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==}
-    engines: {node: '>=12'}
-
   '@wordpress/hooks@4.2.0':
     resolution: {integrity: sha512-N2dRMIb3F6y2dXlcT6m2CH/jDi9/Fe0gaM6ev7DrvwJ8+kX1CRzwAydemmPw34EnhQKvYKQYgGqttrfzvzgKJw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -7925,11 +7878,6 @@ packages:
   '@wordpress/html-entities@4.2.0':
     resolution: {integrity: sha512-NwYv/VSxASrhIqjcgVkKS9s9kAseTJ6NYVpqCm8owz81GqYcpOe2XVCKQxOKHcU8x9Gm99uHR10jztXXJr1Z2Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/i18n@4.58.0':
-    resolution: {integrity: sha512-VfvS3BWv/RDjRKD6PscIcvYfWKnGJcI/DEqyDgUMhxCM6NRwoL478CsUKTiGJIymeyRodNRfprdcF086DpGKYw==}
-    engines: {node: '>=12'}
-    hasBin: true
 
   '@wordpress/i18n@5.2.0':
     resolution: {integrity: sha512-G8z3/o1gm158XHANzthMBLsInQ/iWBFFIUoThiOP8C+VtpVozVpmWpgdayldPoTYolhCdaW6dicNUfdX8fOBTQ==}
@@ -7957,10 +7905,6 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@wordpress/is-shallow-equal@4.58.0':
-    resolution: {integrity: sha512-NH2lbXo/6ix1t4Zu9UBXpXNtoLwSaYmIRSyDH34XNb0ic8a7yjEOhYWVW3LTfSCv9dJVyxlM5TJPtL85q7LdeQ==}
-    engines: {node: '>=12'}
-
   '@wordpress/is-shallow-equal@5.2.0':
     resolution: {integrity: sha512-WIsaAu+vDoAwnfGSWqyOMZiJeKXMXHNj6SzuESieASbL1VcbWgpg8FjDRjCNCEBgu7oe2VQrDOpDfajI1fgVvw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -7976,10 +7920,6 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
-
-  '@wordpress/keycodes@3.58.0':
-    resolution: {integrity: sha512-Q/LRKpx8ndzuHlkxSQ2BD+NTYYKQPIneNNMng8hTAfyU7RFwXpqj06HpeOFGh4XIdPKCs/8hmucoLJRmmLmZJA==}
-    engines: {node: '>=12'}
 
   '@wordpress/keycodes@4.2.0':
     resolution: {integrity: sha512-FJMR+KLfltcfmd0GhpI2C+zohFaGwPwZTYx9e0+cnIDJ5c5Jw1KTToZ+gkWPoSi++U/dlqkxkKYLD4AnGg7L5Q==}
@@ -8033,10 +7973,6 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18
-
-  '@wordpress/priority-queue@2.58.0':
-    resolution: {integrity: sha512-W+qCS8HJWsXG8gE6yK/H/IObowcghPrQMM3cQHtfd/U05yFNU1Bd/fbj3AO1fVRztktS47lIpi9m3ll1evPEHA==}
-    engines: {node: '>=12'}
 
   '@wordpress/priority-queue@3.2.0':
     resolution: {integrity: sha512-Kz/Zv+/TzgsKi5M3/iE2w4sMSi0f2Q3KnmU6taS5bEiiKRHvuC1U629YBsXCvBfi+7QWe2L7J7OVcLRwdEzAkg==}
@@ -8093,10 +8029,6 @@ packages:
   '@wordpress/token-list@3.2.0':
     resolution: {integrity: sha512-4CDvT2x+NmP255E4JSowpHiZUK2wqVOvfrcuY884mm149+ZmPp2OyGuRnn4aqFEs3+Bcxjg5NEz0o4KH0CXt5Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/undo-manager@0.18.0':
-    resolution: {integrity: sha512-upbzPEToa095XG+2JXLHaolF1LfXEMFS0lNMYV37myoUS+eZ7/tl9Gx+yU2+OqWy57TMwx33NlWUX/n+ynzPRw==}
-    engines: {node: '>=12'}
 
   '@wordpress/undo-manager@1.2.0':
     resolution: {integrity: sha512-xOjyl2hRro5I3pBuDYvrF+cLe0617KlPiuJok9YPofjUvfDvgf6gPLSBOAPj2GzYkiGASz0fnsPcE4UxS14ApQ==}
@@ -10445,9 +10377,6 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hash.js@1.1.7:
-    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
-
   hasha@5.2.2:
     resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
     engines: {node: '>=8'}
@@ -10573,11 +10502,6 @@ packages:
     resolution: {integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==}
     engines: {node: '>=14'}
     hasBin: true
-
-  i18n-calypso@7.0.0:
-    resolution: {integrity: sha512-GQesQzd/VYXiJOrjMixJNFOqNOcp43kKGKZTimYu70RabvcObpjfAOqtrQganszXqXWxZ7fAXOnhCTd8NVtf/Q==}
-    peerDependencies:
-      react: ^18.2.0
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -11487,10 +11411,6 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
-  lru@3.1.0:
-    resolution: {integrity: sha512-5OUtoiVIGU4VXBOshidmtOsvBIvcQR6FD/RzWSvaeHyxCGB+PCUCu+52lqMfdc0h/2CLvHhZS4TwUmMQrrMbBQ==}
-    engines: {node: '>= 0.4.0'}
-
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -11741,9 +11661,6 @@ packages:
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
-
-  minimalistic-assert@1.0.1:
-    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -14252,11 +14169,6 @@ packages:
       '@types/react':
         optional: true
 
-  use-subscription@1.6.0:
-    resolution: {integrity: sha512-0Y/cTLlZfw547tJhJMoRA16OUbVqRm6DmvGpiGbmLST6BIA5KU5cKlvlz8DVMrACnWpyEjCkgmhLatthP4jUbA==}
-    peerDependencies:
-      react: ^18.0.0
-
   use-sync-external-store@1.2.2:
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
     peerDependencies:
@@ -14730,23 +14642,17 @@ snapshots:
     dependencies:
       tslib: 2.5.0
 
-  '@automattic/i18n-utils@1.2.1':
+  '@automattic/i18n-utils@1.2.3':
     dependencies:
       '@automattic/calypso-config': 1.2.0
       '@automattic/calypso-url': 1.1.0
       '@automattic/languages': 1.0.0
-      '@wordpress/compose': 6.35.0(react@18.3.1)
-      '@wordpress/i18n': 4.58.0
+      '@wordpress/compose': 7.2.0(react@18.3.1)
+      '@wordpress/i18n': 5.2.0
       react: 18.3.1
       tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
-
-  '@automattic/interpolate-components@1.2.1(@types/react@18.3.1)(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.1
 
   '@automattic/languages@1.0.0':
     dependencies:
@@ -18279,8 +18185,6 @@ snapshots:
 
   '@tannin/postfix@1.1.0': {}
 
-  '@tannin/sprintf@1.2.0': {}
-
   '@tanstack/query-core@4.35.3': {}
 
   '@tanstack/query-core@5.0.5': {}
@@ -19427,23 +19331,6 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@wordpress/compose@6.35.0(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@types/mousetrap': 1.6.15
-      '@wordpress/deprecated': 3.58.0
-      '@wordpress/dom': 3.58.0
-      '@wordpress/element': 5.35.0
-      '@wordpress/is-shallow-equal': 4.58.0
-      '@wordpress/keycodes': 3.58.0
-      '@wordpress/priority-queue': 2.58.0
-      '@wordpress/undo-manager': 0.18.0
-      change-case: 4.1.2
-      clipboard: 2.0.11
-      mousetrap: 1.6.5
-      react: 18.3.1
-      use-memo-one: 1.1.3(react@18.3.1)
-
   '@wordpress/compose@7.2.0(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -19638,11 +19525,6 @@ snapshots:
       json2php: 0.0.7
       webpack: 5.76.0(webpack-cli@4.9.1)
 
-  '@wordpress/deprecated@3.58.0':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@wordpress/hooks': 3.58.0
-
   '@wordpress/deprecated@4.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -19651,11 +19533,6 @@ snapshots:
   '@wordpress/dom-ready@4.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
-
-  '@wordpress/dom@3.58.0':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@wordpress/deprecated': 3.58.0
 
   '@wordpress/dom@4.2.0':
     dependencies:
@@ -19862,17 +19739,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@wordpress/element@5.35.0':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@types/react': 18.3.1
-      '@types/react-dom': 18.3.0
-      '@wordpress/escape-html': 2.58.0
-      change-case: 4.1.2
-      is-plain-object: 5.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@wordpress/element@6.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -19883,10 +19749,6 @@ snapshots:
       is-plain-object: 5.0.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  '@wordpress/escape-html@2.58.0':
-    dependencies:
-      '@babel/runtime': 7.24.7
 
   '@wordpress/escape-html@3.2.0':
     dependencies:
@@ -19941,10 +19803,6 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@wordpress/hooks@3.58.0':
-    dependencies:
-      '@babel/runtime': 7.24.7
-
   '@wordpress/hooks@4.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -19952,15 +19810,6 @@ snapshots:
   '@wordpress/html-entities@4.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
-
-  '@wordpress/i18n@4.58.0':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@wordpress/hooks': 3.58.0
-      gettext-parser: 1.4.0
-      memize: 2.1.0
-      sprintf-js: 1.1.2
-      tannin: 1.2.0
 
   '@wordpress/i18n@5.2.0':
     dependencies:
@@ -20040,10 +19889,6 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@wordpress/is-shallow-equal@4.58.0':
-    dependencies:
-      '@babel/runtime': 7.24.7
-
   '@wordpress/is-shallow-equal@5.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -20061,11 +19906,6 @@ snapshots:
       '@wordpress/element': 6.2.0
       '@wordpress/keycodes': 4.2.0
       react: 18.3.1
-
-  '@wordpress/keycodes@3.58.0':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@wordpress/i18n': 4.58.0
 
   '@wordpress/keycodes@4.2.0':
     dependencies:
@@ -20230,11 +20070,6 @@ snapshots:
       clsx: 2.1.1
       react: 18.3.1
 
-  '@wordpress/priority-queue@2.58.0':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      requestidlecallback: 0.3.0
-
   '@wordpress/priority-queue@3.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -20391,11 +20226,6 @@ snapshots:
   '@wordpress/token-list@3.2.0':
     dependencies:
       '@babel/runtime': 7.24.7
-
-  '@wordpress/undo-manager@0.18.0':
-    dependencies:
-      '@babel/runtime': 7.24.7
-      '@wordpress/is-shallow-equal': 4.58.0
 
   '@wordpress/undo-manager@1.2.0':
     dependencies:
@@ -23228,11 +23058,6 @@ snapshots:
     dependencies:
       has-symbols: 1.0.3
 
-  hash.js@1.1.7:
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-
   hasha@5.2.2:
     dependencies:
       is-stream: 2.0.1
@@ -23387,24 +23212,6 @@ snapshots:
   humps@2.0.1: {}
 
   husky@8.0.3: {}
-
-  i18n-calypso@7.0.0(@types/react@18.3.1)(react@18.3.1):
-    dependencies:
-      '@automattic/interpolate-components': 1.2.1(@types/react@18.3.1)(react@18.3.1)
-      '@babel/runtime': 7.24.7
-      '@tannin/sprintf': 1.2.0
-      '@wordpress/compose': 6.35.0(react@18.3.1)
-      debug: 4.3.4
-      events: 3.3.0
-      hash.js: 1.1.7
-      lodash: 4.17.21
-      lru: 3.1.0
-      react: 18.3.1
-      tannin: 1.2.0
-      use-subscription: 1.6.0(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-      - supports-color
 
   iconv-lite@0.4.24:
     dependencies:
@@ -24623,10 +24430,6 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
-  lru@3.1.0:
-    dependencies:
-      inherits: 2.0.4
-
   lz-string@1.5.0: {}
 
   magic-string@0.27.0:
@@ -25048,8 +24851,6 @@ snapshots:
     dependencies:
       schema-utils: 4.2.0
       webpack: 5.76.0(webpack-cli@4.9.1)
-
-  minimalistic-assert@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -27691,10 +27492,6 @@ snapshots:
       detect-node-es: 1.1.0
       react: 18.3.1
       tslib: 2.5.0
-
-  use-subscription@1.6.0(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   use-sync-external-store@1.2.2(react@18.3.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2197,9 +2197,6 @@ importers:
       babel-plugin-transform-rename-properties:
         specifier: 0.1.0
         version: 0.1.0(@babel/core@7.24.7)
-      events:
-        specifier: 3.3.0
-        version: 3.3.0
       sass:
         specifier: 1.64.1
         version: 1.64.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-localize-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-localize-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Support localizeUrl

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -62,7 +62,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.44.x-dev"
+			"dev-trunk": "5.45.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -38,6 +38,8 @@
 		"@types/react": "^18.2.28",
 		"@types/react-dom": "18.3.0",
 		"babel-plugin-transform-rename-properties": "0.1.0",
+		"events": "3.3.0",
+		"pkg-dir": "^5.0.0",
 		"sass": "1.64.1",
 		"sass-loader": "12.4.0",
 		"typescript": "^5.0.4",
@@ -45,7 +47,9 @@
 		"webpack-cli": "4.9.1"
 	},
 	"dependencies": {
+		"@automattic/i18n-utils": "1.2.1",
 		"@automattic/jetpack-base-styles": "workspace:*",
+		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/typography": "1.0.0",
 		"@preact/signals": "^1.2.2",
@@ -62,6 +66,7 @@
 		"@wordpress/url": "4.2.0",
 		"@wordpress/icons": "10.2.0",
 		"clsx": "2.1.1",
+		"i18n-calypso": "7.0.0",
 		"preact": "^10.13.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -39,7 +39,6 @@
 		"@types/react-dom": "18.3.0",
 		"babel-plugin-transform-rename-properties": "0.1.0",
 		"events": "3.3.0",
-		"pkg-dir": "^5.0.0",
 		"sass": "1.64.1",
 		"sass-loader": "12.4.0",
 		"typescript": "^5.0.4",
@@ -47,9 +46,8 @@
 		"webpack-cli": "4.9.1"
 	},
 	"dependencies": {
-		"@automattic/i18n-utils": "1.2.1",
+		"@automattic/i18n-utils": "1.2.3",
 		"@automattic/jetpack-base-styles": "workspace:*",
-		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/typography": "1.0.0",
 		"@preact/signals": "^1.2.2",
@@ -66,7 +64,6 @@
 		"@wordpress/url": "4.2.0",
 		"@wordpress/icons": "10.2.0",
 		"clsx": "2.1.1",
-		"i18n-calypso": "7.0.0",
 		"preact": "^10.13.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.44.0",
+	"version": "5.45.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -38,7 +38,6 @@
 		"@types/react": "^18.2.28",
 		"@types/react-dom": "18.3.0",
 		"babel-plugin-transform-rename-properties": "0.1.0",
-		"events": "3.3.0",
 		"sass": "1.64.1",
 		"sass-loader": "12.4.0",
 		"typescript": "^5.0.4",

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.44.0';
+	const PACKAGE_VERSION = '5.45.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/common/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/index.php
@@ -36,6 +36,6 @@ function get_iso_639_locale( $language ) {
  * @return string ISO 639 locale string e.g. "en"
  */
 function determine_iso_639_locale() {
-	$locale = get_user_locale() ?? get_locale();
+	$locale = get_user_locale();
 	return get_iso_639_locale( $locale );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/common/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/index.php
@@ -29,3 +29,13 @@ function get_iso_639_locale( $language ) {
 
 	return $language;
 }
+
+/**
+ * Returns ISO 639 conforming locale string of the current user.
+ *
+ * @return string ISO 639 locale string e.g. "en"
+ */
+function determine_iso_639_locale() {
+	$locale = get_user_locale() ?? get_locale();
+	return get_iso_639_locale( $locale );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -111,7 +111,7 @@ class Help_Center {
 			// Load translations directly from widgets.wp.com.
 			wp_enqueue_script(
 				'help-center-translations',
-				'https://widgets.wp.com/help-center/languages/' . self::determine_iso_639_locale() . '-v1.js',
+				'https://widgets.wp.com/help-center/languages/' . Common\determine_iso_639_locale() . '-v1.js',
 				array( 'wp-i18n' ),
 				$version,
 				true
@@ -169,7 +169,7 @@ class Help_Center {
 							'email'        => $user_email,
 						),
 						'site'        => $this->get_current_site(),
-						'locale'      => self::determine_iso_639_locale(),
+						'locale'      => Common\determine_iso_639_locale(),
 					)
 				),
 				'before'
@@ -177,16 +177,6 @@ class Help_Center {
 		}
 	}
 
-	/**
-	 * Determine the ISO 639 locale.
-	 */
-	public static function determine_iso_639_locale() {
-		$locale = get_user_locale();
-		if ( ! $locale ) {
-			$locale = Common\get_iso_639_locale( get_locale() );
-		}
-		return Common\get_iso_639_locale( $locale );
-	}
 	/**
 	 * Get current site details.
 	 */

--- a/projects/packages/jetpack-mu-wpcom/src/features/tags-education/tags-education.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/tags-education/tags-education.js
@@ -1,5 +1,4 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { getUserLocale } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { ExternalLink } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -17,10 +16,7 @@ const addTagsEducationLink = createHigherOrderComponent( PostTaxonomyType => {
 			<>
 				<PostTaxonomyType { ...props } />
 				<ExternalLink
-					href={ localizeUrl(
-						'https://wordpress.com/support/posts/tags/',
-						getUserLocale().toLowerCase()
-					) }
+					href={ localizeUrl( 'https://wordpress.com/support/posts/tags/' ) }
 					onClick={ () => {
 						tracks.recordEvent( 'jetpack_mu_wpcom_tags_education_link_click' );
 					} }

--- a/projects/packages/jetpack-mu-wpcom/src/features/tags-education/tags-education.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/tags-education/tags-education.js
@@ -1,3 +1,5 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { getUserLocale } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { ExternalLink } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -15,7 +17,10 @@ const addTagsEducationLink = createHigherOrderComponent( PostTaxonomyType => {
 			<>
 				<PostTaxonomyType { ...props } />
 				<ExternalLink
-					href="https://wordpress.com/support/posts/tags/"
+					href={ localizeUrl(
+						'https://wordpress.com/support/posts/tags/',
+						getUserLocale().toLowerCase()
+					) }
 					onClick={ () => {
 						tracks.recordEvent( 'jetpack_mu_wpcom_tags_education_link_click' );
 					} }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
@@ -1,5 +1,4 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { getUserLocale } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { JSXElementConstructor, ReactElement } from 'react';
@@ -16,7 +15,7 @@ const createLocalizedDescriptionWithLearnMore = (
 	url: string,
 	postId: number
 ) => {
-	const localizedUrl = localizeUrl( url, getUserLocale().toLowerCase() );
+	const localizedUrl = localizeUrl( url );
 	return createInterpolateElement( '<InlineSupportLink />', {
 		InlineSupportLink: (
 			<DescriptionSupportLink title={ String( title ) } url={ localizedUrl } postId={ postId }>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
@@ -1,3 +1,5 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { getUserLocale } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 import { JSXElementConstructor, ReactElement } from 'react';
@@ -14,9 +16,10 @@ const createLocalizedDescriptionWithLearnMore = (
 	url: string,
 	postId: number
 ) => {
+	const localizedUrl = localizeUrl( url, getUserLocale().toLowerCase() );
 	return createInterpolateElement( '<InlineSupportLink />', {
 		InlineSupportLink: (
-			<DescriptionSupportLink title={ String( title ) } url={ url } postId={ postId }>
+			<DescriptionSupportLink title={ String( title ) } url={ localizedUrl } postId={ postId }>
 				{ description }
 			</DescriptionSupportLink>
 		),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/inline-support-link.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/inline-support-link.tsx
@@ -1,3 +1,5 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { getUserLocale } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, ExternalLink } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -47,7 +49,7 @@ export default function DescriptionSupportLink( {
 				<Button
 					onClick={ () => {
 						setShowHelpCenter( true );
-						setShowSupportDoc( url, postId );
+						setShowSupportDoc( localizeUrl( url, getUserLocale().toLowerCase() ), postId );
 						tracks.recordEvent( 'jetpack_mu_wpcom_block_description_support_link_click', {
 							block: title,
 							support_link: url,

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/inline-support-link.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/inline-support-link.tsx
@@ -1,5 +1,4 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { getUserLocale } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button, ExternalLink } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
@@ -49,7 +48,7 @@ export default function DescriptionSupportLink( {
 				<Button
 					onClick={ () => {
 						setShowHelpCenter( true );
-						setShowSupportDoc( localizeUrl( url, getUserLocale().toLowerCase() ), postId );
+						setShowSupportDoc( localizeUrl( url ), postId );
 						tracks.recordEvent( 'jetpack_mu_wpcom_block_description_support_link_click', {
 							block: title,
 							support_link: url,

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
@@ -1,5 +1,4 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { getUserLocale } from '@automattic/jetpack-components';
 import { addFilter } from '@wordpress/hooks';
 import './wpcom-documentation-links.css';
 
@@ -45,7 +44,7 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 	}
 
 	if ( url ) {
-		return localizeUrl( url, getUserLocale().toLowerCase() );
+		return localizeUrl( url );
 	}
 
 	return translation;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
@@ -16,33 +16,51 @@ declare global {
  * @param text        - string Original text.
  */
 function overrideCoreDocumentationLinksToWpcom( translation: string, text: string ) {
-	let url;
-	switch ( text ) {
-		case 'https://wordpress.org/documentation/article/what-is-an-excerpt-classic-editor/':
-		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt':
-			url = 'https://wordpress.com/support/excerpts/';
-			break;
-		case 'https://wordpress.org/documentation/article/write-posts-classic-editor/#post-field-descriptions':
-		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink':
-			url = 'https://wordpress.com/support/permalinks-and-slugs/';
-			break;
-		case 'https://wordpress.org/documentation/article/wordpress-block-editor/':
-			url = 'https://wordpress.com/support/wordpress-editor/';
-			break;
-		case 'https://wordpress.org/documentation/article/site-editor/':
-			url = 'https://wordpress.com/support/site-editor/';
-			break;
-		case 'https://wordpress.org/documentation/article/block-based-widgets-editor/':
-			url = 'https://wordpress.com/support/widgets/';
-			break;
-		case 'https://wordpress.org/plugins/classic-widgets/':
-			url = 'https://wordpress.com/plugins/classic-widgets';
-			break;
-		case 'https://wordpress.org/documentation/article/styles-overview/':
-			url = 'https://wordpress.com/support/using-styles/';
-			break;
-	}
+	const documentLinksMap = {
+		/**
+		 * Excerpts
+		 */
+		'https://wordpress.org/documentation/article/what-is-an-excerpt-classic-editor/':
+			'https://wordpress.com/support/excerpts/',
+		'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt':
+			'https://wordpress.com/support/excerpts/',
 
+		/**
+		 * Permalinks and Slugs
+		 */
+		'https://wordpress.org/documentation/article/write-posts-classic-editor/#post-field-descriptions':
+			'https://wordpress.com/support/permalinks-and-slugs/',
+		'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink':
+			'https://wordpress.com/support/permalinks-and-slugs/',
+
+		/**
+		 * Wordpress Editor
+		 */
+		'https://wordpress.org/documentation/article/wordpress-block-editor/':
+			'https://wordpress.com/support/wordpress-editor/',
+
+		/**
+		 * Site Editor
+		 */
+		'https://wordpress.org/documentation/article/site-editor/':
+			'https://wordpress.com/support/site-editor/',
+
+		/**
+		 * Widgets
+		 */
+		'https://wordpress.org/documentation/article/block-based-widgets-editor/':
+			'https://wordpress.com/support/widgets/',
+		'https://wordpress.org/plugins/classic-widgets/':
+			'https://wordpress.com/plugins/classic-widgets',
+
+		/**
+		 * Styles
+		 */
+		'https://wordpress.org/documentation/article/styles-overview/':
+			'https://wordpress.com/support/using-styles/',
+	};
+
+	const url = documentLinksMap[ text ] ?? '';
 	if ( url ) {
 		return localizeUrl( url );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
@@ -1,3 +1,5 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { getUserLocale } from '@automattic/jetpack-components';
 import { addFilter } from '@wordpress/hooks';
 import './wpcom-documentation-links.css';
 
@@ -15,23 +17,35 @@ declare global {
  * @param text        - string Original text.
  */
 function overrideCoreDocumentationLinksToWpcom( translation: string, text: string ) {
+	let url;
 	switch ( text ) {
 		case 'https://wordpress.org/documentation/article/what-is-an-excerpt-classic-editor/':
 		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#excerpt':
-			return 'https://wordpress.com/support/excerpts/';
+			url = 'https://wordpress.com/support/excerpts/';
+			break;
 		case 'https://wordpress.org/documentation/article/write-posts-classic-editor/#post-field-descriptions':
 		case 'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink':
-			return 'https://wordpress.com/support/permalinks-and-slugs/';
+			url = 'https://wordpress.com/support/permalinks-and-slugs/';
+			break;
 		case 'https://wordpress.org/documentation/article/wordpress-block-editor/':
-			return 'https://wordpress.com/support/wordpress-editor/';
+			url = 'https://wordpress.com/support/wordpress-editor/';
+			break;
 		case 'https://wordpress.org/documentation/article/site-editor/':
-			return 'https://wordpress.com/support/site-editor/';
+			url = 'https://wordpress.com/support/site-editor/';
+			break;
 		case 'https://wordpress.org/documentation/article/block-based-widgets-editor/':
-			return 'https://wordpress.com/support/widgets/';
+			url = 'https://wordpress.com/support/widgets/';
+			break;
 		case 'https://wordpress.org/plugins/classic-widgets/':
-			return 'https://wordpress.com/plugins/classic-widgets';
+			url = 'https://wordpress.com/plugins/classic-widgets';
+			break;
 		case 'https://wordpress.org/documentation/article/styles-overview/':
-			return 'https://wordpress.com/support/using-styles/';
+			url = 'https://wordpress.com/support/using-styles/';
+			break;
+	}
+
+	if ( url ) {
+		return localizeUrl( url, getUserLocale().toLowerCase() );
 	}
 
 	return translation;

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -1,7 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require( 'path' );
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
+const pkgDir = require( 'pkg-dir' );
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const verbumConfig = require( './verbum.webpack.config.js' );
 
 module.exports = [
@@ -49,6 +50,15 @@ module.exports = [
 		},
 		resolve: {
 			...jetpackWebpackConfig.resolve,
+			alias: {
+				...jetpackWebpackConfig.resolve.alias,
+				'i18n-calypso': findPackage( 'i18n-calypso' ),
+				'@automattic/calypso-config': '@automattic/calypso-config/src/client.js',
+			},
+			fallback: {
+				...jetpackWebpackConfig.resolve.fallback,
+				events: require.resolve( 'events/' ),
+			},
 		},
 		node: false,
 		plugins: [
@@ -87,3 +97,22 @@ module.exports = [
 		},
 	},
 ];
+
+/**
+ * Given a package name, finds the absolute path for it.
+ *
+ * require.resolve() will resolve to the main file of the package, using Node's resolution algorithm to find
+ * a `package.json` and looking at the field `main`. This function will return the folder that contains `package.json`
+ * instead of trying to resolve the main file.
+ *
+ * Example: `@wordpress/data` may resolve to `/home/myUser/wp-calypso/node_modules/@wordpress/data`.
+ *
+ * Note this is not the same as looking for `__dirname+'/node_modules/'+pkgName`, as the package may be in a parent
+ * `node_modules`
+ * @param {string} pkgName - Name of the package to search for.
+ */
+function findPackage( pkgName ) {
+	const fullPath = require.resolve( pkgName );
+	const packagePath = pkgDir.sync( fullPath );
+	return packagePath;
+}

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
-const pkgDir = require( 'pkg-dir' );
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const verbumConfig = require( './verbum.webpack.config.js' );
 
@@ -52,12 +51,7 @@ module.exports = [
 			...jetpackWebpackConfig.resolve,
 			alias: {
 				...jetpackWebpackConfig.resolve.alias,
-				'i18n-calypso': findPackage( 'i18n-calypso' ),
 				'@automattic/calypso-config': '@automattic/calypso-config/src/client.js',
-			},
-			fallback: {
-				...jetpackWebpackConfig.resolve.fallback,
-				events: require.resolve( 'events/' ),
 			},
 		},
 		node: false,
@@ -97,22 +91,3 @@ module.exports = [
 		},
 	},
 ];
-
-/**
- * Given a package name, finds the absolute path for it.
- *
- * require.resolve() will resolve to the main file of the package, using Node's resolution algorithm to find
- * a `package.json` and looking at the field `main`. This function will return the folder that contains `package.json`
- * instead of trying to resolve the main file.
- *
- * Example: `@wordpress/data` may resolve to `/home/myUser/wp-calypso/node_modules/@wordpress/data`.
- *
- * Note this is not the same as looking for `__dirname+'/node_modules/'+pkgName`, as the package may be in a parent
- * `node_modules`
- * @param {string} pkgName - Name of the package to search for.
- */
-function findPackage( pkgName ) {
-	const fullPath = require.resolve( pkgName );
-	const packagePath = pkgDir.sync( fullPath );
-	return packagePath;
-}

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const verbumConfig = require( './verbum.webpack.config.js' );
 
 module.exports = [

--- a/projects/plugins/mu-wpcom-plugin/changelog/mu-wpcom-localize-url
+++ b/projects/plugins/mu-wpcom-plugin/changelog/mu-wpcom-localize-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_4_0"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_4_1_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1005,7 +1005,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "94b20f27ba3452f454c50a288931cc3e57c363ba"
+                "reference": "c26a4dc9f95986ac41f6614a31a59f9efedcb72e"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1039,7 +1039,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.44.x-dev"
+                    "dev-trunk": "5.45.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.4.0
+ * Version: 2.4.1-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.4.0",
+	"version": "2.4.1-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/wpcomsh/changelog/mu-wpcom-localize-url
+++ b/projects/plugins/wpcomsh/changelog/mu-wpcom-localize-url
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_28_0"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_28_1_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1142,7 +1142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "94b20f27ba3452f454c50a288931cc3e57c363ba"
+                "reference": "c26a4dc9f95986ac41f6614a31a59f9efedcb72e"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1176,7 +1176,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.44.x-dev"
+                    "dev-trunk": "5.45.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.28.0",
+	"version": "3.28.1-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.28.0
+ * Version: 3.28.1-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '3.28.0' );
+define( 'WPCOMSH_VERSION', '3.28.1-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8244

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Make the `localizeUrl` function available in the jetpack-mu-wpcom package
* [Support the alternate data of the post on atomic sites](https://github.com/Automattic/jetpack/pull/38318/commits/2f8efd420bc50989bab26a0320b2cdf9fa3f186d)
  * ~The help center uses [useSupportArticleAlternatePostKey](https://github.com/Automattic/wp-calypso/blob/569f34f90e55cfbf8d68eabff5c0e0705f23d67f/packages/help-center/src/hooks/use-support-article-alternates-query.ts#L36) to get the localised blog and post. However, it doesn't seem to work on atomic sites so the "Block Description" cannot open the help center with the correct document. The ETK plugin has the same issue as well~
* [Bump @automattic/i18n-utils to 1.2.3 to get rid of the `i18n-calypso` dependency](https://github.com/Automattic/jetpack/pull/38318/commits/7f38e2c34dad96e2d18eda6e91b99fd1cab95daa)
  * ~There is an issue related to the [useLocale](https://github.com/Automattic/wp-calypso/blob/a7f416670e3f40153058c20eec7e6a5474e4512a/packages/help-center/src/hooks/use-support-article-alternates-query.ts#L35) inside the help center. It would be fixed by https://github.com/Automattic/wp-calypso/pull/92631 and then we can also get rid of the `i18n-calypso` dependency to make it easier to introduce the `localizeUrl` function~

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site
* Make sure the links related to https://github.com/Automattic/dotcom-forge/issues/8037 are localized
  * Block Description 
    * Head to Site Editor.
    * Insert a block such as the Image Block or the List Block.
    * Open the Settings panel and select the Block tab.
    * Ensure that the Block Guide link is as shown in the screenshot above.
    * Ensure that clicking the link opens the Help Center.
    * Ensure it displays the correct locale.
  * Tags Education
    * Head to the Post Editor.
    * Open the Settings panel, and expand the Tags section.
    * Ensure that the link "[Build your audience with tags↗](https://wordpress.com/support/posts/tags/)" is available.
    * Ensure it displays the correct locale.
  * Documentation Links
    * Head to the Post Editor.
    * Open the Settings panel by clicking the Settings icon in the top bar.
    * Click the Link slug in the Post tab.
    * Ensure it displays the correct locale.

