### PR TITLE
General: update WP version requirements to WordPress 6.5

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -40,7 +40,7 @@ case "$WP_BRANCH" in
 	previous)
 		# We hard-code the version here because there's a time near WP releases where
 		# we've dropped the old 'previous' but WP hasn't actually released the new 'latest'
-		WORDPRESS_TAG=6.4
+		WORDPRESS_TAG=6.5
 		;;
 	*)
 		echo "Unrecognized value for WP_BRANCH: $WP_BRANCH" >&2

--- a/.phpcs.config.xml
+++ b/.phpcs.config.xml
@@ -2,7 +2,7 @@
 <!-- This file configures everything except the list of rules. -->
 <!-- The separation is so .github/files/phpcompatibility-dev-phpcs.xml can use the same config with a different rule set. -->
 <ruleset>
-	<config name="minimum_supported_wp_version" value="6.4" />
+	<config name="minimum_supported_wp_version" value="6.5" />
 	<config name="testVersion" value="7.0-"/>
 
 	<!-- Use our custom filter for `.phpcsignore` and `.phpcs.dir.xml` support. -->

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
 		"phan/phan": "^5.4",
 		"php-parallel-lint/php-parallel-lint": "^1.4.0",
 		"php-stubs/woocommerce-stubs": ">=8.7",
-		"php-stubs/wordpress-stubs": ">=6.4",
-		"php-stubs/wordpress-tests-stubs": ">=6.4",
+		"php-stubs/wordpress-stubs": ">=6.5",
+		"php-stubs/wordpress-tests-stubs": ">=6.5",
 		"php-stubs/wp-cli-stubs": "^2.10",
 		"sirbrillig/phpcs-changed": "2.11.4",
 		"squizlabs/php_codesniffer": "^3.6.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34f2d8ac9e65725df2a124991d9ac059",
+    "content-hash": "700fde8d8373ed5610bfc08d87e10fc2",
     "packages": [],
     "packages-dev": [
         {

--- a/projects/plugins/automattic-for-agencies-client/automattic-for-agencies-client.php
+++ b/projects/plugins/automattic-for-agencies-client/automattic-for-agencies-client.php
@@ -4,7 +4,7 @@
  * Plugin Name: Automattic for Agencies Client
  * Plugin URI: https://wordpress.org/plugins/automattic-for-agencies-client
  * Description: Securely connect your clients’ sites to the Automattic for Agencies Sites Dashboard. Manage your sites from one place and see what needs attention.
- * Version: 0.2.2-alpha
+ * Version: 0.3.0-alpha
  * Author: Automattic
  * Author URI: https://automattic.com/for-agencies/
  * License: GPLv2 or later

--- a/projects/plugins/automattic-for-agencies-client/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/automattic-for-agencies-client/composer.json
+++ b/projects/plugins/automattic-for-agencies-client/composer.json
@@ -73,6 +73,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_automattic_for_agencies_clientⓥ0_2_2_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_automattic_for_agencies_clientⓥ0_3_0_alpha"
 	}
 }

--- a/projects/plugins/automattic-for-agencies-client/readme.txt
+++ b/projects/plugins/automattic-for-agencies-client/readme.txt
@@ -1,7 +1,7 @@
 === Automattic For Agencies Client ===
 Contributors: automattic, jeherve, njweller, rcanepa
 Tags: agency, dashboard, management, sites, monitoring
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.0
 Tested up to: 6.6
 Stable tag: 0.2.1

--- a/projects/plugins/backup/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/backup/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/backup/readme.txt
+++ b/projects/plugins/backup/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack VaultPress Backup ===
 Contributors: automattic, bjorsch, fgiannar, initsogar, jeherve, jwebbdev, kraftbj, macbre, pypt, samiff, sermitr, williamvianas
 Tags: jetpack, backup, restore
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.0
 Tested up to: 6.6
 Stable tag: 2.2

--- a/projects/plugins/classic-theme-helper-plugin/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/classic-theme-helper-plugin/readme.txt
+++ b/projects/plugins/classic-theme-helper-plugin/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Classic Theme Helper Plugin ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.0
 Tested up to: 6.6
 Stable tag: 0.1.0-alpha

--- a/projects/plugins/inspect/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/inspect/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/inspect/readme.txt
+++ b/projects/plugins/inspect/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack inspect ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.0
 Tested up to: 6.6
 Stable tag: 1.0.0-alpha

--- a/projects/plugins/jetpack/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/jetpack/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: compat
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -8,7 +8,7 @@
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP: 7.0
  *
  * @package automattic/jetpack
