### PR TITLE
Jetpack: add My Jetpack availability to Jetpack editor initial state

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-editor-state-my-jetpack-availability
+++ b/projects/plugins/jetpack/changelog/add-jetpack-editor-state-my-jetpack-availability
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack Editor State: add is_my_jetpack_available to initial state

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
+use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Dismissed_Notices;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
@@ -718,6 +719,9 @@ class Jetpack_Gutenberg {
 				'is_coming_soon'                => $status->is_coming_soon(),
 				'is_offline_mode'               => $status->is_offline_mode(),
 				'is_newsletter_feature_enabled' => class_exists( '\Jetpack_Memberships' ),
+				// this is the equivalent of JP initial state siteData.showMyJetpack (class-jetpack-redux-state-helper)
+				// used to determine if we can link to My Jetpack from the block editor
+				'is_my_jetpack_available'       => My_Jetpack_Initializer::should_initialize(),
 				/**
 				 * Enable the RePublicize UI in the block editor context.
 				 *


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack-roadmap/issues/1723 & https://github.com/Automattic/jetpack-roadmap/issues/1722

## Proposed changes:
This PR adds is_my_jetpack_available to the initial editor state under `jetpack` data tree. It should be used to know in advance if we can direct the user to any of My Jetpack's product pages/interstitials.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to the editor, open the devtools and check the value of `Jetpack_Editor_Initial_State.jetpack.is_my_jetpack_available`. The property should exist and its value should reflect if My Jetpack is available depending on the site type.