### PR TITLE
AI Assistant: Fix block inserter behavior when Breve is enabled

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-block-inserter
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-block-inserter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Fix block inserter behavior when Breve is enabled

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
@@ -226,27 +226,30 @@ export function registerBreveHighlights() {
 			interactive: false,
 			edit: () => {},
 			...configSettings,
-			__experimentalGetPropsForEditableTreePreparation( _select, { blockClientId } ) {
+			__experimentalGetPropsForEditableTreePreparation() {
 				return {
 					isProofreadEnabled: (
 						globalSelect( 'jetpack/ai-breve' ) as BreveSelect
 					 ).isProofreadEnabled(),
-					currentMd5: ( globalSelect( 'jetpack/ai-breve' ) as BreveSelect ).getBlockMd5(
-						formatName,
-						blockClientId
-					),
 					isFeatureEnabled: ( globalSelect( 'jetpack/ai-breve' ) as BreveSelect ).isFeatureEnabled(
 						config.name
 					),
 				};
 			},
 			__experimentalCreatePrepareEditableTree(
-				{ isProofreadEnabled, isFeatureEnabled, currentMd5 },
+				{ isProofreadEnabled, isFeatureEnabled },
 				{ blockClientId, richTextIdentifier }
 			) {
 				return ( formats: Array< RichTextFormatList >, text: string ) => {
 					const record = { formats, text } as RichTextValue;
 					const type = formatName;
+
+					// Has to be defined here, as adding it to __experimentalGetPropsForEditableTreePreparation
+					// causes an issue with the block inserter. ref p1721746774569699-slack-C054LN8RNVA
+					const currentMd5 = ( globalSelect( 'jetpack/ai-breve' ) as BreveSelect ).getBlockMd5(
+						formatName,
+						blockClientId
+					);
 
 					if ( text && isProofreadEnabled && isFeatureEnabled ) {
 						const block = globalSelect( 'core/block-editor' ).getBlock( blockClientId );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves a call for the state check to the `__experimentalCreatePrepareEditableTree` function.
* Fixes the issue where typing `/ai` closed the block inserter when Breve is enabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor with Breve and its features enabled
* Type /ai
* Check that the AI Assistant is displayed on the block inserter
