### PR TITLE
Newsletters: Add Jetpack Newsletter Plugin Icon + Email Preview option.

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Email Preview endpoint for the WordPress.com REST API.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Status\Host;
+
+require_once __DIR__ . '/trait-wpcom-rest-api-proxy-request-trait.php';
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Email_Preview
+ *
+ * Returns an email preview given a post id.
+ */
+class WPCOM_REST_API_V2_Endpoint_Email_Preview extends WP_REST_Controller {
+
+	use WPCOM_REST_API_Proxy_Request_Trait;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->base_api_path                   = 'wpcom';
+		$this->version                         = 'v2';
+		$this->namespace                       = $this->base_api_path . '/' . $this->version;
+		$this->rest_base                       = '/email-preview';
+		$this->wpcom_is_wpcom_only_endpoint    = true;
+		$this->wpcom_is_site_specific_endpoint = true;
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Registers the routes for email preview.
+	 *
+	 * @see register_rest_route()
+	 */
+	public function register_routes() {
+		$options = array(
+			'show_in_index'       => true,
+			'methods'             => 'GET',
+			// if this is not a wpcom site, we need to proxy the request to wpcom
+			'callback'            => ( ( new Host() )->is_wpcom_simple() ) ? array(
+				$this,
+				'email_preview',
+			) : array( $this, 'proxy_request_to_wpcom_as_user' ),
+			'permission_callback' => array( $this, 'permissions_check' ),
+			'args'                => array(
+				'id' => array(
+					'description' => __( 'Unique identifier for the post.', 'jetpack' ),
+					'type'        => 'integer',
+				),
+			),
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			$options
+		);
+	}
+
+	/**
+	 * Checks if the user is connected and has access to edit the post
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 *
+	 * @return true|WP_Error True if the request has edit access, WP_Error object otherwise.
+	 */
+	public function permissions_check( $request ) {
+		if ( ! ( new Host() )->is_wpcom_simple() ) {
+			if ( ! ( new Manager() )->is_user_connected() ) {
+				l( 'not connected!' );
+				return new WP_Error(
+					'rest_cannot_send_email_preview',
+					__( 'Please connect your user account to WordPress.com', 'jetpack' ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
+		}
+
+		$post = get_post( $request->get_param( 'id' ) );
+
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		if ( $post && ! current_user_can( 'edit_post', $post->ID ) ) {
+			return new WP_Error(
+				'rest_forbidden_context',
+				__( 'Please connect your user account to WordPress.com', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns an email preview of a post.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function email_preview( $request ) {
+		$post_id = $request['post_id'];
+		$post    = get_post( $post_id );
+
+		// Return error if the post cannot be retrieved
+		if ( is_wp_error( $post ) ) {
+			return new WP_Error( 'post_not_found', 'Post not found', array( 'status' => 404 ) );
+		}
+
+		if ( ! defined( 'IS_HTML_EMAIL' ) ) {
+			define( 'IS_HTML_EMAIL', true );
+		}
+		A8C\Block_Rendering\load();
+
+		$subscriber = new Blog_Subscriber( 'foo@example.com' );
+		$mailer     = new Subscription_Mailer( $subscriber, true );
+
+		$mailer_html = $mailer->get_posts( array( $post ) )['html'][0];
+
+		if ( empty( $mailer_html ) ) {
+			return new WP_Error( 'empty_preview', 'Preview generation failed', array( 'status' => 500 ) );
+		}
+
+		$allowed_html    = wp_kses_allowed_html( 'post' );
+		$additional_tags = array(
+			'html'  => array(),
+			'head'  => array(),
+			'meta'  => array(
+				'name'       => true,
+				'content'    => true,
+				'http-equiv' => true,
+				'charset'    => true,
+			),
+			'style' => array(
+				'type' => true,
+			),
+			'body'  => array(),
+		);
+		$allowed_html    = array_merge( $allowed_html, $additional_tags );
+
+		$mailer_html = wp_kses( $mailer_html, $allowed_html );
+
+		return rest_ensure_response(
+			array(
+				'html' => $mailer_html,
+			)
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Email_Preview' );

--- a/projects/plugins/jetpack/changelog/add-email-preview-endpoint
+++ b/projects/plugins/jetpack/changelog/add-email-preview-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack Newsletter: Adds Jetpack Newsletter menu with preview option.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -68,11 +68,8 @@ registerJetpackBlockFromMetadata( metadata, {
 const shouldShowNewsletterMenu = () => {
 	const postType = select( 'core/editor' ).getCurrentPostType();
 	const isPost = postType === 'post';
-
-	const urlParams = new URLSearchParams( window.location.search );
-	const showNewsletterFeature = urlParams.get( 'showNewsletterMenu' ) === 'true';
-
-	return isPost && showNewsletterFeature;
+	// TODO: Remove the query param check once the feature is stable.
+	return isPost && new URLSearchParams( window.location.search ).has( 'showNewsletterMenu' );
 };
 
 // Registers slot/fill panels defined via settings.render and command palette commands

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -1,11 +1,13 @@
 import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
 import { createBlock } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
+import { atSymbol } from '@wordpress/icons';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
 import CommandPalette from './command-palette';
 import deprecated from './deprecated';
 import edit from './edit';
+import NewsletterMenu from './menu';
 import SubscribePanels from './panel';
 
 const blockName = metadata.name.replace( 'jetpack/', '' );
@@ -67,9 +69,11 @@ registerJetpackPlugin( blockName, {
 	render: () => (
 		<>
 			<SubscribePanels />,
+			<NewsletterMenu />,
 			<CommandPalette />
 		</>
 	),
+	icon: atSymbol,
 } );
 
 // Allows block to be inserted inside core navigation block

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -1,5 +1,6 @@
 import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
 import { createBlock } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { atSymbol } from '@wordpress/icons';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
@@ -64,16 +65,28 @@ registerJetpackBlockFromMetadata( metadata, {
 	deprecated,
 } );
 
+const shouldShowNewsletterMenu = () => {
+	const postType = select( 'core/editor' ).getCurrentPostType();
+	const isPost = postType === 'post';
+
+	const urlParams = new URLSearchParams( window.location.search );
+	const showNewsletterFeature = urlParams.get( 'showNewsletterMenu' ) === 'true';
+
+	return isPost && showNewsletterFeature;
+};
+
 // Registers slot/fill panels defined via settings.render and command palette commands
 registerJetpackPlugin( blockName, {
-	render: () => (
-		<>
-			<SubscribePanels />,
-			<NewsletterMenu />,
-			<CommandPalette />
-		</>
-	),
-	icon: atSymbol,
+	render: () => {
+		return (
+			<>
+				<SubscribePanels />
+				{ shouldShowNewsletterMenu() && <NewsletterMenu /> }
+				<CommandPalette />
+			</>
+		);
+	},
+	icon: shouldShowNewsletterMenu() ? atSymbol : undefined,
 } );
 
 // Allows block to be inserted inside core navigation block

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -3,10 +3,10 @@ import { Button, ButtonGroup, Modal, PanelBody, Path, SVG } from '@wordpress/com
 import { useSelect } from '@wordpress/data';
 import { PluginSidebar } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
-import { send as sendIcon } from '@wordpress/icons';
 import { useState, useCallback, useEffect } from 'react';
 
 // Fallback SVG for the send icon that will be released with Gutenberg 19.0
+// Replace with import { send  } from '@wordpress/icons' when available;
 const sendIconSvg = (
 	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 		<Path
@@ -86,7 +86,7 @@ const NewsletterMenu = () => {
 			<PluginSidebar
 				name="newsletter-settings-sidebar"
 				title={ __( 'Newsletter', 'jetpack' ) }
-				icon={ sendIcon || sendIconSvg }
+				icon={ sendIconSvg }
 			>
 				<PanelBody>
 					<p>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -104,9 +104,6 @@ const NewsletterMenu = () => {
 					>
 						{ __( 'Preview email', 'jetpack' ) }
 					</Button>
-					<Button onClick={ openModal } variant="secondary">
-						{ __( 'Send a test', 'jetpack' ) }
-					</Button>
 				</PanelBody>
 			</PluginSidebar>
 			{ isModalOpen && (

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -1,5 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
-import { Button, ButtonGroup, Modal, PanelBody, Path, SVG } from '@wordpress/components';
+import { Button, Modal, PanelBody, Path, SVG } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { PluginSidebar } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
@@ -95,20 +95,18 @@ const NewsletterMenu = () => {
 							'jetpack'
 						) }
 					</p>
-					<ButtonGroup>
-						<Button
-							onClick={ openModal }
-							style={ {
-								marginRight: '18px',
-							} }
-							variant="secondary"
-						>
-							{ __( 'Preview email', 'jetpack' ) }
-						</Button>
-						<Button onClick={ openModal } variant="secondary">
-							{ __( 'Send a test', 'jetpack' ) }
-						</Button>
-					</ButtonGroup>
+					<Button
+						onClick={ openModal }
+						style={ {
+							marginRight: '18px',
+						} }
+						variant="secondary"
+					>
+						{ __( 'Preview email', 'jetpack' ) }
+					</Button>
+					<Button onClick={ openModal } variant="secondary">
+						{ __( 'Send a test', 'jetpack' ) }
+					</Button>
 				</PanelBody>
 			</PluginSidebar>
 			{ isModalOpen && (

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -1,10 +1,21 @@
 import apiFetch from '@wordpress/api-fetch';
-import { Button, Modal } from '@wordpress/components';
+import { Button, ButtonGroup, Modal, PanelBody, Path, SVG } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { PluginSidebar } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
-import { atSymbol } from '@wordpress/icons';
+import { send as sendIcon } from '@wordpress/icons';
 import { useState, useCallback, useEffect } from 'react';
+
+// Fallback SVG for the send icon that will be released with Gutenberg 19.0
+const sendIconSvg = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M6.332 5.748c-1.03-.426-2.06.607-1.632 1.636l1.702 3.93 7.481.575c.123.01.123.19 0 .2l-7.483.575-1.7 3.909c-.429 1.029.602 2.062 1.632 1.636l12.265-5.076c1.03-.426 1.03-1.884 0-2.31L6.332 5.748Z"
+		/>
+	</SVG>
+);
 
 const NewsletterMenu = () => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
@@ -75,15 +86,34 @@ const NewsletterMenu = () => {
 			<PluginSidebar
 				name="newsletter-settings-sidebar"
 				title={ __( 'Newsletter', 'jetpack' ) }
-				icon={ atSymbol }
+				icon={ sendIcon || sendIconSvg }
 			>
-				<Button onClick={ openModal } isPrimary>
-					{ __( 'Email Preview', 'jetpack' ) }
-				</Button>
+				<PanelBody>
+					<p>
+						{ __(
+							'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',
+							'jetpack'
+						) }
+					</p>
+					<ButtonGroup>
+						<Button
+							onClick={ openModal }
+							style={ {
+								marginRight: '18px',
+							} }
+							variant="secondary"
+						>
+							{ __( 'Preview email', 'jetpack' ) }
+						</Button>
+						<Button onClick={ openModal } variant="secondary">
+							{ __( 'Send a test', 'jetpack' ) }
+						</Button>
+					</ButtonGroup>
+				</PanelBody>
 			</PluginSidebar>
 			{ isModalOpen && (
 				<Modal
-					title={ __( 'Email Preview', 'jetpack' ) }
+					title={ __( 'Preview email', 'jetpack' ) }
 					onRequestClose={ closeModal }
 					isFullScreen={ true }
 				>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -1,0 +1,97 @@
+import apiFetch from '@wordpress/api-fetch';
+import { Button, Modal } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { PluginSidebar } from '@wordpress/edit-post';
+import { __ } from '@wordpress/i18n';
+import { atSymbol } from '@wordpress/icons';
+import { useState, useCallback, useEffect } from 'react';
+
+const NewsletterMenu = () => {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ previewHtml, setPreviewHtml ] = useState( '' );
+
+	const { postId } = useSelect( select => {
+		return {
+			postId: select( 'core/editor' ).getCurrentPostId(),
+		};
+	}, [] );
+
+	const fetchPreview = useCallback( async () => {
+		if ( ! postId ) {
+			return;
+		}
+
+		setIsLoading( true );
+		try {
+			const response = await apiFetch( {
+				path: `/wpcom/v2/email-preview/?post_id=${ postId }`,
+				method: 'GET',
+			} );
+
+			if ( response && response.html ) {
+				setPreviewHtml( response.html );
+			} else {
+				throw new Error( 'Invalid response format' );
+			}
+		} catch ( error ) {
+			setPreviewHtml( `<html><body>${ __( 'Error loading preview', 'jetpack' ) }</body></html>` );
+		} finally {
+			setIsLoading( false );
+		}
+	}, [ postId ] );
+
+	const openModal = () => {
+		setIsModalOpen( true );
+	};
+
+	const closeModal = () => setIsModalOpen( false );
+
+	useEffect( () => {
+		if ( isModalOpen ) {
+			fetchPreview();
+		}
+	}, [ isModalOpen, fetchPreview ] );
+
+	const modalContent = (
+		<>
+			{ isLoading && <p>{ __( 'Loading preview…', 'jetpack' ) }</p> }
+			{ ! isLoading && (
+				<iframe
+					srcDoc={ previewHtml }
+					style={ {
+						width: '100%',
+						height: 'calc(100vh - 120px)',
+						border: 'none',
+					} }
+					title={ __( 'Email Preview', 'jetpack' ) }
+				/>
+			) }
+		</>
+	);
+
+	return (
+		<>
+			<PluginSidebar
+				name="newsletter-settings-sidebar"
+				title={ __( 'Newsletter', 'jetpack' ) }
+				icon={ atSymbol }
+			>
+				<Button onClick={ openModal } isPrimary>
+					{ __( 'Email Preview', 'jetpack' ) }
+				</Button>
+			</PluginSidebar>
+			{ isModalOpen && (
+				<Modal
+					title={ __( 'Email Preview', 'jetpack' ) }
+					onRequestClose={ closeModal }
+					isFullScreen={ true }
+				>
+					{ modalContent }
+				</Modal>
+			) }
+		</>
+	);
+};
+
+export default NewsletterMenu;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Improves https://github.com/Automattic/jetpack/issues/38370

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

<img width="954" alt="Screenshot 2024-08-02 at 3 44 33 PM" src="https://github.com/user-attachments/assets/bfb15e0d-11fb-45f7-8c53-9734b61458e6">

<img width="954" alt="Screenshot 2024-08-02 at 3 44 54 PM" src="https://github.com/user-attachments/assets/95fdff1e-ec0d-4cde-a3f7-3120dac9051d">


### Other information:

Needs D157276-code

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check instructions in D157276-code