### PR TITLE
Social: Add preview modal analytics

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-social-preview-modal-analytics
+++ b/projects/js-packages/publicize-components/changelog/add-social-preview-modal-analytics
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added tracking for the publicize settings changes

--- a/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
@@ -21,7 +21,7 @@ export const ConnectionsList: React.FC = () => {
 			toggleById( connectionId );
 			recordEvent( 'jetpack_social_connection_toggled', {
 				location: 'editor',
-				new_state: ! connection.enabled,
+				enabled: ! connection.enabled,
 				service_name: connection.service_name,
 			} );
 		},

--- a/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
@@ -12,15 +12,18 @@ export const ConnectionsList: React.FC = () => {
 	const { recordEvent } = useAnalytics();
 
 	const { connections, toggleById } = useSocialMediaConnections();
-
 	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
 
 	const { needsUserConnection } = usePublicizeConfig();
 
 	const toggleConnection = useCallback(
-		( connectionId: string ) => () => {
+		( connectionId: string, connection ) => () => {
 			toggleById( connectionId );
-			recordEvent( 'jetpack_social_connection_toggled', { location: 'editor' } );
+			recordEvent( 'jetpack_social_connection_toggled', {
+				location: 'editor',
+				new_state: ! connection.enabled,
+				service_name: connection.service_name,
+			} );
 		},
 		[ recordEvent, toggleById ]
 	);
@@ -40,7 +43,7 @@ export const ConnectionsList: React.FC = () => {
 							id={ currentId }
 							label={ display_name }
 							name={ service_name }
-							toggleConnection={ toggleConnection( currentId ) }
+							toggleConnection={ toggleConnection( currentId, conn ) }
 							profilePicture={ profile_picture }
 						/>
 					);

--- a/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
@@ -1,3 +1,5 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { useCallback } from 'react';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import PublicizeConnection from '../connection';
@@ -7,11 +9,21 @@ import styles from './styles.module.scss';
 import { useConnectionState } from './use-connection-state';
 
 export const ConnectionsList: React.FC = () => {
+	const { recordEvent } = useAnalytics();
+
 	const { connections, toggleById } = useSocialMediaConnections();
 
 	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
 
 	const { needsUserConnection } = usePublicizeConfig();
+
+	const toggleConnection = useCallback(
+		( connectionId: string ) => () => {
+			toggleById( connectionId );
+			recordEvent( 'jetpack_social_connection_toggled', { location: 'editor' } );
+		},
+		[ recordEvent, toggleById ]
+	);
 
 	return (
 		<div>
@@ -28,7 +40,7 @@ export const ConnectionsList: React.FC = () => {
 							id={ currentId }
 							label={ display_name }
 							name={ service_name }
-							toggleConnection={ toggleById }
+							toggleConnection={ toggleConnection( currentId ) }
 							profilePicture={ profile_picture }
 						/>
 					);

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -105,7 +105,9 @@ export default function PublicizeForm() {
 
 			{ ! isPublicizeDisabledBySitePlan && (
 				<Fragment>
-					{ isPublicizeEnabled && hasEnabledConnections && <SharePostForm /> }
+					{ isPublicizeEnabled && hasEnabledConnections && (
+						<SharePostForm analyticsData={ { location: 'editor' } } />
+					) }
 					<AdvancedPlanNudge />
 				</Fragment>
 			) }

--- a/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
@@ -3,15 +3,30 @@ import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import MediaSection from '../media-section';
 import MessageBoxControl from '../message-box-control';
 
-export const SharePostForm: React.FC = () => {
+type SharePostFormProps = {
+	analyticsData?: object;
+};
+
+/**
+ * The SharePostForm component.
+ * @param {object} props - The component props.
+ * @param {object} [props.analyticsData] - Data for tracking analytics.
+ * @returns {object} The SharePostForm component.
+ */
+export const SharePostForm: React.FC< SharePostFormProps > = ( { analyticsData = null } ) => {
 	const { message, updateMessage, maxLength } = useSocialMediaMessage();
 
 	const { isEnhancedPublishingEnabled } = usePublicizeConfig();
 
 	return (
 		<>
-			<MessageBoxControl maxLength={ maxLength } onChange={ updateMessage } message={ message } />
-			{ isEnhancedPublishingEnabled && <MediaSection /> }
+			<MessageBoxControl
+				maxLength={ maxLength }
+				onChange={ updateMessage }
+				message={ message }
+				analyticsData={ analyticsData }
+			/>
+			{ isEnhancedPublishingEnabled && <MediaSection analyticsData={ analyticsData } /> }
 		</>
 	);
 };

--- a/projects/js-packages/publicize-components/src/components/media-section/index.js
+++ b/projects/js-packages/publicize-components/src/components/media-section/index.js
@@ -1,4 +1,5 @@
 import { ThemeProvider, getRedirectUrl } from '@automattic/jetpack-components';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Disabled, ExternalLink, Notice, BaseControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -16,14 +17,17 @@ const ADD_MEDIA_LABEL = __( 'Choose Media', 'jetpack' );
  * @param {boolean} [props.disabled=false] - Indicates whether the MediaSection is disabled or not.
  * @param {string} [props.disabledNoticeMessage=''] - An optional notice that's displayed when the section is disabled.
  * @param {import('react').ReactNode} [props.CustomNotice=null] - An optional custom notice that's displayed.
+ * @param {object} [props.analyticsData] - Data for tracking analytics.
  * @returns {object} The media section.
  */
 export default function MediaSection( {
 	disabled = false,
 	disabledNoticeMessage = '',
 	CustomNotice = null,
+	analyticsData,
 } ) {
 	const { attachedMedia, updateAttachedMedia } = useAttachedMedia();
+	const { recordEvent } = useAnalytics();
 
 	const [ mediaDetails ] = useMediaDetails( attachedMedia[ 0 ]?.id );
 
@@ -32,11 +36,13 @@ export default function MediaSection( {
 			if ( ! media ) {
 				updateAttachedMedia( [] );
 			} else {
+				recordEvent( 'jetpack_social_media_attached', analyticsData );
+
 				const { id, url, mime: type } = media;
 				updateAttachedMedia( [ { id, url, type } ] );
 			}
 		},
-		[ updateAttachedMedia ]
+		[ analyticsData, recordEvent, updateAttachedMedia ]
 	);
 
 	const MediaWrapper = disabled ? Disabled : Fragment;

--- a/projects/js-packages/publicize-components/src/components/message-box-control/index.js
+++ b/projects/js-packages/publicize-components/src/components/message-box-control/index.js
@@ -1,7 +1,7 @@
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { TextareaControl } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef } from 'react';
 
 /**
  * Wrapper around a textbox to restrict the number of characters and
@@ -23,15 +23,15 @@ export default function MessageBoxControl( {
 	analyticsData = null,
 } ) {
 	const { recordEvent } = useAnalytics();
-	const [ isFirstChange, setIsFirstChange ] = useState( true );
+	const isFirstChange = useRef( true );
 
 	const charactersRemaining = maxLength - message.length;
 
 	const handleChange = useCallback(
 		newMessage => {
-			if ( isFirstChange ) {
+			if ( isFirstChange.current ) {
 				recordEvent( 'jetpack_social_custom_message_changed', analyticsData );
-				setIsFirstChange( false );
+				isFirstChange.current = false;
 			}
 			onChange( newMessage );
 		},

--- a/projects/js-packages/publicize-components/src/components/message-box-control/index.js
+++ b/projects/js-packages/publicize-components/src/components/message-box-control/index.js
@@ -29,11 +29,11 @@ export default function MessageBoxControl( {
 
 	const handleChange = useCallback(
 		newMessage => {
+			onChange( newMessage );
 			if ( isFirstChange.current ) {
 				recordEvent( 'jetpack_social_custom_message_changed', analyticsData );
 				isFirstChange.current = false;
 			}
-			onChange( newMessage );
 		},
 		[ analyticsData, isFirstChange, onChange, recordEvent ]
 	);

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/modal.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/modal.tsx
@@ -1,5 +1,6 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Modal, PanelRow, Button } from '@wordpress/components';
-import { useReducer } from '@wordpress/element';
+import { useCallback, useReducer } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
 import { PreviewSection } from './preview-section';
@@ -13,6 +14,14 @@ import styles from './styles.module.scss';
  */
 export function SocialPostModal() {
 	const [ isModalOpen, toggleModal ] = useReducer( state => ! state, false );
+	const { recordEvent } = useAnalytics();
+
+	const handleOpenModal = useCallback( () => {
+		if ( ! isModalOpen ) {
+			recordEvent( 'jetpack_social_preview_modal_opened' );
+		}
+		toggleModal();
+	}, [ isModalOpen, recordEvent ] );
 
 	return (
 		<PanelRow className={ styles.panel }>
@@ -35,7 +44,7 @@ export function SocialPostModal() {
 					/>
 				</Modal>
 			) }
-			<Button variant="secondary" onClick={ toggleModal }>
+			<Button variant="secondary" onClick={ handleOpenModal }>
 				{ __( 'Preview social posts', 'jetpack' ) }
 			</Button>
 		</PanelRow>

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -65,9 +65,13 @@ export function PreviewSection() {
 	const { toggleConnectionById } = useDispatch( socialStore );
 
 	const toggleConnection = useCallback(
-		( connectionId: string ) => () => {
+		( connectionId: string, connection ) => () => {
 			toggleConnectionById( connectionId );
-			recordEvent( 'jetpack_social_connection_toggled', { location: 'preview-modal' } );
+			recordEvent( 'jetpack_social_connection_toggled', {
+				location: 'preview-modal',
+				new_state: ! connection.enabled,
+				service_name: connection.service_name,
+			} );
 		},
 		[ recordEvent, toggleConnectionById ]
 	);
@@ -82,7 +86,7 @@ export function PreviewSection() {
 							label={ __( 'Share to this account', 'jetpack' ) }
 							disabled={ shouldBeDisabled( tab ) }
 							checked={ canBeTurnedOn( tab ) && tab.enabled }
-							onChange={ toggleConnection( tab.connection_id ) }
+							onChange={ toggleConnection( tab.connection_id, tab ) }
 						/>
 					</div>
 				) }

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -1,3 +1,4 @@
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { TabPanel } from '@wordpress/components';
 import { ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -16,6 +17,8 @@ import styles from './styles.module.scss';
  * @returns {import('react').ReactNode} - Preview section of the social post modal.
  */
 export function PreviewSection() {
+	const { recordEvent } = useAnalytics();
+
 	const getService = useService();
 
 	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
@@ -64,8 +67,9 @@ export function PreviewSection() {
 	const toggleConnection = useCallback(
 		( connectionId: string ) => () => {
 			toggleConnectionById( connectionId );
+			recordEvent( 'jetpack_social_connection_toggled', { location: 'preview-modal' } );
 		},
-		[ toggleConnectionById ]
+		[ recordEvent, toggleConnectionById ]
 	);
 
 	return (

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -69,7 +69,7 @@ export function PreviewSection() {
 			toggleConnectionById( connectionId );
 			recordEvent( 'jetpack_social_connection_toggled', {
 				location: 'preview-modal',
-				new_state: ! connection.enabled,
+				enabled: ! connection.enabled,
 				service_name: connection.service_name,
 			} );
 		},

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/settings-section.tsx
@@ -14,7 +14,7 @@ export function SettingsSection() {
 				<h2>{ __( 'Social Preview', 'jetpack' ) }</h2>
 			</div>
 			<div className={ styles[ 'settings-content' ] }>
-				<SharePostForm />
+				<SharePostForm analyticsData={ { location: 'preview-modal' } } />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/452

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added tracking for the modal opening c04c0b2831634a019f36d1514ba3e607454a0ab3
* Added tracking for the connection toggles 336db6ddb7d4336e4b93e9fdfd4ba432323c079b
* Added tracking for adding custom media and changing the custom message 9adf75620bcfc3b3e720cd6b68baf52a07d2d84a

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/452
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the post editor with this change
* Open browser console and run `localStorage.setItem('debug', 'dops:analytics');`

#### Opening the preview modal
* Open the preview modal
* You should see it being logged in the console
![image](https://github.com/user-attachments/assets/d151f320-1715-4606-bab6-3af58f377a69)

#### Toggling connections
* Toggle a connection from the editor.
* You should see it being logged as `jetpack_social_connection_toggled` with prop `{location: 'editor'}`
* Now toggle a connection from the preview modal, in the right bottom side with the toggle
* You should see the same event, but with the location of `preview-modal`.

#### Attaching media
* Attach a custom media from the editor.
* You should see the event appearing in the logs, but only when a media is attached and not removed.
* Do the same from the modal. Check the props, it should reflect the correct place.

#### Editing the custom message
* Change the custom message from the editor.
* A tracking event should get logged the first time the textarea is edited. This is needed so we do not spam tracks for each character change.
* Do the same from the modal. Check the props, it should reflect the correct place.

#### Check events on Tracks.
* Wait ~10 minutes.
* Goto MC Live tracking
* Check the events there, and check the props. It should reflect what you saw in the logs before

Events to check:
* `jetpack_social_connection_toggled`
* `jetpack_social_media_attached`
* `jetpack_social_custom_message_changed`
* `jetpack_social_preview_modal_opened`