### PR TITLE
Hide wpcom features when site is agency-managed or user is local

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/agency-managed-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/agency-managed-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Hide wpcom features when site is agency-managed or user is local

--- a/projects/packages/jetpack-mu-wpcom/src/features/agency-managed/agency-managed.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agency-managed/agency-managed.php
@@ -4,13 +4,3 @@
  *
  * @package jetpack-mu-wpcom
  */
-
-/**
- * Whether to enable "fully managed agency site" features.
- * This is primarily used to hide WPCOM links, upsells, and features.
- *
- * @return bool True if the site is "fully managed agency site", false otherwise.
- */
-function is_agency_managed_site() {
-	return ! empty( get_option( 'is_fully_managed_agency_site' ) );
-}

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/hide-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/hide-site-visibility.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Hide various settings related to site visibility.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Hide the "Site Visibility" setting in Reading Settings.
+ */
+function wpcom_hide_site_visibility_setting() {
+	echo '<style>
+		.option-site-visibility {
+			display: none !important;
+		}
+	</style>';
+}
+add_action( 'load-options-reading.php', 'wpcom_hide_site_visibility_setting' );
+
+/**
+ * Remove the "Update Services" section in Writing Settings.
+ */
+add_filter( 'enable_update_services_configuration', '__return_false' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
@@ -55,30 +55,3 @@ function replace_site_visibility() {
 		<?php
 }
 add_action( 'blog_privacy_selector', 'replace_site_visibility' );
-
-/**
- * Hide the "Site visibility" setting in Reading Settings if is_agency_managed_site is true.
- */
-function wpcom_hide_site_visibility_setting() {
-	if ( ! is_agency_managed_site() ) {
-		return;
-	}
-	// Check if the current page is the Reading Settings page.
-	$screen = get_current_screen();
-	if ( $screen->id === 'options-reading' ) {
-		echo '<style>
-            .option-site-visibility {
-                display: none !important;
-            }
-        </style>';
-	}
-}
-add_action( 'admin_head', 'wpcom_hide_site_visibility_setting' );
-
-/**
- * Remove the "Update Services" section in Writing Settings if is_agency_managed_site is true.
- */
-function wpcom_remove_update_services_section() {
-	return ! is_agency_managed_site();
-}
-add_filter( 'enable_update_services_configuration', 'wpcom_remove_update_services_section' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -53,10 +53,6 @@ add_action( 'admin_bar_menu', 'wpcom_enqueue_admin_bar_assets' );
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
 function wpcom_repurpose_wp_logo_as_all_sites_menu( $wp_admin_bar ) {
-	if ( is_agency_managed_site() ) {
-		return;
-	}
-
 	foreach ( $wp_admin_bar->get_nodes() as $node ) {
 		if ( $node->parent === 'wp-logo' || $node->parent === 'wp-logo-external' ) {
 			$wp_admin_bar->remove_node( $node->id );
@@ -86,10 +82,6 @@ add_action( 'admin_bar_menu', 'wpcom_repurpose_wp_logo_as_all_sites_menu', 11 );
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
 function wpcom_add_reader_menu( $wp_admin_bar ) {
-	if ( is_agency_managed_site() ) {
-		return;
-	}
-
 	$wp_admin_bar->add_node(
 		array(
 			'id'    => 'reader',
@@ -109,10 +101,6 @@ add_action( 'admin_bar_menu', 'wpcom_add_reader_menu', 15 );
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
 function wpcom_add_my_account_item_to_profile_menu( $wp_admin_bar ) {
-	if ( is_agency_managed_site() || ! current_user_has_wpcom_account() ) {
-		return;
-	}
-
 	$logout_node = $wp_admin_bar->get_node( 'logout' );
 	if ( $logout_node ) {
 		// Adds the 'My Account' menu item before 'Log Out'.
@@ -133,20 +121,3 @@ function wpcom_add_my_account_item_to_profile_menu( $wp_admin_bar ) {
 	}
 }
 add_action( 'admin_bar_menu', 'wpcom_add_my_account_item_to_profile_menu' );
-
-/**
- * Hides the Help Center menu.
- */
-function wpcom_hide_help_center_menu() {
-	if ( ! is_agency_managed_site() ) {
-		return;
-	}
-	?>
-	<style>
-		#wp-admin-bar-help-center {
-			display: none !important;
-		}
-	</style>
-	<?php
-}
-add_action( 'admin_head', 'wpcom_hide_help_center_menu' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -14,9 +14,6 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
  * The setting is displayed only if the has the wp-admin interface selected.
  */
 function wpcomsh_wpcom_admin_interface_settings_field() {
-	if ( is_agency_managed_site() ) {
-		return;
-	}
 	add_settings_field( 'wpcom_admin_interface', '', 'wpcom_admin_interface_display', 'general', 'default' );
 
 	register_setting( 'general', 'wpcom_admin_interface', array( 'sanitize_callback' => 'esc_attr' ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -41,17 +41,6 @@ function wpcom_add_hosting_menu() {
 	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
 		return;
 	}
-	if ( is_agency_managed_site() ) {
-		return;
-	}
-
-	/**
-	 * Don't show `Hosting` to administrators without a WordPress.com account being attached,
-	 * as they don't have access to any of the pages.
-	 */
-	if ( ! current_user_has_wpcom_account() ) {
-		return;
-	}
 
 	$parent_slug = 'wpcom-hosting-menu';
 	$domain      = wp_parse_url( home_url(), PHP_URL_HOST );
@@ -164,14 +153,6 @@ function wpcom_add_jetpack_submenu() {
 	 * They already get a menu item under Users via nav-unification.
 	 */
 	if ( ( new Host() )->is_wpcom_platform() && get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
-		return;
-	}
-
-	/**
-	 * Don't show to administrators without a WordPress.com account being attached,
-	 * as they don't have access to any of the pages.
-	 */
-	if ( ! current_user_has_wpcom_account() ) {
 		return;
 	}
 
@@ -289,7 +270,6 @@ function wpcom_add_plugins_menu() {
 	$is_simple_site          = defined( 'IS_WPCOM' ) && IS_WPCOM;
 	$is_atomic_site          = ! $is_simple_site;
 	$uses_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
-	$is_agency_managed_site  = is_agency_managed_site();
 
 	if ( $is_simple_site ) {
 		$has_plugins_menu = false;
@@ -329,10 +309,6 @@ function wpcom_add_plugins_menu() {
 		}
 	}
 
-	if ( $is_agency_managed_site || ! current_user_has_wpcom_account() ) {
-		return;
-	}
-
 	$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 	if ( $uses_wp_admin_interface ) {
 		add_submenu_page(
@@ -349,11 +325,6 @@ function wpcom_add_plugins_menu() {
 
 	if ( $is_atomic_site ) {
 		if (
-			/**
-			 * Don't show `Scheduled Updates` to administrators without a WordPress.com account being attached,
-			 * as they don't have access to any of the pages.
-			 */
-			current_user_has_wpcom_account() &&
 			! get_option( 'wpcom_is_staging_site' ) &&
 			function_exists( 'wpcom_site_has_feature' ) &&
 			wpcom_site_has_feature( \WPCOM_Features::SCHEDULED_UPDATES )

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -89,9 +89,6 @@ add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_sidebar_notice_assets' );
  * @return array | null
  */
 function wpcom_get_sidebar_notice() {
-	if ( is_agency_managed_site() ) {
-		return null;
-	}
 	$message_path = 'calypso:sites:sidebar_notice';
 
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php
@@ -32,6 +32,10 @@ class WPCOM_Site_Management_Widget {
 	 * Register widget with WordPress.
 	 */
 	public function __construct() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		add_action( 'admin_head', array( $this, 'admin_head' ) );
 		add_action( 'wp_dashboard_setup', array( $this, 'wp_dashboard_setup' ) );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-fixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-theme-fixes.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * WordPress.com Theme Fixes
+ *
+ * Various fixes to WordPress themes page related to WordPress.com.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+/**
+ * Removes actions from the active theme details added by Core to replicate our custom WP.com submenus.
+ *
+ * Core expect the menus to link to WP Admin, but our submenus point to wordpress.com so the actions won't work.
+ *
+ * @see https://github.com/WordPress/wordpress-develop/blob/80096ddf29d3ffa4d5654f5f788df7f598b48756/src/wp-admin/themes.php#L356-L412
+ */
+function wpcom_themes_remove_wpcom_actions() {
+	wp_enqueue_script(
+		'wpcom-theme-actions',
+		plugins_url( 'js/theme-actions.js', __FILE__ ),
+		array(),
+		Jetpack_Mu_Wpcom::PACKAGE_VERSION,
+		array(
+			'strategy'  => 'defer',
+			'in_footer' => true,
+		)
+	);
+}
+add_action( 'load-themes.php', 'wpcom_themes_remove_wpcom_actions' );
+
+/**
+ * Adds a CSS file to fix UI issues in the theme browser.
+ */
+function wpcom_themes_load_ui_fixes() {
+	wp_enqueue_style(
+		'wpcom-themes-ui-fixes',
+		plugins_url( 'css/ui-fixes.css', __FILE__ ),
+		array(),
+		Jetpack_Mu_Wpcom::PACKAGE_VERSION
+	);
+}
+add_action( 'load-themes.php', 'wpcom_themes_load_ui_fixes' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
@@ -9,13 +9,14 @@
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
+if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
+	return;
+}
+
 /**
  * Displays a banner before the theme browser that links to the WP.com Theme Showcase.
  */
 function wpcom_themes_show_banner() {
-	if ( is_agency_managed_site() || ! current_user_has_wpcom_account() ) {
-		return;
-	}
 	$site_slug        = wp_parse_url( home_url(), PHP_URL_HOST );
 	$wpcom_logo       = plugins_url( 'images/wpcom-logo.svg', __FILE__ );
 	$background_image = plugins_url( 'images/banner-background.webp', __FILE__ );
@@ -55,13 +56,6 @@ add_action( 'load-theme-install.php', 'wpcom_themes_show_banner' );
  * Registers an "Appearance > Theme Showcase" menu.
  */
 function wpcom_themes_add_theme_showcase_menu() {
-	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
-		return;
-	}
-	if ( is_agency_managed_site() || ! current_user_has_wpcom_account() ) {
-		return;
-	}
-
 	$site_slug = wp_parse_url( home_url(), PHP_URL_HOST );
 	add_submenu_page(
 		'themes.php',
@@ -72,37 +66,3 @@ function wpcom_themes_add_theme_showcase_menu() {
 	);
 }
 add_action( 'admin_menu', 'wpcom_themes_add_theme_showcase_menu' );
-
-/**
- * Removes actions from the active theme details added by Core to replicate our custom WP.com submenus.
- *
- * Core expect the menus to link to WP Admin, but our submenus point to wordpress.com so the actions won't work.
- *
- * @see https://github.com/WordPress/wordpress-develop/blob/80096ddf29d3ffa4d5654f5f788df7f598b48756/src/wp-admin/themes.php#L356-L412
- */
-function wpcom_themes_remove_wpcom_actions() {
-	wp_enqueue_script(
-		'wpcom-theme-actions',
-		plugins_url( 'js/theme-actions.js', __FILE__ ),
-		array(),
-		Jetpack_Mu_Wpcom::PACKAGE_VERSION,
-		array(
-			'strategy'  => 'defer',
-			'in_footer' => true,
-		)
-	);
-}
-add_action( 'load-themes.php', 'wpcom_themes_remove_wpcom_actions' );
-
-/**
- * Adds a CSS file to fix UI issues in the theme browser.
- */
-function wpcom_themes_load_ui_fixes() {
-	wp_enqueue_style(
-		'wpcom-themes-ui-fixes',
-		plugins_url( 'css/ui-fixes.css', __FILE__ ),
-		array(),
-		Jetpack_Mu_Wpcom::PACKAGE_VERSION
-	);
-}
-add_action( 'load-themes.php', 'wpcom_themes_load_ui_fixes' );

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -5,7 +5,35 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+/**
+ * Whether the current user is logged-in via WordPress.com account.
+ *
+ * @return bool True if the user has associated WordPress.com account.
+ */
+function is_wpcom_user() {
+	// If the site is explicitly marked as agency-managed, treat the user as non-wpcom user.
+	if ( ! empty( get_option( 'is_fully_managed_agency_site' ) ) ) {
+		return false;
+	}
+
+	$user_id = get_current_user_id();
+
+	if ( function_exists( '\A8C\Billingdaddy\Users\get_wpcom_user' ) ) {
+		// On Simple sites, use get_wpcom_user function to check if the user has a WordPress.com account.
+		$user        = \A8C\Billingdaddy\Users\get_wpcom_user( $user_id );
+		$has_account = isset( $user->ID );
+	} else {
+		// On Atomic sites, use the Connection Manager to check if the user has a WordPress.com account.
+		$connection_manager = new Connection_Manager();
+		$wpcom_user_data    = $connection_manager->get_connected_user_data( $user_id );
+		$has_account        = isset( $wpcom_user_data['ID'] );
+	}
+
+	return $has_account;
+}
 
 /**
  * Helper function to return the site slug for Calypso URLs.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8197

## Proposed changes:

This PR disables the following wpcom-only features if the site is fully agency-managed, or if the user is a local user (not connected to WordPress.com).

It works by consolidating the scattered `is_agency_managed()` checks as follows:

- Implement the `is_wpcom_user()` as discussed here https://github.com/Automattic/dotcom-forge/issues/8197#issuecomment-2221890883.
- Gate the entire individual features with this check inside a new `load_wpcom_user_features()`, instead of gating individual hooks.
   - This way, it's much clearer what features are not loaded on agency sites.

|Feature|Screenshot|
|-|-|
|WP.com masterbar logo pointing to /sites|<img width="40" alt="image" src="https://github.com/user-attachments/assets/86bfd804-6bb5-487d-b94b-85d069daf069">|
|Reader masterbar icon|<img width="94" alt="image" src="https://github.com/user-attachments/assets/e973b8a0-aeae-4c79-a2dc-a39425fb11f7">|
|Help center masterbar icon|<img width="36" alt="image" src="https://github.com/user-attachments/assets/4b343141-69a8-45c7-b024-19810ac0d47e">|
|Howdy menu -> My Account|<img width="265" alt="image" src="https://github.com/user-attachments/assets/796b2e69-9c78-4b74-ae6a-85e386eda1e0">|
|Hosting menu|<img width="163" alt="image" src="https://github.com/user-attachments/assets/ea0147b9-e28e-4fde-87e9-f6c3affbb0bd">|
|Sidebar upsell|<img width="164" alt="image" src="https://github.com/user-attachments/assets/f8a35b74-addc-418a-b4a0-bf28235f0cdc">|
|Site management panel widget|<img width="420" alt="image" src="https://github.com/user-attachments/assets/2d12848d-d639-4d98-a3f6-ae71bc4ccc17">|
|Appearance -> Theme Showcase|<img width="165" alt="image" src="https://github.com/user-attachments/assets/bc7ed7fd-10d0-435d-9069-565c3441a1f2">|
|Appearance -> Themes -> Add New Theme banner|<img width="573" alt="image" src="https://github.com/user-attachments/assets/58a2c205-5041-4cc9-9362-7eab9750e959">|
|Plugins -> {Marketplace, Scheduled Updates}|<img width="157" alt="image" src="https://github.com/user-attachments/assets/9dac360a-b208-40fe-9f79-0501b4403c63">|
|Command palette (cmd-K)|<img width="653" alt="image" src="https://github.com/user-attachments/assets/822cdde5-189e-404b-81e8-0368595a0569">|
|Settings -> General -> Admin Interface Style|<img width="630" alt="image" src="https://github.com/user-attachments/assets/a09bd4d9-4c76-415f-998f-6aec24559589">|
|Settings -> Reading -> Site Visibility link|<img width="471" alt="image" src="https://github.com/user-attachments/assets/f5bf3a03-9360-4550-8bb7-f090043477e1">|
|Settings -> Writing -> Update Services|<img width="189" alt="image" src="https://github.com/user-attachments/assets/15f0447b-3781-4dd0-8d42-10b459c2771f">|

### Note

It looks like Plugin Marketplace banner is still shown to non-wpcom user. I asked for clarification here: https://github.com/Automattic/jetpack/pull/38241/files#r1680796660 cc: @Addison-Stavlo 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test the following scenarios:

- Simple site (Default and Classic)
- Atomic site, wpcom user (Default and Classic)
- Atomic site, local user (Classic)
- Atomic site, wpcom user (Classic) but `is_fully_managed_agency_site` option is `1` on that site

