### PR TITLE
Jetpack Boost: Fix Image Guide Display for SVGs

### DIFF
--- a/projects/js-packages/image-guide/changelog/update-fix-image-guide-svgs
+++ b/projects/js-packages/image-guide/changelog/update-fix-image-guide-svgs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a bug where image guide would show up for svg images.

--- a/projects/js-packages/image-guide/src/find-image-elements.ts
+++ b/projects/js-packages/image-guide/src/find-image-elements.ts
@@ -9,6 +9,9 @@ import { MeasurableImage, type FetchFn } from './MeasurableImage.js';
 export function findMeasurableElements( nodes: Element[] ): HTMLElement[] | HTMLImageElement[] {
 	return nodes.filter( ( el ): el is HTMLElement | HTMLImageElement => {
 		if ( el instanceof HTMLImageElement ) {
+			if ( isSvgUrl( el.src ) ) {
+				return false;
+			}
 			return true;
 		}
 		if ( el instanceof HTMLElement ) {
@@ -75,9 +78,6 @@ export async function getMeasurableImages(
 	const nodes = findMeasurableElements( domNodes );
 	const images = nodes.map( node => {
 		if ( node instanceof HTMLImageElement ) {
-			if ( isSvgUrl( node.src ) ) {
-				return null;
-			}
 			return new MeasurableImage( node, imageTagSource, fetchFn );
 		} else if ( node instanceof HTMLElement ) {
 			if ( ! backgroundImageSource( node ) ) {

--- a/projects/js-packages/image-guide/src/find-image-elements.ts
+++ b/projects/js-packages/image-guide/src/find-image-elements.ts
@@ -55,6 +55,11 @@ export function backgroundImageSource( node: HTMLElement ) {
 	return null;
 }
 
+function isSvgUrl( srcUrl: string ): boolean {
+	const url = new URL( srcUrl );
+	return url.pathname.toLowerCase().endsWith( '.svg' );
+}
+
 /**
  * Create MeasurableImage objects from a list of nodes
  * and remove any nodes that can't be measured.
@@ -70,6 +75,9 @@ export async function getMeasurableImages(
 	const nodes = findMeasurableElements( domNodes );
 	const images = nodes.map( node => {
 		if ( node instanceof HTMLImageElement ) {
+			if ( isSvgUrl( node.src ) ) {
+				return null;
+			}
 			return new MeasurableImage( node, imageTagSource, fetchFn );
 		} else if ( node instanceof HTMLElement ) {
 			if ( ! backgroundImageSource( node ) ) {
@@ -79,7 +87,6 @@ export async function getMeasurableImages(
 				 */
 				return null;
 			}
-
 			return new MeasurableImage( node, backgroundImageSource );
 		}
 

--- a/projects/js-packages/image-guide/src/ui/Bubble.svelte
+++ b/projects/js-packages/image-guide/src/ui/Bubble.svelte
@@ -35,7 +35,9 @@
 	}
 </script>
 
-<!-- eslint-disable-next-line svelte/valid-compile -- Complains about the div needing an ARIA role, but I have no idea what might be correct for this. -->
+<!-- Clear up complaints about needing an ARIA role: -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
+<!-- eslint-disable-next-line svelte/valid-compile -->
 <div
 	class="interaction-area {severity}"
 	bind:this={bubble}

--- a/projects/js-packages/image-guide/src/ui/Main.svelte
+++ b/projects/js-packages/image-guide/src/ui/Main.svelte
@@ -5,6 +5,7 @@
 	import Popup from './Popup.svelte';
 	import type { MeasurableImageStore } from '../stores/MeasurableImageStore';
 	import type { GuideSize } from '../types';
+	import { derived } from 'svelte/store';
 
 	export let stores: MeasurableImageStore[];
 	let show: number | false = false;
@@ -13,16 +14,16 @@
 	 * This onMount is triggered when the window loads
 	 * and the Image Guide UI is first
 	 */
-	onMount( () => {
-		stores.forEach( store => store.updateDimensions() );
-	} );
+	onMount(() => {
+		stores.forEach(store => store.updateDimensions());
+	});
 
-	function closeDetails( e ) {
+	function closeDetails(e) {
 		// Don't exit when hovering the Portal
 		if (
 			e.relatedTarget &&
 			// Don't exit when hovering the Popup
-			e.relatedTarget.classList.contains( 'keep-guide-open' )
+			e.relatedTarget.classList.contains('keep-guide-open')
 		) {
 			return;
 		}
@@ -30,42 +31,50 @@
 		show = false;
 	}
 
-	function getGuideSize( width = -1, height = -1 ): GuideSize {
-		if ( width < 200 || height < 200 ) {
+	function getGuideSize(width = -1, height = -1): GuideSize {
+		if (width < 200 || height < 200) {
 			return 'micro';
-		} else if ( width < 400 || height < 400 ) {
+		} else if (width < 400 || height < 400) {
 			return 'small';
 		}
 		return 'normal';
 	}
 
-	function toggleBackdrop( on = false ) {
-		if ( on ) {
-			stores.forEach( store => store.node.classList.add( 'jetpack-boost-guide__backdrop' ) );
+	function toggleBackdrop(on = false) {
+		if (on) {
+			stores.forEach(store => store.node.classList.add('jetpack-boost-guide__backdrop'));
 		} else {
-			stores.forEach( store => store.node.classList.remove( 'jetpack-boost-guide__backdrop' ) );
+			stores.forEach(store => store.node.classList.remove('jetpack-boost-guide__backdrop'));
 		}
 	}
 
 	// Use the first image available in the stores to determine the guide size
-	const sizeOnPage = stores[ 0 ].sizeOnPage;
-	$: size = getGuideSize( $sizeOnPage.width, $sizeOnPage.height );
+	const sizeOnPage = stores[0].sizeOnPage;
+	$: size = getGuideSize($sizeOnPage.width, $sizeOnPage.height);
 
-	$: toggleBackdrop( show !== false );
+	$: toggleBackdrop(show !== false);
 	let position = {
 		top: 0,
 		left: 0,
 	};
 
-	function hover( e: CustomEvent ) {
+	function hover(e: CustomEvent) {
 		const detail = e.detail;
 		const index = detail.index;
 		position = detail.position;
 		show = index;
 	}
+
+	/**
+	 * Only show image guide if at least one of the images
+	 * has a file size available.
+	 */
+	const hasItemsWithFileSize = derived(stores.map(s => s.fileSize), $fileSizes =>
+		$fileSizes.some(fileSize => fileSize.width !== -1 && fileSize.height !== -1)
+	);
 </script>
 
-{#if $guideState === 'active'}
+{#if $guideState === 'active' && $hasItemsWithFileSize}
 	<!-- Clear up complaints about needing an ARIA role: -->
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<!-- eslint-disable-next-line svelte/valid-compile -->
@@ -85,20 +94,20 @@
 				Intentionally using only a single component here.
 				See <Popup> component source for details.
 			 -->
-			<Popup store={stores[ show ]} {size} {position} on:mouseleave={closeDetails} />
+			<Popup store={stores[show]} {size} {position} on:mouseleave={closeDetails} />
 		{/if}
 	</div>
 {/if}
 
 <style lang="scss">
-	:global( .jetpack-boost-guide ) {
-		&:not( .relative ) {
+	:global(.jetpack-boost-guide) {
+		&:not(.relative) {
 			position: absolute;
 			top: 0;
 			left: 0;
 		}
 	}
-	:global( .jetpack-boost-guide.relative ) {
+	:global(.jetpack-boost-guide.relative) {
 		position: relative;
 	}
 	.guide {
@@ -144,10 +153,10 @@
 		margin-bottom: 15px;
 	}
 
-	:global( .jetpack-boost-guide__backdrop ) {
+	:global(.jetpack-boost-guide__backdrop) {
 		transition:
 			opacity 0.2s ease-in-out,
 			filter 0.2s ease-in-out;
-		filter: brightness( 0.3 );
+		filter: brightness(0.3);
 	}
 </style>

--- a/projects/js-packages/image-guide/src/ui/Main.svelte
+++ b/projects/js-packages/image-guide/src/ui/Main.svelte
@@ -66,7 +66,9 @@
 </script>
 
 {#if $guideState === 'active'}
-	<!-- eslint-disable-next-line svelte/valid-compile -- Complains about the div needing an ARIA role, but I have no idea what might be correct for this. -->
+	<!-- Clear up complaints about needing an ARIA role: -->
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<!-- eslint-disable-next-line svelte/valid-compile -->
 	<div
 		class="guide {size}"
 		class:show={show !== false}

--- a/projects/js-packages/image-guide/src/ui/Popup.svelte
+++ b/projects/js-packages/image-guide/src/ui/Popup.svelte
@@ -67,7 +67,9 @@
 
 <svelte:window bind:scrollY />
 <Portal>
-	<!-- eslint-disable-next-line svelte/valid-compile -- Complains about the div needing an ARIA role, but I have no idea what might be correct for this. -->
+	<!-- Clear up complaints about needing an ARIA role: -->
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<!-- eslint-disable-next-line svelte/valid-compile -->
 	<div
 		class="jetpack-boost-guide-popup keep-guide-open"
 		in:fly={{ duration: 150, y: 4, easing: backOut }}

--- a/projects/js-packages/image-guide/tsconfig.json
+++ b/projects/js-packages/image-guide/tsconfig.json
@@ -7,6 +7,6 @@
 		"sourceMap": true,
 		"outDir": "./build/",
 		"target": "es2019",
-		"verbatimModuleSyntax": true,
+		"verbatimModuleSyntax": true
 	}
 }

--- a/projects/js-packages/image-guide/tsconfig.json
+++ b/projects/js-packages/image-guide/tsconfig.json
@@ -8,7 +8,5 @@
 		"outDir": "./build/",
 		"target": "es2019",
 		"verbatimModuleSyntax": true,
-		"module": "ESNext",
-		"moduleResolution": "bundler"
 	}
 }

--- a/projects/js-packages/image-guide/tsconfig.json
+++ b/projects/js-packages/image-guide/tsconfig.json
@@ -7,6 +7,8 @@
 		"sourceMap": true,
 		"outDir": "./build/",
 		"target": "es2019",
-		"verbatimModuleSyntax": true
+		"verbatimModuleSyntax": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler"
 	}
 }


### PR DESCRIPTION
## Proposed changes:
- Exclude SVGs from displaying the image guide

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?



## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
N/A

## Testing instructions:
- Upload an SVG image to the relevant section of the application
- Ensure that the image guide does not appear for the SVG