### PR TITLE
Shared Extension Utils package: add isMyJetpackAvailable

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/add-shared-extension-util-is-my-jetpack-available
+++ b/projects/js-packages/shared-extension-utils/changelog/add-shared-extension-util-is-my-jetpack-available
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Shared Extension Utils: add isMyJetpackAvailable export

--- a/projects/js-packages/shared-extension-utils/index.js
+++ b/projects/js-packages/shared-extension-utils/index.js
@@ -20,3 +20,4 @@ export { default as JetpackEditorPanelLogo } from './src/components/jetpack-edit
 export { getBlockIconComponent, getBlockIconProp } from './src/get-block-icon-from-metadata';
 export { default as getJetpackBlocksVariation } from './src/get-jetpack-blocks-variation';
 export * from './src/modules-state';
+export { default as isMyJetpackAvailable } from './src/is-my-jetpack-available';

--- a/projects/js-packages/shared-extension-utils/package.json
+++ b/projects/js-packages/shared-extension-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-extension-utils",
-	"version": "0.14.20",
+	"version": "0.15.0-alpha",
 	"description": "Utility functions used by the block editor extensions",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/shared-extension-utils/#readme",
 	"bugs": {

--- a/projects/js-packages/shared-extension-utils/src/is-my-jetpack-available.js
+++ b/projects/js-packages/shared-extension-utils/src/is-my-jetpack-available.js
@@ -1,9 +1,10 @@
 import getJetpackData from './get-jetpack-data';
 
 /**
- * Return whether My Jetpack is available or not.
+ * Return whether My Jetpack is available or not while in editor context.
  *
  * @see https://github.com/Automattic/jetpack/pull/38500 introduced the is_my_jetpack_available flag
+ * The value is the same that can be found on Initial_State.siteData.showMyJetpack (dashboard context)
  *
  * @returns {boolean} Object indicating if My Jetpack is available (so to navigate to interstitials and product pages)
  */

--- a/projects/js-packages/shared-extension-utils/src/is-my-jetpack-available.js
+++ b/projects/js-packages/shared-extension-utils/src/is-my-jetpack-available.js
@@ -1,0 +1,12 @@
+import getJetpackData from './get-jetpack-data';
+
+/**
+ * Return whether My Jetpack is available or not.
+ *
+ * @see https://github.com/Automattic/jetpack/pull/38500 introduced the is_my_jetpack_available flag
+ *
+ * @returns {boolean} Object indicating if My Jetpack is available (so to navigate to interstitials and product pages)
+ */
+export default function isMyJetpackAvailable() {
+	return getJetpackData()?.jetpack?.is_my_jetpack_available === true;
+}


### PR DESCRIPTION
## Proposed changes:
This PR adds a new export `isMyJetpackAvailable` to shared-extension-utils exposing a flag recently introduced on the editor initial state #38500

Such flag can be used to know if a link can point to interstitials and product pages only available on My Jetpack

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1721829884449269-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Build the package: `jetpack build js-packages/shared-extension-utils`. See that the process ends with no issues or errors.

Once built, test by importing it with `import { isMyJetpackAvailable } from '@automattic/jetpack-shared-extension-utils';` and print it to console or expose on window global object. The value should reflect if My Jetpack is available, which you can verify by finding (or not) My Jetpack on the WP -> Jetpack side menu.


- no editor context: use the dashboard `jetpack/_inc/client/at-a-glance/index.jsx` then build plugins/jetpack

- editor context: use some of the blocks, ex `jetpack/extensions/blocks/ai-assistant/edit.js`, then build plugins/jetpack and go to the editor and insert the AI Assistant block 