### PR TITLE
Masterbar - Show the notification bell always

### DIFF
--- a/projects/plugins/jetpack/changelog/update-show-notification-bell-always
+++ b/projects/plugins/jetpack/changelog/update-show-notification-bell-always
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Show the notification bell always

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -232,21 +232,6 @@ class Jetpack_Notifications {
 	var wpNotesLinkAccountsURL = '<?php echo esc_url( $link_accounts_url ); ?>';
 <?php endif; ?>
 /* ]]> */
-	window.addEventListener('message', function ( event ) {
-		// Confirm that the message is from the right origin.
-		if ('https://widgets.wp.com' !== event.origin) {
-			return;
-		}
-		// Check whether 3rd Party Cookies are blocked
-		var has3PCBlocked = 'WPCOM:3PC:blocked' === event.data;
-
-		var tagerElement = document.getElementById('wp-admin-bar-notes');
-
-		if ( has3PCBlocked && tagerElement ) {
-			// Hide the notification button/icon
-			tagerElement.style.display = 'none';
-		}
-	}, false );
 </script>
 		<?php
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to 
- https://github.com/Automattic/dotcom-forge/issues/8061

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR changes to always show the notification bell regardless of third-party cookies. When it cannot access third-party cookies, it redirects users to `wordpress.com/read/notifications`. See https://github.com/Automattic/dotcom-forge/issues/8061 for more context. 

### How?

I removed the code added in https://github.com/Automattic/dotcom-forge/issues/8061.

The notification bell was hidden by https://github.com/Automattic/jetpack/pull/25448 and D85866-code, but we now have D148831-code to redirect users to `wordpress.com/read/notifications` when clicking the bell. 

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to /wp-admin
* Click the bell
* Observe the notification panel is displayed
* Open chrome://settings/cookies, set "Block third-party cookies", and reload the tab
* Observe the bell is still displayed
* Click the bell
* Observe it redirects to https://wordpress.com/read/notifications