### PR TITLE
Jetpack Sync: Add support for WooCommerce HPOS checksums

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-hpos-checksum-support
+++ b/projects/packages/sync/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Sync: Add support for HPOS checksums

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -59,7 +59,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "3.2.x-dev"
+			"dev-trunk": "3.3.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.2.2-alpha';
+	const PACKAGE_VERSION = '3.3.0-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/class-replicastore.php
+++ b/projects/packages/sync/src/class-replicastore.php
@@ -1175,7 +1175,6 @@ class Replicastore implements Replicastore_Interface {
 
 	/**
 	 * Retrieve all the checksums we are interested in.
-	 * Currently that is posts, comments, post meta and comment meta.
 	 *
 	 * @access public
 	 *
@@ -1237,6 +1236,29 @@ class Replicastore implements Replicastore_Interface {
 				$result['woocommerce_order_itemmeta'] = $this->summarize_checksum_histogram( $woocommerce_order_itemmeta_checksum );
 			} catch ( Exception $ex ) {
 				$result['woocommerce_order_itemmeta'] = null;
+			}
+
+			if ( Table_Checksum::enable_woocommerce_hpos_tables() ) {
+				try {
+					$woocommerce_hpos_orders_checksum = $this->checksum_histogram( 'wc_orders' );
+					$result['wc_orders']              = $this->summarize_checksum_histogram( $woocommerce_hpos_orders_checksum );
+				} catch ( Exception $ex ) {
+					$result['wc_orders'] = null;
+				}
+
+				try {
+					$woocommerce_hpos_order_addresses_checksum = $this->checksum_histogram( 'wc_order_addresses' );
+					$result['wc_order_addresses']              = $this->summarize_checksum_histogram( $woocommerce_hpos_order_addresses_checksum );
+				} catch ( Exception $ex ) {
+					$result['wc_order_addresses'] = null;
+				}
+
+				try {
+					$woocommerce_hpos_order_operational_data_checksum = $this->checksum_histogram( 'wc_order_operational_data' );
+					$result['wc_order_operational_data']              = $this->summarize_checksum_histogram( $woocommerce_hpos_order_operational_data_checksum );
+				} catch ( Exception $ex ) {
+					$result['wc_order_operational_data'] = null;
+				}
 			}
 		}
 

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -313,7 +313,7 @@ class Table_Checksum {
 				'key_fields'                => array( 'id' ),
 				'checksum_text_fields'      => array( 'type', 'status', 'payment_method_title' ),
 				'filter_values'             => array(),
-				'is_table_enabled_callback' => array( $this, 'enable_woocommerce_tables' ),
+				'is_table_enabled_callback' => 'Automattic\Jetpack\Sync\Replicastore\Table_Checksum::enable_woocommerce_hpos_tables',
 			),
 			'wc_order_addresses'         => array(
 				'table'                     => "{$wpdb->prefix}wc_order_addresses",
@@ -321,7 +321,7 @@ class Table_Checksum {
 				'key_fields'                => array( 'order_id', 'address_type' ),
 				'checksum_text_fields'      => array( 'address_type' ),
 				'filter_values'             => array(),
-				'is_table_enabled_callback' => array( $this, 'enable_woocommerce_tables' ),
+				'is_table_enabled_callback' => 'Automattic\Jetpack\Sync\Replicastore\Table_Checksum::enable_woocommerce_hpos_tables',
 			),
 			'wc_order_operational_data'  => array(
 				'table'                     => "{$wpdb->prefix}wc_order_operational_data",
@@ -329,7 +329,7 @@ class Table_Checksum {
 				'key_fields'                => array( 'order_id' ),
 				'checksum_text_fields'      => array( 'order_key', 'cart_hash' ),
 				'filter_values'             => array(),
-				'is_table_enabled_callback' => array( $this, 'enable_woocommerce_tables' ),
+				'is_table_enabled_callback' => 'Automattic\Jetpack\Sync\Replicastore\Table_Checksum::enable_woocommerce_hpos_tables',
 			),
 			'users'                      => array(
 				'table'                     => $wpdb->users,
@@ -879,6 +879,37 @@ class Table_Checksum {
 		// TODO more checks if needed. Probably query the DB to make sure the tables exist.
 
 		return true;
+	}
+
+	/**
+	 * Make sure the WooCommerce HPOS tables should be enabled for Checksum/Fix.
+	 *
+	 * @see Automattic\Jetpack\SyncActions::initialize_woocommerce
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function enable_woocommerce_hpos_tables() {
+		/**
+		 * On WordPress.com, we can't directly check if the site has support for WooCommerce HPOS tables.
+		 * Having the option to override the functionality here helps with syncing WooCommerce HPOS tables.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool If we should we force-enable WooCommerce HPOS tables support.
+		 */
+		$force_woocommerce_hpos_support = apply_filters( 'jetpack_table_checksum_force_enable_woocommerce_hpos', false );
+
+		// If we're forcing WooCommerce HPOS tables support, there's no need to check further.
+		// This is used on WordPress.com.
+		if ( $force_woocommerce_hpos_support ) {
+			return true;
+		}
+
+		// If the 'woocommerce_hpos_orders' module is enabled, this means that WooCommerce class exists
+		// and HPOS is enabled too.
+		return false !== Sync\Modules::get_module( 'woocommerce_hpos_orders' );
 	}
 
 	/**

--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -862,7 +862,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+                "reference": "9e674c384f72544b488e3af3d9348692d32cee54"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -895,7 +895,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.2.x-dev"
+                    "dev-trunk": "3.3.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/backup/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/backup/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1526,7 +1526,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+                "reference": "9e674c384f72544b488e3af3d9348692d32cee54"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1559,7 +1559,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.2.x-dev"
+                    "dev-trunk": "3.3.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/boost/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/boost/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1510,7 +1510,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+                "reference": "9e674c384f72544b488e3af3d9348692d32cee54"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1543,7 +1543,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.2.x-dev"
+                    "dev-trunk": "3.3.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/jetpack/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/jetpack/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2536,7 +2536,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+				"reference": "9e674c384f72544b488e3af3d9348692d32cee54"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2569,7 +2569,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "3.2.x-dev"
+					"dev-trunk": "3.3.x-dev"
 				},
 				"dependencies": {
 					"test-only": [

--- a/projects/plugins/migration/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/migration/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1526,7 +1526,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+                "reference": "9e674c384f72544b488e3af3d9348692d32cee54"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1559,7 +1559,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.2.x-dev"
+                    "dev-trunk": "3.3.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1437,7 +1437,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+                "reference": "9e674c384f72544b488e3af3d9348692d32cee54"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1470,7 +1470,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.2.x-dev"
+                    "dev-trunk": "3.3.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/protect/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/protect/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1578,7 +1578,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+                "reference": "9e674c384f72544b488e3af3d9348692d32cee54"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1611,7 +1611,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.2.x-dev"
+                    "dev-trunk": "3.3.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/search/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/search/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1531,7 +1531,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+                "reference": "9e674c384f72544b488e3af3d9348692d32cee54"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1564,7 +1564,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.2.x-dev"
+                    "dev-trunk": "3.3.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/social/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/social/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1521,7 +1521,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+				"reference": "9e674c384f72544b488e3af3d9348692d32cee54"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1554,7 +1554,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "3.2.x-dev"
+					"dev-trunk": "3.3.x-dev"
 				},
 				"dependencies": {
 					"test-only": [

--- a/projects/plugins/starter-plugin/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/starter-plugin/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1382,7 +1382,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+                "reference": "9e674c384f72544b488e3af3d9348692d32cee54"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1415,7 +1415,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.2.x-dev"
+                    "dev-trunk": "3.3.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/videopress/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/videopress/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1382,7 +1382,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+                "reference": "9e674c384f72544b488e3af3d9348692d32cee54"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1415,7 +1415,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.2.x-dev"
+                    "dev-trunk": "3.3.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/wpcomsh/changelog/fix-sync-hpos-checksum-support
+++ b/projects/plugins/wpcomsh/changelog/fix-sync-hpos-checksum-support
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1636,7 +1636,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "89d46505557c31b54cb41a8ae6f38070640f1d0f"
+                "reference": "9e674c384f72544b488e3af3d9348692d32cee54"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1669,7 +1669,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.2.x-dev"
+                    "dev-trunk": "3.3.x-dev"
                 },
                 "dependencies": {
                     "test-only": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds support for WooCommerce HPOS simple checksums and while doing that fixes the check on whether they are supported.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Replicastore`: Adds support for WooCommerce HPOS checksums by adding those in `checksum_all` method
* `Automattic\Jetpack\Sync\Replicastore\Table_Checksum`: Introduces `enable_woocommerce_hpos_tables` method that explicitly checks for WooCommerce HPOS table Checksum support.
* `Automattic\Jetpack\Sync\Replicastore\Table_Checksum`: Introduces `jetpack_table_checksum_force_enable_woocommerce_hpos` filter to allow us to bypass the WooCommerce HPOS table  support checks on WPCOM
* `Automattic\Jetpack\Sync\Replicastore\Table_Checksum`: Updates the `is_table_enabled_callback` for HPOS tables to use the static method we introduced: `enable_woocommerce_hpos_tables` 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-8ec-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
See D155142-code