### PR TITLE
launchpad: bypass for logged out traffic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/launchpad-skip-on-logged-out
+++ b/projects/packages/jetpack-mu-wpcom/changelog/launchpad-skip-on-logged-out
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WPCOM: Launchpad registration skipped for logged out traffic

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -377,8 +377,10 @@ function wpcom_launchpad_get_task_lists( $rebuild = false ) {
  * Register all tasks and task lists on init.
  */
 function wpcom_register_default_launchpad_checklists() {
-	wpcom_launchpad_get_task_lists();
-	wpcom_add_active_task_listener_hooks_to_correct_action();
+	if ( is_user_logged_in() ) {
+		wpcom_launchpad_get_task_lists();
+		wpcom_add_active_task_listener_hooks_to_correct_action();
+	}
 }
 add_action( 'init', 'wpcom_register_default_launchpad_checklists', 11 );
 


### PR DESCRIPTION
## Proposed changes:

* Skip building registering launchpad tasks for logged out traffic.

@daledupreez , Is this a good idea? My thinking is that all launchpad tasks have something to do with making changes to a site, like publishing a post or changing the design, and that logged out traffic can never accomplish a task.

Update: Apparently the changes break the 'guides' test suite on wpcom. I wasn't aware that guides and launchpad are related. I probably don't understand what's happening here well enough.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

I was using D156709-code to try it out on WPCOM, not really sure what to check though.

## Blocker

Apparently this breaks the "Guides" testsuite on wpcom.

