### PR TITLE
WP.com admin bar: Enqueue styles with proper hook

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-p2
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-p2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Minor admin bar fix for P2 sites
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -59,7 +59,8 @@ CSS
 		);
 	}
 }
-add_action( 'admin_bar_menu', 'wpcom_enqueue_admin_bar_assets' );
+add_action( 'wp_enqueue_scripts', 'wpcom_enqueue_admin_bar_assets' );
+add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_admin_bar_assets' );
 
 /**
  * Replaces the WP logo as a link to /sites.


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8357
Fixes https://github.com/Automattic/dotcom-forge/issues/8358

## Proposed changes:

Previously, we were using the `admin_bar_menu` hook to enqueue the needed styles by the WordPress.com admin bar. However, that's not the proper hook to enqueue styles, because it's already too late in [the actions sequence ](https://developer.wordpress.org/apis/hooks/action-reference/#actions-run-during-a-typical-request), causing the styles to be missing under some circumstances.

This PR fixes that by enqueuing the styles with the `wp_enqueue_scripts` (frontend) and `admin_enqueue_scripts`(wp-admin) hooks.

Before | After
--- | ---
<img width="398" alt="Screenshot 2024-07-19 at 10 54 31" src="https://github.com/user-attachments/assets/ee6fee54-6e39-42bd-956f-29b203b76765"> |  <img width="376" alt="Screenshot 2024-07-19 at 10 54 11" src="https://github.com/user-attachments/assets/9a9f1179-41a7-48c5-895d-52af36c18e98">
<img width="244" alt="Screenshot 2024-07-19 at 10 54 35" src="https://github.com/user-attachments/assets/3c0af34c-7172-4568-b044-a5170b8b31e9"> | <img width="242" alt="Screenshot 2024-07-19 at 10 54 16" src="https://github.com/user-attachments/assets/e4e113a4-d5fd-4ce0-9e17-b7840b684fae">

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com sandbox
- Sandbox a P2 site
- Visit the frontend
- Check the admin bar at the top
- Make sure the Reader item has an icon
- Make sure your username and avatar are between the notifications and search icons
- Make sure there are no regressions in other scenarios (non-P2 site frontend, P2 site wp-admin, non-P2 site wp-admin). 

