### PR TITLE
Jetpack: Fix Newsletter settings disabled state

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
@@ -79,7 +79,7 @@ function Newsletter( props ) {
 			>
 				<ModuleToggle
 					slug="subscriptions"
-					disabled={ unavailableInOfflineMode }
+					disabled={ unavailableInOfflineMode || ! isLinked }
 					activated={ isSubscriptionsActive }
 					toggling={ isSavingAnyOption( SUBSCRIPTIONS_MODULE_NAME ) }
 					toggleModule={ toggleModuleNow }

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -42,6 +42,7 @@ function SubscriptionsSettings( props ) {
 		isBlockTheme,
 		siteAdminUrl,
 		themeStylesheet,
+		isLinked,
 	} = props;
 
 	const subscribeModalEditorUrl =
@@ -113,7 +114,7 @@ function SubscriptionsSettings( props ) {
 		);
 	}, [ updateFormStateModuleOption ] );
 
-	const isDisabled = ! isSubscriptionsActive || unavailableInOfflineMode;
+	const isDisabled = ! isSubscriptionsActive || unavailableInOfflineMode || ! isLinked;
 
 	return (
 		<SettingsCard

--- a/projects/plugins/jetpack/changelog/fix-newsletter-settings-disabled-state
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-settings-disabled-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack: disable the toggles in Newsletter settings when not user-connected. This change is to match the functionality with the visuals (that were already in a disabled state).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes an issue where it was possible to toggle the Newsletter settings even when the section was disabled (with the user not connected).

**Before:**

https://github.com/user-attachments/assets/92fdc0be-e312-4ff7-b46d-6516896917f2

**After:**

https://github.com/user-attachments/assets/76697750-9360-42c3-ae30-ebf1375b5f76




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch
* Connect your site (but do not connect your user account yet)
* Go to `/wp-admin/admin.php?page=jetpack#/newsletter`
* Try toggling the options and confirm they are disabled
* Now, connect your user account and confirm you can toggle the options
