### PR TITLE
My Jetpack: change Jetpack AI product page link redirect

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -84,8 +84,7 @@ export default function () {
 		'jetpack-ai-product-page-content-feedback-link'
 	);
 
-	// TODO: switch this to a proper link when the page is ready
-	const jetpackAiLink = getRedirectUrl( 'org-ai' );
+	const videoLinkBreve = getRedirectUrl( 'jetpack-ai-product-page-breve' );
 
 	// isRegistered works as a flag to know if the page can link to a post creation or not
 	const ctaURL = isRegistered
@@ -310,7 +309,7 @@ export default function () {
 										className={ styles[ 'product-interstitial__usage-videos-link' ] }
 										icon={ help }
 										target="_blank"
-										href={ jetpackAiLink }
+										href={ videoLinkBreve }
 									>
 										{ __( 'Learn more', 'jetpack-my-jetpack' ) }
 									</Button>

--- a/projects/packages/my-jetpack/changelog/change-jetpack-ai-product-page-breve-link
+++ b/projects/packages/my-jetpack/changelog/change-jetpack-ai-product-page-breve-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+change Jetpack AI product page link redirect

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.31.0",
+	"version": "4.31.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -41,7 +41,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.31.0';
+	const PACKAGE_VERSION = '4.31.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.


### PR DESCRIPTION
## Proposed changes:
This PR changes the redirect used for Breve feature

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1722437525098239-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Visit the product page at wp-admin/admin.php?page=my-jetpack#/jetpack-ai and verify the first video link still points to jetpack.com/ai
The URL will be changed to the proper support doc once it's ready.