### PR TITLE
Jetpack: Remove "new" badge from firewall card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/security/style.scss
+++ b/projects/plugins/jetpack/_inc/client/security/style.scss
@@ -6,25 +6,6 @@
     align-items: center;
     display: flex;
 
-    .waf__header__badge {
-        background-color: #D0E6B8;
-        border-radius: 3px;
-        font-size: 10px;
-        line-height: 18px;
-        margin-left: 10px;
-        padding: 0px 6px;
-
-        &,
-        &:link,
-        &:active,
-        &:focus,
-        &:hover,
-        &:visited {
-            color: #008710;
-            text-decoration: none;
-        }
-    }
-
     .waf__standalone__mode {
         margin-left: auto;
     }

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -214,14 +214,6 @@ export const Waf = class extends Component {
 		const moduleHeader = (
 			<div className="waf__header">
 				<span>{ _x( 'Firewall', 'Settings header', 'jetpack' ) }</span>
-				<a
-					href={ getRedirectUrl( 'jetpack-support-waf' ) }
-					target="_blank"
-					rel="noopener noreferrer"
-					className="waf__header__badge"
-				>
-					{ _x( 'NEW', 'Settings header badge', 'jetpack' ) }
-				</a>
 				{ this.props.settings?.standaloneMode && (
 					<Status
 						className="waf__standalone__mode"

--- a/projects/plugins/jetpack/changelog/remove-jetpack-firewall-new-badge
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-firewall-new-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove "new" badge from Jetpack Firewall settings card.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the "NEW" badge from the Firewall settings card (the feature has been available for over a year now.)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack#/security` and verify the firewall card renders appropriately.

## Screenshots

Before

<img width="1075" alt="Screenshot 2024-07-18 at 10 47 08 AM" src="https://github.com/user-attachments/assets/e321ae7e-b96f-45c2-b2fa-04db48fc90f5">


