### PR TITLE
AI Logo Generator: add AI extension skeleton on the Site Logo block

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-basic-site-logo-block-extension
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-basic-site-logo-block-extension
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Logo Generator: extend the site logo block to include an AI button on the toolbar.

--- a/projects/plugins/jetpack/extensions/editor.js
+++ b/projects/plugins/jetpack/extensions/editor.js
@@ -7,6 +7,7 @@ import './shared/plan-upgrade-notification';
 import './shared/stripe-connection-notification';
 import './shared/external-media';
 import './extended-blocks/core-embed';
+import './extended-blocks/core-site-logo/index.js';
 import './extended-blocks/core-social-links';
 import './extended-blocks/paid-blocks';
 import './shared/styles/slideshow-fix.scss';

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/components/ai-toolbar-button.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/components/ai-toolbar-button.tsx
@@ -1,0 +1,39 @@
+/*
+ * External dependencies
+ */
+import { aiAssistantIcon } from '@automattic/jetpack-ai-client';
+import { ToolbarButton } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/*
+ * Types
+ */
+import type { ReactElement } from 'react';
+
+/**
+ * The toolbar button that toggles the Logo Generator Modal.
+ *
+ * @param {object} props - The component props.
+ * @param {Function} props.clickHandler - The handler for the click event.
+ * @returns {ReactElement} The toolbar button.
+ */
+export default function AiToolbarButton( {
+	clickHandler,
+}: {
+	clickHandler?: () => void;
+} ): ReactElement {
+	const toggleFromToolbar = useCallback( () => {
+		clickHandler();
+	}, [ clickHandler ] );
+
+	return (
+		<>
+			<ToolbarButton
+				showTooltip
+				onClick={ toggleFromToolbar }
+				label={ __( 'Generate with AI', 'jetpack' ) }
+				icon={ aiAssistantIcon }
+			/>
+		</>
+	);
+}

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/components/ai-toolbar-button.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/components/ai-toolbar-button.tsx
@@ -23,7 +23,7 @@ export default function AiToolbarButton( {
 	clickHandler?: () => void;
 } ): ReactElement {
 	const toggleFromToolbar = useCallback( () => {
-		clickHandler();
+		clickHandler?.();
 	}, [ clickHandler ] );
 
 	return (

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/constants.ts
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/constants.ts
@@ -1,0 +1,1 @@
+export const SITE_LOGO_BLOCK_AI_EXTENSION = 'ai-assistant-site-logo-support' as const;

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -1,0 +1,85 @@
+/*
+ * External dependencies
+ */
+import { BlockControls } from '@wordpress/block-editor';
+import { Modal } from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+/*
+ * Internal dependencies
+ */
+import { getFeatureAvailability } from '../../blocks/ai-assistant/lib/utils/get-feature-availability';
+import AiToolbarButton from './components/ai-toolbar-button.js';
+import { SITE_LOGO_BLOCK_AI_EXTENSION } from './constants.js';
+
+/**
+ * HOC to add the AI button on the Site Logo toolbar.
+ */
+const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
+	return props => {
+		const [ isLogoGeneratorModalVisible, setIsLogoGeneratorModalVisible ] = useState( false );
+
+		const showModal = useCallback( () => {
+			setIsLogoGeneratorModalVisible( true );
+		}, [] );
+
+		const closeModal = useCallback( () => {
+			setIsLogoGeneratorModalVisible( false );
+		}, [] );
+
+		useEffect( () => {
+			return () => {
+				// close modal if open
+				closeModal();
+			};
+		}, [ closeModal ] );
+
+		return (
+			<>
+				<BlockEdit { ...props } />
+				<BlockControls group="block">
+					<AiToolbarButton clickHandler={ showModal } />
+				</BlockControls>
+				{ isLogoGeneratorModalVisible && (
+					<Modal title={ __( 'Coming soon', 'jetpack' ) } onRequestClose={ closeModal }>
+						<p>{ __( 'Coming soon', 'jetpack' ) }</p>
+					</Modal>
+				) }
+			</>
+		);
+	};
+}, 'SiteLogoEditWithAiComponents' );
+
+/**
+ * Function to override the core Site Logo block edit settings.
+ * Will create a HOC to use as the edit implementation.
+ *
+ * @param {object} settings - The block settings.
+ * @param {string} name - The block name.
+ * @returns {object} The new block settings.
+ */
+function jetpackSiteLogoWithAiSupport( settings, name: string ) {
+	// Only extend the core Site Logo block.
+	if ( name !== 'core/site-logo' ) {
+		return settings;
+	}
+
+	// Disable if the feature is not available.
+	if ( ! getFeatureAvailability( SITE_LOGO_BLOCK_AI_EXTENSION ) ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		edit: siteLogoEditWithAiComponents( settings.edit ),
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'jetpack/site-logo-with-ai-support',
+	jetpackSiteLogoWithAiSupport,
+	100
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #38432.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Extend the `core/site-logo` block to add an AI button on the toolbar, but only when the beta features are enabled
* When the toolbar button is clicked, trigger an empty, dummy modal

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable beta extensions on you testing site
* Go to the block editor and insert a Site Logo block:

<img width="200" alt="Screenshot 2024-07-19 at 17 28 07" src="https://github.com/user-attachments/assets/9eeff34e-855d-4186-9fd0-1e8934e879f3">

* Select the block
* Confirm there is an AI button on the toolbar
* Confirm you see the "Generate with AI" label when the cursor is over the button:

<img width="200" alt="Screenshot 2024-07-19 at 17 28 18" src="https://github.com/user-attachments/assets/47ec57aa-bd1f-4036-9306-0a711feaff5e">

* Click the button
* Confirm you see a sample modal:

<img width="500" alt="Screenshot 2024-07-19 at 17 28 31" src="https://github.com/user-attachments/assets/f6fac264-13bb-4b60-aba3-44ab3addeb41">

* Confirm you can close the modal and open it again by clicking the AI button on the block toolbar
* Disable beta extensions and go back to the editor
* Confirm the AI button is gone (important):

<img width="200" alt="Screenshot 2024-07-19 at 17 30 40" src="https://github.com/user-attachments/assets/695fd01d-7cba-4df3-ac2d-1a342283cdf5">
