### PR TITLE
Protect: Refactor useProtectData hook

### DIFF
--- a/projects/plugins/protect/src/js/components/paid-plan-gate/index.tsx
+++ b/projects/plugins/protect/src/js/components/paid-plan-gate/index.tsx
@@ -1,0 +1,29 @@
+import { Navigate } from 'react-router-dom';
+import useProtectData from '../../hooks/use-protect-data';
+
+/**
+ * Paid Plan Gate
+ *
+ * Custom route that only renders when the user has a paid plan.
+ *
+ * @param {object}      props          - The component props.
+ * @param {JSX.Element} props.children - The component to render if the user has a paid plan.
+ * @param {string}      props.redirect - The alternate route to redirect to if the user does not have a paid plan.
+ *
+ * @returns {JSX.Element} The PaidPlanRoute component.
+ */
+export default function PaidPlanGate( {
+	children,
+	redirect = '/',
+}: {
+	children?: JSX.Element;
+	redirect?: string;
+} ): JSX.Element {
+	const { hasRequiredPlan } = useProtectData();
+
+	if ( ! hasRequiredPlan ) {
+		return <Navigate to={ redirect } replace />;
+	}
+
+	return children;
+}

--- a/projects/plugins/protect/src/js/components/summary/index.jsx
+++ b/projects/plugins/protect/src/js/components/summary/index.jsx
@@ -8,7 +8,13 @@ import OnboardingPopover from '../onboarding-popover';
 
 const Summary = () => {
 	const [ isSm ] = useBreakpointMatch( 'sm' );
-	const { numThreats, lastChecked, hasRequiredPlan } = useProtectData();
+	const {
+		counts: {
+			current: { threats: numThreats },
+		},
+		lastChecked,
+		hasRequiredPlan,
+	} = useProtectData();
 
 	// Popover anchors
 	const [ dailyScansPopoverAnchor, setDailyScansPopoverAnchor ] = useState( null );

--- a/projects/plugins/protect/src/js/components/threats-list/index.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/index.jsx
@@ -58,7 +58,7 @@ const ThreatsList = () => {
 					__( 'All %s threats', 'jetpack-protect' ),
 					list.length
 				);
-			case 'wordpress':
+			case 'core':
 				return sprintf(
 					/* translators: placeholder is the amount of WordPress threats found on the site. */
 					__( '%1$s WordPress %2$s', 'jetpack-protect' ),

--- a/projects/plugins/protect/src/js/components/threats-list/navigation.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/navigation.jsx
@@ -15,14 +15,17 @@ import Navigation, { NavigationItem, NavigationGroup } from '../navigation';
 
 const ThreatsNavigation = ( { selected, onSelect, sourceType = 'scan', statusFilter = 'all' } ) => {
 	const {
-		plugins,
-		themes,
-		numThreats,
-		numCoreThreats,
-		numFilesThreats,
-		numDatabaseThreats,
+		results: { plugins, themes },
+		counts: {
+			current: {
+				threats: numThreats,
+				core: numCoreThreats,
+				files: numFilesThreats,
+				database: numDatabaseThreats,
+			},
+		},
 		hasRequiredPlan,
-	} = useProtectData( { sourceType, statusFilter } );
+	} = useProtectData( { sourceType, filter: { status: statusFilter } } );
 
 	const { recordEvent } = useAnalyticsTracks();
 	const [ isSmallOrLarge ] = useBreakpointMatch( 'lg', '<' );
@@ -82,7 +85,7 @@ const ThreatsNavigation = ( { selected, onSelect, sourceType = 'scan', statusFil
 				checked={ true }
 			/>
 			<NavigationItem
-				id="wordpress"
+				id="core"
 				label={ __( 'WordPress', 'jetpack-protect' ) }
 				icon={ coreIcon }
 				badge={ numCoreThreats }

--- a/projects/plugins/protect/src/js/components/threats-list/paid-list.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/paid-list.jsx
@@ -189,7 +189,6 @@ const PaidList = ( { list } ) => {
 						firstDetected,
 						fixedIn,
 						fixedOn,
-						fixed_on,
 						icon,
 						fixable,
 						id,
@@ -210,7 +209,7 @@ const PaidList = ( { list } ) => {
 							filename={ filename }
 							firstDetected={ firstDetected }
 							fixedIn={ fixedIn }
-							fixedOn={ fixedOn ?? fixed_on }
+							fixedOn={ fixedOn }
 							icon={ icon }
 							fixable={ fixable }
 							id={ id }

--- a/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
+++ b/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
@@ -55,9 +55,11 @@ const flattenThreats = ( data, newData ) => {
  */
 const useThreatsList = ( { source, status } = { source: 'scan', status: 'all' } ) => {
 	const [ selected, setSelected ] = useState( 'all' );
-	const { plugins, themes, core, files, database } = useProtectData( {
+	const {
+		results: { plugins, themes, core, files, database },
+	} = useProtectData( {
 		sourceType: source,
-		statusFilter: status,
+		filter: { status, key: selected },
 	} );
 
 	const { unsortedList, item } = useMemo( () => {
@@ -66,19 +68,19 @@ const useThreatsList = ( { source, status } = { source: 'scan', status: 'all' } 
 			// Core, files, and database data threats are already grouped together,
 			// so we just need to flatten them and add the appropriate icon.
 			switch ( selected ) {
-				case 'wordpress':
+				case 'core':
 					return {
 						unsortedList: flattenThreats( core, { icon: coreIcon } ),
 						item: core,
 					};
 				case 'files':
 					return {
-						unsortedList: flattenThreats( files, { icon: filesIcon } ),
+						unsortedList: flattenThreats( { threats: files }, { icon: filesIcon } ),
 						item: files,
 					};
 				case 'database':
 					return {
-						unsortedList: flattenThreats( database, { icon: databaseIcon } ),
+						unsortedList: flattenThreats( { threats: database }, { icon: databaseIcon } ),
 						item: database,
 					};
 				default:
@@ -109,8 +111,8 @@ const useThreatsList = ( { source, status } = { source: 'scan', status: 'all' } 
 				...flattenThreats( core, { icon: coreIcon } ),
 				...flattenThreats( plugins, { icon: pluginsIcon } ),
 				...flattenThreats( themes, { icon: themesIcon } ),
-				...flattenThreats( files, { icon: filesIcon } ),
-				...flattenThreats( database, { icon: databaseIcon } ),
+				...flattenThreats( { threats: files }, { icon: filesIcon } ),
+				...flattenThreats( { threats: database }, { icon: databaseIcon } ),
 			],
 			item: null,
 		};

--- a/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
+++ b/projects/plugins/protect/src/js/hooks/use-protect-data/index.js
@@ -1,16 +1,55 @@
 import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { STORE_ID } from '../../state/store';
+
+// Valid "key" values for filtering.
+const KEY_FILTERS = [ 'all', 'core', 'plugins', 'themes', 'files', 'database' ];
+
+/**
+ * Filter Extension Threats
+ *
+ * @param {Array} threats        - The threats to filter.
+ * @param {object} filter        - The filter to apply to the data.
+ * @param {string} filter.status - The status to filter: 'all', 'fixed', or 'ignored'.
+ * @param {string} filter.key    - The key to filter: 'all', 'core', 'files', 'database', or an extension name.
+ * @param {string} key           - The threat's key: 'all', 'core', 'files', 'database', or an extension name.
+ *
+ * @returns {Array} The filtered threats.
+ */
+const filterThreats = ( threats, filter, key ) => {
+	if ( ! Array.isArray( threats ) ) {
+		return [];
+	}
+
+	return threats.filter( threat => {
+		if ( filter.status && filter.status !== 'all' && threat.status !== filter.status ) {
+			return false;
+		}
+		if ( filter.key && filter.key !== 'all' && filter.key !== key ) {
+			return false;
+		}
+		return true;
+	} );
+};
 
 /**
  * Get parsed data from the initial state
  *
- * @param {object} options - The options to use when getting the data.
- * @param {string} options.sourceType - 'scan' or 'history'.
- * @param {string} options.statusFilter - 'all', 'fixed', or 'ignored'.
+ * @param {object} options               - The options to use when getting the data.
+ * @param {string} options.sourceType    - 'scan' or 'history'.
+ * @param {object} options.filter        - The filter to apply to the data.
+ * _param {string} options.filter.status - 'all', 'fixed', or 'ignored'.
+ * _param {string} options.filter.key    - 'all', 'core', 'files', 'database', or an extension name.
+ *
  * @returns {object} The information available in Protect's initial state.
  */
-export default function useProtectData( { sourceType = 'scan', statusFilter = 'all' } = {} ) {
+export default function useProtectData(
+	{ sourceType, filter } = {
+		sourceType: 'scan',
+		filter: { status: null, key: null },
+	}
+) {
 	const { status, scanHistory, jetpackScan, hasRequiredPlan } = useSelect( select => ( {
 		status: select( STORE_ID ).getStatus(),
 		scanHistory: select( STORE_ID ).getScanHistory(),
@@ -18,90 +57,114 @@ export default function useProtectData( { sourceType = 'scan', statusFilter = 'a
 		hasRequiredPlan: select( STORE_ID ).hasRequiredPlan(),
 	} ) );
 
-	const source = useMemo( () => {
+	const { counts, results, error, lastChecked, hasUncheckedItems } = useMemo( () => {
+		// This hook can provide data from two sources: the current scan or the scan history.
 		const data = sourceType === 'history' ? { ...scanHistory } : { ...status };
 
-		// Filter the threats based on the status filter.
-		if ( statusFilter === 'all' ) {
-			return data;
-		}
-
-		return {
-			core: ( data.core || [] )
-				.map( core => {
-					const threats = core.threats.filter( threat => threat.status === statusFilter );
-					return { ...core, threats };
-				} )
-				.filter( core => core.threats.length > 0 ),
-			plugins: ( data.plugins || [] ).reduce( ( acc, plugin ) => {
-				const threats = plugin.threats.filter( threat => threat.status === statusFilter );
-				if ( threats.length > 0 ) {
-					acc.push( { ...plugin, threats } );
-				}
-				return acc;
-			}, [] ),
-			themes: ( data.themes || [] ).reduce( ( acc, theme ) => {
-				const threats = theme.threats.filter( threat => threat.status === statusFilter );
-				if ( threats.length > 0 ) {
-					acc.push( { ...theme, threats } );
-				}
-				return acc;
-			}, [] ),
-			files: ( data.files || [] ).filter( threat => threat.status === statusFilter ),
-			database: ( data.database || [] ).filter( threat => threat.status === statusFilter ),
+		// Prepare the result object.
+		const result = {
+			results: {
+				core: [],
+				plugins: [],
+				themes: [],
+				files: [],
+				database: [],
+			},
+			counts: {
+				all: {
+					threats: 0,
+					core: 0,
+					plugins: 0,
+					themes: 0,
+					files: 0,
+					database: 0,
+				},
+				current: {
+					threats: 0,
+					core: 0,
+					plugins: 0,
+					themes: 0,
+					files: 0,
+					database: 0,
+				},
+			},
+			error: null,
+			lastChecked: data.lastChecked || null,
+			hasUncheckedItems: data.hasUncheckedItems || false,
 		};
-	}, [ sourceType, status, scanHistory, statusFilter ] );
 
-	const numCoreThreats = useMemo( () => {
-		if ( 'history' === sourceType ) {
-			return ( source.core || [] ).reduce(
-				( numThreats, core ) => numThreats + core.threats.length,
-				0
-			);
+		// Loop through the provided extensions, and update the result object.
+		const processExtensions = ( extensions, key ) => {
+			if ( ! Array.isArray( extensions ) ) {
+				return [];
+			}
+			extensions.forEach( extension => {
+				// Update the total counts.
+				result.counts.all[ key ] += extension?.threats?.length || 0;
+				result.counts.all.threats += extension?.threats?.length || 0;
+
+				// Filter the extension's threats based on the current filters.
+				const filteredThreats = filterThreats(
+					extension?.threats,
+					filter,
+					KEY_FILTERS.includes( filter.key ) ? key : extension?.name
+				);
+
+				// Update the result object with the extension and its filtered threats.
+				result.results[ key ].push( { ...extension, threats: filteredThreats } );
+
+				// Update the current counts.
+				result.counts.current[ key ] += filteredThreats.length;
+				result.counts.current.threats += filteredThreats.length;
+			} );
+		};
+
+		// Loop through the provided threats, and update the result object.
+		const processThreats = ( threatsToProcess, key ) => {
+			if ( ! Array.isArray( threatsToProcess ) ) {
+				return [];
+			}
+
+			result.counts.all[ key ] += threatsToProcess.length;
+			result.counts.all.threats += threatsToProcess.length;
+
+			const filteredThreats = filterThreats( threatsToProcess, filter, key );
+
+			result.results[ key ] = [ ...result.results[ key ], ...filteredThreats ];
+			result.counts.current[ key ] += filteredThreats.length;
+			result.counts.current.threats += filteredThreats.length;
+		};
+
+		// Core data may be either a single object or an array of multiple objects.
+		let cores = Array.isArray( data.core ) ? data.core : [];
+		if ( data.core.threats ) {
+			cores = [ data.core ];
 		}
-		return source.core?.threats?.length || 0;
-	}, [ sourceType, source.core ] );
 
-	const numPluginsThreats = useMemo(
-		() =>
-			( source.plugins || [] ).reduce( ( numThreats, plugin ) => {
-				return numThreats + plugin.threats.length;
-			}, 0 ),
-		[ source.plugins ]
-	);
+		// Process the data
+		processExtensions( cores, 'core' );
+		processExtensions( data?.plugins, 'plugins' );
+		processExtensions( data?.themes, 'themes' );
+		processThreats( data?.files, 'files' );
+		processThreats( data?.database, 'database' );
 
-	const numThemesThreats = useMemo(
-		() =>
-			( source.themes || [] ).reduce( ( numThreats, theme ) => {
-				return numThreats + theme.threats.length;
-			}, 0 ),
-		[ source.themes ]
-	);
+		// Handle errors
+		if ( data.error ) {
+			result.error = {
+				message: data.errorMessage || __( 'An error occurred.', 'jetpack-protect' ),
+				code: data.errorCode || 500,
+			};
+		}
 
-	const numFilesThreats = useMemo( () => source.files?.length || 0, [ source.files ] );
-
-	const numDatabaseThreats = useMemo( () => source.database?.length || 0, [ source.database ] );
-
-	const numThreats =
-		numCoreThreats + numPluginsThreats + numThemesThreats + numFilesThreats + numDatabaseThreats;
+		return result;
+	}, [ scanHistory, sourceType, status, filter ] );
 
 	return {
-		numThreats,
-		numCoreThreats,
-		numPluginsThreats,
-		numThemesThreats,
-		numFilesThreats,
-		numDatabaseThreats,
-		lastChecked: source.lastChecked || null,
-		error: source.error || false,
-		errorCode: source.errorCode || null,
-		errorMessage: source.errorMessage || null,
-		core: source.core || {},
-		plugins: source.plugins || [],
-		themes: source.themes || [],
-		files: { threats: source.files || [] },
-		database: { threats: source.database || [] },
-		hasUncheckedItems: source.hasUncheckedItems,
+		results,
+		counts,
+		error,
+		lastChecked,
+		hasUncheckedItems,
 		jetpackScan,
 		hasRequiredPlan,
 	};

--- a/projects/plugins/protect/src/js/index.tsx
+++ b/projects/plugins/protect/src/js/index.tsx
@@ -3,6 +3,7 @@ import * as WPElement from '@wordpress/element';
 import React, { useEffect } from 'react';
 import { HashRouter, Routes, Route, useLocation, Navigate } from 'react-router-dom';
 import Modal from './components/modal';
+import PaidPlanGate from './components/paid-plan-gate';
 import { OnboardingRenderedContextProvider } from './hooks/use-onboarding';
 import FirewallRoute from './routes/firewall';
 import ScanRoute from './routes/scan';
@@ -42,8 +43,22 @@ function render() {
 					<ScrollToTop />
 					<Routes>
 						<Route path="/scan" element={ <ScanRoute /> } />
-						<Route path="/scan/history" element={ <ScanHistoryRoute /> } />
-						<Route path="/scan/history/:filter" element={ <ScanHistoryRoute /> } />
+						<Route
+							path="/scan/history"
+							element={
+								<PaidPlanGate>
+									<ScanHistoryRoute />
+								</PaidPlanGate>
+							}
+						/>
+						<Route
+							path="/scan/history/:filter"
+							element={
+								<PaidPlanGate>
+									<ScanHistoryRoute />
+								</PaidPlanGate>
+							}
+						/>
 						<Route path="/firewall" element={ <FirewallRoute /> } />
 						<Route path="*" element={ <Navigate to="/scan" replace /> } />
 					</Routes>

--- a/projects/plugins/protect/src/js/routes/scan/history/status-filters.jsx
+++ b/projects/plugins/protect/src/js/routes/scan/history/status-filters.jsx
@@ -6,9 +6,13 @@ import ButtonGroup from '../../../components/button-group';
 /**
  * Status Filters component.
  *
+ * @param {object} props - Component props.
+ * @param {number} props.numFixed - Number of fixed threats.
+ * @param {number} props.numIgnored - Number of ignored threats.
+ *
  * @returns {React.ReactNode} StatusFilters component.
  */
-export default function StatusFilters() {
+export default function StatusFilters( { numFixed, numIgnored } ) {
 	const navigate = useNavigate();
 	const { filter = 'all' } = useParams();
 	const navigateOnClick = useCallback( path => () => navigate( path ), [ navigate ] );
@@ -24,12 +28,14 @@ export default function StatusFilters() {
 			<ButtonGroup.Button
 				variant={ 'fixed' === filter ? 'primary' : 'secondary' }
 				onClick={ navigateOnClick( '/scan/history/fixed' ) }
+				disabled={ ! numFixed }
 			>
 				{ __( 'Fixed', 'jetpack-protect' ) }
 			</ButtonGroup.Button>
 			<ButtonGroup.Button
 				variant={ 'ignored' === filter ? 'primary' : 'secondary' }
 				onClick={ navigateOnClick( '/scan/history/ignored' ) }
+				disabled={ ! numIgnored }
 			>
 				{ __( 'Ignored', 'jetpack-protect' ) }
 			</ButtonGroup.Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The intention of this PR is to enable the ability to access assorted threat counts, ultimately to disable status filters that have no related threats under the current selected category.

Also improves performance and usability of the hook.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moves all filtering of threat data to the `useProtectData()` hook.
* Updates the `useProtectData()` hook to use a single memo-ized loop to generate and filter all threats in one go.
* Adds `counts` property to `useProtectData()` hook, which tracks the amount of total and currently filtered threats across categories.
* Consolidates `core`, `plugins`, `themes`, `files`, and `database` properties into a `threats` property in `useProtectData()`'s return value.
* Updates the application based on changes to the hook.
* Disables the threat status filter buttons when no threats are available for the button's related filter.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Smoke test the scanner view in Jetpack Protect - start with a blank JN site, free plan, and work your way to a paid plan with threats both active and in history.

