### PR TITLE
Jetpack dashboard: dashitem cards spacing

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -405,6 +405,11 @@
 	.jp-dash-item {
 		.dops-card {
 			flex-grow: 1;
+			align-items: flex-start;
+
+			&.dops-section-header {
+				align-items: center
+			}
 		}
 		.dops-card.is-compact {
 			flex-grow: 0;

--- a/projects/plugins/jetpack/changelog/fix-jetpack-dashboard-dash-item-alignment
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-dashboard-dash-item-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack Dashboard: use flex-start alignment for dash item cards for more consistent header-content spacing


### PR DESCRIPTION
Default flex alignment (`center`) makes for misaligned card content due to different spacing between header and content

## Proposed changes:
This PR adds alignment to DashItem cards children for a more consistent space between the card's header and content

Before:
![image](https://github.com/user-attachments/assets/60ec38d2-05ba-4589-bbfd-379cdb2924ec)

After:
![image](https://github.com/user-attachments/assets/5aa83e6e-71be-4263-8612-f293f2147ffc)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1721222227063659-slack-C0D96691V

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Instance a Jurassic Ninja site from the link below and another one without the change (clean, just visit JN and create a site)
Visit JP dashboard and look at the cards, compare side by side. The change is sutil but noticeable.
While the style change is specific to the cards, verify the rest of UI is not affected.