### PR TITLE
WAF: Remove unnecessary mode check before updating rule files

### DIFF
--- a/projects/packages/waf/changelog/remove-waf-update-rules-mode-check
+++ b/projects/packages/waf/changelog/remove-waf-update-rules-mode-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Removed unnecessary check from the method that updates the WAF rule files.
+
+

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -181,11 +181,6 @@ class Waf_Initializer {
 
 				Waf_Compatibility::run_compatibility_migrations();
 
-				Waf_Constants::define_mode();
-				if ( ! Waf_Runner::is_allowed_mode( JETPACK_WAF_MODE ) ) {
-					return new WP_Error( 'waf_mode_invalid', 'Invalid firewall mode.' );
-				}
-
 				try {
 					Waf_Rules_Manager::generate_ip_rules();
 					Waf_Rules_Manager::generate_rules();

--- a/projects/packages/waf/src/class-waf-rules-manager.php
+++ b/projects/packages/waf/src/class-waf-rules-manager.php
@@ -115,10 +115,6 @@ class Waf_Rules_Manager {
 	 * @return void
 	 */
 	public static function update_rules_if_changed() {
-		Waf_Constants::define_mode();
-		if ( ! Waf_Runner::is_allowed_mode( JETPACK_WAF_MODE ) ) {
-			throw new Waf_Exception( 'Invalid firewall mode.' );
-		}
 		$version = get_option( self::VERSION_OPTION_NAME );
 		if ( self::RULES_VERSION !== $version ) {
 			self::generate_automatic_rules();

--- a/projects/packages/waf/src/class-waf-rules-manager.php
+++ b/projects/packages/waf/src/class-waf-rules-manager.php
@@ -74,11 +74,6 @@ class Waf_Rules_Manager {
 	 * @return bool|WP_Error True if rules update is successful, WP_Error on failure.
 	 */
 	public static function update_rules_cron() {
-		Waf_Constants::define_mode();
-		if ( ! Waf_Runner::is_allowed_mode( JETPACK_WAF_MODE ) ) {
-			return new WP_Error( 'waf_invalid_mode', 'Invalid firewall mode.' );
-		}
-
 		try {
 			self::generate_automatic_rules();
 			self::generate_ip_rules();

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -303,11 +303,6 @@ class Waf_Runner {
 	 * @return void
 	 */
 	public static function activate() {
-		Waf_Constants::define_mode();
-		if ( ! self::is_allowed_mode( JETPACK_WAF_MODE ) ) {
-			throw new Waf_Exception( 'Invalid firewall mode.' );
-		}
-
 		$version = get_option( Waf_Rules_Manager::VERSION_OPTION_NAME );
 		if ( ! $version ) {
 			add_option( Waf_Rules_Manager::VERSION_OPTION_NAME, Waf_Rules_Manager::RULES_VERSION );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Working towards the ability to update the IP allow list via `update_waf` regardless of the WAF module's status, I noticed that this check doesn't appear to be useful in several cases. We only use the `JETPACK_WAF_MODE` constant when actually running the firewall, it is not referenced when updating rules or regenerating the bootstrap file for example. See [this comment](https://github.com/Automattic/jetpack/pull/38326#issuecomment-2228996521) below for more details.

This also helps unblock us from using these methods when the WAF is not enabled (no mode option set).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the `Waf_Constants::define_mode()` and subsequent `Waf_Runner::is_allowed_mode()` check from WAF methods that do not use the mode option.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Validate that tests still pass: `jetpack test packages/waf php`
* Proof Read: Review the `update_rules_if_changed` method, and validate that the mode is never used.
* Regression test:
  * Ensure the firewall does not run when not activated.
  * Activate the firewall, ensure a request is blocked.
  * Set the `jetpack_waf_mode` option to "silent", ensure requests are not blocked.
  * Set the `jetpack_waf_mode` option to "invalid", ensure the firewall does not run.