### PR TITLE
MU WPCOM: Only load ETK features for wpcom users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-only-load-etk-features-for-wpcom-user
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-only-load-etk-features-for-wpcom-user
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+MU WPCOM: Only load ETK features for wpcom users

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -153,6 +153,10 @@ class Jetpack_Mu_Wpcom {
 	 * Can be moved back to load_features() once the feature no longer exists in the ETK plugin.
 	 */
 	public static function load_etk_features() {
+		if ( ! is_wpcom_user() ) {
+			return;
+		}
+
 		require_once __DIR__ . '/features/block-editor/custom-line-height.php';
 		require_once __DIR__ . '/features/block-inserter-modifications/block-inserter-modifications.php';
 		require_once __DIR__ . '/features/hide-homepage-title/hide-homepage-title.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to p1722567163421299/1721640177.158509-slack-CRWCHQGUB

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only load ETK features for wpcom users because we don't want to include ETK features for A4A sites or sites that are not connected to wpcom

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your atomic site
* Disable ETK plugin
* Mark your site as a A4A site
  * `update option is_fully_managed_agency_site 1`
* Go to the Editor
* Make sure the ETK features are not loaded
  * What's new
  * Welcome Guide
  * Nux Modals
  * Timeline, Event Countdown, etc blocks
  * Global Style Upsell
  * etc