### PR TITLE
Admin Bar: Make it consistent between Calypso and WP Admin regardless of the value of Admin Interface Style

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-unify-masterbar
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-unify-masterbar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin Bar: Make it consistent between Calypso and WP Admin regardless of the value of Admin Interface Style

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -9,9 +9,7 @@
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
-if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
-	return;
-}
+define( 'WPCOM_ADMIN_BAR_UNIFICATION', true );
 
 /**
  * Enqueue assets needed by the WordPress.com admin bar.

--- a/projects/packages/masterbar/changelog/feat-unify-masterbar
+++ b/projects/packages/masterbar/changelog/feat-unify-masterbar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin Bar: Make it consistent between Calypso and WP Admin regardless of the value of Admin Interface Style

--- a/projects/packages/masterbar/composer.json
+++ b/projects/packages/masterbar/composer.json
@@ -63,7 +63,7 @@
 	"extra": {
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.3.x-dev"
+			"dev-trunk": "0.4.x-dev"
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.3.1",
+	"version": "0.4.0-alpha",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
+++ b/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
@@ -32,7 +32,7 @@ class Admin_Color_Schemes {
 			add_action( 'rest_api_init', array( $this, 'register_admin_color_meta' ) );
 		}
 
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) { // Classic sites.
+		if ( ( defined( 'WPCOM_ADMIN_BAR_UNIFICATION' ) && WPCOM_ADMIN_BAR_UNIFICATION ) || get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) { // Classic sites.
 			add_filter( 'css_do_concat', array( $this, 'disable_css_concat_for_color_schemes' ), 10, 2 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_color_scheme_for_sidebar_notice' ) );
 		} else { // Default and self-hosted sites.

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -276,8 +276,8 @@ abstract class Base_Admin_Menu {
 			)
 		);
 
-		// Load nav unification styles when the user isn't using wp-admin interface style.
-		if ( ! $this->use_wp_admin_interface() ) {
+		// Load nav unification styles for the admin bar when the user isn't using wp-admin interface style.
+		if ( ! $this->use_wp_admin_interface() && ! ( defined( 'WPCOM_ADMIN_BAR_UNIFICATION' ) && WPCOM_ADMIN_BAR_UNIFICATION ) ) {
 			Assets::register_script(
 				'jetpack-admin-nav-unification',
 				$assets_base_path . 'admin-menu-nav-unification.js',

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -29,7 +29,7 @@ class Main {
 
 		new Admin_Color_Schemes();
 
-		if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+		if ( ( defined( 'WPCOM_ADMIN_BAR_UNIFICATION' ) && WPCOM_ADMIN_BAR_UNIFICATION ) || get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
 			return;
 		}
 

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.3.1';
+	const PACKAGE_VERSION = '0.4.0-alpha';
 
 	/**
 	 * Initializer.

--- a/projects/plugins/jetpack/changelog/feat-unify-masterbar
+++ b/projects/plugins/jetpack/changelog/feat-unify-masterbar
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1661,7 +1661,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/masterbar",
-				"reference": "6425113a40fc707923278fa64aeb59aac96f1c3e"
+				"reference": "7eb8932228fd440df85d5459043a7203adf08e35"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1689,7 +1689,7 @@
 			"extra": {
 				"autotagger": true,
 				"branch-alias": {
-					"dev-trunk": "0.3.x-dev"
+					"dev-trunk": "0.4.x-dev"
 				},
 				"changelogger": {
 					"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/plugins/mu-wpcom-plugin/changelog/feat-unify-masterbar
+++ b/projects/plugins/mu-wpcom-plugin/changelog/feat-unify-masterbar
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -926,7 +926,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "6425113a40fc707923278fa64aeb59aac96f1c3e"
+                "reference": "7eb8932228fd440df85d5459043a7203adf08e35"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -954,7 +954,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/plugins/wpcomsh/changelog/feat-unify-masterbar
+++ b/projects/plugins/wpcomsh/changelog/feat-unify-masterbar
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1063,7 +1063,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "6425113a40fc707923278fa64aeb59aac96f1c3e"
+                "reference": "7eb8932228fd440df85d5459043a7203adf08e35"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1091,7 +1091,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8314
Fixes https://github.com/Automattic/dotcom-forge/issues/8311

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* We want to make the admin bar consistent everywhere, so this PR adds the flag `WPCOM_ADMIN_BAR_UNIFICATION` to determine whether to display the consistent admin bar. If the flag is true, we should not initialize the custom Masterbar and avoid the CSS concat for the color schemes due to the loading CSS priority.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site, either atomic or simple
* Apply D155493-code to your simple site
* Check the admin bar on both WP Admin and Calypso
* Change the value of the Admin Interface Style
* The admin bar should be always the same