### PR TITLE
repo-gardening: Remove guessing of release dates

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/remove-gardening-guessing-of-release-dates
+++ b/projects/github-actions/repo-gardening/changelog/remove-gardening-guessing-of-release-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Check description task: Remove general guessing of release dates and code freezes. Add special casing for wpcomsh and mu-wpcom-plugin.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -65,7 +65,7 @@ async function hasProgressLabel( octokit, owner, repo, number ) {
  * @returns {Promise<string>} Promise resolving to info about the release (code freeze, release date).
  */
 async function getMilestoneDates( plugin, nextMilestone ) {
-	let releaseDate;
+	let releaseDate = 'none scheduled';
 	let codeFreezeDate;
 	if ( nextMilestone && nextMilestone.hasOwnProperty( 'due_on' ) && nextMilestone.due_on ) {
 		releaseDate = moment( nextMilestone.due_on ).format( 'LL' );
@@ -77,19 +77,11 @@ async function getMilestoneDates( plugin, nextMilestone ) {
 		// If we have a date and it is valid, use it, otherwise set code freeze to a week before the release.
 		if ( freezeDateDescription && moment( freezeDateDescription[ 1 ] ).isValid() ) {
 			codeFreezeDate = moment( freezeDateDescription[ 1 ] ).format( 'LL' );
-		} else {
-			codeFreezeDate = moment( nextMilestone.due_on ).subtract( 7, 'd' ).format( 'LL' );
 		}
-	} else {
-		// Fallback to raw math calculation
-		// Calculate next release date
-		const firstTuesdayOfMonth = moment().add( 1, 'months' ).startOf( 'month' );
-		while ( firstTuesdayOfMonth.day() !== 2 ) {
-			firstTuesdayOfMonth.add( 1, 'day' );
-		}
-		releaseDate = firstTuesdayOfMonth.format( 'LL' );
-		// Calculate next code freeze date
-		codeFreezeDate = firstTuesdayOfMonth.subtract( 8, 'd' ).format( 'LL' );
+	} else if ( plugin === 'wpcomsh' ) {
+		releaseDate = 'on demand (usually Mondays if not sooner)';
+	} else if ( plugin === 'mu-wpcom-plugin' ) {
+		releaseDate = 'WordPress.com Simple releases happen daily';
 	}
 
 	const capitalizedName = plugin
@@ -113,8 +105,7 @@ ${
 - Releases to self-hosted sites happen monthly. The next release is scheduled for _${ releaseDate }_ (scheduled code freeze on _${ codeFreezeDate }_).`
 		: `
 - Next scheduled release: _${ releaseDate }_.
-- Scheduled code freeze: _${ codeFreezeDate }_.
-`
+${ codeFreezeDate ? `- Scheduled code freeze: _${ codeFreezeDate }_.\n` : '' }`
 }
 
 If you have any questions about the release process, please ask in the #jetpack-releases channel on Slack.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -80,7 +80,7 @@ async function getMilestoneDates( plugin, nextMilestone ) {
 		}
 	} else if ( plugin === 'wpcomsh' ) {
 		releaseDate = 'on demand (usually Mondays if not sooner)';
-	} else if ( plugin === 'mu-wpcom-plugin' ) {
+	} else if ( plugin === 'mu-wpcom' ) {
 		releaseDate = 'WordPress.com Simple releases happen daily';
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We added this guessing back when Jetpack was the only plugin, and we still did a week-long testing week. That just got carried forward as we added additional plugins and so on.

For Jetpack we should be safe relying on the milestone, it's on the release checklist to create the new milestone. For most of the other plugins, if there's no milestone then we may as well just say there's no scheduled release. The exceptions to that are wpcomsh and mu-wpcom-plugin, which get custom messaging if no milestone exists.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf4qpu-u1-p2#comment-436

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a PR based on this one that makes changes to various plugins. Check the messaging.
  * [x] https://github.com/Automattic/jetpack/pull/38463#issuecomment-2243652448