### PR TITLE
AI Assistant: Release Breve to production

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-production
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-production
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Release Breve to production

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -180,7 +180,7 @@ add_action(
 add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
-		if ( apply_filters( 'jetpack_ai_enabled', true ) && apply_filters( 'breve_enabled', false ) ) {
+		if ( apply_filters( 'jetpack_ai_enabled', true ) && apply_filters( 'breve_enabled', true ) ) {
 			\Jetpack_Gutenberg::set_extension_available( 'ai-proofread-breve' );
 		}
 	}

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -68,7 +68,8 @@
 		"ai-featured-image-generator",
 		"ai-title-optimization",
 		"ai-assistant-experimental-image-generation-support",
-		"ai-general-purpose-image-generator"
+		"ai-general-purpose-image-generator",
+		"ai-proofread-breve"
 	],
 	"beta": [
 		"google-docs-embed",
@@ -78,7 +79,6 @@
 		"videopress/video-chapters",
 		"ai-assistant-backend-prompts",
 		"ai-assistant-extensions-support",
-		"ai-proofread-breve",
 		"ai-assistant-site-logo-support"
 	],
 	"experimental": [ "ai-image", "ai-paragraph" ],

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-availability.ts
@@ -1,9 +1,5 @@
 import { getFeatureAvailability } from '../../../../../blocks/ai-assistant/lib/utils/get-feature-availability';
 
-const blogId = parseInt( window?.Jetpack_Editor_Initial_State?.wpcomBlogId );
-
-// Enable backend prompts for beta sites + 50% of production sites.
-const isBreveAvailable =
-	getFeatureAvailability( 'ai-proofread-breve' ) || [ 0, 2, 6, 7, 9 ].includes( blogId % 10 );
+const isBreveAvailable = getFeatureAvailability( 'ai-proofread-breve' );
 
 export default isBreveAvailable;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move feature from beta to production
* Remove special cases
* Changes the `breve_enabled` flag default value so the feature can still be disabled with a snippet

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor in any Jetpack-connected site
* Check that Breve is enabled
* Add this snippet: `add_filter( 'breve_enabled', '__return_false' );`
* Check that Breve is disabled
