### PR TITLE
Shortcode: Fix the test-class.gravatar.php tests

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-test-class-gravatar
+++ b/projects/plugins/jetpack/changelog/fix-test-class-gravatar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Shortcode: Fix the test-class.gravatar.php tests

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.gravatar.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.gravatar.php
@@ -34,11 +34,14 @@ class WP_Test_Jetpack_Shortcodes_Gravatar extends WP_UnitTestCase {
 	 * @since 4.5.0
 	 */
 	public function test_shortcodes_gravatar_image() {
-		$content = "[gravatar email='user@example.org' size='48']";
+		$email   = 'user@example.org';
+		$size    = 48;
+		$content = "[gravatar email='$email' size='$size']";
 
 		$shortcode_content = do_shortcode( $content );
-		$this->assertStringContainsString( "<img alt='' src='http://2.gravatar.com/avatar/572c3489ea700045927076136a969e27?s=48&#038;d=mm&#038;r=g'", $shortcode_content );
-		$this->assertStringContainsString( "class='avatar avatar-48 photo' height='48' width='48'", $shortcode_content );
+		$avatar_url        = get_avatar_url( $email, array( 'size' => $size ) );
+		$this->assertStringContainsString( "<img alt='' src='$avatar_url'", $shortcode_content );
+		$this->assertStringContainsString( "class='avatar avatar-$size photo' height='$size' width='$size'", $shortcode_content );
 	}
 
 	/**
@@ -76,8 +79,9 @@ class WP_Test_Jetpack_Shortcodes_Gravatar extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', $http_request_filter, 10, 1 );
 
 		$shortcode_content = do_shortcode( $content );
+		$avatar_url        = get_avatar_url( $email, array( 'size' => 96 ) );
 		$this->assertStringContainsString( '<div class="grofile vcard" id="grofile-embed-0">', $shortcode_content );
-		$this->assertStringContainsString( '<img src="http://2.gravatar.com/avatar/572c3489ea700045927076136a969e27?s=96&#038;d=mm&#038;r=g" width="96" height="96" class="no-grav gravatar photo"', $shortcode_content );
+		$this->assertStringContainsString( "<img src=\"$avatar_url\" width=\"96\" height=\"96\" class=\"no-grav gravatar photo\"", $shortcode_content );
 
 		remove_filter( 'pre_http_request', $http_request_filter, 10, 1 );
 	}
@@ -88,6 +92,7 @@ class WP_Test_Jetpack_Shortcodes_Gravatar extends WP_UnitTestCase {
 	 * @since 4.5.0
 	 */
 	public function test_shortcodes_gravatar_user_id() {
+		$email   = 'user@example.org';
 		$user    = self::factory()->user->create_and_get( array( 'user_email' => 'user@example.org' ) );
 		$content = "[gravatar_profile who='$user->ID']";
 		wp_set_current_user( $user->ID );
@@ -106,7 +111,8 @@ class WP_Test_Jetpack_Shortcodes_Gravatar extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', $http_request_filter, 10, 1 );
 
 		$shortcode_content = do_shortcode( $content );
-		$this->assertStringContainsString( '<img src="http://2.gravatar.com/avatar/572c3489ea700045927076136a969e27?s=96&#038;d=mm&#038;r=g" width="96" height="96" class="no-grav gravatar photo"', $shortcode_content );
+		$avatar_url        = get_avatar_url( $email, array( 'size' => 96 ) );
+		$this->assertStringContainsString( "<img src=\"$avatar_url\" width=\"96\" height=\"96\" class=\"no-grav gravatar photo\"", $shortcode_content );
 
 		remove_filter( 'pre_http_request', $http_request_filter, 10, 1 );
 	}

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.gravatar.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.gravatar.php
@@ -39,7 +39,7 @@ class WP_Test_Jetpack_Shortcodes_Gravatar extends WP_UnitTestCase {
 		$content = "[gravatar email='$email' size='$size']";
 
 		$shortcode_content = do_shortcode( $content );
-		$avatar_url        = get_avatar_url( $email, array( 'size' => $size ) );
+		$avatar_url        = wptexturize( get_avatar_url( $email, array( 'size' => $size ) ) );
 		$this->assertStringContainsString( "<img alt='' src='$avatar_url'", $shortcode_content );
 		$this->assertStringContainsString( "class='avatar avatar-$size photo' height='$size' width='$size'", $shortcode_content );
 	}
@@ -79,7 +79,7 @@ class WP_Test_Jetpack_Shortcodes_Gravatar extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', $http_request_filter, 10, 1 );
 
 		$shortcode_content = do_shortcode( $content );
-		$avatar_url        = get_avatar_url( $email, array( 'size' => 96 ) );
+		$avatar_url        = wptexturize( get_avatar_url( $email, array( 'size' => 96 ) ) );
 		$this->assertStringContainsString( '<div class="grofile vcard" id="grofile-embed-0">', $shortcode_content );
 		$this->assertStringContainsString( "<img src=\"$avatar_url\" width=\"96\" height=\"96\" class=\"no-grav gravatar photo\"", $shortcode_content );
 
@@ -111,7 +111,7 @@ class WP_Test_Jetpack_Shortcodes_Gravatar extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', $http_request_filter, 10, 1 );
 
 		$shortcode_content = do_shortcode( $content );
-		$avatar_url        = get_avatar_url( $email, array( 'size' => 96 ) );
+		$avatar_url        = wptexturize( get_avatar_url( $email, array( 'size' => 96 ) ) );
 		$this->assertStringContainsString( "<img src=\"$avatar_url\" width=\"96\" height=\"96\" class=\"no-grav gravatar photo\"", $shortcode_content );
 
 		remove_filter( 'pre_http_request', $http_request_filter, 10, 1 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related p1722236204217709-slack-CDLH4C1UZ

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the tests of test-class.gravatar.php because the schema of the URL has been changed by Core. See https://core.trac.wordpress.org/ticket/37454.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the tests are passed successfully