### PR TITLE
Jetpack Sync: Take order type into account when performing HPOS Checksums

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-hpos-checksums
+++ b/projects/packages/sync/changelog/fix-sync-hpos-checksums
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Sync: Take order type into account when performing  HPOS Checksums

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.4.0';
+	const PACKAGE_VERSION = '3.4.1-alpha';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -60,13 +60,11 @@ class WooCommerce_HPOS_Orders extends Module {
 	/**
 	 * Get order types that we want to sync. Adding a new type here is not enough, we would also need to add its prop in filter_order_data method.
 	 *
-	 * @access private
-	 *
 	 * @param bool $prefixed Whether to return prefixed types with shop_ or not.
 	 *
 	 * @return array Order types to sync.
 	 */
-	private function get_order_types_to_sync( $prefixed = false ) {
+	public static function get_order_types_to_sync( $prefixed = false ) {
 		$types = array( 'order', 'order_refund' );
 		if ( $prefixed ) {
 			$types = array_map(
@@ -87,7 +85,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	 * @param callable $callable Action handler callable.
 	 */
 	public function init_listeners( $callable ) {
-		foreach ( $this->get_order_types_to_sync() as $type ) {
+		foreach ( self::get_order_types_to_sync() as $type ) {
 			add_action( "woocommerce_after_{$type}_object_save", $callable );
 			add_filter( "jetpack_sync_before_enqueue_woocommerce_after_{$type}_object_save", array( $this, 'expand_order_object' ) );
 		}
@@ -167,7 +165,7 @@ class WooCommerce_HPOS_Orders extends Module {
 		$orders = wc_get_orders(
 			array(
 				'post__in'    => $ids,
-				'type'        => $this->get_order_types_to_sync( true ),
+				'type'        => self::get_order_types_to_sync( true ),
 				'post_status' => $this->get_all_possible_order_status_keys(),
 				'limit'       => -1,
 			)
@@ -420,7 +418,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	public function get_where_sql( $config ) {
 		global $wpdb;
 		$parent_where           = parent::get_where_sql( $config );
-		$order_types            = $this->get_order_types_to_sync( true );
+		$order_types            = self::get_order_types_to_sync( true );
 		$order_type_placeholder = implode( ', ', array_fill( 0, count( $order_types ), '%s' ) );
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Query is prepared.
 		$where_sql = $wpdb->prepare( "type IN ( $order_type_placeholder )", $order_types );

--- a/projects/packages/sync/src/replicastore/class-table-checksum.php
+++ b/projects/packages/sync/src/replicastore/class-table-checksum.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Sync\Replicastore;
 
 use Automattic\Jetpack\Sync;
+use Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders;
 use Exception;
 use WP_Error;
 
@@ -312,7 +313,12 @@ class Table_Checksum {
 				'range_field'               => 'id',
 				'key_fields'                => array( 'id' ),
 				'checksum_text_fields'      => array( 'type', 'status', 'payment_method_title' ),
-				'filter_values'             => array(),
+				'filter_values'             => array(
+					'type' => array(
+						'operator' => 'IN',
+						'values'   => WooCommerce_HPOS_Orders::get_order_types_to_sync( true ),
+					),
+				),
 				'is_table_enabled_callback' => 'Automattic\Jetpack\Sync\Replicastore\Table_Checksum::enable_woocommerce_hpos_tables',
 			),
 			'wc_order_addresses'         => array(
@@ -320,6 +326,9 @@ class Table_Checksum {
 				'range_field'               => 'order_id',
 				'key_fields'                => array( 'order_id', 'address_type' ),
 				'checksum_text_fields'      => array( 'address_type' ),
+				'parent_table'              => 'wc_orders',
+				'parent_join_field'         => 'id',
+				'table_join_field'          => 'order_id',
 				'filter_values'             => array(),
 				'is_table_enabled_callback' => 'Automattic\Jetpack\Sync\Replicastore\Table_Checksum::enable_woocommerce_hpos_tables',
 			),
@@ -328,6 +337,9 @@ class Table_Checksum {
 				'range_field'               => 'order_id',
 				'key_fields'                => array( 'order_id' ),
 				'checksum_text_fields'      => array( 'order_key', 'cart_hash' ),
+				'parent_table'              => 'wc_orders',
+				'parent_join_field'         => 'id',
+				'table_join_field'          => 'order_id',
 				'filter_values'             => array(),
 				'is_table_enabled_callback' => 'Automattic\Jetpack\Sync\Replicastore\Table_Checksum::enable_woocommerce_hpos_tables',
 			),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

The Sync `WooCommerce_HPOS_Orders` module only allows syncing orders of type: `shop_order` and `shop_order_refund`.
The corresponding HPOS Checksum logic though does not respect this.
This means that while an order with type different than the allowed ones, eg `shop_subscription` is not synced, when the corresponding checksum runs on `wp_wc_orders` it will take it into account causing discrepancies. Same applies for the rest HPOS Checksums, aka: `wc_order_addresses` and `wc_order_operational_data`.
The current PR fixes this.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders`: Update `get_order_types_to_sync` method's visibility to public and make it a static one so it can be used in the corresponding HPOS Checksum logic (both on remote sites and WPCOM)
* `Automattic\Jetpack\Sync\Replicastore\Table_Checksum`: Update the HPOS Checksum configuration by limiting `wc_orders`, `wc_order_addresses` and `wc_order_operational_data` queries to the ones with order (or associated order) type: `shop_order` and `shop_order_refund`. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-8ec-p2#comment-10522

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
D157400-code