### PR TITLE
Jetpack AI Breve: disable feature toggles on main toggle

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-breve-disable-controls-on-toggle
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-breve-disable-controls-on-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI Breve: disable feature toggles on main toggle

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
@@ -4,11 +4,15 @@
 	margin-bottom: 24px;
 
 	.components-checkbox-control {
-		&__input {
+		&__input:not(:disabled) {
 			@include features-colors( ( 'border-color' ) );
 			&:checked {
 				@include features-colors( ( 'background-color' ) );
 			}
+		}
+		&__input:disabled {
+			border-color: #ddd;
+			background-color: #ddd;
 		}
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
@@ -118,6 +118,8 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 					<div className="feature-checkboxes-container">
 						{ features.map( feature => (
 							<CheckboxControl
+								className={ isProofreadEnabled ? '' : 'is-disabled' }
+								disabled={ ! isProofreadEnabled }
 								data-type={ feature.config.name }
 								key={ feature.config.name }
 								label={ feature.config.title }


### PR DESCRIPTION
## Proposed changes:
This PR addresses a feedback on the toggles behavior: individual feature toggles remain actionable even after toggling off Breve

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1722522292336819-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use a Breve enabled site. Go to the editor and look for AI section on the sidebar. Enabling/disabling Breve should turn individual feature toggle elements enabled/disabled (featured enabled/checked status should remain untouched).
The disabled styled for the toggles mimic the disabled buttons color #ddd.
Test the same in the Jetpack sidebar AI section
