### PR TITLE
Footer credit: Remove customizer option for block themes (take 2)

### DIFF
--- a/projects/plugins/wpcomsh/changelog/remove-wpcomsh-customizer-footer-credit-block-themes-2
+++ b/projects/plugins/wpcomsh/changelog/remove-wpcomsh-customizer-footer-credit-block-themes-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Footer credit: Remove customizer option for block themes

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -129,7 +129,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_0_2"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_0_3_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/footer-credit/footer-credit/customizer.php
+++ b/projects/plugins/wpcomsh/footer-credit/footer-credit/customizer.php
@@ -143,5 +143,4 @@ function footercredits_init() {
 		add_action( 'customize_register', 'footercredits_register', 99 );
 	}
 }
-
 add_action( 'init', 'footercredits_init' );

--- a/projects/plugins/wpcomsh/footer-credit/footer-credit/customizer.php
+++ b/projects/plugins/wpcomsh/footer-credit/footer-credit/customizer.php
@@ -134,5 +134,14 @@ function footercredits_sanitize_setting( $val ) {
 	}
 }
 
-// Setup the Theme Customizer settings and controls...
-add_action( 'customize_register', 'footercredits_register', 99 );
+/**
+ * Setup the Footer Credit customizer settings and controls for classic themes only.
+ * We don't support the footer credit on block themes, see https://wp.me/paYJgx-51l.
+ */
+function footercredits_init() {
+	if ( ! wp_is_block_theme() ) {
+		add_action( 'customize_register', 'footercredits_register', 99 );
+	}
+}
+
+add_action( 'init', 'footercredits_init' );

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.0.2",
+	"version": "5.0.3-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.0.2
+ * Version: 5.0.3-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.0.2' );
+define( 'WPCOMSH_VERSION', '5.0.3-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
Take 2 of https://github.com/Automattic/jetpack/pull/38473
Fixes https://github.com/Automattic/wp-calypso/issues/92986

## Proposed changes:

Reintroduces the removal of the "Footer Credit" option from the Customizer for block themes (https://github.com/Automattic/jetpack/pull/38473) which was reverted in https://github.com/Automattic/jetpack/pull/38557 since it caused fatal errors on sites with child themes.

To prevent the fatal errors, we know wait for the `init` action before checking `wp_is_block_theme`.

Props to @Automattic/lego for finding the culprit.

Before | After
--- | ---
<img width="301" alt="Screenshot 2024-07-23 at 12 29 11" src="https://github.com/user-attachments/assets/0f0230d4-3c51-455c-b633-e625871ec7e2"> | <img width="300" alt="Screenshot 2024-07-23 at 12 40 24" src="https://github.com/user-attachments/assets/64c52f1d-2324-4d85-be41-6d792f56c3fc">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to a WoA dev site:
  - Install Jetpack Beta
  - Go to `/wp-admin/admin.php?page=jetpack-beta&plugin=wpcomsh` 
  - Activate the branch of this PR
- Make sure your site has a block theme
- Go to `/wp-admin/customize.php`
- Select "Site Identity"
- Make sure the "Footer Credit" option is not visible
- Switch to a classic theme
- Reload the Customizer
- Make sure the "Footer Credit" option is visible now
- Switch to a custom child theme of a symlinked theme:
  - Install the Hevor theme
  - Install [the Generate Child Theme plugin](https://wordpress.com/plugins/generate-child-theme)
  - Go to `/wp-admin/admin.php?page=generate-child-theme`
  - Create a new child theme of Hevor
- Make sure the "The parent theme is missing. Please install the "hevor" parent theme." does not show up

