### PR TITLE
jetpack: Use better cipher in WPCOM Connection test

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -1594,10 +1594,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		return rest_ensure_response(
 			array(
 				'code'  => 'response',
-				'debug' => array(
-					'data' => $encrypted['data'],
-					'key'  => $encrypted['key'],
-				),
+				'debug' => $encrypted,
 			)
 		);
 	}

--- a/projects/plugins/jetpack/changelog/update-jetpack-site-tester-more-ciphers
+++ b/projects/plugins/jetpack/changelog/update-jetpack-site-tester-more-ciphers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WPCOM Connection test: use better ciphers than RC4, which is no longer available on many hosts.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
RC4 is long obsolete, and likely isn't even available on modern hosts.

Choose AES-256-CTR or AES-256-CBC if available and use that instead. If neither is available, don't even bother with RC4 anymore.

Note this needs D155629-code on the server, or the test in the Jetpack Debugger will show as failing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See D155629-code.
