### PR TITLE
My Jetpack: add support for feature-specific handling to product interstitials

### DIFF
--- a/projects/packages/my-jetpack/_inc/constants.ts
+++ b/projects/packages/my-jetpack/_inc/constants.ts
@@ -14,7 +14,7 @@ export const MyJetpackRoutes = {
 	AddCreator: '/add-creator',
 	AddJetpackAI: '/add-jetpack-ai',
 	AddExtras: '/add-extras',
-	AddProtect: '/add-protect',
+	AddProtect: '/add-protect/:feature?',
 	AddScan: '/add-scan',
 	AddSocial: '/add-social',
 	AddSearch: '/add-search',

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-product-urls-by-feature
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-product-urls-by-feature
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: add support for feature-specific handling to product interstitials.

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -150,35 +150,37 @@ abstract class Product {
 			throw new \Exception( 'Product classes must declare the $slug attribute.' );
 		}
 		return array(
-			'slug'                      => static::$slug,
-			'plugin_slug'               => static::$plugin_slug,
-			'name'                      => static::get_name(),
-			'title'                     => static::get_title(),
-			'description'               => static::get_description(),
-			'long_description'          => static::get_long_description(),
-			'tiers'                     => static::get_tiers(),
-			'features'                  => static::get_features(),
-			'features_by_tier'          => static::get_features_by_tier(),
-			'disclaimers'               => static::get_disclaimers(),
-			'status'                    => static::get_status(),
-			'pricing_for_ui'            => static::get_pricing_for_ui(),
-			'is_bundle'                 => static::is_bundle_product(),
-			'is_plugin_active'          => static::is_plugin_active(),
-			'is_upgradable'             => static::is_upgradable(),
-			'is_upgradable_by_bundle'   => static::is_upgradable_by_bundle(),
-			'supported_products'        => static::get_supported_products(),
-			'wpcom_product_slug'        => static::get_wpcom_product_slug(),
-			'requires_user_connection'  => static::$requires_user_connection,
-			'has_any_plan_for_product'  => static::has_any_plan_for_product(),
-			'has_free_plan_for_product' => static::has_free_plan_for_product(),
-			'has_paid_plan_for_product' => static::has_paid_plan_for_product(),
-			'has_free_offering'         => static::$has_free_offering,
-			'manage_url'                => static::get_manage_url(),
-			'purchase_url'              => static::get_purchase_url(),
-			'post_activation_url'       => static::get_post_activation_url(),
-			'standalone_plugin_info'    => static::get_standalone_info(),
-			'class'                     => static::class,
-			'post_checkout_url'         => static::get_post_checkout_url(),
+			'slug'                            => static::$slug,
+			'plugin_slug'                     => static::$plugin_slug,
+			'name'                            => static::get_name(),
+			'title'                           => static::get_title(),
+			'description'                     => static::get_description(),
+			'long_description'                => static::get_long_description(),
+			'tiers'                           => static::get_tiers(),
+			'features'                        => static::get_features(),
+			'features_by_tier'                => static::get_features_by_tier(),
+			'disclaimers'                     => static::get_disclaimers(),
+			'status'                          => static::get_status(),
+			'pricing_for_ui'                  => static::get_pricing_for_ui(),
+			'is_bundle'                       => static::is_bundle_product(),
+			'is_plugin_active'                => static::is_plugin_active(),
+			'is_upgradable'                   => static::is_upgradable(),
+			'is_upgradable_by_bundle'         => static::is_upgradable_by_bundle(),
+			'supported_products'              => static::get_supported_products(),
+			'wpcom_product_slug'              => static::get_wpcom_product_slug(),
+			'requires_user_connection'        => static::$requires_user_connection,
+			'has_any_plan_for_product'        => static::has_any_plan_for_product(),
+			'has_free_plan_for_product'       => static::has_free_plan_for_product(),
+			'has_paid_plan_for_product'       => static::has_paid_plan_for_product(),
+			'has_free_offering'               => static::$has_free_offering,
+			'manage_url'                      => static::get_manage_url(),
+			'purchase_url'                    => static::get_purchase_url(),
+			'post_activation_url'             => static::get_post_activation_url(),
+			'post_activation_urls_by_feature' => static::get_manage_urls_by_feature(),
+			'standalone_plugin_info'          => static::get_standalone_info(),
+			'class'                           => static::class,
+			'post_checkout_url'               => static::get_post_checkout_url(),
+			'post_checkout_urls_by_feature'   => static::get_post_checkout_urls_by_feature(),
 		);
 	}
 
