### PR TITLE
Fix `get_products_by_ownership` to always return an array

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-get-products-by-ownership-return
+++ b/projects/packages/my-jetpack/changelog/fix-get-products-by-ownership-return
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: This change is not visible to the end user.
+
+

--- a/projects/packages/my-jetpack/src/class-products.php
+++ b/projects/packages/my-jetpack/src/class-products.php
@@ -212,7 +212,9 @@ class Products {
 					)
 				)
 			),
-			'unowned' => array_unique( $unowned_products ),
+			'unowned' => array_values(
+				array_unique( $unowned_products )
+			),
 		);
 
 		return $data[ $type ];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes the return of `get_products_by_ownership` so both `owned` and `unowned` products always return an `array`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* N/a

