### PR TITLE
Instant Search: Include a8c-support-theme kb_article taxonomies

### DIFF
--- a/projects/packages/sync/changelog/update-class-search-taxonomies-kb-article
+++ b/projects/packages/sync/changelog/update-class-search-taxonomies-kb-article
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Instant Search: add taxonomies for a8c-support-theme kb_article cpt.

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -1729,6 +1729,10 @@ class Search extends Module {
 		// wp.com martketplace search - @see https://wp.me/pdh6GB-Ax#comment-2104
 		'wpcom_marketplace_categories',
 
+		// wp.com a8c-support-theme taxonomies.
+		'kb_category',
+		'kb_tag',
+
 	); // end taxonomies.
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR extends Instant Search to include taxonomies which are part the a8c-support-theme.
* The a8c-support-theme is the parent to the child themes used on A4A support site, and the upcoming refresh of the Pocket Casts support site.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/a8cteam51/a8c-support-theme/issues/27

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
I'm not completely sure how to test this change, but ideally:
* Create/visit a site using the a8c-support-theme.
* Add and setup Jetpack Instant Search so it includes results from the `kb_articles` CPT, including the filter options in the widget.
* On the front-end, try a new search. The filters available should include relevant entries for the `kb_category` and `kb_tag` taxonomies.


