### PR TITLE
Social: Fix connection_test_result call merging issue

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-connection-test-result-logic
+++ b/projects/js-packages/publicize-components/changelog/fix-social-connection-test-result-logic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed an issue with connection and connection_test_result merging

--- a/projects/js-packages/publicize-components/src/hooks/use-sync-post-data-to-store/test/index.test.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-sync-post-data-to-store/test/index.test.js
@@ -13,7 +13,7 @@ import {
 const connections = connectionsList.map( connection => ( { ...connection, enabled: true } ) );
 
 const post = {
-	jetpack_publicize_connections: [ connections[ 0 ] ],
+	jetpack_publicize_connections: [ connections ],
 };
 
 const getMethod = options =>

--- a/projects/js-packages/publicize-components/src/social-store/actions/connection-data.js
+++ b/projects/js-packages/publicize-components/src/social-store/actions/connection-data.js
@@ -83,6 +83,22 @@ export function mergeConnections( freshConnections ) {
 			toggleable: true,
 		};
 
+		// A connection was added after the test call started, so we need to add it to the list.
+		if ( prevConnections.length > freshConnections.length ) {
+			const addedConnection = prevConnections.find(
+				conn =>
+					! freshConnections.some( freshConn =>
+						freshConn.connection_id
+							? freshConn.connection_id === conn.connection_id
+							: freshConn.id === conn.id
+					)
+			);
+
+			if ( addedConnection ) {
+				connections.push( addedConnection );
+			}
+		}
+
 		/*
 		 * Iterate connection by connection,
 		 * in order to refresh or update current connections.
@@ -93,6 +109,11 @@ export function mergeConnections( freshConnections ) {
 					? conn.connection_id === freshConnection.connection_id
 					: conn.id === freshConnection.id
 			);
+
+			// If a connection was removed after the test call started, we need to remove it from freshConnections.
+			if ( ! prevConnection ) {
+				continue;
+			}
 
 			const connection = {
 				...defaults,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/448

On slower connections there is a scenario which could happen that messes up the connection state:
- On page load the `test_connections` call fires, but takes 10-15 seconds to complete
- In the meantime the user adds/removes a connection, changing the state
- If the addition/remove of connection finishes faster, the `test_connections` call will mess up the state when it finishes, it will either remove the new connection from the UI, or add back the removed one.

If you have a speedy network it's harder to reproduce, so one solution for that is to make changes in the `mergeConnections` function in the `projects/js-packages/publicize-components/src/social-store/actions/connection-data.js` file, make the inner function async, and add the await line at the start like so:
```diff
export function mergeConnections( freshConnections ) {
-	return function ( { dispatch, select } ) {
+	return async function ( { dispatch, select } ) {
+		await new Promise( resolve => setTimeout( resolve, 10000 ) );
```

### Issue presented with connection removal - the connection gets added back after `test_connections` finishes:

https://github.com/user-attachments/assets/b03c8461-f95c-406c-a67c-a2b86eec4f6c

### Issue presented with the connection addition - the connection gets removed after `test_connections` finishes:

https://github.com/user-attachments/assets/e4127389-46bb-4f32-9671-d86e64337433


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Handles scenarios where `prevConnections` and `freshConnections` is not the same
  * if a connection was added, we just add it to freshConnections from prevConnections
  * if a connection was removed, we remove it from freshConnections so it won't get added back

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* If your network is _too fast_ follow the instructions at the top of the PR to include the timeout
* Go to the post editor, switch to Jetpack tab and _quickly_ add a new connection. It should not disappear after the test_connections call finishes
* Refresh the page, and now _quickly_ remove the connection. It should not get added back after the test_connections call finishes.
