### PR TITLE
wpcomsh: COLOURlovers: Remove Temporary Patterns Tracking

### DIFF
--- a/projects/plugins/wpcomsh/changelog/remove-wpcomsh-colourlovers-tracking
+++ b/projects/plugins/wpcomsh/changelog/remove-wpcomsh-colourlovers-tracking
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Removed temporary internal colourlovers pattern tracking
+
+

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -1972,38 +1972,6 @@ function add_color_palette( $palette, $title = false ) {
 }
 
 /**
- * This is a quick and easy function to track usage of COLOURlovers patterns across Dotcom.
- * We intend to run it for a few weeks and then remove it.
- *
- * We also maintain a WPCOM version for Simple sites.
- *
- * @see pdKhl6-3qP-p2
- */
-function wpcomsh_temporarily_maybe_track_colourlovers_pattern_usage() {
-	$cache_key = 'stats_tmp_colourlovers_pattern';
-	$found     = false;
-	wp_cache_get( $cache_key, 'stats', false, $found );
-
-	// We don't need to track all page views, just once per site.
-	if ( $found ) {
-		return;
-	}
-
-	$bg = get_theme_mod( 'background_image' );
-	wp_cache_set( $cache_key, $bg, 'stats' );
-
-	if ( ! empty( $bg ) && str_contains( $bg, 'colourlovers' ) ) {
-		$event_properties = array(
-			'siteid'  => (int) Jetpack_Options::get_option( 'id' ),
-			'pattern' => pathinfo( $bg, PATHINFO_FILENAME ),
-			'theme'   => get_stylesheet(),
-		);
-		wpcomsh_record_tracks_event( 'wpcom_tmp_cl_pattern', $event_properties );
-	}
-}
-add_action( 'wp_footer', 'wpcomsh_temporarily_maybe_track_colourlovers_pattern_usage', 101 );
-
-/**
  * Gutenberg color manager.
  */
 class Colors_Manager_Gutenberg extends Colors_Manager_Common {


### PR DESCRIPTION
## Proposed changes:

* Removes temporary tracking of COLOURlovers pattern usage added 3 months ago.
* See: PR 1819 on the old wpcomsh repo + pdKhl6-3qP-p2#comment-7087

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Verify no references to `wpcomsh_temporarily_maybe_track_colourlovers_pattern_usage` remain
* Basic tests