### PR TITLE
AI Assistant: Add feedback link to the sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-sidebar-feedback
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-sidebar-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Add feedback link to the sidebar

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -3,12 +3,13 @@
  */
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { PanelBody, PanelRow, BaseControl } from '@wordpress/components';
+import { PanelBody, PanelRow, BaseControl, Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { PluginPrePublishPanel, PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
+import { Icon, external } from '@wordpress/icons';
 import debugFactory from 'debug';
 import React from 'react';
 /**
@@ -88,15 +89,25 @@ const JetpackAndSettingsContent = ( {
 				</PanelRow>
 			) }
 			{ requireUpgrade && ! isUsagePanelAvailable && (
-				<PanelRow>
+				<PanelRow className="jetpack-ai-upgrade-control__header">
 					<Upgrade placement={ placement } type={ upgradeType } upgradeUrl={ checkoutUrl } />
 				</PanelRow>
 			) }
 			{ isUsagePanelAvailable && (
-				<PanelRow>
+				<PanelRow className="jetpack-ai-usage-control__header">
 					<UsagePanel placement={ placement } />
 				</PanelRow>
 			) }
+
+			<Button
+				variant="link"
+				className="jetpack-ai__feedback-button"
+				href="https://jetpack.com/redirect/?source=jetpack-ai-feedback"
+				target="_blank"
+			>
+				<span>{ __( 'Provide feedback', 'jetpack' ) }</span>
+				<Icon icon={ external } className="icon" />
+			</Button>
 		</>
 	);
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/style.scss
@@ -1,7 +1,9 @@
 .jetpack-ai-logo-generator-control__header,
 .jetpack-ai-feedback__header,
 .jetpack-ai-featured-image-control__header,
-.jetpack-ai-title-optimization__header {
+.jetpack-ai-title-optimization__header,
+.jetpack-ai-upgrade-control__header,
+.jetpack-ai-usage-control__header {
 	margin-bottom: 2em;
 }
 
@@ -10,5 +12,14 @@
 	gap: 16px;
 	.components-toggle-control {
 		margin-bottom: 8px;
+	}
+}
+
+.jetpack-ai__feedback-button {
+	.icon {
+		width: 20px;
+		height: 20px;
+		color: var( --studio-gray-20 );
+		margin-left: 4px;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38523

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the same feedback link from the image modal to the bottom of the sidebar

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Check that there is a feedback link at the bottom of the sidebar

![2024-07-24_20-19-30](https://github.com/user-attachments/assets/f1c94489-3339-47f4-b20a-cbb793e86620)
