### PR TITLE
Search: fix Tracks value that is causing event to be rejected

### DIFF
--- a/projects/packages/search/changelog/fix-jetpack_search_customberg-events
+++ b/projects/packages/search/changelog/fix-jetpack_search_customberg-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: This commit fixes the property of a Tracks event that was being sent as a JSON, which is not a valid Tracks value.
+
+

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.12",
+	"version": "0.44.13-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.12';
+	const VERSION = '0.44.13-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/customberg/components/save-button/index.jsx
+++ b/projects/packages/search/src/customberg/components/save-button/index.jsx
@@ -1,7 +1,6 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import useEntityRecordState from 'hooks/use-entity-record-state';
-import { SERVER_OBJECT_NAME } from 'instant-search/lib/constants';
 import { eventPrefix, recordEvent } from 'lib/analytics';
 import './styles.scss';
 
@@ -11,22 +10,13 @@ import './styles.scss';
  * @returns {Element} component instance
  */
 export default function SaveButton() {
-	const {
-		editedEntities: editedSettings,
-		isSaving,
-		hasUnsavedEdits,
-		saveRecords,
-	} = useEntityRecordState();
+	const { isSaving, hasUnsavedEdits, saveRecords } = useEntityRecordState();
 
 	const onClick = ( ...args ) => {
 		if ( isSaving ) {
 			return;
 		}
-		recordEvent( `${ eventPrefix }_save_button_click`, {
-			initialSettings: JSON.stringify( window[ SERVER_OBJECT_NAME ].overlayOptions ),
-			changedSettings: JSON.stringify( editedSettings ),
-			changedSettingNames: Object.keys( editedSettings ).join( ',' ),
-		} );
+		recordEvent( `${ eventPrefix }_save_button_click` );
 		saveRecords( ...args );
 	};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Context: pbmo2S-2Eb-p2#comment-3225

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes a Tracks event that was trying to store a JSON-encoded string as value, but it was causing the event to be rejected (since it doesn't match the allowed pattern)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbmo2S-2Eb-p2#comment-3225

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

N/a