### PR TITLE
AI Assistant: Remove Breve readability star

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-remove-star
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-remove-star
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Remove Breve readability star

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
@@ -29,8 +29,4 @@
 		flex-direction: column;
 		gap: 12px;
 	}
-
-	.grade-level-container {
-		display: flex;
-	}
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
@@ -2,7 +2,13 @@
  * WordPress dependencies
  */
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { BaseControl, PanelRow, CheckboxControl, ToggleControl } from '@wordpress/components';
+import {
+	BaseControl,
+	PanelRow,
+	CheckboxControl,
+	ToggleControl,
+	Tooltip,
+} from '@wordpress/components';
 import { compose, useDebounce } from '@wordpress/compose';
 import { useDispatch, useSelect, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -81,20 +87,22 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 			<PanelRow>
 				<BaseControl>
 					<div className="grade-level-container">
-						<p>
-							{ gradeLevel === null ? (
+						{ gradeLevel === null ? (
+							<p>
 								<em className="breve-help-text">
 									{ __( 'Write some words to see your grade level.', 'jetpack' ) }
 								</em>
-							) : (
-								<>
+							</p>
+						) : (
+							<Tooltip text={ __( 'To make it easy to read, aim for level 8-12', 'jetpack' ) }>
+								<p>
 									{ gradeLevel }
 									<span className="jetpack-ai-proofread__grade-label">
 										{ __( 'Readability score', 'jetpack' ) }
 									</span>
-								</>
-							) }
-						</p>
+								</p>
+							</Tooltip>
+						) }
 					</div>
 				</BaseControl>
 			</PanelRow>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
@@ -83,7 +83,9 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 					<div className="grade-level-container">
 						<p>
 							{ gradeLevel === null ? (
-								<em className="breve-help-text">Write some words to see your grade&nbsp;level.</em>
+								<em className="breve-help-text">
+									{ __( 'Write some words to see your grade level.', 'jetpack' ) }
+								</em>
 							) : (
 								<>
 									{ gradeLevel }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
@@ -2,14 +2,7 @@
  * WordPress dependencies
  */
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import {
-	BaseControl,
-	PanelRow,
-	SVG,
-	Path,
-	CheckboxControl,
-	ToggleControl,
-} from '@wordpress/components';
+import { BaseControl, PanelRow, CheckboxControl, ToggleControl } from '@wordpress/components';
 import { compose, useDebounce } from '@wordpress/compose';
 import { useDispatch, useSelect, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -88,17 +81,6 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 			<PanelRow>
 				<BaseControl>
 					<div className="grade-level-container">
-						{ gradeLevel !== null && gradeLevel <= 12 && (
-							<>
-								<SVG xmlns="http://www.w3.org/2000/svg" width={ 16 } height={ 15 } fill="none">
-									<Path
-										fill="#000"
-										d="M7.776.454a.25.25 0 0 1 .448 0l2.069 4.192a.25.25 0 0 0 .188.137l4.626.672a.25.25 0 0 1 .139.426l-3.348 3.263a.251.251 0 0 0-.072.222l.79 4.607a.25.25 0 0 1-.362.263l-4.138-2.175a.25.25 0 0 0-.232 0l-4.138 2.175a.25.25 0 0 1-.363-.263l.79-4.607a.25.25 0 0 0-.071-.222L.754 5.881a.25.25 0 0 1 .139-.426l4.626-.672a.25.25 0 0 0 .188-.137L7.776.454Z"
-									/>
-								</SVG>
-								&nbsp;
-							</>
-						) }
 						<p>
 							{ gradeLevel === null ? (
 								<em className="breve-help-text">Write some words to see your grade&nbsp;level.</em>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/complex-words/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/complex-words/index.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
  * Internal dependencies
  */
 import { escapeRegExp } from '../../utils/escapeRegExp';
@@ -12,7 +16,7 @@ export const dictionary = phrases;
 
 export const COMPLEX_WORDS: BreveFeatureConfig = {
 	name: 'complex-words',
-	title: 'Complex words',
+	title: __( 'Complex words', 'jetpack' ),
 	tagName: 'span',
 	className: 'has-proofread-highlight--complex-words',
 	defaultEnabled: true,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/long-sentences/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/long-sentences/index.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
  * Internal dependencies
  */
 import { escapeRegExp } from '../../utils/escapeRegExp';
@@ -9,7 +13,7 @@ import type { BreveFeatureConfig, HighlightedText } from '../../types';
 
 export const LONG_SENTENCES: BreveFeatureConfig = {
 	name: 'long-sentences',
-	title: 'Long sentences',
+	title: __( 'Long sentences', 'jetpack' ),
 	tagName: 'span',
 	className: 'has-proofread-highlight--long-sentences',
 	defaultEnabled: false,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/unconfident-words/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/unconfident-words/index.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
  * Internal dependencies
  */
 import { escapeRegExp } from '../../utils/escapeRegExp';
@@ -10,7 +14,7 @@ import type { BreveFeatureConfig, HighlightedText } from '../../types';
 
 export const UNCONFIDENT_WORDS: BreveFeatureConfig = {
 	name: 'unconfident-words',
-	title: 'Unconfident words',
+	title: __( 'Unconfident words', 'jetpack' ),
 	tagName: 'span',
 	className: 'has-proofread-highlight--unconfident-words',
 	defaultEnabled: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38502
Fixes #38511

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the star icon
* Fix untranslated strings
* Adds a tooltip on the readability text

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and add just enough content to have a low readability score
* Check that the star is not there anymore

| Before | After |
| - | - |
| ![2024-07-24_19-09-29](https://github.com/user-attachments/assets/d26d8ea1-1a71-46ec-a554-5b0cbb1a6bd2) | ![2024-07-24_19-16-24](https://github.com/user-attachments/assets/5369d583-db48-4ddf-b0d9-6199a453d21a) |

