### PR TITLE
Jetpack Dashboard: Add Jetpack AI card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -34,6 +34,7 @@ import DashBackups from './backups';
 import DashBoost from './boost';
 import DashConnections from './connections';
 import DashCRM from './crm';
+import DashJetpackAi from './jetpack-ai';
 import DashMonitor from './monitor';
 import DashPhoton from './photon';
 import DashProtect from './protect';
@@ -162,6 +163,10 @@ class AtAGlance extends Component {
 
 			if ( this.props.userCanManagePlugins ) {
 				performanceCards.push( <DashCRM siteAdminUrl={ this.props.siteAdminUrl } /> );
+			}
+
+			if ( this.shouldAddCard( 'jetpack-ai' ) ) {
+				performanceCards.push( <DashJetpackAi /> );
 			}
 
 			const redeemPartnerCoupon = ! this.props.isOfflineMode && this.props.partnerCoupon && (

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/jetpack-ai.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/jetpack-ai.jsx
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import DashItem from 'components/dash-item';
+import JetpackBanner from 'components/jetpack-banner';
+import { getJetpackProductUpsellByFeature, PLAN_JETPACK_AI_YEARLY } from 'lib/plans/constants';
+import { getProductDescriptionUrl } from 'product-descriptions/utils';
+import { connect } from 'react-redux';
+import {
+	connectUser,
+	hasConnectedOwner as hasConnectedOwnerSelector,
+	isOfflineMode,
+} from 'state/connection';
+import { getSiteAdminUrl } from 'state/initial-state';
+import { siteHasFeature } from 'state/site';
+
+/**
+ * Jetpack AI Dashboard card.
+ * @param {object} props - Component props
+ * @returns {object} DashJetpackAi component
+ */
+function DashJetpackAi( props ) {
+	const { hasFeature, isOffline, hasConnectedOwner } = props;
+	const cardText = __(
+		'Turn your ideas into ready-to-publish content at light speed. Generate content, images and optimize your publishing process with just a few clicks.',
+		'jetpack'
+	);
+	const support = {
+		text: cardText,
+		link: getRedirectUrl( 'org-ai' ),
+	};
+
+	const learnMoreLink = createInterpolateElement(
+		__( '<ExternalLink>Learn more</ExternalLink>', 'jetpack' ),
+		{
+			ExternalLink: <ExternalLink href={ getRedirectUrl( 'org-ai' ) } />,
+		}
+	);
+
+	const showConnectBanner = ! hasConnectedOwner && ! isOffline;
+	const showUpgradeBanner = hasConnectedOwner && ! isOffline && ! hasFeature;
+	const showTeaserBanner = hasConnectedOwner && ! isOffline && hasFeature;
+
+	return (
+		<DashItem
+			label="AI"
+			module="ai-assistant"
+			support={ isOffline ? support : {} }
+			noToggle={ true }
+			className={ isOffline || ! hasFeature ? 'jp-dash-item__is-inactive' : '' }
+			overrideContent={
+				( showConnectBanner && (
+					<JetpackBanner
+						title={ __(
+							'Connect your WordPress.com account to enable AI features and assistant.',
+							'jetpack'
+						) }
+						noIcon={ true }
+						plan={ getJetpackProductUpsellByFeature( PLAN_JETPACK_AI_YEARLY ) }
+						callToAction={ __( 'Connect', 'jetpack' ) }
+						onClick={ props.connectUser }
+						eventFeature="ai-assistant"
+						path="dashboard"
+						eventProps={ { type: 'connect' } }
+					/>
+				) ) ||
+				( showUpgradeBanner && (
+					<JetpackBanner
+						title={ cardText }
+						noIcon={ true }
+						description={ learnMoreLink }
+						plan={ getJetpackProductUpsellByFeature( PLAN_JETPACK_AI_YEARLY ) }
+						callToAction={ __( 'Upgrade', 'jetpack' ) }
+						href={ props.upgradeUrl }
+						eventFeature="ai-assistant"
+						path="dashboard"
+					/>
+				) ) ||
+				( showTeaserBanner && (
+					<JetpackBanner
+						title={ cardText }
+						noIcon={ true }
+						callToAction={ __( 'All features', 'jetpack' ) }
+						href={ `${ props.siteAdminUrl }admin.php?page=my-jetpack#/jetpack-ai` }
+						eventFeature="ai-assistant"
+						path="dashboard"
+						eventProps={ { type: 'teaser' } }
+					/>
+				) ) ||
+				null
+			}
+		>
+			{ isOffline && (
+				<p className="jp-dash-item__description">
+					{ __( 'Unavailable in Offline Mode', 'jetpack' ) }
+				</p>
+			) }
+		</DashItem>
+	);
+}
+
+export default connect(
+	state => ( {
+		hasConnectedOwner: hasConnectedOwnerSelector( state ),
+		isOffline: isOfflineMode( state ),
+		// TODO: feature (ai-assistant) differs from product (jetpack-ai), see myJetpack (package) routes and maybe change those to ai-assistant
+		upgradeUrl: getProductDescriptionUrl( state, 'jetpack-ai' ),
+		hasFeature: siteHasFeature( state, 'ai-assistant' ),
+		siteAdminUrl: getSiteAdminUrl( state ),
+	} ),
+	dispatch => ( {
+		connectUser: () => {
+			return dispatch( connectUser() );
+		},
+	} )
+)( DashJetpackAi );

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/jetpack-ai.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/jetpack-ai.jsx
@@ -18,7 +18,7 @@ import {
 	hasConnectedOwner as hasConnectedOwnerSelector,
 	isOfflineMode,
 } from 'state/connection';
-import { getSiteAdminUrl } from 'state/initial-state';
+import { getSiteAdminUrl, showMyJetpack } from 'state/initial-state';
 import { siteHasFeature } from 'state/site';
 
 /**
@@ -27,7 +27,7 @@ import { siteHasFeature } from 'state/site';
  * @returns {object} DashJetpackAi component
  */
 function DashJetpackAi( props ) {
-	const { hasFeature, isOffline, hasConnectedOwner } = props;
+	const { hasFeature, hasConnectedOwner, isOffline, isMyJetpackReachable } = props;
 	const cardText = __(
 		'Turn your ideas into ready-to-publish content at light speed. Generate content, images and optimize your publishing process with just a few clicks.',
 		'jetpack'
@@ -45,8 +45,9 @@ function DashJetpackAi( props ) {
 	);
 
 	const showConnectBanner = ! hasConnectedOwner && ! isOffline;
-	const showUpgradeBanner = hasConnectedOwner && ! isOffline && ! hasFeature;
-	const showTeaserBanner = hasConnectedOwner && ! isOffline && hasFeature;
+	const showUpgradeBanner =
+		hasConnectedOwner && isMyJetpackReachable && ! isOffline && ! hasFeature;
+	const showTeaserBanner = hasConnectedOwner && isMyJetpackReachable && ! isOffline && hasFeature;
 
 	return (
 		<DashItem
@@ -98,9 +99,16 @@ function DashJetpackAi( props ) {
 			}
 		>
 			{ isOffline && (
-				<p className="jp-dash-item__description">
+				<div className="jp-dash-item__description">
 					{ __( 'Unavailable in Offline Mode', 'jetpack' ) }
-				</p>
+				</div>
+			) }
+			{ ! isOffline && (
+				<div className="jp-dash-item__description">
+					{ cardText }
+					<br />
+					{ learnMoreLink }
+				</div>
 			) }
 		</DashItem>
 	);
@@ -114,6 +122,7 @@ export default connect(
 		upgradeUrl: getProductDescriptionUrl( state, 'jetpack-ai' ),
 		hasFeature: siteHasFeature( state, 'ai-assistant' ),
 		siteAdminUrl: getSiteAdminUrl( state ),
+		isMyJetpackReachable: showMyJetpack( state ),
 	} ),
 	dispatch => ( {
 		connectUser: () => {

--- a/projects/plugins/jetpack/_inc/client/components/banner/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/banner/index.jsx
@@ -154,17 +154,15 @@ export class Banner extends Component {
 				</div>
 				{ callToAction && (
 					<div className="dops-banner__action">
-						{ callToAction && (
-							<Button
-								rna={ rna }
-								compact
-								href={ this.getHref() }
-								onClick={ this.handleClick }
-								primary
-							>
-								{ callToAction }
-							</Button>
-						) }
+						<Button
+							rna={ rna }
+							compact
+							href={ this.getHref() }
+							onClick={ this.handleClick }
+							primary
+						>
+							{ callToAction }
+						</Button>
 					</div>
 				) }
 			</div>

--- a/projects/plugins/jetpack/_inc/client/product-descriptions/constants.js
+++ b/projects/plugins/jetpack/_inc/client/product-descriptions/constants.js
@@ -8,6 +8,7 @@ export const PRODUCT_DESCRIPTION_PRODUCTS = {
 	JETPACK_SECURITY: 'security',
 	JETPACK_SOCIAL: 'social',
 	JETPACK_VIDEOPRESS: 'videopress',
+	JETPACK_AI: 'jetpack-ai',
 };
 
 export const productDescriptionRoutes = [
@@ -26,6 +27,7 @@ export const myJetpackRoutes = [
 	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_SEARCH }`,
 	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_SOCIAL }`,
 	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_VIDEOPRESS }`,
+	`/add-${ PRODUCT_DESCRIPTION_PRODUCTS.JETPACK_AI }`,
 ];
 
 export const productIllustrations = {

--- a/projects/plugins/jetpack/changelog/add-jetpack-dashboard-ai-card
+++ b/projects/plugins/jetpack/changelog/add-jetpack-dashboard-ai-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack Dashboard: add AI Assistant card


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-roadmap/issues/1720

## Proposed changes:
Add Jetpack AI dashboard card. The card shows as unavailable when offline, "Connect" button if connected use is not owner, "Upgrade" if the feature is free/not available and "All features", linking to My Jetpack product page as a teaser, when the user has a purchased plan.

<img width="437" alt="image" src="https://github.com/user-attachments/assets/787ad9b8-1d59-4848-be87-be1a65fbb1c9">

<img width="434" alt="image" src="https://github.com/user-attachments/assets/cb0c88c1-d0da-4814-9386-1acc0b23faac">

<img width="444" alt="image" src="https://github.com/user-attachments/assets/05726c17-dcb9-4c8b-a99b-47d48caf89bb">

<img width="439" alt="image" src="https://github.com/user-attachments/assets/c9725226-d730-484d-b4b8-582803aeb6b0">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-t9s-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Spin up a JN site. Once on the site, we'll keep an eye on the devtools to check the button event properties. Enable `debug` on the devtools console: `localStorage.setItem( 'debug', 'dops:analytics' );`. Then reload the site (don't close devtools).

Go to Jetpack dashboard.
- [ ] See the new card is shown at the bottom of the list. It should be in inactive state showing the "Upgrade" button. 

Click the "Upgrade" button and immediately ESC key (so to prevent the navigation).
- [ ] Devtools should show an event with these properties `{"target":"banner","type":"upgrade","feature":"ai-assistant","path":"dashboard"}`

Click the "Upgrade" button again.
- [ ] You should land in the interstitial for Jetpack AI

Proceed with a purchase. Once finished, go to Jetpack dashboard again.
- [ ] See that the card is now active and reads "All features" button

Click the "All features" button and immediately ESC key.
- [ ] Devtools should show an event with these properties `{"target":"banner","type":"teaser","feature":"ai-assistant","path":"dashboard"}`

Click the "All features" button again
- [ ] You should land in My Jetpack's AI product page