### PR TITLE
Form Block: fix display of the picker following changes in WP 6.6

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-block-picker
+++ b/projects/packages/forms/changelog/fix-contact-form-block-picker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Block Picker: fix display of the picker in the block editor following changes in WordPress 6.6.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -19,6 +19,8 @@
 					max-width: none;
 					margin: 0;
 					flex: 0;
+					text-align: center;
+					padding: 0 2px;
 				}
 
 				.block-editor-block-variation-picker__variation {
@@ -175,6 +177,7 @@
 	.form-placeholder__external-link {
 		font-size: 13px;
 		padding: 0;
+		font-weight: 400;
 
 		&, &:hover, &:active, &:focus {
 			background-color: unset;


### PR DESCRIPTION
Fixes #38405

## Proposed changes:

Following changes in Core, let's adjust a bit the display of our pattern picker.

| **6.6** | **6.6 + changes** |
|--------|--------|
| <img width="726" alt="image" src="https://github.com/user-attachments/assets/07ac458d-9735-4c33-a42d-0663952ec98e"> | <img width="914" alt="image" src="https://github.com/user-attachments/assets/19a5b2b7-779d-4e0e-b1ea-011d064365e5"> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Pages > Add New
* Add a `/form` block
* Check the look of the pattern picker, as above.

