### PR TITLE
Masterbar: Fix RLT secondary admin bar

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-rtl-admin-bar
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-rtl-admin-bar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix RTL admin bar

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -100,6 +100,7 @@
 	body.rtl & {
 		#wp-admin-bar-top-secondary {
 			left: 0;
+			right: inherit;
 		}
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -96,6 +96,13 @@
 		}
 	}
 
+	// Move the secondary admin bar to the left side if the site is RTL.
+	body.rtl & {
+		#wp-admin-bar-top-secondary {
+			left: 0;
+		}
+	}
+
 	#wp-admin-bar-top-secondary {
 		float: none;
 		position: absolute;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8516

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR applies to wp-admin and moves the secondary bar in the master from the right to the left on RTL sites.

Before | After
--|--
<img width="1331" alt="Screenshot 2024-07-31 at 2 27 23 PM" src="https://github.com/user-attachments/assets/a2fee152-47f3-4b96-b85b-e7288bb8c815">  | <img width="1333" alt="Screenshot 2024-07-31 at 2 27 10 PM" src="https://github.com/user-attachments/assets/d733ed6f-d1f1-4cc3-a8fd-71e8b6ae1517">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use the [instructions](https://github.com/Automattic/jetpack/pull/38654#issuecomment-2261152119) in the comment below to test this PR on a Simple and Atomic site.
* First go to a wp-admin page like /wp-admin/profile.php, and check an English or other LTR site to ensure the masterbar looks correct and there are no regressions
* Next set your site's user profile language to a RTL language and check the master bar.
* The "secondary" bar (your profile, help, and notification icons) should appear on the left hand of the screen.
* Click all the Masterbar icons and ensure they still work.
* Test it in mobile

