### PR TITLE
Protect: Remove manual scan messaging from history view

### DIFF
--- a/projects/plugins/protect/src/js/components/scan-button/index.jsx
+++ b/projects/plugins/protect/src/js/components/scan-button/index.jsx
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import React, { forwardRef } from 'react';
 import { STORE_ID } from '../../state/store';
 
-const ScanButton = forwardRef( ( props, ref ) => {
+const ScanButton = forwardRef( ( { variant = 'secondary', children, ...props }, ref ) => {
 	const { scan } = useDispatch( STORE_ID );
 	const scanIsEnqueuing = useSelect( select => select( STORE_ID ).getScanIsEnqueuing(), [] );
 
@@ -18,12 +18,12 @@ const ScanButton = forwardRef( ( props, ref ) => {
 	return (
 		<Button
 			ref={ ref }
-			variant="secondary"
+			variant={ variant }
 			isLoading={ scanIsEnqueuing }
 			onClick={ handleScanClick() }
 			{ ...props }
 		>
-			{ __( 'Scan now', 'jetpack-protect' ) }
+			{ children ?? __( 'Scan now', 'jetpack-protect' ) }
 		</Button>
 	);
 } );

--- a/projects/plugins/protect/src/js/components/threats-list/index.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/index.jsx
@@ -1,5 +1,13 @@
-import { Container, Col, Title, Button, useBreakpointMatch } from '@automattic/jetpack-components';
+import {
+	Container,
+	Col,
+	Title,
+	Button,
+	useBreakpointMatch,
+	Text,
+} from '@automattic/jetpack-components';
 import { useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import React, { useCallback, useState } from 'react';
 import useProtectData from '../../hooks/use-protect-data';
@@ -137,6 +145,17 @@ const ThreatsList = () => {
 							<>
 								<div ref={ setUnderstandSeverityPopoverAnchor }>
 									<PaidList list={ list } />
+									<Text className={ styles[ 'manual-scan' ] } variant="body-small">
+										{ createInterpolateElement(
+											__(
+												'If you have manually fixed any of the threats listed above, <manualScanLink>you can run a manual scan now</manualScanLink> or wait for Jetpack to scan your site later today.',
+												'jetpack-protect'
+											),
+											{
+												manualScanLink: <ScanButton variant="link" />,
+											}
+										) }
+									</Text>
 								</div>
 								<OnboardingPopover
 									id="paid-understand-severity"

--- a/projects/plugins/protect/src/js/components/threats-list/paid-list.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/paid-list.jsx
@@ -1,6 +1,5 @@
 import { Text, Button, useBreakpointMatch } from '@automattic/jetpack-components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import React, { useCallback } from 'react';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
@@ -143,25 +142,6 @@ const ThreatAccordionItem = ( {
 };
 
 const PaidList = ( { list } ) => {
-	const { scan } = useDispatch( STORE_ID );
-
-	const handleScanClick = () => {
-		return event => {
-			event.preventDefault();
-			scan();
-		};
-	};
-
-	const manualScan = createInterpolateElement(
-		__(
-			'If you have manually fixed any of the threats listed above, <manualScanLink>you can run a manual scan now</manualScanLink> or wait for Jetpack to scan your site later today.',
-			'jetpack-protect'
-		),
-		{
-			manualScanLink: <Button variant="link" onClick={ handleScanClick() } />,
-		}
-	);
-
 	const [ isSmall ] = useBreakpointMatch( [ 'sm', 'lg' ], [ null, '<' ] );
 
 	return (
@@ -223,9 +203,6 @@ const PaidList = ( { list } ) => {
 					)
 				) }
 			</PaidAccordion>
-			<Text className={ styles[ 'manual-scan' ] } variant="body-small">
-				{ manualScan }
-			</Text>
 		</>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves the manual scan message into the `/scan` route, so it will not be shown on the history page.
* Updates the `<ScanButton>` component to accept custom `variant` and `children` props, so it can be used in the manual scan blurb.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack/pull/38117

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Validate the manual scan message is shown under the scanner threats list
* Validate the manual scan message is not shown under the history threats list
* Validate the scan buttons on the page continue to function as expected

## Screenshots
<img width="1148" alt="Screenshot 2024-07-30 at 1 31 48 PM" src="https://github.com/user-attachments/assets/65b2d31d-fad2-43be-b415-ac0721f5a766">
<img width="1164" alt="Screenshot 2024-07-30 at 1 31 37 PM" src="https://github.com/user-attachments/assets/1bc10844-e51f-4ce7-9f7b-fa9d01f65aa2">

