### PR TITLE
Remove mj backup card functionality to hide item on smaller screens

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
@@ -4,7 +4,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
-import { useEffect, useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { PRODUCT_STATUSES } from '../../../constants';
 import {
 	REST_API_REWINDABLE_BACKUP_EVENTS_ENDPOINT,
@@ -196,7 +196,6 @@ const WithBackupsValueSection = ( { admin, slug } ) => {
 };
 
 const NoBackupsValueSection = ( { admin, slug } ) => {
-	const [ itemsToShow, setItemsToShow ] = useState( 3 );
 	const { data: backupStats, isLoading } = useSimpleQuery( {
 		name: QUERY_BACKUP_STATS_KEY,
 		query: {
@@ -227,22 +226,6 @@ const NoBackupsValueSection = ( { admin, slug } ) => {
 		return data;
 	}, [ backupStats ] );
 
-	// Only show 2 data points on certain screen widths where the cards are squished
-	useEffect( () => {
-		window.onresize = () => {
-			if ( ( window.innerWidth >= 961 && window.innerWidth <= 1070 ) || window.innerWidth < 290 ) {
-				setItemsToShow( 2 );
-			} else {
-				setItemsToShow( 3 );
-			}
-		};
-
-		return () => {
-			window.onresize = null;
-		};
-	}, [] );
-
-	const moreValue = sortedStats.length > itemsToShow ? sortedStats.length - itemsToShow : 0;
 	const shortenedNumberConfig = { maximumFractionDigits: 1, notation: 'compact' };
 
 	return (
@@ -261,27 +244,16 @@ const NoBackupsValueSection = ( { admin, slug } ) => {
 								key={ i + itemSlug }
 							>
 								<>
-									{ i < itemsToShow && (
-										<span className={ clsx( styles[ 'visual-stat' ] ) } aria-hidden="true">
-											{ getIcon( itemSlug ) }
-											<span>{ numberFormat( value, shortenedNumberConfig ) }</span>
-										</span>
-									) }
+									<span className={ clsx( styles[ 'visual-stat' ] ) } aria-hidden="true">
+										{ getIcon( itemSlug ) }
+										<span>{ numberFormat( value, shortenedNumberConfig ) }</span>
+									</span>
 									<VisuallyHidden>{ getStatRenderFn( itemSlug )( value ) }</VisuallyHidden>
 								</>
 							</li>
 						);
 					} ) }
 				</ul>
-
-				{ moreValue > 0 && (
-					<span className={ styles[ 'more-stats' ] } aria-hidden="true">
-						{
-							// translators: %s is the number of items that are not shown
-							sprintf( __( '+%s more', 'jetpack-my-jetpack' ), moreValue )
-						}
-					</span>
-				) }
 			</div>
 		</ProductCard>
 	);

--- a/projects/packages/my-jetpack/changelog/remove-mj-backup-card-functionality-to-hide-item-on-smaller-screens
+++ b/projects/packages/my-jetpack/changelog/remove-mj-backup-card-functionality-to-hide-item-on-smaller-screens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove functionality that hid 1 value on the backup card for mid-sized screens


### PR DESCRIPTION
## Proposed changes:

* The min-width on the MJ product cards got increased in [this PR](https://github.com/Automattic/jetpack/pull/38332) so hiding one of the items on the backup card on certain widths is no longer needed

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/pull/38332#pullrequestreview-2180805106

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack
3. Make sure you can see all 3 items on the backup card on all screen widths
![image](https://github.com/user-attachments/assets/04873d9b-7fb4-4d5d-bc8a-70c65c022938)
![image](https://github.com/user-attachments/assets/6e625300-8e32-404e-8633-619827bad63c)
![image](https://github.com/user-attachments/assets/80ac03f3-e92f-4333-90b3-2775ff10c84c)
![image](https://github.com/user-attachments/assets/7c5e3933-25f7-46f2-8d40-8d0cde310b71)
![image](https://github.com/user-attachments/assets/c8d594c0-54b5-4ffa-817f-586505921705)


