### PR TITLE
Do not show scan error when optimistically scanning

### DIFF
--- a/projects/plugins/protect/src/js/components/interstitial-page/stories/broken/mock.js
+++ b/projects/plugins/protect/src/js/components/interstitial-page/stories/broken/mock.js
@@ -1,3 +1,5 @@
+import { SCAN_STATUS_SCHEDULED } from '../../../../constants';
+
 export const jetpackProtectInitialState = {
 	apiRoot: 'http://localhost/wp-json/',
 	apiNonce: 'f2d2d42e2a',
@@ -7,7 +9,7 @@ export const jetpackProtectInitialState = {
 		num_threats: 6,
 		num_plugins_threats: 3,
 		num_themes_threats: 3,
-		status: 'scheduled',
+		status: SCAN_STATUS_SCHEDULED,
 		wordpress: {
 			version: '5.9.3',
 			threats: [],

--- a/projects/plugins/protect/src/js/constants.js
+++ b/projects/plugins/protect/src/js/constants.js
@@ -3,3 +3,17 @@ export const FREE_PLUGIN_SUPPORT_URL = 'https://wordpress.org/support/plugin/jet
 export const PAID_PLUGIN_SUPPORT_URL = 'https://jetpack.com/contact-support/?rel=support';
 
 export const JETPACK_SCAN_SLUG = 'jetpack_scan';
+
+/**
+ * Scan Status Constants
+ */
+export const SCAN_STATUS_SCHEDULED = 'scheduled';
+export const SCAN_STATUS_SCANNING = 'scanning';
+export const SCAN_STATUS_OPTIMISTICALLY_SCANNING = 'optimistically_scanning';
+export const SCAN_STATUS_IDLE = 'idle';
+export const SCAN_STATUS_UNAVAILABLE = 'unavailable';
+export const SCAN_IN_PROGRESS_STATUSES = [
+	SCAN_STATUS_SCHEDULED,
+	SCAN_STATUS_SCANNING,
+	SCAN_STATUS_OPTIMISTICALLY_SCANNING,
+];

--- a/projects/plugins/protect/src/js/routes/scan/use-status-polling.js
+++ b/projects/plugins/protect/src/js/routes/scan/use-status-polling.js
@@ -2,6 +2,11 @@ import apiFetch from '@wordpress/api-fetch';
 import { useDispatch, useSelect } from '@wordpress/data';
 import camelize from 'camelize';
 import { useEffect } from 'react';
+import {
+	SCAN_IN_PROGRESS_STATUSES,
+	SCAN_STATUS_IDLE,
+	SCAN_STATUS_UNAVAILABLE,
+} from '../../constants';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import { STORE_ID } from '../../state/store';
 
@@ -20,11 +25,11 @@ const useStatusPolling = () => {
 		const pollDuration = 10000;
 
 		const statusIsInProgress = currentStatus =>
-			[ 'scheduled', 'scanning' ].indexOf( currentStatus ) >= 0;
+			SCAN_IN_PROGRESS_STATUSES.indexOf( currentStatus ) >= 0;
 
 		// if there has never been a scan, and the scan status is idle, then we must still be getting set up
 		const scanIsInitializing = ( currentStatus, lastChecked ) =>
-			! lastChecked && currentStatus === 'idle';
+			! lastChecked && SCAN_STATUS_IDLE === currentStatus;
 
 		const pollStatus = () => {
 			return new Promise( ( resolve, reject ) => {
@@ -74,7 +79,7 @@ const useStatusPolling = () => {
 			setStatusIsFetching( true );
 			pollStatus()
 				.then( newStatus => {
-					setScanIsUnavailable( 'unavailable' === newStatus.status );
+					setScanIsUnavailable( SCAN_STATUS_UNAVAILABLE === newStatus.status );
 					setStatus( camelize( newStatus ) );
 					recordEvent( 'jetpack_protect_scan_completed', {
 						scan_status: newStatus.status,

--- a/projects/plugins/protect/src/js/state/actions.js
+++ b/projects/plugins/protect/src/js/state/actions.js
@@ -2,6 +2,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { sprintf, _n, __ } from '@wordpress/i18n';
 import camelize from 'camelize';
 import API from '../api';
+import { SCAN_STATUS_UNAVAILABLE } from '../constants';
 
 const SET_CREDENTIALS_STATE_IS_FETCHING = 'SET_CREDENTIALS_STATE_IS_FETCHING';
 const SET_CREDENTIALS_STATE = 'SET_CREDENTIALS_STATE';
@@ -84,7 +85,7 @@ const refreshStatus =
 			return fetchStatus( hardRefresh )
 				.then( checkStatus )
 				.then( status => {
-					dispatch( setScanIsUnavailable( 'unavailable' === status.status ) );
+					dispatch( setScanIsUnavailable( SCAN_STATUS_UNAVAILABLE === status.status ) );
 					dispatch( setStatus( camelize( status ) ) );
 					resolve( status );
 				} )
@@ -120,7 +121,7 @@ const refreshScanHistory = () => {
  */
 const checkStatus = ( currentStatus, attempts = 0 ) => {
 	return new Promise( ( resolve, reject ) => {
-		if ( 'unavailable' === currentStatus.status && attempts < 3 ) {
+		if ( SCAN_STATUS_UNAVAILABLE === currentStatus.status && attempts < 3 ) {
 			fetchStatus( true )
 				.then( newStatus => {
 					setTimeout( () => {

--- a/projects/plugins/protect/src/js/state/reducers.js
+++ b/projects/plugins/protect/src/js/state/reducers.js
@@ -1,5 +1,6 @@
 import { combineReducers } from '@wordpress/data';
 import camelize from 'camelize';
+import { SCAN_STATUS_OPTIMISTICALLY_SCANNING } from '../constants';
 import {
 	SET_CREDENTIALS_STATE,
 	SET_CREDENTIALS_STATE_IS_FETCHING,
@@ -61,7 +62,7 @@ const status = ( state = {}, action ) => {
 		case SET_STATUS_PROGRESS:
 			return { ...state, currentProgress: action.currentProgress };
 		case START_SCAN_OPTIMISTICALLY:
-			return { ...state, currentProgress: 0, status: 'optimistically_scanning' };
+			return { ...state, currentProgress: 0, status: SCAN_STATUS_OPTIMISTICALLY_SCANNING };
 	}
 	return state;
 };

--- a/projects/plugins/protect/src/js/state/selectors.js
+++ b/projects/plugins/protect/src/js/state/selectors.js
@@ -1,3 +1,76 @@
+import { __ } from '@wordpress/i18n';
+import { SCAN_IN_PROGRESS_STATUSES, SCAN_STATUS_OPTIMISTICALLY_SCANNING } from '../constants';
+
+/**
+ * Scan in progress selector.
+ *
+ * @param {object} state - The current state.
+ * @returns {boolean} Whether a scan is in progress.
+ */
+const scanInProgress = state => {
+	const { status, error, lastChecked } = selectors.getStatus( state );
+	const unavailable = selectors.getScanIsUnavailable( state );
+
+	// When "optimistically" scanning, ignore any other status or error.
+	if ( SCAN_STATUS_OPTIMISTICALLY_SCANNING === status ) {
+		return true;
+	}
+
+	// If there is an error or the scan is unavailable, scanning is not in progress.
+	if ( error || unavailable ) {
+		return false;
+	}
+
+	// If the status is one of the scanning statuses, or if we have never checked, we are scanning.
+	if ( SCAN_IN_PROGRESS_STATUSES.includes( status.status ) || ! lastChecked ) {
+		return true;
+	}
+
+	return false;
+};
+
+/**
+ * Scan error selector.
+ *
+ * @param {object} state - The current state.
+ *
+ * @typedef {object} ScanError
+ * @property {string} code    - The code identifying the type of error.
+ * @property {string} message - A message describing the error.
+ *
+ * @returns {ScanError|null} The error object or null.
+ */
+const scanError = state => {
+	const { status, error, errorCode, errorMessage } = selectors.getStatus( state );
+	const unavailable = selectors.getScanIsUnavailable( state );
+	const isFetching = selectors.getStatusIsFetching( state );
+
+	// When "optimistically" scanning, ignore any errors.
+	if ( SCAN_STATUS_OPTIMISTICALLY_SCANNING === status ) {
+		return null;
+	}
+
+	// While still fetching the status, ignore any errors.
+	if ( isFetching ) {
+		return null;
+	}
+
+	// If the scan results include an error, return it.
+	if ( error ) {
+		return { code: errorCode, message: errorMessage };
+	}
+
+	// If the scan is unavailable, return an error.
+	if ( unavailable ) {
+		return {
+			code: 'scan_unavailable',
+			message: __( 'We are having problems scanning your site.', 'jetpack-protect' ),
+		};
+	}
+
+	return null;
+};
+
 const selectors = {
 	getCredentials: state => state.credentials || null,
 	getCredentialsIsFetching: state => state.credentialsIsFetching || false,
@@ -8,6 +81,8 @@ const selectors = {
 	getStatusIsFetching: state => state.statusIsFetching || false,
 	getScanIsUnavailable: state => state.scanIsUnavailable || false,
 	getScanIsEnqueuing: state => state.scanIsEnqueuing || false,
+	scanInProgress,
+	scanError,
 	getWpVersion: state => state.wpVersion || '',
 	getJetpackScan: state => state.jetpackScan || {},
 	getThreatsUpdating: state => state.threatsUpdating || {},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When a site has just activated Protect Free for the first time, their initial scan status data will have a "site not connected" error. This PR ensures that we show the scan in progress screen while refreshing the status, to avoid showing old errors or scan results.
* Adds new `scanInProgress` and `scanError` selectors.
* Adds constants for scan status values.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Issue identified in https://github.com/Automattic/jetpack/pull/38637#pullrequestreview-2216130870

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using a new JN site, activate the free version of Protect. Validate the scan in progress screen is shown immediately, until the first Protect report results are loaded.
* Upgrade to a paid Protect plan, validate the scanner screen starts a new scan, and shows the in progress screen for the duration of the scan.

