### PR TITLE
Admin Bar: Adjust wpcom logo size on mobile

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/admin-bar-wpcom-logo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/admin-bar-wpcom-logo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin Bar: Adjust wpcom logo size on mobile

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -36,11 +36,11 @@
 	top: 2px;
 
 	@media (max-width: 782px) {
-		width: 36px;
-		height: 36px;
-		margin: 0 8px;
+		width: 32px;
+		height: 32px;
+		margin: 0 10px;
 		mask-size: cover;
-		top: 5px;
+		top: 7px;
 	}
 }
 
@@ -145,5 +145,3 @@
 		}
 	}
 }
-
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/8293

## Proposed changes:

This PR reduces the wpcom logo in admin bar on mobile view to match Core's and Calypso.

|Before|After|Calypso|Core|
|-|-|-|-|
|<img width="96" alt="image" src="https://github.com/user-attachments/assets/22a02da5-f4c3-4efb-a77f-0a521f2284cd">|<img width="96" alt="image" src="https://github.com/user-attachments/assets/dfb22d5f-4d2a-4baa-8e2c-dc99b5412cdc">|<img width="96" alt="image" src="https://github.com/user-attachments/assets/e801aaa7-acf7-4ab8-b465-1921fc833956">|<img width="96" alt="image" src="https://github.com/user-attachments/assets/c13608fc-7d85-483f-9e1b-8f7e22404be0">|



### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to /wp-admin
2. Verify that the wpcom logo is reduced as screenshot above.

