### PR TITLE
Sync Package: Replace use of Brute_Force_Protection class with a filter hook

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-remove-waf-class-usage
+++ b/projects/packages/sync/changelog/fix-sync-remove-waf-class-usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync: Fix integration of Brute Force Login Protection

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.5.0';
+	const PACKAGE_VERSION = '3.5.1-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/modules/class-protect.php
+++ b/projects/packages/sync/src/modules/class-protect.php
@@ -68,7 +68,7 @@ class Protect extends Module {
 		 *
 		 * Example: When Jetpack's Brute Force Login Protection is active, this filter will return false if the user is currently locked out.
 		 *
-		 * @since $next-version$
+		 * @since $$next-version$$
 		 *
 		 * @package sync
 		 *

--- a/projects/packages/sync/src/modules/class-protect.php
+++ b/projects/packages/sync/src/modules/class-protect.php
@@ -44,11 +44,14 @@ class Protect extends Module {
 	 * @access private
 	 */
 	private function has_login_ability_fallback() {
+		// Fall back to the Brute Force Protection class if it is available.
 		if ( class_exists( 'Brute_Force_Protection' ) ) {
 			$brute_force_protection = Brute_Force_Protection::instance();
 			return $brute_force_protection->has_login_ability();
 		}
 
+		// If the login ability can not be determined, the feature is not active,
+		// or something is wrong, default to not syncing failed login attempts.
 		return false;
 	}
 
@@ -60,7 +63,18 @@ class Protect extends Module {
 	 * @param array $failed_attempt Failed attempt data.
 	 */
 	public function maybe_log_failed_login_attempt( $failed_attempt ) {
-		$has_login_ability = apply_filters( 'jpp_has_login_ability', $this->has_login_ability_fallback() );
+		/**
+		 * Filter which provides Jetpack's decision as to whether the current requestor can attempt logging in.
+		 *
+		 * Example: When Jetpack's Brute Force Login Protection is active, this filter will return false if the user is currently locked out.
+		 *
+		 * @since $next-version$
+		 *
+		 * @package sync
+		 *
+		 * @return bool True if the user should be allowed to attempt logging in, false otherwise.
+		 */
+		$has_login_ability = apply_filters( 'jetpack_has_login_ability', $this->has_login_ability_fallback() );
 
 		if ( $has_login_ability && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );

--- a/projects/packages/sync/src/modules/class-protect.php
+++ b/projects/packages/sync/src/modules/class-protect.php
@@ -39,6 +39,20 @@ class Protect extends Module {
 	}
 
 	/**
+	 * Provide a fallback value for has_login_ability.
+	 *
+	 * @access private
+	 */
+	private function has_login_ability_fallback() {
+		if ( class_exists( 'Brute_Force_Protection' ) ) {
+			$brute_force_protection = Brute_Force_Protection::instance();
+			return $brute_force_protection->has_login_ability();
+		}
+
+		return false;
+	}
+
+	/**
 	 * Maybe log a failed login attempt.
 	 *
 	 * @access public
@@ -46,8 +60,9 @@ class Protect extends Module {
 	 * @param array $failed_attempt Failed attempt data.
 	 */
 	public function maybe_log_failed_login_attempt( $failed_attempt ) {
-		$brute_force_protection = Brute_Force_Protection::instance();
-		if ( $brute_force_protection->has_login_ability() && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
+		$has_login_ability = apply_filters( 'jpp_has_login_ability', $this->has_login_ability_fallback() );
+
+		if ( $has_login_ability && ! Jetpack_Constants::is_true( 'XMLRPC_REQUEST' ) ) {
 			do_action( 'jetpack_valid_failed_login_attempt', $failed_attempt );
 		}
 	}

--- a/projects/packages/waf/changelog/fix-sync-remove-waf-class-usage
+++ b/projects/packages/waf/changelog/fix-sync-remove-waf-class-usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Brute Force Protection: Add `jpp_has_login_ability` hook.

--- a/projects/packages/waf/changelog/fix-sync-remove-waf-class-usage
+++ b/projects/packages/waf/changelog/fix-sync-remove-waf-class-usage
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Brute Force Protection: Add `jpp_has_login_ability` hook.
+Brute Force Protection: Add `jetpack_has_login_ability` hook.

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -132,7 +132,7 @@ class Brute_Force_Protection {
 		add_action( 'jetpack_modules_loaded', array( $this, 'modules_loaded' ) );
 		add_action( 'login_form', array( $this, 'check_use_math' ), 0 );
 		add_filter( 'authenticate', array( $this, 'check_preauth' ), 10, 3 );
-		add_filter( 'jpp_has_login_ability', array( $this, 'has_login_ability' ) );
+		add_filter( 'jetpack_has_login_ability', array( $this, 'has_login_ability' ) );
 		add_action( 'wp_login', array( $this, 'log_successful_login' ), 10, 2 );
 		add_action( 'wp_login_failed', array( $this, 'log_failed_attempt' ) );
 		add_action( 'admin_init', array( $this, 'maybe_update_headers' ) );

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -132,6 +132,7 @@ class Brute_Force_Protection {
 		add_action( 'jetpack_modules_loaded', array( $this, 'modules_loaded' ) );
 		add_action( 'login_form', array( $this, 'check_use_math' ), 0 );
 		add_filter( 'authenticate', array( $this, 'check_preauth' ), 10, 3 );
+		add_filter( 'jpp_has_login_ability', array( $this, 'has_login_ability' ) );
 		add_action( 'wp_login', array( $this, 'log_successful_login' ), 10, 2 );
 		add_action( 'wp_login_failed', array( $this, 'log_failed_attempt' ) );
 		add_action( 'admin_init', array( $this, 'maybe_update_headers' ) );

--- a/projects/plugins/jetpack/changelog/fix-sync-remove-waf-class-usage
+++ b/projects/plugins/jetpack/changelog/fix-sync-remove-waf-class-usage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated tests
+
+

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-module-protect.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-module-protect.php
@@ -1,11 +1,19 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
 
 /**
  * Test pluggable functionality for bruteprotect
  */
 class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_Sync_Base {
+
+	public function set_up() {
+		parent::set_up();
+
+		// Ensure the Brute Force Protection module is loaded
+		Brute_Force_Protection::instance();
+	}
 
 	public function test_sends_failed_login_message() {
 		$user_id = self::factory()->user->create();
@@ -15,8 +23,7 @@ class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_Sync_Base {
 		do_action(
 			'jpp_log_failed_attempt',
 			array(
-				'login'             => $user->user_email,
-				'has_login_ability' => true,
+				'login' => $user->user_email,
 			)
 		);
 
@@ -35,8 +42,7 @@ class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_Sync_Base {
 		do_action(
 			'jpp_log_failed_attempt',
 			array(
-				'login'             => $user->user_email,
-				'has_login_ability' => true,
+				'login' => $user->user_email,
 			)
 		);
 		Constants::clear_single_constant( 'XMLRPC_REQUEST' );
@@ -51,8 +57,7 @@ class WP_Test_Jetpack_Sync_Module_Protect extends WP_Test_Jetpack_Sync_Base {
 		do_action(
 			'jpp_log_failed_attempt',
 			array(
-				'login'             => null,
-				'has_login_ability' => true,
+				'login' => null,
 			)
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/38460

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a new `jpp_has_login_ability` filter to the `waf` package.
* Uses the new `jpp_has_login_ability` filter in the `sync` package – when the `waf` package is available, it will provide the computed value through the WordPress hook. If it is unavailable, which technically/ideally should not happen, a default value of `false` is used.
* Keeps the use of `Brute_Force_Protection::has_login_ability()` in the `sync` package, but with a conditional to prevent exceptions. This ensures functionality in cases where the sync package is updated (starts using filter), but the waf package is not (has not started providing filter).

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/issues/38460

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* **Test on a site where the sync package is autoloaded from Jetpack Boost.**
* Install Jetpack (current release) and Jetpack Boost (feature branch) on a JN site.
* Test the brute force login protection feature - repeatedly fail login attempts and verify you are presented the math challenge, and then eventually get hard blocked from accessing the login page.

