### PR TITLE
WAF: Improve cross-compatibility of IP list options

### DIFF
--- a/projects/packages/waf/changelog/waf-ip-list-additional-compatibility
+++ b/projects/packages/waf/changelog/waf-ip-list-additional-compatibility
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Improved backwards/cross compatibility of option deprecation related to IP block/allow lists.
+
+

--- a/projects/packages/waf/src/class-compatibility.php
+++ b/projects/packages/waf/src/class-compatibility.php
@@ -30,9 +30,6 @@ class Waf_Compatibility {
 		add_filter( 'option_' . Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME, __CLASS__ . '::filter_option_waf_ip_allow_list', 10, 1 );
 		add_filter( 'default_option_' . Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::default_option_waf_ip_allow_list_enabled', 10, 3 );
 		add_filter( 'default_option_' . Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::default_option_waf_ip_block_list_enabled', 10, 3 );
-		add_action( 'pre_update_option_' . Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, __CLASS__ . '::update_option_waf_ip_lists_enabled', 10, 3 );
-		add_action( 'pre_update_option_' . Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::update_option_waf_ip_allow_list_enabled', 10, 3 );
-		add_action( 'pre_update_option_' . Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::update_option_waf_ip_block_list_enabled', 10, 3 );
 	}
 
 	/**
@@ -249,13 +246,13 @@ class Waf_Compatibility {
 	public static function default_option_waf_ip_allow_list_enabled( $default, $option, $passed_default ) {
 		// If the deprecated IP lists option was set to false, disable the allow list.
 		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
-		$deprecated_option = get_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, true );
+		$deprecated_option = Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, true );
 		if ( ! $deprecated_option ) {
 			return false;
 		}
 
 		// If the allow list is empty, disable the allow list.
-		if ( ! get_option( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME ) ) {
+		if ( ! Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME ) ) {
 			return false;
 		}
 
@@ -286,57 +283,6 @@ class Waf_Compatibility {
 		}
 
 		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
-		return get_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, false );
-	}
-
-	/**
-	 * Keep the new IP list options in sync with the old generic IP lists enabled option.
-	 *
-	 * @since $next-version$
-	 *
-	 * @param mixed $old_value The old value of the option.
-	 * @param mixed $value     The new value of the option.
-	 */
-	public static function update_option_waf_ip_lists_enabled( $old_value, $value ) {
-		$allow_list_enabled = Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, false );
-		$block_list_enabled = Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, false );
-
-		if ( $value && ! $allow_list_enabled ) {
-			update_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, true );
-		}
-		if ( $value && ! $block_list_enabled ) {
-			update_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, true );
-		}
-	}
-
-	/**
-	 * Keep the legacy IP lists enabled option in sync with the new allow list enabled option.
-	 *
-	 * @since $next-version$
-	 *
-	 * @param mixed $old_value The old value of the option.
-	 * @param mixed $value     The new value of the option.
-	 */
-	public static function update_option_waf_ip_allow_list_enabled( $old_value, $value ) {
-		$legacy_option_enabled = Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, false );
-
-		if ( $value && ! $legacy_option_enabled ) {
-			update_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, true );
-		}
-	}
-
-	/**
-	 * Keep the legacy IP lists enabled option in sync with the new block list enabled option.
-	 *
-	 * @since $next-version$
-	 *
-	 * @param mixed $old_value The old value of the option.
-	 * @param mixed $value     The new value of the option.
-	 */
-	public static function update_option_waf_ip_block_list_enabled( $old_value, $value ) {
-		$legacy_option_enabled = Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, false );
-		if ( $value && ! $legacy_option_enabled ) {
-			update_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, true );
-		}
+		return Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, false );
 	}
 }

