### PR TITLE
WP.com API: Include Errors Listed for Broken Themes

### DIFF
--- a/projects/plugins/jetpack/changelog/add-theme-errors-api
+++ b/projects/plugins/jetpack/changelog/add-theme-errors-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+WP.com API: Include errors listed for broken themes.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -140,6 +140,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'unmapped_url',
 		'featured_images_enabled',
 		'theme_slug',
+		'theme_errors',
 		'header_image',
 		'background_color',
 		'image_default_link_type',
@@ -661,6 +662,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'theme_slug':
 					$options[ $key ] = $site->get_theme_slug();
+					break;
+				case 'theme_errors':
+					$options[ $key ] = $site->get_theme_errors();
 					break;
 				case 'header_image':
 					$options[ $key ] = $site->get_header_image();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1071,8 +1071,8 @@ abstract class SAL_Site {
 
 			if ( ! empty( $errors->get_error_messages() ) ) {
 				$theme_errors[] = array(
-					'name'   => $theme->get( 'Name' ),
-					'errors' => $errors->get_error_messages(),
+					'name'   => sanitize_title( $theme->get( 'Name' ) ),
+					'errors' => (array) $errors->get_error_messages(),
 				);
 			}
 		}

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1061,7 +1061,7 @@ abstract class SAL_Site {
 	 * Returns a list of errors for broken themes on the site.
 	 *
 	 * @return array
-	 **/
+	 */
 	public function get_theme_errors() {
 		$themes_with_errors = wp_get_themes( array( 'errors' => true ) );
 		$theme_errors       = array();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1063,13 +1063,13 @@ abstract class SAL_Site {
 	 * @return array
 	 **/
 	public function get_theme_errors() {
-		$themes       = wp_get_themes( array( 'errors' => null ) );
-		$theme_errors = array();
+		$themes_with_errors = wp_get_themes( array( 'errors' => true ) );
+		$theme_errors       = array();
 
-		foreach ( $themes as $theme ) {
+		foreach ( $themes_with_errors as $theme ) {
 			$errors = $theme->errors();
 
-			if ( ! empty( $errors ) ) {
+			if ( ! empty( $errors->get_error_messages() ) ) {
 				$theme_errors[] = array(
 					'name'   => $theme->get( 'Name' ),
 					'errors' => $errors->get_error_messages(),

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1058,6 +1058,29 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Returns a list of errors for broken themes on the site.
+	 *
+	 * @return array
+	 **/
+	public function get_theme_errors() {
+		$themes       = wp_get_themes( array( 'errors' => null ) );
+		$theme_errors = array();
+
+		foreach ( $themes as $theme ) {
+			$errors = $theme->errors();
+
+			if ( ! empty( $errors ) ) {
+				$theme_errors[] = array(
+					'name'   => $theme->get( 'Name' ),
+					'errors' => $errors->get_error_messages(),
+				);
+			}
+		}
+
+		return $theme_errors;
+	}
+
+	/**
 	 * Gets the header image data.
 	 *
 	 * @return bool|object

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1069,7 +1069,7 @@ abstract class SAL_Site {
 		foreach ( $themes_with_errors as $theme ) {
 			$errors = $theme->errors();
 
-			if ( ! empty( $errors->get_error_messages() ) ) {
+			if ( is_wp_error( $errors ) && ! empty( $errors->get_error_messages() ) ) {
 				$theme_errors[] = array(
 					'name'   => sanitize_title( $theme->get( 'Name' ) ),
 					'errors' => (array) $errors->get_error_messages(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Needed for Automattic/wp-calypso#93132

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Includes the errors of Broken Themes in the WP.com API. The aim is to include them in Calypso, but I think that I'd need some help with configuring this endpoint first.

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Automattic/wp-calypso#93132.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:

As this is a change to the site endpoint, my ability to test is limited so please double-check the testing here:

- Install a theme on your site and break it

- You should see an error under the Themes section in WP-Admin like so.
<img width="1074" alt="Screenshot 2024-07-31 at 12 15 45" src="https://github.com/user-attachments/assets/9be119a3-bf65-4479-a3cb-b81469172cf6">

- With these changes, those errors should now be included in the endpoint like below. Confirm that is the case.

<img width="1088" alt="Screenshot 2024-07-31 at 12 12 43" src="https://github.com/user-attachments/assets/b348e7b1-360c-4e38-8660-ac07c6f5b479">

Steps for breaking a theme (there's a lot of options but this is probably the easiest):

- Go to https://wordpress.com/theme/maywood
- Install and activate the theme
- Remove the Varia child theme on which Maywood (or any of the other Varia-based themes from WordPress.com) depend on
