### PR TITLE
Jetpack API: add 'jsonAPI' REST endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-json-api-rest-endpoint
+++ b/projects/plugins/jetpack/changelog/add-json-api-rest-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+API: add jsonAPI endpoint to supplement the XML-RPC one.


### PR DESCRIPTION
## Proposed changes:
* Add the REST endpoint `/jetpack/v4/json-api` to supplement the existing XML-RPC one.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/415

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
TBD