### PR TITLE
AI Logo Generator: open logo generator modal when logo block extension is clicked

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-connect-logo-generator-to-block-extension
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-connect-logo-generator-to-block-extension
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Logo Generator: make the initial prompt update when the site name and description are fully laoded from store.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.15.0",
+	"version": "0.15.1-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -128,7 +128,7 @@ Site description: ${ description }`;
 				throw error;
 			}
 		},
-		[ setFirstLogoPromptFetchError, increaseAiAssistantRequestsCount ]
+		[ setFirstLogoPromptFetchError, increaseAiAssistantRequestsCount, name, description ]
 	);
 
 	const enhancePrompt = async function ( { prompt }: { prompt: string } ): Promise< string > {

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-connect-logo-generator-to-block-extension
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-connect-logo-generator-to-block-extension
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: connect the site logo block extension to AI Logo Generator modal.

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -4,6 +4,7 @@
 import { GeneratorModal } from '@automattic/jetpack-ai-client';
 import { BlockControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 /*
@@ -12,6 +13,34 @@ import { addFilter } from '@wordpress/hooks';
 import { getFeatureAvailability } from '../../blocks/ai-assistant/lib/utils/get-feature-availability';
 import AiToolbarButton from './components/ai-toolbar-button.js';
 import { SITE_LOGO_BLOCK_AI_EXTENSION } from './constants.js';
+
+/**
+ * Mininal type definition for the core select function.
+ */
+type CoreSelect = {
+	getEntityRecord: (
+		kind: string,
+		name: string
+	) => {
+		url: string;
+		title: string;
+		description: string;
+	};
+};
+
+const useSiteDetails = () => {
+	const siteSettings = useSelect( select => {
+		return ( select( 'core' ) as CoreSelect ).getEntityRecord( 'root', 'site' );
+	}, [] );
+
+	return {
+		ID: parseInt( window?.Jetpack_Editor_Initial_State?.wpcomBlogId ),
+		URL: siteSettings?.url,
+		domain: window?.Jetpack_Editor_Initial_State?.siteFragment,
+		name: siteSettings?.title,
+		description: siteSettings?.description,
+	};
+};
 
 /**
  * HOC to add the AI button on the Site Logo toolbar.
@@ -35,13 +64,7 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			};
 		}, [ closeModal ] );
 
-		const siteDetails = {
-			ID: parseInt( window?.Jetpack_Editor_Initial_State?.wpcomBlogId ),
-			URL: window?.Jetpack_Editor_Initial_State?.siteFragment,
-			domain: window?.Jetpack_Editor_Initial_State?.siteFragment,
-			name: '',
-			description: '',
-		};
+		const siteDetails = useSiteDetails();
 
 		return (
 			<>

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -1,12 +1,11 @@
 /*
  * External dependencies
  */
+import { GeneratorModal } from '@automattic/jetpack-ai-client';
 import { BlockControls } from '@wordpress/block-editor';
-import { Modal } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
-import { __ } from '@wordpress/i18n';
 /*
  * Internal dependencies
  */
@@ -36,17 +35,26 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			};
 		}, [ closeModal ] );
 
+		const siteDetails = {
+			ID: parseInt( window?.Jetpack_Editor_Initial_State?.wpcomBlogId ),
+			URL: window?.Jetpack_Editor_Initial_State?.siteFragment,
+			domain: window?.Jetpack_Editor_Initial_State?.siteFragment,
+			name: '',
+			description: '',
+		};
+
 		return (
 			<>
 				<BlockEdit { ...props } />
 				<BlockControls group="block">
 					<AiToolbarButton clickHandler={ showModal } />
 				</BlockControls>
-				{ isLogoGeneratorModalVisible && (
-					<Modal title={ __( 'Coming soon', 'jetpack' ) } onRequestClose={ closeModal }>
-						<p>{ __( 'Coming soon', 'jetpack' ) }</p>
-					</Modal>
-				) }
+				<GeneratorModal
+					isOpen={ isLogoGeneratorModalVisible }
+					onClose={ closeModal }
+					context="block-editor"
+					siteDetails={ siteDetails }
+				/>
 			</>
 		);
 	};

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -1,15 +1,13 @@
 /**
  * External dependencies
  */
