### PR TITLE
Protect: Update Auto fix all button message

### DIFF
--- a/projects/plugins/protect/changelog/update-auto-fix-all-threats-button
+++ b/projects/plugins/protect/changelog/update-auto-fix-all-threats-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Auto fix all button message

--- a/projects/plugins/protect/src/js/components/threats-list/index.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/index.jsx
@@ -111,8 +111,8 @@ const ThreatsList = () => {
 												onClick={ handleFixAllThreatsClick( fixableList ) }
 											>
 												{ sprintf(
-													/* translators: Translates to Auto fix all. $s: Number of fixable threats. */
-													__( 'Auto fix all (%s)', 'jetpack-protect' ),
+													/* translators: Translates to Show fixable threats $s: Number of fixable threats. */
+													__( 'Show fixable threats (%s)', 'jetpack-protect' ),
 													fixableList.length
 												) }
 											</Button>

--- a/projects/plugins/protect/src/js/components/threats-list/index.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/index.jsx
@@ -111,8 +111,8 @@ const ThreatsList = () => {
 												onClick={ handleFixAllThreatsClick( fixableList ) }
 											>
 												{ sprintf(
-													/* translators: Translates to Show fixable threats $s: Number of fixable threats. */
-													__( 'Show fixable threats (%s)', 'jetpack-protect' ),
+													/* translators: Translates to Show auto fixers $s: Number of fixable threats. */
+													__( 'Show auto fixers (%s)', 'jetpack-protect' ),
 													fixableList.length
 												) }
 											</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Description
Make the Auto fix all button message clearer so users understand that this triggers confirmation modal before triggering the fixers.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1285

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start a new JN site with this branch running on the Beta tester
* Upgrade and add fixable threats
* Verify that the button displays the expected text above the current list
* Ensure no regressions are introduced

## Screenshots
![Screen Shot on 2024-07-17 at 15-17-29](https://github.com/user-attachments/assets/496b8048-de0f-4542-81e7-d890cbe02ee1)

