### PR TITLE
AI Logo Generator: Allow free plans to generate logos using the extension

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-allow-free-plans-on-logo-generator
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-allow-free-plans-on-logo-generator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Logo Generator: fix code to allow free plans to generate logos, within request balance limits.

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -96,8 +96,10 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			const logoCost = feature?.costs?.[ 'jetpack-ai-logo-generator' ]?.logo ?? DEFAULT_LOGO_COST;
 			const promptCreationCost = 1;
 			const currentLimit = feature?.currentTier?.limit || 0;
-			const currentUsage = feature?.usagePeriod?.requestsCount || 0;
 			const isUnlimited = feature?.currentTier?.value === 1;
+			const isFree = feature?.currentTier?.value === 0;
+			const currentUsage =
+				isUnlimited || isFree ? feature?.requestsCount : feature?.usagePeriod?.requestsCount || 0;
 			const hasNoNextTier = ! feature?.nextTier; // If there is no next tier, the user cannot upgrade.
 
 			// The user needs an upgrade immediately if they have no logos and not enough requests remaining for one prompt and one logo generation.

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -95,9 +95,9 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			const hasHistory = ! isLogoHistoryEmpty( String( siteId ) );
 			const logoCost = feature?.costs?.[ 'jetpack-ai-logo-generator' ]?.logo ?? DEFAULT_LOGO_COST;
 			const promptCreationCost = 1;
-			const currentLimit = feature?.currentTier?.value || 0;
+			const currentLimit = feature?.currentTier?.limit || 0;
 			const currentUsage = feature?.usagePeriod?.requestsCount || 0;
-			const isUnlimited = currentLimit === 1;
+			const isUnlimited = feature?.currentTier?.value === 1;
 			const hasNoNextTier = ! feature?.nextTier; // If there is no next tier, the user cannot upgrade.
 
 			// The user needs an upgrade immediately if they have no logos and not enough requests remaining for one prompt and one logo generation.

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -70,8 +70,12 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 	const featureData = getAiAssistantFeature( String( site?.id || '' ) );
 
 	const currentLimit = featureData?.currentTier?.limit || 0;
-	const currentUsage = featureData?.usagePeriod?.requestsCount || 0;
 	const isUnlimited = featureData?.currentTier?.value === 1;
+	const isFree = featureData?.currentTier?.value === 0;
+	const currentUsage =
+		isUnlimited || isFree
+			? featureData?.requestsCount
+			: featureData?.usagePeriod?.requestsCount || 0;
 
 	useEffect( () => {
 		if ( currentLimit - currentUsage <= 0 ) {

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -69,9 +69,9 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 
 	const featureData = getAiAssistantFeature( String( site?.id || '' ) );
 
-	const currentLimit = featureData?.currentTier?.value || 0;
+	const currentLimit = featureData?.currentTier?.limit || 0;
 	const currentUsage = featureData?.usagePeriod?.requestsCount || 0;
-	const isUnlimited = currentLimit === 1;
+	const isUnlimited = featureData?.currentTier?.value === 1;
 
 	useEffect( () => {
 		if ( currentLimit - currentUsage <= 0 ) {

--- a/projects/js-packages/ai-client/src/logo-generator/store/reducer.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/reducer.ts
@@ -122,9 +122,6 @@ export default function reducer(
 					aiAssistantFeature: {
 						costs: defaultCosts,
 						...action.feature,
-						// re evaluate requireUpgrade as the logo generator does not allow free usage
-						requireUpgrade:
-							action.feature?.requireUpgrade || action.feature?.currentTier?.value === 0,
 						_meta: {
 							...state?.features?.aiAssistantFeature?._meta,
 							isRequesting: false,
@@ -179,8 +176,7 @@ export default function reducer(
 			const isOverLimit = currentCount >= requestsLimit;
 
 			// highest tier holds a soft limit so requireUpgrade is false on that case (nextTier null means highest tier)
-			const requireUpgrade =
-				isFreeTierPlan || ( isOverLimit && state?.features?.aiAssistantFeature?.nextTier !== null );
+			const requireUpgrade = isOverLimit && state?.features?.aiAssistantFeature?.nextTier !== null;
 
 			return {
 				...state,

--- a/projects/js-packages/ai-client/src/logo-generator/store/selectors.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/selectors.ts
@@ -122,9 +122,9 @@ const selectors = {
 	getRequireUpgrade( state: LogoGeneratorStateProp ): boolean {
 		const feature = state.features.aiAssistantFeature;
 		const logoCost = feature?.costs?.[ 'jetpack-ai-logo-generator' ]?.logo ?? DEFAULT_LOGO_COST;
-		const currentLimit = feature?.currentTier?.value || 0;
+		const currentLimit = feature?.currentTier?.limit || 0;
 		const currentUsage = feature?.usagePeriod?.requestsCount || 0;
-		const isUnlimited = currentLimit === 1;
+		const isUnlimited = feature?.currentTier?.value === 1;
 		const hasNoNextTier = ! feature?.nextTier; // If there is no next tier, the user cannot upgrade.
 
 		// Add a local check on top of the feature flag, based on the current usage and logo cost.

--- a/projects/js-packages/ai-client/src/logo-generator/store/selectors.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/selectors.ts
@@ -123,8 +123,10 @@ const selectors = {
 		const feature = state.features.aiAssistantFeature;
 		const logoCost = feature?.costs?.[ 'jetpack-ai-logo-generator' ]?.logo ?? DEFAULT_LOGO_COST;
 		const currentLimit = feature?.currentTier?.limit || 0;
-		const currentUsage = feature?.usagePeriod?.requestsCount || 0;
 		const isUnlimited = feature?.currentTier?.value === 1;
+		const isFree = feature?.currentTier?.value === 0;
+		const currentUsage =
+			isUnlimited || isFree ? feature?.requestsCount : feature?.usagePeriod?.requestsCount || 0;
 		const hasNoNextTier = ! feature?.nextTier; // If there is no next tier, the user cannot upgrade.
 
 		// Add a local check on top of the feature flag, based on the current usage and logo cost.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38575.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the rules present on the code to not mark the free plan as one that requires upgrade
* Fix the code that gets the current usage data, to get it from the right place when the plan is free or unlimited
* Since the first generation costs 10 + 1 request, free users can generate up to 1 logo, but at least they can try/discover the feature

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test it on a site with a free plan (spin a new JN site, for example)
* Go to the block editor
* Add a site logo block and click on the AI extension button
* Confirm the logo generation process will start
* Since it costs 10 + 1 request on the first generation, confirm you see the upgrade nudge on the modal
* Confirm you can close and open the modal again:
   * given that you have a logo on the history, the modal will open again and you can see the logo generated before
   * also, given you may have only 9 requests left (20 - 1 - 10), the upgrade nudge shoud be visible
* Close the modal and then clean you logo generation history (on the local storage, delete the `logo-history-SITE_ID` key)
* Try to open the logo generator modal again
* This time, confirm you see an alert modal saying that you need to upgrade to generate logos (since you don't have enough requests)
* Use the AI Assistant upgrade button to upgrade your plan to a paid one
* Return to the block editor and try to use the logo generator again
* This time, you can use the tool as usual
* Confirm the remaining requests counter makes sense
* **Note:** the upgrade links around the logo generator UI are still not working; I will fix it soon