### PR TITLE
Disable block registration for simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-disable-blog-stats-simple
+++ b/projects/plugins/jetpack/changelog/fix-disable-blog-stats-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Disable blog stats block for simple sites

--- a/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
+++ b/projects/plugins/jetpack/extensions/blocks/blog-stats/blog-stats.php
@@ -13,7 +13,6 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Stats\WPCOM_Stats;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 
 /**
@@ -22,13 +21,7 @@ use Jetpack_Gutenberg;
  * registration if we need to.
  */
 function register_block() {
-	if (
-		( new Host() )->is_wpcom_simple()
-		|| (
-			( new Connection_Manager( 'jetpack' ) )->has_connected_owner()
-			&& ! ( new Status() )->is_offline_mode()
-		)
-	) {
+	if ( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() && ! ( new Status() )->is_offline_mode() ) {
 		Blocks::jetpack_register_block(
 			__DIR__,
 			array( 'render_callback' => __NAMESPACE__ . '\load_assets' )

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
@@ -12,7 +12,6 @@ namespace Automattic\Jetpack\Extensions\Top_Posts;
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
 use Jetpack_Top_Posts_Helper;
 
@@ -26,13 +25,7 @@ if ( ! class_exists( 'Jetpack_Top_Posts_Helper' ) ) {
  * registration if we need to.
  */
 function register_block() {
-	if (
-		( new Host() )->is_wpcom_simple()
-		|| (
-			( new Connection_Manager( 'jetpack' ) )->has_connected_owner()
-			&& ! ( new Status() )->is_offline_mode()
-		)
-	) {
+	if ( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() && ! ( new Status() )->is_offline_mode() ) {
 		Blocks::jetpack_register_block(
 			__DIR__,
 			array( 'render_callback' => __NAMESPACE__ . '\load_assets' )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The blog stats block doesn't work on simple websites.
The request to fetch the stats fails in this case.
This PR disables the block for simple sites. Later the implementation can be fixed to work for simple sites.

Fixes #
https://github.com/Automattic/jetpack/issues/36141

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* disable block for simple sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sync the PR to your sandbox
* Open a simple site and open the editor. Try to add the blog stats block. It shouldn't be available.
* Sync the PR with an atomic site via the beta tester plugin
* Open the atomic site and open the editor. Try to add the blog stats block. The block should be added successfully 
*

