### PR TITLE
AI Logo Generator: fix save logo button style issue

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-logo-generator-fix-ui-issues
+++ b/projects/js-packages/ai-client/changelog/update-ai-logo-generator-fix-ui-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Logo Generator: fix UI issues.

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -79,10 +79,10 @@ const SaveInLibraryButton: React.FC< { siteId: string } > = ( { siteId } ) => {
 			<span className="action-text">{ __( 'Save in Library', 'jetpack-ai-client' ) }</span>
 		</Button>
 	) : (
-		<button className="jetpack-ai-logo-generator-modal-presenter__action">
+		<Button className="jetpack-ai-logo-generator-modal-presenter__action">
 			<Icon icon={ saving ? <MediaIcon /> : <CheckIcon /> } />
 			<span className="action-text">{ saving ? savingLabel : savedLabel }</span>
-		</button>
+		</Button>
 	);
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use the proper markup so the button inherits the right styles, looking similar to the other button

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure your testing site has a paid Jetpack AI plan and has beta extensions enabled
* Go to the block editor, insert a Site Logo block and open the logo generator modal by clicking on the AI extension toolbar button
* If you did not have a logo on the history yet, wait for the first one to be generated
* Notice the "Saved" button near the logo
* Confirm it has the same style as the "Use on block" button

| Before | After |
| --- | --- |
| <img width="500" alt="Screenshot 2024-07-29 at 11 17 37" src="https://github.com/user-attachments/assets/ac00044c-2ffe-466d-a346-0934ae97c095"> | <img width="500" alt="Screenshot 2024-07-29 at 11 28 47" src="https://github.com/user-attachments/assets/d3acacfb-9981-40b4-aa44-c1959597ecbb"> |


