### PR TITLE
Social: Add settings section to social post modal

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-settings-section-to-social-post-modal
+++ b/projects/js-packages/publicize-components/changelog/add-settings-section-to-social-post-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Social: Added settings section to the social post modal

--- a/projects/js-packages/publicize-components/src/components/media-section/index.js
+++ b/projects/js-packages/publicize-components/src/components/media-section/index.js
@@ -72,7 +72,10 @@ export default function MediaSection( {
 						mediaDetails={ mediaDetails }
 						onChange={ onChange }
 					/>
-					<ExternalLink href={ getRedirectUrl( 'jetpack-social-media-support-information' ) }>
+					<ExternalLink
+						href={ getRedirectUrl( 'jetpack-social-media-support-information' ) }
+						className={ styles[ 'learn-more' ] }
+					>
 						{ __( 'Learn photo and video best practices', 'jetpack' ) }
 					</ExternalLink>
 				</MediaWrapper>

--- a/projects/js-packages/publicize-components/src/components/media-section/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/media-section/styles.module.scss
@@ -32,6 +32,11 @@
 	}
 }
 
+.subtitle {
+	color: var(--jp-gray-40);
+	margin-top: 0;
+}
+
 .learn-more {
 	display: block;
 	margin-top: 1rem;

--- a/projects/js-packages/publicize-components/src/components/media-section/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/media-section/styles.module.scss
@@ -31,3 +31,8 @@
 		margin: 0 0 4px;
 	}
 }
+
+.learn-more {
+	display: block;
+	margin-top: 1rem;
+}

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/modal.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/modal.tsx
@@ -36,7 +36,7 @@ export function SocialPostModal() {
 				</Modal>
 			) }
 			<Button variant="secondary" onClick={ toggleModal }>
-				{ __( 'Create custom posts', 'jetpack' ) }
+				{ __( 'Preview social posts', 'jetpack' ) }
 			</Button>
 		</PanelRow>
 	);

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { SharePostForm } from '../form/share-post-form';
 import styles from './styles.module.scss';
 
 /**
@@ -13,7 +14,7 @@ export function SettingsSection() {
 				<h2>{ __( 'Social Preview', 'jetpack' ) }</h2>
 			</div>
 			<div className={ styles[ 'settings-content' ] }>
-				<textarea />
+				<SharePostForm />
 			</div>
 		</div>
 	);

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
@@ -9,7 +9,7 @@ import styles from './styles.module.scss';
  */
 export function SettingsSection() {
 	return (
-		<div>
+		<div className={ styles[ 'settings-section' ] }>
 			<div className={ styles[ 'settings-header' ] }>
 				<h2>{ __( 'Social Preview', 'jetpack' ) }</h2>
 			</div>

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/styles.module.scss
@@ -54,8 +54,15 @@
     }
 }
 
+.settings-section {
+    @include break-medium {
+        flex: 1
+    }
+}
+
 .settings-content {
     padding: 2rem;
+
     @include break-medium {
         border-inline-end: 1px solid var(--studio-gray-5);
     }
@@ -64,6 +71,10 @@
 .preview-section {
     flex: 1;
     background: var(--jp-gray-0); // closest to #F0F2F5;
+
+    @include break-medium {
+        flex: 2;
+    }
 
     :global(.components-tab-panel__tabs) {
         justify-content: center;


### PR DESCRIPTION
We need the custom message and media settings inputs inside the social post modal

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add the settings section to the social post modal
* Update the trigger label to "Preview social posts"

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the editor preview feature - `define( 'JETPACK_SOCIAL_HAS_EDITOR_PREVIEW', true );`
* Goto post editor
* Open Jetpack or Social sidebar
* Under "Share this post" section, click on "Create custom posts"
* Confirm that you see the settings section in the modal
* Confirm that it matches the design
* Add some text into the textarea and attach some media
* Close the modal
* Confirm that both the custom message and media are reflected in the Social/Jetpack sidebar

When there is no media/text
<img width="1239" alt="Screenshot 2024-08-02 at 2 46 57 PM" src="https://github.com/user-attachments/assets/7f15cc50-95e8-4bd9-9846-9cb8a863aaae">

When there is media and text
<img width="1258" alt="Screenshot 2024-08-02 at 2 46 14 PM" src="https://github.com/user-attachments/assets/bfb12e1e-5621-4b19-a0e2-f0b8e765fcf6">
