### PR TITLE
Fix class-wpcom-admin-bar.php fatal error

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-error
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix fatal error in admin bar

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php
@@ -60,6 +60,11 @@ class WPCOM_Admin_Bar extends \WP_Admin_Bar {
 	 * }
 	 */
 	public function add_node( $args ) {
+		// Ensure $args is an array.
+		if ( is_object( $args ) ) {
+			$args = (array) $args;
+		}
+
 		if ( empty( $args['href'] ) ) {
 			parent::add_node( $args );
 			return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php
@@ -60,12 +60,7 @@ class WPCOM_Admin_Bar extends \WP_Admin_Bar {
 	 * }
 	 */
 	public function add_node( $args ) {
-		// Ensure $args is an array.
-		if ( is_object( $args ) ) {
-			$args = (array) $args;
-		}
-
-		if ( empty( $args['href'] ) ) {
+		if ( ! is_array( $args ) || empty( $args['href'] ) ) {
 			parent::add_node( $args );
 			return;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1721840431003479-slack-C02FMH4G8

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We saw the following fatal error with class-wpcom-admin-bar.php while it was in production before it was rolled back.
```
PHP Fatal error:  Uncaught Error: Cannot use object of type stdClass as array in /wordpress/plugins/wpcomsh/5.0.0/vendor/automattic/jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php:63
```

This error can be reproduced on an Atomic site by adding the Elementor plugin.

This PR addresses the fatal error by ensuring $args is an array before continuing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* First, reproduce the original error by using Jetpack Beta plugin and loading the bleeding edge of jetpack-mu-plugin.
* Ensure your test Atomic site is set to the Default admin interface.
* Install the Elementor plugin on your Atomic test site and go a wp-admin page like /wp-admin/plugins.php
* You should receive the fatal error at this point.
* If you go to /_cli on your Atomic site and run the command `wp plugin deactivate elementor` the error should disappear.
* Now use Jetpack Beta plugin to load this PR and re-enable Elementor. (You can use /_cli to do this)
* With this PR loaded go to a wp-admin page like /wp-admin/plugins.php. You should no longer see the fatal error.
* With the fatal error gone, ensure the code still works using these instructions https://github.com/Automattic/jetpack/pull/38377 
* Consider how other plugins might affect this code.