### PR TITLE
Backport mu-wpcom-plugin 2.5.2, jetpack 13.7-a.7, wpcomsh 5.1.0 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2024-07-29
+### Added
+- AI Logo Generator: support placement property on the generator modal, for tracking purposes. [#38574]
+
+### Fixed
+- AI Logo Generator: make the initial prompt update when the site name and description are fully laoded from store. [#38491]
+- AI Logo Generator: provide the saved media ID on the save logo callback. [#38552]
+
 ## [0.15.0] - 2024-07-22
 ### Added
 - Jetpack AI: Add logo generator codebase to the ai-client package. [#38391]
@@ -358,6 +366,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.16.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.6...v0.15.0
 [0.14.6]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.5...v0.14.6
 [0.14.5]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.4...v0.14.5

--- a/projects/js-packages/ai-client/changelog/upate-jetpack-ai-fix-logo-generation-event-tracking
+++ b/projects/js-packages/ai-client/changelog/upate-jetpack-ai-fix-logo-generation-event-tracking
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-AI Logo Generator: support placement property on the generator modal, for tracking purposes.

--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-connect-logo-generator-to-block-extension
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-connect-logo-generator-to-block-extension
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Logo Generator: make the initial prompt update when the site name and description are fully laoded from store.

--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-fix-use-on-site-button
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-fix-use-on-site-button
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Logo Generator: provide the saved media ID on the save logo callback.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.16.0-alpha",
+	"version": "0.16.0",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/licensing/CHANGELOG.md
+++ b/projects/js-packages/licensing/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.21 - 2024-07-29
+### Fixed
+- Updated package dependencies. [#38464]
+
 ## 0.12.20 - 2024-07-22
 ### Changed
 - Update dependencies. [#37982]

--- a/projects/js-packages/licensing/changelog/prerelease
+++ b/projects/js-packages/licensing/changelog/prerelease
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Updated package dependencies.

--- a/projects/js-packages/licensing/package.json
+++ b/projects/js-packages/licensing/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-licensing",
-	"version": "0.12.21-alpha",
+	"version": "0.12.21",
 	"description": "Jetpack licensing flow",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/licensing/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.57.0] - 2024-07-29
+### Added
+- Added mentioning of Manual Sharing [#38411]
+
+### Fixed
+- Fixed broken connection notices to make them more helpful [#38450]
+
 ## [0.56.2] - 2024-07-22
 ### Fixed
 - Fixed double request issue and simplifed refresh logic [#38350]
@@ -788,6 +795,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.57.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.56.2...v0.57.0
 [0.56.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.56.1...v0.56.2
 [0.56.1]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.56.0...v0.56.1
 [0.56.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.55.1...v0.56.0

--- a/projects/js-packages/publicize-components/changelog/add-social-connections-manual-share-mention
+++ b/projects/js-packages/publicize-components/changelog/add-social-connections-manual-share-mention
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added mentioning of Manual Sharing

--- a/projects/js-packages/publicize-components/changelog/update-improve-social-broken-connection-notices
+++ b/projects/js-packages/publicize-components/changelog/update-improve-social-broken-connection-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed broken connection notices to make them more helpful

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.57.0-alpha",
+	"version": "0.57.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/explat/CHANGELOG.md
+++ b/projects/packages/explat/CHANGELOG.md
@@ -5,3 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 - 2024-07-29
+### Added
+- Adds a new component to fetch experiments specifically for authenticated users [#37999]
+- Initial version. [#37910]
+- Introduce the both the backend layer and frontend components for the ExPlat package. [#37958]
+
+### Changed
+- ExPlat: add condition to prevent fetching the experiment assignment if there's not anon id (meaning that Tracks is likely disabled) [#38327]
+- Updated package dependencies. [#38132]

--- a/projects/packages/explat/changelog/add-explat-authenticated-component
+++ b/projects/packages/explat/changelog/add-explat-authenticated-component
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Adds a new component to fetch experiments specifically for authenticated users

--- a/projects/packages/explat/changelog/add-explat-components
+++ b/projects/packages/explat/changelog/add-explat-components
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Introduce the both the backend layer and frontend components for the ExPlat package.

--- a/projects/packages/explat/changelog/initial-version
+++ b/projects/packages/explat/changelog/initial-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Initial version.

--- a/projects/packages/explat/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/explat/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Updated package dependencies.

--- a/projects/packages/explat/changelog/update-explat-experiment-fetching
+++ b/projects/packages/explat/changelog/update-explat-experiment-fetching
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-ExPlat: add condition to prevent fetching the experiment assignment if there's not anon id (meaning that Tracks is likely disabled)

--- a/projects/packages/explat/package.json
+++ b/projects/packages/explat/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-explat",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"description": "A package for running A/B tests on the Experimentation Platform (ExPlat) in the plugin.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/explat/#readme",
 	"bugs": {

--- a/projects/packages/explat/src/class-explat.php
+++ b/projects/packages/explat/src/class-explat.php
@@ -20,7 +20,7 @@ class ExPlat {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	const PACKAGE_VERSION = '0.1.0';
 
 	/**
 	 * Initializer.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.6] - 2024-07-29
+### Changed
+- Update dependencies. [#38558]
+
 ## [0.32.5] - 2024-07-22
 ### Fixed
 - Block Picker: Fixed display of the picker in the block editor following changes in WordPress 6.6. [#38406]
@@ -611,6 +615,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.32.6]: https://github.com/automattic/jetpack-forms/compare/v0.32.5...v0.32.6
 [0.32.5]: https://github.com/automattic/jetpack-forms/compare/v0.32.4...v0.32.5
 [0.32.4]: https://github.com/automattic/jetpack-forms/compare/v0.32.3...v0.32.4
 [0.32.3]: https://github.com/automattic/jetpack-forms/compare/v0.32.2...v0.32.3

--- a/projects/packages/forms/changelog/force-a-release
+++ b/projects/packages/forms/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.32.6-alpha",
+	"version": "0.32.6",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.32.6-alpha';
+	const PACKAGE_VERSION = '0.32.6';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.51.0] - 2024-07-29
+### Changed
+- Hide the plugin banner on non-wpcom-connected users or agency-managed users [#38532]
+
+### Fixed
+- Admin Bar: Fix the order of the top-right items on Atomic sites [#38533]
+
 ## [5.50.0] - 2024-07-26
 ### Added
 - Added a new task to the readymade-template launchpad for generating content with AI [#38507]
@@ -1054,6 +1061,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.51.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.50.0...v5.51.0
 [5.50.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.49.1...v5.50.0
 [5.49.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.49.0...v5.49.1
 [5.49.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.48.0...v5.49.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-order
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-order
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Admin Bar: Fix the order of the top-right items on Atomic sites

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-plugins
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-plugins
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Hide the plugin banner on non-wpcom-connected users or agency-managed users

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.51.0-alpha",
+	"version": "5.51.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.51.0-alpha';
+	const PACKAGE_VERSION = '5.51.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/masterbar/CHANGELOG.md
+++ b/projects/packages/masterbar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2024-07-29
+### Changed
+- Remove Browse sites from sidebar as it's on WordPress logo in masterbar [#38547]
+
 ## [0.5.0] - 2024-07-22
 ### Added
 - Add background color to address overlapping. [#38438]
@@ -76,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#37669]
 - Updated package dependencies. [#37706]
 
+[0.6.0]: https://github.com/Automattic/jetpack-masterbar/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Automattic/jetpack-masterbar/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Automattic/jetpack-masterbar/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Automattic/jetpack-masterbar/compare/v0.3.0...v0.3.1

--- a/projects/packages/masterbar/changelog/remove-browse-sites-from-sidebar
+++ b/projects/packages/masterbar/changelog/remove-browse-sites-from-sidebar
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Remove Browse sites from sidebar as it's on WordPress logo in masterbar

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.6.0-alpha",
+	"version": "0.6.0",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.6.0-alpha';
+	const PACKAGE_VERSION = '0.6.0';
 
 	/**
 	 * Initializer.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.30.0] - 2024-07-29
+### Added
+- Async card update after async site connection [#38549]
+- My Jetpack: add A/A experiment to test for correct random assignment and prevent bias in metric performance. [#38327]
+- Show View button on product card along with upgrade cta [#38550]
+
+### Changed
+- Final minor enhancements to the Protect product card in My Jetpack. [#38420]
+
+### Removed
+- Remove functionality that hid 1 value on the backup card for mid-sized screens [#38441]
+
+### Fixed
+- Include Jetpack Legacy plans when checking if user has social included with plan [#38516]
+- Update all tracks to snake case, camel case is not supported [#38576]
+
 ## [4.29.0] - 2024-07-22
 ### Added
 - Added the auto-firewall status to the Protect product  card in My Jetpack. [#38332]
@@ -1582,6 +1598,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.30.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.29.0...4.30.0
 [4.29.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.28.0...4.29.0
 [4.28.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.27.2...4.28.0
 [4.27.2]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.27.1...4.27.2

--- a/projects/packages/my-jetpack/changelog/add-mj-card-update-after-async-site-connection
+++ b/projects/packages/my-jetpack/changelog/add-mj-card-update-after-async-site-connection
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Async card update after async site connection

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-aa-experiment
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-aa-experiment
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-My Jetpack: add A/A experiment to test for correct random assignment and prevent bias in metric performance.

--- a/projects/packages/my-jetpack/changelog/add-view-cta-when-product-status-is-can-upgrade
+++ b/projects/packages/my-jetpack/changelog/add-view-cta-when-product-status-is-can-upgrade
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Show View button on product card along with upgrade cta

--- a/projects/packages/my-jetpack/changelog/fix-get-products-by-ownership-return
+++ b/projects/packages/my-jetpack/changelog/fix-get-products-by-ownership-return
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: This change is not visible to the end user.
-
-

--- a/projects/packages/my-jetpack/changelog/fix-mj-social-card-showing-no-plan-with-legacy-plans
+++ b/projects/packages/my-jetpack/changelog/fix-mj-social-card-showing-no-plan-with-legacy-plans
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Include Jetpack Legacy plans when checking if user has social included with plan

--- a/projects/packages/my-jetpack/changelog/remove-mj-backup-card-functionality-to-hide-item-on-smaller-screens
+++ b/projects/packages/my-jetpack/changelog/remove-mj-backup-card-functionality-to-hide-item-on-smaller-screens
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Remove functionality that hid 1 value on the backup card for mid-sized screens

--- a/projects/packages/my-jetpack/changelog/update-all-tracks-to-snake-case
+++ b/projects/packages/my-jetpack/changelog/update-all-tracks-to-snake-case
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Update all tracks to snake case, camel case is not supported

--- a/projects/packages/my-jetpack/changelog/update-mj-protect-card-update-n-refactor
+++ b/projects/packages/my-jetpack/changelog/update-mj-protect-card-update-n-refactor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Final minor enhancements to the Protect product card in My Jetpack.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.30.0-alpha",
+	"version": "4.30.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -41,7 +41,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.30.0-alpha';
+	const PACKAGE_VERSION = '4.30.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2024-07-29
+### Added
+- Add support for syncing Jetpack WAF options. [#37957]
+
 ## [3.3.1] - 2024-07-26
 ### Fixed
 - Jetpack Sync: Ensure duplicate Sync modules are not loaded [#38503]
@@ -1215,6 +1219,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[3.4.0]: https://github.com/Automattic/jetpack-sync/compare/v3.3.1...v3.4.0
 [3.3.1]: https://github.com/Automattic/jetpack-sync/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/Automattic/jetpack-sync/compare/v3.2.1...v3.3.0
 [3.2.1]: https://github.com/Automattic/jetpack-sync/compare/v3.2.0...v3.2.1

--- a/projects/packages/sync/changelog/add-waf-options
+++ b/projects/packages/sync/changelog/add-waf-options
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add support for syncing Jetpack WAF options.

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.4.0-alpha';
+	const PACKAGE_VERSION = '3.4.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.29] - 2024-07-29
+### Changed
+- Update dependencies. [#38558]
+
 ## [0.23.28] - 2024-07-22
 ### Changed
 - Update dependencies. [#38402]
@@ -1373,6 +1377,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.29]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.28...v0.23.29
 [0.23.28]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.27...v0.23.28
 [0.23.27]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.26...v0.23.27
 [0.23.26]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.25...v0.23.26

--- a/projects/packages/videopress/changelog/force-a-release
+++ b/projects/packages/videopress/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.29-alpha",
+	"version": "0.23.29",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.29-alpha';
+	const PACKAGE_VERSION = '0.23.29';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/CHANGELOG.md
+++ b/projects/packages/wordads/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.25] - 2024-07-29
+### Fixed
+- Updated package dependencies. [#38464]
+
 ## [0.3.24] - 2024-07-22
 ### Changed
 - Update dependencies. [#38017]
@@ -375,6 +379,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PHPCS: Fix `WordPress.Security.ValidatedSanitizedInput`
 - Updated package dependencies.
 
+[0.3.25]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.24...v0.3.25
 [0.3.24]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.23...v0.3.24
 [0.3.23]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.22...v0.3.23
 [0.3.22]: https://github.com/Automattic/jetpack-wordads/compare/v0.3.21...v0.3.22

--- a/projects/packages/wordads/changelog/prerelease
+++ b/projects/packages/wordads/changelog/prerelease
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Updated package dependencies.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.25-alpha",
+	"version": "0.3.25",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.25-alpha';
+	const VERSION = '0.3.25';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.7-a.7 - 2024-07-29
+### Enhancements
+- AI Assistant: Add feedback link to the sidebar. [#38528]
+- AI Assistant: Breve UI enhancements. [#38545]
+- AI Assistant: Disable first Breve hover on mobile. [#38527]
+- AI Assistant: Disable long sentences Breve feature by default. [#38508]
+- AI Assistant: Enable Breve for 10% of production sites. [#38465]
+- AI Assistant: Enable Breve for 20% of production sites. [#38572]
+- General: Losslessly optimized PNG images. [#38398]
+- Site Editor: Remove extra site editor notices in favor of the ones provided by WordPress directly. [#38459]
+
+### Improved compatibility
+- Masterbar: Always show the notification bell. [#38494]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Admin page: Remove propTypes and defaultProps from code due to React legacy code warnings. [#38546]
+- AI Assistant: Add animation on loading for AI Proofread. [#38541]
+- AI Assistant: Add events for Breve. [#38481]
+- AI Assistant: Breve UI and text enhancements. [#38553]
+- AI Assistant: Fix highlight not working on formatted texts. [#38540]
+- AI Assistant: Display AI sidebar on first highlight hover. [#38468]
+- AI Assistant: Fix block inserter behavior when Breve is enabled. [#38483]
+- AI Assistant: Remove Breve readability star. [#38524]
+- AI Assistant: Rename Breve and proofread entries on sidebar [#38456]
+- AI Logo Generator: Support saving the logo and the icon when an image is ready. [#38552]
+- Google Analytics: Remove the module and its remnants. [#37960]
+- Jetpack AI: Add action links on sidebar for feature discoverability. [#38531]
+- Jetpack AI: Connect the site logo block extension to AI Logo Generator modal. [#38491]
+- Jetpack AI: Fix event tracking of logo generator to inform the proper placement. [#38574]
+- Jetpack AI: Remove unused ai-assistant-panel component. [#38489]
+- Jetpack Editor State: Add is_my_jetpack_available to initial state. [#38500]
+- Newsletter: Byline settings return the correct default value. [#38435]
+- Popover: Refactor some code to use refs, adding in tests to future proof. [#38339]
+- Premium Content Block: Only show it as a transformation option if group or columns blocks are selected or if multiple blocks are selected. [#38569]
+- Remove Browse sites from sidebar as it's on WordPress logo in masterbar. [#38547]
+- Shortcode: Fix the test-class.gravatar.php tests. [#38582]
+- Social Menus: Requiring the feature from the Classic Theme Helper package. [#38297]
+- Tests: Removing test_sync_maybe_update_core test skip as core bug now fixed. [#38583]
+- Tests: Skipping test_sync_maybe_update_core test due to core bug. [#38476]
+- WPCOM API: Return actual value instead of bool for some settings after update. [#38498]
+- WPCOM API: Return list of newsletter category IDs after saving. [#38560]
+- WPCOM Connection test: use better ciphers than RC4, which is no longer available on many hosts. [#38393]
+- WPCOM Settings API: Add synced options from Jetpack WAF. [#37957]
+
 ## 13.7-a.5 - 2024-07-22
 ### Enhancements
 - Dashboard: Add a dashboard card for AI Assistant. [#38413]

--- a/projects/plugins/jetpack/changelog/add-13.7-testing-instructions
+++ b/projects/plugins/jetpack/changelog/add-13.7-testing-instructions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Added testing instructions.
-
-

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-action-link
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-action-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack AI: add action links on sidebar for feature discoverability

--- a/projects/plugins/jetpack/changelog/add-jetpack-editor-state-my-jetpack-availability
+++ b/projects/plugins/jetpack/changelog/add-jetpack-editor-state-my-jetpack-availability
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack Editor State: add is_my_jetpack_available to initial state

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-aa-experiment
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-aa-experiment
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-aa-experiment#2
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-aa-experiment#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-require-social-menu-classic-theme-helper-package
+++ b/projects/plugins/jetpack/changelog/add-require-social-menu-classic-theme-helper-package
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Social Menus: Requiring the feature from the Classic Theme Helper package.

--- a/projects/plugins/jetpack/changelog/add-require-social-menu-classic-theme-helper-package#2
+++ b/projects/plugins/jetpack/changelog/add-require-social-menu-classic-theme-helper-package#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-require-social-menu-classic-theme-helper-package#3
+++ b/projects/plugins/jetpack/changelog/add-require-social-menu-classic-theme-helper-package#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-sync-waf-options
+++ b/projects/plugins/jetpack/changelog/add-sync-waf-options
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-waf-options-to-rest-api
+++ b/projects/plugins/jetpack/changelog/add-waf-options-to-rest-api
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-WPCOM Settings API: Add synced options from Jetpack WAF.

--- a/projects/plugins/jetpack/changelog/delete-jetpack-module-google-analytics
+++ b/projects/plugins/jetpack/changelog/delete-jetpack-module-google-analytics
@@ -1,4 +1,0 @@
-Significance: major
-Type: other
-
-Google Analytics: remove the module and its remnants.

--- a/projects/plugins/jetpack/changelog/fix-ai-proofread-popover-hover
+++ b/projects/plugins/jetpack/changelog/fix-ai-proofread-popover-hover
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Fix highlight not working on formatted texts

--- a/projects/plugins/jetpack/changelog/fix-defaultprops-connect-settings-form-warnings
+++ b/projects/plugins/jetpack/changelog/fix-defaultprops-connect-settings-form-warnings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Admin page: Remove propTypes and defaultProps from code due to React legacy code warnings.

--- a/projects/plugins/jetpack/changelog/fix-dotcom-default-settings-for-newsletter-byline
+++ b/projects/plugins/jetpack/changelog/fix-dotcom-default-settings-for-newsletter-byline
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Newsletter: byline settings return the correct default value

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-block-inserter
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-block-inserter
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Fix block inserter behavior when Breve is enabled

--- a/projects/plugins/jetpack/changelog/fix-jsx-runtime-react-19-polyfill
+++ b/projects/plugins/jetpack/changelog/fix-jsx-runtime-react-19-polyfill
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-test-class-gravatar
+++ b/projects/plugins/jetpack/changelog/fix-test-class-gravatar
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Shortcode: Fix the test-class.gravatar.php tests

--- a/projects/plugins/jetpack/changelog/fix-wrong-jetpack-contributor
+++ b/projects/plugins/jetpack/changelog/fix-wrong-jetpack-contributor
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Not a functionality change at all. Just fixed the contributor name.
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.7-a.8
+
+

--- a/projects/plugins/jetpack/changelog/remove-browse-sites-from-sidebar
+++ b/projects/plugins/jetpack/changelog/remove-browse-sites-from-sidebar
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Remove Browse sites from sidebar as it's on WordPress logo in masterbar

--- a/projects/plugins/jetpack/changelog/remove-jetpack-ai-unused-ai-assistant-panel
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-ai-unused-ai-assistant-panel
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: remove unused ai-assistant-panel component

--- a/projects/plugins/jetpack/changelog/remove-show-browse-sites-link
+++ b/projects/plugins/jetpack/changelog/remove-show-browse-sites-link
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/rm-site-snackbars
+++ b/projects/plugins/jetpack/changelog/rm-site-snackbars
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Site Editor: remove extra site editor notices in favor of the ones provided by WordPress directly.

--- a/projects/plugins/jetpack/changelog/try-lossless-image-optmization-plugins-jetpack-png
+++ b/projects/plugins/jetpack/changelog/try-lossless-image-optmization-plugins-jetpack-png
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Lossless optimization of PNGs in plugins/jetpack.

--- a/projects/plugins/jetpack/changelog/upate-jetpack-ai-fix-logo-generation-event-tracking
+++ b/projects/plugins/jetpack/changelog/upate-jetpack-ai-fix-logo-generation-event-tracking
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: fix event tracking of logo generator to inform the proper placement.

--- a/projects/plugins/jetpack/changelog/update-ai-proofread-pulse
+++ b/projects/plugins/jetpack/changelog/update-ai-proofread-pulse
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add animation on loading for AI Proofread

--- a/projects/plugins/jetpack/changelog/update-fix-wpcom-api-responses
+++ b/projects/plugins/jetpack/changelog/update-fix-wpcom-api-responses
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-WPCOM API: Return actual value instead of bool for some settings after update

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-disable-long-sentences-default
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-disable-long-sentences-default
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Disable long sentences Breve feature by default

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-events
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-events
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Add events for Breve

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-first-hover
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-first-hover
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Display AI sidebar on first highlight hover

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-mobile-first-hover
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-mobile-first-hover
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Disable first Breve hover on mobile

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-production-10
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-production-10
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Enable Breve for 10% of production sites

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-release-20
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-release-20
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Release Breve for 20% of sites

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-remove-star
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-remove-star
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Remove Breve readability star

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-text
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-text
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Breve UI and text enhancements

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-ui
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-ui
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Breve UI enhancements

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-connect-logo-generator-to-block-extension
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-connect-logo-generator-to-block-extension
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Jetpack AI: connect the site logo block extension to AI Logo Generator modal.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-use-on-site-button
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-use-on-site-button
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-AI Logo Generator: support saving the logo and the icon when an image is ready.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-proofread-rename
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-proofread-rename
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Rename Breve and proofread entries on sidebar

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-sidebar-feedback
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-sidebar-feedback
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Add feedback link to the sidebar

--- a/projects/plugins/jetpack/changelog/update-jetpack-site-tester-more-ciphers
+++ b/projects/plugins/jetpack/changelog/update-jetpack-site-tester-more-ciphers
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-WPCOM Connection test: use better ciphers than RC4, which is no longer available on many hosts.

--- a/projects/plugins/jetpack/changelog/update-newsletter-categories-wpcomapi
+++ b/projects/plugins/jetpack/changelog/update-newsletter-categories-wpcomapi
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-WPCOM API: Return list of newsletter category IDs after saving

--- a/projects/plugins/jetpack/changelog/update-popover-component-remove-findDOMMode
+++ b/projects/plugins/jetpack/changelog/update-popover-component-remove-findDOMMode
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Popover: Refactor some code to use refs, adding in tests to future proof.

--- a/projects/plugins/jetpack/changelog/update-premium-content-block-transform
+++ b/projects/plugins/jetpack/changelog/update-premium-content-block-transform
@@ -1,4 +1,0 @@
-Significance: major
-Type: enhancement
-
-Premium Content Block: Only show it as a transformation option if group or columns blocks are selected or if multiple blocks are selected.

--- a/projects/plugins/jetpack/changelog/update-remove-skip-test_sync_maybe_update_core
+++ b/projects/plugins/jetpack/changelog/update-remove-skip-test_sync_maybe_update_core
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Tests: Removing test_sync_maybe_update_core test skip as core bug now fixed.

--- a/projects/plugins/jetpack/changelog/update-show-notification-bell-always
+++ b/projects/plugins/jetpack/changelog/update-show-notification-bell-always
@@ -1,4 +1,0 @@
-Significance: minor
-Type: compat
-
-Show the notification bell always

--- a/projects/plugins/jetpack/changelog/update-temporarily-skip-test_sync_maybe_update_core-until-core-fix
+++ b/projects/plugins/jetpack/changelog/update-temporarily-skip-test_sync_maybe_update_core-until-core-fix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Tests: Skipping test_sync_maybe_update_core test due to core bug.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_7_a_7",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_7_a_8",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_7_a_6",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_7_a_7",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.7-a.7
+ * Version: 13.7-a.8
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.5' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.7-a.7' );
+define( 'JETPACK__VERSION', '13.7-a.8' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.7-a.6
+ * Version: 13.7-a.7
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.5' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.7-a.6' );
+define( 'JETPACK__VERSION', '13.7-a.7' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/modules/theme-tools/social-menu.php
+++ b/projects/plugins/jetpack/modules/theme-tools/social-menu.php
@@ -19,7 +19,7 @@ if ( ! class_exists( '\Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 		 * @uses current_theme_supports()
 		 */
 		function jetpack_social_menu_init() {
-			_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+			_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 			// Only load our code if our theme declares support
 			if ( ! current_theme_supports( 'jetpack-social-menu' ) ) {
 				return;
@@ -65,7 +65,7 @@ if ( ! class_exists( '\Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 		 * @return null|string $menu_type
 		 */
 		function jetpack_social_menu_get_type() {
-			_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+			_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 			$options = get_theme_support( 'jetpack-social-menu' );
 
 			if ( ! $options ) {
@@ -86,7 +86,7 @@ if ( ! class_exists( '\Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 		 * Function to enqueue the CSS.
 		 */
 		function jetpack_social_menu_style() {
-			_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+			_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 			$menu_type = jetpack_social_menu_get_type();
 
 			if ( ! $menu_type ) {
@@ -106,7 +106,7 @@ if ( ! class_exists( '\Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 		 * Create the function for the menu.
 		 */
 		function jetpack_social_menu() {
-			_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+			_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 			if ( has_nav_menu( 'jetpack-social-menu' ) ) :
 				$menu_type  = jetpack_social_menu_get_type();
 				$link_after = '</span>';

--- a/projects/plugins/jetpack/modules/theme-tools/social-menu/icon-functions.php
+++ b/projects/plugins/jetpack/modules/theme-tools/social-menu/icon-functions.php
@@ -10,7 +10,7 @@ if ( ! function_exists( 'jetpack_social_menu_include_svg_icons' ) ) {
 	 * Add SVG definitions to the footer.
 	 */
 	function jetpack_social_menu_include_svg_icons() {
-		_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 		// Return early if Social Menu doesn't exist.
 		if ( ! has_nav_menu( 'jetpack-social-menu' ) ) {
 			return;
@@ -37,7 +37,7 @@ if ( ! function_exists( 'jetpack_social_menu_get_svg' ) ) {
 	 * @return string SVG markup.
 	 */
 	function jetpack_social_menu_get_svg( $args = array() ) {
-		_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 		// Make sure $args are an array.
 		if ( empty( $args ) ) {
 			return esc_html__( 'Please define default parameters in the form of an array.', 'jetpack' );
@@ -94,7 +94,7 @@ if ( ! function_exists( 'jetpack_social_menu_nav_menu_social_icons' ) ) {
 	 * @return string  $item_output The menu item output with social icon.
 	 */
 	function jetpack_social_menu_nav_menu_social_icons( $item_output, $item, $depth, $args ) {
-		_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 		// Get supported social icons.
 		$social_icons = jetpack_social_menu_social_links_icons();
 
@@ -136,7 +136,7 @@ if ( ! function_exists( 'jetpack_social_menu_social_links_icons' ) ) {
 	 * @return array $social_links_icons
 	 */
 	function jetpack_social_menu_social_links_icons() {
-		_deprecated_function( __FUNCTION__, 'jetpack-$$next-version$$' );
+		_deprecated_function( __FUNCTION__, 'jetpack-13.7' );
 		// Supported social links icons.
 		$social_links_icons = array(
 			'#https?:\/\/(www\.)?amazon\.(com|cn|in|fr|de|it|nl|es|co|ca)\/#' => 'amazon',

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.7.0-a.7",
+	"version": "13.7.0-a.8",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.7.0-a.6",
+	"version": "13.7.0-a.7",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,19 +326,19 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.7-a.5 - 2024-07-22
+### 13.7-a.7 - 2024-07-29
 #### Enhancements
-- Dashboard: Add a dashboard card for AI Assistant.
-- Security: Add separate IP allow and block list toggles in Web Application Firewall settings.
-- Settings: Add a link to the AI assistant product page.
+- AI Assistant: Add feedback link to the sidebar.
+- AI Assistant: Breve UI enhancements.
+- AI Assistant: Disable first Breve hover on mobile.
+- AI Assistant: Disable long sentences Breve feature by default.
+- AI Assistant: Enable Breve for 10% of production sites.
+- AI Assistant: Enable Breve for 20% of production sites.
+- General: Losslessly optimized PNG images.
+- Site Editor: Remove extra site editor notices in favor of the ones provided by WordPress directly.
 
 #### Improved compatibility
-- Contact Form: Ensure checkboxes are properly displayed when using the Twenty Twenty or the Twenty Twenty One theme.
-- General: Remove code for compatibility with WordPress versions before 6.5.
-- General: Update WordPress version requirements to WordPress 6.5.
-
-#### Bug fixes
-- Blocks: Check if the fontFamily block attribute is a string before trying to format.
+- Masterbar: Always show the notification bell.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.5.2 - 2024-07-29
+### Changed
+- Internal updates.
+
 ## 2.5.1 - 2024-07-25
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-readymade-template-generate-content-task-definition
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-readymade-template-generate-content-task-definition
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-sync-waf-options
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-sync-waf-options
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/remove-show-browse-sites-link
+++ b/projects/plugins/mu-wpcom-plugin/changelog/remove-show-browse-sites-link
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-wpcom-plugins
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-wpcom-plugins
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-wpcom-plugins#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-wpcom-plugins#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_2_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_2"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.5.2-alpha
+ * Version: 2.5.2
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.5.2-alpha",
+	"version": "2.5.2",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/wpcomsh/CHANGELOG.md
+++ b/projects/plugins/wpcomsh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.1.0 - 2024-07-29
+### Changed
+- Hide the plugin banner on non-wpcom-connected users or agency-managed users [#38532]
+
 ## 5.0.3 - 2024-07-26
 ### Removed
 - Footer credit: Remove customizer option for block themes [#38559]

--- a/projects/plugins/wpcomsh/changelog/add-sync-waf-options
+++ b/projects/plugins/wpcomsh/changelog/add-sync-waf-options
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/remove-show-browse-sites-link
+++ b/projects/plugins/wpcomsh/changelog/remove-show-browse-sites-link
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/update-wpcom-plugins
+++ b/projects/plugins/wpcomsh/changelog/update-wpcom-plugins
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Hide the plugin banner on non-wpcom-connected users or agency-managed users

--- a/projects/plugins/wpcomsh/changelog/update-wpcom-plugins#2
+++ b/projects/plugins/wpcomsh/changelog/update-wpcom-plugins#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/update-wpcom-plugins#3
+++ b/projects/plugins/wpcomsh/changelog/update-wpcom-plugins#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -129,7 +129,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_1_0_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_1_0"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.1.0-alpha",
+	"version": "5.1.0",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.1.0-alpha
+ * Version: 5.1.0
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.1.0-alpha' );
+define( 'WPCOMSH_VERSION', '5.1.0' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.5.2, jetpack 13.7-a.7, wpcomsh 5.1.0

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.