### PR TITLE
My Jetpack: replace Creator card with Newsletter

### DIFF
--- a/projects/packages/my-jetpack/.phan/baseline.php
+++ b/projects/packages/my-jetpack/.phan/baseline.php
@@ -46,6 +46,7 @@ return [
         'src/products/class-hybrid-product.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnNullable'],
         'src/products/class-jetpack-ai.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/products/class-module-product.php' => ['PhanTypeMismatchReturnProbablyReal'],
+        'src/products/class-newsletter.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal'],
         'src/products/class-product.php' => ['PhanAbstractStaticMethodCallInStatic', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
         'src/products/class-protect.php' => ['PhanTypeMismatchPropertyDefault'],
         'src/products/class-scan.php' => ['PhanTypeMismatchArgumentNullable'],

--- a/projects/packages/my-jetpack/.phan/baseline.php
+++ b/projects/packages/my-jetpack/.phan/baseline.php
@@ -46,7 +46,6 @@ return [
         'src/products/class-hybrid-product.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchReturnNullable'],
         'src/products/class-jetpack-ai.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/products/class-module-product.php' => ['PhanTypeMismatchReturnProbablyReal'],
-        'src/products/class-newsletter.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal'],
         'src/products/class-product.php' => ['PhanAbstractStaticMethodCallInStatic', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchPropertyDefault'],
         'src/products/class-protect.php' => ['PhanTypeMismatchPropertyDefault'],
         'src/products/class-scan.php' => ['PhanTypeMismatchArgumentNullable'],

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
@@ -7,8 +7,8 @@ import AiCard from './ai-card';
 import AntiSpamCard from './anti-spam-card';
 import BackupCard from './backup-card';
 import BoostCard from './boost-card';
-import CreatorCard from './creator-card';
 import CrmCard from './crm-card';
+import NewsletterCard from './newsletter-card';
 import ProtectCard from './protect-card';
 import SearchCard from './search-card';
 import SocialCard from './social-card';
@@ -29,7 +29,7 @@ type DisplayItemType = Record<
 
 const DisplayItems: FC< DisplayItemsProps > = ( { slugs } ) => {
 	const { showFullJetpackStatsCard = false } = getMyJetpackWindowInitialState( 'myJetpackFlags' );
-	const { isAtomic = false, userIsAdmin = false } = getMyJetpackWindowInitialState();
+	const { userIsAdmin = false } = getMyJetpackWindowInitialState();
 
 	const items: DisplayItemType = {
 		backup: BackupCard,
@@ -40,7 +40,7 @@ const DisplayItems: FC< DisplayItemsProps > = ( { slugs } ) => {
 		videopress: VideopressCard,
 		stats: StatsCard,
 		crm: CrmCard,
-		creator: ! isAtomic ? CreatorCard : null,
+		newsletter: NewsletterCard,
 		social: SocialCard,
 		'jetpack-ai': AiCard,
 	};

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/index.tsx
@@ -21,11 +21,15 @@ type DisplayItemsProps = {
 	slugs: JetpackModule[];
 };
 
+type ExcludedModules = 'extras' | 'scan' | 'security' | 'creator';
+
 type DisplayItemType = Record<
 	// We don't have a card for Security or Extras, and scan is displayed as protect.
-	Exclude< JetpackModule, 'extras' | 'scan' | 'security' >,
+	Exclude< JetpackModule, ExcludedModules >,
 	FC< { admin: boolean } >
 >;
+
+const excludedModules: ExcludedModules[] = [ 'extras', 'scan', 'security', 'creator' ];
 
 const DisplayItems: FC< DisplayItemsProps > = ( { slugs } ) => {
 	const { showFullJetpackStatsCard = false } = getMyJetpackWindowInitialState( 'myJetpackFlags' );
@@ -101,10 +105,7 @@ const ProductCardsSection: FC< ProductCardsSectionProps > = ( { noticeMessage } 
 
 	const filterProducts = ( products: JetpackModule[] ) => {
 		return products.filter( product => {
-			if ( product === 'scan' || product === 'security' || product === 'extras' ) {
-				return false;
-			}
-			return true;
+			return ! excludedModules.includes( product );
 		} );
 	};
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
@@ -6,10 +6,10 @@ import ProductCard from '../connected-product-card';
 const NewsletterCard = ( { admin } ) => {
 	const actionOverride = {
 		[ PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE ]: {
-			href: 'admin.php?page=jetpack#/settings?term=newsletter',
+			href: 'admin.php?page=jetpack#/newsletter',
 		},
 		[ PRODUCT_STATUSES.NEEDS_FIRST_SITE_CONNECTION ]: {
-			href: 'admin.php?page=jetpack#/settings?term=newsletter',
+			href: 'admin.php?page=jetpack#/newsletter',
 		},
 	};
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
@@ -1,15 +1,28 @@
+import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
 import ProductCard from '../connected-product-card';
 
+const NEWSLETTER_SETTINGS_PAGE_URL = 'admin.php?page=jetpack#/newsletter';
+
 const NewsletterCard = ( { admin } ) => {
 	const actionOverride = {
 		[ PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE ]: {
-			href: 'admin.php?page=jetpack#/newsletter',
+			href: NEWSLETTER_SETTINGS_PAGE_URL,
 		},
 		[ PRODUCT_STATUSES.NEEDS_FIRST_SITE_CONNECTION ]: {
-			href: 'admin.php?page=jetpack#/newsletter',
+			href: NEWSLETTER_SETTINGS_PAGE_URL,
+		},
+		[ PRODUCT_STATUSES.INACTIVE ]: {
+			href: NEWSLETTER_SETTINGS_PAGE_URL,
+			label: __( 'View', 'jetpack-my-jetpack' ),
+			onClick: () => {},
+		},
+		[ PRODUCT_STATUSES.MODULE_DISABLED ]: {
+			href: NEWSLETTER_SETTINGS_PAGE_URL,
+			label: __( 'View', 'jetpack-my-jetpack' ),
+			onClick: () => {},
 		},
 	};
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
@@ -10,14 +10,7 @@ const NewsletterCard = ( { admin } ) => {
 		},
 	};
 
-	return (
-		<ProductCard
-			admin={ admin }
-			slug="newsletter"
-			upgradeInInterstitial={ true }
-			primaryActionOverride={ actionOverride }
-		/>
-	);
+	return <ProductCard admin={ admin } slug="newsletter" primaryActionOverride={ actionOverride } />;
 };
 
 NewsletterCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
@@ -1,9 +1,23 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { PRODUCT_STATUSES } from '../../constants';
 import ProductCard from '../connected-product-card';
 
 const NewsletterCard = ( { admin } ) => {
-	return <ProductCard admin={ admin } slug="newsletter" upgradeInInterstitial={ true } />;
+	const actionOverride = {
+		[ PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE ]: {
+			href: 'admin.php?page=jetpack#/settings?term=newsletter',
+		},
+	};
+
+	return (
+		<ProductCard
+			admin={ admin }
+			slug="newsletter"
+			upgradeInInterstitial={ true }
+			primaryActionOverride={ actionOverride }
+		/>
+	);
 };
 
 NewsletterCard.propTypes = {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ProductCard from '../connected-product-card';
+
+const NewsletterCard = ( { admin } ) => {
+	return <ProductCard admin={ admin } slug="newsletter" upgradeInInterstitial={ true } />;
+};
+
+NewsletterCard.propTypes = {
+	admin: PropTypes.bool.isRequired,
+};
+
+export default NewsletterCard;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/newsletter-card.jsx
@@ -8,6 +8,9 @@ const NewsletterCard = ( { admin } ) => {
 		[ PRODUCT_STATUSES.NEEDS_PURCHASE_OR_FREE ]: {
 			href: 'admin.php?page=jetpack#/settings?term=newsletter',
 		},
+		[ PRODUCT_STATUSES.NEEDS_FIRST_SITE_CONNECTION ]: {
+			href: 'admin.php?page=jetpack#/settings?term=newsletter',
+		},
 	};
 
 	return <ProductCard admin={ admin } slug="newsletter" primaryActionOverride={ actionOverride } />;

--- a/projects/packages/my-jetpack/changelog/add-newsletter-card
+++ b/projects/packages/my-jetpack/changelog/add-newsletter-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: add a new product card for Newsletter and replace Creator with it.

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -14,17 +14,18 @@ type JetpackModule =
 	| 'anti-spam'
 	| 'backup'
 	| 'boost'
-	| 'crm'
 	| 'creator'
+	| 'crm'
 	| 'extras'
 	| 'jetpack-ai'
+	| 'newsletter'
+	| 'protect'
 	| 'scan'
 	| 'search'
-	| 'social'
 	| 'security'
-	| 'protect'
-	| 'videopress'
-	| 'stats';
+	| 'social'
+	| 'stats'
+	| 'videopress';
 
 type ThreatItem = {
 	// Protect API properties (free plan)

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -105,21 +105,22 @@ class Products {
 	 */
 	public static function get_products_classes() {
 		$classes = array(
+			'ai'         => Products\Jetpack_Ai::class,
 			'anti-spam'  => Products\Anti_Spam::class,
 			'backup'     => Products\Backup::class,
 			'boost'      => Products\Boost::class,
-			'crm'        => Products\Crm::class,
 			'creator'    => Products\Creator::class,
+			'crm'        => Products\Crm::class,
 			'extras'     => Products\Extras::class,
 			'jetpack-ai' => Products\Jetpack_Ai::class,
+			'newsletter' => Products\Newsletter::class,
+			'protect'    => Products\Protect::class,
 			'scan'       => Products\Scan::class,
 			'search'     => Products\Search::class,
-			'social'     => Products\Social::class,
 			'security'   => Products\Security::class,
-			'protect'    => Products\Protect::class,
-			'videopress' => Products\Videopress::class,
+			'social'     => Products\Social::class,
 			'stats'      => Products\Stats::class,
-			'ai'         => Products\Jetpack_Ai::class,
+			'videopress' => Products\Videopress::class,
 		);
 
 		/**

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -220,7 +220,7 @@ class Products {
 					)
 				)
 			),
-			'unowned' => array_unique( $unowned_products ),
+			'unowned' => array_values( array_unique( $unowned_products ) ),
 		);
 
 		return $data[ $type ];

--- a/projects/packages/my-jetpack/src/products/class-newsletter.php
+++ b/projects/packages/my-jetpack/src/products/class-newsletter.php
@@ -45,11 +45,11 @@ class Newsletter extends Module_Product {
 	public static $plugin_filename = self::JETPACK_PLUGIN_FILENAME;
 
 	/**
-	 * Newsletter only requires site connection, not user connection
+	 * Newsletter requires user connection
 	 *
 	 * @var bool
 	 */
-	public static $requires_user_connection = false;
+	public static $requires_user_connection = true;
 
 	/**
 	 * Newsletter does not have a standalone plugin yet

--- a/projects/packages/my-jetpack/src/products/class-newsletter.php
+++ b/projects/packages/my-jetpack/src/products/class-newsletter.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Jetpack Newsletter
+ *
+ * @package my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack\Products;
+
+use Automattic\Jetpack\My_Jetpack\Initializer;
+use Automattic\Jetpack\My_Jetpack\Module_Product;
+use Automattic\Jetpack\My_jetpack\Products;
+use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
+
+/**
+ * Class responsible for handling the Jetpack Newsletter (subscriptions) module
+ */
+class Newsletter extends Module_Product {
+	/**
+	 * The product slug
+	 *
+	 * @var string
+	 */
+	public static $slug = 'newsletter';
+
+	/**
+	 * The Jetpack module name associated with this product
+	 *
+	 * @var string|null
+	 */
+	public static $module_name = 'subscriptions';
+
+	/**
+	 * The Plugin slug associated with Newsletter
+	 *
+	 * @var string|null
+	 */
+	public static $plugin_slug = self::JETPACK_PLUGIN_SLUG;
+
+	/**
+	 * The Plugin file associated with Newsletter
+	 *
+	 * @var string|null
+	 */
+	public static $plugin_filename = self::JETPACK_PLUGIN_FILENAME;
+
+	/**
+	 * Newsletter only requires site connection, not user connection
+	 *
+	 * @var bool
+	 */
+	public static $requires_user_connection = false;
+
+	/**
+	 * Newsletter does not have a standalone plugin yet
+	 *
+	 * @var bool
+	 */
+	public static $has_standalone_plugin = false;
+
+	/**
+	 * Whether this product has a free offering
+	 *
+	 * @var bool
+	 */
+	public static $has_free_offering = true;
+
+	/**
+	 * Get the product name
+	 *
+	 * @return string
+	 */
+	public static function get_name() {
+		return 'Newsletter';
+	}
+
+	/**
+	 * Get the product title
+	 *
+	 * @return string
+	 */
+	public static function get_title() {
+		return 'Jetpack Newsletter';
+	}
+
+	/**
+	 * Get the internationalized product description
+	 *
+	 * @return string
+	 */
+	public static function get_description() {
+		return __( 'Deliver your content with ease.', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized product long description
+	 *
+	 * @return string
+	 */
+	public static function get_long_description() {
+		return __( 'Write and share your content, get more subscribers, and monetize your writing.', 'jetpack-my-jetpack' );
+	}
+
+	/**
+	 * Get the internationalized features list
+	 *
+	 * @return array Newsletter features list
+	 */
+	public static function get_features() {
+		return array(
+			__( 'Instant blog‑to‑newsletter delivery', 'jetpack-my-jetpack' ),
+			__( 'Effortlessly reach your subscribers with fresh content', 'jetpack-my-jetpack' ),
+			__( 'Earn money through your Newsletter', 'jetpack-my-jetpack' ),
+		);
+	}
+
+	/**
+	 * Get the product pricing details
+	 * Only showing the pricing details for the commercial product
+	 *
+	 * @return array Pricing details
+	 */
+	public static function get_pricing_for_ui() {
+		return array(
+			'available' => true,
+			'is_free'   => true,
+		);
+	}
+
+	/**
+	 * Gets the 'status' of the Newsletter module
+	 *
+	 * @return string
+	 */
+	public static function get_status() {
+		$status = parent::get_status();
+		if ( Products::STATUS_MODULE_DISABLED === $status && ! Initializer::is_registered() ) {
+			// If the site has never been connected before, show the "Learn more" CTA.
+			// It should point to the settings page where the user can manage Newsletter
+			$status = Products::STATUS_NEEDS_PURCHASE_OR_FREE;
+		}
+		return $status;
+	}
+
+	/**
+	 * Checks whether the product can be upgraded to a different product.
+	 * Newsletter is not upgradable.
+	 *
+	 * @return boolean
+	 */
+	public static function is_upgradable() {
+		return false;
+	}
+
+	/**
+	 * Checks if the site has a paid plan that supports this product
+	 *
+	 * @return boolean
+	 */
+	public static function has_paid_plan_for_product() {
+		$purchases_data = Wpcom_Products::get_site_current_purchases();
+		if ( is_wp_error( $purchases_data ) ) {
+			return false;
+		}
+		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
+			foreach ( $purchases_data as $purchase ) {
+				// Newsletter is also part of Creator and Complete plans.
+				if ( strpos( $purchase->product_slug, 'jetpack_complete' ) !== false || str_starts_with( $purchase->product_slug, 'jetpack_creator' ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Checks whether the product supports trial or not.
+	 * Since Jetpack Newsletter has a free product, it "supports" a trial.
+	 *
+	 * @return boolean
+	 */
+	public static function has_trial_support() {
+		return true;
+	}
+
+	/**
+	 * Get the URL where the user manages the product
+	 *
+	 * @return ?string
+	 */
+	public static function get_manage_url() {
+		return admin_url( 'admin.php?page=jetpack#/settings?term=newsletter' );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

More context: p1HpG7-sYs-p2 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds a new card for Newsletter and replaces Creator with it. The CTA in the card links to the Newsletter settings page

Not connected:

<img width="357" alt="image" src="https://github.com/user-attachments/assets/9ad7cc9e-df17-4da3-b9c6-cf365a33c52f">

User connected with settings off:

<img width="365" alt="image" src="https://github.com/user-attachments/assets/4fb0499e-6503-4c79-af9f-4ba6456387e1">

User connected with settings on:

<img width="354" alt="image" src="https://github.com/user-attachments/assets/7afcfa67-7f9a-4e45-b044-770f1d558163">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-sYs-p2 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch
* Go to My Jetpack and confirm that you see "Newsletter" instead of "Creator"
* The button in the card will always link to the settings page on the Newsletter menu
  * If the user is not connected to Jetpack, that will redirect to the User connection screen
  * If the user is connected, you'll see the Newsletter section on the Settings page.
* After turning the settings on, if you go back to My Jetpack, you'll see the card marked as Active