### PR TITLE
webpack-config: Pass default Babel options to I18nCheck plugin

### DIFF
--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -184,6 +184,8 @@ This provides an instance of [@wordpress/i18n-check-webpack-plugin](https://www.
 
 The default configuration sets a filter that excludes `node_modules` other than `@automattic/*`. This may be accessed as `I18nCheckPlugin.defaultFilter`.
 
+The default configuration also sets `extractorOptions.babelOptions`: If `path.resolve( 'babel.config.js' )` exists, `configFile` will default to that. Otherwise, `presets` will default to set some appropriate defaults (which will require the peer dependencies on [@babel/core](https://www.npmjs.com/package/@babel/core) and [@babel/runtime](https://www.npmjs.com/package/@babel/runtime)).
+
 ##### `I18nLoaderPlugin( options )`
 
 This provides an instance of [@automattic/i18n-loader-webpack-plugin](https://www.npmjs.com/package/@automattic/i18n-loader-webpack-plugin). The `options` are passed to the plugin.

--- a/projects/js-packages/webpack-config/changelog/fix-webpack-config-I18nCheck-babel-options
+++ b/projects/js-packages/webpack-config/changelog/fix-webpack-config-I18nCheck-babel-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Pass default Babel options to I18nCheckWebpackPlugin if none are supplied, as we already do for TranspileRule.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "3.2.10",
+	"version": "3.2.11-alpha",
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -136,13 +136,16 @@ const I18nCheckPlugin = options => {
 
 	// Default Babel options for extractor.
 	if ( typeof opts.extractorOptions?.babelOptions === 'undefined' ) {
-		opts.extractorOptions ??= {};
+		const babelOptions = { babelrc: false };
 		const configFile = path.resolve( 'babel.config.js' );
 		if ( fs.existsSync( configFile ) ) {
-			opts.extractorOptions.babelOptions = { configFile };
+			babelOptions.configFile = configFile;
 		} else {
-			opts.extractorOptions.babelOptions = { presets: [ require.resolve( './babel-preset.js' ) ] };
+			babelOptions.presets = [ require.resolve( './babel-preset.js' ) ];
 		}
+
+		opts.extractorOptions ??= {};
+		opts.extractorOptions.babelOptions = babelOptions;
 	}
 
 	return [ new I18nCheckWebpackPlugin( opts ) ];

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -128,9 +128,23 @@ const ForkTSCheckerPlugin = options => [
 
 const I18nCheckPlugin = options => {
 	const opts = { filter: i18nFilterFunction, ...options };
+
+	// Default text domain.
 	if ( typeof opts.expectDomain === 'undefined' ) {
 		opts.expectDomain = loadTextDomainFromComposerJson();
 	}
+
+	// Default Babel options for extractor.
+	if ( typeof opts.extractorOptions?.babelOptions === 'undefined' ) {
+		opts.extractorOptions ??= {};
+		const configFile = path.resolve( 'babel.config.js' );
+		if ( fs.existsSync( configFile ) ) {
+			opts.extractorOptions.babelOptions = { configFile };
+		} else {
+			opts.extractorOptions.babelOptions = { presets: [ require.resolve( './babel-preset.js' ) ] };
+		}
+	}
+
 	return [ new I18nCheckWebpackPlugin( opts ) ];
 };
 I18nCheckPlugin.defaultFilter = i18nFilterFunction;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Otherwise, if no babel.config.js exists in the package being compiled, it'll do the wrong thing if Babel needs any of the default configuration.

We already do this same thing in TranspileRule.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See if this fixes the compilation problem in #38430.
