### PR TITLE
Jetpack AI: Register ai-assistant-site-logo-support beta extension

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-logo-extension-beta-feature
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-logo-extension-beta-feature
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: add beta flag to control logo generator extension.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -185,3 +185,15 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Register the `ai-assistant-site-logo-support` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		if ( apply_filters( 'jetpack_ai_enabled', true ) ) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-assistant-site-logo-support' );
+		}
+	}
+);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -79,7 +79,8 @@
 		"videopress/video-chapters",
 		"ai-assistant-backend-prompts",
 		"ai-assistant-extensions-support",
-		"ai-proofread-breve"
+		"ai-proofread-breve",
+		"ai-assistant-site-logo-support"
 	],
 	"experimental": [ "ai-image", "ai-paragraph" ],
 	"no-post-editor": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #34377.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create `ai-assistant-site-logo-support` beta flag to control the logo generator release on the block editor

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Open the dev console
* With the `beta` extensions disabled, confirm that `Jetpack_Editor_Initial_State.available_blocks["ai-assistant-site-logo-support"]` is not set:

<img width="500" alt="Screenshot 2024-07-12 at 13 12 20" src="https://github.com/user-attachments/assets/85092460-fb60-488e-9cad-53167cd9c65b">

* With the `beta` extensions enabled, confirm that `Jetpack_Editor_Initial_State.available_blocks["ai-assistant-site-logo-support"]` is set to `available: true`

<img width="500" alt="Screenshot 2024-07-12 at 13 11 52" src="https://github.com/user-attachments/assets/6da0dd89-3526-4eef-9e99-ab08f3747821">