--- a/projects/packages/waf/src/class-compatibility.php
+++ b/projects/packages/waf/src/class-compatibility.php
@@ -244,6 +244,11 @@ class Waf_Compatibility {
 	 * @return mixed The default value to return if the option does not exist in the database.
 	 */
 	public static function default_option_waf_ip_allow_list_enabled( $default, $option, $passed_default ) {
+		// Allow get_option() to override this default value
+		if ( $passed_default ) {
+			return $default;
+		}
+
 		// If the deprecated IP lists option was set to false, disable the allow list.
 		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
 		$deprecated_option = Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, true );
@@ -254,11 +259,6 @@ class Waf_Compatibility {
 		// If the allow list is empty, disable the allow list.
 		if ( ! Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME ) ) {
 			return false;
-		}
-
-		// Allow get_option() to override this default value
-		if ( $passed_default ) {
-			return $default;
 		}
 
 		// Default to enabling the allow list.

--- a/projects/packages/waf/src/class-compatibility.php
+++ b/projects/packages/waf/src/class-compatibility.php
@@ -30,6 +30,9 @@ class Waf_Compatibility {
 		add_filter( 'option_' . Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME, __CLASS__ . '::filter_option_waf_ip_allow_list', 10, 1 );
 		add_filter( 'default_option_' . Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::default_option_waf_ip_allow_list_enabled', 10, 3 );
 		add_filter( 'default_option_' . Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::default_option_waf_ip_block_list_enabled', 10, 3 );
+		add_action( 'pre_update_option_' . Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, __CLASS__ . '::update_option_waf_ip_lists_enabled', 10, 3 );
+		add_action( 'pre_update_option_' . Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::update_option_waf_ip_allow_list_enabled', 10, 3 );
+		add_action( 'pre_update_option_' . Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::update_option_waf_ip_block_list_enabled', 10, 3 );
 	}
 
 	/**
@@ -284,5 +287,56 @@ class Waf_Compatibility {
 
 		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
 		return get_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, false );
+	}
+
+	/**
+	 * Keep the new IP list options in sync with the old generic IP lists enabled option.
+	 *
+	 * @since $next-version$
+	 *
+	 * @param mixed $old_value The old value of the option.
+	 * @param mixed $value     The new value of the option.
+	 */
+	public static function update_option_waf_ip_lists_enabled( $old_value, $value ) {
+		$allow_list_enabled = Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, false );
+		$block_list_enabled = Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, false );
+
+		if ( $value && ! $allow_list_enabled ) {
+			update_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, true );
+		}
+		if ( $value && ! $block_list_enabled ) {
+			update_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, true );
+		}
+	}
+
+	/**
+	 * Keep the legacy IP lists enabled option in sync with the new allow list enabled option.
+	 *
+	 * @since $next-version$
+	 *
+	 * @param mixed $old_value The old value of the option.
+	 * @param mixed $value     The new value of the option.
+	 */
+	public static function update_option_waf_ip_allow_list_enabled( $old_value, $value ) {
+		$legacy_option_enabled = Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, false );
+
+		if ( $value && ! $legacy_option_enabled ) {
+			update_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, true );
+		}
+	}
+
+	/**
+	 * Keep the legacy IP lists enabled option in sync with the new block list enabled option.
+	 *
+	 * @since $next-version$
+	 *
+	 * @param mixed $old_value The old value of the option.
+	 * @param mixed $value     The new value of the option.
+	 */
+	public static function update_option_waf_ip_block_list_enabled( $old_value, $value ) {
+		$legacy_option_enabled = Jetpack_Options::get_raw_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, false );
+		if ( $value && ! $legacy_option_enabled ) {
+			update_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, true );
+		}
 	}
 }

--- a/projects/packages/waf/src/class-rest-controller.php
+++ b/projects/packages/waf/src/class-rest-controller.php
@@ -103,14 +103,17 @@ class REST_Controller {
 	public static function update_waf( $request ) {
 		// Automatic Rules Enabled
 		if ( isset( $request[ Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME ] ) ) {
-			update_option( Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME, (bool) $request->get_param( Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME ) );
+			update_option( Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME, $request->get_param( Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME ) ? '1' : '' );
 		}
 
-		// IP Lists Enabled
-		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
-		if ( isset( $request[ Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME ] ) ) {
-			// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
-			update_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME, (bool) $request->get_param( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME ) );
+		/**
+		 * IP Lists Enabled
+		 *
+		 * @deprecated $next-version$ This is a legacy option maintained here for backwards compatibility.
+		 */
+		if ( isset( $request['jetpack_waf_ip_list'] ) ) {
+			update_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, $request['jetpack_waf_ip_list'] ? '1' : '' );
+			update_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, $request['jetpack_waf_ip_list'] ? '1' : '' );
 		}
 
 		// IP Block List
@@ -118,7 +121,7 @@ class REST_Controller {
 			update_option( Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME, $request[ Waf_Rules_Manager::IP_BLOCK_LIST_OPTION_NAME ] );
 		}
 		if ( isset( $request[ Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME ] ) ) {
-			update_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, $request[ Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME ] );
+			update_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, $request[ Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME ] ? '1' : '' );
 		}
 
 		// IP Allow List
