### PR TITLE
Social: Add connection toggle to the social post modal

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-connection-toggle-to-the-social-post-modal
+++ b/projects/js-packages/publicize-components/changelog/add-connection-toggle-to-the-social-post-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added connection toggle to social post preview

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -1,5 +1,8 @@
 import { TabPanel } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { ToggleControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
 import { store as socialStore } from '../../social-store';
 import ConnectionIcon from '../connection-icon';
 import { useService } from '../services/use-service';
@@ -48,12 +51,26 @@ export function PreviewSection() {
 		[ getService ]
 	);
 
+	const { toggleConnectionById } = useDispatch( socialStore );
+
+	const toggleConnection = useCallback(
+		( connectionId: string ) => () => {
+			toggleConnectionById( connectionId );
+		},
+		[ toggleConnectionById ]
+	);
+
 	return (
 		<div className={ styles[ 'preview-section' ] }>
 			<TabPanel tabs={ connections }>
 				{ ( tab: ( typeof connections )[ number ] ) => (
 					<div className={ styles[ 'preview-content' ] }>
 						<PostPreview connection={ tab } />
+						<ToggleControl
+							label={ __( 'Share to this account', 'jetpack' ) }
+							checked={ tab.enabled }
+							onChange={ toggleConnection( tab.connection_id ) }
+						/>
 					</div>
 				) }
 			</TabPanel>

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { store as socialStore } from '../../social-store';
 import ConnectionIcon from '../connection-icon';
+import { useConnectionState } from '../form/use-connection-state';
 import { useService } from '../services/use-service';
 import { PostPreview } from './post-preview';
 import styles from './styles.module.scss';
@@ -59,6 +60,7 @@ export function PreviewSection() {
 		},
 		[ toggleConnectionById ]
 	);
+	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
 
 	return (
 		<div className={ styles[ 'preview-section' ] }>
@@ -68,7 +70,8 @@ export function PreviewSection() {
 						<PostPreview connection={ tab } />
 						<ToggleControl
 							label={ __( 'Share to this account', 'jetpack' ) }
-							checked={ tab.enabled }
+							disabled={ shouldBeDisabled( tab ) }
+							checked={ canBeTurnedOn( tab ) && tab.enabled }
 							onChange={ toggleConnection( tab.connection_id ) }
 						/>
 					</div>

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -40,12 +40,15 @@ export function PreviewSection() {
 								profilePicture={ connection.profile_picture }
 							/>
 						);
-						const disabled = shouldBeDisabled( connection );
+						const disabled =
+							shouldBeDisabled( connection ) ||
+							! canBeTurnedOn( connection ) ||
+							! connection.enabled;
 
 						return {
 							...connection,
 							// Add the props needed for the TabPanel component
-							disabled,
+							className: disabled ? styles[ 'disabled-tab' ] : '',
 							name,
 							title,
 							icon,

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -18,6 +18,8 @@ import styles from './styles.module.scss';
 export function PreviewSection() {
 	const getService = useService();
 
+	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
+
 	const connections = useSelect(
 		select => {
 			const store = select( socialStore );
@@ -38,10 +40,12 @@ export function PreviewSection() {
 								profilePicture={ connection.profile_picture }
 							/>
 						);
+						const disabled = shouldBeDisabled( connection );
 
 						return {
 							...connection,
 							// Add the props needed for the TabPanel component
+							disabled,
 							name,
 							title,
 							icon,
@@ -49,7 +53,7 @@ export function PreviewSection() {
 					} )
 			);
 		},
-		[ getService ]
+		[ getService, shouldBeDisabled ]
 	);
 
 	const { toggleConnectionById } = useDispatch( socialStore );
@@ -60,7 +64,6 @@ export function PreviewSection() {
 		},
 		[ toggleConnectionById ]
 	);
-	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
 
 	return (
 		<div className={ styles[ 'preview-section' ] }>

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/styles.module.scss
@@ -92,3 +92,7 @@
     gap: 3rem;
     padding: 2rem;
 }
+
+.disabled-tab {
+    opacity: 0.5;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add connection toggle in the preview section for social post modal

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


* Enable the editor preview feature - `define( 'JETPACK_SOCIAL_HAS_EDITOR_PREVIEW', true );`
* Goto post editor
* Open Jetpack or Social sidebar
* Under "Share this post" section, click on "Create custom posts"
* Confirm that you see the "Share to this account" toggle for each preview
* Toggle it ON and OFF confirm that it toggles the connection

<img width="942" alt="image" src="https://github.com/user-attachments/assets/5da71b2c-e848-446b-a005-a4a62c9bed05">

