### PR TITLE
Adminbar: Fix profile menu colors on certain pages

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-adminbar-profile-menu-colors
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-adminbar-profile-menu-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Adminbar: Fix profile menu colors

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -101,6 +101,14 @@
 		position: absolute;
 		right: 0;
 
+		#wp-admin-bar-my-account {
+			.ab-item {
+				> .display-name {
+					color: currentColor;
+				}
+			}
+		}
+
 		@media (max-width: 782px) {
 			#wp-admin-bar-help-center {
 				display: block !important;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/93120

## Proposed changes:
Fixed the colors for the name and "Edit profile" in Profile menu for /blog and /go pages.


| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/3a021791-d7a7-4c48-a9f1-4531fa40a164) | ![image](https://github.com/user-attachments/assets/32216ab9-05f1-4249-9187-793f64d74714) |
| ![image](https://github.com/user-attachments/assets/1f3e484a-2cde-491e-a978-e5a63bb1e622) | ![image](https://github.com/user-attachments/assets/3d59f23d-6357-4805-85a6-d1003445f958) |


## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Follow the instructions from the first post to apply this on your sandbox
* Sandbox `en.blog.wordpress.com`, `enwpgo.wordpress.com`, and `wordpress.com`
* Check the colors of the profile menu on wordpress.com/blog and wordpress.com/go
* Check for regressions on other sites/schemas

