### PR TITLE
Fix jetpack comments via chrome when logged in

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-comments-chrome
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-comments-chrome
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack Comments: fix replying to comments in chrome when logged in to both wordpress.com and the jetpack site

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -661,7 +661,7 @@ HTML;
 	 * Handle Jetpack Comments POST requests: process the comment form, then client-side POST the results to the self-hosted blog
 	 *
 	 * This function exists because when we submit the form via the jetpack.wordpress.com iframe
-	 * in Chrome the request comes in to jetpack but for some reason the request doesn't hace access to cookies yet.
+	 * in Chrome the request comes in to Jetpack but for some reason the request doesn't have access to cookies yet.
 	 * By submitting the form again locally with the same data the process works as expected.
 	 *
 	 * @return never

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -667,9 +667,9 @@ HTML;
 	 * @return never
 	 */
 	public function retry_submit_comment_form_locally() {
-		// We are not doing any valiodation here since all the validation will be done again by pre_comment_on_post().
-		// if the comment has been posted, this is where we do our service verification checks
-		$comment_data = stripslashes_deep( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		// We are not doing any validation here since all the validation will be done again by pre_comment_on_post().
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$comment_data = stripslashes_deep( $_POST );
 		?>
 		<!DOCTYPE html>
 		<html>

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -620,12 +620,14 @@ HTML;
 		// Bail if missing the Jetpack token.
 		if ( ! isset( $post_array['sig'] ) || ! isset( $post_array['token_key'] ) ) {
 			unset( $_POST['hc_post_as'] );
-
 			return;
 		}
 
 		if ( empty( $post_array['jetpack_comments_nonce'] ) || ! wp_verify_nonce( $post_array['jetpack_comments_nonce'], "jetpack_comments_nonce-{$post_array['comment_post_ID']}" ) ) {
-				wp_die( esc_html__( 'Nonce verification failed.', 'jetpack' ), 400 );
+			if ( ! isset( $_GET['only_once'] ) ) {
+				self::retry_submit_comment_form_locally();
+			}
+			wp_die( esc_html__( 'Nonce verification failed.', 'jetpack' ), 400 );
 		}
 
 		if ( str_contains( $post_array['hc_avatar'], '.gravatar.com' ) ) {
@@ -653,6 +655,54 @@ HTML;
 
 			wp_die( esc_html__( 'Comments are not allowed.', 'jetpack' ), 403 );
 		}
+	}
+
+	/**
+	 * Handle Jetpack Comments POST requests: process the comment form, then client-side POST the results to the self-hosted blog
+	 *
+	 * This function exists because when we submit the form via the jetpack.wordpress.com iframe
+	 * in Chrome the request comes in to jetpack but for some reason the request doesn't hace access to cookies yet.
+	 * By submitting the form again locally with the same data the process works as expected.
+	 */
+	public function retry_submit_comment_form_locally() {
+		// We are not doing any valiodation here since all the validation will be done again by pre_comment_on_post().
+		// if the comment has been posted, this is where we do our service verification checks
+		$comment_data = stripslashes_deep( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		?>
+		<!DOCTYPE html>
+		<html>
+		<head>
+		<link rel="preload" as="image" href="https://jetpack.wordpress.com/wp-admin/images/spinner.gif"> <!-- Preload the spinner image -->
+		<meta charset="utf-8">
+		<title><?php echo esc_html__( 'Submitting Comment', 'jetpack' ); ?></title>
+		<style type="text/css">
+			body {
+				display: table;
+				width: 100%;
+				height: 60%;
+				position: absolute;
+				top: 0;
+				left: 0;
+				overflow: hidden;
+				color: #333;
+			}
+		</style>
+		</head>
+		<body>
+		<img src="https://jetpack.wordpress.com/wp-admin/images/spinner.gif" >
+		<form id="jetpack-remote-comment-post-form" action="<?php echo esc_url( get_site_url() ); ?>/wp-comments-post.php?for=jetpack&only_once=true" method="POST">
+			<?php foreach ( $comment_data as $key => $val ) : ?>
+				<input type="hidden" name="<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $val ); ?>" />
+			<?php endforeach; ?>
+		</form>
+
+		<script type="text/javascript">
+			document.getElementById("jetpack-remote-comment-post-form").submit();
+		</script>
+		</body>
+		</html>
+		<?php
+		exit;
 	}
 
 	/** Capabilities **********************************************************/

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -663,6 +663,8 @@ HTML;
 	 * This function exists because when we submit the form via the jetpack.wordpress.com iframe
 	 * in Chrome the request comes in to jetpack but for some reason the request doesn't hace access to cookies yet.
 	 * By submitting the form again locally with the same data the process works as expected.
+	 *
+	 * @return never
 	 */
 	public function retry_submit_comment_form_locally() {
 		// We are not doing any valiodation here since all the validation will be done again by pre_comment_on_post().


### PR DESCRIPTION

Fixes https://github.com/Automattic/jetpack/issues/38520

Before:

https://github.com/user-attachments/assets/c3f0f718-362f-458a-9c98-d64b6e8b1097


After:

https://github.com/user-attachments/assets/aeb637d6-c352-4042-9426-aacb6480c5b7

## Proposed changes:
* This PR implements a retry process for users that try to submit comment but for some reason the browser that is submitting the comment from jetpack.wordpress.com iframe doesn't send the cookies. This will make it so that the nonce verification fails there is a retry process that happens on the jetpack site that submits make the same request as the remote one. This PR doesn't change the verification steps. That the comment goes though but since the request is now being done on from the jetpack site it the cookies are being forwarded as expected and the request succeeds. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Enable jetpack comments. 
In latest Chrome login to wordpress.com as well the jetpack site. leave a comment. 
Notice that you are able to leave a comment successfully. There might be a slight glitch with the spinner that you might notice but I think this is a better solution that currently exists. 


