### PR TITLE
Backport mu-wpcom-plugin 2.5.1 Changes

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.55.1] - 2024-07-25
+### Added
+- Added `className` prop to `Alert` component [#38450]
+
+### Changed
+- React compatibility: Ensuring createRoot is not called more than once. [#38495]
+
 ## [0.55.0] - 2024-07-22
 ### Removed
 - Remove compatibility with WordPress 6.4. [#38386]
@@ -1091,6 +1098,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.55.1]: https://github.com/Automattic/jetpack-components/compare/0.55.0...0.55.1
 [0.55.0]: https://github.com/Automattic/jetpack-components/compare/0.54.4...0.55.0
 [0.54.4]: https://github.com/Automattic/jetpack-components/compare/0.54.3...0.54.4
 [0.54.3]: https://github.com/Automattic/jetpack-components/compare/0.54.2...0.54.3

--- a/projects/js-packages/components/changelog/fix-create-root-react-19-compat
+++ b/projects/js-packages/components/changelog/fix-create-root-react-19-compat
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-React compatibility: Ensuring createRoot is not called more than once.

--- a/projects/js-packages/components/changelog/update-improve-social-broken-connection-notices
+++ b/projects/js-packages/components/changelog/update-improve-social-broken-connection-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added `className` prop to `Alert` component

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.55.1-alpha",
+	"version": "0.55.1",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/classic-theme-helper/CHANGELOG.md
+++ b/projects/packages/classic-theme-helper/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2024-07-25
+### Changed
+- Social Menus: Requiring the feature from the Classic Theme Helper package. [#38297]
+
 ## [0.4.2] - 2024-07-22
 ### Added
 - Added Jetpack_Color class. [#38357]
@@ -50,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add wordpress folder on gitignore. [#37177]
 
+[0.4.3]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.3.1...v0.4.0

--- a/projects/packages/classic-theme-helper/changelog/add-require-social-menu-classic-theme-helper-package
+++ b/projects/packages/classic-theme-helper/changelog/add-require-social-menu-classic-theme-helper-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Social Menus: Requiring the feature from the Classic Theme Helper package.

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-classic-theme-helper",
-	"version": "0.4.3-alpha",
+	"version": "0.4.3",
 	"description": "Features used with classic themes",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/classic-theme-helper/#readme",
 	"bugs": {

--- a/projects/packages/classic-theme-helper/src/class-main.php
+++ b/projects/packages/classic-theme-helper/src/class-main.php
@@ -14,7 +14,7 @@ use WP_Error;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.4.3-alpha';
+	const PACKAGE_VERSION = '0.4.3';
 
 	/**
 	 * Modules to include.

--- a/projects/packages/classic-theme-helper/src/shared-functions.php
+++ b/projects/packages/classic-theme-helper/src/shared-functions.php
@@ -11,7 +11,7 @@ if ( ! function_exists( 'jetpack_mastodon_get_instance_list' ) ) {
 	 * Build a list of Mastodon instance hosts.
 	 * That list can be extended via a filter.
 	 *
-	 * @since $$next-version$$ in Classic Theme Helper (previously in Jetpack since 11.8)
+	 * @since 0.4.3 in Classic Theme Helper (previously in Jetpack since 11.8)
 	 *
 	 * @return array
 	 */
@@ -33,7 +33,7 @@ if ( ! function_exists( 'jetpack_mastodon_get_instance_list' ) ) {
 		/**
 		 * Filter the list of Mastodon instances.
 		 *
-		 * @since $$next-version$$ in Classic Theme Helper (previously in Jetpack since 11.8)
+		 * @since 0.4.3 in Classic Theme Helper (previously in Jetpack since 11.8)
 		 *
 		 * @module widgets, theme-tools
 		 *

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.49.0] - 2024-07-25
+### Added
+- Add a12n notice about proxied toolbar [#38519]
+
+### Changed
+- Add query param to URL only for users with manage options permission [#38493]
+- Admin Bar: Point the (Profile) -> Edit Profile menu to /me when appropriate [#38530]
+
+### Fixed
+- Fix fatal error in admin bar [#38526]
+- MU WPCOM: Load built version of wpcom-sidebar-notice.js [#38479]
+
 ## [5.48.0] - 2024-07-23
 ### Changed
 - Always use house icon for site name in admin-bar. [#38457]
@@ -1034,6 +1046,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.49.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.48.0...v5.49.0
 [5.48.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.47.0...v5.48.0
 [5.47.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.46.0...v5.47.0
 [5.46.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.45.0...v5.46.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-profile-toolbar-notice
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-profile-toolbar-notice
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a12n notice about proxied toolbar

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-edit-profile
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-edit-profile
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Admin Bar: Point the (Profile) -> Edit Profile menu to /me when appropriate

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-error
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-error
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix fatal error in admin bar

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-sidebar-notice
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-sidebar-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-MU WPCOM: Load built version of wpcom-sidebar-notice.js

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-do-not-add-originsiteid
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-do-not-add-originsiteid
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Add query param to URL only for users with manage options permission

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.49.0-alpha",
+	"version": "5.49.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.49.0-alpha';
+	const PACKAGE_VERSION = '5.49.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.5.1 - 2024-07-25
+### Changed
+- Internal updates.
+
 ## 2.5.0 - 2024-07-22
 ### Added
 - Add missing `scssphp/scssphp` dependency to the plugin zip. [#38337]

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-require-social-menu-classic-theme-helper-package
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-require-social-menu-classic-theme-helper-package
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-require-social-menu-classic-theme-helper-package#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-require-social-menu-classic-theme-helper-package#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-jsx-runtime-react-19-polyfill
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-jsx-runtime-react-19-polyfill
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-do-not-add-originsiteid
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-do-not-add-originsiteid
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_1_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_1"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.5.1-alpha
+ * Version: 2.5.1
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.5.1-alpha",
+	"version": "2.5.1",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.5.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.