### PR TITLE
Update/all tracks to snake case

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -196,8 +196,8 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 	const hasSiteConnectionBrokenModules = brokenModules?.needs_site_connection.length > 0;
 	const tracksEventData = useMemo( () => {
 		return {
-			userConnectionBrokenModules: brokenModules?.needs_user_connection.join( ', ' ),
-			siteConnectionBrokenModules: brokenModules?.needs_site_connection.join( ', ' ),
+			user_connection_broken_modules: brokenModules?.needs_user_connection.join( ', ' ),
+			site_connection_broken_modules: brokenModules?.needs_site_connection.join( ', ' ),
 		};
 	}, [ brokenModules ] );
 
@@ -209,7 +209,7 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 			e && e.preventDefault();
 			recordEvent( 'jetpack_myjetpack_connection_manage_dialog_click', {
 				...tracksEventData,
-				connectionType,
+				connection_type: connectionType,
 			} );
 			setIsManageConnectionDialogOpen( true );
 		},

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -44,7 +44,7 @@ const GlobalNotice = ( { message, title, options } ) => {
 		const tracksArgs = options?.tracksArgs || {};
 
 		recordEvent( 'jetpack_myjetpack_global_notice_view', {
-			noticeId: options.id,
+			notice_id: options.id,
 			...tracksArgs,
 		} );
 	}, [ options.id, recordEvent, options?.tracksArgs ] );

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/scan-threats-status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/scan-threats-status.tsx
@@ -208,7 +208,7 @@ function ScanStatus( { status }: { status: 'success' | 'partial' | 'off' } ) {
 						tracksEventProps={ {
 							location: 'scan',
 							status: status,
-							hasPaidPlan: false,
+							has_paid_plan: false,
 							threats: 0,
 						} }
 					>

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts
@@ -5,7 +5,7 @@ import useMyJetpackConnection from '../use-my-jetpack-connection';
 
 type TracksRecordEvent = (
 	event: `jetpack_${ string }`, // Enforces the event name to start with "jetpack_"
-	properties?: Record< string, unknown >
+	properties?: Record< Lowercase< string >, unknown >
 ) => void;
 
 const useAnalytics = () => {
@@ -44,8 +44,8 @@ const useAnalytics = () => {
 		jetpackAnalytics.tracks.recordEvent( event, {
 			...properties,
 			version: myJetpackVersion,
-			isSiteConnected,
-			isUserConnected,
+			is_site_connected: isSiteConnected,
+			is_user_connected: isUserConnected,
 			referring_plugins: connectedPluginsSlugs,
 		} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-site-connection-notice.tsx
@@ -113,7 +113,7 @@ const useSiteConnectionNotice = ( redBubbleAlerts: RedBubbleAlerts ) => {
 			isRedBubble: true,
 			tracksArgs: {
 				type: connectionError.type,
-				isError: connectionError.is_error,
+				is_error: connectionError.is_error,
 			},
 		};
 

--- a/projects/packages/my-jetpack/changelog/update-all-tracks-to-snake-case
+++ b/projects/packages/my-jetpack/changelog/update-all-tracks-to-snake-case
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update all tracks to snake case, camel case is not supported


### PR DESCRIPTION
## Proposed changes:

* Update all tracks properties to snake case keys

Camel case keys were causing tracks to not be tracked correctly

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pbNhbs-bbY-p2#comment-22980

## Does this pull request change what data or activity we track or use?

Yes, we should start to see more tracks in relation to the event properties that are being updated

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. You don't have to check all the props, just make sure there aren't any camel case ones left and look through the code to make sure the ones that were changed look good
3. Go to My Jetpack on a connected site and in tracks vigilante make sure you don't see any camel case props in any events
![image](https://github.com/user-attachments/assets/1d0d4198-6bdc-49fe-97b9-3f855499469e)

