### PR TITLE
Photon: do not serve Amazon images from our CDN

### DIFF
--- a/projects/packages/image-cdn/changelog/fix-photon-amazon-cdn
+++ b/projects/packages/image-cdn/changelog/fix-photon-amazon-cdn
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Do not serve media from Amazon CDN from Jetpack's CDN.

--- a/projects/packages/image-cdn/src/class-image-cdn-core.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-core.php
@@ -342,6 +342,7 @@ class Image_CDN_Core {
 			'/\.cdninstagram\.com$/',
 			'/^(commons|upload)\.wikimedia\.org$/',
 			'/\.wikipedia\.org$/',
+			'/^m\.media-amazon\.com$/',
 		);
 
 		$host = wp_parse_url( $image_url, PHP_URL_HOST );

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Image_CDN;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.4.3';
+	const PACKAGE_VERSION = '0.4.4-alpha';
 
 	/**
 	 * Singleton.

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
@@ -428,6 +428,10 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 				true,
 				'https://en.wikipedia.org/wiki/File:MM10249.jpg',
 			),
+			'Banned Amazon domain'       => array(
+				true,
+				'http://m.media-amazon.com/images/I/41YeeCMUwTL._SL300_.jpg',
+			),
 		);
 	}
 }


### PR DESCRIPTION

## Proposed changes:

Let's not serve images from Amazon's own CDN via Photon ; no need to go through 2 CDNs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Internal reference: p1722583835923719-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

*  Do the tests pass?
* Start on a site where the Site Accelerator feature is active.
* In a new post, add an image block, using the "URL" setting, linking to this image: `http://m.media-amazon.com/images/I/41YeeCMUwTL._SL300_.jpg`
* Publish your post
* Check frontend ; the image should be served directly from Amazon, not from Photon.