### PR TITLE
Backport mu-wpcom-plugin 2.4.1 Changes

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.54.4] - 2024-07-18
+### Changed
+- Internal updates.
+
 ## [0.54.3] - 2024-07-03
 ### Changed
 - Updated package dependencies. [#38132]
@@ -1083,6 +1087,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.54.4]: https://github.com/Automattic/jetpack-components/compare/0.54.3...0.54.4
 [0.54.3]: https://github.com/Automattic/jetpack-components/compare/0.54.2...0.54.3
 [0.54.2]: https://github.com/Automattic/jetpack-components/compare/0.54.1...0.54.2
 [0.54.1]: https://github.com/Automattic/jetpack-components/compare/0.54.0...0.54.1

--- a/projects/js-packages/components/changelog/add-segmentation-to-jetpack-products-my-jetpack
+++ b/projects/js-packages/components/changelog/add-segmentation-to-jetpack-products-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.54.4-alpha",
+	"version": "0.54.4",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [0.34.0] - 2024-07-18
+### Changed
+- Connection Screen: remove mention of Stats from the list of available free features. [#38328]
+
 ## [0.33.19] - 2024-07-03
 ### Changed
 - Updated package dependencies. [#38132]
@@ -797,6 +801,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[0.34.0]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.19...v0.34.0
 [0.33.19]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.18...v0.33.19
 [0.33.18]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.17...v0.33.18
 [0.33.17]: https://github.com/Automattic/jetpack-connection-js/compare/v0.33.16...v0.33.17

--- a/projects/js-packages/connection/changelog/remove-stats-from-connection-interstitial
+++ b/projects/js-packages/connection/changelog/remove-stats-from-connection-interstitial
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Connection Screen: remove mention of Stats from the list of available free features.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "0.34.0-alpha",
+	"version": "0.34.0",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/partner-coupon/changelog/force-a-release
+++ b/projects/js-packages/partner-coupon/changelog/force-a-release
@@ -1,5 +1,4 @@
 Significance: patch
 Type: changed
-Comment: Updated composer.lock.
 
-
+Update dependencies.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.82",
+	"version": "0.2.83-alpha",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/CHANGELOG.md
+++ b/projects/js-packages/shared-extension-utils/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.18] - 2024-07-18
+### Changed
+- Update dependencies. [#37356]
+
 ## [0.14.17] - 2024-07-03
 ### Changed
 - Updated package dependencies. [#38132]
@@ -400,6 +404,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Core: prepare utility for release
 
+[0.14.18]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.17...0.14.18
 [0.14.17]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.16...0.14.17
 [0.14.16]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.15...0.14.16
 [0.14.15]: https://github.com/Automattic/jetpack-shared-extension-utils/compare/0.14.14...0.14.15

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.14.17",
+	"version": "0.14.18",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/packages/backup/changelog/force-a-release
+++ b/projects/packages/backup/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.4.1';
+	const PACKAGE_VERSION = '3.4.2-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.45.0] - 2024-07-18
+### Added
+- MU WPCOM: Support localizeUrl [#38318]
+
+### Changed
+- Block Perplexity AI bot in robots.txt when opted out of data sharing. [#38400]
+- Hide wpcom features when site is agency-managed or user is local [#38364]
+
+### Fixed
+- Admin Bar: Hotfix the order of the admin menu items for WP 6.6 [#38347]
+
 ## [5.44.0] - 2024-07-15
 ### Added
 - Add Profile -> My Account menu to admin bar. [#38294]
@@ -997,6 +1008,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.45.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.44.0...v5.45.0
 [5.44.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.43.0...v5.44.0
 [5.43.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.42.1...v5.43.0
 [5.42.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.42.0...v5.42.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-block-perplexity-ai-bot
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-block-perplexity-ai-bot
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Block Perplexity AI bot in robots.txt when opted out of data sharing.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-manual-previous-70-testing
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-manual-previous-70-testing
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix a test to work with both WP 6.4 and 6.5.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/agency-managed-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/agency-managed-check
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Hide wpcom features when site is agency-managed or user is local

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-menu-order
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-menu-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Admin Bar: Hotfix the order of the admin menu items for WP 6.6

--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-localize-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-localize-url
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-MU WPCOM: Support localizeUrl

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-admin-bar-wp-logo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-admin-bar-wp-logo
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Minor image replacement
-
-

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.45.0-alpha",
+	"version": "5.45.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.45.0-alpha';
+	const PACKAGE_VERSION = '5.45.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jitm/CHANGELOG.md
+++ b/projects/packages/jitm/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.14] - 2024-07-18
+### Changed
+- Update margins on jitms in my jetpack [#38283]
+
 ## [3.1.13] - 2024-07-03
 ### Changed
 - Updated package dependencies. [#38132]
@@ -731,6 +735,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Jetpack to use new JITM package
 
+[3.1.14]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.13...v3.1.14
 [3.1.13]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.12...v3.1.13
 [3.1.12]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.11...v3.1.12
 [3.1.11]: https://github.com/Automattic/jetpack-jitm/compare/v3.1.10...v3.1.11

--- a/projects/packages/jitm/changelog/update-my-jetpack-jitm-css
+++ b/projects/packages/jitm/changelog/update-my-jetpack-jitm-css
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update margins on jitms in my jetpack

--- a/projects/packages/jitm/src/class-jitm.php
+++ b/projects/packages/jitm/src/class-jitm.php
@@ -20,7 +20,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '3.1.14-alpha';
+	const PACKAGE_VERSION = '3.1.14';
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/projects/packages/search/changelog/force-a-release
+++ b/projects/packages/search/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.12",
+	"version": "0.44.13-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.12';
+	const VERSION = '0.44.13-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/videopress/changelog/force-a-release
+++ b/projects/packages/videopress/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.27",
+	"version": "0.23.28-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.27';
+	const PACKAGE_VERSION = '0.23.28-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.4.1 - 2024-07-18
+### Changed
+- Internal updates.
+
 ## 2.4.0 - 2024-07-15
 ### Added
 - Composer lock update. [#38241]

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_4_1_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_4_1"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.4.1-alpha
+ * Version: 2.4.1
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.4.1-alpha",
+	"version": "2.4.1",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.4.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.