### PR TITLE
Admin bar: fix icon alignment on small screen widths

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-icon-margins
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-icon-margins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: fix icon alignment on small screen widths

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -29,6 +29,15 @@
 }
 
 /**
+ * Hamburger menu
+ */
+#wpadminbar #wp-admin-bar-menu-toggle>.ab-item .ab-icon {
+	@media (max-width: 480px) {
+		width: 48px;
+	}
+}
+
+/**
  * WP logo menu
  */
 #wpadminbar #wp-admin-bar-wpcom-logo>.ab-item .ab-icon {
@@ -62,7 +71,7 @@
 	// Site admin on mobile viewport (the first child is the hamburger menu)
 	@media (max-width: 480px) {
 		>.ab-item .ab-icon:before {
-			margin: 0 7px 0 1px;
+			margin: 0 7px 0 5px;
 		}
 	}
 }
@@ -116,14 +125,19 @@
 	}
 }
 
-#wpadminbar #wp-admin-bar-site-name>.ab-item:before {
-	/**
-	 * Always show the House icon by the site name.
-	 */
-	content: "\f102" !important;
+#wpadminbar #wp-admin-bar-site-name {
+    > .ab-item:before {
+        /**
+    	 * Always show the House icon by the site name.
+    	 */
+	    content: "\f102" !important;
+    }
 
 	@media (max-width: 480px) {
-		max-width: 46px;
+        > a.ab-item,
+		> a.ab-item:before {
+    		width: 46px;
+		}
 	}
 }
 
@@ -161,7 +175,7 @@
 		}
 
 		@media (max-width: 782px) {
-			height: 31px;
+			height: 45px;
 
 			#wp-admin-bar-help-center {
 				display: block !important;
@@ -200,6 +214,9 @@
 			}
 		}
 		@media (max-width: 480px) {
+			#wp-admin-bar-help-center {
+				width: 46px !important;
+			}
 			#wp-admin-bar-notes {
 				width: 46px !important;
 			}


### PR DESCRIPTION
## Proposed changes

This PR polishes some icon alignment on wp-admin screens with <= 480px as follows.

Note that with this PR, it is discovered that Calypso version can be improved; which is of course out of the scope of this PR. **Anyone is welcome to replicate this on Calypso side** 😄 

The gap between help center and notification icons is fixed (matching Calypso). Additionally, the size of the selected state of various icons is fixed:

||Hamburger is selected|
|-|-|
|Before|<img width="430" alt="image" src="https://github.com/user-attachments/assets/1bb0dcff-d532-43f5-87de-c8515a49375b">|
|After|<img width="430" alt="image" src="https://github.com/user-attachments/assets/93d4b0fd-1afb-419a-b034-71eb5bb42320">|
|Calypso|<img width="430" alt="image" src="https://github.com/user-attachments/assets/d4e43a1b-2270-4298-9255-f9a29679b5c6"><br><br>Can be improved:<br>- right margin/padding of the hamburger icon|

||Site icon is selected|
|-|-|
|Before|<img width="430" alt="image" src="https://github.com/user-attachments/assets/3b7e6ce5-a56a-482c-90b9-6128ce399944">|
|After|<img width="430" alt="image" src="https://github.com/user-attachments/assets/e225f9b1-412b-49d9-bd7e-24d9e7ddd299">|
|Calypso|<img width="430" alt="image" src="https://github.com/user-attachments/assets/cbeccb40-72b8-4710-bb58-407773737017"><br><br>Can be improved:<br>- icon selected state background|

This also fixes a regression where I broke the "icon superposition feature" for really small width:

|||
|-|-|
|Before|<img width="230" alt="image" src="https://github.com/user-attachments/assets/ee362280-9b4f-4444-9bbf-9b015ef46091">|
|After|<img width="230" alt="image" src="https://github.com/user-attachments/assets/99d0e4c2-c1e4-4f0f-8545-b562547bb532">|


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this PR.
2. Check on small mobile resolutions as explained above.
3. Check no regression on Desktop resolution.

