### PR TITLE
Add Toolbar proxy notice for Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-profile-toolbar-notice
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-profile-toolbar-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a12n notice about proxied toolbar

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -92,6 +92,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/error-reporting/error-reporting.php';
 		require_once __DIR__ . '/features/first-posts-stream/first-posts-stream-helpers.php';
 		require_once __DIR__ . '/features/font-smoothing-antialiased/font-smoothing-antialiased.php';
+		require_once __DIR__ . '/features/google-analytics/google-analytics.php';
 		require_once __DIR__ . '/features/import-customizations/import-customizations.php';
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';
@@ -99,8 +100,8 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-admin-dashboard/wpcom-admin-dashboard.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';
+		require_once __DIR__ . '/features/wpcom-profile-settings/profile-settings-notices.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-theme-fixes.php';
-		require_once __DIR__ . '/features/google-analytics/google-analytics.php';
 
 		// Initializers, if needed.
 		\Marketplace_Products_Updater::init();

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-notices.php
@@ -2,46 +2,51 @@
 /**
  * Custom notices for wp-admin/profile.php
  *
- * Hooks to add notices to the user Profile page.
- *
  * @package automattic/jetpack-mu-wpcom
  */
 
 /**
- * Adds a notice for Automatticians informing that the Toolbar always shows on the front end on Atomic sites if
- * connected to Autoproxxy.
+ * Adds a notice for Automatticians informing them that the Toolbar always shows on the front end on Atomic sites if
+ * they are connected to Autoproxxy.
  */
-function maybe_show_wpcom_toolbar_autoproxxy_notice() {
-	?>
-	<style>
-		.toolbar-autoproxxy-notice {
-			color: #666;
-			font-style: italic;
-			margin-top: 5px;
-		}
-	</style>
-	<script type="text/javascript">
-		document.addEventListener('DOMContentLoaded', function () {
-			// Find the Toolbar checkbox label container using the unique ID.
-			var toolbarCheckboxLabel = document.querySelector('#admin_bar_front').parentNode;
-			if (toolbarCheckboxLabel) {
-				// Create a new div for the notice.
-				var newDiv = document.createElement('div');
-				newDiv.className = 'toolbar-autoproxxy-notice';
-				newDiv.textContent = 'Toolbar will always be shown under Automattic proxy.';
+function maybe_show_wpcom_toolbar_proxy_notice() {
+	$is_proxied = isset( $_SERVER['A8C_PROXIED_REQUEST'] )
+			? sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) )
+			: defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
+	$is_atomic  = defined( 'IS_ATOMIC' ) && IS_ATOMIC;
 
-				// Insert the new div after the checkbox and label.
-				toolbarCheckboxLabel.appendChild(newDiv);
-
-				// Find and remove the <br> tag following the label to improve spacing.
-				var brElement = toolbarCheckboxLabel.nextSibling;
-				if (brElement && brElement.tagName === 'BR') {
-					brElement.parentNode.removeChild(brElement);
-				}
+	if ( $is_proxied && $is_atomic ) {
+		?>
+		<style>
+			.toolbar-autoproxxy-notice {
+				color: #666;
+				font-style: italic;
+				margin-top: 5px;
 			}
-		});
-	</script>
-	<?php
+		</style>
+		<script type="text/javascript">
+			document.addEventListener('DOMContentLoaded', function () {
+				// Find the Toolbar checkbox label container using the unique ID.
+				var toolbarCheckboxLabel = document.querySelector('#admin_bar_front').parentNode;
+				if (toolbarCheckboxLabel) {
+					// Create a new div for the notice.
+					var newDiv = document.createElement('div');
+					newDiv.className = 'toolbar-autoproxxy-notice';
+					newDiv.textContent = 'The toolbar is always visible on Atomic sites while connected to the Automattic proxy.';
+
+					// Insert the new div after the checkbox and label.
+					toolbarCheckboxLabel.appendChild(newDiv);
+
+					// Find and remove the <br> tag following the label to improve spacing.
+					var brElement = toolbarCheckboxLabel.nextSibling;
+					if (brElement && brElement.tagName === 'BR') {
+						brElement.parentNode.removeChild(brElement);
+					}
+				}
+			});
+		</script>
+		<?php
+	}
 }
 
