### PR TITLE
Protect: Fix global stats type check

### DIFF
--- a/projects/packages/waf/changelog/fix-protect-global-stats-type-check
+++ b/projects/packages/waf/changelog/fix-protect-global-stats-type-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix global stats type check

--- a/projects/packages/waf/src/class-waf-stats.php
+++ b/projects/packages/waf/src/class-waf-stats.php
@@ -150,10 +150,10 @@ class Waf_Stats {
 			$global_stats = self::get_global_stats_from_options();
 		}
 
-		// // Ensure that $global_stats is of the correct type
-		// if ( ( ! is_array( $global_stats ) && ! ( $global_stats instanceof \WP_Error ) ) ) {
-		// return new \WP_Error( 'unexpected_type', 'Unexpected type or null returned for global stats' );
-		// }
+		// Ensure that $global_stats is of the correct type
+		if ( ( ! is_object( $global_stats ) && ! ( $global_stats instanceof \WP_Error ) ) ) {
+			return new \WP_Error( 'unexpected_type', 'Unexpected type or null returned for global stats' );
+		}
 
 		return $global_stats;
 	}

--- a/projects/packages/waf/src/class-waf-stats.php
+++ b/projects/packages/waf/src/class-waf-stats.php
@@ -150,10 +150,10 @@ class Waf_Stats {
 			$global_stats = self::get_global_stats_from_options();
 		}
 
-		// Ensure that $global_stats is the correct type
-		if ( ! is_array( $global_stats ) && ! ( $global_stats instanceof \WP_Error ) ) {
-			return new \WP_Error( 'unexpected_type', 'Unexpected type or null returned for global stats' );
-		}
+		// // Ensure that $global_stats is of the correct type
+		// if ( ( ! is_array( $global_stats ) && ! ( $global_stats instanceof \WP_Error ) ) ) {
+		// return new \WP_Error( 'unexpected_type', 'Unexpected type or null returned for global stats' );
+		// }
 
 		return $global_stats;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
Currently `Waf_Stats::get_global_stats` always returns a `unexpected_type` error because the check is not accounting for the various cases it should.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the type check block to ensure we handle incorrect types and allow correct ones.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1323

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch on JT with an upgrade
* Install Protect and begin your first scan
* Log the `jetpackProtectInitialState` variable to the console and very that `waf.globalStats.totalVulnerabilities` exists
* Ensure no regressions are introduced

