### PR TITLE
AIOWP Helper: Add `target_blog_id` eventprop to Tracks events

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-aiowp-target-blog-id
+++ b/projects/plugins/wpcomsh/changelog/add-aiowp-target-blog-id
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add target_blog_id prop to AIOWP tracks events

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -128,7 +128,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_1_3_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_2_0_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.1.3-alpha",
+	"version": "5.2.0-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
@@ -72,7 +72,7 @@ function aiowp_migration_logging_helper() {
 	// Filter that gets called when import starts
 	add_filter(
 		'ai1wm_import',
-		function ( $params = array() ) {
+		function ( $params = array() ) use ( $target_blog_id ) {
 			wpcomsh_record_tracks_event(
 				'wpcom_site_migration_start',
 				array(
@@ -88,7 +88,7 @@ function aiowp_migration_logging_helper() {
 	// Filter that gets called when import finishes or is cancelled by the user
 	add_filter(
 		'ai1wm_import',
-		function ( $params = array() ) {
+		function ( $params = array() ) use ( $target_blog_id ) {
 			wpcomsh_record_tracks_event(
 				'wpcom_site_migration_done',
 				array(

--- a/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
@@ -75,6 +75,7 @@ function aiowp_migration_logging_helper() {
 				'wpcom_site_migration_start',
 				array(
 					'migration_tool' => 'aiowp',
+					'target_blog_id' => get_current_blog_id(),
 				)
 			);
 			return $params;
@@ -90,6 +91,7 @@ function aiowp_migration_logging_helper() {
 				'wpcom_site_migration_done',
 				array(
 					'migration_tool' => 'aiowp',
+					'target_blog_id' => get_current_blog_id(),
 				)
 			);
 			return $params;

--- a/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
@@ -67,6 +67,8 @@ function aiowp_migration_logging_helper() {
 		return;
 	}
 
+	$target_blog_id = class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null;
+
 	// Filter that gets called when import starts
 	add_filter(
 		'ai1wm_import',
@@ -75,7 +77,7 @@ function aiowp_migration_logging_helper() {
 				'wpcom_site_migration_start',
 				array(
 					'migration_tool' => 'aiowp',
-					'target_blog_id' => get_current_blog_id(),
+					'target_blog_id' => $target_blog_id,
 				)
 			);
 			return $params;
@@ -91,7 +93,7 @@ function aiowp_migration_logging_helper() {
 				'wpcom_site_migration_done',
 				array(
 					'migration_tool' => 'aiowp',
-					'target_blog_id' => get_current_blog_id(),
+					'target_blog_id' => $target_blog_id,
 				)
 			);
 			return $params;

--- a/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-migration-helpers/site-migration-helpers.php
@@ -67,7 +67,7 @@ function aiowp_migration_logging_helper() {
 		return;
 	}
 
-	$target_blog_id = class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null;
+	$target_blog_id = _wpcom_get_current_blog_id();
 
 	// Filter that gets called when import starts
 	add_filter(

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -9,7 +9,7 @@
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.1.2-alpha' );
+define( 'WPCOMSH_VERSION', '5.2.0-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.1.3-alpha
+ * Version: 5.2.0-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.1.3-alpha' );
+define( 'WPCOMSH_VERSION', '5.1.2-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a `target_blog_id` eventprop to the Tracks events fired when an AIOWP migration is started and finished.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pa1C6h-3hm-p2#comment-13537 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create a new Business site, mark it as a WoA Dev site, and take it Atomic.
2. Rsync the wpcomsh changes on this branch to your WoA site: `jetpack rsync wpcomsh yourtestsite.wordpress.com@sftp.wp.com:htdocs/wp-content/mu-plugins`
3. On your WoA test site, install the AIOWPM plugin: https://wordpress.com/plugins/all-in-one-wp-migration/
4. Activate the plugin and go to All in One WP Migration -> Export
5. Create and download an export file
6. Go to All in One WP Migration -> Import
7. Start the import from the file you created
8. Check Tracks Live for the migration start and end events (may take a few minutes to get there): `wpcom_site_migration_start` and `wpcom_site_migration_done`
9. Ensure the events have a `target_blog_id` eventprop set to your test site's blog ID

<img width="420" alt="Screenshot 2024-07-30 at 2 24 44 PM" src="https://github.com/user-attachments/assets/57ad5a0d-2bd8-42f4-8fc0-f077fbaac814">
