### PR TITLE
Set `#wp-admin-bar-top-secondary` absolutely positioned to the right

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-prevent-profile-from-floating-out
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-prevent-profile-from-floating-out
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set `#wp-admin-bar-top-secondary` absolutely positioned to the right. This prevents it from floating ut of place when the window shrinks.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -50,6 +50,8 @@ function wpcom_enqueue_admin_bar_assets() {
 				#wpadminbar .quicklinks #wp-admin-bar-top-secondary {
 					display: flex;
 					flex-direction: row-reverse;
+					position: absolute;
+    				right: 0;
 				}
 
 				#wpadminbar .quicklinks #wp-admin-bar-top-secondary #wp-admin-bar-search {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -50,8 +50,6 @@ function wpcom_enqueue_admin_bar_assets() {
 				#wpadminbar .quicklinks #wp-admin-bar-top-secondary {
 					display: flex;
 					flex-direction: row-reverse;
-					position: absolute;
-    				right: 0;
 				}
 
 				#wpadminbar .quicklinks #wp-admin-bar-top-secondary #wp-admin-bar-search {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -87,6 +87,6 @@
 
 #wpadminbar #wp-admin-bar-top-secondary {
 	float: none;
-    position: absolute;
-    right: 0;
+	position: absolute;
+	right: 0;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -85,6 +85,9 @@
 	}
 }
 
+/**
+ * Profile section of the admin bar
+ */
 #wpadminbar #wp-admin-bar-top-secondary {
 	float: none;
 	position: absolute;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -84,3 +84,9 @@
 		}
 	}
 }
+
+#wpadminbar #wp-admin-bar-top-secondary {
+	float: none;
+    position: absolute;
+    right: 0;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8348

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prevent the container from floating out of place when the window shrinks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this changes in an atomic site
* Shrink the window
* Check that the profile container on the right side doesn't float out of place

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/6592e070-63ed-42b0-b147-48ade5290351)|![image](https://github.com/user-attachments/assets/bbf84a05-4206-4e99-9d12-bcabdeba9802)|