### PR TITLE
Admin Bar: Fix the order of the top-right items on Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-order
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin Bar: Fix the order of the top-right items on Atomic sites

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.50.0",
+	"version": "5.50.1-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.50.0';
+	const PACKAGE_VERSION = '5.50.1-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -83,12 +83,9 @@ class Help_Center {
 		$script_dependencies = $dependencies ?? array();
 
 		if ( $variant === 'wp-admin' || $variant === 'wp-admin-disconnected' ) {
-			// Crazy high number to prevent Jetpack removing it
-			// https://github.com/Automattic/jetpack/blob/30213ee594cd06ca27199f73b2658236fda24622/projects/plugins/jetpack/modules/masterbar/masterbar/class-masterbar.php#L196.
 			add_action(
-				'wp_before_admin_bar_render',
-				function () {
-					global $wp_admin_bar;
+				'admin_bar_menu',
+				function ( $wp_admin_bar ) {
 					$wp_admin_bar->add_menu(
 						array(
 							'id'     => 'help-center',
@@ -102,8 +99,7 @@ class Help_Center {
 							),
 						)
 					);
-				},
-				100000
+				}
 			);
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -60,6 +60,10 @@ function wpcom_enqueue_admin_bar_assets() {
 				#wpadminbar .quicklinks #wp-admin-bar-top-secondary #wp-admin-bar-search {
 					order: -1;
 				}
+
+				#wpadminbar .quicklinks #wp-admin-bar-top-secondary #wp-admin-bar-help-center {
+					order: 1;
+				}
 CSS
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8443

## Proposed changes:

Timeline of events:

1. We updated WordPress on Simple Sites to 6.6.
2. It contains a [bug](https://github.com/Automattic/dotcom-forge/issues/8220) which messed up the admin bar menus.
3. We hotfixed that [here](https://github.com/Automattic/jetpack/pull/38347).
4. Core released a "fix" [here](https://core.trac.wordpress.org/ticket/61615).
    - the fix does not fully restore the original behavior seen in older versions.
6. We updated WordPress on Atomic sites to 6.6.1, containing the above Core fix.
7. Our hotfix from before does not apply, so we need to actually fix the order of items (in this PR).
    - we need to hotfix our previous hotfix on Simple class to ensure that the help center icon is in correct location.

|Type|Before|After|
|-|-|-|
|Simple|<img width="245" alt="image" src="https://github.com/user-attachments/assets/f4c498bf-327f-4d73-ba97-ac253eee4c89">|<img width="241" alt="image" src="https://github.com/user-attachments/assets/2402920c-7cbb-45e4-9e4a-a1eb1d75a22a">|
|Atomic|<img width="388" alt="image" src="https://github.com/user-attachments/assets/5cddbb25-c206-4fd5-a133-3092c5797afb">|<img width="379" alt="image" src="https://github.com/user-attachments/assets/e7484465-19e0-4cef-9b74-bf334ee1a7e9">|

> [!NOTE]
> I did not try to fix the order of the Debug menu, as it comes from our internal company proxy plugin...

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Test all the scenarios above.
2. Verify that you can still see the help center icon!
3. Test also site frontend; make sure the search icon is still at the top-rightmost (ignoring the Debug menu).

