### PR TITLE
Update/camel case track props to snake case

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -272,12 +272,12 @@ const ProductDetailCard = ( {
 	const ctaLabel = ctaButtonLabel || defaultCtaLabel;
 
 	const clickHandler = useCallback( () => {
-		trackButtonClick( { ctaText: ctaLabel } );
+		trackButtonClick( { cta_text: ctaLabel } );
 		onClick?.( mainCheckoutRedirect, detail );
 	}, [ onClick, trackButtonClick, mainCheckoutRedirect, detail, ctaLabel ] );
 
 	const trialClickHandler = useCallback( () => {
-		trackButtonClick( { customSlug: wpcomFreeProductSlug, ctaText: 'Start for free' } );
+		trackButtonClick( { custom_slug: wpcomFreeProductSlug, cta_text: 'Start for free' } );
 		onClick?.( trialCheckoutRedirect, detail );
 	}, [ onClick, trackButtonClick, trialCheckoutRedirect, wpcomFreeProductSlug, detail ] );
 

--- a/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-table/index.jsx
@@ -138,7 +138,7 @@ const ProductDetailTableColumn = ( {
 
 	// Register the click handler for the product button.
 	const onClick = useCallback( () => {
-		trackProductButtonClick( { isFreePlan: isFree, ctaText: callToAction } );
+		trackProductButtonClick( { is_free_plan: isFree, cta_text: callToAction } );
 		onProductButtonClick?.( runCheckout, detail, tier );
 	}, [
 		trackProductButtonClick,

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -121,7 +121,7 @@ export default function ProductInterstitial( {
 			recordEvent( 'jetpack_myjetpack_product_interstitial_add_link_click', {
 				product: productSlug,
 				product_slug: getProductSlugForTrackEvent( isFreePlan ),
-				ctaText,
+				cta_text: ctaText,
 			} );
 		},
 		[ recordEvent, slug, getProductSlugForTrackEvent, bundle ]

--- a/projects/packages/my-jetpack/changelog/update-camel-case-track-props-to-snake-case
+++ b/projects/packages/my-jetpack/changelog/update-camel-case-track-props-to-snake-case
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+


### PR DESCRIPTION
## Proposed changes:

* Fix additional camel case props with snake case for interstitial tracks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

Yes, there were some events failing to track due to camel case props. They will now be recorded correctly

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to any product interstitial from My Jetpack
3. Click on the CTA
4. Make sure `cta_text` is now recorded as snake case

