### PR TITLE
Extend ProductCard component and create recommendations UI

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -95,7 +95,7 @@ const ConnectedProductCard = ( {
 
 ConnectedProductCard.propTypes = {
 	children: PropTypes.node,
-	admin: PropTypes.bool.isRequired,
+	admin: PropTypes.bool,
 	recommendation: PropTypes.bool,
 	slug: PropTypes.string.isRequired,
 	isDataLoading: PropTypes.bool,

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -35,7 +35,13 @@ const ConnectedProductCard = ( {
 		useInstallStandalonePlugin( slug );
 	const { activate, isPending: isActivating } = useActivate( slug );
 	const { detail } = useProduct( slug );
-	const { name, description: defaultDescription, requiresUserConnection, status } = detail;
+	const {
+		name,
+		description: defaultDescription,
+		longDescription,
+		requiresUserConnection,
+		status,
+	} = detail;
 
 	const navigateToConnectionPage = useMyJetpackNavigate( MyJetpackRoutes.Connection );
 
@@ -58,8 +64,9 @@ const ConnectedProductCard = ( {
 	] );
 
 	const DefaultDescription = () => {
+		const productDescription = ! recommendation ? defaultDescription : longDescription;
 		// Replace the last space with a non-breaking space to prevent widows
-		const cardDescription = defaultDescription.replace( /\s(?=[^\s]*$)/, '\u00A0' );
+		const cardDescription = productDescription.replace( /\s(?=[^\s]*$)/, '\u00A0' );
 
 		return (
 			<Text variant="body-small" style={ { flexGrow: 1 } }>

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -17,6 +17,7 @@ import ProductCard from '../product-card';
 
 const ConnectedProductCard = ( {
 	admin,
+	recommendation,
 	slug,
 	children,
 	isDataLoading,
@@ -73,6 +74,7 @@ const ConnectedProductCard = ( {
 			Description={ Description ? Description : DefaultDescription }
 			status={ status }
 			admin={ admin }
+			recommendation={ recommendation }
 			isFetching={ isActivating || isInstalling }
 			isDataLoading={ isDataLoading }
 			isInstallingStandalone={ isInstalling }
@@ -94,6 +96,7 @@ const ConnectedProductCard = ( {
 ConnectedProductCard.propTypes = {
 	children: PropTypes.node,
 	admin: PropTypes.bool.isRequired,
+	recommendation: PropTypes.bool,
 	slug: PropTypes.string.isRequired,
 	isDataLoading: PropTypes.bool,
 	additionalActions: PropTypes.array,

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.jsx
@@ -35,13 +35,7 @@ const ConnectedProductCard = ( {
 		useInstallStandalonePlugin( slug );
 	const { activate, isPending: isActivating } = useActivate( slug );
 	const { detail } = useProduct( slug );
-	const {
-		name,
-		description: defaultDescription,
-		longDescription,
-		requiresUserConnection,
-		status,
-	} = detail;
+	const { name, description: defaultDescription, requiresUserConnection, status } = detail;
 
 	const navigateToConnectionPage = useMyJetpackNavigate( MyJetpackRoutes.Connection );
 
@@ -64,9 +58,8 @@ const ConnectedProductCard = ( {
 	] );
 
 	const DefaultDescription = () => {
-		const productDescription = ! recommendation ? defaultDescription : longDescription;
 		// Replace the last space with a non-breaking space to prevent widows
-		const cardDescription = productDescription.replace( /\s(?=[^\s]*$)/, '\u00A0' );
+		const cardDescription = defaultDescription.replace( /\s(?=[^\s]*$)/, '\u00A0' );
 
 		return (
 			<Text variant="body-small" style={ { flexGrow: 1 } }>

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
@@ -1,5 +1,5 @@
 import { Container, Col, Text } from '@automattic/jetpack-components';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import useEvaluationRecommendations from '../../data/evaluation-recommendations/use-evaluation-recommendations';
 import { JetpackModuleToProductCard } from '../product-cards-section/all';
 
@@ -14,13 +14,18 @@ const EvaluationRecommendations: React.FC = () => {
 		<Container horizontalGap={ 2 } horizontalSpacing={ 8 }>
 			<Col>
 				<Text variant="headline-small">
-					{ __( 'Our recommendations for you', 'jetpack-my-jetpack' ) }
+					{ _n(
+						'Our recommendation for you',
+						'Our recommendations for you',
+						recommendedModules.length,
+						'jetpack-my-jetpack'
+					) }
 				</Text>
 			</Col>
 			<Col>
 				<Text>
 					{ __(
-						'Here are the features that will best help you protect your site:',
+						'Here are the features that will best help you with your site:',
 						'jetpack-my-jetpack'
 					) }
 				</Text>
@@ -32,7 +37,7 @@ const EvaluationRecommendations: React.FC = () => {
 						return (
 							Card && (
 								<Col key={ module } lg={ 4 }>
-									<Card recommendation={ true } />
+									<Card recommendation />
 								</Col>
 							)
 						);

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
@@ -1,4 +1,7 @@
+import { Container, Col, Text } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
 import useRecommendationsSection from '../../data/recommendations-section/use-recommendations-section';
+import { JetpackModuleToProductCard } from '../product-cards-section/all';
 
 const EvaluationRecommendations: React.FC = () => {
 	const { isSectionVisible, recommendedModules } = useRecommendationsSection();
@@ -7,7 +10,37 @@ const EvaluationRecommendations: React.FC = () => {
 		return null;
 	}
 
-	return <>EvaluationRecommendations TBD: { recommendedModules.join( ', ' ) }</>;
+	return (
+		<Container horizontalGap={ 2 } horizontalSpacing={ 8 }>
+			<Col>
+				<Text variant="headline-small">
+					{ __( 'Our recommendations for you', 'jetpack-my-jetpack' ) }
+				</Text>
+			</Col>
+			<Col>
+				<Text>
+					{ __(
+						'Here are the features that will best help you protect your site:',
+						'jetpack-my-jetpack'
+					) }
+				</Text>
+			</Col>
+			<Col>
+				<Container horizontalGap={ 4 } horizontalSpacing={ 2 } fluid>
+					{ recommendedModules.map( module => {
+						const Card = JetpackModuleToProductCard[ module ];
+						return (
+							Card && (
+								<Col key={ module } lg={ 4 }>
+									<Card recommendation={ true } />
+								</Col>
+							)
+						);
+					} ) }
+				</Container>
+			</Col>
+		</Container>
+	);
 };
 
 export default EvaluationRecommendations;

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
@@ -1,10 +1,10 @@
 import { Container, Col, Text } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import useRecommendationsSection from '../../data/recommendations-section/use-recommendations-section';
+import useEvaluationRecommendations from '../../data/evaluation-recommendations/use-evaluation-recommendations';
 import { JetpackModuleToProductCard } from '../product-cards-section/all';
 
 const EvaluationRecommendations: React.FC = () => {
-	const { isSectionVisible, recommendedModules } = useRecommendationsSection();
+	const { isSectionVisible, recommendedModules } = useEvaluationRecommendations();
 
 	if ( ! isSectionVisible ) {
 		return null;

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -169,7 +169,7 @@ export default function MyJetpackScreen() {
 					{ showFullJetpackStatsCard && (
 						<Col
 							className={ clsx( {
-								[ styles.stats ]: statsDetails?.status !== PRODUCT_STATUSES.ERROR,
+								[ styles.stats ]: statsDetails?.status !== PRODUCT_STATUSES.SITE_CONNECTION_ERROR,
 							} ) }
 						>
 							<StatsSection />

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, chevronDown, external, check } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useCallback, useState, useEffect, useMemo, useRef, FC, ComponentProps } from 'react';
+import { useCallback, useState, useEffect, useMemo, useRef } from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
 import useProduct from '../../data/products/use-product';
 import useAnalytics from '../../hooks/use-analytics';
@@ -10,6 +10,7 @@ import useOutsideAlerter from '../../hooks/use-outside-alerter';
 import { type SecondaryButtonProps } from './secondary-button';
 import styles from './style.module.scss';
 import { ProductCardProps } from '.';
+import type { FC, ComponentProps } from 'react';
 
 type ActionButtonProps< A = () => void > = ProductCardProps & {
 	onFixConnection?: A;

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
@@ -7,9 +7,9 @@ import { PRODUCT_STATUSES } from '../../constants';
 import useProduct from '../../data/products/use-product';
 import useAnalytics from '../../hooks/use-analytics';
 import useOutsideAlerter from '../../hooks/use-outside-alerter';
-import { type SecondaryButtonProps } from './secondary-button';
 import styles from './style.module.scss';
 import { ProductCardProps } from '.';
+import type { SecondaryButtonProps } from './secondary-button';
 import type { FC, ComponentProps } from 'react';
 
 type ActionButtonProps< A = () => void > = ProductCardProps & {

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
@@ -2,14 +2,33 @@ import { Button } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, chevronDown, external, check } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useCallback, useState, useEffect, useMemo, useRef } from 'react';
+import {
+	useCallback,
+	useState,
+	useEffect,
+	useMemo,
+	useRef,
+	FC,
+	ComponentProps,
+	MouseEventHandler,
+} from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
 import useProduct from '../../data/products/use-product';
 import useAnalytics from '../../hooks/use-analytics';
 import useOutsideAlerter from '../../hooks/use-outside-alerter';
 import styles from './style.module.scss';
+import { ProductCardProps } from '.';
 
-const ActionButton = ( {
+type ActionButtonProps< A = MouseEventHandler< HTMLButtonElement > > = ProductCardProps & {
+	onFixConnection?: A;
+	onManage?: A;
+	onAdd?: A;
+	onInstall?: A;
+	onLearnMore?: A;
+	className?: string;
+};
+
+const ActionButton: FC< ActionButtonProps > = ( {
 	status,
 	admin,
 	name,
@@ -28,7 +47,7 @@ const ActionButton = ( {
 	upgradeInInterstitial,
 } ) => {
 	const [ isDropdownOpen, setIsDropdownOpen ] = useState( false );
-	const [ currentAction, setCurrentAction ] = useState( {} );
+	const [ currentAction, setCurrentAction ] = useState< ComponentProps< typeof Button > >( {} );
 	const { detail } = useProduct( slug );
 	const { manageUrl, purchaseUrl } = detail;
 	const isManageDisabled = ! manageUrl;
@@ -165,8 +184,8 @@ const ActionButton = ( {
 					label: __( 'Fix connection', 'jetpack-my-jetpack' ),
 					onClick: onFixConnection,
 					...( primaryActionOverride &&
-						PRODUCT_STATUSES.ERROR in primaryActionOverride &&
-						primaryActionOverride[ PRODUCT_STATUSES.ERROR ] ),
+						PRODUCT_STATUSES.SITE_CONNECTION_ERROR in primaryActionOverride &&
+						primaryActionOverride[ PRODUCT_STATUSES.SITE_CONNECTION_ERROR ] ),
 				};
 			case PRODUCT_STATUSES.USER_CONNECTION_ERROR:
 				return {

--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
@@ -2,24 +2,16 @@ import { Button } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, chevronDown, external, check } from '@wordpress/icons';
 import clsx from 'clsx';
-import {
-	useCallback,
-	useState,
-	useEffect,
-	useMemo,
-	useRef,
-	FC,
-	ComponentProps,
-	MouseEventHandler,
-} from 'react';
+import { useCallback, useState, useEffect, useMemo, useRef, FC, ComponentProps } from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
 import useProduct from '../../data/products/use-product';
 import useAnalytics from '../../hooks/use-analytics';
 import useOutsideAlerter from '../../hooks/use-outside-alerter';
+import { type SecondaryButtonProps } from './secondary-button';
 import styles from './style.module.scss';
 import { ProductCardProps } from '.';
 
-type ActionButtonProps< A = MouseEventHandler< HTMLButtonElement > > = ProductCardProps & {
+type ActionButtonProps< A = () => void > = ProductCardProps & {
 	onFixConnection?: A;
 	onManage?: A;
 	onAdd?: A;
@@ -66,7 +58,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 		};
 	}, [ isBusy, className ] );
 
-	const getStatusAction = useCallback( () => {
+	const getStatusAction = useCallback( (): SecondaryButtonProps => {
 		switch ( status ) {
 			case PRODUCT_STATUSES.ABSENT: {
 				const buttonText = __( 'Learn more', 'jetpack-my-jetpack' );

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -7,7 +7,7 @@ import Card from '../card';
 import ActionButton from './action-button';
 import PriceComponent from './pricing-component';
 import RecommendationActions from './recommendation-actions';
-import SecondaryButton, { SecondaryButtonProps } from './secondary-button';
+import SecondaryButton, { type SecondaryButtonProps } from './secondary-button';
 import Status from './status';
 import styles from './style.module.scss';
 
@@ -35,14 +35,14 @@ export type ProductCardProps = {
 	isDataLoading?: boolean;
 	isInstallingStandalone?: boolean;
 	isManageDisabled?: boolean;
-	onActivate?: MouseEventHandler< HTMLButtonElement >;
+	onActivate?: () => void;
 	slug: string;
-	additionalActions?: unknown[];
+	additionalActions?: SecondaryButtonProps[];
 	upgradeInInterstitial?: boolean;
 	primaryActionOverride?: Record< string, { href?: string; label?: string } >;
 	secondaryAction?: Record< string, SecondaryButtonProps & { positionFirst?: boolean } >;
-	onInstallStandalone?: MouseEventHandler< HTMLButtonElement >;
-	onActivateStandalone?: MouseEventHandler< HTMLButtonElement >;
+	onInstallStandalone?: () => void;
+	onActivateStandalone?: () => void;
 	status: ( typeof PRODUCT_STATUSES )[ keyof typeof PRODUCT_STATUSES ];
 	onMouseEnter?: MouseEventHandler< HTMLButtonElement >;
 	onMouseLeave?: MouseEventHandler< HTMLButtonElement >;
@@ -96,16 +96,12 @@ const ProductCard: FC< ProductCardProps > = props => {
 	/**
 	 * Calls the passed function onActivate after firing Tracks event
 	 */
-	const activateHandler = useCallback(
-		event => {
-			event.preventDefault();
-			recordEvent( 'jetpack_myjetpack_product_card_activate_click', {
-				product: slug,
-			} );
-			onActivate( event );
-		},
-		[ slug, onActivate, recordEvent ]
-	);
+	const activateHandler = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_product_card_activate_click', {
+			product: slug,
+		} );
+		onActivate();
+	}, [ slug, onActivate, recordEvent ] );
 
 	/**
 	 * Calls the passed function onAdd after firing Tracks event
@@ -146,16 +142,12 @@ const ProductCard: FC< ProductCardProps > = props => {
 	/**
 	 * Use a Tracks event to count a standalone plugin install request
 	 */
-	const installStandaloneHandler = useCallback(
-		event => {
-			event.preventDefault();
-			recordEvent( 'jetpack_myjetpack_product_card_install_standalone_plugin_click', {
-				product: slug,
-			} );
-			onInstallStandalone( event );
-		},
-		[ slug, onInstallStandalone, recordEvent ]
-	);
+	const installStandaloneHandler = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_product_card_install_standalone_plugin_click', {
+			product: slug,
+		} );
+		onInstallStandalone();
+	}, [ slug, onInstallStandalone, recordEvent ] );
 
 	/**
 	 * Sends an event when the card loads

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { FC, MouseEventHandler, ReactNode, useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
 import useAnalytics from '../../hooks/use-analytics';
 import Card from '../card';
@@ -10,6 +10,7 @@ import RecommendationActions from './recommendation-actions';
 import SecondaryButton, { type SecondaryButtonProps } from './secondary-button';
 import Status from './status';
 import styles from './style.module.scss';
+import type { FC, MouseEventHandler, ReactNode } from 'react';
 
 export const PRODUCT_STATUSES_LABELS = {
 	[ PRODUCT_STATUSES.ACTIVE ]: __( 'Active', 'jetpack-my-jetpack' ),

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -177,8 +177,9 @@ const ProductCard: FC< ProductCardProps > = props => {
 				children
 			) }
 
-			{ recommendation && <RecommendationActions slug={ slug } /> }
-			{ ! recommendation && (
+			{ recommendation ? (
+				<RecommendationActions slug={ slug } />
+			) : (
 				<div className={ styles.actions }>
 					<div className={ styles.buttons }>
 						{ secondaryAction && secondaryAction?.positionFirst && (

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -1,15 +1,12 @@
-import formatCurrency from '@automattic/format-currency';
-import { Button, getProductCheckoutUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { FC, MouseEventHandler, ReactNode, useCallback, useEffect } from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
-import useProduct from '../../data/products/use-product';
-import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../hooks/use-analytics';
-import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import Card from '../card';
 import ActionButton from './action-button';
+import PriceComponent from './pricing-component';
+import RecommendationActions from './recommendation-actions';
 import SecondaryButton, { SecondaryButtonProps } from './secondary-button';
 import Status from './status';
 import styles from './style.module.scss';
@@ -178,7 +175,7 @@ const ProductCard: FC< ProductCardProps > = props => {
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
 		>
-			{ recommendation && <Price slug={ slug } /> }
+			{ recommendation && <PriceComponent slug={ slug } /> }
 			<Description />
 
 			{ isDataLoading ? (
@@ -218,77 +215,6 @@ const ProductCard: FC< ProductCardProps > = props => {
 				</div>
 			) }
 		</Card>
-	);
-};
-
-const usePricing = ( slug: string ) => {
-	const { detail } = useProduct( slug );
-
-	if ( detail.tiers.length === 0 ) {
-		const {
-			pricingForUi: { discountPricePerMonth, fullPricePerMonth, currencyCode },
-		} = detail;
-		return { discountPrice: discountPricePerMonth, fullPrice: fullPricePerMonth, currencyCode };
-	}
-
-	if ( detail.tiers.includes( 'upgraded' ) ) {
-		const { discountPrice, fullPrice, currencyCode } = detail.pricingForUi.tiers.upgraded;
-		const hasDiscount = discountPrice && discountPrice !== fullPrice;
-		return {
-			discountPrice: hasDiscount ? discountPrice / 12 : null,
-			fullPrice: fullPrice / 12,
-			currencyCode,
-		};
-	}
-
-	return { discountPrice: 0, fullPrice: 0, currencyCode: '' };
-};
-
-const Price = ( { slug }: { slug: string } ) => {
-	const { discountPrice, fullPrice, currencyCode } = usePricing( slug );
-
-	return (
-		<div className={ styles.priceContainer }>
-			{ discountPrice && (
-				<span className={ clsx( styles.price ) }>
-					{ formatCurrency( discountPrice, currencyCode ) }
-				</span>
-			) }
-			<span className={ clsx( styles.price, discountPrice && styles.discounted ) }>
-				{ formatCurrency( fullPrice, currencyCode ) }
-			</span>
-			<span className={ styles.term }>/month, billed yearly</span>
-		</div>
-	);
-};
-
-const RecommendationActions = ( { slug }: { slug: string } ) => {
-	const { detail } = useProduct( slug );
-	const { isUserConnected } = useMyJetpackConnection();
-	const { adminUrl, siteSuffix } = getMyJetpackWindowInitialState();
-	const purchaseUrl = getProductCheckoutUrl(
-		detail.wpcomProductSlug,
-		siteSuffix,
-		`${ adminUrl }?page=my-jetpack`,
-		isUserConnected
-	);
-	const learnMoreUrl = `#/add-${ slug }`;
-	return (
-		<div className={ styles.actions }>
-			<div className={ clsx( styles.buttons, styles.recommendation ) }>
-				<Button size="small" href={ purchaseUrl }>
-					{ __( 'Purchase', 'jetpack-my-jetpack' ) }
-				</Button>
-				<Button
-					className={ styles.recommendationLink }
-					size="small"
-					variant="link"
-					href={ learnMoreUrl }
-				>
-					{ __( 'Learn more', 'jetpack-my-jetpack' ) }
-				</Button>
-			</div>
-		</div>
 	);
 };
 

--- a/projects/packages/my-jetpack/_inc/components/product-card/pricing-component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/pricing-component.tsx
@@ -10,9 +10,7 @@ const PriceComponent = ( { slug }: { slug: string } ) => {
 	return (
 		<div className={ styles.priceContainer }>
 			{ discountPrice && (
-				<span className={ clsx( styles.price ) }>
-					{ formatCurrency( discountPrice, currencyCode ) }
-				</span>
+				<span className={ styles.price }>{ formatCurrency( discountPrice, currencyCode ) }</span>
 			) }
 			<span className={ clsx( styles.price, discountPrice && styles.discounted ) }>
 				{ formatCurrency( fullPrice, currencyCode ) }

--- a/projects/packages/my-jetpack/_inc/components/product-card/pricing-component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/pricing-component.tsx
@@ -1,0 +1,24 @@
+import formatCurrency from '@automattic/format-currency';
+import clsx from 'clsx';
+import styles from './style.module.scss';
+import usePricingData from './use-pricing-data';
+
+const PriceComponent = ( { slug }: { slug: string } ) => {
+	const { discountPrice, fullPrice, currencyCode } = usePricingData( slug );
+
+	return (
+		<div className={ styles.priceContainer }>
+			{ discountPrice && (
+				<span className={ clsx( styles.price ) }>
+					{ formatCurrency( discountPrice, currencyCode ) }
+				</span>
+			) }
+			<span className={ clsx( styles.price, discountPrice && styles.discounted ) }>
+				{ formatCurrency( fullPrice, currencyCode ) }
+			</span>
+			<span className={ styles.term }>/month, billed yearly</span>
+		</div>
+	);
+};
+
+export default PriceComponent;

--- a/projects/packages/my-jetpack/_inc/components/product-card/pricing-component.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/pricing-component.tsx
@@ -1,4 +1,5 @@
 import formatCurrency from '@automattic/format-currency';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import styles from './style.module.scss';
 import usePricingData from './use-pricing-data';
@@ -16,7 +17,7 @@ const PriceComponent = ( { slug }: { slug: string } ) => {
 			<span className={ clsx( styles.price, discountPrice && styles.discounted ) }>
 				{ formatCurrency( fullPrice, currencyCode ) }
 			</span>
-			<span className={ styles.term }>/month, billed yearly</span>
+			<span className={ styles.term }>{ __( '/month, billed yearly', 'jetpack-my-jetpack' ) }</span>
 		</div>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
@@ -10,11 +10,11 @@ const useUpsellLinks = ( slug: string, wpcomProductSlug: string ) => {
 	const { isUserConnected } = useMyJetpackConnection();
 
 	return useMemo( () => {
-		const { adminUrl, siteSuffix } = getMyJetpackWindowInitialState();
+		const { myJetpackUrl, siteSuffix } = getMyJetpackWindowInitialState();
 		const purchaseUrl = getProductCheckoutUrl(
 			wpcomProductSlug,
 			siteSuffix,
-			`${ adminUrl }admin.php?page=my-jetpack`,
+			myJetpackUrl,
 			isUserConnected
 		);
 		const interstitialUrl = `#/add-${ slug }`;

--- a/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
@@ -1,46 +1,42 @@
-import { Button, getProductCheckoutUrl } from '@automattic/jetpack-components';
+import { Button } from '@automattic/jetpack-components';
+import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import clsx from 'clsx';
-import { useMemo } from 'react';
+import { useCallback } from 'react';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import styles from './style.module.scss';
 import usePricingData from './use-pricing-data';
 
-const useUpsellLinks = ( slug: string, wpcomProductSlug: string ) => {
-	const { isUserConnected } = useMyJetpackConnection();
-
-	return useMemo( () => {
-		const { myJetpackUrl, siteSuffix } = getMyJetpackWindowInitialState();
-		const purchaseUrl = getProductCheckoutUrl(
-			wpcomProductSlug,
-			siteSuffix,
-			myJetpackUrl,
-			isUserConnected
-		);
-		const interstitialUrl = `#/add-${ slug }`;
-
-		return { purchaseUrl, interstitialUrl };
-	}, [ slug, wpcomProductSlug, isUserConnected ] );
-};
-
 const RecommendationActions = ( { slug }: { slug: string } ) => {
+	const { isUserConnected } = useMyJetpackConnection();
 	const { wpcomProductSlug, learnMoreAction, purchaseAction } = usePricingData( slug );
 
-	const { purchaseUrl, interstitialUrl } = useUpsellLinks( slug, wpcomProductSlug );
+	const { myJetpackUrl, siteSuffix } = getMyJetpackWindowInitialState();
+	const { run: runCheckout } = useProductCheckoutWorkflow( {
+		from: 'my-jetpack',
+		productSlug: wpcomProductSlug,
+		redirectUrl: myJetpackUrl,
+		connectAfterCheckout: ! isUserConnected,
+		siteSuffix,
+	} );
+
+	const handleCheckout = useCallback( () => {
+		if ( slug === 'crm' ) {
+			window.open( 'https://jetpackcrm.com/pricing/', '_blank' );
+			return;
+		}
+		runCheckout();
+	}, [ runCheckout, slug ] );
+
 	return (
 		<div className={ styles.actions }>
 			<div className={ clsx( styles.buttons, styles.upsell ) }>
 				{ purchaseAction && (
-					<Button size="small" href={ purchaseUrl }>
+					<Button size="small" onClick={ handleCheckout }>
 						{ purchaseAction }
 					</Button>
 				) }
-				<Button
-					className={ styles.recommendationLink }
-					size="small"
-					variant="link"
-					href={ interstitialUrl }
-				>
+				<Button size="small" variant="secondary" href={ `#/add-${ slug }` }>
 					{ learnMoreAction }
 				</Button>
 			</div>

--- a/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
@@ -1,0 +1,50 @@
+import { Button, getProductCheckoutUrl } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useMemo } from 'react';
+import useProduct from '../../data/products/use-product';
+import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
+import styles from './style.module.scss';
+
+const useUpsellLinks = ( slug: string ) => {
+	const { detail } = useProduct( slug );
+	const { isUserConnected } = useMyJetpackConnection();
+
+	return useMemo( () => {
+		const { adminUrl, siteSuffix } = getMyJetpackWindowInitialState();
+		const purchaseUrl = getProductCheckoutUrl(
+			detail.wpcomProductSlug,
+			siteSuffix,
+			`${ adminUrl }?page=my-jetpack`,
+			isUserConnected
+		);
+		const learnMoreUrl = `#/add-${ slug }`;
+
+		return { purchaseUrl, learnMoreUrl };
+	}, [ slug, detail.wpcomProductSlug, isUserConnected ] );
+};
+
+const RecommendationActions = ( { slug }: { slug: string } ) => {
+	const { purchaseUrl, learnMoreUrl } = useUpsellLinks( slug );
+
+	return (
+		<div className={ styles.actions }>
+			<div className={ clsx( styles.buttons, styles.upsell ) }>
+				<Button size="small" href={ purchaseUrl }>
+					{ __( 'Purchase', 'jetpack-my-jetpack' ) }
+				</Button>
+				<Button
+					className={ styles.recommendationLink }
+					size="small"
+					variant="link"
+					href={ learnMoreUrl }
+				>
+					{ __( 'Learn more', 'jetpack-my-jetpack' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default RecommendationActions;

--- a/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
@@ -1,5 +1,4 @@
 import { Button, getProductCheckoutUrl } from '@automattic/jetpack-components';
-import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useMemo } from 'react';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
@@ -25,7 +24,7 @@ const useUpsellLinks = ( slug: string, wpcomProductSlug: string ) => {
 };
 
 const RecommendationActions = ( { slug }: { slug: string } ) => {
-	const { wpcomProductSlug, canStartForFree, purchaseAction } = usePricingData( slug );
+	const { wpcomProductSlug, learnMoreAction, purchaseAction } = usePricingData( slug );
 
 	const { purchaseUrl, interstitialUrl } = useUpsellLinks( slug, wpcomProductSlug );
 	return (
@@ -42,9 +41,7 @@ const RecommendationActions = ( { slug }: { slug: string } ) => {
 					variant="link"
 					href={ interstitialUrl }
 				>
-					{ canStartForFree
-						? __( 'Start for free', 'jetpack-my-jetpack' )
-						: __( 'Learn more', 'jetpack-my-jetpack' ) }
+					{ learnMoreAction }
 				</Button>
 			</div>
 		</div>

--- a/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
@@ -19,14 +19,14 @@ const useUpsellLinks = ( slug: string ) => {
 			`${ adminUrl }?page=my-jetpack`,
 			isUserConnected
 		);
-		const learnMoreUrl = `#/add-${ slug }`;
+		const interstitialUrl = `#/add-${ slug }`;
 
-		return { purchaseUrl, learnMoreUrl };
+		return { purchaseUrl, interstitialUrl };
 	}, [ slug, detail.wpcomProductSlug, isUserConnected ] );
 };
 
 const RecommendationActions = ( { slug }: { slug: string } ) => {
-	const { purchaseUrl, learnMoreUrl } = useUpsellLinks( slug );
+	const { purchaseUrl, interstitialUrl } = useUpsellLinks( slug );
 
 	return (
 		<div className={ styles.actions }>
@@ -38,9 +38,9 @@ const RecommendationActions = ( { slug }: { slug: string } ) => {
 					className={ styles.recommendationLink }
 					size="small"
 					variant="link"
-					href={ learnMoreUrl }
+					href={ interstitialUrl }
 				>
-					{ __( 'Learn more', 'jetpack-my-jetpack' ) }
+					{ __( 'Start for free', 'jetpack-my-jetpack' ) }
 				</Button>
 			</div>
 		</div>

--- a/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
@@ -14,7 +14,7 @@ const useUpsellLinks = ( slug: string, wpcomProductSlug: string ) => {
 		const purchaseUrl = getProductCheckoutUrl(
 			wpcomProductSlug,
 			siteSuffix,
-			`${ adminUrl }?page=my-jetpack`,
+			`${ adminUrl }admin.php?page=my-jetpack`,
 			isUserConnected
 		);
 		const interstitialUrl = `#/add-${ slug }`;

--- a/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
@@ -2,19 +2,18 @@ import { Button, getProductCheckoutUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useMemo } from 'react';
-import useProduct from '../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import styles from './style.module.scss';
+import usePricingData from './use-pricing-data';
 
-const useUpsellLinks = ( slug: string ) => {
-	const { detail } = useProduct( slug );
+const useUpsellLinks = ( slug: string, wpcomProductSlug: string ) => {
 	const { isUserConnected } = useMyJetpackConnection();
 
 	return useMemo( () => {
 		const { adminUrl, siteSuffix } = getMyJetpackWindowInitialState();
 		const purchaseUrl = getProductCheckoutUrl(
-			detail.wpcomProductSlug,
+			wpcomProductSlug,
 			siteSuffix,
 			`${ adminUrl }?page=my-jetpack`,
 			isUserConnected
@@ -22,25 +21,30 @@ const useUpsellLinks = ( slug: string ) => {
 		const interstitialUrl = `#/add-${ slug }`;
 
 		return { purchaseUrl, interstitialUrl };
-	}, [ slug, detail.wpcomProductSlug, isUserConnected ] );
+	}, [ slug, wpcomProductSlug, isUserConnected ] );
 };
 
 const RecommendationActions = ( { slug }: { slug: string } ) => {
-	const { purchaseUrl, interstitialUrl } = useUpsellLinks( slug );
+	const { wpcomProductSlug, canStartForFree, purchaseAction } = usePricingData( slug );
 
+	const { purchaseUrl, interstitialUrl } = useUpsellLinks( slug, wpcomProductSlug );
 	return (
 		<div className={ styles.actions }>
 			<div className={ clsx( styles.buttons, styles.upsell ) }>
-				<Button size="small" href={ purchaseUrl }>
-					{ __( 'Purchase', 'jetpack-my-jetpack' ) }
-				</Button>
+				{ purchaseAction && (
+					<Button size="small" href={ purchaseUrl }>
+						{ purchaseAction }
+					</Button>
+				) }
 				<Button
 					className={ styles.recommendationLink }
 					size="small"
 					variant="link"
 					href={ interstitialUrl }
 				>
-					{ __( 'Start for free', 'jetpack-my-jetpack' ) }
+					{ canStartForFree
+						? __( 'Start for free', 'jetpack-my-jetpack' )
+						: __( 'Learn more', 'jetpack-my-jetpack' ) }
 				</Button>
 			</div>
 		</div>

--- a/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
@@ -1,43 +1,22 @@
 import { Button } from '@automattic/jetpack-components';
-import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import clsx from 'clsx';
-import { useCallback } from 'react';
-import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
-import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import styles from './style.module.scss';
 import usePricingData from './use-pricing-data';
 
 const RecommendationActions = ( { slug }: { slug: string } ) => {
-	const { isUserConnected } = useMyJetpackConnection();
-	const { wpcomProductSlug, learnMoreAction, purchaseAction } = usePricingData( slug );
-
-	const { myJetpackUrl, siteSuffix } = getMyJetpackWindowInitialState();
-	const { run: runCheckout } = useProductCheckoutWorkflow( {
-		from: 'my-jetpack',
-		productSlug: wpcomProductSlug,
-		redirectUrl: myJetpackUrl,
-		connectAfterCheckout: ! isUserConnected,
-		siteSuffix,
-	} );
-
-	const handleCheckout = useCallback( () => {
-		if ( slug === 'crm' ) {
-			window.open( 'https://jetpackcrm.com/pricing/', '_blank' );
-			return;
-		}
-		runCheckout();
-	}, [ runCheckout, slug ] );
+	const { secondaryAction, purchaseAction, isActivating, hasCheckoutStarted } =
+		usePricingData( slug );
 
 	return (
 		<div className={ styles.actions }>
 			<div className={ clsx( styles.buttons, styles.upsell ) }>
 				{ purchaseAction && (
-					<Button size="small" onClick={ handleCheckout }>
-						{ purchaseAction }
+					<Button size="small" disabled={ hasCheckoutStarted } { ...purchaseAction }>
+						{ purchaseAction.label }
 					</Button>
 				) }
-				<Button size="small" variant="secondary" href={ `#/add-${ slug }` }>
-					{ learnMoreAction }
+				<Button size="small" variant="secondary" disabled={ isActivating } { ...secondaryAction }>
+					{ secondaryAction.label }
 				</Button>
 			</div>
 		</div>

--- a/projects/packages/my-jetpack/_inc/components/product-card/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/secondary-button.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+import { FC, ReactNode } from 'react';
+
+export type SecondaryButtonProps = {
+	href?: string;
+	size?: 'normal' | 'small';
+	variant?: 'primary' | 'secondary' | 'link' | 'tertiary';
+	weight?: 'bold' | 'regular';
+	label?: string;
+	shouldShowButton?: () => boolean;
+	onClick?: () => void;
+	isExternalLink?: boolean;
+	icon?: ReactNode;
+	iconSize?: number;
+	disabled?: boolean;
+	isLoading?: boolean;
+	className?: string;
+};
+
+// SecondaryButton component
+const SecondaryButton: FC< SecondaryButtonProps > = props => {
+	const { shouldShowButton = () => true, ...buttonProps } = {
+		size: 'small',
+		variant: 'secondary',
+		weight: 'regular',
+		label: __( 'Learn more', 'jetpack-my-jetpack' ),
+		...props,
+	};
+
+	if ( ! shouldShowButton() ) {
+		return false;
+	}
+
+	return <Button { ...buttonProps }>{ buttonProps.label }</Button>;
+};
+
+export default SecondaryButton;

--- a/projects/packages/my-jetpack/_inc/components/product-card/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/secondary-button.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import { FC, ReactNode } from 'react';
+import type { FC, ReactNode } from 'react';
 
 export type SecondaryButtonProps = {
 	href?: string;

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -115,6 +115,34 @@ $box-shadow-color: rgba( 0, 0, 0, 0.1 );
 	}
 }
 
+.priceContainer {
+	display: flex;
+	align-items: baseline;
+	gap: calc(var(--spacing-base) * 0.5);
+	margin-bottom: var(--spacing-base);
+}
+
+.price {
+	font-size: var(--font-body);
+	color: var(--jp-gray-100);
+	font-weight: 600;
+
+	&.discounted {
+		color: var(--jp-gray-30);
+		text-decoration: line-through;
+	}
+}
+
+.term {
+	font-size: var(--font-body-extra-small);
+	color: var(--jp-gray-30);
+}
+
+.recommendationLink {
+	padding: calc(var(--spacing-base) * 0.5) var(--spacing-base) !important;
+}
+
+
 .status {
 	white-space: nowrap;
 	height: $actions-size;

--- a/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-card/style.module.scss
@@ -138,11 +138,6 @@ $box-shadow-color: rgba( 0, 0, 0, 0.1 );
 	color: var(--jp-gray-30);
 }
 
-.recommendationLink {
-	padding: calc(var(--spacing-base) * 0.5) var(--spacing-base) !important;
-}
-
-
 .status {
 	white-space: nowrap;
 	height: $actions-size;

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -1,7 +1,12 @@
+import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
+import useActivate from '../../data/products/use-activate';
 import useProduct from '../../data/products/use-product';
 import { ProductCamelCase } from '../../data/types';
+import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
+import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 
 const parsePricingData = ( pricingForUi: ProductCamelCase[ 'pricingForUi' ] ) => {
 	const { tiers } = pricingForUi;
@@ -32,7 +37,7 @@ const parsePricingData = ( pricingForUi: ProductCamelCase[ 'pricingForUi' ] ) =>
 	};
 };
 
-const getPurchaseAction = ( detail: ProductCamelCase ) => {
+const getPurchaseAction = ( detail: ProductCamelCase, onCheckout: () => void ) => {
 	const isUpgradable =
 		detail.status === PRODUCT_STATUSES.ACTIVE &&
 		( detail.isUpgradableByBundle.length || detail.isUpgradable );
@@ -41,15 +46,15 @@ const getPurchaseAction = ( detail: ProductCamelCase ) => {
 
 	if ( detail.status === PRODUCT_STATUSES.CAN_UPGRADE || isUpgradable ) {
 		if ( upgradeHasPrice ) {
-			return __( 'Upgrade', 'jetpack-my-jetpack' );
+			return { label: __( 'Upgrade', 'jetpack-my-jetpack' ), onClick: onCheckout };
 		}
 		return null;
 	}
 
-	return __( 'Purchase', 'jetpack-my-jetpack' );
+	return { label: __( 'Purchase', 'jetpack-my-jetpack' ), onClick: onCheckout };
 };
 
-const getLearnMoreAction = ( detail: ProductCamelCase ) => {
+const getSecondaryAction = ( detail: ProductCamelCase, onActivate: () => void ) => {
 	const isNotActiveOrNeedsExplicitFreePlan =
 		! detail.isPluginActive || detail.status === PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE;
 
@@ -57,18 +62,49 @@ const getLearnMoreAction = ( detail: ProductCamelCase ) => {
 		isNotActiveOrNeedsExplicitFreePlan &&
 		( detail.tiers.includes( 'free' ) || detail.hasFreeOffering )
 	) {
-		return __( 'Start for free', 'jetpack-my-jetpack' );
+		return {
+			label: __( 'Start for free', 'jetpack-my-jetpack' ),
+			onClick: onActivate,
+		};
 	}
 
-	return __( 'Learn more', 'jetpack-my-jetpack' );
+	return { label: __( 'Learn more', 'jetpack-my-jetpack' ), href: `#/add-${ detail.slug }` };
 };
 
 const usePricingData = ( slug: string ) => {
 	const { detail } = useProduct( slug );
+	const { wpcomProductSlug, ...data } = parsePricingData( detail.pricingForUi );
+
+	const { isUserConnected } = useMyJetpackConnection();
+	const { myJetpackUrl, siteSuffix } = getMyJetpackWindowInitialState();
+	const { activate, isPending: isActivating } = useActivate( slug );
+	const { run: runCheckout, hasCheckoutStarted } = useProductCheckoutWorkflow( {
+		from: 'my-jetpack',
+		productSlug: wpcomProductSlug,
+		redirectUrl: myJetpackUrl,
+		connectAfterCheckout: ! isUserConnected,
+		siteSuffix,
+	} );
+
+	const handleActivate = useCallback( () => {
+		activate( {} );
+	}, [ activate ] );
+
+	const handleCheckout = useCallback( () => {
+		if ( slug === 'crm' ) {
+			activate( {} );
+			window.open( 'https://jetpackcrm.com/pricing/', '_blank' );
+			return;
+		}
+		runCheckout();
+	}, [ activate, runCheckout, slug ] );
+
 	return {
-		learnMoreAction: getLearnMoreAction( detail ),
-		purchaseAction: getPurchaseAction( detail ),
-		...parsePricingData( detail.pricingForUi ),
+		secondaryAction: getSecondaryAction( detail, handleActivate ),
+		purchaseAction: getPurchaseAction( detail, handleCheckout ),
+		isActivating,
+		hasCheckoutStarted,
+		...data,
 	};
 };
 

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -52,9 +52,11 @@ const getPurchaseAction = ( detail: ProductCamelCase ) => {
 const getLearnMoreAction = ( detail: ProductCamelCase ) => {
 	const isNotActiveOrNeedsExplicitFreePlan =
 		! detail.isPluginActive || detail.status === PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE;
-	const hasFreeTierOrFreeOffering = detail.tiers.includes( 'free' ) || detail.hasFreeOffering;
 
-	if ( isNotActiveOrNeedsExplicitFreePlan && hasFreeTierOrFreeOffering ) {
+	if (
+		isNotActiveOrNeedsExplicitFreePlan &&
+		( detail.tiers.includes( 'free' ) || detail.hasFreeOffering )
+	) {
 		return __( 'Start for free', 'jetpack-my-jetpack' );
 	}
 

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -1,0 +1,26 @@
+import useProduct from '../../data/products/use-product';
+
+const usePricingData = ( slug: string ) => {
+	const { detail } = useProduct( slug );
+
+	if ( detail.tiers.length === 0 ) {
+		const {
+			pricingForUi: { discountPricePerMonth, fullPricePerMonth, currencyCode },
+		} = detail;
+		return { discountPrice: discountPricePerMonth, fullPrice: fullPricePerMonth, currencyCode };
+	}
+
+	if ( detail.tiers.includes( 'upgraded' ) ) {
+		const { discountPrice, fullPrice, currencyCode } = detail.pricingForUi.tiers.upgraded;
+		const hasDiscount = discountPrice && discountPrice !== fullPrice;
+		return {
+			discountPrice: hasDiscount ? discountPrice / 12 : null,
+			fullPrice: fullPrice / 12,
+			currencyCode,
+		};
+	}
+
+	return { discountPrice: 0, fullPrice: 0, currencyCode: '' };
+};
+
+export default usePricingData;

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -40,11 +40,19 @@ const getPurchaseAction = ( detail: ProductCamelCase ) => {
 	return null;
 };
 
+const getLearnMoreAction = ( detail: ProductCamelCase ) => {
+	if ( detail.status !== PRODUCT_STATUSES.ACTIVE && detail.tiers.includes( 'free' ) ) {
+		return __( 'Start for free', 'jetpack-my-jetpack' );
+	}
+
+	return __( 'Learn more', 'jetpack-my-jetpack' );
+};
+
 const usePricingData = ( slug: string ) => {
 	const { detail } = useProduct( slug );
 	return {
 		wpcomProductSlug: detail.wpcomProductSlug,
-		canStartForFree: detail.status !== PRODUCT_STATUSES.ACTIVE && detail.tiers.includes( 'free' ),
+		learnMoreAction: getLearnMoreAction( detail ),
 		purchaseAction: getPurchaseAction( detail ),
 		...parsePricingData( detail.pricingForUi ),
 	};

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -7,18 +7,25 @@ const parsePricingData = ( pricingForUi: ProductCamelCase[ 'pricingForUi' ] ) =>
 	const { tiers } = pricingForUi;
 
 	if ( pricingForUi.tiers ) {
-		const { discountPrice, fullPrice, currencyCode } = tiers.upgraded;
+		const { discountPrice, fullPrice, currencyCode, wpcomProductSlug } = tiers.upgraded;
 		const hasDiscount = discountPrice && discountPrice !== fullPrice;
 		return {
+			wpcomProductSlug,
 			discountPrice: hasDiscount ? discountPrice / 12 : null,
 			fullPrice: fullPrice / 12,
 			currencyCode,
 		};
 	}
 
-	const { discountPricePerMonth, fullPricePerMonth, currencyCode, isIntroductoryOffer } =
-		pricingForUi;
+	const {
+		discountPricePerMonth,
+		fullPricePerMonth,
+		currencyCode,
+		isIntroductoryOffer,
+		wpcomProductSlug,
+	} = pricingForUi;
 	return {
+		wpcomProductSlug,
 		discountPrice: isIntroductoryOffer ? discountPricePerMonth : null,
 		fullPrice: fullPricePerMonth,
 		currencyCode,
@@ -47,7 +54,6 @@ const getLearnMoreAction = ( detail: ProductCamelCase ) => {
 const usePricingData = ( slug: string ) => {
 	const { detail } = useProduct( slug );
 	return {
-		wpcomProductSlug: detail.wpcomProductSlug,
 		learnMoreAction: getLearnMoreAction( detail ),
 		purchaseAction: getPurchaseAction( detail ),
 		...parsePricingData( detail.pricingForUi ),

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -29,11 +29,7 @@ const getPurchaseAction = ( detail: ProductCamelCase ) => {
 	if ( detail.status === PRODUCT_STATUSES.CAN_UPGRADE ) {
 		return __( 'Upgrade', 'jetpack-my-jetpack' );
 	}
-	if (
-		[ PRODUCT_STATUSES.NEEDS_PURCHASE, PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE ].includes(
-			detail.status
-		)
-	) {
+	if ( ! [ PRODUCT_STATUSES.ACTIVE ].includes( detail.status ) ) {
 		return __( 'Purchase', 'jetpack-my-jetpack' );
 	}
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -5,7 +5,7 @@ import { useRef } from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
 import ProductCard from '../connected-product-card';
 
-const AiCard = ( { admin } ) => {
+const AiCard = props => {
 	const { userConnectionData } = useConnection();
 	const { currentUser } = userConnectionData;
 	const { wpcomUser } = currentUser;
@@ -27,10 +27,10 @@ const AiCard = ( { admin } ) => {
 
 	return (
 		<ProductCard
-			admin={ admin }
 			slug="jetpack-ai"
-			upgradeInInterstitial={ true }
 			primaryActionOverride={ userOverrides }
+			upgradeInInterstitial
+			{ ...props }
 		/>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/all.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/all.ts
@@ -1,0 +1,32 @@
+import AiCard from './ai-card';
+import AntiSpamCard from './anti-spam-card';
+import BackupCard from './backup-card';
+import BoostCard from './boost-card';
+import CreatorCard from './creator-card';
+import CrmCard from './crm-card';
+import ProtectCard from './protect-card';
+import SearchCard from './search-card';
+import SocialCard from './social-card';
+import StatsCard from './stats-card';
+import VideopressCard from './videopress-card';
+
+export const JetpackModuleToProductCard: {
+	[ key in JetpackModule ]: React.FC< { recommendation?: boolean; admin?: boolean } > | null;
+} = {
+	backup: BackupCard,
+	protect: ProtectCard,
+	'anti-spam': AntiSpamCard,
+	boost: BoostCard,
+	search: SearchCard,
+	videopress: VideopressCard,
+	stats: StatsCard,
+	crm: CrmCard,
+	creator: CreatorCard,
+	social: SocialCard,
+	ai: AiCard,
+	'jetpack-ai': AiCard,
+	// Not existing:
+	extras: null,
+	scan: null,
+	security: null,
+};

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/anti-spam-card.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ProductCard from '../connected-product-card';
 
-const AntiSpamCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="anti-spam" />;
+const AntiSpamCard = props => {
+	return <ProductCard slug="anti-spam" { ...props } />;
 };
 
 AntiSpamCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
@@ -121,16 +121,16 @@ const getTimeSinceLastRenewableEvent = lastRewindableEventTime => {
 	}
 };
 
-const BackupCard = ( { admin } ) => {
+const BackupCard = props => {
 	const slug = 'backup';
 	const { detail } = useProduct( slug );
 	const { status } = detail;
 	const hasBackups = status === PRODUCT_STATUSES.ACTIVE || status === PRODUCT_STATUSES.CAN_UPGRADE;
 
 	return hasBackups ? (
-		<WithBackupsValueSection admin={ admin } slug={ slug } />
+		<WithBackupsValueSection slug={ slug } { ...props } />
 	) : (
-		<NoBackupsValueSection admin={ admin } slug={ slug } />
+		<NoBackupsValueSection slug={ slug } { ...props } />
 	);
 };
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
@@ -134,7 +134,7 @@ const BackupCard = props => {
 	);
 };
 
-const WithBackupsValueSection = ( { admin, slug } ) => {
+const WithBackupsValueSection = props => {
 	const { data, isLoading } = useSimpleQuery( {
 		name: QUERY_BACKUP_HISTORY_KEY,
 		query: {
@@ -149,7 +149,7 @@ const WithBackupsValueSection = ( { admin, slug } ) => {
 
 	const handleUndoClick = () => {
 		recordEvent( 'jetpack_myjetpack_backup_card_undo_click', {
-			product: slug,
+			product: props.slug,
 			undo_backup_id: undoBackupId,
 		} );
 	};
@@ -178,8 +178,7 @@ const WithBackupsValueSection = ( { admin, slug } ) => {
 
 	return (
 		<ProductCard
-			admin={ admin }
-			slug={ slug }
+			{ ...props }
 			showMenu
 			isDataLoading={ isLoading }
 			Description={ lastRewindableEvent ? WithBackupsDescription : null }
@@ -195,7 +194,7 @@ const WithBackupsValueSection = ( { admin, slug } ) => {
 	);
 };
 
-const NoBackupsValueSection = ( { admin, slug } ) => {
+const NoBackupsValueSection = props => {
 	const [ itemsToShow, setItemsToShow ] = useState( 3 );
 	const { data: backupStats, isLoading } = useSimpleQuery( {
 		name: QUERY_BACKUP_STATS_KEY,
@@ -246,7 +245,7 @@ const NoBackupsValueSection = ( { admin, slug } ) => {
 	const shortenedNumberConfig = { maximumFractionDigits: 1, notation: 'compact' };
 
 	return (
-		<ProductCard admin={ admin } slug={ slug } showMenu isDataLoading={ isLoading }>
+		<ProductCard { ...props } showMenu isDataLoading={ isLoading }>
 			<div className={ styles[ 'no-backup-stats' ] }>
 				{ /* role="list" is required for VoiceOver on Safari */ }
 				{ /* eslint-disable-next-line jsx-a11y/no-redundant-roles */ }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/index.tsx
@@ -5,7 +5,7 @@ import ProductCard from '../../connected-product-card';
 import BoostSpeedScore from './boost-speed-score';
 import type { FC } from 'react';
 
-const BoostCard: FC< { admin: boolean } > = ( { admin } ) => {
+const BoostCard: FC< { admin: boolean } > = props => {
 	const [ shouldShowTooltip, setShouldShowTooltip ] = useState( false );
 	// Override the primary action button to read "Boost your site" instead
 	// of the default text, "Lern more".
@@ -25,11 +25,11 @@ const BoostCard: FC< { admin: boolean } > = ( { admin } ) => {
 
 	return (
 		<ProductCard
-			admin={ admin }
 			slug="boost"
 			primaryActionOverride={ primaryActionOverride }
 			onMouseEnter={ handleMouseEnter }
 			onMouseLeave={ handleMouseLeave }
+			{ ...props }
 		>
 			<BoostSpeedScore shouldShowTooltip={ shouldShowTooltip } />
 		</ProductCard>

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/creator-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/creator-card.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ProductCard from '../connected-product-card';
 
-const CreatorCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="creator" upgradeInInterstitial={ true } />;
+const CreatorCard = props => {
+	return <ProductCard slug="creator" upgradeInInterstitial { ...props } />;
 };
 
 CreatorCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/crm-card.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ProductCard from '../connected-product-card';
 
-const CrmCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="crm" />;
+const CrmCard = props => {
+	return <ProductCard slug="crm" { ...props } />;
 };
 
 CrmCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/extras-card.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ProductCard from '../connected-product-card';
 
-const ExtrasCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="extras" />;
+const ExtrasCard = props => {
+	return <ProductCard slug="extras" { ...props } />;
 };
 
 ExtrasCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ProductCard from '../connected-product-card';
 
-const ProtectCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug={ 'protect' } />;
+const ProtectCard = props => {
+	return <ProductCard slug="protect" { ...props } />;
 };
 
 ProtectCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/search-card.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ProductCard from '../connected-product-card';
 
-const SearchCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="search" showMenu />;
+const SearchCard = props => {
+	return <ProductCard slug="search" showMenu { ...props } />;
 };
 
 SearchCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/social-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/social-card.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ProductCard from '../connected-product-card';
 
-const SocialCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="social" showMenu />;
+const SocialCard = props => {
+	return <ProductCard slug="social" showMenu { ...props } />;
 };
 
 SocialCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/stats-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/stats-card.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ProductCard from '../connected-product-card';
 
-const StatsCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="stats" showMenu />;
+const StatsCard = props => {
+	return <ProductCard slug="stats" showMenu { ...props } />;
 };
 
 StatsCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card.jsx
@@ -54,18 +54,18 @@ const useVideoPressStats = () => {
 	};
 };
 
-const VideopressCard = ( { admin } ) => {
+const VideopressCard = props => {
 	const { videoPressStats = false } = getMyJetpackWindowInitialState( 'myJetpackFlags' );
 	const { loading, hasError, change, currentFormatted, changePercentage } = useVideoPressStats();
 
 	if ( ! videoPressStats || hasError ) {
-		return <ProductCard admin={ admin } slug="videopress" showMenu />;
+		return <ProductCard slug="videopress" showMenu { ...props } />;
 	}
 
 	const description = __( 'Views, last 7 days', 'jetpack-my-jetpack' );
 
 	return (
-		<ProductCard admin={ admin } slug="videopress" showMenu>
+		<ProductCard slug="videopress" showMenu { ...props }>
 			<SingleContextualInfo
 				loading={ loading }
 				description={ description }

--- a/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
@@ -53,7 +53,7 @@ const StatsSection = () => {
 		[ PRODUCT_STATUSES.ACTIVE ]: {
 			label: __( 'View detailed stats', 'jetpack-my-jetpack' ),
 		},
-		[ PRODUCT_STATUSES.ERROR ]: {
+		[ PRODUCT_STATUSES.SITE_CONNECTION_ERROR ]: {
 			label: __( 'Connect Jetpack to use Stats', 'jetpack-my-jetpack' ),
 		},
 	};

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
@@ -2,7 +2,7 @@ import { Container, Col, Button } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import useRecommendationsSection from '../../data/recommendations-section/use-recommendations-section';
+import useEvaluationRecommendations from '../../data/evaluation-recommendations/use-evaluation-recommendations';
 import useWelcomeBanner from '../../data/welcome-banner/use-welcome-banner';
 import useAnalytics from '../../hooks/use-analytics';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
@@ -16,7 +16,7 @@ import type { FC } from 'react';
 const WelcomeFlow: FC = () => {
 	const { recordEvent } = useAnalytics();
 	const { isWelcomeBannerVisible, dismissWelcomeBanner } = useWelcomeBanner();
-	const { submitEvaluation, saveEvaluationResult } = useRecommendationsSection();
+	const { submitEvaluation, saveEvaluationResult } = useEvaluationRecommendations();
 	const {
 		siteIsRegistered,
 		siteIsRegistering,

--- a/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
+++ b/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
@@ -13,7 +13,7 @@ import useWelcomeBanner from '../welcome-banner/use-welcome-banner';
 
 type SubmitRecommendationsResult = Record< string, number >;
 
-const useRecommendationsSection = () => {
+const useEvaluationRecommendations = () => {
 	const { isWelcomeBannerVisible } = useWelcomeBanner();
 	const [ recommendedModules, setRecommendedModules ] = useValueStore(
 		'recommendedModules',
@@ -77,4 +77,4 @@ const useRecommendationsSection = () => {
 	};
 };
 
-export default useRecommendationsSection;
+export default useEvaluationRecommendations;

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -128,6 +128,25 @@ interface Window {
 							transition_after_renewal_count: number;
 							usage_limit?: number;
 						};
+						tiers?: {
+							[ key: string ]: {
+								available: boolean;
+								currencyCode: string;
+								discountPrice: number;
+								fullPrice: number;
+								introductoryOffer?: {
+									costPerInterval: number;
+									intervalCount: number;
+									intervalUnit: string;
+									shouldProrateWhenOfferEnds: boolean;
+									transitionAfterRenewalCount: number;
+									usageLimit?: number;
+								};
+								isIntroductoryOffer: boolean;
+								productTerm: string;
+								wpcomProductSlug: string;
+							};
+						};
 					};
 					purchase_url?: string;
 					requires_user_connection: boolean;

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -100,6 +100,7 @@ interface Window {
 					description: string;
 					disclaimers: Array< string[] >;
 					features: string[];
+					has_free_offering: boolean;
 					has_paid_plan_for_product: boolean;
 					features_by_tier: Array< string >;
 					is_bundle: boolean;
@@ -146,6 +147,7 @@ interface Window {
 								isIntroductoryOffer: boolean;
 								productTerm: string;
 								wpcomProductSlug: string;
+								quantity: number;
 							};
 						};
 					};

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -104,6 +104,7 @@ interface Window {
 					features_by_tier: Array< string >;
 					is_bundle: boolean;
 					is_plugin_active: boolean;
+					is_upgradable: boolean;
 					is_upgradable_by_bundle: string[];
 					long_description: string;
 					manage_url: string;


### PR DESCRIPTION
## Proposed changes:
- **Refactor ProductCard to ts, add 'recommendation' property**
- **Add price/discount calculation and checkout buttons to the product card variation**
- **Update useRecommendationsSection() to useEvaluationRecommendations()**

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
* Run JN ninja with Jetpack Beta
* Activate Jetpack plugin with `add/recommendations-section-component` branch
* Go to My Jetpack page, and go through onboarding process: Connect site, choose goals for your site
* As a result, you'll be presented "Our recommendations for you" section, you can confirm prices are correct, and links work well etc.
![CleanShot 2024-07-16 at 14 23 23@2x](https://github.com/user-attachments/assets/5bc86edb-9b47-4fc3-b2b3-4b8a7952abd3)


