### PR TITLE
WPCOMSH: plugin-dance improvements

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-plugin-dance-improvements
+++ b/projects/plugins/wpcomsh/changelog/add-plugin-dance-improvements
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Improve plugin-dance command.

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -1053,7 +1053,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 						$result = WP_CLI::runcommand(
 							sprintf( '--skip-themes plugin activate %s', $plugin_to_deactivate['name'] ),
 							array(
-								'launch'     => true,  // needed for exit_erorr => false.
+								'launch'     => true,  // needed for exit_error => false.
 								'return'     => true,
 								'exit_error' => false,
 							)
@@ -1089,12 +1089,8 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 					WP_CLI::log( '❌ Site health check failed after deactivating all plugins. Something non-plugin related is causing the issue. Trying to reactivate all plugins.' );
 
 					WP_CLI::runcommand(
-						'--skip-themes reactivate-user-plugins',
-						array(
-							'launch'     => true, // needed for exit_error => false.
-							'return'     => true,
-							'exit_error' => false,
-						)
+						'--skip-themes --skip-plugins wpcomsh reactivate-user-plugins',
+						array()
 					);
 					return;
 				}

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -1036,6 +1036,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 					$plugin_to_deactivate = array_pop( $plugins_to_reactivate );
 					if ( empty( $plugin_to_deactivate ) ) {
 						WP_CLI::error( '❌ Site health check failed after testing all plugins one by one.' );
+						return;
 					}
 
 					WP_CLI::runcommand(

--- a/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-cli-commands.php
@@ -1036,7 +1036,6 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 					$plugin_to_deactivate = array_pop( $plugins_to_reactivate );
 					if ( empty( $plugin_to_deactivate ) ) {
 						WP_CLI::error( '❌ Site health check failed after testing all plugins one by one.' );
-						return;
 					}
 
 					WP_CLI::runcommand(
@@ -1054,7 +1053,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 						$result = WP_CLI::runcommand(
 							sprintf( '--skip-themes plugin activate %s', $plugin_to_deactivate['name'] ),
 							array(
-								'launch'     => true,  // needed for exit_eror => false.
+								'launch'     => true,  // needed for exit_erorr => false.
 								'return'     => true,
 								'exit_error' => false,
 							)
@@ -1087,20 +1086,16 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 				);
 
 				if ( ! $this->do_plugin_dance_health_check() ) {
-					WP_CLI::error( '❌ Site health check failed after deactivating all plugins. Something non-plugin related is causing the issue. Trying to reactivate all plugins.' );
+					WP_CLI::log( '❌ Site health check failed after deactivating all plugins. Something non-plugin related is causing the issue. Trying to reactivate all plugins.' );
 
-					// Reactivate all plugins.
-					foreach ( $plugins_to_reactivate as $plugin ) {
-						WP_CLI::runcommand(
-							sprintf( '--skip-themes plugin activate %s', $plugin['name'] ),
-							array(
-								'launch'     => true, // needed for exit_eror => false.
-								'return'     => true,
-								'exit_error' => false,
-							)
-						);
-					}
-
+					WP_CLI::runcommand(
+						'--skip-themes reactivate-user-plugins',
+						array(
+							'launch'     => true, // needed for exit_error => false.
+							'return'     => true,
+							'exit_error' => false,
+						)
+					);
 					return;
 				}
 
@@ -1111,7 +1106,7 @@ if ( class_exists( 'WP_CLI_Command' ) ) {
 					$result = WP_CLI::runcommand(
 						sprintf( '--skip-themes plugin activate %s', $plugin['name'] ),
 						array(
-							'launch'     => true, // needed for exit_eror => false.
+							'launch'     => true, // needed for exit_error => false.
 							'return'     => true,
 							'exit_error' => false,
 						)


### PR DESCRIPTION
## Proposed changes:
- Does no longer disable/enable plugins that are also not disabled by `deactivate-user-plugins`
- More robust error handling (when a plugin does not like to be enabled again, the command no longer breaks)
- Two strategies:

| Name | Description |
|-|-|
| `one-by-one` (default) | Tries to disable/enable every plugin one by one until the site is healthy. |
| `disable-all` | We will start by disabling all user plugins and then re-enabling them individually. |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- This command is a pain to test 😃
- Rsync it to your site, and make sure everything is setup to test (`define( 'JETPACK_AUTOLOAD_DEV', true );`): 

`jetpack rsync wpcomsh yoursite.wordpress.com@sftp.wp.com:htdocs/wp-content/mu-plugins/wpcomsh`

- SSH into your site and create two plugins that don't fail:

`mkdir htdocs/wp-content/plugins/plugin1`
`nano htdocs/wp-content/plugins/plugin1.php`
```
<?php
/**
 * Plugin Name: PHP 8.1 Fatal
 * Description: This plugin demonstrates a fatal error in PHP 8.1+ but works in PHP 7.4 on all pages
 * Version: 1.0
 * Author: Tim Broddin
 */

function php_version_fatal_init() {
	return true;
}

// Use the 'init' hook to run on all page loads
add_action('init', 'php_version_fatal_init');

``` 
`mkdir htdocs/wp-content/plugins/plugin2`
`nano htdocs/wp-content/plugins/plugin2.php`

```
<?php
/**
 * Plugin Name: PHP 8.1 Fatal
 * Description: This plugin demonstrates a fatal error in PHP 8.1+ but works in PHP 7.4 on all pages
 * Version: 1.0
 * Author: Tim Broddin
 */

function php_version_fatal_init2() {
	return true;
}

// Use the 'init' hook to run on all page loads
add_action('init', 'php_version_fatal_init2');
```

- Visit https://yoursite.wordpress.com/_cli
- Activate these plugins= `plugin activate plugin1` & `plugin activate plugin2`
- Now edit both plugins and paste in something that would give a fatal. For example change `return true;` to `return true ? false : true ? 'a' : 'b';`
- If you want you can now visit your site & confirm that it is broken.
- Do the plugin dance: `--skip-theme --skip-plugins wpcomsh plugin-dance`
- Confirm that the site works again

Expected output (different plugin names):

```
ℹ️ Skipping akismet.
ℹ️ Skipping classic-editor.
ℹ️ Skipping layout-grid.
ℹ️ Skipping page-optimize.
ℹ️ Deactivating php81-fatal2 to find the breaking plugin.
ℹ️ Site health check still failed after deactivating: php81-fatal2. Reactivating.
❌ Plugin did not like being activated: php81-fatal2 (probably broken).
ℹ️ Deactivating php-81-fatal to find the breaking plugin.
✔ Site health check passed after deactivating: php-81-fatal.
+--------------+---------+
| name         | version |
+--------------+---------+
| php81-fatal2 | 1.0     |
| php-81-fatal | 1.0     |
+--------------+---------+
```

- Change the two plugins to `return true;` again.
- Reactivate them: `plugin activate plugin1` & `plugin activate plugin2`
- Change both plugins to fatal again.
- Do the plugin dance with another strategy: --skip-theme --skip-plugins wpcomsh plugin-dance --strategy=disable-all`

Expected output (different plugin names):

```
ℹ️ Skipping akismet.
ℹ️ Skipping classic-editor.
ℹ️ Skipping layout-grid.
ℹ️ Skipping page-optimize.
ℹ️ Deactivating all user plugins.
  - skipping 'akismet'
  - skipping 'classic-editor'
  - skipping 'layout-grid'
  - skipping 'page-optimize'
  ✔ deactivated 'jetpack-dev'
  ✔ deactivated 'jetpack-beta'
  ✔ deactivated 'php-81-fatal'
  ✔ deactivated 'php81-fatal2'
ℹ️ 4 plugins will be reactivated one by one to find the breaking plugin.
✔ Plugin activated and site health check passed: jetpack-dev.
✔ Plugin activated and site health check passed: jetpack-beta.
❌ Plugin did not like being activated: php-81-fatal (probably broken).
❌ Plugin did not like being activated: php81-fatal2 (probably broken).
+--------------+---------+
| name         | version |
+--------------+---------+
| php-81-fatal | 1.0     |
| php81-fatal2 | 1.0     |
+--------------+---------+
```








