### PR TITLE
Add: paid subscription importer - connect stripe flow

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -58,6 +58,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 										'gutenberg',
 										'gutenberg-wpcom',
 										'launchpad',
+										'import-paid-subscribers',
 									),
 									true
 								);

--- a/projects/plugins/jetpack/changelog/add-paid-importer-connect-memebership-flow
+++ b/projects/plugins/jetpack/changelog/add-paid-importer-connect-memebership-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Newsletter: add source for the paid importer


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/93154

Used by https://github.com/Automattic/wp-calypso/pull/93198

This lets us create a 'import-paid-subscribers' stripe connection flow. 
By making this flow identifiable which will let us redirect to the correct place in the UI after the flow has been completed or cancelled. 

## Proposed changes:
* Add the `import-paid-subscribers` source which we can then detect and redirect the user back to the importer flow. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Are there any spelling mistakes? 
