### PR TITLE
Add/mj card update after async site connection

### DIFF
--- a/projects/js-packages/components/changelog/export-button-props-type
+++ b/projects/js-packages/components/changelog/export-button-props-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Export button props type to be used elsewhere

--- a/projects/js-packages/components/index.ts
+++ b/projects/js-packages/components/index.ts
@@ -48,6 +48,7 @@ export { default as ToggleControl } from './components/toggle-control';
 export { default as numberFormat } from './components/number-format';
 export { default as QRCode } from './components/qr-code';
 export { default as Button } from './components/button';
+export type { ButtonProps } from './components/button/types';
 export { default as LoadingPlaceholder } from './components/loading-placeholder';
 export { default as TermsOfService } from './components/terms-of-service';
 export { default as Chip } from './components/chip';

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.55.1",
+	"version": "0.55.2-alpha",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
@@ -4,11 +4,12 @@
 import { Text } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import PropTypes from 'prop-types';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 /**
  * Internal dependencies
  */
 import { MyJetpackRoutes } from '../../constants';
+import { PRODUCT_STATUSES } from '../../constants';
 import useActivate from '../../data/products/use-activate';
 import useInstallStandalonePlugin from '../../data/products/use-install-standalone-plugin';
 import useProduct from '../../data/products/use-product';
