### PR TITLE
Masterbar: Remove dead Help icon CSS code

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-dead-css-code
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-dead-css-code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed dead CSS code

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -108,11 +108,6 @@
 				margin-right: 0 !important;
 				.ab-item {
 					width: 52px;
-					svg {
-						width: 36px;
-						height: 36px;
-						padding: 4px 8px;
-					}
 				}
 			}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/pull/93122#discussion_r1698094599

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes dead CSS code.

> [!NOTE]  
> Automerge is enabled on this PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using the [testing instructions below](https://github.com/Automattic/jetpack/pull/38659#issuecomment-2261523873), apply this diff and ensure the Help icon still looks correct.

