### PR TITLE
wpcomsh: Update wc-calypso-bridge to 2.5.5

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wc-calypso-bridge-2.5.5
+++ b/projects/plugins/wpcomsh/changelog/update-wc-calypso-bridge-2.5.5
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WooCommerce Calypso Bridge version update to 2.5.5

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -129,7 +129,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_0_0"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_0_1_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.5.4",
+		"automattic/wc-calypso-bridge": "2.5.5",
 		"wordpress/classic-editor-plugin": "1.5",
 		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-post-list": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9dedc290e93c633c02b3289fb40bcd2",
+    "content-hash": "a2b3dc7a7194b89327a123f9d4fe88fb",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -1863,16 +1863,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.5.4",
+            "version": "v2.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "164752a01f038220202455c00844a80ee8e51ef0"
+                "reference": "f7dc90d348ac82031f26dff6076e4cf492b09138"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/164752a01f038220202455c00844a80ee8e51ef0",
-                "reference": "164752a01f038220202455c00844a80ee8e51ef0",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/f7dc90d348ac82031f26dff6076e4cf492b09138",
+                "reference": "f7dc90d348ac82031f26dff6076e4cf492b09138",
                 "shasum": ""
             },
             "require": {
@@ -1913,7 +1913,7 @@
                     "phpcbf -p"
                 ]
             },
-            "time": "2024-07-22T10:08:33+00:00"
+            "time": "2024-07-23T22:02:25+00:00"
         },
         {
             "name": "composer/installers",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.0.0",
+	"version": "5.0.1-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.0.0
+ * Version: 5.0.1-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.0.0' );
+define( 'WPCOMSH_VERSION', '5.0.1-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR bumps the version of `wc-calypso-bridge` to `2.5.5`, which includes the following change:
- https://github.com/Automattic/wc-calypso-bridge/pull/1492

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, it does not.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The changes related to the `wc-calypso-bridge` were already tested in the related PR https://github.com/Automattic/wc-calypso-bridge/pull/1492. In that PR, there are some testing instructions