### PR TITLE
Fix missing "Theme Showcase" sub menu item on Simple Classic site Calyspo pages

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-simple-theme-showcase-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-simple-theme-showcase-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix bug so Theme Showcase menu appears on Simple Classic sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-themes/wpcom-themes.php
@@ -9,14 +9,14 @@
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
-if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
-	return;
-}
-
 /**
  * Displays a banner before the theme browser that links to the WP.com Theme Showcase.
  */
 function wpcom_themes_show_banner() {
+	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
+		return;
+	}
+
 	$site_slug        = wp_parse_url( home_url(), PHP_URL_HOST );
 	$wpcom_logo       = plugins_url( 'images/wpcom-logo.svg', __FILE__ );
 	$background_image = plugins_url( 'images/banner-background.webp', __FILE__ );
@@ -56,6 +56,10 @@ add_action( 'load-theme-install.php', 'wpcom_themes_show_banner' );
  * Registers an "Appearance > Theme Showcase" menu.
  */
 function wpcom_themes_add_theme_showcase_menu() {
+	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
+		return;
+	}
+
 	$site_slug = wp_parse_url( home_url(), PHP_URL_HOST );
 	add_submenu_page(
 		'themes.php',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8521

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes a bug so the "Theme Showcase" menu appears on Simple Classic site Calypso pages under the "Appearance" menu.
* In this PR we move the "Classic site gate" inside the hook callback function. This fixes the issue because Calypso gets the menu data via an API call. That API call user does not have the "Classic site option" enabled. Eventually, the API call switches to the calling user. At that point, we can accurately check for the `wpcom_admin_interface` site option. By the time the `admin_menu` action is called, the API has switched to the correct user, and things work as expected.

Before | After
--|--
<img width="328" alt="Screenshot 2024-08-02 at 4 36 10 PM" src="https://github.com/user-attachments/assets/0663c6c2-fc79-4fc2-a1db-23eac3708118">  | <img width="339" alt="Screenshot 2024-08-02 at 4 35 32 PM" src="https://github.com/user-attachments/assets/ebe4ce98-34e9-403d-a34f-0b5f2dfcd5ea">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this PR on your sandbox using the [instructions in the comment below](https://github.com/Automattic/jetpack/pull/38698#issuecomment-2266156116).
* Go to a Simple classic site Calypso page like /plans/[site] and view the "Theme Showcase" under the "Appearance" menu.
* Go to /wp-admin/themes.php and ensure the banner still displays on Classic sites.

