### PR TITLE
Fix Newsletter byline link font-size and icon

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -308,13 +308,7 @@ const EmailSettings = props => {
 								'jetpack'
 							),
 							{
-								settingsLink: (
-									<ExternalLink
-										// variant="link"
-										// isExternalLink={ true }
-										href={ adminUrl + 'options-general.php' }
-									/>
-								),
+								settingsLink: <ExternalLink href={ adminUrl + 'options-general.php' } />,
 							}
 						) }
 					</div>

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -7,6 +7,7 @@ import {
 	Chip,
 	Button as JetpackButton,
 } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import Button from 'components/button';
@@ -308,7 +309,7 @@ const EmailSettings = props => {
 							),
 							{
 								settingsLink: (
-									<JetpackButton
+									<ExternalLink
 										variant="link"
 										isExternalLink={ true }
 										href={ adminUrl + 'options-general.php' }

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -310,8 +310,8 @@ const EmailSettings = props => {
 							{
 								settingsLink: (
 									<ExternalLink
-										variant="link"
-										isExternalLink={ true }
+										// variant="link"
+										// isExternalLink={ true }
 										href={ adminUrl + 'options-general.php' }
 									/>
 								),

--- a/projects/plugins/jetpack/changelog/fix-newsletter-byline-link-fontsize
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-byline-link-fontsize
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Tiny font-size update
+
+


### PR DESCRIPTION
## Proposed changes
Tiny change to align the `general settings` link with the other external links that appear above it in Newsletter Settings.

|Before|After|
|---|---|
|<img width="548" alt="Screenshot 2024-07-29 at 16 30 12" src="https://github.com/user-attachments/assets/c4e5b600-b3d4-476e-b843-e18f2858d95a">|<img width="528" alt="Screenshot 2024-07-29 at 16 30 05" src="https://github.com/user-attachments/assets/597d0352-a8e2-4f2b-a4de-85a9b6568e1c">|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?
- [ ] 
## Does this pull request change what data or activity we track or use?

Nope.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Switch to this branch
* Go to `Jetpack > Settings > Newsletter`
* Scroll down to `Email byline` and ensure the `general settings` has the same format as the other external links above

