### PR TITLE
WPCOM API: Return actual value instead of bool for some settings after update

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-wpcom-api-responses
+++ b/projects/plugins/jetpack/changelog/update-fix-wpcom-api-responses
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WPCOM API: Return actial value instead of bool for some settings after update

--- a/projects/plugins/jetpack/changelog/update-fix-wpcom-api-responses
+++ b/projects/plugins/jetpack/changelog/update-fix-wpcom-api-responses
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-WPCOM API: Return actial value instead of bool for some settings after update
+WPCOM API: Return actual value instead of bool for some settings after update

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1018,10 +1018,10 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'jetpack_subscriptions_reply_to':
 					require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
 					$to_set_value = Automattic\Jetpack\Modules\Subscriptions\Settings::is_valid_reply_to( $value )
-						? $value
+						? (string) $value
 						: Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();
 
-					if ( update_option( $key, (string) $to_set_value ) ) {
+					if ( update_option( $key, $to_set_value ) ) {
 						$updated[ $key ] = $to_set_value;
 					}
 					break;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1005,7 +1005,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 
 				case 'rss_use_excerpt':
-					$sanitized_value = (bool) $value;
+					$sanitized_value = (int) (bool) $value;
 					update_option( $key, $sanitized_value );
 					$updated[ $key ] = $sanitized_value;
 					break;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1005,7 +1005,9 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 
 				case 'rss_use_excerpt':
-					update_option( 'rss_use_excerpt', (int) (bool) $value );
+					$sanitized_value = (bool) $value;
+					update_option( $key, $sanitized_value );
+					$updated[ $key ] = $sanitized_value;
 					break;
 
 				case 'wpcom_subscription_emails_use_excerpt':
@@ -1019,13 +1021,16 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						? $value
 						: Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();
 
-					update_option( 'jetpack_subscriptions_reply_to', (string) $to_set_value );
-					$updated[ $key ] = (bool) $value;
+					if ( update_option( $key, (string) $to_set_value ) ) {
+						$updated[ $key ] = $to_set_value;
+					}
 					break;
+
 				case 'jetpack_subscriptions_from_name':
-					$to_set_value = sanitize_text_field( $value );
-					update_option( 'jetpack_subscriptions_from_name', (string) $to_set_value );
-					$updated[ $key ] = (bool) $value;
+					$sanitized_value = sanitize_text_field( $value );
+					if ( update_option( $key, $sanitized_value ) ) {
+						$updated[ $key ] = $sanitized_value;
+					}
 					break;
 
 				case 'instant_search_enabled':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/92908

## Proposed changes:

Fixes the WPCOM API response for some settings by returning an actual setting value instead of true/false after the setting is updated.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* apply this change to your sandbox
* sandbox `public-api.wordpress.com`
* go to Newsletter Settings page https://wordpress.com/settings/newsletter/{siteUrl}
* change "Sender name" setting
* save settings
* navigate to a different page
* make sure the "You have unsaved changes. Are you sure you want to leave this page?" confirm window is not visible
* repeat with "Reply-to settings" setting

The `rss_use_excerpt` setting requires some additional changes in the Calypso repo to work correctly. I'll open a followup PR with the fix.