### PR TITLE
 Newsletter settings: set all settings on the page disabled when module is disabled

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -67,7 +67,8 @@ const EmailSettings = props => {
 		siteName,
 	} = props;
 
-	const disabled = ! isSubscriptionsActive || unavailableInOfflineMode || unavailableInSiteConnectionMode;
+	const disabled =
+		! isSubscriptionsActive || unavailableInOfflineMode || unavailableInSiteConnectionMode;
 	const gravatarInputDisabled = disabled || isSavingAnyOption( [ GRAVATER_OPTION ] );
 	const authorInputDisabled = disabled || isSavingAnyOption( [ AUTHOR_OPTION ] );
 	const postDateInputDisabled = disabled || isSavingAnyOption( [ POST_DATE_OPTION ] );

--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -46,6 +46,7 @@ const FROM_NAME_OPTION = 'jetpack_subscriptions_from_name';
 
 const EmailSettings = props => {
 	const {
+		isSubscriptionsActive,
 		isSavingAnyOption,
 		subscriptionsModule,
 		unavailableInOfflineMode,
@@ -66,7 +67,7 @@ const EmailSettings = props => {
 		siteName,
 	} = props;
 
-	const disabled = unavailableInOfflineMode || unavailableInSiteConnectionMode;
+	const disabled = ! isSubscriptionsActive || unavailableInOfflineMode || unavailableInSiteConnectionMode;
 	const gravatarInputDisabled = disabled || isSavingAnyOption( [ GRAVATER_OPTION ] );
 	const authorInputDisabled = disabled || isSavingAnyOption( [ AUTHOR_OPTION ] );
 	const postDateInputDisabled = disabled || isSavingAnyOption( [ POST_DATE_OPTION ] );
@@ -195,7 +196,7 @@ const EmailSettings = props => {
 			>
 				<ToggleControl
 					disabled={ featuredImageInputDisabled }
-					checked={ isFeaturedImageInEmailEnabled }
+					checked={ isFeaturedImageInEmailEnabled && isSubscriptionsActive }
 					toogling={ isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] ) }
 					label={
 						<span className="jp-form-toggle-explanation">
@@ -233,7 +234,7 @@ const EmailSettings = props => {
 				<div className="email-settings__gravatar">
 					<ToggleControl
 						disabled={ gravatarInputDisabled }
-						checked={ isGravatarEnabled }
+						checked={ isGravatarEnabled && isSubscriptionsActive }
 						toogling={ isSavingAnyOption( [ GRAVATER_OPTION ] ) }
 						label={
 							<span className="jp-form-toggle-explanation">
@@ -279,7 +280,7 @@ const EmailSettings = props => {
 				</div>
 				<ToggleControl
 					disabled={ authorInputDisabled }
-					checked={ isAuthorEnabled }
+					checked={ isAuthorEnabled && isSubscriptionsActive }
 					toogling={ isSavingAnyOption( [ AUTHOR_OPTION ] ) }
 					label={
 						<span className="jp-form-toggle-explanation">
@@ -291,7 +292,7 @@ const EmailSettings = props => {
 
 				<ToggleControl
 					disabled={ postDateInputDisabled }
-					checked={ isPostDateEnabled }
+					checked={ isPostDateEnabled && isSubscriptionsActive }
 					toogling={ isSavingAnyOption( [ POST_DATE_OPTION ] ) }
 					label={
 						<span className="jp-form-toggle-explanation">
@@ -461,6 +462,7 @@ export default withModuleSettingsFormHelpers(
 		return {
 			moduleName: ownProps.moduleName,
 			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
+			isSubscriptionsActive: ownProps.getOptionValue( SUBSCRIPTIONS_MODULE_NAME ),
 			isSavingAnyOption: ownProps.isSavingAnyOption,
 			isFeaturedImageInEmailEnabled: ownProps.getOptionValue( FEATURED_IMAGE_IN_EMAIL_OPTION ),
 			isGravatarEnabled: ownProps.getOptionValue( GRAVATER_OPTION ),

--- a/projects/plugins/jetpack/_inc/client/newsletter/messages-setting.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/messages-setting.jsx
@@ -14,6 +14,7 @@ const SUBSCRIPTION_OPTIONS = 'subscription_options';
 
 const MessagesSetting = props => {
 	const {
+		isSubscriptionsActive,
 		isSavingAnyOption,
 		subscriptionsModule,
 		onOptionChange,
@@ -33,6 +34,7 @@ const MessagesSetting = props => {
 	);
 
 	const disabled =
+		! isSubscriptionsActive ||
 		unavailableInOfflineMode ||
 		unavailableInSiteConnectionMode ||
 		isSavingAnyOption( [ SUBSCRIPTION_OPTIONS ] );
@@ -81,6 +83,7 @@ const MessagesSetting = props => {
 export default withModuleSettingsFormHelpers(
 	connect( ( state, ownProps ) => {
 		return {
+			isSubscriptionsActive: ownProps.getOptionValue( SUBSCRIPTIONS_MODULE_NAME ),
 			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
 			isSavingAnyOption: ownProps.isSavingAnyOption,
 			moduleName: ownProps.moduleName,

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -39,6 +39,7 @@ const mapCategoriesIds = category => {
 function NewsletterCategories( props ) {
 	const {
 		updateFormStateModuleOption,
+		isSubscriptionsActive,
 		isNewsletterCategoriesEnabled,
 		newsletterCategories,
 		categories,
@@ -81,6 +82,7 @@ function NewsletterCategories( props ) {
 	);
 
 	const disabled =
+		! isSubscriptionsActive ||
 		unavailableInOfflineMode ||
 		unavailableInSiteConnectionMode ||
 		isSavingAnyOption( [ NEWSLETTER_CATEGORIES_ENABLED_OPTION, NEWSLETTER_CATEGORIES_OPTION ] );
@@ -114,7 +116,7 @@ function NewsletterCategories( props ) {
 				<div className="newsletter-categories-toggle-wrapper">
 					<ToggleControl
 						disabled={ disabled }
-						checked={ isNewsletterCategoriesEnabled }
+						checked={ isNewsletterCategoriesEnabled && isSubscriptionsActive }
 						onChange={ handleEnableNewsletterCategoriesToggleChange }
 						label={
 							<span className="jp-form-toggle-explanation">
@@ -125,7 +127,7 @@ function NewsletterCategories( props ) {
 				</div>
 				<div
 					className={ clsx( 'newsletter-colapsable', {
-						hide: ! isNewsletterCategoriesEnabled,
+						hide: ! isNewsletterCategoriesEnabled || ! isSubscriptionsActive,
 					} ) }
 				>
 					<TreeDropdown
@@ -138,7 +140,7 @@ function NewsletterCategories( props ) {
 			</SettingsGroup>
 			<div
 				className={ clsx( 'newsletter-card-colapsable', {
-					hide: ! isNewsletterCategoriesEnabled,
+					hide: ! isNewsletterCategoriesEnabled || ! isSubscriptionsActive,
 				} ) }
 			>
 				<Card
@@ -157,6 +159,7 @@ function NewsletterCategories( props ) {
 export default withModuleSettingsFormHelpers(
 	connect( ( state, ownProps ) => {
 		return {
+			isSubscriptionsActive: ownProps.getOptionValue( SUBSCRIPTIONS_MODULE_NAME ),
 			subscriptionsModule: getModule( state, SUBSCRIPTIONS_MODULE_NAME ),
 			isNewsletterCategoriesEnabled: ownProps.getOptionValue(
 				NEWSLETTER_CATEGORIES_ENABLED_OPTION

--- a/projects/plugins/jetpack/changelog/fix-jetpack-settings-disabled-state
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-settings-disabled-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter settings: set all settings on the page disabled when module is disabled.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable UIs in the settings page when the main toggle (module state) is switched _off_.

#### Before

<img alt="before" width="300" src="https://github.com/user-attachments/assets/4779dfd4-b434-464c-9348-e1aba71bb1d9"/>


#### After

<img alt="before" width="300" src="https://github.com/user-attachments/assets/a29c9094-45eb-4427-9e5a-f2412299396f"/>


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack -> Settings -> Newsletter
* Enable/disable module
* See everything get disabled consistently
* Note also how category-settings get hidden when module is disabled, as if the category feature is disabled.

