### PR TITLE
AI Logo Generator: fix the "Use on site" button

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-fix-use-on-site-button
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-fix-use-on-site-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Logo Generator: provide the saved media ID on the save logo callback.

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -63,7 +63,6 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		useLogoGenerator();
 	const { featureFetchError, firstLogoPromptFetchError, clearErrors } = useRequestErrors();
 	const siteId = siteDetails?.ID;
-	const siteURL = siteDetails?.URL;
 	const [ logoAccepted, setLogoAccepted ] = useState( false );
 
 	// First fetch the feature data so we have the most up-to-date info from the backend.
@@ -228,7 +227,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 				/>
 				{ logoAccepted ? (
 					<div className="jetpack-ai-logo-generator__accept">
-						<VisitSiteBanner siteURL={ siteURL } onVisitBlankTarget={ closeModal } />
+						<VisitSiteBanner onVisitBlankTarget={ closeModal } />
 						<div className="jetpack-ai-logo-generator__accept-actions">
 							<Button variant="primary" onClick={ closeModal }>
 								{ __( 'Close', 'jetpack-ai-client' ) }

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -171,15 +171,6 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		onApplyLogo?.();
 	};
 
-	const handleCloseAndReload = () => {
-		closeModal();
-
-		setTimeout( () => {
-			// Reload the page to update the logo.
-			window.location.reload();
-		}, 1000 );
-	};
-
 	const handleFeedbackClick = () => {
 		recordTracksEvent( EVENT_FEEDBACK, { context } );
 	};
@@ -237,13 +228,10 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 				/>
 				{ logoAccepted ? (
 					<div className="jetpack-ai-logo-generator__accept">
-						<VisitSiteBanner siteURL={ siteURL } onVisitBlankTarget={ handleCloseAndReload } />
+						<VisitSiteBanner siteURL={ siteURL } onVisitBlankTarget={ closeModal } />
 						<div className="jetpack-ai-logo-generator__accept-actions">
-							<Button variant="link" onClick={ handleCloseAndReload }>
-								{ __( 'Close and refresh', 'jetpack-ai-client' ) }
-							</Button>
-							<Button href={ siteURL } variant="primary">
-								{ __( 'Visit site', 'jetpack-ai-client' ) }
+							<Button variant="primary" onClick={ closeModal }>
+								{ __( 'Close', 'jetpack-ai-client' ) }
 							</Button>
 						</div>
 					</div>
@@ -273,7 +261,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			{ isOpen && (
 				<Modal
 					className="jetpack-ai-logo-generator-modal"
-					onRequestClose={ logoAccepted ? handleCloseAndReload : closeModal }
+					onRequestClose={ closeModal }
 					shouldCloseOnClickOutside={ false }
 					shouldCloseOnEsc={ false }
 					title={ __( 'Jetpack AI Logo Generator', 'jetpack-ai-client' ) }

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -165,9 +165,9 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		recordTracksEvent( EVENT_MODAL_CLOSE, { context, placement: EVENT_PLACEMENT_QUICK_LINKS } );
 	};
 
-	const handleApplyLogo = () => {
+	const handleApplyLogo = ( mediaId: number ) => {
 		setLogoAccepted( true );
-		onApplyLogo?.();
+		onApplyLogo?.( mediaId );
 	};
 
 	const handleFeedbackClick = () => {

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -43,6 +43,7 @@ const debug = debugFactory( 'jetpack-ai-calypso:generator-modal' );
 export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	isOpen,
 	onClose,
+	onApplyLogo,
 	siteDetails,
 	context,
 } ) => {
@@ -167,6 +168,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 
 	const handleApplyLogo = () => {
 		setLogoAccepted( true );
+		onApplyLogo?.();
 	};
 
 	const handleCloseAndReload = () => {

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -86,7 +86,9 @@ const SaveInLibraryButton: React.FC< { siteId: string } > = ( { siteId } ) => {
 	);
 };
 
-const UseOnSiteButton: React.FC< { onApplyLogo: () => void } > = ( { onApplyLogo } ) => {
+const UseOnSiteButton: React.FC< { onApplyLogo: ( mediaId: number ) => void } > = ( {
+	onApplyLogo,
+} ) => {
 	const { tracks } = useAnalytics();
 	const { recordEvent: recordTracksEvent } = tracks;
 	const { isSavingLogoToLibrary, selectedLogo, logos, selectedLogoIndex, context } =
@@ -100,7 +102,7 @@ const UseOnSiteButton: React.FC< { onApplyLogo: () => void } > = ( { onApplyLogo
 				selected_logo: selectedLogoIndex != null ? selectedLogoIndex + 1 : 0,
 			} );
 
-			onApplyLogo?.();
+			onApplyLogo?.( selectedLogo?.mediaId );
 		}
 	};
 
@@ -127,11 +129,11 @@ const LogoLoading: React.FC = () => {
 	);
 };
 
-const LogoReady: React.FC< { siteId: string; logo: Logo; onApplyLogo: () => void } > = ( {
-	siteId,
-	logo,
-	onApplyLogo,
-} ) => {
+const LogoReady: React.FC< {
+	siteId: string;
+	logo: Logo;
+	onApplyLogo: ( mediaId: number ) => void;
+} > = ( { siteId, logo, onApplyLogo } ) => {
 	return (
 		<>
 			<img

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -162,7 +162,7 @@ const LogoUpdated: React.FC< { logo: Logo } > = ( { logo } ) => {
 			/>
 			<div className="jetpack-ai-logo-generator-modal-presenter__success-wrapper">
 				<Icon icon={ <CheckIcon /> } />
-				<span>{ __( 'Your logo has been successfully updated!', 'jetpack-ai-client' ) }</span>
+				<span>{ __( 'Your new logo was set to the block!', 'jetpack-ai-client' ) }</span>
 			</div>
 		</>
 	);

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -89,39 +89,22 @@ const SaveInLibraryButton: React.FC< { siteId: string } > = ( { siteId } ) => {
 const UseOnSiteButton: React.FC< { onApplyLogo: () => void } > = ( { onApplyLogo } ) => {
 	const { tracks } = useAnalytics();
 	const { recordEvent: recordTracksEvent } = tracks;
-	const {
-		applyLogo,
-		isSavingLogoToLibrary,
-		isApplyingLogo,
-		selectedLogo,
-		logos,
-		selectedLogoIndex,
-		context,
-	} = useLogoGenerator();
+	const { isSavingLogoToLibrary, selectedLogo, logos, selectedLogoIndex, context } =
+		useLogoGenerator();
 
 	const handleClick = async () => {
-		if ( ! isApplyingLogo && ! isSavingLogoToLibrary ) {
+		if ( ! isSavingLogoToLibrary ) {
 			recordTracksEvent( EVENT_USE, {
 				context,
 				logos_count: logos.length,
 				selected_logo: selectedLogoIndex != null ? selectedLogoIndex + 1 : 0,
 			} );
 
-			try {
-				await applyLogo();
-				onApplyLogo();
-			} catch ( error ) {
-				debug( 'Error applying logo', error );
-			}
+			onApplyLogo?.();
 		}
 	};
 
-	return isApplyingLogo && ! isSavingLogoToLibrary ? (
-		<button className="jetpack-ai-logo-generator-modal-presenter__action">
-			<Icon icon={ <LogoIcon /> } />
-			<span className="action-text">{ __( 'Applying logo…', 'jetpack-ai-client' ) }</span>
-		</button>
-	) : (
+	return (
 		<Button
 			className="jetpack-ai-logo-generator-modal-presenter__action"
 			onClick={ handleClick }

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -128,7 +128,7 @@ const UseOnSiteButton: React.FC< { onApplyLogo: () => void } > = ( { onApplyLogo
 			disabled={ isSavingLogoToLibrary || ! selectedLogo?.mediaId }
 		>
 			<Icon icon={ <LogoIcon /> } />
-			<span className="action-text">{ __( 'Use on Site', 'jetpack-ai-client' ) }</span>
+			<span className="action-text">{ __( 'Use on block', 'jetpack-ai-client' ) }</span>
 		</Button>
 	);
 };

--- a/projects/js-packages/ai-client/src/logo-generator/components/visit-site-banner.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/visit-site-banner.tsx
@@ -17,9 +17,8 @@ import type React from 'react';
 
 export const VisitSiteBanner: React.FC< {
 	className?: string;
-	siteURL?: string;
 	onVisitBlankTarget: () => void;
-} > = ( { className = null, siteURL = '#', onVisitBlankTarget } ) => {
+} > = ( { className = null, onVisitBlankTarget } ) => {
 	return (
 		<div className={ clsx( 'jetpack-ai-logo-generator-modal-visit-site-banner', className ) }>
 			<div className="jetpack-ai-logo-generator-modal-visit-site-banner__jetpack-logo">
@@ -39,8 +38,13 @@ export const VisitSiteBanner: React.FC< {
 					) }
 				</span>
 				<div>
-					<Button variant="link" href={ siteURL } target="_blank" onClick={ onVisitBlankTarget }>
-						{ __( 'Visit website', 'jetpack-ai-client' ) }
+					<Button
+						variant="link"
+						href="https://jetpack.com/redirect/?source=logo_generator_learn_more_about_jetpack_ai"
+						target="_blank"
+						onClick={ onVisitBlankTarget }
+					>
+						{ __( 'Learn more about Jetpack AI', 'jetpack-ai-client' ) }
 						<Icon icon={ external } size={ 20 } />
 					</Button>
 				</div>

--- a/projects/js-packages/ai-client/src/logo-generator/lib/wpcom-limited-request.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/lib/wpcom-limited-request.ts
@@ -9,7 +9,6 @@ import apiFetch from '../../api-fetch/index.js';
 const MAX_CONCURRENT_REQUESTS = 5;
 
 let concurrentCounter = 0;
-let lastCallTimestamp: number | null = null;
 
 /**
  * Concurrency-limited request to wpcom-proxy-request.
@@ -24,16 +23,6 @@ export default async function wpcomLimitedRequest< T >( params: object ): Promis
 		concurrentCounter -= 1;
 		throw new Error( 'Too many requests' );
 	}
-
-	const now = Date.now();
-
-	// Check if the last call was made less than 100 milliseconds ago
-	if ( lastCallTimestamp && now - lastCallTimestamp < 100 ) {
-		concurrentCounter -= 1;
-		throw new Error( 'Too many requests' );
-	}
-
-	lastCallTimestamp = now; // Update the timestamp
 
 	return apiFetch< T >( params ).finally( () => {
 		concurrentCounter -= 1;

--- a/projects/js-packages/ai-client/src/logo-generator/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/types.ts
@@ -15,14 +15,14 @@ export interface GeneratorModalProps {
 	siteDetails?: SiteDetails;
 	isOpen: boolean;
 	onClose: () => void;
-	onApplyLogo: () => void;
+	onApplyLogo: ( mediaId: number ) => void;
 	context: string;
 }
 
 export interface LogoPresenterProps {
 	logo?: Logo;
 	loading?: boolean;
-	onApplyLogo: () => void;
+	onApplyLogo: ( mediaId: number ) => void;
 	logoAccepted?: boolean;
 	siteId: string | number;
 }

--- a/projects/js-packages/ai-client/src/logo-generator/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/types.ts
@@ -15,6 +15,7 @@ export interface GeneratorModalProps {
 	siteDetails?: SiteDetails;
 	isOpen: boolean;
 	onClose: () => void;
+	onApplyLogo: () => void;
 	context: string;
 }
 

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-use-on-site-button
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-use-on-site-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+AI Logo Generator: support saving the logo and the icon when an image is ready.

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -4,7 +4,7 @@
 import { GeneratorModal } from '@automattic/jetpack-ai-client';
 import { BlockControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 /*
@@ -28,6 +28,46 @@ type CoreSelect = {
 	};
 };
 
+/**
+ * Hook to set the site logo on the local state, affecting the logo block.
+ *
+ * @returns {object} An object with the setLogo function.
+ */
+const useSetLogo = () => {
+	const editEntityRecord = useDispatch( 'core' ).editEntityRecord;
+	const saveLogo = useCallback(
+		( mediaId: number ) => {
+			editEntityRecord( 'root', 'site', undefined, {
+				site_logo: mediaId,
+			} );
+		},
+		[ editEntityRecord ]
+	);
+
+	const saveIcon = useCallback(
+		( mediaId: number ) => {
+			editEntityRecord( 'root', 'site', undefined, {
+				site_icon: mediaId,
+			} );
+		},
+		[ editEntityRecord ]
+	);
+
+	const setLogo = useCallback(
+		( mediaId: number, updateIcon: boolean ) => {
+			saveLogo( mediaId );
+			if ( updateIcon ) {
+				saveIcon( mediaId );
+			}
+		},
+		[ saveLogo, saveIcon ]
+	);
+
+	return {
+		setLogo,
+	};
+};
+
 const useSiteDetails = () => {
 	const siteSettings = useSelect( select => {
 		return ( select( 'core' ) as CoreSelect ).getEntityRecord( 'root', 'site' );
@@ -48,6 +88,8 @@ const useSiteDetails = () => {
 const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 	return props => {
 		const [ isLogoGeneratorModalVisible, setIsLogoGeneratorModalVisible ] = useState( false );
+		const { setLogo } = useSetLogo();
+		const shouldSyncIcon = props?.attributes?.shouldSyncIcon || false;
 
 		const showModal = useCallback( () => {
 			setIsLogoGeneratorModalVisible( true );
@@ -57,9 +99,18 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			setIsLogoGeneratorModalVisible( false );
 		}, [] );
 
+		const applyLogoHandler = useCallback(
+			( mediaId: number ) => {
+				if ( mediaId ) {
+					setLogo( mediaId, shouldSyncIcon );
+				}
+			},
+			[ setLogo, shouldSyncIcon ]
+		);
+
 		useEffect( () => {
 			return () => {
-				// close modal if open
+				// close modal if open when the component unmounts
 				closeModal();
 			};
 		}, [ closeModal ] );
@@ -75,6 +126,7 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				<GeneratorModal
 					isOpen={ isLogoGeneratorModalVisible }
 					onClose={ closeModal }
+					onApplyLogo={ applyLogoHandler }
 					context="block-editor"
 					siteDetails={ siteDetails }
 				/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38548.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the button label to "Use on block"
* Make the button set the logo on the state, updating the block with it
* Update the "post-use" screen to remove unnecessary actions, fix the messaging and add a proper link to the "learn more about Jetpack AI" section
* Remove the timing restriction on the `wpcomLimitedRequest` lib so it does not break when there are more than 1 logo block on the editor

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure your testing site has a paid tier for Jetpack AI (the logo generator is still not working with free plans)
* Go to the block editor and add a Site Logo block
* Look for the AI extension icon on the block toolbar and click on it:

<img width="200" alt="Screenshot 2024-07-19 at 17 28 18" src="https://github.com/user-attachments/assets/315df036-7e1e-45ba-b1b8-e15f254ce848">

* Confirm the logo generator modal will show up
* If that is the first time you open it, wait for the first logo to be generated:

<img width="500" alt="Screenshot 2024-07-19 at 07 28 14" src="https://github.com/user-attachments/assets/d94e31a5-9d5d-412d-89bd-850c194c32bb">

* If not, confirm you see your history of logos and can generate another one:

<img width="500" alt="Screenshot 2024-07-25 at 18 24 47" src="https://github.com/user-attachments/assets/35c7fa7c-e596-43ff-9685-c5b46623dc9b">

* When you have a logo you like, click the "Use on block" button:

<img width="400" alt="Screenshot 2024-07-25 at 18 25 42" src="https://github.com/user-attachments/assets/5c53953e-9f7a-48df-941b-7a44d622d5a1">

* Confirm the logo generator modal will show the "post-use" screen:

<img width="500" alt="Screenshot 2024-07-25 at 18 26 21" src="https://github.com/user-attachments/assets/afb24282-ef80-46a6-ae90-a27a0a74363e">

* Confirm the "Learn more about Jetpack AI" link in the "post-use" screen will lead you to the Jetpack AI product page on `jetpack.com`
* Confirm the modal will be closed after clicking the link (or the close button, or the X button at the top)
* Confirm the logo block got updated with the new logo:

<img width="300" alt="Screenshot 2024-07-25 at 18 28 10" src="https://github.com/user-attachments/assets/db5bdc5d-84f4-4cba-a9ce-cbc1f2b4acfc">

* Save the post so the new logo is set on the site (there is a confirmation step on the sidebar, asking you to allow updating the logo)
* Confirm you can click on the AI extension button again and choose a new logo, that will replace the previous one correctly
* If possible, test it on a Simple site
* If possible, test in on the site editor