### PR TITLE
Welcome Flow: fixes and improvements pt. 2

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
@@ -34,7 +34,7 @@ const EvaluationRecommendations: React.FC = () => {
 					</FlexItem>
 					<FlexItem>
 						<DropdownMenu
-							menuProps={ { className: styles.dropdownMenu } }
+							menuProps={ { className: styles[ 'dropdown-menu' ] } }
 							popoverProps={ { position: 'bottom left' } }
 							icon={ moreHorizontalMobile }
 							label={ __( 'Recommendations menu', 'jetpack-my-jetpack' ) }
@@ -53,12 +53,18 @@ const EvaluationRecommendations: React.FC = () => {
 				</Flex>
 			</Col>
 			<Col>
-				<Container horizontalGap={ 4 } horizontalSpacing={ 2 } fluid>
+				<Container
+					tagName="ul"
+					className={ styles[ 'recommendations-list' ] }
+					horizontalGap={ 4 }
+					horizontalSpacing={ 2 }
+					fluid
+				>
 					{ recommendedModules.map( module => {
 						const Card = JetpackModuleToProductCard[ module ];
 						return (
 							Card && (
-								<Col key={ module } lg={ 4 }>
+								<Col tagName="li" key={ module } lg={ 4 }>
 									<Card recommendation />
 								</Col>
 							)

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
@@ -2,6 +2,16 @@
     margin-bottom: 0.75rem;
 }
 
-.dropdownMenu {
+.dropdown-menu {
     width: 200px;
+}
+
+// Setting min-width of recommendation (product) cards to 300px; see: /components/product-cards-section/style.module.scss:62
+@media screen and (min-width: 599px) and (max-width: 1290px) {
+	ul.recommendations-list {
+		grid-template-columns: repeat( auto-fill, minmax( 300px, 1fr ) );
+		> li {
+			grid-column-end: auto;
+		}
+	}	
 }

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
@@ -53,7 +53,12 @@ const ConnectionStep = ( { onActivateSite, isActivating }: ConnectionStepProps )
 					) }
 				</Text>
 				<TermsOfService agreeButtonLabel={ activationButtonLabel } mb={ 4 } />
-				<Button variant="primary" disabled={ isActivating } onClick={ onConnectSiteClick }>
+				<Button
+					variant="primary"
+					disabled={ isActivating }
+					isLoading={ isActivating }
+					onClick={ onConnectSiteClick }
+				>
 					{ isActivating ? __( 'Activating…', 'jetpack-my-jetpack' ) : activationButtonLabel }
 				</Button>
 			</Col>

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -352,7 +352,7 @@ class Initializer {
 		if ( class_exists( 'Jetpack' ) && ! empty( $active_modules ) ) {
 			$active_modules = array_diff( $active_modules, Jetpack::get_default_modules() );
 		}
-		return $active_modules;
+		return array_values( $active_modules );
 	}
 
 	/**
@@ -373,12 +373,7 @@ class Initializer {
 		// TODO: add a data point for the last known connection/ disconnection time
 
 		// are any modules active?
-		$modules        = new Modules();
-		$active_modules = $modules->get_active();
-		// if the Jetpack plugin is active, filter out the modules that are active by default
-		if ( class_exists( 'Jetpack' ) && ! empty( $active_modules ) ) {
-			$active_modules = array_diff( $active_modules, Jetpack::get_default_modules() );
-		}
+		$active_modules = self::get_active_modules();
 		if ( ! empty( $active_modules ) ) {
 			return false;
 		}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
- **Apply min-width 300px to cards**
- **Set loading state of site connection button**
- **Fix parsing active modules array**

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Again, start JN with Jetpack branch activated in Jetpack Beta plugin
2. Go to "My Jetpack"
3. Go through acquisition flow, and play around with recommendations
4. Notice that: cards break to second line (instead of shrinking) on smaller width screens
5. Notice that: button with connecting site to Jetpack has loading state
6. When you activate up to 3 plugins, recommendations will show in My Jetpack (before, they were disappearing as soon as first plugin got activated due to a bug)
