### PR TITLE
AI Assistant: Release Breve for 20% of sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-release-20
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-release-20
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Release Breve for 20% of sites

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
@@ -2,7 +2,7 @@ import { getFeatureAvailability } from '../../../../../blocks/ai-assistant/lib/u
 
 const blogId = parseInt( window?.Jetpack_Editor_Initial_State?.wpcomBlogId );
 
-// Enable backend prompts for beta sites + 10% of production sites.
+// Enable backend prompts for beta sites + 20% of production sites.
 const isBreveAvailable =
 	getFeatureAvailability( 'ai-proofread-breve' ) || [ 0, 6 ].includes( blogId % 10 );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
@@ -3,6 +3,7 @@ import { getFeatureAvailability } from '../../../../../blocks/ai-assistant/lib/u
 const blogId = parseInt( window?.Jetpack_Editor_Initial_State?.wpcomBlogId );
 
 // Enable backend prompts for beta sites + 10% of production sites.
-const isBreveAvailable = getFeatureAvailability( 'ai-proofread-breve' ) || blogId % 10 === 0;
+const isBreveAvailable =
+	getFeatureAvailability( 'ai-proofread-breve' ) || [ 0, 6 ].includes( blogId % 10 );
 
 export default isBreveAvailable;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds another digit to the release check

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a simple site with blog id ending in something other than 0 or 6, check that Breve is not enabled
* On a simple site with blog id ending in 6, check that Breve is enabled

