### PR TITLE
MU WPCOM: Port enqueue_coblocks_gallery_scripts from the ETK

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-coblocks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-coblocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Port enqueue_coblocks_gallery_scripts from the ETK

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -160,6 +160,7 @@ class Jetpack_Mu_Wpcom {
 			return;
 		}
 
+		define( 'MU_WPCOM_COBLOCKS_GALLERY', true );
 		define( 'MU_WPCOM_CUSTOM_LINE_HEIGHT', true );
 		define( 'MU_WPCOM_BLOCK_INSERTER_MODIFICATIONS', true );
 		define( 'MU_WPCOM_HOMEPAGE_TITLE_HIDDEN', true );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-legacy-fse/wpcom-legacy-fse.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-legacy-fse/wpcom-legacy-fse.php
@@ -142,7 +142,7 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_fse' );
  * not aware of content sections outside of post_content yet.
  */
 function enqueue_coblocks_gallery_scripts() {
-	if ( ! function_exists( 'CoBlocks' ) || ! is_full_site_editing_active() ) {
+	if ( ! defined( 'COBLOCKS_VERSION' ) || ! function_exists( 'CoBlocks' ) || ! is_full_site_editing_active() ) {
 		return;
 	}
 
@@ -151,9 +151,11 @@ function enqueue_coblocks_gallery_scripts() {
 	$footer   = $template->get_template_content( 'footer' );
 
 	// Define where the asset is loaded from.
+	// @phan-suppress-next-line PhanUndeclaredFunction
 	$dir = CoBlocks()->asset_source( 'js' );
 
 	// Define where the vendor asset is loaded from.
+	// @phan-suppress-next-line PhanUndeclaredFunction
 	$vendors_dir = CoBlocks()->asset_source( 'js', 'vendors' );
 
 	// Masonry block.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-legacy-fse/wpcom-legacy-fse.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-legacy-fse/wpcom-legacy-fse.php
@@ -132,3 +132,50 @@ function load_wpcom_fse() {
 	add_action( 'init', __NAMESPACE__ . '\wpcom_fse_register_template_post_types' );
 }
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_wpcom_fse' );
+
+/**
+ * Add front-end CoBlocks gallery block scripts.
+ *
+ * This function performs the same enqueueing duties as `CoBlocks_Block_Assets::frontend_scripts`,
+ * but for dotcom FSE header and footer content. `frontend_scripts` uses
+ * `has_block` to determine if gallery blocks are present, and `has_block` is
+ * not aware of content sections outside of post_content yet.
+ */
+function enqueue_coblocks_gallery_scripts() {
+	if ( ! function_exists( 'CoBlocks' ) || ! is_full_site_editing_active() ) {
+		return;
+	}
+
+	$template = new WP_Template();
+	$header   = $template->get_template_content( 'header' );
+	$footer   = $template->get_template_content( 'footer' );
+
+	// Define where the asset is loaded from.
+	$dir = CoBlocks()->asset_source( 'js' );
+
+	// Define where the vendor asset is loaded from.
+	$vendors_dir = CoBlocks()->asset_source( 'js', 'vendors' );
+
+	// Masonry block.
+	if ( has_block( 'coblocks/gallery-masonry', $header . $footer ) ) {
+		wp_enqueue_script(
+			'coblocks-masonry',
+			$dir . 'coblocks-masonry.min.js',
+			array( 'jquery', 'masonry', 'imagesloaded' ),
+			COBLOCKS_VERSION,
+			true
+		);
+	}
+
+	// Carousel block.
+	if ( has_block( 'coblocks/gallery-carousel', $header . $footer ) ) {
+		wp_enqueue_script(
+			'coblocks-flickity',
+			$vendors_dir . '/flickity.js',
+			array( 'jquery' ),
+			COBLOCKS_VERSION,
+			true
+		);
+	}
+}
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_coblocks_gallery_scripts' );

--- a/projects/plugins/mu-wpcom-plugin/changelog/mu-wpcom-coblocks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/mu-wpcom-coblocks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/changelog/mu-wpcom-coblocks
+++ b/projects/plugins/wpcomsh/changelog/mu-wpcom-coblocks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/8208

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Port enqueue_coblocks_gallery_scripts from the ETK. I'm unsure whether it's still in use (the feature requires the specific blocks in the header/footer of the legacy fse) so just moving the code from ETK to jetpack-mu-wpcom to avoid missing something

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site
* Just make sure nothing broken

