### PR TITLE
AI Logo Generator: open logo block extension to production sites

### DIFF
--- a/projects/plugins/jetpack/changelog/update-ai-logo-generator-move-to-production
+++ b/projects/plugins/jetpack/changelog/update-ai-logo-generator-move-to-production
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: enable the logo block AI logo generator extension in production.

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -149,9 +149,7 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
  * @returns {boolean} True if the feature is available.
  */
 function isFeatureAvailable() {
-	const siteId = parseInt( window?.Jetpack_Editor_Initial_State?.wpcomBlogId );
-
-	return getFeatureAvailability( SITE_LOGO_BLOCK_AI_EXTENSION ) || siteId % 10 === 0;
+	return getFeatureAvailability( SITE_LOGO_BLOCK_AI_EXTENSION );
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -68,7 +68,8 @@
 		"ai-featured-image-generator",
 		"ai-title-optimization",
 		"ai-assistant-experimental-image-generation-support",
-		"ai-general-purpose-image-generator"
+		"ai-general-purpose-image-generator",
+		"ai-assistant-site-logo-support"
 	],
 	"beta": [
 		"google-docs-embed",
@@ -78,8 +79,7 @@
 		"videopress/video-chapters",
 		"ai-assistant-backend-prompts",
 		"ai-assistant-extensions-support",
-		"ai-proofread-breve",
-		"ai-assistant-site-logo-support"
+		"ai-proofread-breve"
 	],
 	"experimental": [ "ai-image", "ai-paragraph" ],
 	"no-post-editor": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change `ai-assistant-site-logo-support` feature flag from beta to production, opening the logo block AI extension to every site
* Drop the check for the 10% soft-release

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin a new JN site, connect it and make sure to add a Jetpack AI plan to it
* Keep the blocks variation as production (the default value)
* Go to the block editor, add a "Site Logo" block image block and confirm you can see the AI button on the toolbar:

<img width="400" alt="Screenshot 2024-08-02 at 17 36 01" src="https://github.com/user-attachments/assets/a408dd06-f2b4-4eb6-be09-094d18f87c0c">

* Click the button and confirm you can generate logos and use them on the logo block