### PR TITLE
AI Logo Generator: fix placement property for open and close modal events

### DIFF
--- a/projects/js-packages/ai-client/changelog/upate-jetpack-ai-fix-logo-generation-event-tracking
+++ b/projects/js-packages/ai-client/changelog/upate-jetpack-ai-fix-logo-generation-event-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Logo Generator: support placement property on the generator modal, for tracking purposes.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.15.1-alpha",
+	"version": "0.16.0-alpha",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -17,7 +17,6 @@ import {
 	EVENT_MODAL_OPEN,
 	EVENT_FEEDBACK,
 	EVENT_MODAL_CLOSE,
-	EVENT_PLACEMENT_QUICK_LINKS,
 	EVENT_GENERATE,
 } from '../constants.js';
 import useLogoGenerator from '../hooks/use-logo-generator.js';
@@ -46,6 +45,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	onApplyLogo,
 	siteDetails,
 	context,
+	placement,
 } ) => {
 	const { tracks } = useAnalytics();
 	const { recordEvent: recordTracksEvent } = tracks;
@@ -148,10 +148,10 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 
 	const handleModalOpen = useCallback( async () => {
 		setContext( context );
-		recordTracksEvent( EVENT_MODAL_OPEN, { context, placement: EVENT_PLACEMENT_QUICK_LINKS } );
+		recordTracksEvent( EVENT_MODAL_OPEN, { context, placement } );
 
 		initializeModal();
-	}, [ setContext, context, initializeModal ] );
+	}, [ setContext, context, placement, initializeModal ] );
 
 	const closeModal = () => {
 		// Reset the state when the modal is closed, so we trigger the modal initialization again when it's opened.
@@ -162,7 +162,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		setNeedsMoreRequests( false );
 		clearErrors();
 		setLogoAccepted( false );
-		recordTracksEvent( EVENT_MODAL_CLOSE, { context, placement: EVENT_PLACEMENT_QUICK_LINKS } );
+		recordTracksEvent( EVENT_MODAL_CLOSE, { context, placement } );
 	};
 
 	const handleApplyLogo = ( mediaId: number ) => {

--- a/projects/js-packages/ai-client/src/logo-generator/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/types.ts
@@ -17,6 +17,7 @@ export interface GeneratorModalProps {
 	onClose: () => void;
 	onApplyLogo: ( mediaId: number ) => void;
 	context: string;
+	placement: string;
 }
 
 export interface LogoPresenterProps {

--- a/projects/plugins/jetpack/changelog/upate-jetpack-ai-fix-logo-generation-event-tracking
+++ b/projects/plugins/jetpack/changelog/upate-jetpack-ai-fix-logo-generation-event-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: fix event tracking of logo generator to inform the proper placement.

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/constants.ts
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/constants.ts
@@ -1,1 +1,3 @@
+export const TOOL_PLACEMENT = 'site-logo-block-extension' as const;
+export const PLACEMENT_CONTEXT = 'block-editor' as const;
 export const SITE_LOGO_BLOCK_AI_EXTENSION = 'ai-assistant-site-logo-support' as const;

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -12,7 +12,7 @@ import { addFilter } from '@wordpress/hooks';
  */
 import { getFeatureAvailability } from '../../blocks/ai-assistant/lib/utils/get-feature-availability';
 import AiToolbarButton from './components/ai-toolbar-button.js';
-import { SITE_LOGO_BLOCK_AI_EXTENSION } from './constants.js';
+import { SITE_LOGO_BLOCK_AI_EXTENSION, TOOL_PLACEMENT, PLACEMENT_CONTEXT } from './constants.js';
 
 /**
  * Mininal type definition for the core select function.
@@ -127,7 +127,8 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					isOpen={ isLogoGeneratorModalVisible }
 					onClose={ closeModal }
 					onApplyLogo={ applyLogoHandler }
-					context="block-editor"
+					context={ PLACEMENT_CONTEXT }
+					placement={ TOOL_PLACEMENT }
 					siteDetails={ siteDetails }
 				/>
 			</>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38571.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Support `placement` on the `GeneratorModal` component, and use it when tracking open and close modal events
* Change the extension code to provide `site-logo-block-extension` as the placement for the logo generator modal, when triggered from the extension
* After some review, this is the only change necessary on the event tracking, everything else is location/placement agnostic, and contains the basic information we need for tracking; I don't want to change the event strcuture so we can keep using the dashboard we already have, just highlighting the new context and placement values

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with a paid Jetpack AI plan, go to the block editor and add a site logo block
* Open the browser console, and enable debugging with `localStorage.setItem( 'debug', '*' );`
* Filter the console messages using `dops:analytics` so it is easier to check the tracking messages
* Click on the toolbar AI extension button to open the logo generator
* Use the tool and confirm the following actions are tracked:
   * open the modal
   * enhance some prompt typed on the prompt box
   * generate logos
   * navigate between logos on the logo carousel
   * click on the "provide feedback" link
   * use a logo on the block
   * close the modal
* Confirm the context for all events is "block-editor"
* Confirm the placement for modal open and close events is "site-logo-block-extension"

<img width="600" alt="Screenshot 2024-07-26 at 16 15 36" src="https://github.com/user-attachments/assets/772d73d3-a979-43a4-ae18-b280a552de8e">