### PR TITLE
Footer credit: Clean up unused `remove_action` calls

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-footercredits-action
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-footercredits-action
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Removed unused logic
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -180,7 +180,6 @@ add_action( 'jetpack_admin_menu', 'wpcom_add_jetpack_submenu' );
 function wpcom_hide_customizer_submenu_on_block_theme() {
 	if ( wp_is_block_theme() && ! is_customize_preview() ) {
 		remove_action( 'customize_register', 'add_logotool_button', 20 );
-		remove_action( 'customize_register', 'footercredits_register', 99 );
 		remove_action( 'customize_register', 'wpcom_disable_customizer_site_icon', 20 );
 
 		if ( class_exists( '\Jetpack_Fonts' ) ) {

--- a/projects/packages/masterbar/changelog/remove-footercredits-action
+++ b/projects/packages/masterbar/changelog/remove-footercredits-action
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Removed unused logic
+
+

--- a/projects/packages/masterbar/src/admin-menu/load.php
+++ b/projects/packages/masterbar/src/admin-menu/load.php
@@ -51,7 +51,6 @@ function hide_customizer_menu_on_block_theme() {
 		function () {
 			if ( wp_is_block_theme() && ! is_customize_preview() ) {
 				remove_action( 'customize_register', 'add_logotool_button', 20 );
-				remove_action( 'customize_register', 'footercredits_register', 99 );
 				remove_action( 'customize_register', 'wpcom_disable_customizer_site_icon', 20 );
 
 				if ( class_exists( '\Jetpack_Fonts' ) ) {

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -108,7 +108,6 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 	private function hide_customizer_menu_on_block_theme() {
 		if ( wp_is_block_theme() && ! is_customize_preview() ) {
 			remove_action( 'customize_register', 'add_logotool_button', 20 );
-			remove_action( 'customize_register', 'footercredits_register', 99 );
 			remove_action( 'customize_register', 'wpcom_disable_customizer_site_icon', 20 );
 
 			if ( class_exists( '\Jetpack_Fonts' ) ) {

--- a/projects/plugins/jetpack/changelog/remove-footercredits-action
+++ b/projects/plugins/jetpack/changelog/remove-footercredits-action
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Removed unused logic
+
+

--- a/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
+++ b/projects/plugins/jetpack/modules/masterbar/admin-menu/load.php
@@ -63,7 +63,6 @@ function hide_customizer_menu_on_block_theme() {
 		function () {
 			if ( wp_is_block_theme() && ! is_customize_preview() ) {
 				remove_action( 'customize_register', 'add_logotool_button', 20 );
-				remove_action( 'customize_register', 'footercredits_register', 99 );
 				remove_action( 'customize_register', 'wpcom_disable_customizer_site_icon', 20 );
 
 				if ( class_exists( '\Jetpack_Fonts' ) ) {


### PR DESCRIPTION
Follow-up of https://github.com/Automattic/jetpack/pull/38559

## Proposed changes:

The `footercredits_register` action is no longer hooked into the `customize_register` action for block themes as of https://github.com/Automattic/jetpack/pull/38559 so we no longer need to remove it with `remove_action`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com simple and Atomic sites.
- Make sure the behavior of the Appearance > Customize menu does not change when a block theme is activated:

Site | Admin interface | Visible
--- | --- | ---
Simple | Default | Yes (*)
Simple | Classic | No
Atomic | Default | No
Atomic | Classic | No

(*) This is not expected, but it's unrelated to these changes because it's currently visible in prod too.

