### PR TITLE
Tests: Removing test skip for test_sync_maybe_update_core as WP core bug now fixed

### DIFF
--- a/projects/plugins/jetpack/changelog/update-remove-skip-test_sync_maybe_update_core
+++ b/projects/plugins/jetpack/changelog/update-remove-skip-test_sync_maybe_update_core
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tests: Removing test_sync_maybe_update_core test skip as core bug now fixed.

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -153,8 +153,6 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_sync_maybe_update_core() {
-		$this->markTestSkipped( 'Skipped due to core bug. See p1721736489043329-slack-C034JEXD1RD' );
-		// @phan-suppress-next-line PhanPluginUnreachableCode
 		if ( is_multisite() ) {
 			$this->markTestSkipped( 'Not compatible with multisite mode' );
 		}


### PR DESCRIPTION

## Proposed changes:


* This PR removes the skip from a test - `test_sync_maybe_update_core` - as the core bug that resulting in the need for the skip has now been resolved. The skip was added here: https://github.com/Automattic/jetpack/pull/38476

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/jetpack/pull/38476

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* The PHP tests: PHP 8.2 WP trunk should pass in this PR.