@@ -32,7 +32,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '6.4' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '6.5' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
 define( 'JETPACK__VERSION', '13.7-a.4' );
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, arsihasi, azaozz, barry, batmoo, beaulebens, bindlegirl, biskobe, bjorsch, blobaugh, brbrr, brileyhooper, cainm, cena, cfinke, cgastrell, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, daniloercoli, davoraltman, delawski, designsimply, dkmyta, dllh, drawmyface, dsmart, jwidavid, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, joen, jblz, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lhkowalski, lschuyler, macmanx, martinremy, matt, mattwiebe, matveb, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, miguelxavierpenha, mikeyarce, mkaz, nancythanki, nickmomrik, njweller, nunyvega, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, renatoagds, retrofox, richardmtl, richardmuscat, robertbpugh, roccotripaldi, ryancowles, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, thehenridev, tmoorewp, tyxla, Viper007Bond, westi, williamvianas, wpkaren, yoavf, zinigor
 Tags: Security, backup, malware, scan, performance
 Stable tag: 13.6
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.0
 Tested up to: 6.6
 License: GPLv2 or later

--- a/projects/plugins/migration/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/migration/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/migration/composer.json
+++ b/projects/plugins/migration/composer.json
@@ -71,6 +71,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_migrationⓥ2_1_0_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_migrationⓥ3_0_0_alpha"
 	}
 }

--- a/projects/plugins/migration/readme.txt
+++ b/projects/plugins/migration/readme.txt
@@ -1,7 +1,7 @@
 === Move to WordPress.com ===
 Contributors: automattic
 Tags: migrate, migration, backup, restore, transfer, move, copy, wordpress.com, automattic, import, importer, hosting
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.0
 Tested up to: 6.6
 Stable tag: 2.0.0

--- a/projects/plugins/migration/wpcom-migration.php
+++ b/projects/plugins/migration/wpcom-migration.php
@@ -4,7 +4,7 @@
  * Plugin Name: Move to WordPress.com
  * Plugin URI: https://wordpress.org/plugins/wpcom-migration
  * Description: A WordPress plugin that helps users to migrate their sites to WordPress.com.
- * Version: 2.1.0-alpha
+ * Version: 3.0.0-alpha
  * Author: Automattic
  * Author URI: https://wordpress.com/
  * License: GPLv2 or later

--- a/projects/plugins/protect/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/protect/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -79,6 +79,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ2_3_0_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ3_0_0_alpha"
 	}
 }

--- a/projects/plugins/protect/jetpack-protect.php
+++ b/projects/plugins/protect/jetpack-protect.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Protect
  * Plugin URI: https://wordpress.org/plugins/jetpack-protect
  * Description: Security tools that keep your site safe and sound, from posts to plugins.
- * Version: 2.3.0-alpha
+ * Version: 3.0.0-alpha
  * Author: Automattic - Jetpack Security team
  * Author URI: https://jetpack.com/protect/
  * License: GPLv2 or later
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'JETPACK_PROTECT_VERSION', '2.3.0-alpha' );
+define( 'JETPACK_PROTECT_VERSION', '3.0.0-alpha' );
 define( 'JETPACK_PROTECT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_PROTECT_ROOT_FILE', __FILE__ );
 define( 'JETPACK_PROTECT_ROOT_FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );

--- a/projects/plugins/protect/readme.txt
+++ b/projects/plugins/protect/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Protect ===
 Contributors: automattic, retrofox, leogermani, renatoagds, bjorsch, ebinnion, fgiannar, zinigor, miguelxavierpenha, dsmart, jeherve, manzoorwanijk, njweller, oskosk, samiff, siddarthan, wpkaren, arsihasi, kraftbj, kev, sermitr, kangzj, pabline, dkmyta
 Tags: jetpack, protect, security, malware, scan
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.0
 Tested up to: 6.6
 Stable tag: 1.4.1

--- a/projects/plugins/search/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/search/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/search/composer.json
+++ b/projects/plugins/search/composer.json
@@ -62,7 +62,7 @@
 	},
 	"config": {
 		"sort-packages": true,
-		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ2_1_1_alpha",
+		"autoloader-suffix": "b462338fb66be23595d68a93345c9e3d_jetpack_searchⓥ3_0_0_alpha",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true,

--- a/projects/plugins/search/jetpack-search.php
+++ b/projects/plugins/search/jetpack-search.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Search
  * Plugin URI: https://jetpack.com/search/
  * Description: Easily add cloud-powered instant search and filters to your website or WooCommerce store with advanced algorithms that boost your search results based on traffic to your site.
- * Version: 2.1.1-alpha
+ * Version: 3.0.0-alpha
  * Author: Automattic - Jetpack Search team
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ define( 'JETPACK_SEARCH_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__FILE', __FILE__ );
 define( 'JETPACK_SEARCH_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
 define( 'JETPACK_SEARCH_PLUGIN__SLUG', 'jetpack-search' );
-define( 'JETPACK_SEARCH_PLUGIN__VERSION', '2.1.1-alpha' );
+define( 'JETPACK_SEARCH_PLUGIN__VERSION', '3.0.0-alpha' );
 
 defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
 

--- a/projects/plugins/search/readme.txt
+++ b/projects/plugins/search/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Search ===
 Contributors: automattic, annamcphee, bluefuton, kangzj, jsnmoon, robfelty, gibrown, trakos, dognose24, a8ck3n
 Tags: search, filter, woocommerce search, ajax search, product search, free cloud-based search
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.0
 Tested up to: 6.6
 Stable tag: 1.4.0

--- a/projects/plugins/social/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/social/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -84,6 +84,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ4_5_3_alpha"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_socialⓥ5_0_0_alpha"
 	}
 }

