### PR TITLE
Admin bar: help center and notification icons now follow color scheme

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-icon-color
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-icon-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: help center and notification icons now follow color scheme

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -90,8 +90,8 @@ CSS
 	wp_add_inline_style(
 		'wpcom-admin-bar',
 		<<<CSS
-			#wpadminbar.mobile .quicklinks .ab-icon:before,
-			#wpadminbar.mobile .quicklinks .ab-item:before {
+			#wpadminbar.mobile .quicklinks li:not(#wpwrap.wp-responsive-open #wp-admin-bar-menu-toggle) .ab-icon:before,
+			#wpadminbar.mobile .quicklinks li:not(#wpwrap.wp-responsive-open #wp-admin-bar-menu-toggle) .ab-item:before {
 				color: $admin_icon_color !important;
 			}
 CSS

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -96,6 +96,16 @@ CSS
 			}
 CSS
 	);
+
+	// Force wpcom icons to have consistent color.
+	wp_add_inline_style(
+		'wpcom-admin-bar',
+		<<<CSS
+			#wpadminbar .ab-icon {
+				color: $admin_icon_color;
+			}
+CSS
+	);
 }
 add_action( 'wp_enqueue_scripts', 'wpcom_enqueue_admin_bar_assets' );
 add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_admin_bar_assets' );

--- a/projects/plugins/jetpack/changelog/fix-wpcom-icon-color
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-icon-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin bar: help center and notification icons now follow color scheme

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -212,7 +212,7 @@ class Jetpack_Notifications {
 	 */
 	private static function get_notes_markup() {
 		return '<span id="wpnt-notes-unread-count" class="wpnt-loading wpn-read"></span>
-<span class="noticon noticon-bell"></span>
+<span class="noticon noticon-bell ab-icon"></span>
 <span class="screen-reader-text">' . esc_html__( 'Notifications', 'jetpack' ) . '</span>';
 	}
 


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/8379

## Proposed changes:

This PR fixes the color of wpcom icons on the top-right admin bar so that they follow the current color scheme. Examples:

|Scheme|Before|After|
|-|-|-|
|Default|<img width="90" alt="image" src="https://github.com/user-attachments/assets/496779b3-5eb1-4c2e-8a43-92f68427ee86">|<img width="90" alt="image" src="https://github.com/user-attachments/assets/521d8383-9d1f-4052-9716-05aa99b644d8">|
|Light|<img width="90" alt="image" src="https://github.com/user-attachments/assets/d472eb13-4f3e-4fa2-b0ca-5a9722b8d7de">|<img width="90" alt="image" src="https://github.com/user-attachments/assets/8ce0a6f9-2dca-4c92-bf15-4c14015a9e12">|
|Classic Blue|<img width="90" alt="image" src="https://github.com/user-attachments/assets/4831c757-5d80-40af-8b51-0d62825c5b59">|<img width="90" alt="image" src="https://github.com/user-attachments/assets/92be685a-e644-4b37-aeac-057db8fb1913">|

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. On your Jetpack Beta Tester, apply this branch for Jetpack and WordPress.com Features (must be BOTH).
2. Try changing color schemes and verify that help center and notification icons have the same color as the top-left icons.
   - Note: sometimes you need to actually save the profile page to see the correct color... I consider this to be out of scope of this PR.
4. Test on Simple Sites as well.
5. Test on mobile resolution as well.
