### PR TITLE
Jetpack Color & Tonesque: add deprecation warning in codebase

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.color.php
+++ b/projects/plugins/jetpack/_inc/lib/class.color.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'Jetpack_Color' ) ) {
 		 */
 		public function __construct( $color = null, $type = 'hex' ) {
 			_deprecated_function( 'Jetpack_Color::__construct', 'jetpack-$$next-version$$' );
-			
+
 			if ( $color ) {
 				switch ( $type ) {
 					case 'hex':

--- a/projects/plugins/jetpack/_inc/lib/class.color.php
+++ b/projects/plugins/jetpack/_inc/lib/class.color.php
@@ -36,6 +36,8 @@ if ( ! class_exists( 'Jetpack_Color' ) ) {
 		 *        One of hex (default), rgb, hsl, int.
 		 */
 		public function __construct( $color = null, $type = 'hex' ) {
+			_deprecated_function( 'Jetpack_Color::__construct', 'jetpack-$$next-version$$' );
+			
 			if ( $color ) {
 				switch ( $type ) {
 					case 'hex':

--- a/projects/plugins/jetpack/_inc/lib/tonesque.php
+++ b/projects/plugins/jetpack/_inc/lib/tonesque.php
@@ -69,7 +69,7 @@ if ( ! class_exists( 'Tonesque' ) ) {
 		 */
 		public static function imagecreatefromurl( $image_url ) {
 			_deprecated_function( 'Tonesque::imagecreatefromurl', 'jetpack-$$next-version$$' );
-			
+
 			$data = null;
 
 			// If it's a URL.

--- a/projects/plugins/jetpack/_inc/lib/tonesque.php
+++ b/projects/plugins/jetpack/_inc/lib/tonesque.php
@@ -38,6 +38,8 @@ if ( ! class_exists( 'Tonesque' ) ) {
 		 * @param string $image_url Image URL.
 		 */
 		public function __construct( $image_url ) {
+			_deprecated_function( 'Tonesque::__construct', 'jetpack-$$next-version$$' );
+
 			if ( ! class_exists( 'Jetpack_Color' ) ) {
 				require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class.color.php';
 			}
@@ -66,6 +68,8 @@ if ( ! class_exists( 'Tonesque' ) ) {
 		 * @return object|bool Image object or false if the image could not be loaded.
 		 */
 		public static function imagecreatefromurl( $image_url ) {
+			_deprecated_function( 'Tonesque::imagecreatefromurl', 'jetpack-$$next-version$$' );
+			
 			$data = null;
 
 			// If it's a URL.

--- a/projects/plugins/jetpack/changelog/update-deprecate-jetpack-color
+++ b/projects/plugins/jetpack/changelog/update-deprecate-jetpack-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack Color & Tonesque: add deprecation warning in codebase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/397

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds a deprecation warning in the constructors of the `Jetpack_Color` and `Tonesque` classes, as they'll be removed from the Jetpack plugin (see project thread below for more detail).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pfwV0U-e1-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Checkout this branch locally
- Make sure you can see the server logs
- Somewhere in the code, require these 2 files:

```
require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class.color.php';
require_once JETPACK__PLUGIN_DIR . '/_inc/lib/tonesque.php';
```

- Instanciate `Jetpack_Color` (e.g. `$color = new Jetpack_Color();`)
- Notice the following warning in the logs:

```
PHP Deprecated:  Class Jetpack_Color is deprecated since version jetpack-$$next-version$$ with no alternative available.
```

- Instanciate `Tonesque` (e.g. `$tonesque = new Tonesque('/');`)
- Notice the following warning in the logs:

```
PHP Deprecated:  Class Tonesque is deprecated since version jetpack-$$next-version$$ with no alternative available.
```