### PR TITLE
Footer credit: Remove customizer option for block themes

### DIFF
--- a/projects/plugins/wpcomsh/changelog/remove-footer-credit-customizer
+++ b/projects/plugins/wpcomsh/changelog/remove-footer-credit-customizer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Footer credit: Remove customizer option for block themes

--- a/projects/plugins/wpcomsh/footer-credit/footer-credit/customizer.php
+++ b/projects/plugins/wpcomsh/footer-credit/footer-credit/customizer.php
@@ -134,5 +134,10 @@ function footercredits_sanitize_setting( $val ) {
 	}
 }
 
-// Setup the Theme Customizer settings and controls...
-add_action( 'customize_register', 'footercredits_register', 99 );
+/**
+ * Setup the Footer Credit customizer settings and controls for classic themes only
+ * We don't support the footer credit on block themes, see https://wp.me/paYJgx-51l.
+ */
+if ( ! wp_is_block_theme() ) {
+	add_action( 'customize_register', 'footercredits_register', 99 );
+}


### PR DESCRIPTION
Part of https://github.com/Automattic/dotcom-forge/issues/8232
Counterpart of D156084-code for Atomic sites

## Proposed changes:

Removes the "Footer Credit" option from the Customizer for block themes

Before | After
--- | ---
<img width="301" alt="Screenshot 2024-07-23 at 12 29 11" src="https://github.com/user-attachments/assets/0f0230d4-3c51-455c-b633-e625871ec7e2"> | <img width="300" alt="Screenshot 2024-07-23 at 12 40 24" src="https://github.com/user-attachments/assets/64c52f1d-2324-4d85-be41-6d792f56c3fc">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to a WoA dev site:
  - Install Jetpack Beta
  - Go to `/wp-admin/admin.php?page=jetpack-beta&plugin=wpcomsh` 
  - Activate the branch of this PR
- Make sure your site has a block theme
- Go to `/wp-admin/customize.php`
- Select "Site Identity"
- Make sure the "Footer Credit" option is not visible
- Switch to a classic theme
- Reload the Customizer
- Make sure the "Footer Credit" option is visible now