### PR TITLE
My Jetpack: change AI card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/action-button.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, chevronDown, external, check } from '@wordpress/icons';
 import clsx from 'clsx';
+import debugFactory from 'debug';
 import { useCallback, useState, useEffect, useMemo, useRef } from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
 import useProduct from '../../data/products/use-product';
@@ -21,6 +22,8 @@ type ActionButtonProps< A = () => void > = ProductCardProps & {
 	className?: string;
 	isOwned?: boolean;
 };
+
+const debug = debugFactory( 'my-jetpack:product-card:action-button' );
 
 const ActionButton: FC< ActionButtonProps > = ( {
 	status,
@@ -50,6 +53,8 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	const chevronRef = useRef( null );
 	const { recordEvent } = useAnalytics();
 
+	slug === 'jetpack-ai' && debug( slug, detail );
+
 	const isBusy = isFetching || isInstallingStandalone;
 	const hasAdditionalActions = additionalActions?.length > 0;
 
@@ -64,6 +69,7 @@ const ActionButton: FC< ActionButtonProps > = ( {
 	}, [ isBusy, className ] );
 
 	const getStatusAction = useCallback( (): SecondaryButtonProps => {
+		slug === 'jetpack-ai' && debug( slug, status );
 		switch ( status ) {
 			case PRODUCT_STATUSES.ABSENT: {
 				const buttonText = __( 'Learn more', 'jetpack-my-jetpack' );

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -1,34 +1,36 @@
-import { useConnection } from '@automattic/jetpack-connection';
-import { __ } from '@wordpress/i18n';
+// import { useConnection } from '@automattic/jetpack-connection';
+// import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
-import { useRef } from 'react';
-import { PRODUCT_STATUSES } from '../../constants';
+// import { useRef } from 'react';
+// import { PRODUCT_STATUSES } from '../../constants';
 import ProductCard from '../connected-product-card';
+// import { ExperimentWithAuth } from '@automattic/jetpack-explat';
+// import { useExperimentWithAuth } from '@automattic/jetpack-explat';
 
 const AiCard = props => {
-	const { userConnectionData } = useConnection();
-	const { currentUser } = userConnectionData;
-	const { wpcomUser } = currentUser;
-	const userId = currentUser?.id || 0;
-	const blogId = currentUser?.blogId || 0;
-	const wpcomUserId = wpcomUser?.ID || 0;
-	const userOptKey = `jetpack_ai_optfree_${ userId }_${ blogId }_${ wpcomUserId }`;
-	const userOptFree = useRef( localStorage.getItem( userOptKey ) );
+	// const { userConnectionData } = useConnection();
+	// const { currentUser } = userConnectionData;
+	// const { wpcomUser } = currentUser;
+	// const userId = currentUser?.id || 0;
+	// const blogId = currentUser?.blogId || 0;
+	// const wpcomUserId = wpcomUser?.ID || 0;
+	// const userOptKey = `jetpack_ai_optfree_${ userId }_${ blogId }_${ wpcomUserId }`;
+	// const userOptFree = useRef( localStorage.getItem( userOptKey ) );
 
-	const userOverrides = {
-		[ PRODUCT_STATUSES.CAN_UPGRADE ]: {
-			href: '#/jetpack-ai',
-			label: __( 'View', 'jetpack-my-jetpack' ),
-		},
-		[ PRODUCT_STATUSES.NEEDS_PLAN ]: {
-			href: userOptFree.current ? '#/jetpack-ai' : '#/add-jetpack-ai',
-		},
-	};
+	// const userOverrides = {
+	// 	[ PRODUCT_STATUSES.CAN_UPGRADE ]: {
+	// 		href: '#/jetpack-ai',
+	// 		label: __( 'View', 'jetpack-my-jetpack' ),
+	// 	},
+	// 	[ PRODUCT_STATUSES.NEEDS_PLAN ]: {
+	// 		href: '#/jetpack-ai',
+	// 	},
+	// };
 
 	return (
 		<ProductCard
 			slug="jetpack-ai"
-			primaryActionOverride={ userOverrides }
+			// primaryActionOverride={ userOverrides }
 			upgradeInInterstitial
 			{ ...props }
 		/>

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/ai-card.jsx
@@ -1,44 +1,7 @@
-// import { useConnection } from '@automattic/jetpack-connection';
-// import { __ } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
-// import { useRef } from 'react';
-// import { PRODUCT_STATUSES } from '../../constants';
 import ProductCard from '../connected-product-card';
-// import { ExperimentWithAuth } from '@automattic/jetpack-explat';
-// import { useExperimentWithAuth } from '@automattic/jetpack-explat';
 
 const AiCard = props => {
-	// const { userConnectionData } = useConnection();
-	// const { currentUser } = userConnectionData;
-	// const { wpcomUser } = currentUser;
-	// const userId = currentUser?.id || 0;
-	// const blogId = currentUser?.blogId || 0;
-	// const wpcomUserId = wpcomUser?.ID || 0;
-	// const userOptKey = `jetpack_ai_optfree_${ userId }_${ blogId }_${ wpcomUserId }`;
-	// const userOptFree = useRef( localStorage.getItem( userOptKey ) );
-
-	// const userOverrides = {
-	// 	[ PRODUCT_STATUSES.CAN_UPGRADE ]: {
-	// 		href: '#/jetpack-ai',
-	// 		label: __( 'View', 'jetpack-my-jetpack' ),
-	// 	},
-	// 	[ PRODUCT_STATUSES.NEEDS_PLAN ]: {
-	// 		href: '#/jetpack-ai',
-	// 	},
-	// };
-
-	return (
-		<ProductCard
-			slug="jetpack-ai"
-			// primaryActionOverride={ userOverrides }
-			upgradeInInterstitial
-			{ ...props }
-		/>
-	);
-};
-
-AiCard.propTypes = {
-	admin: PropTypes.bool.isRequired,
+	return <ProductCard slug="jetpack-ai" upgradeInInterstitial { ...props } />;
 };
 
 export default AiCard;

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -55,6 +55,8 @@ export default function () {
 	const videoTitleForms = __( 'Build forms using prompts', 'jetpack-my-jetpack' );
 	const videoTitleContentFeedback = __( 'Get feedback on posts', 'jetpack-my-jetpack' );
 
+	const videoTitleBreve = __( 'Make your writing easy to read', 'jetpack-my-jetpack' );
+
 	debug( aiAssistantFeature );
 	const {
 		requestsCount: allTimeRequests = 0,
@@ -81,6 +83,7 @@ export default function () {
 	const videoLinkContentFeedback = getRedirectUrl(
 		'jetpack-ai-product-page-content-feedback-link'
 	);
+	const jetpackAiLink = getRedirectUrl( 'org-ai' );
 
 	// isRegistered works as a flag to know if the page can link to a post creation or not
 	const ctaURL = isRegistered
@@ -283,6 +286,40 @@ export default function () {
 									<iframe
 										width="280"
 										height="157"
+										src="https://videopress.com/embed/gRn8jXrG?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F07%2Fjetpack-ai-breve-poster.png%3Fw%3D560"
+										allowFullScreen
+										allow="clipboard-write"
+										title={ videoTitleBreve }
+									></iframe>
+									<script src="https://videopress.com/videopress-iframe.js"></script>
+								</div>
+								<div className={ styles[ 'product-interstitial__usage-videos-content' ] }>
+									<div className={ styles[ 'product-interstitial__usage-videos-heading' ] }>
+										{ videoTitleBreve }
+										{ newBadge }
+									</div>
+									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
+										{ __(
+											"Simplify your writing with AI suggestions to fix long sentences and complex words, and sound more confident. View your writing's grade score as you type to ensure it suits your audience.",
+											'jetpack-my-jetpack'
+										) }
+									</div>
+									<Button
+										className={ styles[ 'product-interstitial__usage-videos-link' ] }
+										icon={ help }
+										target="_blank"
+										href={ jetpackAiLink }
+									>
+										{ __( 'Learn more', 'jetpack-my-jetpack' ) }
+									</Button>
+								</div>
+							</div>
+
+							<div className={ styles[ 'product-interstitial__usage-videos-item' ] }>
+								<div className={ styles[ 'product-interstitial__usage-videos-video' ] }>
+									<iframe
+										width="280"
+										height="157"
 										src="https://videopress.com/embed/GdXmtVtW?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F02%2Fimage-37.png%3Fw%3D560"
 										allowFullScreen
 										allow="clipboard-write"
@@ -325,7 +362,6 @@ export default function () {
 								<div className={ styles[ 'product-interstitial__usage-videos-content' ] }>
 									<div className={ styles[ 'product-interstitial__usage-videos-heading' ] }>
 										{ videoTitleFeaturedImages }
-										{ newBadge }
 									</div>
 									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
 										{ __(
@@ -359,7 +395,6 @@ export default function () {
 								<div className={ styles[ 'product-interstitial__usage-videos-content' ] }>
 									<div className={ styles[ 'product-interstitial__usage-videos-heading' ] }>
 										{ videoTitleTitleOptimization }
-										{ newBadge }
 									</div>
 									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
 										{ __(

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -302,7 +302,7 @@ export default function () {
 									</div>
 									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
 										{ __(
-											"Simplify your writing with AI suggestions to fix long sentences and complex words, and sound more confident. View your writing's grade score as you type to ensure it suits your audience.",
+											'Simplify your writing with AI suggestions to fix long sentences and complex words and sound more confident. As you type, check your Reading Grade score to make sure it suits your audience.',
 											'jetpack-my-jetpack'
 										) }
 									</div>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -12,7 +12,6 @@ import {
 } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import { Button, Card, ExternalLink } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, plus, help, check } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -57,15 +56,6 @@ export default function () {
 	const videoTitleContentFeedback = __( 'Get feedback on posts', 'jetpack-my-jetpack' );
 
 	const videoTitleBreve = __( 'Make your writing easy to read', 'jetpack-my-jetpack' );
-	const videoDescriptionBreve = createInterpolateElement(
-		__(
-			'Simplify your writing with AI suggestions to fix long sentences and complex words and sound more confident. As you type, check your <em>Reading grade score</em> to make sure it suits your audience.',
-			'jetpack-my-jetpack'
-		),
-		{
-			em: <em />,
-		}
-	);
 
 	debug( aiAssistantFeature );
 	const {
@@ -311,7 +301,10 @@ export default function () {
 										{ newBadge }
 									</div>
 									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
-										{ videoDescriptionBreve }
+										{ __(
+											'Simplify your writing with AI suggestions to fix long sentences and complex words and sound more confident. As you type, check your Reading grade score to make sure it suits your audience.',
+											'jetpack-my-jetpack'
+										) }
 									</div>
 									<Button
 										className={ styles[ 'product-interstitial__usage-videos-link' ] }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -12,6 +12,7 @@ import {
 } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import { Button, Card, ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, plus, help, check } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -56,6 +57,15 @@ export default function () {
 	const videoTitleContentFeedback = __( 'Get feedback on posts', 'jetpack-my-jetpack' );
 
 	const videoTitleBreve = __( 'Make your writing easy to read', 'jetpack-my-jetpack' );
+	const videoDescriptionBreve = createInterpolateElement(
+		__(
+			'Simplify your writing with AI suggestions to fix long sentences and complex words and sound more confident. As you type, check your <em>Reading grade score</em> to make sure it suits your audience.',
+			'jetpack-my-jetpack'
+		),
+		{
+			em: <em />,
+		}
+	);
 
 	debug( aiAssistantFeature );
 	const {
@@ -288,7 +298,7 @@ export default function () {
 									<iframe
 										width="280"
 										height="157"
-										src="https://videopress.com/embed/gRn8jXrG?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F07%2Fjetpack-ai-breve-poster.png%3Fw%3D560"
+										src="https://videopress.com/embed/2OU6GCMs?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F07%2Fjetpack-ai-breve-poster.png%3Fw%3D560"
 										allowFullScreen
 										allow="clipboard-write"
 										title={ videoTitleBreve }
@@ -301,10 +311,7 @@ export default function () {
 										{ newBadge }
 									</div>
 									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
-										{ __(
-											'Simplify your writing with AI suggestions to fix long sentences and complex words and sound more confident. As you type, check your Reading Grade score to make sure it suits your audience.',
-											'jetpack-my-jetpack'
-										) }
+										{ videoDescriptionBreve }
 									</div>
 									<Button
 										className={ styles[ 'product-interstitial__usage-videos-link' ] }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -83,6 +83,8 @@ export default function () {
 	const videoLinkContentFeedback = getRedirectUrl(
 		'jetpack-ai-product-page-content-feedback-link'
 	);
+
+	// TODO: switch this to a proper link when the page is ready
 	const jetpackAiLink = getRedirectUrl( 'org-ai' );
 
 	// isRegistered works as a flag to know if the page can link to a post creation or not

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/style.module.scss
@@ -231,7 +231,7 @@
 		.product-interstitial__usage-videos-text {
 			font-size: 16px;
 			line-height: 24px;
-			font-weight: 400;
+			font-weight: 300;
 			color: var( --jp-gray-60 );
 			flex-grow: 1;
 		}

--- a/projects/packages/my-jetpack/changelog/change-my-jetpack-ai-card
+++ b/projects/packages/my-jetpack/changelog/change-my-jetpack-ai-card
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+My Jetpack: modify Jetpack AI product class and interstitial links

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -83,7 +83,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.30.x-dev"
+			"dev-trunk": "4.31.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.30.1-alpha",
+	"version": "4.31.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -41,7 +41,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.30.1-alpha';
+	const PACKAGE_VERSION = '4.31.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -446,11 +446,14 @@ class Jetpack_Ai extends Product {
 	public static function is_upgradable() {
 		$has_ai_feature = static::does_site_have_feature( 'ai-assistant' );
 		$current_tier   = self::get_current_usage_tier();
+		$info           = self::get_ai_assistant_feature();
+		$has_next_tier  = isset( $info['next-tier']['value'] ) && $info['next-tier']['value'];
+		$is_over_limit  = isset( $info['is-over-limit'] ) && $info['is-over-limit'];
 
 		// If there's a next tier available, the product is upgradable.
-		// if ( self::get_next_usage_tier() ) {
-		// return true;
-		// }
+		if ( $has_next_tier && $is_over_limit ) {
+			return true;
+		}
 
 		// TODO: this check is debatable, not having the feature should not flag as not upgradable.
 		// Mark as not upgradable if user is on unlimited tier or does not have any plan.

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -448,12 +448,12 @@ class Jetpack_Ai extends Product {
 		$current_tier   = self::get_current_usage_tier();
 		$next_tier      = self::get_next_usage_tier();
 
-		// If there's a next tier available, the product is upgradable.
+		// The check below is debatable, not having the feature should not flag as not upgradable.
+		// If user is free (tier = 0), not unlimited (tier = 1) and has a next tier, then it's upgradable.
 		if ( $current_tier !== null && $current_tier !== 1 && $next_tier ) {
 			return true;
 		}
 
-		// TODO: this check is debatable, not having the feature should not flag as not upgradable.
 		// Mark as not upgradable if user is on unlimited tier or does not have any plan.
 		if ( ! $has_ai_feature || null === $current_tier || 1 === $current_tier ) {
 			return false;

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -447,6 +447,12 @@ class Jetpack_Ai extends Product {
 		$has_ai_feature = static::does_site_have_feature( 'ai-assistant' );
 		$current_tier   = self::get_current_usage_tier();
 
+		// If there's a next tier available, the product is upgradable.
+		// if ( self::get_next_usage_tier() ) {
+		// return true;
+		// }
+
+		// TODO: this check is debatable, not having the feature should not flag as not upgradable.
 		// Mark as not upgradable if user is on unlimited tier or does not have any plan.
 		if ( ! $has_ai_feature || null === $current_tier || 1 === $current_tier ) {
 			return false;
@@ -479,7 +485,7 @@ class Jetpack_Ai extends Product {
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
-		return '/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai';
+		return '/wp-admin/admin.php?page=my-jetpack#/jetpack-ai';
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -449,7 +449,7 @@ class Jetpack_Ai extends Product {
 		$next_tier      = self::get_next_usage_tier();
 
 		// If there's a next tier available, the product is upgradable.
-		if ( $current_tier && $current_tier !== 1 && $next_tier ) {
+		if ( $current_tier !== null && $current_tier !== 1 && $next_tier ) {
 			return true;
 		}
 

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -446,12 +446,10 @@ class Jetpack_Ai extends Product {
 	public static function is_upgradable() {
 		$has_ai_feature = static::does_site_have_feature( 'ai-assistant' );
 		$current_tier   = self::get_current_usage_tier();
-		$info           = self::get_ai_assistant_feature();
-		$has_next_tier  = isset( $info['next-tier']['value'] ) && $info['next-tier']['value'];
-		$is_over_limit  = isset( $info['is-over-limit'] ) && $info['is-over-limit'];
+		$next_tier      = self::get_next_usage_tier();
 
 		// If there's a next tier available, the product is upgradable.
-		if ( $has_next_tier && $is_over_limit ) {
+		if ( $current_tier && $current_tier !== 1 && $next_tier ) {
 			return true;
 		}
 

--- a/projects/plugins/backup/changelog/change-my-jetpack-ai-card
+++ b/projects/plugins/backup/changelog/change-my-jetpack-ai-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1160,7 +1160,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "524d5410bf385fd2e2c03092430d398339745aa4"
+                "reference": "bbef3f2e2f857e066d0fa2a74f86c4abfa1bb810"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1199,7 +1199,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.30.x-dev"
+                    "dev-trunk": "4.31.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/boost/changelog/change-my-jetpack-ai-card
+++ b/projects/plugins/boost/changelog/change-my-jetpack-ai-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1079,7 +1079,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "524d5410bf385fd2e2c03092430d398339745aa4"
+                "reference": "bbef3f2e2f857e066d0fa2a74f86c4abfa1bb810"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1118,7 +1118,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.30.x-dev"
+                    "dev-trunk": "4.31.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/jetpack-ai.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/jetpack-ai.jsx
@@ -44,6 +44,8 @@ function DashJetpackAi( props ) {
 		}
 	);
 
+	// TODO: useExperiment to switch upgradeUrl between add-jetpack-ai (default from getProductDescriptionUrl) and jetpack-ai
+
 	const showConnectBanner = ! hasConnectedOwner && ! isOffline;
 	const showUpgradeBanner =
 		hasConnectedOwner && isMyJetpackReachable && ! isOffline && ! hasFeature;

--- a/projects/plugins/jetpack/changelog/change-my-jetpack-ai-card
+++ b/projects/plugins/jetpack/changelog/change-my-jetpack-ai-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: useExperiment note

--- a/projects/plugins/jetpack/changelog/change-my-jetpack-ai-card#2
+++ b/projects/plugins/jetpack/changelog/change-my-jetpack-ai-card#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1744,7 +1744,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "524d5410bf385fd2e2c03092430d398339745aa4"
+				"reference": "bbef3f2e2f857e066d0fa2a74f86c4abfa1bb810"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1783,7 +1783,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.30.x-dev"
+					"dev-trunk": "4.31.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/changelog/change-my-jetpack-ai-card
+++ b/projects/plugins/migration/changelog/change-my-jetpack-ai-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1160,7 +1160,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "524d5410bf385fd2e2c03092430d398339745aa4"
+                "reference": "bbef3f2e2f857e066d0fa2a74f86c4abfa1bb810"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1199,7 +1199,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.30.x-dev"
+                    "dev-trunk": "4.31.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/protect/changelog/change-my-jetpack-ai-card
+++ b/projects/plugins/protect/changelog/change-my-jetpack-ai-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1073,7 +1073,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "524d5410bf385fd2e2c03092430d398339745aa4"
+                "reference": "bbef3f2e2f857e066d0fa2a74f86c4abfa1bb810"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1112,7 +1112,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.30.x-dev"
+                    "dev-trunk": "4.31.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/change-my-jetpack-ai-card
+++ b/projects/plugins/search/changelog/change-my-jetpack-ai-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "524d5410bf385fd2e2c03092430d398339745aa4"
+                "reference": "bbef3f2e2f857e066d0fa2a74f86c4abfa1bb810"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1055,7 +1055,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.30.x-dev"
+                    "dev-trunk": "4.31.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/change-my-jetpack-ai-card
+++ b/projects/plugins/social/changelog/change-my-jetpack-ai-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1016,7 +1016,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "524d5410bf385fd2e2c03092430d398339745aa4"
+				"reference": "bbef3f2e2f857e066d0fa2a74f86c4abfa1bb810"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1055,7 +1055,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.30.x-dev"
+					"dev-trunk": "4.31.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/change-my-jetpack-ai-card
+++ b/projects/plugins/starter-plugin/changelog/change-my-jetpack-ai-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "524d5410bf385fd2e2c03092430d398339745aa4"
+                "reference": "bbef3f2e2f857e066d0fa2a74f86c4abfa1bb810"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1055,7 +1055,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.30.x-dev"
+                    "dev-trunk": "4.31.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/change-my-jetpack-ai-card
+++ b/projects/plugins/videopress/changelog/change-my-jetpack-ai-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "524d5410bf385fd2e2c03092430d398339745aa4"
+                "reference": "bbef3f2e2f857e066d0fa2a74f86c4abfa1bb810"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1055,7 +1055,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.30.x-dev"
+                    "dev-trunk": "4.31.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/wpcomsh/changelog/change-my-jetpack-ai-card
+++ b/projects/plugins/wpcomsh/changelog/change-my-jetpack-ai-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: modify Jetpack AI product class and interstitial links


### PR DESCRIPTION
WIP: needs debug

Fixes https://github.com/Automattic/jetpack-roadmap/issues/1744

## Proposed changes:
This PR adds Breve feature/video to AI product page and updates product backend class for proper linking from the card/interstitial.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-tun-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Create a JN instance from this PR, do not connect Jetpack yet. Open devtools and set debug messages with `localStorage.setItem( 'debug', 'my-jetpack:*' );`

Go to My Jetpack, the AI card should show a "Learn more" CTA linking to AI interstitial page. This is default behavior for the card action.
<img width="363" alt="image" src="https://github.com/user-attachments/assets/f077bde8-f1e3-4070-a78c-f3b3ebb1c03d">


Connect Jetpack (use link on Jetpack or My Jetpack page). Navigate back to My Jetpack. AI card should now show "Upgrade" and "View", linking to interstitial and product page respectively.
<img width="403" alt="image" src="https://github.com/user-attachments/assets/7e39e064-5676-475d-b9ea-22ed931c86d1">

Navigate to the product page. Verify there's a new entry for Breve (at the top), with the "NEW" tag. The video should work just fine. The copy edit should be:
```
Simplify your writing with AI suggestions to fix long sentences and complex words and sound more confident. As you type, check your Reading grade score to make sure it suits your audience.
```

No other entries should now have the "NEW" tag.