### PR TITLE
Fix "Show Toolbar when viewing site" on Classic Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-hide-admin-bar
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-hide-admin-bar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Honor user preference for show_admin_bar_front

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -142,6 +142,11 @@ add_action( 'admin_bar_menu', 'wpcom_add_my_account_item_to_profile_menu' );
  * @return string Name of the admin bar class.
  */
 function wpcom_custom_wpcom_admin_bar_class( $wp_admin_bar_class ) {
+	// Honor the user's preference to hide the admin bar on the front end.
+	if ( ! is_admin() && get_user_option( 'show_admin_bar_front' ) !== 'true' ) {
+		return '';
+	}
+
 	if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
 		return $wp_admin_bar_class;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7622

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* If the user has the option `show_admin_bar_front` set to `true`, then do not load the custom admin bar if we're on the front end.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR to an Atomic Classic test site using the instructions below.
* Go to /wp-admin/profile.php and ensure "Show Toolbar when viewing site" is enabled.
* Go to the "front end" of your test site, you should see the admin-toolbar at the top of the page.
* Go to /wp-admin/profile.php and ensure "Show Toolbar when viewing site" is disabled.
* Go to the "front end" of your test site, you should NOT see the admin-toolbar at the top of the page.
* This will also work on Atomic Default sites if you deep link to /wp-admin/profile.php to change the value of "Show Toolbar when viewing the site."
* This PR should not introduce any regressions to Simple sites. The "Show Toolbar when viewing site" option should continue to work on Simple Classic sites with this PR applied. The "Show Toolbar when viewing site" is unavailable on Simple Default sites.

