### PR TITLE
Add/view cta when product status is can upgrade

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/index.tsx
@@ -1,36 +1,9 @@
-import { __ } from '@wordpress/i18n';
 import { useCallback, type FC } from 'react';
-import useProduct from '../../../data/products/use-product';
-import useAnalytics from '../../../hooks/use-analytics';
 import ProductCard from '../../connected-product-card';
 import ProtectValueSection from './protect-value-section';
 
 const ProtectCard: FC< { admin: boolean } > = ( { admin } ) => {
-	const { recordEvent } = useAnalytics();
 	const slug = 'protect';
-	const { detail } = useProduct( slug );
-	const { isPluginActive, hasPaidPlanForProduct: hasProtectPaidPlan } = detail || {};
-
-	/**
-	 * Called when secondary "View" button is clicked.
-	 */
-	const onViewButtonClick = useCallback( () => {
-		recordEvent( 'jetpack_myjetpack_product_card_manage_click', {
-			product: slug,
-		} );
-	}, [ recordEvent ] );
-
-	const shouldShowSecondaryButton = useCallback(
-		() => isPluginActive && ! hasProtectPaidPlan,
-		[ hasProtectPaidPlan, isPluginActive ]
-	);
-
-	const viewButton = {
-		href: 'admin.php?page=jetpack-protect',
-		label: __( 'View', 'jetpack-my-jetpack' ),
-		onClick: onViewButtonClick,
-		shouldShowButton: shouldShowSecondaryButton,
-	};
 
 	// This is a workaround to remove the Description from the product card. However if we end
 	// up needing to remove the Description from additional cards in the future, we might consider
@@ -42,7 +15,6 @@ const ProtectCard: FC< { admin: boolean } > = ( { admin } ) => {
 			admin={ admin }
 			slug={ slug }
 			upgradeInInterstitial={ true }
-			secondaryAction={ viewButton }
 			Description={ noDescription }
 		>
 			<ProtectValueSection />

--- a/projects/packages/my-jetpack/changelog/add-view-cta-when-product-status-is-can-upgrade
+++ b/projects/packages/my-jetpack/changelog/add-view-cta-when-product-status-is-can-upgrade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Show View button on product card along with upgrade cta


### PR DESCRIPTION
## Proposed changes:

* When a MJ card is in the status of "CAN_UPGRADE", show a View CTA as well

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No, we are adding a function that tracks this secondary CTA, but it is an existing track that is used for the usual "View" CTA

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect your site
3. Make sure the Protect and Creator cards both show "View" as a secondary CTA and that they both lead to the correct place
![image](https://github.com/user-attachments/assets/e409a2bc-1ecd-4ab2-bec1-35a3cd0e4e6a)

