### PR TITLE
Fix: My Jetpack Social plan showing no paid plan with Jetpack legacy plans

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-mj-social-card-showing-no-plan-with-legacy-plans
+++ b/projects/packages/my-jetpack/changelog/fix-mj-social-card-showing-no-plan-with-legacy-plans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Include Jetpack Legacy plans when checking if user has social included with plan

--- a/projects/packages/my-jetpack/src/products/class-anti-spam.php
+++ b/projects/packages/my-jetpack/src/products/class-anti-spam.php
@@ -113,6 +113,14 @@ class Anti_Spam extends Product {
 	 * @return bool - whether an API key was found
 	 */
 	public static function has_paid_plan_for_product() {
+		$products_with_anti_spam = array(
+			'jetpack_anti_spam',
+			'jetpack_complete',
+			'jetpack_security',
+			'jetpack_personal',
+			'jetpack_premium',
+			'jetpack_business',
+		);
 		// Check if the site has an API key for Akismet
 		$akismet_api_key = apply_filters( 'akismet_get_api_key', defined( 'WPCOM_API_KEY' ) ? constant( 'WPCOM_API_KEY' ) : get_option( 'wordpress_api_key' ) );
 		$fallback        = ! empty( $akismet_api_key );
@@ -125,13 +133,10 @@ class Anti_Spam extends Product {
 
 		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
 			foreach ( $purchases_data as $purchase ) {
-				// Anti-spam is available as standalone bundle and as part of the Security and Complete plans.
-				if (
-					strpos( $purchase->product_slug, 'jetpack_anti_spam' ) !== false ||
-					str_starts_with( $purchase->product_slug, 'jetpack_complete' ) ||
-					str_starts_with( $purchase->product_slug, 'jetpack_security' )
-				) {
-					return true;
+				foreach ( $products_with_anti_spam as $product ) {
+					if ( strpos( $purchase->product_slug, $product ) !== false ) {
+						return true;
+					}
 				}
 			}
 		}

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -267,19 +267,24 @@ class Protect extends Product {
 	 * @return boolean
 	 */
 	public static function has_paid_plan_for_product() {
+		$plans_with_scan = array(
+			'jetpack_scan',
+			'jetpack_security',
+			'jetpack_complete',
+			'jetpack_premium',
+			'jetpack_business',
+		);
+
 		$purchases_data = Wpcom_Products::get_site_current_purchases();
 		if ( is_wp_error( $purchases_data ) ) {
 			return false;
 		}
 		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
 			foreach ( $purchases_data as $purchase ) {
-				// Protect is available as jetpack_scan product and as part of the Security or Complete plan.
-				if (
-					strpos( $purchase->product_slug, 'jetpack_scan' ) !== false ||
-					str_starts_with( $purchase->product_slug, 'jetpack_security' ) ||
-					str_starts_with( $purchase->product_slug, 'jetpack_complete' )
-				) {
-					return true;
+				foreach ( $plans_with_scan as $plan ) {
+					if ( strpos( $purchase->product_slug, $plan ) !== false ) {
+						return true;
+					}
 				}
 			}
 		}

--- a/projects/packages/my-jetpack/src/products/class-social.php
+++ b/projects/packages/my-jetpack/src/products/class-social.php
@@ -150,6 +150,13 @@ class Social extends Hybrid_Product {
 	 * @return boolean
 	 */
 	public static function has_paid_plan_for_product() {
+		$plans_with_social = array(
+			'jetpack_social',
+			'jetpack_complete',
+			'jetpack_business',
+			'jetpack_premium',
+			'jetpack_personal',
+		);
 		// For atomic sites, do a feature check to see if the republicize feature is available
 		// This feature is available by default on all Jetpack sites
 		if ( ( new Host() )->is_woa_site() ) {
@@ -160,11 +167,13 @@ class Social extends Hybrid_Product {
 		if ( is_wp_error( $purchases_data ) ) {
 			return false;
 		}
+
 		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
 			foreach ( $purchases_data as $purchase ) {
-				// Social is available as standalone bundle and as part of the Complete plan.
-				if ( strpos( $purchase->product_slug, 'jetpack_social' ) !== false || str_starts_with( $purchase->product_slug, 'jetpack_complete' ) ) {
-					return true;
+				foreach ( $plans_with_social as $plan ) {
+					if ( strpos( $purchase->product_slug, $plan ) !== false ) {
+						return true;
+					}
 				}
 			}
 		}

--- a/projects/packages/my-jetpack/src/products/class-videopress.php
+++ b/projects/packages/my-jetpack/src/products/class-videopress.php
@@ -179,14 +179,22 @@ class Videopress extends Hybrid_Product {
 	 * @return boolean
 	 */
 	public static function has_paid_plan_for_product() {
-		$purchases_data = Wpcom_Products::get_site_current_purchases();
+		$plans_with_videopress = array(
+			'jetpack_videopress',
+			'jetpack_complete',
+			'jetpack_business',
+			'jetpack_premium',
+		);
+		$purchases_data        = Wpcom_Products::get_site_current_purchases();
 		if ( is_wp_error( $purchases_data ) ) {
 			return false;
 		}
 		if ( is_array( $purchases_data ) && ! empty( $purchases_data ) ) {
 			foreach ( $purchases_data as $purchase ) {
-				if ( str_contains( $purchase->product_slug, 'jetpack_videopress' ) || str_starts_with( $purchase->product_slug, 'jetpack_complete' ) ) {
-					return true;
+				foreach ( $plans_with_videopress as $plan ) {
+					if ( strpos( $purchase->product_slug, $plan ) !== false ) {
+						return true;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Proposed changes:

* Check for Jetpack Legacy plans with Social included when determining whether user has paid plan for social or  not

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1719203892478369-slack-C01264051NE

## Does this pull request change what data or activity we track or use?

No

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Assign a Jetpack Personal, Premium, or Professional plan to your site
3. Go to My Jetpack and log `myJetpackInitialState.products.items.social` to the console and ensure that `has_paid_plan_for_product` is true
![Screenshot 2024-07-24 at 12 11 23 PM](https://github.com/user-attachments/assets/93318c72-2ef8-4578-a863-4fffe31e5461)
4. Social does not require the standalone plugin so you should be able to activate the card from My Jetpack and it should show up in your owned products
![image](https://github.com/user-attachments/assets/9d4c7316-ea2d-4129-a0f6-f448fc35f89f)
