### PR TITLE
Premium Content Block: Update Transformation Rules

### DIFF
--- a/projects/plugins/jetpack/changelog/update-premium-content-block-transform
+++ b/projects/plugins/jetpack/changelog/update-premium-content-block-transform
@@ -1,0 +1,4 @@
+Significance: major
+Type: enhancement
+
+Premium Content Block: Only show it as a transformation option if group or columns blocks are selected or if multiple blocks are selected.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/editor.js
@@ -24,18 +24,6 @@ import {
 } from './subscriber-view/.';
 
 /**
- * A list of blocks that should be disallowed to be transformed to Premium content block since they are mostly markup blocks.
- */
-const disallowFromTransformations = [
-	'core/nextpage',
-	'core/spacer',
-	'core/separator',
-	'core/more',
-	'core/loginout',
-	'core/post-navigation-link',
-];
-
-/**
  * Check if the given blocks are transformable to premium-content block
  *
  * This is because transforming blocks that are already premium content blocks, or have one as a descendant or ancestor
@@ -47,6 +35,16 @@ const disallowFromTransformations = [
  * @returns {boolean} Whether the blocks should be allowed to be transformed to a premium content block
  */
 const blocksCanBeTransformed = blocks => {
+	if ( ! blocks ) {
+		return false;
+	}
+
+	if ( blocks.length === 1 ) {
+		if ( ! [ 'core/group', 'core/columns' ].includes( blocks[ 0 ].name ) ) {
+			return false;
+		}
+	}
+
 	// Avoid transforming any premium-content block.
 	if ( blocks.some( blockContainsPremiumBlock ) ) {
 		return false;
@@ -58,13 +56,7 @@ const blocksCanBeTransformed = blocks => {
 		return false;
 	}
 
-	// Check if the blocks selected are all in the disallowFromTransformations.
-	// If  they are, they don't have any value in allowing them to be transformed to Premium Content.
-	const isInDisallowList = blocks.every( block =>
-		disallowFromTransformations.includes( block.name )
-	);
-
-	return ! isInDisallowList;
+	return true;
 };
 
 registerJetpackBlockFromMetadata(
@@ -82,9 +74,8 @@ registerJetpackBlockFromMetadata(
 						if ( fromAttributes.some( attributes => attributes.isPremiumContentChild ) ) {
 							return false;
 						}
-						// The fromBlocks parameter doesn't exist in Gutenberg < 11.1.0, so if it isn't passed, allow the
-						// match, fallback code in the convert method will handle it.
-						return fromBlocks === undefined || blocksCanBeTransformed( fromBlocks );
+
+						return blocksCanBeTransformed( fromBlocks );
 					},
 					__experimentalConvert( blocks ) {
 						// This is checked here as well as in isMatch because the isMatch function isn't fully compatible


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Improves https://github.com/Automattic/wp-calypso/issues/67635

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Restricts the transformation of blocks to Premium Content only if group or columns blocks are selected, or if multiple blocks are selected.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify Transformation Restrictions: Add various blocks to the editor, including group, columns, and multiple block selections. Confirm that the option to transform to a Premium Content block only appears when group or columns blocks are selected, or when multiple blocks are selected. Verify that the transformation option does not appear for the following blocks: core/nextpage, core/spacer, core/separator, core/more, core/html, core/loginout, core/post-navigation-link.

* Single Block Transformation: Select a single block that is not a group or columns block. Confirm that the option to transform to a Premium Content block does not appear.

* Multiple Blocks Transformation: Select multiple blocks, including combinations of group and columns blocks. Confirm that the transformation to Premium Content block option appears and is functional.
