### PR TITLE
Jetpack Sync: Update WooCommerce Post Meta whitelist

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-orders-address_index
+++ b/projects/packages/sync/changelog/fix-sync-orders-address_index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync: update WooCommerce Post Meta whitelist.

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -549,8 +549,8 @@ class WooCommerce extends Module {
 		'_date_completed',
 		'_date_paid',
 		'_payment_tokens',
-		'_billing_address_index',
-		'_shipping_address_index',
+		// '_billing_address_index', do not sync these as they contain personal data.
+		// '_shipping_address_index',
 		'_recorded_sales',
 		'_recorded_coupon_usage_counts',
 		// See https://github.com/woocommerce/woocommerce/blob/8ed6e7436ff87c2153ed30edd83c1ab8abbdd3e9/includes/data-stores/class-wc-order-data-store-cpt.php#L539 .


### PR DESCRIPTION
When a store uses WordPress posts storage (legacy) for Orders Storage, the post meta `_billing_address_index` and `_shipping_address_index` might contain personal data.

This PR removes them from the whitelist by commenting them, following what was done [for other post meta](https://github.com/Automattic/jetpack/blob/1092a65a68dd49a4ef61c617b2a3531f3e920144/projects/packages/sync/src/modules/class-woocommerce.php#L513). 
For reference: https://github.com/Automattic/jetpack/pull/9058

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\WooCommerce`: comment  `_billing_address_index` and `_shipping_address_index` on Sync's WooCommerce post meta whitelist.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p4H3ND-1Kr-p2#comment-3654
Previous: p90Yrv-Cl-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Pre-requisites: A JP connected site with WooCommerce and Jetpack plugins active. 

- Go to WP Admin > WooCommerce > Settings > Advanced > Features and make sure WordPress posts storage (legacy) is selected and Analytics are enabled.
- Try syncing an order with/without this PR applied
- Inspect the corresponding postmeta table on WPCOM and confirm that with the PR applied the post metas `_billing_address_index` and `_shipping_address_index` are not present.

