### PR TITLE
WPCOM: Update plan names in plan notices

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcom-plan-name-revert
+++ b/projects/plugins/wpcomsh/changelog/update-wpcom-plan-name-revert
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Plan names: Revert plan names to Personal/Premium/Business/Commerce

--- a/projects/plugins/wpcomsh/notices/plan-notices.php
+++ b/projects/plugins/wpcomsh/notices/plan-notices.php
@@ -86,22 +86,22 @@ function wpcomsh_plan_notices() {
 		$plan_messages = array(
 			/* translators: %1$s is a link for plan renewal, %2$s human readable time e.g. January 1, 2021, %3$s site URL */
 			'personal'  => __(
-				'The Starter plan for <strong>%3$s</strong> expires on %2$s. <a href="%1$s">Renew your plan</a> to retain Starter plan features such as 6 GB storage space, no WordPress.com ads, and Subscriber-only content.',
+				'The Personal plan for <strong>%3$s</strong> expires on %2$s. <a href="%1$s">Renew your plan</a> to retain Personal plan features such as 6 GB storage space, no WordPress.com ads, and Subscriber-only content.',
 				'wpcomsh'
 			),
 			/* translators: %1$s is a link for plan renewal, %2$s human readable time e.g. January 1, 2021, %3$s site URL */
 			'premium'   => __(
-				'The Explorer plan for <strong>%3$s</strong> expires on %2$s. <a href="%1$s">Renew your plan</a> to retain Explorer plan features such as site monetization, VideoPress, and Google Analytics support.',
+				'The Premium plan for <strong>%3$s</strong> expires on %2$s. <a href="%1$s">Renew your plan</a> to retain Premium plan features such as site monetization, VideoPress, and Google Analytics support.',
 				'wpcomsh'
 			),
 			/* translators: %1$s is a link for plan renewal, %2$s human readable time e.g. January 1, 2021, %3$s site URL */
 			'business'  => __(
-				'The Creator plan for <strong>%3$s</strong> expires on %2$s. <a href="%1$s">Renew your plan</a> to retain Creator plan features such as custom plugins and themes, SFTP, and phpMyAdmin access.',
+				'The Business plan for <strong>%3$s</strong> expires on %2$s. <a href="%1$s">Renew your plan</a> to retain Business plan features such as custom plugins and themes, SFTP, and phpMyAdmin access.',
 				'wpcomsh'
 			),
 			/* translators: %1$s is a link for plan renewal, %2$s human readable time e.g. January 1, 2021, %3$s site URL */
 			'ecommerce' => __(
-				'The Entrepreneur plan for <strong>%3$s</strong> expires on %2$s. <a href="%1$s">Renew your plan</a> to retain Entrepreneur plan features such as custom plugins and themes, SFTP, and phpMyAdmin access.',
+				'The Commerce plan for <strong>%3$s</strong> expires on %2$s. <a href="%1$s">Renew your plan</a> to retain Commerce plan features such as custom plugins and themes, SFTP, and phpMyAdmin access.',
 				'wpcomsh'
 			),
 			/* translators: %1$s is a link for plan renewal, %2$s human readable time e.g. January 1, 2021, %3$s site URL */

--- a/projects/plugins/wpcomsh/notices/plan-notices.php
+++ b/projects/plugins/wpcomsh/notices/plan-notices.php
@@ -117,22 +117,22 @@ function wpcomsh_plan_notices() {
 		$plan_messages = array(
 			/* translators: %1$s is a link for plan renewal, %2$s human readable time e.g. January 1, 2021, %3$s site URL */
 			'personal'  => __(
-				'The Starter plan for <strong>%3$s</strong> expired on %2$s. <a href="%1$s">Reactivate your plan</a> to retain Starter plan features such as 6 GB storage space, no WordPress.com ads, and Subscriber-only content.',
+				'The Personal plan for <strong>%3$s</strong> expired on %2$s. <a href="%1$s">Reactivate your plan</a> to retain Personal plan features such as 6 GB storage space, no WordPress.com ads, and Subscriber-only content.',
 				'wpcomsh'
 			),
 			/* translators: %1$s is a link for plan renewal, %2$s human readable time e.g. January 1, 2021, %3$s site URL */
 			'premium'   => __(
-				'The Explorer plan for <strong>%3$s</strong> expired on %2$s. <a href="%1$s">Reactivate your plan</a> to retain Explorer plan features such as site monetization, VideoPress, and Google Analytics support.',
+				'The Premium plan for <strong>%3$s</strong> expired on %2$s. <a href="%1$s">Reactivate your plan</a> to retain Premium plan features such as site monetization, VideoPress, and Google Analytics support.',
 				'wpcomsh'
 			),
 			/* translators: %1$s is a link for plan renewal, %2$s human readable time e.g. January 1, 2021, %3$s site URL */
 			'business'  => __(
-				'The Creator plan for <strong>%3$s</strong> expired on %2$s. <a href="%1$s">Reactivate your plan</a> to retain Creator plan features such as custom plugins and themes, SFTP, and phpMyAdmin access.',
+				'The Business plan for <strong>%3$s</strong> expired on %2$s. <a href="%1$s">Reactivate your plan</a> to retain Business plan features such as custom plugins and themes, SFTP, and phpMyAdmin access.',
 				'wpcomsh'
 			),
 			/* translators: %1$s is a link for plan renewal, %2$s human readable time e.g. January 1, 2021, %3$s site URL */
 			'ecommerce' => __(
-				'The Entrepreneur plan for <strong>%3$s</strong> expired on %2$s. <a href="%1$s">Reactivate your plan</a> to retain Entrepreneur plan features such as custom plugins and themes, SFTP, and phpMyAdmin access.',
+				'The Commerce plan for <strong>%3$s</strong> expired on %2$s. <a href="%1$s">Reactivate your plan</a> to retain Commerce plan features such as custom plugins and themes, SFTP, and phpMyAdmin access.',
 				'wpcomsh'
 			),
 			/* translators: %1$s is a link for plan renewal, %2$s human readable time e.g. January 1, 2021, %3$s site URL */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This updates the plan names in plan notices. We're changing WPCOM plan names as described in https://github.com/Automattic/wp-calypso/pull/92901.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The steps are same as https://github.com/Automattic/wpcomsh/pull/1640, I'll still add the details below.

1. Create a new Business site and mark it a WoA dev blog by visiting the link given in 353e0-pb.
2. Setup your local Jetpack monorepo using the instructions given in pf4qpu-sv-p2. Note: I had some setup difficulties which were resolved in the Slack chat p1722509413639079-Slack-C05Q5HSS013.
3. Checkout this branch in your local repo.
4. Go to `projects/plugins/wpcomsh` folder and run the following command:
```
WPCOMSH_DEVMODE=1 make clean build 
pnpm install && pnpm jetpack build --deps plugins/wpcomsh
pnpm jetpack rsync wpcomsh <WoASiteSlug>.wordpress.com@sftp.wp.com:htdocs/wp-content/mu-plugins/wpcomsh
```
5. Use the store admin to set your site to expire in <30 days.
6. Go to /wp-admin and verify that the site notice has "Business" as the plan name.

<img width="1455" alt="Screenshot 2024-08-01 at 10 42 24 PM" src="https://github.com/user-attachments/assets/e6222c53-1f10-4479-91a2-78fbd33e5d43">



