### PR TITLE
jetpack_get_google_fonts_data: Add optional pre_ filter to shortcircuit fetching google fonts data

### DIFF
--- a/projects/plugins/jetpack/changelog/update-google-fonts-prefilter
+++ b/projects/plugins/jetpack/changelog/update-google-fonts-prefilter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+jetpack_get_google_fonts_data: Added an optional filter to short circuit fetching google font data

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -18,6 +18,22 @@ if ( ! class_exists( 'Jetpack_Google_Font_Face' ) ) {
  * @return object[] The collection data of the Google Fonts.
  */
 function jetpack_get_google_fonts_data() {
+	/**
+	 * Filters the Google Fonts data before the default retrieval process.
+	 *
+	 * This filter allows short-circuiting the default Google Fonts data retrieval process.
+	 * Returning a non-null value from this filter will bypass the default retrieval
+	 * and return the filtered value instead.
+	 *
+	 * @since TBD
+	 *
+	 * @param null|array $pre The pre-filtered Google Fonts data, default null.
+	 */
+	$pre = apply_filters( 'pre_jetpack_get_google_fonts_data', null );
+	if ( null !== $pre ) {
+		return $pre;
+	}
+
 	$default_google_fonts_api_url        = 'https://fonts.gstatic.com';
 	$jetpack_google_fonts_collection_url = 'https://s0.wp.com/i/font-collections/jetpack-google-fonts.json';
 	$cache_key                           = 'jetpack_google_fonts_' . md5( $jetpack_google_fonts_collection_url );

--- a/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts/current/load-google-fonts.php
@@ -25,7 +25,9 @@ function jetpack_get_google_fonts_data() {
 	 * Returning a non-null value from this filter will bypass the default retrieval
 	 * and return the filtered value instead.
 	 *
-	 * @since TBD
+	 * @module google-fonts
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param null|array $pre The pre-filtered Google Fonts data, default null.
 	 */


### PR DESCRIPTION

## Proposed changes:

* Add a new optional filter, `pre_jetpack_get_google_fonts_data`, to short circuit caching and retrieval of the google fonts data.
  *  On WPCOM, I'd like to tweak the caching by using a global cache group instead of one cache entry per blog, and to also use APCu to save trips to memcached servers. However, I don't want to change the transient method that end users are using, or to put a bunch of wpcom specific code in Jetpack. With the filter, WPCOM can have its own implementation.
  * You can see what I'm thinking of here: D155329-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Go to '..'
*

