### PR TITLE
AI Proofread: Add long sentences and unconfident word checks

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-proofread-add-features
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-proofread-add-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Proofread: Add long sentences and unconfident word checks

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/_features.colors.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/_features.colors.scss
@@ -3,7 +3,7 @@
 
 $features-colors: (
 	'complex-words': rgba( 240, 184, 73, 1 ),
-	'ambiguous-words': rgba( 0, 175, 82, 1 ),
+	'unconfident-words': rgba( 0, 175, 82, 1 ),
 	'long-sentences': rgba( 122, 0, 223, 1 ),
 );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/index.ts
@@ -1,9 +1,9 @@
 /**
  * Features
  */
-import ambiguousWords, { AMBIGUOUS_WORDS } from './ambiguous-words';
 import complexWords, { COMPLEX_WORDS, dictionary as dicComplex } from './complex-words';
 import longSentences, { LONG_SENTENCES } from './long-sentences';
+import unconfidentWords, { UNCONFIDENT_WORDS } from './unconfident-words';
 /**
  * Types
  */
@@ -21,8 +21,8 @@ const features: Array< BreveFeature > = [
 		highlight: longSentences,
 	},
 	{
-		config: AMBIGUOUS_WORDS,
-		highlight: ambiguousWords,
+		config: UNCONFIDENT_WORDS,
+		highlight: unconfidentWords,
 	},
 ];
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/unconfident-words/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/unconfident-words/index.ts
@@ -2,22 +2,22 @@
  * Internal dependencies
  */
 import { escapeRegExp } from '../../utils/escapeRegExp';
-import weaselWords from './words';
+import words from './words';
 /**
  * Types
  */
 import type { BreveFeatureConfig, HighlightedText } from '../../types';
 
-export const AMBIGUOUS_WORDS: BreveFeatureConfig = {
-	name: 'ambiguous-words',
-	title: 'Ambiguous words',
+export const UNCONFIDENT_WORDS: BreveFeatureConfig = {
+	name: 'unconfident-words',
+	title: 'Unconfident words',
 	tagName: 'span',
-	className: 'has-proofread-highlight--ambiguous-words',
+	className: 'has-proofread-highlight--unconfident-words',
 };
 
-const list = new RegExp( `\\b(${ weaselWords.map( escapeRegExp ).join( '|' ) })\\b`, 'gi' );
+const list = new RegExp( `\\b(${ words.map( escapeRegExp ).join( '|' ) })\\b`, 'gi' );
 
-export default function ambiguousWords( blockText: string ): Array< HighlightedText > {
+export default function unconfidentWords( blockText: string ): Array< HighlightedText > {
 	const matches = blockText.matchAll( list );
 	const highlightedTexts: Array< HighlightedText > = [];
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/unconfident-words/words.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/unconfident-words/words.ts
@@ -1,4 +1,4 @@
-const weaselWords = [
+const unconfidentWords = [
 	'may',
 	'might',
 	'could',
@@ -10,4 +10,4 @@ const weaselWords = [
 	'relatively',
 ];
 
-export default weaselWords;
+export default unconfidentWords;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
@@ -116,12 +116,13 @@ export default function Highlight() {
 	const handleSuggestions = () => {
 		const target = ( anchor as HTMLElement )?.innerText;
 		const parent = getNonLinkAncestor( anchor as HTMLElement );
-		const sentence = parent?.innerText as string;
+		// The text containing the target
+		const text = parent?.innerText as string;
 		// Get the index of the target in the parent
 		const startIndex = getNodeTextIndex( parent as HTMLElement, anchor as HTMLElement );
 		// Get the occurrences of the target in the sentence
 		const targetRegex = new RegExp( target, 'gi' );
-		const matches = Array.from( sentence.matchAll( targetRegex ) ).map( match => match.index );
+		const matches = Array.from( text.matchAll( targetRegex ) ).map( match => match.index );
 		// Get the right occurrence of the target in the sentence
 		const occurrence = Math.max( 1, matches.indexOf( startIndex ) + 1 );
 		const ordinalOccurence = numberToOrdinal( occurrence );
@@ -130,7 +131,7 @@ export default function Highlight() {
 			id,
 			target,
 			feature,
-			sentence,
+			text,
 			blockId,
 			occurrence: ordinalOccurence,
 		} );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/actions.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/actions.ts
@@ -69,14 +69,14 @@ export function setSuggestions( {
 	id,
 	feature,
 	target,
-	sentence,
+	text,
 	blockId,
 	occurrence,
 }: {
 	id: string;
 	feature: string;
 	target: string;
-	sentence: string;
+	text: string;
 	blockId: string;
 	occurrence: string;
 } ) {
@@ -93,7 +93,7 @@ export function setSuggestions( {
 			getRequestMessages( {
 				feature,
 				target,
-				sentence,
+				text,
 				blockId,
 				occurrence,
 			} ),

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
@@ -80,7 +80,7 @@ export type BreveDispatch = {
 		id: string;
 		feature: string;
 		target: string;
-		sentence: string;
+		text: string;
 		blockId: string;
 		occurrence: string;
 	} ) => void;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-request-messages.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-request-messages.ts
@@ -7,15 +7,12 @@ import features from '../features/index.js';
 
 // Map of types to the corresponding AI Assistant request type.
 const requestTypeMap = {
-	'complex-words': 'breve-phrase',
-	// TODO: Return as soon start to support these features
-	// 'ambiguous-words': 'breve-weasel',
-	// 'long-sentence': 'breve-long-sentence',
-	// adverb: 'breve-adverb',
-	// adjective: 'breve-adjective',
+	'complex-words': 'breve-complex-word',
+	'ambiguous-words': 'breve-unconfident-word',
+	'long-sentences': 'breve-long-sentence',
 };
 
-export const getRequestMessages = ( { feature, target, sentence, blockId, occurrence } ) => {
+export const getRequestMessages = ( { feature, target, text, blockId, occurrence } ) => {
 	const block = select( 'core/block-editor' ).getBlock( blockId );
 	const html = getBlockContent( block );
 	const dictionary = features?.find?.( ftr => ftr.config.name === feature )?.dictionary || {};
@@ -27,7 +24,7 @@ export const getRequestMessages = ( { feature, target, sentence, blockId, occurr
 			context: {
 				type: requestTypeMap[ feature ],
 				target,
-				sentence,
+				text,
 				html,
 				replacement,
 				occurrence,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-request-messages.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-request-messages.ts
@@ -8,7 +8,7 @@ import features from '../features/index.js';
 // Map of types to the corresponding AI Assistant request type.
 const requestTypeMap = {
 	'complex-words': 'breve-complex-word',
-	'ambiguous-words': 'breve-unconfident-word',
+	'unconfident-words': 'breve-unconfident-word',
 	'long-sentences': 'breve-long-sentence',
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Requires D155999-code
Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the long sentences and ambiguous words features back
* Renames "ambiguous" to "unconfident"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D155999-code and sandbox the public API
* Enable long sentences and unconfident words
* Check that both features work in the same way as the complex words
