### PR TITLE
Assistant: Disable long sentences Breve feature by default

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-disable-long-sentences-default
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-disable-long-sentences-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Disable long sentences Breve feature by default

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/complex-words/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/complex-words/index.ts
@@ -15,6 +15,7 @@ export const COMPLEX_WORDS: BreveFeatureConfig = {
 	title: 'Complex words',
 	tagName: 'span',
 	className: 'has-proofread-highlight--complex-words',
+	defaultEnabled: true,
 };
 
 const list = new RegExp(

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/long-sentences/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/long-sentences/index.ts
@@ -12,6 +12,7 @@ export const LONG_SENTENCES: BreveFeatureConfig = {
 	title: 'Long sentences',
 	tagName: 'span',
 	className: 'has-proofread-highlight--long-sentences',
+	defaultEnabled: false,
 };
 
 const sentenceRegex = /[^\s][^.!?]+[.!?]+/g;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/unconfident-words/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/unconfident-words/index.ts
@@ -13,6 +13,7 @@ export const UNCONFIDENT_WORDS: BreveFeatureConfig = {
 	title: 'Unconfident words',
 	tagName: 'span',
 	className: 'has-proofread-highlight--unconfident-words',
+	defaultEnabled: true,
 };
 
 const list = new RegExp( `\\b(${ words.map( escapeRegExp ).join( '|' ) })\\b`, 'gi' );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/reducer.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/reducer.ts
@@ -3,6 +3,10 @@
  */
 import { combineReducers } from '@wordpress/data';
 /**
+ * Internal dependencies
+ */
+import features from '../features';
+/**
  * Types
  */
 import type { BreveState } from '../types';
@@ -14,7 +18,11 @@ const disabledFeaturesFromLocalStorage = window.localStorage.getItem(
 const initialConfiguration = {
 	enabled: enabledFromLocalStorage === 'true' || enabledFromLocalStorage === null,
 	disabled:
-		disabledFeaturesFromLocalStorage !== null ? JSON.parse( disabledFeaturesFromLocalStorage ) : [],
+		disabledFeaturesFromLocalStorage !== null
+			? JSON.parse( disabledFeaturesFromLocalStorage )
+			: features
+					.filter( feature => ! feature.config.defaultEnabled )
+					.map( feature => feature.config.name ),
 };
 
 export function configuration(

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
@@ -91,6 +91,7 @@ export type BreveFeatureConfig = {
 	title: string;
 	tagName: string;
 	className: string;
+	defaultEnabled: boolean;
 };
 
 export type BreveFeature = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disables long sentences by default

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Delete the `jetpack-ai-breve-disabled-features` entry from localStorage if there is one
* Reload the page
* Check that Complex words and Unconfident words are turned on by default, but not long sentences

