### PR TITLE
AI Logo Generator: small UI fixes

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-ai-logo-generator-small-ui-fixes
+++ b/projects/js-packages/ai-client/changelog/update-ai-logo-generator-small-ui-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Logo Generator: fix small UI issues.

--- a/projects/js-packages/ai-client/src/logo-generator/components/feature-fetch-failure-screen.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/feature-fetch-failure-screen.tsx
@@ -13,7 +13,7 @@ export const FeatureFetchFailureScreen: React.FC< {
 	onRetry: () => void;
 } > = ( { onCancel, onRetry } ) => {
 	const errorMessage = __(
-		'We are sorry. There was an error loading your Jetpack AI account settings. Please, try again.',
+		'We are sorry. There was an error loading your Jetpack AI plan data. Please, try again.',
 		'jetpack-ai-client'
 	);
 

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -235,7 +235,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 				/>
 				{ logoAccepted ? (
 					<div className="jetpack-ai-logo-generator__accept">
-						<VisitSiteBanner onVisitBlankTarget={ closeModal } />
+						<VisitSiteBanner />
 						<div className="jetpack-ai-logo-generator__accept-actions">
 							<Button variant="primary" onClick={ closeModal }>
 								{ __( 'Close', 'jetpack-ai-client' ) }

--- a/projects/js-packages/ai-client/src/logo-generator/components/visit-site-banner.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/visit-site-banner.tsx
@@ -17,7 +17,7 @@ import type React from 'react';
 
 export const VisitSiteBanner: React.FC< {
 	className?: string;
-	onVisitBlankTarget: () => void;
+	onVisitBlankTarget?: () => void;
 } > = ( { className = null, onVisitBlankTarget } ) => {
 	return (
 		<div className={ clsx( 'jetpack-ai-logo-generator-modal-visit-site-banner', className ) }>
@@ -42,7 +42,7 @@ export const VisitSiteBanner: React.FC< {
 						variant="link"
 						href="https://jetpack.com/redirect/?source=logo_generator_learn_more_about_jetpack_ai"
 						target="_blank"
-						onClick={ onVisitBlankTarget }
+						onClick={ onVisitBlankTarget ? onVisitBlankTarget : null }
 					>
 						{ __( 'Learn more about Jetpack AI', 'jetpack-ai-client' ) }
 						<Icon icon={ external } size={ 20 } />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

Two UI fixes based on feedback from the Jetpack testing week:

- p8oabR-1yB-p2#comment-8150
- p8oabR-1yB-p2#comment-8149

* do not close the generator modal when the "Learn more about Jetpack AI" link from the "success" screen is clicked (it was closing it before)
* change the wording on the loading error modal to remove referece to a "Jetpack AI account"; we mean Jetpack AI plan, so I fixed it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you test it on a site with a paid Jetpack AI plan and with beta extensions enabled
* First, let's check if the error message update worked
* Go to the block editor and set the tab as offline on the throttling settings
* Add a logo block
* Click the AI extension button on it
* Confirm you see the updated error message:

| Before | After |
| --- | --- |
| <img width="400" alt="Screenshot 2024-07-30 at 14 26 42" src="https://github.com/user-attachments/assets/53b7953e-3358-4146-a523-ba1eff91808f"> | <img width="400" alt="Screenshot 2024-08-01 at 14 52 29" src="https://github.com/user-attachments/assets/d6d12123-61a1-4141-b351-9938f4fd4051"> |

* Now, let's confirm the modal will not be closed automatically by a click on the "Learn more..." link
* Remove the throttling settings of the tab and reload the editor
* Insert a logo block
* Click the AI extension button and generate at least one logo (you will get the first one automatically if did not have one)
* When the logo is ready, click "Use on block"
* The "success" screen will show up; click the "Learn more..." link on it:

<img width="500" alt="Screenshot 2024-08-01 at 14 58 57" src="https://github.com/user-attachments/assets/133da00c-40b3-4976-b5b4-4a9d9cc56cd8">

* Confirm the link opens on a new tab
* Go back to the editor tab
* Confirm the "success" screen is still visible:

<img width="500" alt="Screenshot 2024-08-01 at 14 59 57" src="https://github.com/user-attachments/assets/3bc4ea77-3e2c-46c2-8fba-1739e689046b">

* Confirm you can close the modal without issues