### PR TITLE
Masterbar: Show notification+help icons on mobile

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-notifications-help-icons-on-mobile
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-notifications-help-icons-on-mobile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Show notifications and help icons on mobile

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -94,8 +94,6 @@
 	right: 0;
 
 	@media (max-width: 782px) {
-		background-color: blue;
-
 		#wp-admin-bar-help-center {
 			display: block !important;
 			width: 52px !important;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -92,7 +92,6 @@
 	float: none;
 	position: absolute;
 	right: 0;
-	background-color: currentColor;
 
 	@media (max-width: 782px) {
 		#wp-admin-bar-help-center {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -89,14 +89,18 @@
  * Profile section of the admin bar
  */
 #wpadminbar {
+	// Add background color to the right side of the admin bar for the mobile view
 	.quicklinks {
 		background-color: inherit;
+		#wp-admin-bar-top-secondary {
+			background-color: inherit;
+		}
 	}
+
 	#wp-admin-bar-top-secondary {
 		float: none;
 		position: absolute;
 		right: 0;
-		background-color: inherit;
 	
 		@media (max-width: 782px) {
 			#wp-admin-bar-help-center {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -92,4 +92,49 @@
 	float: none;
 	position: absolute;
 	right: 0;
+	background-color: currentColor;
+
+	@media (max-width: 782px) {
+		#wp-admin-bar-help-center {
+			display: block !important;
+			width: 52px !important;
+			margin-right: 0 !important;
+			.ab-item {
+				width: 52px;
+				svg {
+					width: 36px;
+					height: 36px;
+					padding: 4px 8px;
+				}
+			}
+		}
+
+		#wp-admin-bar-notes {
+			display: block !important;
+			width: 52px !important;
+			.ab-item {
+				justify-content: center;
+
+				.noticon-bell {
+					width: 36px;
+					height: 46px;
+					top: 0;
+
+					&:before {
+						background-position-y: bottom;
+						background-position-x: center;
+						right: 0;
+						width: 36px !important;
+						height: 40px !important;
+        				background-size: contain;
+					}
+				}
+			}
+
+			#wpnt-notes-panel2 {
+				top: 46px;
+			}
+		}
+	}
 }
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -88,52 +88,59 @@
 /**
  * Profile section of the admin bar
  */
-#wpadminbar #wp-admin-bar-top-secondary {
-	float: none;
-	position: absolute;
-	right: 0;
-
-	@media (max-width: 782px) {
-		#wp-admin-bar-help-center {
-			display: block !important;
-			width: 52px !important;
-			margin-right: 0 !important;
-			.ab-item {
-				width: 52px;
-				svg {
-					width: 36px;
-					height: 36px;
-					padding: 4px 8px;
-				}
-			}
-		}
-
-		#wp-admin-bar-notes {
-			display: block !important;
-			width: 52px !important;
-			.ab-item {
-				justify-content: center;
-
-				.noticon-bell {
-					width: 36px;
-					height: 46px;
-					top: 0;
-
-					&:before {
-						background-position-y: bottom;
-						background-position-x: center;
-						right: 0;
-						width: 36px !important;
-						height: 40px !important;
-        				background-size: contain;
+#wpadminbar {
+	.quicklinks {
+		background-color: inherit;
+	}
+	#wp-admin-bar-top-secondary {
+		float: none;
+		position: absolute;
+		right: 0;
+		background-color: inherit;
+	
+		@media (max-width: 782px) {
+			#wp-admin-bar-help-center {
+				display: block !important;
+				width: 52px !important;
+				margin-right: 0 !important;
+				.ab-item {
+					width: 52px;
+					svg {
+						width: 36px;
+						height: 36px;
+						padding: 4px 8px;
 					}
 				}
 			}
-
-			#wpnt-notes-panel2 {
-				top: 46px;
+	
+			#wp-admin-bar-notes {
+				display: block !important;
+				width: 52px !important;
+				.ab-item {
+					justify-content: center;
+	
+					.noticon-bell {
+						width: 36px;
+						height: 46px;
+						top: 0;
+	
+						&:before {
+							background-position-y: bottom;
+							background-position-x: center;
+							right: 0;
+							width: 36px !important;
+							height: 40px !important;
+									background-size: contain;
+						}
+					}
+				}
+	
+				#wpnt-notes-panel2 {
+					top: 46px;
+				}
 			}
 		}
 	}
 }
+
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -94,6 +94,8 @@
 	right: 0;
 
 	@media (max-width: 782px) {
+		background-color: blue;
+
 		#wp-admin-bar-help-center {
 			display: block !important;
 			width: 52px !important;

--- a/projects/packages/masterbar/changelog/update-notifications-help-icons-on-mobile
+++ b/projects/packages/masterbar/changelog/update-notifications-help-icons-on-mobile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add background color to address overlapping

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/_core-overrides.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/_core-overrides.scss
@@ -15,6 +15,10 @@
 		box-shadow: inset 0 -1px 0 $menu-submenu-background;
 	}
 
+	#wpadminbar #wp-admin-bar-top-secondary {
+		background-color: $masterbar-background;
+	}
+
 	#wpadminbar .ab-top-menu > #wp-admin-bar-blog > .ab-item {
 		background: $menu-submenu-background;
 		color: $text-color !important;

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/_core-overrides.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/_core-overrides.scss
@@ -15,10 +15,6 @@
 		box-shadow: inset 0 -1px 0 $menu-submenu-background;
 	}
 
-	#wpadminbar #wp-admin-bar-top-secondary {
-		background-color: $masterbar-background;
-	}
-
 	#wpadminbar .ab-top-menu > #wp-admin-bar-blog > .ab-item {
 		background: $menu-submenu-background;
 		color: $text-color !important;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8366
Fixes https://github.com/Automattic/dotcom-forge/issues/8372

## Proposed changes:
Show Notifications & help icons on small screens, make right section shows over the left one on small screens.

Before: 

<!-- https://github.com/user-attachments/assets/5ecdb001-73c7-46d6-9cf2-d4a15fb2592e -->
https://github.com/user-attachments/assets/d8eada63-b845-46eb-870c-c8507c9a0419


After:

<!-- https://github.com/user-attachments/assets/c9dab294-c77d-47ed-8a87-fd802c30b3f7 -->
https://github.com/user-attachments/assets/88f8b1d3-314c-48f9-ad59-86c353357d26


## Jetpack product discussion
Check issue

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Go to '/wp-admin'.
* Check the notifications & help icons to show on small screen sizes.
* Check clicking on them to see if it works.
* Check for regressions.

