### PR TITLE
Backport mu-wpcom-plugin 2.5.4, jetpack 13.7-beta, wpcomsh 5.2.1 Changes

### DIFF
--- a/projects/js-packages/ai-client/CHANGELOG.md
+++ b/projects/js-packages/ai-client/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2024-08-05
+### Changed
+- AI Logo Generator: fix UI issues. [#38590]
+- Fixup versions [#38612]
+
+### Fixed
+- AI Logo Generator: fix multiple feature requests error + retry handling. [#38630]
+- AI Logo Generator: fix small UI issues. [#38676]
+- AI Logo Generator: fix upgrade URLs so they work on any site type. [#38598]
+- AI Logo Generator: update upgrade message. [#38690]
+
 ## [0.16.0] - 2024-07-29
 ### Added
 - AI Logo Generator: support placement property on the generator modal, for tracking purposes. [#38574]
@@ -366,6 +377,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#31659]
 - Updated package dependencies. [#31785]
 
+[0.16.1]: https://github.com/Automattic/jetpack-ai-client/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.6...v0.15.0
 [0.14.6]: https://github.com/Automattic/jetpack-ai-client/compare/v0.14.5...v0.14.6

--- a/projects/js-packages/ai-client/changelog/fix-eslint-no-empty-catch-blocks
+++ b/projects/js-packages/ai-client/changelog/fix-eslint-no-empty-catch-blocks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Add comment to empty `catch` blocks. No change to functionality.
-
-

--- a/projects/js-packages/ai-client/changelog/fix-mastodon-fediverse-creator-og-fatals
+++ b/projects/js-packages/ai-client/changelog/fix-mastodon-fediverse-creator-og-fatals
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Fixup versions

--- a/projects/js-packages/ai-client/changelog/update-ai-logo-generator-fix-ui-issues
+++ b/projects/js-packages/ai-client/changelog/update-ai-logo-generator-fix-ui-issues
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-AI Logo Generator: fix UI issues.

--- a/projects/js-packages/ai-client/changelog/update-ai-logo-generator-fix-upgrade-links
+++ b/projects/js-packages/ai-client/changelog/update-ai-logo-generator-fix-upgrade-links
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Logo Generator: fix upgrade URLs so they work on any site type.

--- a/projects/js-packages/ai-client/changelog/update-ai-logo-generator-fix-upgrade-message
+++ b/projects/js-packages/ai-client/changelog/update-ai-logo-generator-fix-upgrade-message
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Logo Generator: update upgrade message.

--- a/projects/js-packages/ai-client/changelog/update-ai-logo-generator-prevent-multiple-feature-data-requests
+++ b/projects/js-packages/ai-client/changelog/update-ai-logo-generator-prevent-multiple-feature-data-requests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Logo Generator: fix multiple feature requests error + retry handling.

--- a/projects/js-packages/ai-client/changelog/update-ai-logo-generator-small-ui-fixes
+++ b/projects/js-packages/ai-client/changelog/update-ai-logo-generator-small-ui-fixes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-AI Logo Generator: fix small UI issues.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -1,7 +1,7 @@
 {
 	"private": false,
 	"name": "@automattic/jetpack-ai-client",
-	"version": "0.16.1-alpha",
+	"version": "0.16.1",
 	"description": "A JS client for consuming Jetpack AI services",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/ai-client/#readme",
 	"bugs": {

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [0.55.5] - 2024-08-05
+### Fixed
+- Fixed TS types for Notice components by marking optional props as such [#38686]
+
 ## [0.55.4] - 2024-08-01
 ### Added
 - Update Welcome Banner and set async site-only connection [#38534]
@@ -1110,6 +1114,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[0.55.5]: https://github.com/Automattic/jetpack-components/compare/0.55.4...0.55.5
 [0.55.4]: https://github.com/Automattic/jetpack-components/compare/0.55.3...0.55.4
 [0.55.3]: https://github.com/Automattic/jetpack-components/compare/0.55.2...0.55.3
 [0.55.2]: https://github.com/Automattic/jetpack-components/compare/0.55.1...0.55.2

--- a/projects/js-packages/components/changelog/add-preview-section-to-the-social-post-modal
+++ b/projects/js-packages/components/changelog/add-preview-section-to-the-social-post-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed TS types for Notice components by marking optional props as such

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "0.55.5-alpha",
+	"version": "0.55.5",
 	"description": "Jetpack Components Package",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.59.0] - 2024-08-05
+### Added
+- Added connection toggle to social post preview [#38686]
+- Added feature flag management for social [#38669]
+- Added preview section to the social post modal [#38686]
+- Added Social post UI modal and trigger [#38666]
+- Added tracking for the publicize settings changes [#38714]
+- Social: Added settings section to the social post modal [#38683]
+
+### Fixed
+- Fix the media validation notice for Instagram when SIG is enabled [#38689]
+
 ## [0.58.0] - 2024-08-01
 ### Changed
 - Fixup versions [#38612]
@@ -807,6 +819,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.59.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.58.0...v0.59.0
 [0.58.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.57.0...v0.58.0
 [0.57.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.56.2...v0.57.0
 [0.56.2]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.56.1...v0.56.2

--- a/projects/js-packages/publicize-components/changelog/add-connection-toggle-to-the-social-post-modal
+++ b/projects/js-packages/publicize-components/changelog/add-connection-toggle-to-the-social-post-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added connection toggle to social post preview

--- a/projects/js-packages/publicize-components/changelog/add-preview-section-to-the-social-post-modal
+++ b/projects/js-packages/publicize-components/changelog/add-preview-section-to-the-social-post-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Added preview section to the social post modal

--- a/projects/js-packages/publicize-components/changelog/add-settings-section-to-social-post-modal
+++ b/projects/js-packages/publicize-components/changelog/add-settings-section-to-social-post-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Social: Added settings section to the social post modal

--- a/projects/js-packages/publicize-components/changelog/add-social-feature-flag-management-fixed
+++ b/projects/js-packages/publicize-components/changelog/add-social-feature-flag-management-fixed
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added feature flag management for social

--- a/projects/js-packages/publicize-components/changelog/add-social-post-ui-modal
+++ b/projects/js-packages/publicize-components/changelog/add-social-post-ui-modal
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added Social post UI modal and trigger

--- a/projects/js-packages/publicize-components/changelog/add-social-preview-modal-analytics
+++ b/projects/js-packages/publicize-components/changelog/add-social-preview-modal-analytics
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added tracking for the publicize settings changes

--- a/projects/js-packages/publicize-components/changelog/fix-no-media-notice-for-instagram-when-sig-is-on
+++ b/projects/js-packages/publicize-components/changelog/fix-no-media-notice-for-instagram-when-sig-is-on
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix the media validation notice for Instagram when SIG is enabled

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.59.0-alpha",
+	"version": "0.59.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.7] - 2024-08-05
+### Changed
+- React compatibility: Changing ReactDOM.render usage to be via ReactDOM.createRoot. [#38649]
+
 ## [0.32.6] - 2024-07-29
 ### Changed
 - Update dependencies. [#38558]
@@ -615,6 +619,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.32.7]: https://github.com/automattic/jetpack-forms/compare/v0.32.6...v0.32.7
 [0.32.6]: https://github.com/automattic/jetpack-forms/compare/v0.32.5...v0.32.6
 [0.32.5]: https://github.com/automattic/jetpack-forms/compare/v0.32.4...v0.32.5
 [0.32.4]: https://github.com/automattic/jetpack-forms/compare/v0.32.3...v0.32.4

--- a/projects/packages/forms/changelog/fix-contact-form-php-fatals
+++ b/projects/packages/forms/changelog/fix-contact-form-php-fatals
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Prevent PHP fatals
-
-

--- a/projects/packages/forms/changelog/update-react-19-compat-ReactDOM-render
+++ b/projects/packages/forms/changelog/update-react-19-compat-ReactDOM-render
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-React compatibility: Changing ReactDOM.render usage to be via ReactDOM.createRoot.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.32.7-alpha",
+	"version": "0.32.7",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.32.7-alpha';
+	const PACKAGE_VERSION = '0.32.7';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/image-cdn/CHANGELOG.md
+++ b/projects/packages/image-cdn/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2024-08-05
+### Changed
+- Do not serve media from Amazon CDN from Jetpack's CDN. [#38682]
+
 ## [0.4.3] - 2024-06-21
 ### Changed
 - Image CDN: Added support for query strings in image URLs [#37931]
@@ -102,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add image CDN package. [#29561]
 
+[0.4.4]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/Automattic/jetpack-image-cdn/compare/v0.4.0...v0.4.1

--- a/projects/packages/image-cdn/changelog/fix-photon-amazon-cdn
+++ b/projects/packages/image-cdn/changelog/fix-photon-amazon-cdn
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Do not serve media from Amazon CDN from Jetpack's CDN.

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Image_CDN;
  */
 final class Image_CDN {
 
-	const PACKAGE_VERSION = '0.4.4-alpha';
+	const PACKAGE_VERSION = '0.4.4';
 
 	/**
 	 * Singleton.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.53.1] - 2024-08-05
+### Changed
+- Internal updates.
+
 ## [5.53.0] - 2024-08-05
 ### Added
 - Added wpcom-block-editor-nux feature from calypso's ETK package. [#38674]
@@ -1097,6 +1101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.53.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.53.0...v5.53.1
 [5.53.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.52.1...v5.53.0
 [5.52.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.52.0...v5.52.1
 [5.52.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.51.0...v5.52.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/revert-38454-mu-wpcom-newspack-blocks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/revert-38454-mu-wpcom-newspack-blocks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: removed
-Comment: Reverted a previous change.
-
-

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.53.1-alpha",
+	"version": "5.53.1",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.53.1-alpha';
+	const PACKAGE_VERSION = '5.53.1';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.32.0] - 2024-08-05
+### Added
+- Add Tracks events for Welcome Flow [#38641]
+
+### Changed
+- change Jetpack AI product page link redirect [#38691]
+- copy updates [#38648]
+- Modify the Google Analytics notice to notify of the feature removal. [#38701]
+
 ## [4.31.0] - 2024-08-01
 ### Added
 - Update Welcome Banner and set async site-only connection [#38534]
@@ -1607,6 +1616,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[4.32.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.31.0...4.32.0
 [4.31.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.30.0...4.31.0
 [4.30.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.29.0...4.30.0
 [4.29.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/4.28.0...4.29.0

--- a/projects/packages/my-jetpack/changelog/Add Tracks events for Welcome Flow
+++ b/projects/packages/my-jetpack/changelog/Add Tracks events for Welcome Flow
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add Tracks events for Welcome Flow

--- a/projects/packages/my-jetpack/changelog/add-ab-experiment-welcome-flow
+++ b/projects/packages/my-jetpack/changelog/add-ab-experiment-welcome-flow
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Added a simple A/B experimento to the Welcome Flow on My Jetpack.
-
-

--- a/projects/packages/my-jetpack/changelog/change-jetpack-ai-product-page-breve-link
+++ b/projects/packages/my-jetpack/changelog/change-jetpack-ai-product-page-breve-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-change Jetpack AI product page link redirect

--- a/projects/packages/my-jetpack/changelog/update-camel-case-track-props-to-snake-case
+++ b/projects/packages/my-jetpack/changelog/update-camel-case-track-props-to-snake-case
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-

--- a/projects/packages/my-jetpack/changelog/update-ga-deprecation-notices
+++ b/projects/packages/my-jetpack/changelog/update-ga-deprecation-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Modify the Google Analytics notice to notify of the feature removal.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-product-card-copy
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-product-card-copy
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-copy updates

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.32.0-alpha",
+	"version": "4.32.0",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -41,7 +41,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.32.0-alpha';
+	const PACKAGE_VERSION = '4.32.0';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.0] - 2024-08-05
+### Added
+- Added endpoint to sync shares post meta back to the self-hosted site. [#38702]
+- Added feature flag management for social [#38669]
+
+### Fixed
+- Cleaned-up publicize shares rest endpoint [#38709]
+
 ## [0.47.4] - 2024-08-01
 ### Removed
 - Removed Fediverse og filters to fix fatals [#38612]
@@ -632,6 +640,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.48.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.47.4...v0.48.0
 [0.47.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.47.3...v0.47.4
 [0.47.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.47.2...v0.47.3
 [0.47.2]: https://github.com/Automattic/jetpack-publicize/compare/v0.47.1...v0.47.2

--- a/projects/packages/publicize/changelog/add-endpoint-to-sync-shares-meta
+++ b/projects/packages/publicize/changelog/add-endpoint-to-sync-shares-meta
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added endpoint to sync shares post meta back to the self-hosted site. 

--- a/projects/packages/publicize/changelog/add-social-feature-flag-management-fixed
+++ b/projects/packages/publicize/changelog/add-social-feature-flag-management-fixed
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Added feature flag management for social

--- a/projects/packages/publicize/changelog/updat-cleanup-publicize-shares-rest-endpoint
+++ b/projects/packages/publicize/changelog/updat-cleanup-publicize-shares-rest-endpoint
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Cleaned-up publicize shares rest endpoint

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.48.0-alpha",
+	"version": "0.48.0",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/search/CHANGELOG.md
+++ b/projects/packages/search/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.44.14] - 2024-08-05
+### Changed
+- React compatibility: Changing ReactDOM.render usage to be via ReactDOM.createRoot. [#38649]
+
 ## [0.44.13] - 2024-07-22
 ### Changed
 - Update dependencies. [#38402]
@@ -992,6 +996,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update PHPUnit configs to include just what needs coverage rather than include everything then try to exclude stuff that doesn't.
 
+[0.44.14]: https://github.com/Automattic/jetpack-search/compare/v0.44.13...v0.44.14
 [0.44.13]: https://github.com/Automattic/jetpack-search/compare/v0.44.12...v0.44.13
 [0.44.12]: https://github.com/Automattic/jetpack-search/compare/v0.44.11...v0.44.12
 [0.44.11]: https://github.com/Automattic/jetpack-search/compare/v0.44.10...v0.44.11

--- a/projects/packages/search/changelog/update-react-19-compat-ReactDOM-render
+++ b/projects/packages/search/changelog/update-react-19-compat-ReactDOM-render
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-React compatibility: Changing ReactDOM.render usage to be via ReactDOM.createRoot.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.14-alpha",
+	"version": "0.44.14",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.14-alpha';
+	const VERSION = '0.44.14';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.1] - 2024-08-05
+### Fixed
+- Jetpack Sync: Take order type into account when performing  HPOS Checksums [#38688]
+
 ## [3.4.0] - 2024-07-29
 ### Added
 - Add support for syncing Jetpack WAF options. [#37957]
@@ -1219,6 +1223,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[3.4.1]: https://github.com/Automattic/jetpack-sync/compare/v3.4.0...v3.4.1
 [3.4.0]: https://github.com/Automattic/jetpack-sync/compare/v3.3.1...v3.4.0
 [3.3.1]: https://github.com/Automattic/jetpack-sync/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/Automattic/jetpack-sync/compare/v3.2.1...v3.3.0

--- a/projects/packages/sync/changelog/fix-sync-hpos-checksums
+++ b/projects/packages/sync/changelog/fix-sync-hpos-checksums
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Jetpack Sync: Take order type into account when performing  HPOS Checksums

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.4.1-alpha';
+	const PACKAGE_VERSION = '3.4.1';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.30] - 2024-08-05
+### Changed
+- Fixup versions [#38612]
+- React: Changing global JSX namespace to React.JSX [#38585]
+
 ## [0.23.29] - 2024-07-29
 ### Changed
 - Update dependencies. [#38558]
@@ -1377,6 +1382,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.30]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.29...v0.23.30
 [0.23.29]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.28...v0.23.29
 [0.23.28]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.27...v0.23.28
 [0.23.27]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.26...v0.23.27

--- a/projects/packages/videopress/changelog/fix-eslint-no-empty-catch-blocks
+++ b/projects/packages/videopress/changelog/fix-eslint-no-empty-catch-blocks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Add comment to empty `catch` blocks. No change to functionality.
-
-

--- a/projects/packages/videopress/changelog/fix-mastodon-fediverse-creator-og-fatals
+++ b/projects/packages/videopress/changelog/fix-mastodon-fediverse-creator-og-fatals
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Fixup versions

--- a/projects/packages/videopress/changelog/update-jsx-namespace-usage
+++ b/projects/packages/videopress/changelog/update-jsx-namespace-usage
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-React: Changing global JSX namespace to React.JSX

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.30-alpha",
+	"version": "0.23.30",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.30-alpha';
+	const PACKAGE_VERSION = '0.23.30';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.7-beta - 2024-08-05
+### Enhancements
+- AI Assistant: Make Jetpack Breve available to general public. [#38697]
+- Jetpack: Port additional Full Site Editing features from WP Cloud. [#38212]
+- Jetpack AI: Enable the AI Logo generator extension. [#38696]
+- Jetpack Newsletter: Add Jetpack Newsletter menu with preview option. [#38675]
+
+### Bug fixes
+- Jetpack Comments: Fix replying to comments in Chrome when logged in to both WordPress.com and Jetpack. [#38554]
+- Sharing: Do not include Gravatar images in Open Graph Meta tags. [#38692]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Admin bar: Help center and notification icons now follow color scheme. [#38672]
+- AI Assistant: Add ignore button for AI Proofread. [#38517]
+- AI Assistant: Change Breve readability score text. [#38620]
+- AI Assistant: Disable AI Proofread by default. [#38715]
+- AI Assistant: Release Breve for 50% of sites. [#38604]
+- AI Assistant: Remove slash highlights on Breve. [#38700]
+- AI Logo Generator: Fix the retry button when a feature request fails. [#38630]
+- AI Logo Generator: Only extend the logo block when the AI Assistant is available and not hidden on the editor. [#38603]
+- AI Logo Generator: Release site logo extension to 10% of sites. [#38646]
+- Fix suggestion invalidation on different features. [#38633]
+- Jetpack AI: Apply text-wrap: pretty to AI assistant sidebar sections. [#38653]
+- Jetpack AI: useExperiment note. [#38602]
+- Jetpack AI Breve: Disable feature toggles on main toggle. [#38678]
+- Jetpack Social: Added feature flag management. [#38669]
+- Jetpack Social: Removed the media auto-conversion UI. [#38497]
+- Jetpack Stats: Disable blog stats block for simple sites. [#38564]
+- General: Changing global JSX namespace to React.JSX. [#38585]
+- General: Changing ReactDOM.render usage to be via ReactDOM.createRoot. [#38649]
+- General: Modify the Google Analytics notice to notify of the feature removal. [#38701]
+- Newsletter: Add source for the paid importer. [#38679]
+- Newsletter: Set all settings on the page disabled when module is disabled. [#38716]
+- Jetpack Blocks: Update Podcast Player blockt to be compatible with React 19. [#38619]
+- Social Links: Adding a function_exists check within the social-links.php file, to prevent conflicts with package version. [#38593]
+- WP.com API: Include errors listed for broken themes. [#38642]
+
 ## 13.7-a.7 - 2024-07-29
 ### Enhancements
 - AI Assistant: Add feedback link to the sidebar. [#38528]

--- a/projects/plugins/jetpack/changelog/add-email-preview-endpoint
+++ b/projects/plugins/jetpack/changelog/add-email-preview-endpoint
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Jetpack Newsletter: Adds Jetpack Newsletter menu with preview option.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-breve-disable-controls-on-toggle
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-breve-disable-controls-on-toggle
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI Breve: disable feature toggles on main toggle

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-runts-css-pretty-wrap
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-runts-css-pretty-wrap
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: apply text-wrap: pretty to AI assistant sidebar sections

--- a/projects/plugins/jetpack/changelog/add-paid-importer-connect-memebership-flow
+++ b/projects/plugins/jetpack/changelog/add-paid-importer-connect-memebership-flow
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Newsletter: add source for the paid importer

--- a/projects/plugins/jetpack/changelog/add-proofread-ignore-button
+++ b/projects/plugins/jetpack/changelog/add-proofread-ignore-button
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Add ignore button for AI Proofread

--- a/projects/plugins/jetpack/changelog/add-protect-global-waf-stats
+++ b/projects/plugins/jetpack/changelog/add-protect-global-waf-stats
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-social-feature-flag-management-fixed
+++ b/projects/plugins/jetpack/changelog/add-social-feature-flag-management-fixed
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Added feature flag management for Social

--- a/projects/plugins/jetpack/changelog/add-social-links-to-classic-theme-helper-package
+++ b/projects/plugins/jetpack/changelog/add-social-links-to-classic-theme-helper-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Social Links: Adding a function_exists check within the social-links.php file, to preventconflicts with package version.

--- a/projects/plugins/jetpack/changelog/add-sync-waf-options-2
+++ b/projects/plugins/jetpack/changelog/add-sync-waf-options-2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Janitorial: Updated jetpack_waf_ip_allow_list_enabled options group from "waf" to "settings".
-
-

--- a/projects/plugins/jetpack/changelog/add-theme-errors-api
+++ b/projects/plugins/jetpack/changelog/add-theme-errors-api
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-WP.com API: Include errors listed for broken themes.

--- a/projects/plugins/jetpack/changelog/add-welcome-flow-tracks-events
+++ b/projects/plugins/jetpack/changelog/add-welcome-flow-tracks-events
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/change-my-jetpack-ai-card
+++ b/projects/plugins/jetpack/changelog/change-my-jetpack-ai-card
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Jetpack AI: useExperiment note

--- a/projects/plugins/jetpack/changelog/change-my-jetpack-ai-card#2
+++ b/projects/plugins/jetpack/changelog/change-my-jetpack-ai-card#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/fix-disable-blog-stats-simple
+++ b/projects/plugins/jetpack/changelog/fix-disable-blog-stats-simple
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Disable blog stats block for simple sites

--- a/projects/plugins/jetpack/changelog/fix-eslint-no-empty-catch-blocks
+++ b/projects/plugins/jetpack/changelog/fix-eslint-no-empty-catch-blocks
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Add comment to empty `catch` blocks. No change to functionality.
-
-

--- a/projects/plugins/jetpack/changelog/fix-eslint-no-empty-catch-blocks#2
+++ b/projects/plugins/jetpack/changelog/fix-eslint-no-empty-catch-blocks#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: In webpack.config.extensions.js, remove a catch for JSON errors that would fail with "Cannot read properties of undefined (reading 'replace')" on the next line anyway.
-
-

--- a/projects/plugins/jetpack/changelog/fix-eslint-no-empty-catch-blocks#3
+++ b/projects/plugins/jetpack/changelog/fix-eslint-no-empty-catch-blocks#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Add copy-pasted libraries in `projects/plugins/jetpack/modules/shortcodes/js/` to `.eslintignore`, we don't want to lint them.
-
-

--- a/projects/plugins/jetpack/changelog/fix-eslint-no-empty-catch-blocks#4
+++ b/projects/plugins/jetpack/changelog/fix-eslint-no-empty-catch-blocks#4
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Simplify code in projects/plugins/jetpack/extensions/shared/block-editor-asset-loader.js
-
-

--- a/projects/plugins/jetpack/changelog/fix-invalidate-suggestion
+++ b/projects/plugins/jetpack/changelog/fix-invalidate-suggestion
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Fix suggestion invalidation on different features

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-complex-word-slash
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-complex-word-slash
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Remove slash highlights on Breve

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-readability-text
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-readability-text
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Change Breve readability score text

--- a/projects/plugins/jetpack/changelog/fix-jetpack-comments-chrome
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-comments-chrome
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Jetpack Comments: fix replying to comments in chrome when logged in to both wordpress.com and the jetpack site

--- a/projects/plugins/jetpack/changelog/fix-jetpack-settings-disabled-state
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-settings-disabled-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Newsletter settings: set all settings on the page disabled when module is disabled.

--- a/projects/plugins/jetpack/changelog/fix-newsletter-byline-link-fontsize
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-byline-link-fontsize
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Tiny font-size update
-
-

--- a/projects/plugins/jetpack/changelog/fix-wpcom-icon-color
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-icon-color
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Admin bar: help center and notification icons now follow color scheme

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Init 13.8-a.0
+
+

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.7-a.8
-
-

--- a/projects/plugins/jetpack/changelog/mu-wpcom-a8c-fse
+++ b/projects/plugins/jetpack/changelog/mu-wpcom-a8c-fse
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Jetpack: Port FSE feature from ETK

--- a/projects/plugins/jetpack/changelog/update-ai-logo-generator-improve-extension-availability-check
+++ b/projects/plugins/jetpack/changelog/update-ai-logo-generator-improve-extension-availability-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Logo Generator: only extend the logo block when the AI Assistant is available and not hidden on the editor.

--- a/projects/plugins/jetpack/changelog/update-ai-logo-generator-move-to-production
+++ b/projects/plugins/jetpack/changelog/update-ai-logo-generator-move-to-production
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Jetpack AI: enable the logo block AI logo generator extension in production.

--- a/projects/plugins/jetpack/changelog/update-ai-logo-generator-prevent-multiple-feature-data-requests
+++ b/projects/plugins/jetpack/changelog/update-ai-logo-generator-prevent-multiple-feature-data-requests
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Logo Generator: Fix the retry button when a feature request fails.

--- a/projects/plugins/jetpack/changelog/update-ai-logo-generator-release-to-simple-sites
+++ b/projects/plugins/jetpack/changelog/update-ai-logo-generator-release-to-simple-sites
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Logo Generator: Release site logo extension to 10% of sites.

--- a/projects/plugins/jetpack/changelog/update-ai-proofread-disabled
+++ b/projects/plugins/jetpack/changelog/update-ai-proofread-disabled
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Disable AI Proofread by default

--- a/projects/plugins/jetpack/changelog/update-ga-deprecation-notices
+++ b/projects/plugins/jetpack/changelog/update-ga-deprecation-notices
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Modify the Google Analytics notice to notify of the feature removal.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-empty-text
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-empty-text
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Just a minor text change
-
-

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-production
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-production
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-AI Assistant: Release Breve to production

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-release-50
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-release-50
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Release Breve for 50% of sites

--- a/projects/plugins/jetpack/changelog/update-jsx-namespace-usage
+++ b/projects/plugins/jetpack/changelog/update-jsx-namespace-usage
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-React: Changing global JSX namespace to React.JSX

--- a/projects/plugins/jetpack/changelog/update-post-images-gravatar
+++ b/projects/plugins/jetpack/changelog/update-post-images-gravatar
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Sharing: do not include Gravatar images in Open Graph Meta tags.

--- a/projects/plugins/jetpack/changelog/update-react-19-compat-ReactDOM-render
+++ b/projects/plugins/jetpack/changelog/update-react-19-compat-ReactDOM-render
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-React Compatibility: Changing ReactDOM.render usage to be via ReactDOM.createRoot.

--- a/projects/plugins/jetpack/changelog/update-react-19-compat-unmountComponentAtNode
+++ b/projects/plugins/jetpack/changelog/update-react-19-compat-unmountComponentAtNode
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Podcast Player Block: Update component unmount method to be compatible with React 19.

--- a/projects/plugins/jetpack/changelog/update-social-Remove-the-auto-conversion-toggle-UI
+++ b/projects/plugins/jetpack/changelog/update-social-Remove-the-auto-conversion-toggle-UI
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Social | Removed the media auto-conversion UI

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_7_beta",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_8_a_0",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_7_a_8",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_7_beta",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.7-beta
+ * Version: 13.8-a.0
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.5' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.7-beta' );
+define( 'JETPACK__VERSION', '13.8-a.0' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.7-a.8
+ * Version: 13.7-beta
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.5' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.7-a.8' );
+define( 'JETPACK__VERSION', '13.7-beta' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.7.0-a.8",
+	"version": "13.7.0-beta",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.7.0-beta",
+	"version": "13.8.0-a.0",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -328,13 +328,42 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 == Changelog ==
 ### 13.7-beta - 2024-08-05
 #### Enhancements
+- AI Assistant: Add feedback link to the sidebar.
+- AI Assistant: Breve UI enhancements.
+- AI Assistant: Disable first Breve hover on mobile.
+- AI Assistant: Disable long sentences Breve feature by default.
+- AI Assistant: Enable Breve for 10% of production sites.
+- AI Assistant: Enable Breve for 20% of production sites.
 - AI Assistant: Make Jetpack Breve available to general public.
+- AI Assistant: The general purpose image generator is now available to all users.
+- Blocks: Add the EventCoutdown block.
+- Blocks: Add the Timeline block.
+- Dashboard: Add a dashboard card for AI Assistant.
+- General: Losslessly optimized PNG images.
 - Jetpack: Port additional Full Site Editing features from WP Cloud.
 - Jetpack AI: Enable the AI Logo generator extension.
 - Jetpack Newsletter: Add Jetpack Newsletter menu with preview option.
+- Newsletter: Improve the modal overlay.
+- Security: Add separate IP allow and block list toggles in Web Application Firewall settings.
+- Settings: Add a link to the AI assistant product page.
+- Site Editor: Remove extra site editor notices in favor of the ones provided by WordPress directly.
+- Social: Added recommendation steps for the Social plan.
+- Subscriptions: Add command palette commands for quickly changing post access.
+- Subscriptions: Implemented a more dynamic approach to displaying the modal.
+- Subscriptions: Improve the Subscribe block loading animation.
+
+#### Improved compatibility
+- Blocks: Changed the use of default parameters in the Map block for React 19 compatibility.
+- Contact Form: Ensure checkboxes are properly displayed when using the Twenty Twenty or the Twenty Twenty One theme.
+- General: Remove code for compatibility with WordPress versions before 6.5.
+- General: Update WordPress version requirements to WordPress 6.5.
+- Masterbar: Always show the notification bell.
 
 #### Bug fixes
+- Blocks: Check if the fontFamily block attribute is a string before trying to format.
+- Donations Block: Fix undefined array key warnings with old/malformed blocks.
 - Jetpack Comments: Fix replying to comments in Chrome when logged in to both WordPress.com and Jetpack.
+- Like block: Fix warning displayed when trying to load the Like block on unsupported pages.
 - Sharing: Do not include Gravatar images in Open Graph Meta tags.
 
 --------

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,19 +326,16 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.7-a.7 - 2024-07-29
+### 13.7-beta - 2024-08-05
 #### Enhancements
-- AI Assistant: Add feedback link to the sidebar.
-- AI Assistant: Breve UI enhancements.
-- AI Assistant: Disable first Breve hover on mobile.
-- AI Assistant: Disable long sentences Breve feature by default.
-- AI Assistant: Enable Breve for 10% of production sites.
-- AI Assistant: Enable Breve for 20% of production sites.
-- General: Losslessly optimized PNG images.
-- Site Editor: Remove extra site editor notices in favor of the ones provided by WordPress directly.
+- AI Assistant: Make Jetpack Breve available to general public.
+- Jetpack: Port additional Full Site Editing features from WP Cloud.
+- Jetpack AI: Enable the AI Logo generator extension.
+- Jetpack Newsletter: Add Jetpack Newsletter menu with preview option.
 
-#### Improved compatibility
-- Masterbar: Always show the notification bell.
+#### Bug fixes
+- Jetpack Comments: Fix replying to comments in Chrome when logged in to both WordPress.com and Jetpack.
+- Sharing: Do not include Gravatar images in Open Graph Meta tags.
 
 --------
 

--- a/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
+++ b/projects/plugins/jetpack/tests/php/media/test-class.jetpack-post-images.php
@@ -43,7 +43,7 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 	/**
 	 * Ensure that Gravatar images are not included in the list of images extracted from the post contents (html).
 	 *
-	 * @since $$next-version$$
+	 * @since 13.7
 	 */
 	public function test_from_html_gravatar() {
 		$s = '<img class="jetpack-blogging-prompt__answers-gravatar wp-hovercard-attachment grav-hashed grav-hijack" aria-hidden="true" src="https://0.gravatar.com/avatar/89f071d1932fe8c204a3381e00bd6794ddc28bcdb0642f29c9f48beaa5e277af?s=96&d=identicon&r=G">';

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.5.4 - 2024-08-05
+### Changed
+- Fixup versions [#38612]
+
 ## 2.5.3 - 2024-07-30
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/HEAD
+++ b/projects/plugins/mu-wpcom-plugin/changelog/HEAD
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-mastodon-fediverse-creator-og-fatals
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-mastodon-fediverse-creator-og-fatals
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Fixup versions

--- a/projects/plugins/mu-wpcom-plugin/changelog/port-starter-page-templates
+++ b/projects/plugins/mu-wpcom-plugin/changelog/port-starter-page-templates
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/port-starter-page-templates#2
+++ b/projects/plugins/mu-wpcom-plugin/changelog/port-starter-page-templates#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/port-starter-page-templates#3
+++ b/projects/plugins/mu-wpcom-plugin/changelog/port-starter-page-templates#3
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-subscriber-login-description-link
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-subscriber-login-description-link
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_4_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_4"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.5.4-alpha
+ * Version: 2.5.4
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.5.4-alpha",
+	"version": "2.5.4",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/wpcomsh/CHANGELOG.md
+++ b/projects/plugins/wpcomsh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.2.1 - 2024-08-05
+### Changed
+- Internal updates.
+
 ## 5.2.0 - 2024-08-05
 ### Changed
 - Add target_blog_id prop to AIOWP tracks events [#38615]

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -128,7 +128,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_2_0"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_2_1"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.2.0",
+	"version": "5.2.1",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.2.0
+ * Version: 5.2.1
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.2.0' );
+define( 'WPCOMSH_VERSION', '5.2.1' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.5.4, jetpack 13.7-beta, wpcomsh 5.2.1

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.