### PR TITLE
Masterbar: Fix undefined array key warning in Base_Admin_Menu::hide_parent_of_hidden_submenus

### DIFF
--- a/projects/packages/masterbar/changelog/fix-warning-masterbar-undefined-array-key
+++ b/projects/packages/masterbar/changelog/fix-warning-masterbar-undefined-array-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Masterbar: Fix undefined array key warning in Base_Admin_Menu::hide_parent_of_hidden_submenus

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.3.1",
+	"version": "0.3.2-alpha",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -497,7 +497,7 @@ abstract class Base_Admin_Menu {
 			$has_submenus = isset( $submenu[ $menu_item[2] ] );
 
 			// Skip if the menu doesn't have submenus.
-			if ( ! $has_submenus || ! is_array( $submenu[ $menu_item[2] ] ) ) {
+			if ( ! $has_submenus || ! is_array( $submenu[ $menu_item[2] ] ) || empty( $submenu[ $menu_item[2] ] ) ) {
 				continue;
 			}
 

--- a/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-base-admin-menu.php
@@ -494,10 +494,8 @@ abstract class Base_Admin_Menu {
 		$this->sort_hidden_submenus();
 
 		foreach ( $menu as $menu_index => $menu_item ) {
-			$has_submenus = isset( $submenu[ $menu_item[2] ] );
-
 			// Skip if the menu doesn't have submenus.
-			if ( ! $has_submenus || ! is_array( $submenu[ $menu_item[2] ] ) || empty( $submenu[ $menu_item[2] ] ) ) {
+			if ( empty( $submenu[ $menu_item[2] ] ) || ! is_array( $submenu[ $menu_item[2] ] ) ) {
 				continue;
 			}
 

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.3.1';
+	const PACKAGE_VERSION = '0.3.2-alpha';
 
 	/**
 	 * Initializer.

--- a/projects/packages/masterbar/tests/php/test-class-admin-menu.php
+++ b/projects/packages/masterbar/tests/php/test-class-admin-menu.php
@@ -500,6 +500,15 @@ class Test_Admin_Menu extends TestCase {
 				),
 				array( '', 'read', 'test-slug', '', Base_Admin_Menu::HIDE_CSS_CLASS ),
 			),
+			array(
+				array(
+					array( '', 'read', 'test-empty-submenu', '', '' ),
+				),
+				array(
+					'test-empty-submenu' => array(),
+				),
+				array( '', 'read', 'test-empty-submenu', '', '' ),
+			),
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a Warning: `Undefined array key 0` in `Automattic\Jetpack\Masterbar\Base_Admin_Menu::hide_parent_of_hidden_submenus` when the corresponding submenu exists but is empty.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Masterbar\Base_Admin_Menu`:  Adds an extra check in `hide_parent_of_hidden_submenus` to skip checking the current submenu if it exists but is an empty array.
* Adds a relevant unit test that will return an error without this PR applied.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-tpT-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:

I was able to reproduce this by visiting `https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs` with a **non A12n account**. You'll also need to sandbox `dashboard.wordpress.com`.

- Confirm you see the Warning without the PR applied
- Run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/warning-masterbar-undefined-array-key` on your sandbox
- Confirm the Warning is no longer there