### PR TITLE
Social: Cleanup publicize shares rest endpoint

### DIFF
--- a/projects/packages/publicize/changelog/updat-cleanup-publicize-shares-rest-endpoint
+++ b/projects/packages/publicize/changelog/updat-cleanup-publicize-shares-rest-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cleaned-up publicize shares rest endpoint

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -172,7 +172,7 @@ class REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'update_post_shares' ),
-					'permission_callback' => array( $this, 'update_post_shares_permission_callback' ),
+					'permission_callback' => array( Rest_Authentication::class, 'is_signed_with_blog_token' ),
 					'args'                => array(
 						'meta' => array(
 							'type'       => 'object',
@@ -639,7 +639,7 @@ class REST_Controller {
 		$post_meta = $request_body['meta'];
 		$post      = get_post( $post_id );
 
-		if ( $post && $post->post_status === 'publish' && isset( $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] ) ) {
+		if ( $post && 'publish' === $post->post_status && isset( $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] ) ) {
 			update_post_meta( $post_id, self::SOCIAL_SHARES_POST_META_KEY, $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] );
 			return rest_ensure_response( new WP_REST_Response() );
 		}
@@ -649,21 +649,5 @@ class REST_Controller {
 			__( 'Failed to update the post meta', 'jetpack-publicize-pkg' ),
 			array( 'status' => 500 )
 		);
-	}
-
-	/**
-	 * Permissions callback.
-	 */
-	public function update_post_shares_permission_callback() {
-		if ( Rest_Authentication::is_signed_with_blog_token() ) {
-			return true;
-		}
-
-		$error_msg = esc_html__(
-			'You are not allowed to perform this action.',
-			'jetpack-publicize-pkg'
-		);
-
-		return new WP_Error( 'rest_forbidden', $error_msg, array( 'status' => rest_authorization_required_code() ) );
 	}
 }


### PR DESCRIPTION
This is a follow up of #38702 to clean up the code a bit

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the unnecessary logic in the permission callback for publicize shares endpoint

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Same as #38702