@@ -33,7 +34,7 @@ const ConnectedProductCard = ( {
 	const { install: installStandalonePlugin, isPending: isInstalling } =
 		useInstallStandalonePlugin( slug );
 	const { activate, isPending: isActivating } = useActivate( slug );
-	const { detail } = useProduct( slug );
+	const { detail, refetch } = useProduct( slug );
 	const { name, description: defaultDescription, requiresUserConnection, status } = detail;
 
 	const navigateToConnectionPage = useMyJetpackNavigate( MyJetpackRoutes.Connection );
@@ -66,6 +67,16 @@ const ConnectedProductCard = ( {
 			</Text>
 		);
 	};
+
+	useEffect( () => {
+		if (
+			isRegistered &&
+			( status === PRODUCT_STATUSES.SITE_CONNECTION_ERROR ||
+				status === PRODUCT_STATUSES.NEEDS_FIRST_SITE_CONNECTION )
+		) {
+			refetch();
+		}
+	}, [ isRegistered, status, refetch ] );
 
 	return (
 		<ProductCard

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
@@ -3,7 +3,6 @@
  */
 import { Text } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
-import PropTypes from 'prop-types';
 import { useCallback, useEffect } from 'react';
 /**
  * Internal dependencies
@@ -15,8 +14,24 @@ import useInstallStandalonePlugin from '../../data/products/use-install-standalo
 import useProduct from '../../data/products/use-product';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import ProductCard from '../product-card';
+import type { AdditionalAction, SecondaryAction } from '../product-card/types';
+import type { FC, ReactNode } from 'react';
 
-const ConnectedProductCard = ( {
+interface ConnectedProductCardProps {
+	admin: boolean;
+	slug: string;
+	children: ReactNode;
+	isDataLoading?: boolean;
+	Description?: JSX.Element | ( () => null );
+	additionalActions?: AdditionalAction[];
+	secondaryAction?: SecondaryAction;
+	upgradeInInterstitial?: boolean;
+	primaryActionOverride?: AdditionalAction;
+	onMouseEnter?: () => void;
+	onMouseLeave?: () => void;
+}
+
+const ConnectedProductCard: FC< ConnectedProductCardProps > = ( {
 	admin,
 	slug,
 	children,
@@ -100,18 +115,6 @@ const ConnectedProductCard = ( {
 			{ children }
 		</ProductCard>
 	);
-};
-
-ConnectedProductCard.propTypes = {
-	children: PropTypes.node,
-	admin: PropTypes.bool.isRequired,
-	slug: PropTypes.string.isRequired,
-	isDataLoading: PropTypes.bool,
-	additionalActions: PropTypes.array,
-	primaryActionOverride: PropTypes.object,
-	secondaryAction: PropTypes.object,
-	onMouseEnter: PropTypes.func,
-	onMouseLeave: PropTypes.func,
 };
 
 export default ConnectedProductCard;

--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
@@ -34,7 +34,7 @@ const ConnectedProductCard = ( {
 	const { install: installStandalonePlugin, isPending: isInstalling } =
 		useInstallStandalonePlugin( slug );
 	const { activate, isPending: isActivating } = useActivate( slug );
-	const { detail, refetch } = useProduct( slug );
+	const { detail, refetch, isLoading: isProductDataLoading } = useProduct( slug );
 	const { name, description: defaultDescription, requiresUserConnection, status } = detail;
 
 	const navigateToConnectionPage = useMyJetpackNavigate( MyJetpackRoutes.Connection );
@@ -84,7 +84,7 @@ const ConnectedProductCard = ( {
 			Description={ Description ? Description : DefaultDescription }
 			status={ status }
 			admin={ admin }
-			isFetching={ isActivating || isInstalling }
+			isFetching={ isActivating || isInstalling || isProductDataLoading }
 			isDataLoading={ isDataLoading }
 			isInstallingStandalone={ isInstalling }
 			additionalActions={ additionalActions }

--- a/projects/packages/my-jetpack/_inc/components/product-card/types.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/types.ts
@@ -1,0 +1,27 @@
+import type { ButtonProps } from '@automattic/jetpack-components';
+import type { ReactNode } from 'react';
+
+type ProductButtonProps = Pick<
+	ButtonProps,
+	'size' | 'variant' | 'weight' | 'disabled' | 'className'
+>;
+
+export type AdditionalAction = ProductButtonProps & {
+	href: string;
+	label: string;
+	onClick: () => void;
+};
+
+export type SecondaryAction = ProductButtonProps & {
+	href: string;
+	label: string;
+	shouldShowButton?: () => boolean;
+	onClick: () => void;
+	positionFirst?: boolean;
+	isExternalLink?: boolean;
+	icon?: ReactNode;
+	iconSize?: number;
+	disabled?: boolean;
+	isLoading?: boolean;
+	className?: string;
+};

--- a/projects/packages/my-jetpack/_inc/data/products/use-product.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-product.ts
@@ -35,7 +35,7 @@ export const useAllProducts = (): { [ key: string ]: ProductCamelCase } => {
 // Create query to fetch new product data from the server
 const useFetchProduct = ( productId: string ) => {
 	const queryResult = useSimpleQuery< ProductSnakeCase >( {
-		name: QUERY_PRODUCT_KEY,
+		name: `${ QUERY_PRODUCT_KEY }${ productId }`,
 		query: {
 			path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/${ productId }`,
 		},

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -38,7 +38,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 
 		const productSlugsThatRequireUserConnection =
 			getProductSlugsThatRequireUserConnection( products );
-		const requiresUserConnection = connectionError.type === 'user';
+		const requiresUserConnection = false; //connectionError.type === 'user';
 
 		const onActionButtonClick = () => {
 			if ( requiresUserConnection ) {

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -38,7 +38,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 
 		const productSlugsThatRequireUserConnection =
 			getProductSlugsThatRequireUserConnection( products );
-		const requiresUserConnection = false; //connectionError.type === 'user';
+		const requiresUserConnection = connectionError.type === 'user';
 
 		const onActionButtonClick = () => {
 			if ( requiresUserConnection ) {

--- a/projects/packages/my-jetpack/changelog/add-mj-card-update-after-async-site-connection
+++ b/projects/packages/my-jetpack/changelog/add-mj-card-update-after-async-site-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Async card update after async site connection


### PR DESCRIPTION
## Proposed changes:

* Async update product cards when the site connection status changes
* Update connected product card file to typescript
* This PR incidentally fixes an issue where more than one product could not be refetched in the same session. This was due to the key being the same for all product refetch queries

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Install the Backup, Boost, Protect, Social, and Videopress standalone plugins
3. Go to My Jetpack and you should see something like this
![image](https://github.com/user-attachments/assets/9333d7b7-086d-4b6f-ac71-f551340dcded)
4. Make sure you also see the "site connection" global notice
![image](https://github.com/user-attachments/assets/3f1bb02f-cb8c-43d4-8aa1-4137ce65c03b)
5. Click on "Connect your site" to initiate async site connection
6. Carefully watch the My Jetpack cards below. Make sure that only the "Needs Connection" cards update to a loading state, and once they finish loading, they update to a correct state. Depending on your setup, this could be "Needs user connection", "Active", "Upgrade", etc. 

https://github.com/user-attachments/assets/a1caa01d-f79a-4d6e-87ea-2f6cf9eaa806

Note: You'll notice that after the refresh, more cards show up in the owned state. This is because there are several products that only need a site connection (if the Jetpack plugin is installed, not just a standalone) to be active. You should see these statuses update async in the "unowned" section as well


