### PR TITLE
Add exception output escaping for the Color library.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.color.php
+++ b/projects/plugins/jetpack/_inc/lib/class.color.php
@@ -92,15 +92,30 @@ if ( ! class_exists( 'Jetpack_Color' ) ) {
 		 */
 		public function fromRgbInt( $red, $green, $blue ) {
 			if ( $red < 0 || $red > 255 ) {
-				throw new RangeException( 'Red value ' . $red . ' out of valid color code range' );
+				throw new RangeException(
+					sprintf(
+						'Red value %s out of valid color code range',
+						esc_html( $red )
+					)
+				);
 			}
 
 			if ( $green < 0 || $green > 255 ) {
-				throw new RangeException( 'Green value ' . $green . ' out of valid color code range' );
+				throw new RangeException(
+					sprintf(
+						'Green value %s out of valid color code range',
+						esc_html( $green )
+					)
+				);
 			}
 
 			if ( $blue < 0 || $blue > 255 ) {
-				throw new RangeException( 'Blue value ' . $blue . ' out of valid color code range' );
+				throw new RangeException(
+					sprintf(
+						'Blue value %s out of valid color code range',
+						esc_html( $blue )
+					)
+				);
 			}
 
 			$this->color = ( intval( $red ) << 16 ) + ( intval( $green ) << 8 ) + intval( $blue );
@@ -186,7 +201,12 @@ if ( ! class_exists( 'Jetpack_Color' ) ) {
 		 */
 		public function fromInt( $int_value ) {
 			if ( $int_value < 0 || $int_value > 16777215 ) {
-				throw new RangeException( $int_value . ' out of valid color code range' );
+				throw new RangeException(
+					sprintf(
+						'%s out of valid color code range',
+						esc_html( $int_value )
+					)
+				);
 			}
 
 			$this->color = $int_value;

--- a/projects/plugins/jetpack/changelog/add-exception-output-escaping-color
+++ b/projects/plugins/jetpack/changelog/add-exception-output-escaping-color
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Minor changes that only add output escaping.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes PHPCS sniff errors on Exception escaping.

## Proposed changes:
* Adds `esc_html` to the output values for exceptions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1721235892454269-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Go to '..'
*