### PR TITLE
Contact Form: overwrite checkboxes' styles with 2020 & 2021

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-contact-form-input-twentytwenty-themes
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-input-twentytwenty-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Contact Form: ensure checkboxes are properly displayed when using the Twenty Twenty or the Twenty Twenty One theme.

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.css
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentytwenty.css
@@ -298,3 +298,11 @@
 .screen-reader-text {
 	position: absolute;
 }
+
+/* Contact form */
+/* See https: //core.trac.wordpress.org/browser/trunk/src/wp-content/themes/twentytwenty/style.css?rev=58726#L710 */
+.contact-form input.grunion-field[type="checkbox"] {
+	padding: 0;
+	width: 1.5rem;
+	height: 1.5rem;
+}

--- a/projects/plugins/jetpack/modules/theme-tools/compat/twentytwentyone.css
+++ b/projects/plugins/jetpack/modules/theme-tools/compat/twentytwentyone.css
@@ -96,3 +96,13 @@ body.infinity-end .site-main > div:last-of-type > article:last-of-type .entry-fo
 		grid-template-columns: repeat( 3, minmax(0, 1fr) );
 	}
 }
+
+/* Contact form */
+/* See https: //core.trac.wordpress.org/browser/trunk/src/wp-content/themes/twentytwentyone/style.css?rev=58726#L1276 */
+@supports (-webkit-appearance: none) or (-moz-appearance: none) {
+	.contact-form input.grunion-field[type=checkbox],
+	.contact-form input.grunion-field[type=radio] {
+		width: 25px;
+		height: 25px;
+	}
+}


### PR DESCRIPTION
Fixes #38392

## Proposed changes:

The 2 default themes include styles for checkbox input fields, that overwrote the checkboxes added with contact forms.

**Twenty Twenty**

| **Before** | **After** |
|--------|--------|
| <img width="551" alt="image" src="https://github.com/user-attachments/assets/b9658482-c641-4a26-ab00-057ae5b7f26b"> | <img width="527" alt="image" src="https://github.com/user-attachments/assets/6ae8f191-7e1b-4726-b3d2-3662204ca214"> |

**Twenty Twenty One**

| **Before** | **After** |
|--------|--------|
| <img width="465" alt="image" src="https://github.com/user-attachments/assets/0f74477a-227d-43a2-9320-24b59f5f8d3e"> | <img width="727" alt="image" src="https://github.com/user-attachments/assets/5625d1ad-39f2-4418-bf2f-6b564780c105"> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Pages > Add New
* Add a new form ; include a checkbox field.
* Publish your page.
* Install and activate the Twenty Twenty theme
* View the page you had published
    * The checkbox should be displayed properly (see screenshot above)
* Install and activate the Twenty Twenty One theme
* Check the page, and the look of the checkbox again.