--- a/projects/plugins/social/jetpack-social.php
+++ b/projects/plugins/social/jetpack-social.php
@@ -4,7 +4,7 @@
  * Plugin Name: Jetpack Social
  * Plugin URI: https://wordpress.org/plugins/jetpack-social
  * Description: Share your site’s posts on several social media networks automatically when you publish a new post.
- * Version: 4.5.3-alpha
+ * Version: 5.0.0-alpha
  * Author: Automattic - Jetpack Social team
  * Author URI: https://jetpack.com/social/
  * License: GPLv2 or later

--- a/projects/plugins/social/readme.txt
+++ b/projects/plugins/social/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Social  ===
 Contributors: automattic, pabline, siddarthan, gmjuhasz, manzoorwanijk
 Tags: social media automation, social media scheduling, auto share, social sharing, social media marketing
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.0
 Tested up to: 6.6
 Stable tag: 4.5.1

--- a/projects/plugins/starter-plugin/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/starter-plugin/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/starter-plugin/readme.txt
+++ b/projects/plugins/starter-plugin/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack Starter Plugin ===
 Contributors: automattic,
 Tags: jetpack, stuff
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.0
 Tested up to: 6.6
 Stable tag: 0.1.0-alpha

--- a/projects/plugins/super-cache/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/super-cache/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/super-cache/composer.json
+++ b/projects/plugins/super-cache/composer.json
@@ -51,6 +51,6 @@
 		"wp-svn-autopublish": true
 	},
 	"config": {
-		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ1_12_3"
+		"autoloader-suffix": "6fe342bc02f0b440f7b3c8d8ade42286_super_cacheⓥ2_0_0_alpha"
 	}
 }

--- a/projects/plugins/super-cache/package.json
+++ b/projects/plugins/super-cache/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-super-cache",
-	"version": "1.12.3",
+	"version": "2.0.0-alpha",
 	"description": "A very fast caching engine for WordPress that produces static html files.",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/super-cache/readme.txt
+++ b/projects/plugins/super-cache/readme.txt
@@ -1,7 +1,7 @@
 === WP Super Cache ===
 Contributors: donncha, automattic, adnan007, dilirity, mikemayhem3030, pyronaur, thingalon
 Tags: performance, caching, wp-cache, wp-super-cache, cache
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.0
 Tested up to: 6.6
 Stable tag: 1.12.3

--- a/projects/plugins/super-cache/wp-cache.php
+++ b/projects/plugins/super-cache/wp-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Super Cache
  * Plugin URI: https://wordpress.org/plugins/wp-super-cache/
  * Description: Very fast caching plugin for WordPress.
- * Version: 1.12.3
+ * Version: 2.0.0-alpha
  * Author: Automattic
  * Author URI: https://automattic.com/
  * License: GPL2+

--- a/projects/plugins/videopress/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/videopress/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, retrofox, oskosk, thehenridev, renatoagds, lhkowalski, nunyvega, leogermani, cgastrell
 Tags: video, video-hosting, video-player, cdn, video-streaming
 
-Requires at least: 6.4
+Requires at least: 6.5
 Tested up to: 6.6
 Stable tag: 1.5
 Requires PHP: 7.0

--- a/projects/plugins/wpcomsh/changelog/update-minimum-wp-to-6.5
+++ b/projects/plugins/wpcomsh/changelog/update-minimum-wp-to-6.5
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+General: update WordPress version requirements to WordPress 6.5.

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -130,7 +130,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ3_28_1_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ4_0_0_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "3.28.1-alpha",
+	"version": "4.0.0-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/readme.txt
+++ b/projects/plugins/wpcomsh/readme.txt
@@ -1,7 +1,7 @@
 === WP.com Site Helper ===
 Contributors: lamosty, obenland, automattic
 Tags: WP.com
-Requires at least: 6.4
+Requires at least: 6.5
 Requires PHP: 7.4
 Tested up to: 6.6
 Stable tag: trunk

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 3.28.1-alpha
+ * Version: 4.0.0-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '3.28.1-alpha' );
+define( 'WPCOMSH_VERSION', '4.0.0-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -956,7 +956,7 @@ function createReadMeTxt( answers ) {
 		`=== Jetpack ${ answers.name } ===\n` +
 		'Contributors: automattic,\n' +
 		'Tags: jetpack, stuff\n' +
-		'Requires at least: 6.4\n' +
+		'Requires at least: 6.5\n' +
 		'Requires PHP: 7.0\n' +
 		'Tested up to: 6.6\n' +
 		`Stable tag: ${ answers.version }\n` +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Now that WordPress 6.6 is out, we can start requiring WordPress 6.5.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Epic: #36721

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not much to test. 🤷
* While previous bumps such as #37047 were flagged as "patch" significance, I did these as "major" since we're dropping support for WordPress 6.4 and dropping support for older versions of the platform is supposed to be a major bump. If someone disagrees with that, let's discuss.