### PR TITLE
Fix/subscribe height auto

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-height-auto
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-height-auto
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscribe block: set block button height to "auto"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -58,6 +58,7 @@
 			white-space: nowrap !important;
 			min-width: auto !important;
 			cursor: pointer;
+			height: auto; // Avoid theme styles leaking in
 		}
 
 		input[type="email"]::placeholder,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes theme setting `height` on button elements and overriding subscribe block's button height.

Before
<img width="653" alt="Screenshot 2024-08-05 at 19 16 06" src="https://github.com/user-attachments/assets/17a3763b-e127-4de5-bf71-91513527ad37">

After
<img width="636" alt="image" src="https://github.com/user-attachments/assets/203f3eac-7007-4154-9cc8-e25c8c444c69">



In its current state, still leaves input/button different heights so needs a bit more figuring out.


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

