### PR TITLE
Tests: Marking test_sync_maybe_update_core as skipped due to WP core bug

### DIFF
--- a/projects/plugins/jetpack/changelog/update-temporarily-skip-test_sync_maybe_update_core-until-core-fix
+++ b/projects/plugins/jetpack/changelog/update-temporarily-skip-test_sync_maybe_update_core-until-core-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tests: Skipping test_sync_maybe_update_core test due to core bug.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -154,6 +154,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_sync_maybe_update_core() {
 		$this->markTestSkipped( 'Skipped due to core bug. See p1721736489043329-slack-C034JEXD1RD' );
+		// @phan-suppress-next-line PhanPluginUnreachableCode
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'Not compatible with multisite mode' );
 		}

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -153,6 +153,7 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_sync_maybe_update_core() {
+		$this->markTestSkipped( 'Skipped due to core bug. See p1721736489043329-slack-C034JEXD1RD' );
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'Not compatible with multisite mode' );
 		}


### PR DESCRIPTION
## Proposed changes:

* This PR marks a test - `test_sync_maybe_update_core` - as skipped, due to a bug caused by a recent merge to WordPress trunk at https://github.com/WordPress/wordpress-develop/pull/6964
* More information on the debugging can be found in Slack (internal link): p1721736489043329-slack-C034JEXD1RD

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1721736489043329-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* The PHP tests: PHP 8.2 WP trunk should pass in this PR.