### PR TITLE
Update/subscribe overlay track

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscribe-overlay-track
+++ b/projects/plugins/jetpack/changelog/update-subscribe-overlay-track
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Adds an internal subscription source to understan how users subscribe to sites
+
+

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -127,7 +127,7 @@ class Jetpack_Subscribe_Overlay {
 
 		$tagline_block
 
-		<!-- wp:jetpack/subscriptions /-->
+		<!-- wp:jetpack/subscriptions {"appSource":"subscribe-overlay"} /-->
 
 		<!-- wp:paragraph {"align":"center","className":"jetpack-subscribe-overlay__to-content"} -->
 		<p class="has-text-align-center jetpack-subscribe-overlay__to-content"><a href="$home_url">$skip_to_content ↓</a></p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This allows us to gain better insight into which subscription sources are more successful.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add appSource to subscription block in Subscribe Overlay.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D153451-code and sandbox API.
* In Newsletters setting turn on "Subscription overlay on homepage"
* In an incognito session Subscribe from the Subscription overlay.
* After confirming the email, check that `wpcom_blog_email_subscribe` gets tracked with `subscribe-overlay` as source property.