### PR TITLE
Block Perplexity AI bot when opted out of data sharing.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-block-perplexity-ai-bot
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-block-perplexity-ai-bot
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Block Perplexity AI bot in robots.txt when opted out of data sharing.

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -45,6 +45,7 @@ function robots_txt( string $output, $public ): string {
 			'GPTBot',
 			'omgili',
 			'omgilibot',
+			'PerplexityBot',
 			'SentiBot',
 			'sentibot',
 		);

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
@@ -61,6 +61,9 @@ Disallow: /
 User-agent: omgilibot
 Disallow: /
 
+User-agent: PerplexityBot
+Disallow: /
+
 User-agent: SentiBot
 Disallow: /
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8338

## Proposed changes:
- Block Perplexity AI

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

- Follow the testing instructions [https://github.com/Automattic/jetpack/pull/38400#issuecomment-2235723072](below) for both Simple & Atomic.
-  
> [!WARNING]  
> Beware: On Atomic I had to update the main Jetpack to RC as well, otherwise I'd get a fatal: `Cannot redeclare jetpack_responsive_videos_init() (previously declared in /srv/htdocs/wp-content/plugins/jetpack-mu-wpcom-plugin-dev/vendor/automattic/jetpack-classic-theme-helper/src/responsive-videos.php:16) in /srv/htdocs/wp-content/plugins/jetpack/modules/theme-tools/responsive-videos.php on line 36`
- Go to `https://wordpress.com/settings/general/yoursite` and check "Prevent third-party sharing for newbroddinatomic.blog"
- Visit `https://yoursite.com/robots.txt` 
- PerplexityBot should be listed there:

Example output for Atomic. Simple should look similar.
```
Sitemap: https://newbroddinatomic.blog/sitemap.xml
Sitemap: https://newbroddinatomic.blog/news-sitemap.xml
User-agent: *
Disallow: /wp-admin/
Allow: /wp-admin/admin-ajax.php

User-agent: Amazonbot
Disallow: /

User-agent: anthropic-ai
Disallow: /

User-agent: Bytespider
Disallow: /

User-agent: CCBot
Disallow: /

User-agent: ClaudeBot
Disallow: /

User-agent: FacebookBot
Disallow: /

User-agent: Google-Extended
Disallow: /

User-agent: GPTBot
Disallow: /

User-agent: omgili
Disallow: /

User-agent: omgilibot
Disallow: /

User-agent: PerplexityBot
Disallow: /

User-agent: SentiBot
Disallow: /

User-agent: sentibot
Disallow: /

User-agent: Applebot-Extended
Disallow: /private/
```