@@ -306,6 +308,15 @@ abstract class Product {
 	abstract public static function get_manage_url();
 
 	/**
+	 * Get the URL where the user manages the product for each product feature
+	 *
+	 * @return ?array
+	 */
+	public static function get_manage_urls_by_feature() {
+		return null;
+	}
+
+	/**
 	 * Get the URL the user is taken after activating the product
 	 *
 	 * @return ?string
@@ -320,6 +331,15 @@ abstract class Product {
 	 * @return ?string
 	 */
 	public static function get_post_checkout_url() {
+		return null;
+	}
+
+	/**
+	 * Get the URL the user is taken after purchasing the product through the checkout for each product feature
+	 *
+	 * @return ?array
+	 */
+	public static function get_post_checkout_urls_by_feature() {
 		return null;
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-protect.php
+++ b/projects/packages/my-jetpack/src/products/class-protect.php
@@ -22,6 +22,9 @@ class Protect extends Product {
 	const UPGRADED_TIER_SLUG         = 'upgraded';
 	const UPGRADED_TIER_PRODUCT_SLUG = 'jetpack_scan';
 
+	const SCAN_FEATURE_SLUG     = 'scan';
+	const FIREWALL_FEATURE_SLUG = 'firewall';
+
 	/**
 	 * The product slug
 	 *
@@ -310,12 +313,36 @@ class Protect extends Product {
 	}
 
 	/**
+	 * Get the URL the user is taken after purchasing the product through the checkout for each product feature
+	 *
+	 * @return ?array
+	 */
+	public static function get_post_checkout_urls_by_feature() {
+		return array(
+			self::SCAN_FEATURE_SLUG     => self::get_post_checkout_url(),
+			self::FIREWALL_FEATURE_SLUG => admin_url( 'admin.php?page=jetpack-protect#/firewall' ),
+		);
+	}
+
+	/**
 	 * Get the URL where the user manages the product
 	 *
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
 		return admin_url( 'admin.php?page=jetpack-protect' );
+	}
+
+	/**
+	 * Get the URL where the user manages the product for each product feature
+	 *
+	 * @return ?array
+	 */
+	public static function get_manage_urls_by_feature() {
+		return array(
+			self::SCAN_FEATURE_SLUG     => self::get_manage_url(),
+			self::FIREWALL_FEATURE_SLUG => admin_url( 'admin.php?page=jetpack-protect#/firewall' ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves https://github.com/Automattic/jetpack-scan-team/issues/1306

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds support to the product interstitial component in My Jetpack to accept a `feature` slug prop, to enable alternate functionality or output based on the provided product's feature.
* Adds support to the Jetpack Protect product interstitial page in My Jetpack (`/add-protect`) to accept a feature slug to be provided via an optional secondary path segment (`/add-protect/firewall`), and adds custom redirect functionality when the parameter is present to ensure the user is redirected to the specific feature's settings screen after activating or purchasing the product.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack-scan-team/issues/1306

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Start with a user-connected Jetpack site, as the userless connection flow currently doesn't respect My Jetpack's post-checkout redirect urls.
* Go to `/wp-admin/admin.php?feature=firewall&page=my-jetpack#/add-protect/firewall`
* Activate Protect and verify you are redirected to the firewall settings screen.
* Repeat the process and purchase a plan, verify you are redirected to the firewall settings screen after checkout.
* Repeat the process without the `/firewall` path prepended, verify you are redirected to the scan results screen after activation/checkout.
* Repeat the process for a product that is not Jetpack Protect.

