### PR TITLE
Jetpack Sync: extract video and audio shortcodes

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
@@ -36,6 +36,7 @@ class Jetpack_Media_Meta_Extractor {
 		'vimeo',
 		'hulu',
 		'ted',
+		'video',
 		'wpvideo',
 		'videopress',
 	);
@@ -197,6 +198,8 @@ class Jetpack_Media_Meta_Extractor {
 							$id = call_user_func( $shortcode_get_id_func, $attr );
 						} elseif ( method_exists( $shortcode_class_name, $shortcode_get_id_method ) ) {
 							$id = call_user_func( array( $shortcode_class_name, $shortcode_get_id_method ), $attr );
+						} elseif ( 'video' === $shortcode ) {
+							$id = $attr['url'] ?? $attr['mp4'] ?? $attr['m4v'] ?? $attr['webm'] ?? $attr['ogv'] ?? $attr['wmv'] ?? $attr['flv'] ?? null;
 						}
 						if ( ! empty( $id )
 							&& ( ! isset( $shortcode_details[ $shortcode_name ] ) || ! in_array( $id, $shortcode_details[ $shortcode_name ], true ) ) ) {

--- a/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
@@ -32,6 +32,7 @@ class Jetpack_Media_Meta_Extractor {
 	 * @var string[]
 	 */
 	private static $keeper_shortcodes = array(
+		'audio',
 		'youtube',
 		'vimeo',
 		'hulu',
@@ -200,6 +201,9 @@ class Jetpack_Media_Meta_Extractor {
 							$id = call_user_func( array( $shortcode_class_name, $shortcode_get_id_method ), $attr );
 						} elseif ( 'video' === $shortcode ) {
 							$id = $attr['url'] ?? $attr['mp4'] ?? $attr['m4v'] ?? $attr['webm'] ?? $attr['ogv'] ?? $attr['wmv'] ?? $attr['flv'] ?? null;
+						} elseif ( 'audio' === $shortcode ) {
+							preg_match( '#(https?://(?:[^\s"|\']+)\.(?:mp3|ogg|flac|m4a|wav))([ "\'|]|$)#', implode( ' ', $attr ), $matches );
+							$id = $matches[1] ?? null;
 						}
 						if ( ! empty( $id )
 							&& ( ! isset( $shortcode_details[ $shortcode_name ] ) || ! in_array( $id, $shortcode_details[ $shortcode_name ], true ) ) ) {

--- a/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
@@ -200,10 +200,10 @@ class Jetpack_Media_Meta_Extractor {
 						} elseif ( method_exists( $shortcode_class_name, $shortcode_get_id_method ) ) {
 							$id = call_user_func( array( $shortcode_class_name, $shortcode_get_id_method ), $attr );
 						} elseif ( 'video' === $shortcode ) {
-							$id = $attr['url'] ?? $attr['mp4'] ?? $attr['m4v'] ?? $attr['webm'] ?? $attr['ogv'] ?? $attr['wmv'] ?? $attr['flv'] ?? null;
+							$id = $attr['src'] ?? $attr['url'] ?? $attr['mp4'] ?? $attr['m4v'] ?? $attr['webm'] ?? $attr['ogv'] ?? $attr['wmv'] ?? $attr['flv'] ?? null;
 						} elseif ( 'audio' === $shortcode ) {
-							preg_match( '#(https?://(?:[^\s"|\']+)\.(?:mp3|ogg|flac|m4a|wav))([ "\'|]|$)#', implode( ' ', $attr ), $matches );
-							$id = $matches[1] ?? null;
+							preg_match( '#(https?://(?:[^\s"|\']+)\.(?:mp3|ogg|flac|m4a|wav))([ "\'|]|$)#', implode( ' ', $attr ), $audio_matches );
+							$id = $audio_matches[1] ?? null;
 						}
 						if ( ! empty( $id )
 							&& ( ! isset( $shortcode_details[ $shortcode_name ] ) || ! in_array( $id, $shortcode_details[ $shortcode_name ], true ) ) ) {

--- a/projects/plugins/jetpack/changelog/add-extracting-video-audio-shortcodes
+++ b/projects/plugins/jetpack/changelog/add-extracting-video-audio-shortcodes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Support video and audio shortcodes in Media Extractor

--- a/projects/plugins/jetpack/changelog/add-extracting-video-shortcode
+++ b/projects/plugins/jetpack/changelog/add-extracting-video-shortcode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Support video shortcodes in Media Extractor

--- a/projects/plugins/jetpack/changelog/add-extracting-video-shortcode
+++ b/projects/plugins/jetpack/changelog/add-extracting-video-shortcode
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Support video shortcodes in Media Extractor

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-extractor.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-extractor.php
@@ -749,4 +749,69 @@ EOT;
 
 		$this->assertEquals( $expected, $result );
 	}
+
+	/**
+	 * Verify that audio shortcode URL is extracted.
+	 *
+	 * @covers Jetpack_Media_Meta_Extractor::extract
+	 */
+	public function test_audio_shortcode() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_content' => 'Sed dapibus ut mauris imperdiet volutpat. [audio http://example.com/files/2011/02/audio-post.mp3|titles=Audio Post] Nullam [audio https://example.com/place/test/filename.flac] in dolor vel nulla pulvinar accumsan facilisis quis lorem. [audio="http://example.com/file.wav"]',
+			)
+		);
+
+		$expected = array(
+			'has'             => array( 'shortcode' => 3 ),
+			'shortcode'       => array(
+				'audio' => array(
+					'count' => 3,
+					'id'    => array(
+						'http://example.com/files/2011/02/audio-post.mp3',
+						'https://example.com/place/test/filename.flac',
+						'http://example.com/file.wav',
+					),
+				),
+			),
+			'shortcode_types' => array( 'audio' ),
+		);
+
+		$result = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id );
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Verify that video shortcode URL is extracted.
+	 *
+	 * @covers Jetpack_Media_Meta_Extractor::extract
+	 */
+	public function test_video_shortcode() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_content' => 'Lorem ipsum. [video wmv="http://example.com/video.wmv"][/video] Sed dapibus ut mauris imperdiet volutpat. [video width="1920" height="1080" mp4="https://example.files.wordpress.com/dir1/dir2/file.mp4"][/video] Nullam [video url="https://example.com/promo.mp4"] in dolor vel nulla pulvinar accumsan facilisis quis lorem. [video src="https://example.com/promo.m4v"] ',
+			)
+		);
+
+		$expected = array(
+			'has'             => array( 'shortcode' => 4 ),
+			'shortcode'       => array(
+				'video' => array(
+					'count' => 4,
+					'id'    => array(
+						'http://example.com/video.wmv',
+						'https://example.files.wordpress.com/dir1/dir2/file.mp4',
+						'https://example.com/promo.mp4',
+						'https://example.com/promo.m4v',
+					),
+				),
+			),
+			'shortcode_types' => array( 'video' ),
+		);
+
+		$result = Jetpack_Media_Meta_Extractor::extract( get_current_blog_id(), $post_id );
+
+		$this->assertEquals( $expected, $result );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-extractor.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-media-extractor.php
@@ -566,6 +566,9 @@ class WP_Test_Jetpack_MediaExtractor extends WP_UnitTestCase {
 				),
 				'video'   => array(
 					'count' => 1,
+					'id'    => array(
+						'video-source.mp4',
+					),
 				),
 				'gallery' => array(
 					'count' => 1,


### PR DESCRIPTION
## Proposed changes:
 
Support video and audio shortcodes in Media Extractor.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

panfyZ-3Qs-p2#comment-9718

Requires D156727-code to update tests first.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Testing on a post in wpcom: 35368-pb/#plain