### PR TITLE
CRM: Woo sync issue with an undefinned variable warning message and casting a non float fee value

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-woo-sync-issue
+++ b/projects/plugins/crm/changelog/fix-crm-woo-sync-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WooSync: Fix a warning message on sync and fatal error when a fee value is not a number

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1623,6 +1623,8 @@ class Woo_Sync_Background_Sync_Job {
 
 			$order_data['subtotal'] = 0.0;
 
+			$item_tax_rate_ids = null;
+
 			// cycle through order items to create crm line items
 			foreach ( $order_items as $item_key => $item ) {
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -1733,7 +1733,7 @@ class Woo_Sync_Background_Sync_Job {
 							$new_line_item['taxes'] = implode( ',', $item_tax_rate_ids );
 						}
 
-						$order_data['subtotal'] += $new_line_item['price'];
+						$order_data['subtotal'] += floatval( $new_line_item['price'] );
 
 						// Add fee as an item to the invoice
 						$data['lineitems'][] = $new_line_item;


### PR DESCRIPTION
Resolves: https://github.com/Automattic/zero-bs-crm/issues/3473

## Proposed changes:

This PRs fixes an issue with WooSync. Sometimes, a warning message appears when an order doesn't have a tax value because `$item_tax_rate_ids` is not defined before a conditional. The fix is to declare the `$item_tax_rate_ids` as null.

Also, it fixes another issue when, for some reason, the value fee provided is not a number, provoking a fatal error. The fix is to cast it to a float using `floatval`.



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
- Check the code and see logically what was happening.
- Apply this change
- The issue is not trivial to replicate, you have to install WooCommerce and create some orders.
- Activate the PHP debug log for warnings.
- Create a simple orders (pending status) with a product. In trunk, you should see the warning. In this branch, it's fixed.
- Create an order with a fee value with text or symbols. I couldn't replicate it, WooCommerce didn't allow me to set non numeric values or without percentages. The fee item in WooCommerce is given as string, but we have to cast it to a float to ensure we don't get a fatal error.



