### PR TITLE
AI Assistant: Breve UI and text enhancements

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-text
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Breve UI and text enhancements

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
@@ -4,8 +4,6 @@
 	margin-bottom: 24px;
 
 	.components-checkbox-control {
-		color: #757575;
-
 		&__input {
 			@include features-colors( ( 'border-color' ) );
 			&:checked {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
@@ -84,6 +84,7 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 
 	return (
 		<div className="jetpack-ai-proofread">
+			<p> { __( 'Improve your writing with AI.', 'jetpack' ) }</p>
 			<PanelRow>
 				<BaseControl>
 					<div className="grade-level-container">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/_features.colors.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/_features.colors.scss
@@ -3,7 +3,7 @@
 
 $features-colors: (
 	'complex-words': rgb( 240, 184, 73 ),
-	'unconfident-words': rgb( 0, 175, 82 ),
+	'unconfident-words': rgb( 9, 181, 133 ),
 	'long-sentences': rgb( 122, 0, 223 ),
 );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
@@ -215,7 +215,7 @@ export default function Highlight() {
 									{ suggestions?.suggestion }
 								</Button>
 								<div className="helper">
-									{ __( 'Click on a suggestion to insert it.', 'jetpack' ) }
+									{ __( 'Click on the suggestion to insert it.', 'jetpack' ) }
 								</div>
 							</div>
 						) : (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38510

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Small fixes

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the AI Assistant sidebar entry
* [ ] The "Improve your writing with AI." text is visible
* [ ] The feature toggles' labels are not gray anymore
* [ ] The suggestion helper text refers to the suggestion, not a suggestion
* [ ] The unconfident words color is a bit more green. You need to tell the difference with your eyes, no cheating :eyes:

