### PR TITLE
Jetpack AI: add sidebar action links

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-action-link
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-action-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: add action links on sidebar for feature discoverability

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -9,7 +9,14 @@ import {
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { rawHandler } from '@wordpress/blocks';
-import { Notice, PanelBody, PanelRow, KeyboardShortcuts } from '@wordpress/components';
+import {
+	Notice,
+	PanelBody,
+	PanelRow,
+	KeyboardShortcuts,
+	ExternalLink,
+	Button,
+} from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { RawHTML, useState, useCallback, useEffect, useRef } from '@wordpress/element';
@@ -29,6 +36,7 @@ import { getStoreBlockId } from './extensions/ai-assistant/with-ai-assistant';
 import useAIAssistant from './hooks/use-ai-assistant';
 import useAICheckout from './hooks/use-ai-checkout';
 import useAiFeature from './hooks/use-ai-feature';
+import useAiProductPage from './hooks/use-ai-product-page';
 import { isUserConnected } from './lib/connection';
 import './editor.scss';
 
@@ -117,6 +125,13 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 	const isLoadingCompletion = [ 'requesting', 'suggesting' ].includes( requestingState );
 
 	const connected = isUserConnected();
+
+	const {
+		productPageUrl,
+		isRedirecting,
+		autosaveAndRedirect: redirectToProductPage,
+		isMyJetpackAvailable,
+	} = useAiProductPage();
 
 	/*
 	 * Auto request the prompt if we detect
@@ -345,6 +360,20 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					</div>
 				) }
 				<InspectorControls>
+					{ /* Mock BlockCard component styles to keep alignment */ }
+					<div className="block-editor-block-card" style={ { paddingTop: 0 } }>
+						<span className="block-editor-block-icon"></span>
+						{ isMyJetpackAvailable && (
+							<Button variant="link" onClick={ redirectToProductPage } disabled={ isRedirecting }>
+								{ __( 'Discover all features', 'jetpack' ) }
+							</Button>
+						) }
+						{ ! isMyJetpackAvailable && (
+							<ExternalLink href={ productPageUrl }>
+								{ __( 'Discover all features', 'jetpack' ) }
+							</ExternalLink>
+						) }
+					</div>
 					<PanelBody initialOpen={ true }>
 						<PanelRow>
 							<UsagePanel placement={ USAGE_PANEL_PLACEMENT_BLOCK_SETTINGS_SIDEBAR } />

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -15,7 +15,6 @@ import {
 	PanelRow,
 	KeyboardShortcuts,
 	ExternalLink,
-	Button,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -126,12 +125,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 
 	const connected = isUserConnected();
 
-	const {
-		productPageUrl,
-		isRedirecting,
-		autosaveAndRedirect: redirectToProductPage,
-		isMyJetpackAvailable,
-	} = useAiProductPage();
+	const { productPageUrl } = useAiProductPage();
 
 	/*
 	 * Auto request the prompt if we detect
@@ -363,16 +357,9 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					{ /* Mock BlockCard component styles to keep alignment */ }
 					<div className="block-editor-block-card" style={ { paddingTop: 0 } }>
 						<span className="block-editor-block-icon"></span>
