### PR TITLE
WPCOM API: Return list of newsletter category IDs after saving

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-categories-wpcomapi
+++ b/projects/plugins/jetpack/changelog/update-newsletter-categories-wpcomapi
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-WPCOM API: Return list of newsletter categories after saving
+WPCOM API: Return list of newsletter categories IDs after saving

--- a/projects/plugins/jetpack/changelog/update-newsletter-categories-wpcomapi
+++ b/projects/plugins/jetpack/changelog/update-newsletter-categories-wpcomapi
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WPCOM API: Return list of newsletter categories after saving

--- a/projects/plugins/jetpack/changelog/update-newsletter-categories-wpcomapi
+++ b/projects/plugins/jetpack/changelog/update-newsletter-categories-wpcomapi
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-WPCOM API: Return list of newsletter categories IDs after saving
+WPCOM API: Return list of newsletter category IDs after saving

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1056,7 +1056,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					);
 
 					if ( update_option( $key, $new_value ) ) {
-						$updated[ $key ] = $new_value;
+						$updated[ $key ] = $sanitized_category_ids;
 					}
 					break;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/92908

## Proposed changes:

Fixes the WPCOM API response for `wpcom_newsletter_categories` setting by returning a list of newsletter category IDs instead of objects with `term_id` after the setting is saved.

It prevents the "You have unsaved changes. Are you sure you want to leave this page?" prompt from being shown in Calypso after the categories are saved.

### Before

```JSON
{
    "code": 200,
    "headers": [
        {
            "name": "Content-Type",
            "value": "application\/json"
        }
    ],
    "body": {
        "updated": {
            "wpcom_newsletter_categories": [
                {
                    "term_id": 768700663
                },
                {
                    "term_id": 769393513
                },
                {
                    "term_id": 1
                }
            ]
        }
    }
}
```

### After

```JSON
{
    "code": 200,
    "headers": [
        {
            "name": "Content-Type",
            "value": "application\/json"
        }
    ],
    "body": {
        "updated": {
            "wpcom_newsletter_categories": [
                768700663,
                769393513,
                1
            ]
        }
    }
}
```

@Automattic/apex could you take a look? I don't want to break something 😅 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* have some post categories
* apply this change to your sandbox
* sandbox `public-api.wordpress.com`
* go to Newsletter Settings page https://wordpress.com/settings/newsletter/{siteUrl}
* enable the "Enable newsletter categories" toggle and check some categories
* save settings
* navigate away making sure the "You have unsaved changes. Are you sure you want to leave this page?" prompt is not visible

