### PR TITLE
Social | Improve broken shared connection message for non admins

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-improve-broken-connection-message-for-non-admins
+++ b/projects/js-packages/publicize-components/changelog/update-social-improve-broken-connection-message-for-non-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improved broken connection messaging for non-admins

--- a/projects/js-packages/publicize-components/src/components/services/service-connection-info.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/service-connection-info.tsx
@@ -35,10 +35,16 @@ export const ServiceConnectionInfo = ( {
 			<div className={ styles[ 'connection-details' ] }>
 				<ConnectionName connection={ connection } />
 				{ ( conn => {
-					if ( conn.status === 'broken' ) {
+					/**
+					 * Showing only the connection status makes sense only
+					 * if the user can disconnect the connection.
+					 * Otherwise, non-admin authors will see only the status without any further context.
+					 */
+					if ( conn.status === 'broken' && conn.can_disconnect ) {
 						return <ConnectionStatus connection={ conn } service={ service } />;
 					}
 
+					// Only admins can mark connections as shared
 					if ( isAdmin ) {
 						return (
 							<div className={ styles[ 'mark-shared-wrap' ] }>
@@ -53,10 +59,19 @@ export const ServiceConnectionInfo = ( {
 						);
 					}
 
+					/**
+					 * Now if the user is not an admin, we tell them that the connection
+					 * was added by an admin and show the connection status if it's broken.
+					 */
 					return ! conn.can_disconnect ? (
-						<Text className={ styles.description }>
-							{ __( 'This connection is added by a site administrator.', 'jetpack' ) }
-						</Text>
+						<>
+							<Text className={ styles.description }>
+								{ __( 'This connection is added by a site administrator.', 'jetpack' ) }
+							</Text>
+							{ conn.status === 'broken' ? (
+								<ConnectionStatus connection={ conn } service={ service } />
+							) : null }
+						</>
 					) : null;
 				} )( connection ) }
 			</div>


### PR DESCRIPTION
<details>
<summary>When shared connection is broken, we don't tell the non-admin authors that the connection is added by an admin. We simply mention that the connection has an issue. It's better to inform in broken state as well that the connection belongs to an admin.</summary>

![Image](https://github.com/user-attachments/assets/0b9b03a7-4c47-420b-8196-1eadb6fb4c8e)

</details>


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* For broken shared connections, inform the non-admin admins that the connection is added by an admin, apart from saying that the connection is broken

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

<details>
    <summary>To simulate a broken connection, you can make these changes (click to expand)</summary>

```diff
diff --git a/projects/packages/publicize/src/class-publicize.php b/projects/packages/publicize/src/class-publicize.php
index 715d6cd3f8..63e1ee048e 100644
--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -255,7 +255,7 @@ class Publicize extends Publicize_Base {
                                                                        'can_disconnect' => self::can_manage_connection( $connection['connection_data'] ),
                                                                        'profile_link'   => $this->get_profile_link( $service_name, $connection ),
                                                                        'shared'         => '0' === $connection['connection_data']['user_id'],
-                                                                       'status'         => 'ok',
+                                                                       'status'         => 'broken',
                                                                )
                                                        );
                                                } else {
@@ -287,7 +287,7 @@ class Publicize extends Publicize_Base {
                $connection_results_map = array();

                foreach ( $connection_results as $connection_result ) {
-                       $connection_results_map[ $connection_result['connection_id'] ] = $connection_result['test_success'] ? 'ok' : 'broken';
+                       $connection_results_map[ $connection_result['connection_id'] ] = $connection_result['test_success'] ? 'broken' : 'broken';
                }
                foreach ( $connections as $key => $connection ) {
                        if ( isset( $connection_results_map[ $connection['connection_id'] ] ) ) {
```

</details>

* Add some connections as an admin and mark a few as shared
* Apply the above changes to simulate broken connections
* Goto post editor using a non-admin author account
* Open connections management modal
* Confirm that shared broken connections now mention that they are added by an admin
* Confirm that they show that there is an issue with the connection
* Confirm that non-admins cannot reconnect shared connections
* Confirm that they can reconnect their own connections
* Confirm that they can see broken connection notice for their own connections
* Confirm that everything works same as before for admin users

<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <th colspan="2">Admin (No difference)</th>
        </tr>
        <tr>
            <td>
<img width="1049" alt="Screenshot 2024-07-31 at 11 10 26 AM" src="https://github.com/user-attachments/assets/616d3f62-351b-4284-b3cd-59b40f57e14b">
</td>
            <td>
<img width="1049" alt="Screenshot 2024-07-31 at 11 10 26 AM" src="https://github.com/user-attachments/assets/616d3f62-351b-4284-b3cd-59b40f57e14b">
</td>
        </tr>
        <tr>
            <th colspan="2">Non-admin</th>
        </tr>
        <tr>
            <td colspan="2">Shared connections: <code>Boring Boardgames</code>, <code>Test page</code> and <code>manzoor.a8c</code></td>
        </tr>
        <tr>
            <td>
<img width="1048" alt="Screenshot 2024-07-31 at 11 12 40 AM" src="https://github.com/user-attachments/assets/fe997501-6d74-432d-9359-653d0e2d7859">

</td>
            <td>
<img width="1045" alt="Screenshot 2024-07-31 at 11 09 33 AM" src="https://github.com/user-attachments/assets/f90de9cf-fa23-4071-8273-2163ae6cdeea">
</td>
        </tr>
    </tbody>
</table>
