### PR TITLE
A4A: Add `is_a4a_client` attribute to sites api response.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-a4a-site_is_a4a_client
+++ b/projects/plugins/jetpack/changelog/add-a4a-site_is_a4a_client
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+WordPress.com REST API: exposed is_a4a_client attribute with sites API response

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -119,7 +119,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpcom_atomic',
 		'is_wpcom_staging_site',
 		'is_deleted',
-		'is_a4a_client'
+		'is_a4a_client',
 	);
 
 	/**

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -84,6 +84,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'was_hosting_trial'           => '(bool) If the site ever used a hosting trial.',
 		'wpcom_site_setup'            => '(string) The WP.com site setup identifier.',
 		'is_deleted'                  => '(bool) If the site flagged as deleted.',
+		'is_a4a_client'               => '(bool) If the site is an A4A client site.',
 	);
 
 	/**
@@ -118,6 +119,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpcom_atomic',
 		'is_wpcom_staging_site',
 		'is_deleted',
+		'is_a4a_client'
 	);
 
 	/**
@@ -605,6 +607,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'is_deleted':
 				$response[ $key ] = $this->site->is_deleted();
+				break;
+			case 'is_a4a_client':
+				$response[ $key ] = $this->site->is_a4a_client();
 				break;
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -78,6 +78,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'was_migration_trial'         => '(bool) If the site ever used a migration trial.',
 		'was_hosting_trial'           => '(bool) If the site ever used a hosting trial.',
 		'is_deleted'                  => '(bool) If the site flagged as deleted.',
+		'is_a4a_client'               => '(bool) If the site is an A4A client site.',
 	);
 
 	/**

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -417,6 +417,13 @@ abstract class SAL_Site {
 	abstract public function is_deleted();
 
 	/**
+	 * Indicates that a site is an A4A client. Not used in Jetpack.
+	 *
+	 * @see class.json-api-site-jetpack.php for implementation.
+	 */
+	abstract public function is_a4a_client();
+
+	/**
 	 * Return the user interactions with a site. Not used in Jetpack.
 	 *
 	 * @param string $role The capability to check.

--- a/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-jetpack.php
@@ -656,6 +656,17 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	/**
+	 * Indicates that a site is an A4A client. Not used in Jetpack.
+	 *
+	 * @see /wpcom/public.api/rest/sal/trait.json-api-site-wpcom.php.
+	 *
+	 * @return bool
+	 */
+	public function is_a4a_client() {
+		return false;
+	}
+
+	/**
 	 * Detect whether a site is WordPress.com Staging Site. Not used in Jetpack.
 	 *
 	 * @see /wpcom/public.api/rest/sal/trait.json-api-site-wpcom.php.


### PR DESCRIPTION
This PR is part of a multi-patch that fixes the issue with the A4A Site selector unable to support sites connected via the A4A plugin.

We want to distinguish which sites are connected via the A4A plugin. To do this, we must introduce a new `is_a4a_client` property to the 'me/sites' endpoint.

**Context:**
p1720798646587609-slack-C06JY8QL0TU

**Other Patches:**
D155869-code
https://github.com/Automattic/wp-calypso/pull/92832

## Proposed changes:

* Add a new `is_a4a_client` attribute to the Sites API response, allowing us to surface this information to consumers like the Calypso platform.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

This needs to be tested with the other patches to test the functionality fully. Please see D155869-code and https://github.com/Automattic/wp-calypso/pull/92832 for the test instructions.