### PR TITLE
AI Logo Generator: open the logo block extension to 10% of user base

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-logo-generator-release-to-simple-sites
+++ b/projects/plugins/jetpack/changelog/update-ai-logo-generator-release-to-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Logo Generator: Release site logo extension to 10% of sites.

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -144,6 +144,17 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 }, 'SiteLogoEditWithAiComponents' );
 
 /**
+ * Function to check if the feature is available depending on the site ID.
+ *
+ * @returns {boolean} True if the feature is available.
+ */
+function isFeatureAvailable() {
+	const siteId = parseInt( window?.Jetpack_Editor_Initial_State?.wpcomBlogId );
+
+	return getFeatureAvailability( SITE_LOGO_BLOCK_AI_EXTENSION ) || siteId % 10 === 0;
+}
+
+/**
  * Function to check if the block can be extended.
  *
  * @param {string} name - The block name.
@@ -162,7 +173,7 @@ function canExtendBlock( name: string ): boolean {
 	}
 
 	// Disable if the feature is not available.
-	if ( ! getFeatureAvailability( SITE_LOGO_BLOCK_AI_EXTENSION ) ) {
+	if ( ! isFeatureAvailable() ) {
 		return false;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Open the logo block extension to all sites with side ID ending in 0 (~10% of user base)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on a site with blog id ending in 0
* The AI extension on the site logo block should be enabled regardless of the block variation (either beta or production)
* Check on a site with a blog id ending in any other digit
* Without beta blocks, the feature should remain disabled
* With beta blocks, the feature should be enabled

You can change the `siteId % 10 === 0` condition locally to match your site ID ending, so you can test on any site.