### PR TITLE
Forms: prevent PHP fatals

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-php-fatals
+++ b/projects/packages/forms/changelog/fix-contact-form-php-fatals
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP fatals
+
+

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.32.6",
+	"version": "0.32.7-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.32.6';
+	const PACKAGE_VERSION = '0.32.7-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -190,7 +190,7 @@ class Admin {
 		$grunion     = Contact_Form_Plugin::init();
 		$export_data = $grunion->get_feedback_entries_from_post();
 
-		$fields    = array_keys( $export_data );
+		$fields    = is_array( $export_data ) ? array_keys( $export_data ) : array();
 		$row_count = count( reset( $export_data ) );
 
 		$sheet_data = array( $fields );

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -191,7 +191,7 @@ class Admin {
 		$export_data = $grunion->get_feedback_entries_from_post();
 
 		$fields    = is_array( $export_data ) ? array_keys( $export_data ) : array();
-		$row_count = count( reset( $export_data ) );
+		$row_count = empty( $fields ) ? 0 : count( reset( $export_data ) );
 
 		$sheet_data = array( $fields );
 

--- a/projects/packages/forms/src/contact-form/class-admin.php
+++ b/projects/packages/forms/src/contact-form/class-admin.php
@@ -191,7 +191,7 @@ class Admin {
 		$export_data = $grunion->get_feedback_entries_from_post();
 
 		$fields    = is_array( $export_data ) ? array_keys( $export_data ) : array();
-		$row_count = empty( $fields ) ? 0 : count( reset( $export_data ) );
+		$row_count = ! is_array( $export_data ) || empty( $export_data ) ? 0 : count( reset( $export_data ) );
 
 		$sheet_data = array( $fields );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1050,35 +1050,50 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		// For each of the "standard" fields, grab their field label and value.
 		if ( isset( $field_ids['name'] ) ) {
-			$field          = $this->fields[ $field_ids['name'] ];
-			$comment_author = Contact_Form_Plugin::strip_tags(
-				stripslashes(
-					/** This filter is already documented in core/wp-includes/comment-functions.php */
-					apply_filters( 'pre_comment_author_name', addslashes( is_string( $field->value ) ? $field->value : '' ) )
-				)
-			);
+			$field = $this->fields[ $field_ids['name'] ];
+
+			if ( is_string( $field->value ) ) {
+				$comment_author = Contact_Form_Plugin::strip_tags(
+					stripslashes(
+						/** This filter is already documented in core/wp-includes/comment-functions.php */
+						apply_filters( 'pre_comment_author_name', addslashes( $field->value ) )
+					)
+				);
+			} elseif ( is_array( $field->value ) ) {
+				$field->value = '';
+			}
 		}
 
 		if ( isset( $field_ids['email'] ) ) {
-			$field                = $this->fields[ $field_ids['email'] ];
-			$comment_author_email = Contact_Form_Plugin::strip_tags(
-				stripslashes(
-					/** This filter is already documented in core/wp-includes/comment-functions.php */
-					apply_filters( 'pre_comment_author_email', addslashes( is_string( $field->value ) ? $field->value : '' ) )
-				)
-			);
+			$field = $this->fields[ $field_ids['email'] ];
+
+			if ( is_string( $field->value ) ) {
+				$comment_author_email = Contact_Form_Plugin::strip_tags(
+					stripslashes(
+						/** This filter is already documented in core/wp-includes/comment-functions.php */
+						apply_filters( 'pre_comment_author_email', addslashes( $field->value ) )
+					)
+				);
+			} elseif ( is_array( $field->value ) ) {
+				$field->value = '';
+			}
 		}
 
 		if ( isset( $field_ids['url'] ) ) {
-			$field              = $this->fields[ $field_ids['url'] ];
-			$comment_author_url = Contact_Form_Plugin::strip_tags(
-				stripslashes(
-					/** This filter is already documented in core/wp-includes/comment-functions.php */
-					apply_filters( 'pre_comment_author_url', addslashes( is_string( $field->value ) ? $field->value : '' ) )
-				)
-			);
-			if ( 'http://' === $comment_author_url ) {
-				$comment_author_url = '';
+			$field = $this->fields[ $field_ids['url'] ];
+
+			if ( is_string( $field->value ) ) {
+				$comment_author_url = Contact_Form_Plugin::strip_tags(
+					stripslashes(
+						/** This filter is already documented in core/wp-includes/comment-functions.php */
+						apply_filters( 'pre_comment_author_url', addslashes( $field->value ) )
+					)
+				);
+				if ( 'http://' === $comment_author_url ) {
+					$comment_author_url = '';
+				}
+			} elseif ( is_array( $field->value ) ) {
+				$field->value = '';
 			}
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -310,7 +310,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				"</h4>\n\n";
 
 			// Don't show the feedback details unless the nonce matches
-			if ( $feedback_id && isset( $_GET['_wpnonce'] ) && wp_verify_nonce( stripslashes( $_GET['_wpnonce'] ), "contact-form-sent-{$feedback_id}" ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( $feedback_id && isset( $_GET['_wpnonce'] ) && is_string( $_GET['_wpnonce'] ) && wp_verify_nonce( stripslashes( $_GET['_wpnonce'] ), "contact-form-sent-{$feedback_id}" ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				$r_success_message .= self::success_message( $feedback_id, $form );
 			}
 
@@ -1050,35 +1050,44 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		// For each of the "standard" fields, grab their field label and value.
 		if ( isset( $field_ids['name'] ) ) {
-			$field          = $this->fields[ $field_ids['name'] ];
-			$comment_author = Contact_Form_Plugin::strip_tags(
-				stripslashes(
-					/** This filter is already documented in core/wp-includes/comment-functions.php */
-					apply_filters( 'pre_comment_author_name', addslashes( $field->value ) )
-				)
-			);
+			$field = $this->fields[ $field_ids['name'] ];
+
+			if ( is_string( $field->value ) ) {
+				$comment_author = Contact_Form_Plugin::strip_tags(
+					stripslashes(
+						/** This filter is already documented in core/wp-includes/comment-functions.php */
+						apply_filters( 'pre_comment_author_name', addslashes( $field->value ) )
+					)
+				);
+			}
 		}
 
 		if ( isset( $field_ids['email'] ) ) {
-			$field                = $this->fields[ $field_ids['email'] ];
-			$comment_author_email = Contact_Form_Plugin::strip_tags(
-				stripslashes(
-					/** This filter is already documented in core/wp-includes/comment-functions.php */
-					apply_filters( 'pre_comment_author_email', addslashes( $field->value ) )
-				)
-			);
+			$field = $this->fields[ $field_ids['email'] ];
+
+			if ( is_string( $field->value ) ) {
+				$comment_author_email = Contact_Form_Plugin::strip_tags(
+					stripslashes(
+						/** This filter is already documented in core/wp-includes/comment-functions.php */
+						apply_filters( 'pre_comment_author_email', addslashes( $field->value ) )
+					)
+				);
+			}
 		}
 
 		if ( isset( $field_ids['url'] ) ) {
-			$field              = $this->fields[ $field_ids['url'] ];
-			$comment_author_url = Contact_Form_Plugin::strip_tags(
-				stripslashes(
-					/** This filter is already documented in core/wp-includes/comment-functions.php */
-					apply_filters( 'pre_comment_author_url', addslashes( $field->value ) )
-				)
-			);
-			if ( 'http://' === $comment_author_url ) {
-				$comment_author_url = '';
+			$field = $this->fields[ $field_ids['url'] ];
+
+			if ( is_string( $field->value ) ) {
+				$comment_author_url = Contact_Form_Plugin::strip_tags(
+					stripslashes(
+						/** This filter is already documented in core/wp-includes/comment-functions.php */
+						apply_filters( 'pre_comment_author_url', addslashes( $field->value ) )
+					)
+				);
+				if ( 'http://' === $comment_author_url ) {
+					$comment_author_url = '';
+				}
 			}
 		}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -310,7 +310,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 				"</h4>\n\n";
 
 			// Don't show the feedback details unless the nonce matches
-			if ( $feedback_id && isset( $_GET['_wpnonce'] ) && is_string( $_GET['_wpnonce'] ) && wp_verify_nonce( stripslashes( $_GET['_wpnonce'] ), "contact-form-sent-{$feedback_id}" ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if (
+				$feedback_id
+				&& isset( $_GET['_wpnonce'] )
+				&& wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), "contact-form-sent-{$feedback_id}" )
+			) {
 				$r_success_message .= self::success_message( $feedback_id, $form );
 			}
 

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1050,44 +1050,35 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		// For each of the "standard" fields, grab their field label and value.
 		if ( isset( $field_ids['name'] ) ) {
-			$field = $this->fields[ $field_ids['name'] ];
-
-			if ( is_string( $field->value ) ) {
-				$comment_author = Contact_Form_Plugin::strip_tags(
-					stripslashes(
-						/** This filter is already documented in core/wp-includes/comment-functions.php */
-						apply_filters( 'pre_comment_author_name', addslashes( $field->value ) )
-					)
-				);
-			}
+			$field          = $this->fields[ $field_ids['name'] ];
+			$comment_author = Contact_Form_Plugin::strip_tags(
+				stripslashes(
+					/** This filter is already documented in core/wp-includes/comment-functions.php */
+					apply_filters( 'pre_comment_author_name', addslashes( is_string( $field->value ) ? $field->value : '' ) )
+				)
+			);
 		}
 
 		if ( isset( $field_ids['email'] ) ) {
-			$field = $this->fields[ $field_ids['email'] ];
-
-			if ( is_string( $field->value ) ) {
-				$comment_author_email = Contact_Form_Plugin::strip_tags(
-					stripslashes(
-						/** This filter is already documented in core/wp-includes/comment-functions.php */
-						apply_filters( 'pre_comment_author_email', addslashes( $field->value ) )
-					)
-				);
-			}
+			$field                = $this->fields[ $field_ids['email'] ];
+			$comment_author_email = Contact_Form_Plugin::strip_tags(
+				stripslashes(
+					/** This filter is already documented in core/wp-includes/comment-functions.php */
+					apply_filters( 'pre_comment_author_email', addslashes( is_string( $field->value ) ? $field->value : '' ) )
+				)
+			);
 		}
 
 		if ( isset( $field_ids['url'] ) ) {
-			$field = $this->fields[ $field_ids['url'] ];
-
-			if ( is_string( $field->value ) ) {
-				$comment_author_url = Contact_Form_Plugin::strip_tags(
-					stripslashes(
-						/** This filter is already documented in core/wp-includes/comment-functions.php */
-						apply_filters( 'pre_comment_author_url', addslashes( $field->value ) )
-					)
-				);
-				if ( 'http://' === $comment_author_url ) {
-					$comment_author_url = '';
-				}
+			$field              = $this->fields[ $field_ids['url'] ];
+			$comment_author_url = Contact_Form_Plugin::strip_tags(
+				stripslashes(
+					/** This filter is already documented in core/wp-includes/comment-functions.php */
+					apply_filters( 'pre_comment_author_url', addslashes( is_string( $field->value ) ? $field->value : '' ) )
+				)
+			);
+			if ( 'http://' === $comment_author_url ) {
+				$comment_author_url = '';
 			}
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the `forms` package to prevent PHP fatals that have been raised.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1722410167616409-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Review the code. Let's check the form functionalities still work:
- Spin up a test site with this branch
- Create a new post
- Add a Contact Form block
- Save the post and open the preview
- Fill the form and submit it
- Notice it works as expected

Optionally, test that the Google Drive export works.
- Visit `/wp-admin/admin.php?page=jetpack-forms#/responses`
- Select the `Inbox` view
<img width="253" alt="Screenshot 2024-07-31 at 10 42 33 AM" src="https://github.com/user-attachments/assets/7556f2ef-eee6-489b-914d-6d67173d9894">

- Verify that at least one item is present in the `Inbox` tab
<img width="312" alt="Screenshot 2024-07-31 at 10 51 34 AM" src="https://github.com/user-attachments/assets/30e6a78e-a071-436f-afa0-c4df71266a17">


- Click the `Export` button and  follow the connection process
<img width="1289" alt="Screenshot 2024-07-31 at 10 15 11 AM" src="https://github.com/user-attachments/assets/90574910-cf55-4ed9-9bad-ffd8a9238f90">

- A new tab with a Google Spreadsheet should open