### PR TITLE
AI Logo Generator: prevent multiple feature data requests

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-logo-generator-prevent-multiple-feature-data-requests
+++ b/projects/js-packages/ai-client/changelog/update-ai-logo-generator-prevent-multiple-feature-data-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Logo Generator: fix multiple feature requests error + retry handling.

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -3,7 +3,7 @@
  */
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Modal, Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { external, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -50,6 +50,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	const { tracks } = useAnalytics();
 	const { recordEvent: recordTracksEvent } = tracks;
 	const { setSiteDetails, fetchAiAssistantFeature, loadLogoHistory } = useDispatch( STORE_NAME );
+	const { getIsRequestingAiAssistantFeature } = select( STORE_NAME );
 	const [ loadingState, setLoadingState ] = useState<
 		'loadingFeature' | 'analyzing' | 'generating' | null
 	>( null );
@@ -182,10 +183,13 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 
 		// When the site details are set, we need to fetch the feature data.
 		if ( ! requestedFeatureData.current ) {
-			requestedFeatureData.current = true;
-			fetchAiAssistantFeature();
+			const isRequestingFeature = getIsRequestingAiAssistantFeature();
+			if ( ! isRequestingFeature ) {
+				requestedFeatureData.current = true;
+				fetchAiAssistantFeature();
+			}
 		}
-	}, [ siteId, siteDetails, setSiteDetails ] );
+	}, [ siteId, siteDetails, setSiteDetails, getIsRequestingAiAssistantFeature ] );
 
 	// Handles modal opening logic
 	useEffect( () => {

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -43,6 +43,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	isOpen,
 	onClose,
 	onApplyLogo,
+	onReload,
 	siteDetails,
 	context,
 	placement,
@@ -210,7 +211,15 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	if ( loadingState ) {
 		body = <FirstLoadScreen state={ loadingState } />;
 	} else if ( featureFetchError || firstLogoPromptFetchError ) {
-		body = <FeatureFetchFailureScreen onCancel={ closeModal } onRetry={ initializeModal } />;
+		body = (
+			<FeatureFetchFailureScreen
+				onCancel={ closeModal }
+				onRetry={ () => {
+					closeModal();
+					onReload?.();
+				} }
+			/>
+		);
 	} else if ( needsFeature || needsMoreRequests ) {
 		body = (
 			<UpgradeScreen

--- a/projects/js-packages/ai-client/src/logo-generator/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/types.ts
@@ -16,6 +16,7 @@ export interface GeneratorModalProps {
 	isOpen: boolean;
 	onClose: () => void;
 	onApplyLogo: ( mediaId: number ) => void;
+	onReload: () => void;
 	context: string;
 	placement: string;
 }

--- a/projects/plugins/jetpack/changelog/update-ai-logo-generator-prevent-multiple-feature-data-requests
+++ b/projects/plugins/jetpack/changelog/update-ai-logo-generator-prevent-multiple-feature-data-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Logo Generator: Fix the retry button when a feature request fails.

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -99,6 +99,11 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			setIsLogoGeneratorModalVisible( false );
 		}, [] );
 
+		const reloadModal = useCallback( () => {
+			closeModal();
+			showModal();
+		}, [ closeModal, showModal ] );
+
 		const applyLogoHandler = useCallback(
 			( mediaId: number ) => {
 				if ( mediaId ) {
@@ -127,6 +132,7 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					isOpen={ isLogoGeneratorModalVisible }
 					onClose={ closeModal }
 					onApplyLogo={ applyLogoHandler }
+					onReload={ reloadModal }
 					context={ PLACEMENT_CONTEXT }
 					placement={ TOOL_PLACEMENT }
 					siteDetails={ siteDetails }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38625.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

The reported error was happening due to a sum of events:

* when managing the layout on the site editor, you can have the logo block inside a pattern with multiple variations (like a header with multiple variations)
* when you select the pattern, the block editor sidebar will list the multiple variations; the logo block on each preview is a working logo block, and therefore is extended by the AI Logo Generator; one example for the Twenty Twenty-Four theme:

<img width="303" alt="Screenshot 2024-07-30 at 16 07 07" src="https://github.com/user-attachments/assets/0bdf59dd-add4-4dd2-9e30-8b387e0b1686">

* every instance of the logo generator requests it's own feature data, resulting on N feature data requests at the same time
* the logo generator code has an internal check to prevent an excess of multiple requests, limited to 5 requests at the same time
* this sequence of things would result on some requests failing, and setting the tool on an error state

I changed it to:

* Use the current requesting state boolean value to prevent a new request while a previous one is still in progress
* Addionally, added support for an `onReload` callback function on the GeneratorModal component, that can be called to close and open the modal again, allowing to retry when the feature data loading fails

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

First, let's confirm the start up error went away:

* Enable the Twenty Twenty-Four theme on your testing site (a reliable way to have a header with multiple variations on the editor)
* Clean your site's logo generation history, in case you have a history: delete the `logo-history-SITE_ID` key on the browser's local storage
* Open the browser's network console to inspect the network requests
* Open the site editor (needs to be tested there)
* A logo is probably present on the editor, inside a header pattern:

<img width="500" alt="Screenshot 2024-07-30 at 16 49 46" src="https://github.com/user-attachments/assets/ddc0f45e-1d03-492a-be42-b566413c851e">

* Select the header pattern; click on the blank area so you don't select a child element instead of the header
* Confirm you can see the multiple variations of it on the sitebar:

<img width="500" alt="Screenshot 2024-07-30 at 16 50 04" src="https://github.com/user-attachments/assets/d6b0efcd-c29d-4086-8aa9-bebfa30895ba">

* Confirm only one request was made to the `ai-assistant-feature` endpoint
* On the editor, select the logo block and click the AI extension button on it, to launch the logo generator
* Confirm the tool will generate the first logo as expected
* Confirm you can use the logo on the block
* Confirm you can close and open the tool multiple times without issues

Now, let's confirm the "Try again" button on the error message will work as expected:

* On the same site, clean the logo history again and refresh the site editor
* Open the browser's network console and change the throttling settings to `Offline`; the idea is to generate a request error on the next step
* Select the header pattern again; click on the blank area so you don't select a child element instead of the header
* Notice that a request to the `ai-assistant-feature` endpoint will fail on the network tab:

<img width="300" alt="Screenshot 2024-07-30 at 16 43 28" src="https://github.com/user-attachments/assets/29fc909e-7119-4e90-81ab-f225af780ac6">

* Change the throttling settings back to "No throttling" and try to open the AI Logo Generator
* Confirm you see the "Generating logo…" window, and then an error message:

<img width="400" alt="Screenshot 2024-07-30 at 16 56 05" src="https://github.com/user-attachments/assets/dd25affc-1d9c-4ec2-a526-f8a892a4012b">

* Click the "Try again" button
* Confirm now the logo generator tool will start as expected:

<img width="500" alt="Screenshot 2024-07-30 at 16 56 35" src="https://github.com/user-attachments/assets/76283e27-3568-448d-92bd-1260dc61f3e0">