-						{ isMyJetpackAvailable && (
-							<Button variant="link" onClick={ redirectToProductPage } disabled={ isRedirecting }>
-								{ __( 'Discover all features', 'jetpack' ) }
-							</Button>
-						) }
-						{ ! isMyJetpackAvailable && (
-							<ExternalLink href={ productPageUrl }>
-								{ __( 'Discover all features', 'jetpack' ) }
-							</ExternalLink>
-						) }
+						<ExternalLink href={ productPageUrl }>
+							{ __( 'Discover all features', 'jetpack' ) }
+						</ExternalLink>
 					</div>
 					<PanelBody initialOpen={ true }>
 						<PanelRow>

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-product-page/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-product-page/index.ts
@@ -1,0 +1,33 @@
+/*
+ * External dependencies
+ */
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
+import useAutosaveAndRedirect from '../../../../shared/use-autosave-and-redirect';
+/*
+ * Types
+ */
+import type { MouseEvent } from 'react';
+
+export default function useAiProductPage(): {
+	autosaveAndRedirect: ( event: MouseEvent< HTMLButtonElement > ) => void;
+	isRedirecting: boolean;
+	productPageUrl: string;
+	isMyJetpackAvailable: boolean;
+} {
+	// TODO: use isMyJetpackAvailable from shared-extension-utils once PR is merged and package published:
+	// https://github.com/Automattic/jetpack/pull/38529
+	const isMyJetpackAvailable = getJetpackData()?.jetpack?.is_my_jetpack_available;
+	const productPageUrl = isMyJetpackAvailable
+		? `${ getJetpackData()?.adminUrl || '' }admin.php?page=my-jetpack#/jetpack-ai`
+		: getRedirectUrl( 'org-ai' );
+
+	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( productPageUrl );
+
+	return {
+		productPageUrl,
+		autosaveAndRedirect,
+		isRedirecting,
+		isMyJetpackAvailable,
+	};
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -114,12 +114,12 @@ const JetpackAndSettingsContent = ( {
 			<PanelRow>
 				{ ! isMyJetpackAvailable && (
 					<ExternalLink href={ productPageUrl }>
-						{ __( 'Discover all features', 'jetpack' ) }
+						{ __( 'Learn more about Jetpack AI', 'jetpack' ) }
 					</ExternalLink>
 				) }
 				{ isMyJetpackAvailable && (
 					<Button variant="link" disabled={ isRedirecting } onClick={ autosaveAndRedirect }>
-						{ __( 'Discover all features', 'jetpack' ) }
+						{ __( 'Learn more about Jetpack AI', 'jetpack' ) }
 					</Button>
 				) }
 			</PanelRow>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -3,13 +3,12 @@
  */
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { PanelBody, PanelRow, BaseControl, ExternalLink, Button } from '@wordpress/components';
+import { PanelBody, PanelRow, BaseControl, ExternalLink } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { PluginPrePublishPanel, PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-import { Icon, external } from '@wordpress/icons';
 import debugFactory from 'debug';
 import React from 'react';
 /**
@@ -58,8 +57,7 @@ const JetpackAndSettingsContent = ( {
 	upgradeType,
 }: JetpackSettingsContentProps ) => {
 	const { checkoutUrl } = useAICheckout();
-	const { isMyJetpackAvailable, productPageUrl, autosaveAndRedirect, isRedirecting } =
-		useAiProductPage();
+	const { productPageUrl } = useAiProductPage();
 
 	return (
 		<>
@@ -92,36 +90,26 @@ const JetpackAndSettingsContent = ( {
 				</PanelRow>
 			) }
 			{ requireUpgrade && ! isUsagePanelAvailable && (
-				<PanelRow className="jetpack-ai-upgrade-control__header">
+				<PanelRow>
 					<Upgrade placement={ placement } type={ upgradeType } upgradeUrl={ checkoutUrl } />
 				</PanelRow>
 			) }
 			{ isUsagePanelAvailable && (
-				<PanelRow className="jetpack-ai-usage-control__header">
+				<PanelRow className="jetpack-ai-sidebar__feature-section">
 					<UsagePanel placement={ placement } />
 				</PanelRow>
 			) }
 
-			<Button
-				variant="link"
-				className="jetpack-ai__feedback-button"
-				href="https://jetpack.com/redirect/?source=jetpack-ai-feedback"
-				target="_blank"
-			>
-				<span>{ __( 'Provide feedback', 'jetpack' ) }</span>
-				<Icon icon={ external } className="icon" />
-			</Button>
 			<PanelRow>
-				{ ! isMyJetpackAvailable && (
-					<ExternalLink href={ productPageUrl }>
-						{ __( 'Learn more about Jetpack AI', 'jetpack' ) }
-					</ExternalLink>
-				) }
-				{ isMyJetpackAvailable && (
-					<Button variant="link" disabled={ isRedirecting } onClick={ autosaveAndRedirect }>
-						{ __( 'Learn more about Jetpack AI', 'jetpack' ) }
-					</Button>
-				) }
+				<ExternalLink href="https://jetpack.com/redirect/?source=jetpack-ai-feedback">
+					{ __( 'Provide feedback', 'jetpack' ) }
+				</ExternalLink>
+			</PanelRow>
+
+			<PanelRow>
+				<ExternalLink href={ productPageUrl }>
+					{ __( 'Learn more about Jetpack AI', 'jetpack' ) }
+				</ExternalLink>
 			</PanelRow>
 		</>
 	);

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -3,7 +3,7 @@
  */
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { PanelBody, PanelRow, BaseControl, Button } from '@wordpress/components';
+import { PanelBody, PanelRow, BaseControl, ExternalLink, Button } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { PluginPrePublishPanel, PluginDocumentSettingPanel } from '@wordpress/edit-post';
@@ -17,6 +17,7 @@ import React from 'react';
  */
 import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout';
 import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
+import useAiProductPage from '../../../../blocks/ai-assistant/hooks/use-ai-product-page';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
 import { FeaturedImage } from '../ai-image';
 import { Breve, registerBreveHighlights, Highlight } from '../breve';
@@ -57,6 +58,8 @@ const JetpackAndSettingsContent = ( {
 	upgradeType,
 }: JetpackSettingsContentProps ) => {
 	const { checkoutUrl } = useAICheckout();
+	const { isMyJetpackAvailable, productPageUrl, autosaveAndRedirect, isRedirecting } =
+		useAiProductPage();
 
 	return (
 		<>
@@ -108,6 +111,18 @@ const JetpackAndSettingsContent = ( {
 				<span>{ __( 'Provide feedback', 'jetpack' ) }</span>
 				<Icon icon={ external } className="icon" />
 			</Button>
+			<PanelRow>
+				{ ! isMyJetpackAvailable && (
+					<ExternalLink href={ productPageUrl }>
+						{ __( 'Discover all features', 'jetpack' ) }
+					</ExternalLink>
+				) }
+				{ isMyJetpackAvailable && (
+					<Button variant="link" disabled={ isRedirecting } onClick={ autosaveAndRedirect }>
+						{ __( 'Discover all features', 'jetpack' ) }
+					</Button>
+				) }
+			</PanelRow>
 		</>
 	);
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -64,28 +64,28 @@ const JetpackAndSettingsContent = ( {
 	return (
 		<>
 			{ isBreveAvailable && (
-				<PanelRow className="jetpack-ai-proofread-control__header">
+				<PanelRow>
 					<BaseControl label={ __( 'Write Brief with AI (BETA)', 'jetpack' ) }>
 						<Breve />
 					</BaseControl>
 				</PanelRow>
 			) }
 
-			<PanelRow className="jetpack-ai-feedback__header">
+			<PanelRow className="jetpack-ai-sidebar__feature-section">
 				<BaseControl label={ __( 'AI Feedback', 'jetpack' ) }>
 					<Feedback placement={ placement } busy={ false } disabled={ requireUpgrade } />
 				</BaseControl>
 			</PanelRow>
 
 			{ isAITitleOptimizationAvailable && (
-				<PanelRow className="jetpack-ai-title-optimization__header">
+				<PanelRow className="jetpack-ai-sidebar__feature-section">
 					<BaseControl label={ __( 'Optimize Publishing', 'jetpack' ) }>
 						<TitleOptimization placement={ placement } busy={ false } disabled={ requireUpgrade } />
 					</BaseControl>
 				</PanelRow>
 			) }
 			{ isAIFeaturedImageAvailable && (
-				<PanelRow className="jetpack-ai-featured-image-control__header">
+				<PanelRow className="jetpack-ai-sidebar__feature-section">
 					<BaseControl label={ __( 'AI Featured Image', 'jetpack' ) }>
 						<FeaturedImage busy={ false } disabled={ requireUpgrade } placement={ placement } />
 					</BaseControl>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/style.scss
@@ -1,9 +1,4 @@
-.jetpack-ai-logo-generator-control__header,
-.jetpack-ai-feedback__header,
-.jetpack-ai-featured-image-control__header,
-.jetpack-ai-title-optimization__header,
-.jetpack-ai-upgrade-control__header,
-.jetpack-ai-usage-control__header {
+.jetpack-ai-sidebar__feature-section {
 	margin-bottom: 2em;
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-roadmap/issues/1723
Fixes https://github.com/Automattic/jetpack-roadmap/issues/1722

## Proposed changes:
This PR adds action links for product page on Post settings and Jetpack sidebars

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-t9s-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Go to editor and insert an AI Assistant block.
- [x] On the block card (header of the block inspector) you should see a link "Discover all features"
- [x] Clicking the link should autosave any changes and land you on My Jetpack's product page for AI
- [ ] if My Jetpack is not available (atomic, simple sites) the link should show as external link and open  jetpack.com/ai on a new page

Open Jetpack sidebar and uncollapse AI Assistant section
- [ ] at the bottom of the section, you should see a link "Learn more about Jetpack AI"
- [ ] Link should behave as the above one (link to AI page on My Jetpack or open new tab to jetpack.com/ai otherwise)
