### PR TITLE
Ensure Jetpack Posts page Stats link points to wp-admin

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-posts-stats-link
+++ b/projects/plugins/jetpack/changelog/fix-posts-stats-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Ensure Jetpack posts stats link points to wp-admin stats

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1811,14 +1811,17 @@ function jetpack_stats_post_table_cell( $column, $post_id ) {
 				esc_html__( 'No stats', 'jetpack' )
 			);
 		} else {
-			$stats_post_url = 'wp-admin' === get_option( 'wpcom_admin_interface' )
-			? admin_url( sprintf( 'admin.php?page=stats#!/stats/post/%d/%d', $post_id, Jetpack_Options::get_option( 'id', 0 ) ) )
-			: Redirect::get_url(
-				'calypso-stats-post',
-				array(
-					'path' => $post_id,
-				)
-			);
+			// Link to the wp-admin stats page.
+			$stats_post_url = admin_url( sprintf( 'admin.php?page=stats#!/stats/post/%d/%d', $post_id, Jetpack_Options::get_option( 'id', 0 ) ) );
+			// Unless the user is on a Default style WOA site, in which case link to Calypso.
+			if ( ( new Host() )->is_woa_site() && Stats_Options::get_option( 'enable_odyssey_stats' ) && 'wp-admin' !== get_option( 'wpcom_admin_interface' ) ) {
+				$stats_post_url = Redirect::get_url(
+					'calypso-stats-post',
+					array(
+						'path' => $post_id,
+					)
+				);
+			}
 
 			printf(
 				'<a href="%s" title="%s" class="dashicons dashicons-chart-bar" target="_blank"></a>',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jpop-issues/issues/9140

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes a regression introduced in https://github.com/Automattic/jetpack/pull/38013
* It ensures that the Stats link on the Jetpack Posts page links to wp-admin and does NOT redirect to WordPress.com.

<img width="910" alt="Screenshot 2024-07-17 at 11 08 48 AM" src="https://github.com/user-attachments/assets/83bdcb23-2bb3-416d-9560-a104a5195fe1">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Jetpack Beta tester to check out this branch
* Test that the following is true:
* Atomic Classic links to: /wp-admin stats
* Atomic Default links to: Calypso Stats
* Atomic Default with that particular page set to Classic view: Calypso Stats
* **Jetpack Sites links to: /wp-admin stats** 
* Ensure that nothing breaks on simple sites. Though, the code in this PR should not affect simple sites.