### PR TITLE
Post Images: don't fetch Gravatars from post content

### DIFF
--- a/projects/plugins/jetpack/changelog/update-post-images-gravatar
+++ b/projects/plugins/jetpack/changelog/update-post-images-gravatar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: do not include Gravatar images in Open Graph Meta tags.

--- a/projects/plugins/jetpack/class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/class.jetpack-post-images.php
@@ -515,6 +515,12 @@ class Jetpack_PostImages {
 			if ( stripos( $img_src, '/smilies/' ) ) {
 				continue;
 			}
+
+			// Do not grab Gravatar images.
+			if ( stripos( $img_src, 'gravatar.com' ) ) {
+				continue;
+			}
+
 			// First try to get the width and height from the img attributes, but if they are not set, check to see if they are specified in the url. WordPress automatically names files like foo-1024x768.jpg during the upload process
 			$width  = (int) $image_tag->getAttribute( 'width' );
 			$height = (int) $image_tag->getAttribute( 'height' );

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
@@ -41,6 +41,20 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure that Gravatar images are not included in the list of images extracted from the post contents (html).
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_from_html_gravatar() {
+		$s = '<img class="jetpack-blogging-prompt__answers-gravatar wp-hovercard-attachment grav-hashed grav-hijack" aria-hidden="true" src="https://0.gravatar.com/avatar/89f071d1932fe8c204a3381e00bd6794ddc28bcdb0642f29c9f48beaa5e277af?s=96&d=identicon&r=G">';
+
+		$result = Jetpack_PostImages::from_html( $s );
+
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
+
+	/**
 	 * Test image size extract in src filename
 	 *
 	 * @covers Jetpack_PostImages::from_html


### PR DESCRIPTION
Fixes #38501

## Proposed changes:

When fetching images from a post's content, do not include Gravatar images in the array of returned results. Those Gravatars are most likely not representative of the post ; they're most likely references to folks mentioned in the post.

See the discussion in #38501 to find out more.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Enable the Sharing module on your site.
* Go to Posts > Add New 
* Add a blogging prompt block
* Add some content, but no images
* Publish your post
* Visit the post and look for the Open Graph Meta Tags in the `head`
    * There should be no Gravatar images referenced.