-import { GeneratorModal } from '@automattic/jetpack-ai-client';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { PanelBody, PanelRow, BaseControl, Button } from '@wordpress/components';
+import { PanelBody, PanelRow, BaseControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { PluginPrePublishPanel, PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
-import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import React from 'react';
@@ -52,23 +50,13 @@ const isAITitleOptimizationAvailable =
 	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'ai-title-optimization' ]?.available ||
 	false;
 
-const siteDetails = {
-	ID: parseInt( window?.Jetpack_Editor_Initial_State?.wpcomBlogId ),
-	URL: window?.Jetpack_Editor_Initial_State?.siteFragment,
-	domain: window?.Jetpack_Editor_Initial_State?.siteFragment,
-	name: '',
-	description: '',
-};
-
 const JetpackAndSettingsContent = ( {
 	placement,
 	requireUpgrade,
 	upgradeType,
 }: JetpackSettingsContentProps ) => {
 	const isBreveAvailable = getFeatureAvailability( 'ai-proofread-breve' );
-	const isLogoGeneratorAvailable = getFeatureAvailability( 'ai-assistant-site-logo-support' );
 	const { checkoutUrl } = useAICheckout();
-	const [ showLogoGeneratorModal, setShowLogoGeneratorModal ] = useState( false );
 
 	return (
 		<>
@@ -103,28 +91,6 @@ const JetpackAndSettingsContent = ( {
 			{ requireUpgrade && ! isUsagePanelAvailable && (
 				<PanelRow>
 					<Upgrade placement={ placement } type={ upgradeType } upgradeUrl={ checkoutUrl } />
-				</PanelRow>
-			) }
-			{ isLogoGeneratorAvailable && (
-				<PanelRow className="jetpack-ai-logo-generator-control__header">
-					<BaseControl label={ __( 'AI Logo Generator', 'jetpack' ) }>
-						<GeneratorModal
-							isOpen={ showLogoGeneratorModal }
-							onClose={ () => setShowLogoGeneratorModal( false ) }
-							context="jetpack-ai-sidebar"
-							siteDetails={ siteDetails }
-						/>
-
-						<p>
-							{ __(
-								'Experimental panel to trigger the logo generator modal. Will be dropped after the extension is ready.',
-								'jetpack'
-							) }
-						</p>
-						<Button variant="secondary" onClick={ () => setShowLogoGeneratorModal( true ) }>
-							{ __( 'Generate Logo', 'jetpack' ) }
-						</Button>
-					</BaseControl>
 				</PanelRow>
 			) }
 			{ isUsagePanelAvailable && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38432.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When the block extension button is clicked, trigger the logo generator modal

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Setup:

* Enable beta extensions
* Make sure your testing site has a name and a description; you can set it on WP-Admin, on the Settings menu
* Clean your site's logo generation history on the local storage (look for a `logo-history-SITE_ID` property and, if present, delete it)
* Add a paid Jetpack AI plan to your site, if it does not have one yet (see the notes at the end of the instructions to understand why)

Testing:

* Go to block editor and insert a site logo block
* Look for the AI extension on the logo block toolbar and click it

<img width="200" alt="Screenshot 2024-07-23 at 18 04 44" src="https://github.com/user-attachments/assets/e1677ef5-8b67-4970-b582-76c1397766bf">

* Confirm the logo generator modal will show up
* On the first time opening the tool:
   * confirm it will start generating the first logo automatically
   * confirm your site name and description are taken into account while generating the first option

_First example:_

| Request containing site info | Site info present on the prompt |
| --- | --- |
| <img width="500" alt="Screenshot 2024-07-23 at 18 01 30" src="https://github.com/user-attachments/assets/ab84c4f3-16b0-493e-ab5d-c7e75475127c"> | <img width="500" alt="Screenshot 2024-07-23 at 18 02 40" src="https://github.com/user-attachments/assets/b1261b13-ce3c-45a2-a20c-4cd018d53b77"> |

_Another example:_

| Request containing site info | Site info present on the prompt |
| --- | --- |
| <img width="500" alt="Screenshot 2024-07-23 at 18 11 34" src="https://github.com/user-attachments/assets/a0a1c907-c3be-495f-a80b-08c1f728d31a"> | <img width="500" alt="Screenshot 2024-07-23 at 18 12 02" src="https://github.com/user-attachments/assets/d989c524-a191-469e-b9f1-9040d3afda89"> |

* Confirm you can generate more logos by typing a prompt on the proper field

<img width="500" alt="Screenshot 2024-07-23 at 18 03 38" src="https://github.com/user-attachments/assets/3f214068-20ba-428f-8358-18449303b2ed">

* Confirm you can close the modal and open it again; when doing it:
   * confirm you see the logo generation history
   * confirm you can keep generating logos as long as you have requests available
* Do the test on a Simple site as well

Notes:

* the "Use on site" button is not working yet, it will be handled on a follow up
* the track events being fired may have the wrong `placement` value, it will also be handled on a follow up (we have tasks for both on the board)
* the tool will not work for sites on the free plan; there is a check that will show a small message when the site is free, this is the original business decision from Calypso, I plan to remove it on a follow up since we can allow free users to generate images, as long as they have enought requests on the balance