-add_action( 'admin_footer-profile.php', 'maybe_show_wpcom_toolbar_autoproxxy_notice' );
+add_action( 'admin_footer-profile.php', 'maybe_show_wpcom_toolbar_proxy_notice' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-notices.php
@@ -32,7 +32,7 @@ function maybe_show_wpcom_toolbar_proxy_notice() {
 					// Create a new div for the notice.
 					var newDiv = document.createElement('div');
 					newDiv.className = 'toolbar-autoproxxy-notice';
-					newDiv.textContent = 'The toolbar is always visible on Atomic sites while connected to the Automattic proxy.';
+					newDiv.textContent = '<?php echo esc_js( __( 'The toolbar is always visible on Atomic sites while connected to the Automattic proxy.', 'jetpack-mu-wpcom' ) ); ?>'
 
 					// Insert the new div after the checkbox and label.
 					toolbarCheckboxLabel.appendChild(newDiv);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-notices.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Custom notices for wp-admin/profile.php
+ *
+ * Hooks to add notices to the user Profile page.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Adds a notice for Automatticians informing that the Toolbar always shows on the front end on Atomic sites if
+ * connected to Autoproxxy.
+ */
+function maybe_show_wpcom_toolbar_autoproxxy_notice() {
+	?>
+	<style>
+		.toolbar-autoproxxy-notice {
+			color: #666;
+			font-style: italic;
+			margin-top: 5px;
+		}
+	</style>
+	<script type="text/javascript">
+		document.addEventListener('DOMContentLoaded', function () {
+			// Find the Toolbar checkbox label container using the unique ID.
+			var toolbarCheckboxLabel = document.querySelector('#admin_bar_front').parentNode;
+			if (toolbarCheckboxLabel) {
+				// Create a new div for the notice.
+				var newDiv = document.createElement('div');
+				newDiv.className = 'toolbar-autoproxxy-notice';
+				newDiv.textContent = 'Toolbar will always be shown under Automattic proxy.';
+
+				// Insert the new div after the checkbox and label.
+				toolbarCheckboxLabel.appendChild(newDiv);
+
+				// Find and remove the <br> tag following the label to improve spacing.
+				var brElement = toolbarCheckboxLabel.nextSibling;
+				if (brElement && brElement.tagName === 'BR') {
+					brElement.parentNode.removeChild(brElement);
+				}
+			}
+		});
+	</script>
+	<?php
+}
+
+add_action( 'admin_footer-profile.php', 'maybe_show_wpcom_toolbar_autoproxxy_notice' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-notices.php
@@ -32,7 +32,7 @@ function maybe_show_wpcom_toolbar_proxy_notice() {
 					// Create a new div for the notice.
 					var newDiv = document.createElement('div');
 					newDiv.className = 'toolbar-autoproxxy-notice';
-					newDiv.textContent = '<?php echo esc_js( __( 'The toolbar is always visible on Atomic sites while connected to the Automattic proxy.', 'jetpack-mu-wpcom' ) ); ?>'
+					newDiv.textContent = '<?php echo esc_js( __( 'The Toolbar is always visible on Atomic sites while connected to the Automattic proxy.', 'jetpack-mu-wpcom' ) ); ?>'
 
 					// Insert the new div after the checkbox and label.
 					toolbarCheckboxLabel.appendChild(newDiv);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7622

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds a notice in profile.php for a12ns informing them that the Toolbar is always visible on Atomic sites when connected to the a8c proxy. This is due to the debug-bar-loader plugin forcing the toolbar to be enabled. p1714985574878659-slack-C7YPW6K40
* The message shown below is visible when proxied on Atomic sites.

No proxy & Simple sites | Proxied Atomic sites
--|--
<img width="744" alt="Screenshot 2024-07-24 at 3 55 45 PM" src="https://github.com/user-attachments/assets/0253e357-8a56-4c85-b86d-0bd3393525a1"> | <img width="804" alt="Screenshot 2024-07-24 at 3 55 32 PM" src="https://github.com/user-attachments/assets/baba5fde-b1c9-47d0-9ae8-e91b63f7587a">




### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this PR using the [instructions below](https://github.com/Automattic/jetpack/pull/38519#issuecomment-2248887368).
* On your test Atomic site go to /wp-admin/profile.php while connected to the proxy. You should see the notice mentioned above.
* Disconnect from the proxy and refresh the page. The notice should not be visible.
* On a test Classic Simple site, go to /wp-admin/profile.php while connected to the proxy. You should NOT see the notice because Simple sites do not load the debug-bar-loader plugin, so we do not need to show it, as the toolbar works as expected.