@@ -126,27 +129,27 @@ class REST_Controller {
 			update_option( Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME, $request[ Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME ] );
 		}
 		if ( isset( $request[ Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME ] ) ) {
-			update_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, $request[ Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME ] );
+			update_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, $request[ Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME ] ? '1' : '' );
 		}
 
 		// Share Data
 		if ( isset( $request[ Waf_Runner::SHARE_DATA_OPTION_NAME ] ) ) {
 			// If a user disabled the regular share we should disable the debug share data option.
-			if ( false === $request[ Waf_Runner::SHARE_DATA_OPTION_NAME ] ) {
-				update_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, false );
+			if ( ! $request[ Waf_Runner::SHARE_DATA_OPTION_NAME ] ) {
+				update_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, '' );
 			}
 
-			update_option( Waf_Runner::SHARE_DATA_OPTION_NAME, (bool) $request[ Waf_Runner::SHARE_DATA_OPTION_NAME ] );
+			update_option( Waf_Runner::SHARE_DATA_OPTION_NAME, $request[ Waf_Runner::SHARE_DATA_OPTION_NAME ] ? '1' : '' );
 		}
 
 		// Share Debug Data
 		if ( isset( $request[ Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME ] ) ) {
 			// If a user toggles the debug share we should enable the regular share data option.
-			if ( true === $request[ Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME ] ) {
-				update_option( Waf_Runner::SHARE_DATA_OPTION_NAME, true );
+			if ( $request[ Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME ] ) {
+				update_option( Waf_Runner::SHARE_DATA_OPTION_NAME, 1 );
 			}
 
-			update_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, (bool) $request[ Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME ] );
+			update_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, $request[ Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME ] ? '1' : '' );
 		}
 
 		// Brute Force Protection

--- a/projects/packages/waf/src/class-waf-rules-manager.php
+++ b/projects/packages/waf/src/class-waf-rules-manager.php
@@ -53,15 +53,13 @@ class Waf_Rules_Manager {
 		// Re-activate the WAF any time an option is added or updated.
 		add_action( 'add_option_' . self::AUTOMATIC_RULES_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		add_action( 'update_option_' . self::AUTOMATIC_RULES_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
-		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
-		add_action( 'add_option_' . self::IP_LISTS_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
-		// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
-		add_action( 'update_option_' . self::IP_LISTS_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
-		add_action( 'add_option_' . self::IP_ALLOW_LIST_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		add_action( 'add_option_' . self::IP_ALLOW_LIST_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
+		add_action( 'update_option_' . self::IP_ALLOW_LIST_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
+		add_action( 'add_option_' . self::IP_ALLOW_LIST_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		add_action( 'update_option_' . self::IP_ALLOW_LIST_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
-		add_action( 'add_option_' . self::IP_BLOCK_LIST_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		add_action( 'add_option_' . self::IP_BLOCK_LIST_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
+		add_action( 'update_option_' . self::IP_BLOCK_LIST_ENABLED_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
+		add_action( 'add_option_' . self::IP_BLOCK_LIST_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		add_action( 'update_option_' . self::IP_BLOCK_LIST_OPTION_NAME, array( static::class, 'reactivate_on_rules_option_change' ), 10, 0 );
 		// Register the cron job.
 		add_action( 'jetpack_waf_rules_update_cron', array( static::class, 'update_rules_cron' ) );

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -179,7 +179,7 @@ class Waf_Runner {
 			 * @deprecated $next-version$
 			 */
 			// @phan-suppress-next-line PhanDeprecatedClassConstant -- Needed for backwards compatibility.
-			Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME => get_option( Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME ),
+			Waf_Rules_Manager::IP_LISTS_ENABLED_OPTION_NAME => get_option( Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME ) || get_option( Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME ),
 		);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the WAF REST API endpoint to compute the legacy "jetpack_waf_ip_lists" value based on the new block and allow list option values, and similarly set the new block and allow list values directly when the legacy "jetpack_waf_ip_lists" parameter is included in a POST request.
* Use `Jetpack_Options::get_raw_option()` in compatibility hooks, to use the unfiltered value from the database.
* Use `'1'` or `''` as option values to ensure related hooks fire ([source](https://wordpress.stackexchange.com/questions/330289/update-option-option-action-not-working-as-expected)).
* Update/fix tests to correctly mock option values.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a site with running one of the following environments:
  * Jetpack with branch applied, Protect from production
  * Jetpack from production, Protect with branch applied
  * Both Jetpack AND Protect with branch applied
  * Jetpack OR Protect with branch applied
* Test toggling between the Jetpack and Protect WAF UI, and updating the new block and allow list toggles in Protect, and updating the legacy IP lists toggle in Jetpack.

