### PR TITLE
Admin bar: Force mobile viewport to have the same icon color as desktop

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-color
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin bar: Force mobile viewport to have the same icon color as desktop

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -12,6 +12,21 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
 define( 'WPCOM_ADMIN_BAR_UNIFICATION', true );
 
+// The $icon-color variable for admin color schemes.
+// See: https://github.com/WordPress/wordpress-develop/blob/679cc0c4a261a77bd8fdb140cd9b0b2ff80ebf37/src/wp-admin/css/colors/_variables.scss#L9
+// Only the ones different from the "fresh" scheme are listed.
+const WPCOM_ADMIN_ICON_COLORS = array(
+	'blue'      => '#e5f8ff',
+	'coffee'    => '#f3f2f1',
+	'ectoplasm' => '#ece6f6',
+	'midnight'  => '#f3f2f1',
+	'fresh'     => '#a7aaad',
+	'ocean'     => '#f2fcff',
+	'light'     => '#999',
+	'modern'    => '#f3f1f1',
+	'sunrise'   => '#f3f1f1',
+);
+
 /**
  * Adds the origin_site_id query parameter to a URL.
  *
@@ -67,6 +82,20 @@ function wpcom_enqueue_admin_bar_assets() {
 CSS
 		);
 	}
+
+	$admin_color      = get_user_option( 'admin_color' );
+	$admin_icon_color = WPCOM_ADMIN_ICON_COLORS[ $admin_color ] ?? WPCOM_ADMIN_ICON_COLORS['fresh'];
+
+	// Force the icon colors to have desktop color even on mobile viewport.
+	wp_add_inline_style(
+		'wpcom-admin-bar',
+		<<<CSS
+			#wpadminbar.mobile .quicklinks .ab-icon:before,
+			#wpadminbar.mobile .quicklinks .ab-item:before {
+				color: $admin_icon_color !important;
+			}
+CSS
+	);
 }
 add_action( 'wp_enqueue_scripts', 'wpcom_enqueue_admin_bar_assets' );
 add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_admin_bar_assets' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/8379

## Proposed changes:

This PR forces the admin bar on mobile viewport to have the same icon color as desktop, for consistency with Calypso. Note that this only applies to the left-side icons (wpcom, reader, +New, ...) and not the right-side ones.

### How

We do that by hardcoding the Core's icon color CSS here.

### Other approaches

I tried various other approaches, but I believe this is the best one. 😅 

1. Removing `.mobile` from `#wpadminbar` via JavaScript.
    - I'm afraid there's some plugins that rely on this selector.
2. Removing the `#wpadminbar.mobile` CSS rules via JavaScript (https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/deleteRule).
    - This looks very hacky.
3. Adding `color: unset !important;` (or `initial` / `inherit`) to `#wpadminbar.mobile`.
    - Does not work...

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this PR to Jetpack Beta Tester.
5. Open /wp-admin on mobile viewport.
6. Refresh the page to force the `.mobile` selector on `#wpadminbar`.
7. Try various color schemes and verify that the LEFT-SIDE icons have the same color as when you open wp-admin pages on desktop viewport.