### PR TITLE
My Jetpack: fix postCheckoutUrl in product interstitial component

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -131,10 +131,6 @@ export default function ProductInterstitial( {
 
 	const clickHandler = useCallback(
 		( checkout, product, tier ) => {
-			let postCheckoutUrl = product?.postCheckoutUrl
-				? product?.postCheckoutUrl
-				: myJetpackCheckoutUri;
-
 			ctaCallback?.( { slug, product, tier } );
 
 			if ( product?.isBundle || directCheckout ) {
@@ -146,8 +142,8 @@ export default function ProductInterstitial( {
 			activate(
 				{ productId: slug },
 				{
-					onSettled: ( { productId: activatedProduct } ) => {
-						postCheckoutUrl = activatedProduct?.post_checkout_url
+					onSettled: activatedProduct => {
+						const postCheckoutUrl = activatedProduct?.post_checkout_url
 							? activatedProduct.post_checkout_url
 							: myJetpackCheckoutUri;
 						// there is a separate hasRequiredTier, but it is not implemented

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -143,9 +143,7 @@ export default function ProductInterstitial( {
 				{ productId: slug },
 				{
 					onSettled: activatedProduct => {
-						const postCheckoutUrl = activatedProduct?.post_checkout_url
-							? activatedProduct.post_checkout_url
-							: myJetpackCheckoutUri;
+						const postCheckoutUrl = activatedProduct?.post_checkout_url || myJetpackCheckoutUri;
 						// there is a separate hasRequiredTier, but it is not implemented
 						const hasPaidPlanForProduct = product?.hasPaidPlanForProduct;
 						const isFree = tier

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-post-checkout-urls
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-post-checkout-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: ensure product screens redirect to the correct post-checkout URLs.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The initial `let postCheckoutUrl` declaration is always overwritten, so this PR removes it.
* The `onSettled` mutation callback always returns `null` for the `activatedProduct`, due to attempting to destucture `activatedProduct` from the activation response's `productId` property. This PR adjusts the parameters from `( { productId: activatedProduct } ) => {}` to `activatedProduct => {}`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To reproduce the issue:
* Purchase a paid plan via a My Jetpack product card.
* After completing checkout, you will not be redirected to the specific product's `post_checkout_url`.

Testing this PR:
* Use a JN site running this branch via Jetpack Beta.
* Purchase a paid plan via a My Jetpack product card.
* After completing checkout, you should be redirected to the specific product's `post_checkout_url`.
