### PR TITLE
Remove `< Browse sites` from sidebar

### DIFF
--- a/projects/packages/masterbar/changelog/remove-browse-sites-from-sidebar
+++ b/projects/packages/masterbar/changelog/remove-browse-sites-from-sidebar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Remove Browse sites from sidebar as it's on WordPress logo in masterbar

--- a/projects/packages/masterbar/composer.json
+++ b/projects/packages/masterbar/composer.json
@@ -63,7 +63,7 @@
 	"extra": {
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.5.x-dev"
+			"dev-trunk": "0.6.x-dev"
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.5.0",
+	"version": "0.6.0-alpha",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -85,7 +85,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 
 		// Not needed outside of wp-admin.
 		if ( ! $this->is_api_request ) {
-			$this->add_browse_sites_link();
 			$this->add_site_card_menu();
 			$this->add_new_site_link();
 		}
@@ -192,21 +191,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		$submenus_to_update = array( 'plugin-install.php' => $plugins_slug );
 
 		$this->update_submenus( 'plugins.php', $submenus_to_update );
-	}
-
-	/**
-	 * Adds the site switcher link if user has more than one site.
-	 */
-	public function add_browse_sites_link() {
-		$site_count = get_user_option( 'wpcom_site_count' );
-		if ( ! $site_count || $site_count < 2 ) {
-			return;
-		}
-
-		// Add the menu item.
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_menu_page( __( 'site-switcher', 'jetpack-masterbar' ), __( 'Browse sites', 'jetpack-masterbar' ), 'read', 'https://wordpress.com/sites', null, 'dashicons-arrow-left-alt2', 0 );
-		add_filter( 'add_menu_classes', array( $this, 'set_browse_sites_link_class' ) );
 	}
 
 	/**

--- a/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-wpcom-admin-menu.php
@@ -50,7 +50,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		// Not needed outside of wp-admin.
 		if ( ! $this->is_api_request ) {
-			$this->add_browse_sites_link();
 			$this->add_site_card_menu();
 			$this->add_new_site_link();
 		}
@@ -100,20 +99,6 @@ class WPcom_Admin_Menu extends Admin_Menu {
 
 		$blogs = get_blogs_of_user( get_current_user_id() );
 		return is_countable( $blogs ) ? count( $blogs ) : 0;
-	}
-
-	/**
-	 * Adds the site switcher link if user has more than one site.
-	 */
-	public function add_browse_sites_link() {
-		if ( $this->get_current_user_blog_count() < 2 ) {
-			return;
-		}
-
-		// Add the menu item.
-		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_menu_page( __( 'site-switcher', 'jetpack-masterbar' ), __( 'Browse sites', 'jetpack-masterbar' ), 'read', 'https://wordpress.com/sites', null, 'dashicons-arrow-left-alt2', 0 );
-		add_filter( 'add_menu_classes', array( $this, 'set_browse_sites_link_class' ) );
 	}
 
 	/**

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.5.0';
+	const PACKAGE_VERSION = '0.6.0-alpha';
 
 	/**
 	 * Initializer.

--- a/projects/packages/masterbar/tests/php/test-class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/tests/php/test-class-atomic-admin-menu.php
@@ -104,19 +104,6 @@ class Test_Atomic_Admin_Menu extends TestCase {
 	}
 
 	/**
-	 * Tests add_browse_sites_link.
-	 *
-	 * @covers ::add_browse_sites_link
-	 */
-	public function test_add_browse_sites_link() {
-		global $menu;
-
-		// No output when executed in single site mode.
-		static::$admin_menu->add_browse_sites_link();
-		$this->assertArrayNotHasKey( 0, $menu );
-	}
-
-	/**
 	 * Tests add_new_site_link.
 	 *
 	 * @covers ::add_new_site_link

--- a/projects/packages/masterbar/tests/php/test-class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/tests/php/test-class-atomic-admin-menu.php
@@ -117,41 +117,6 @@ class Test_Atomic_Admin_Menu extends TestCase {
 	}
 
 	/**
-	 * Tests add_browse_sites_link.
-	 *
-	 * @covers ::add_browse_sites_link
-	 */
-	public function test_add_browse_sites_link_multisite() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Only used on multisite' );
-		}
-
-		global $menu;
-
-		// No output when user has just one site.
-		static::$admin_menu->add_browse_sites_link();
-		$this->assertArrayNotHasKey( 0, $menu );
-
-		// Give user a second site.
-		update_user_option( static::$user_id, 'wpcom_site_count', 2 );
-
-		static::$admin_menu->add_browse_sites_link();
-
-		$browse_sites_menu_item = array(
-			'Browse sites',
-			'read',
-			'https://wordpress.com/sites',
-			'site-switcher',
-			'menu-top toplevel_page_https://wordpress.com/sites',
-			'toplevel_page_https://wordpress.com/sites',
-			'dashicons-arrow-left-alt2',
-		);
-		$this->assertSame( $menu[0], $browse_sites_menu_item );
-
-		delete_user_option( static::$user_id, 'wpcom_site_count' );
-	}
-
-	/**
 	 * Tests add_new_site_link.
 	 *
 	 * @covers ::add_new_site_link

--- a/projects/plugins/jetpack/changelog/remove-browse-sites-from-sidebar
+++ b/projects/plugins/jetpack/changelog/remove-browse-sites-from-sidebar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove Browse sites from sidebar as it's on WordPress logo in masterbar

--- a/projects/plugins/jetpack/changelog/remove-show-browse-sites-link
+++ b/projects/plugins/jetpack/changelog/remove-show-browse-sites-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1665,7 +1665,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/masterbar",
-				"reference": "afde100c2bbad9a2e337db64b54ddc650efc9720"
+				"reference": "9f21b1d7607b21df7becfcdb49002d310d891440"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1693,7 +1693,7 @@
 			"extra": {
 				"autotagger": true,
 				"branch-alias": {
-					"dev-trunk": "0.5.x-dev"
+					"dev-trunk": "0.6.x-dev"
 				},
 				"changelogger": {
 					"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-atomic-admin-menu.php
@@ -96,16 +96,6 @@ class Atomic_Admin_Menu extends Masterbar_Atomic_Admin_Menu {
 	}
 
 	/**
-	 * Adds the site switcher link if user has more than one site.
-	 *
-	 * @deprecated 13.7
-	 */
-	public function add_browse_sites_link() {
-		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\Atomic_Admin_Menu::add_browse_sites_link' );
-		parent::add_browse_sites_link();
-	}
-
-	/**
 	 * Adds a custom element class for Site Switcher menu item.
 	 *
 	 * @deprecated 13.7

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/class-wpcom-admin-menu.php
@@ -65,16 +65,6 @@ class WPcom_Admin_Menu extends Masterbar_WPcom_Admin_Menu {
 	}
 
 	/**
-	 * Adds the site switcher link if user has more than one site.
-	 *
-	 * @deprecated 13.7
-	 */
-	public function add_browse_sites_link() {
-		_deprecated_function( __METHOD__, 'jetpack-13.7', 'Automattic\\Jetpack\\Masterbar\\WPcom_Admin_Menu::add_browse_sites_link' );
-		parent::add_browse_sites_link();
-	}
-
-	/**
 	 * Adds a custom element class for Site Switcher menu item.
 	 *
 	 * @deprecated 13.7

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -95,21 +95,6 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests add_browse_sites_link.
-	 *
-	 * @covers ::add_browse_sites_link
-	 *
-	 * @expectedDeprecated Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu::add_browse_sites_link
-	 */
-	public function test_add_browse_sites_link() {
-		global $menu;
-
-		// No output when executed in single site mode.
-		static::$admin_menu->add_browse_sites_link();
-		$this->assertArrayNotHasKey( 0, $menu );
-	}
-
-	/**
 	 * Tests add_new_site_link.
 	 *
 	 * @covers ::add_new_site_link

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -110,43 +110,6 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests add_browse_sites_link.
-	 *
-	 * @covers ::add_browse_sites_link
-	 *
-	 * @expectedDeprecated Automattic\Jetpack\Dashboard_Customizations\Atomic_Admin_Menu::add_browse_sites_link
-	 */
-	public function test_add_browse_sites_link_multisite() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Only used on multisite' );
-		}
-
-		global $menu;
-
-		// No output when user has just one site.
-		static::$admin_menu->add_browse_sites_link();
-		$this->assertArrayNotHasKey( 0, $menu );
-
-		// Give user a second site.
-		update_user_option( static::$user_id, 'wpcom_site_count', 2 );
-
-		static::$admin_menu->add_browse_sites_link();
-
-		$browse_sites_menu_item = array(
-			'Browse sites',
-			'read',
-			'https://wordpress.com/sites',
-			'site-switcher',
-			'menu-top toplevel_page_https://wordpress.com/sites',
-			'toplevel_page_https://wordpress.com/sites',
-			'dashicons-arrow-left-alt2',
-		);
-		$this->assertSame( $menu[0], $browse_sites_menu_item );
-
-		delete_user_option( static::$user_id, 'wpcom_site_count' );
-	}
-
-	/**
 	 * Tests add_new_site_link.
 	 *
 	 * @covers ::add_new_site_link

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-wpcom-admin-menu.php
@@ -112,43 +112,6 @@ class Test_WPcom_Admin_Menu extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests add_browse_sites_link.
-	 *
-	 * @covers ::add_browse_sites_link
-	 */
-	public function test_add_browse_sites_link() {
-		if ( ! function_exists( 'add_user_to_blog' ) ) {
-			$this->markTestSkipped( 'Only used on multisite' );
-		}
-		$this->setExpectedDeprecated( 'Automattic\Jetpack\Dashboard_Customizations\WPcom_Admin_Menu::get_current_user_blog_count' );
-		$this->setExpectedDeprecated( 'Automattic\Jetpack\Dashboard_Customizations\WPcom_Admin_Menu::add_browse_sites_link' );
-		global $menu;
-
-		// No output when user has just one site.
-		static::$admin_menu->add_browse_sites_link();
-		$this->assertArrayNotHasKey( 0, $menu );
-
-		// Give user a second site.
-		$blog_id = self::factory()->blog->create();
-		add_user_to_blog( $blog_id, get_current_user_id(), 'editor' );
-
-		static::$admin_menu->add_browse_sites_link();
-
-		$browse_sites_menu_item = array(
-			'Browse sites',
-			'read',
-			'https://wordpress.com/sites',
-			'site-switcher',
-			'menu-top toplevel_page_https://wordpress.com/sites',
-			'toplevel_page_https://wordpress.com/sites',
-			'dashicons-arrow-left-alt2',
-		);
-		$this->assertSame( $menu[0], $browse_sites_menu_item );
-
-		remove_user_from_blog( get_current_user_id(), $blog_id );
-	}
-
-	/**
 	 * Tests add_new_site_link.
 	 *
 	 * @covers ::add_new_site_link

--- a/projects/plugins/mu-wpcom-plugin/changelog/remove-show-browse-sites-link
+++ b/projects/plugins/mu-wpcom-plugin/changelog/remove-show-browse-sites-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -926,7 +926,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "afde100c2bbad9a2e337db64b54ddc650efc9720"
+                "reference": "9f21b1d7607b21df7becfcdb49002d310d891440"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -954,7 +954,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.5.x-dev"
+                    "dev-trunk": "0.6.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/plugins/wpcomsh/changelog/remove-show-browse-sites-link
+++ b/projects/plugins/wpcomsh/changelog/remove-show-browse-sites-link
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -129,7 +129,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_0_3"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_0_4_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1063,7 +1063,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "afde100c2bbad9a2e337db64b54ddc650efc9720"
+                "reference": "9f21b1d7607b21df7becfcdb49002d310d891440"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1091,7 +1091,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.5.x-dev"
+                    "dev-trunk": "0.6.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.0.3",
+	"version": "5.0.4-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.0.3
+ * Version: 5.0.4-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.0.3' );
+define( 'WPCOMSH_VERSION', '5.0.4-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8416

| - | Before | After |
| --- | --- | --- |
| Simple | ![image](https://github.com/user-attachments/assets/601720b6-f7fb-484d-a76c-808ee7a1535f) | ![image](https://github.com/user-attachments/assets/abeb4375-6839-4785-80eb-f9a5d6804865) |
| Atomic | ![image](https://github.com/user-attachments/assets/7a6c0cbf-73cb-4344-8019-d9a8b4b0de2a) | ![image](https://github.com/user-attachments/assets/b3263e5a-7d3b-4b69-8d68-5a2556efe370) |


## Proposed changes:
Remove `Browse sites` from the top of the sidebar as it's now on WordPress logo.

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Go to '/wp-admin'
* `Browse sites` at the top of the sidebar should not exist.

