### PR TITLE
connection: Fix textdomain on imported IDC code

### DIFF
--- a/projects/packages/connection/.phpcs.dir.xml
+++ b/projects/packages/connection/.phpcs.dir.xml
@@ -5,14 +5,12 @@
 		<properties>
 			<property name="text_domain" type="array">
 				<element value="jetpack-connection" />
-				<element value="jetpack-idc" />
 			</property>
 		</properties>
 	</rule>
 	<rule ref="Jetpack.Functions.I18n">
 		<properties>
 			<property name="text_domain" value="jetpack-connection" />
-			<property name="text_domain" value="jetpack-idc" />
 		</properties>
 	</rule>
 

--- a/projects/packages/connection/changelog/fix-connection-textdomain
+++ b/projects/packages/connection/changelog/fix-connection-textdomain
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix textdomain on i18n messages imported from the IDC package.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '2.11.1';
+	const PACKAGE_VERSION = '2.11.2-alpha';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -241,7 +241,7 @@ class Identity_Crisis {
 		$consumer_data = UI::get_consumer_data();
 		$label         = isset( $consumer_data['customContent']['adminBarSafeModeLabel'] )
 			? esc_html( $consumer_data['customContent']['adminBarSafeModeLabel'] )
-			: esc_html__( 'Jetpack Safe Mode', 'jetpack-idc' );
+			: esc_html__( 'Jetpack Safe Mode', 'jetpack-connection' );
 
 		$title = sprintf(
 			'<span class="jp-idc-admin-bar">%s %s</span>',
@@ -448,7 +448,7 @@ class Identity_Crisis {
 				'cannot_parse_url',
 				sprintf(
 				/* translators: %s: URL to parse. */
-					esc_html__( 'Cannot parse URL %s', 'jetpack-idc' ),
+					esc_html__( 'Cannot parse URL %s', 'jetpack-connection' ),
 					$url
 				)
 			);

--- a/projects/packages/connection/src/identity-crisis/class-rest-endpoints.php
+++ b/projects/packages/connection/src/identity-crisis/class-rest-endpoints.php
@@ -59,7 +59,7 @@ class REST_Endpoints {
 				'permission_callback' => __CLASS__ . '::identity_crisis_mitigation_permission_check',
 				'args'                => array(
 					'redirect_uri' => array(
-						'description' => __( 'URI of the admin page where the user should be redirected after connection flow', 'jetpack-idc' ),
+						'description' => __( 'URI of the admin page where the user should be redirected after connection flow', 'jetpack-connection' ),
 						'type'        => 'string',
 					),
 				),
@@ -98,7 +98,7 @@ class REST_Endpoints {
 				'permission_callback' => array( static::class, 'compare_url_secret_permission_check' ),
 				'args'                => array(
 					'secret' => array(
-						'description' => __( 'URL secret to compare to the ones stored in the database.', 'jetpack-idc' ),
+						'description' => __( 'URL secret to compare to the ones stored in the database.', 'jetpack-connection' ),
 						'type'        => 'string',
 						'required'    => true,
 					),
@@ -127,7 +127,7 @@ class REST_Endpoints {
 
 		return new WP_Error(
 			'error_setting_jetpack_safe_mode',
-			esc_html__( 'Could not confirm safe mode.', 'jetpack-idc' ),
+			esc_html__( 'Could not confirm safe mode.', 'jetpack-connection' ),
 			array( 'status' => 500 )
 		);
 	}
@@ -144,7 +144,7 @@ class REST_Endpoints {
 		if ( Jetpack_Options::get_option( 'sync_error_idc' ) && ! Jetpack_Options::delete_option( 'sync_error_idc' ) ) {
 			return new WP_Error(
 				'error_deleting_sync_error_idc',
-				esc_html__( 'Could not delete sync error option.', 'jetpack-idc' ),
+				esc_html__( 'Could not delete sync error option.', 'jetpack-connection' ),
 				array( 'status' => 500 )
 			);
 		}
@@ -158,7 +158,7 @@ class REST_Endpoints {
 		}
 		return new WP_Error(
 			'error_setting_jetpack_migrate',
-			esc_html__( 'Could not confirm migration.', 'jetpack-idc' ),
+			esc_html__( 'Could not confirm migration.', 'jetpack-connection' ),
 			array( 'status' => 500 )
 		);
 	}
@@ -221,7 +221,7 @@ class REST_Endpoints {
 		$error_msg = esc_html__(
 			'You do not have the correct user permissions to perform this action.
 			Please contact your site admin if you think this is a mistake.',
-			'jetpack-idc'
+			'jetpack-connection'
 		);
 
 		return new WP_Error( 'invalid_user_permission_identity_crisis', $error_msg, array( 'status' => rest_authorization_required_code() ) );
@@ -250,7 +250,7 @@ class REST_Endpoints {
 		$secret = new URL_Secret();
 
 		if ( ! $secret->exists() ) {
-			return new WP_Error( 'missing_url_secret', esc_html__( 'URL secret does not exist.', 'jetpack-idc' ) );
+			return new WP_Error( 'missing_url_secret', esc_html__( 'URL secret does not exist.', 'jetpack-connection' ) );
 		}
 
 		return rest_ensure_response(
@@ -299,7 +299,7 @@ class REST_Endpoints {
 			? true
 			: new WP_Error(
 				'invalid_user_permission_identity_crisis',
-				esc_html__( 'You do not have the correct user permissions to perform this action.', 'jetpack-idc' ),
+				esc_html__( 'You do not have the correct user permissions to perform this action.', 'jetpack-connection' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 	}
@@ -314,7 +314,7 @@ class REST_Endpoints {
 		return ( new Connection_Manager() )->is_connected()
 			? new WP_Error(
 				'invalid_connection_status',
-				esc_html__( 'The endpoint is not available on connected sites.', 'jetpack-idc' ),
+				esc_html__( 'The endpoint is not available on connected sites.', 'jetpack-connection' ),
 				array( 'status' => 403 )
 			)
 			: true;

--- a/projects/packages/connection/src/identity-crisis/class-ui.php
+++ b/projects/packages/connection/src/identity-crisis/class-ui.php
@@ -64,7 +64,7 @@ class UI {
 				__FILE__,
 				array(
 					'in_footer'  => true,
-					'textdomain' => 'jetpack-idc',
+					'textdomain' => 'jetpack-connection',
 				)
 			);
 			Assets::enqueue_script( 'jp_identity_crisis_banner' );

--- a/projects/packages/connection/src/identity-crisis/class-url-secret.php
+++ b/projects/packages/connection/src/identity-crisis/class-url-secret.php
@@ -89,7 +89,7 @@ class URL_Secret {
 		$result = Jetpack_Options::update_option( static::OPTION_KEY, $secret_data );
 
 		if ( ! $result ) {
-			throw new Exception( esc_html__( 'Unable to save new URL secret', 'jetpack-idc' ) );
+			throw new Exception( esc_html__( 'Unable to save new URL secret', 'jetpack-connection' ) );
 		}
 
 		$this->secret     = $secret_data['secret'];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When #36968 merged the IDC package into this package, instead of fixing the textdomains we tried to have both domains allowed. This doesn't actually work, as the mapping only applies to the domain declared in composer.json `.extra.textdomain`, so these messages weren't being translated at runtime.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack/pull/38330#discussion_r1682134188

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set the blog language to non-English, and make sure translations are updated.
* Check if IDC messages are being translated. One easy to see message can be found with `curl -v 'https://<host>/wp-json/' | jq '.routes["/jetpack/v4/identity-crisis/start-fresh"]'`.

P.S. If trying to do before-and-after testing on a JN site, you'll probably need to run `wp edge-cache disable` first so over-aggressive caching won't get in the way.