### PR TITLE
AI Proofread: Wrap suggestion text

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-proofread-popover-wrap
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-proofread-popover-wrap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Proofread: Wrap suggestion text

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
@@ -130,6 +130,7 @@ export default function Highlight() {
 		const block = getBlock( blockId );
 
 		if ( ! block ) {
+			setPopoverHover( false );
 			return;
 		}
 
@@ -148,6 +149,7 @@ export default function Highlight() {
 
 		const [ newBlock ] = rawHandler( { HTML: render } );
 		updateBlockAttributes( blockId, newBlock.attributes );
+		setPopoverHover( false );
 	};
 
 	return (

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/style.scss
@@ -83,6 +83,12 @@
 
 			.components-button.is-tertiary {
 				color: #000000;
+				white-space: break-spaces;
+				min-height: 36px;
+				height: unset;
+				min-width: 300px;
+				justify-content: center;
+				text-align: unset;
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Addresses https://github.com/Automattic/jetpack/pull/38397#pullrequestreview-2186633077

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Wrapps the suggestion text to avoid a huge popover

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get a suggestion
* Check the popover text, it should be wrapped if the response is long enough

| Before | After |
| - | - |
| ![2024-07-19_15-33-18](https://github.com/user-attachments/assets/e448ccca-9334-4f3d-b32d-71bb1d2e60e9) | ![2024-07-19_15-32-40](https://github.com/user-attachments/assets/0515737a-c9ca-4867-9cb9-0830048b14af) |

