### PR TITLE
Increased pre-push hook buffer to avoid truncation.

### DIFF
--- a/tools/js-tools/git-hooks/pre-push-hook.js
+++ b/tools/js-tools/git-hooks/pre-push-hook.js
@@ -20,16 +20,12 @@ function checkFilenameCollisions() {
 
 	const compare = Intl.Collator( 'und', { sensitivity: 'accent' } ).compare;
 
-	const files = spawnSync( 'git', [
-		'-c',
-		'core.quotepath=off',
-		'ls-tree',
-		'-rt',
-		'--name-only',
-		'HEAD',
-	] )
+	const files = spawnSync(
+		'git',
+		[ '-c', 'core.quotepath=off', 'ls-tree', '-rt', '--name-only', 'HEAD' ],
+		{ maxBuffer: 4096 * 1024 }
+	)
 		.stdout.toString()
-		.trim()
 		.split( '\n' )
 		.sort( compare );
 

--- a/tools/js-tools/git-hooks/pre-push-hook.js
+++ b/tools/js-tools/git-hooks/pre-push-hook.js
@@ -26,6 +26,7 @@ function checkFilenameCollisions() {
 		{ maxBuffer: 4096 * 1024 }
 	)
 		.stdout.toString()
+		.trim()
 		.split( '\n' )
 		.sort( compare );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a problem with STDOUT buffer truncation that could cause a duplicate file check to show a false positive. For example, when a list of files gets truncated at a certain position like this:

```
...
projects/plugins/wpcomsh
projects/plugins/wpcomsh/.circleci
projects/plugins/wpcomsh <--- TRUNCATED HERE
```

We are ending up with two same strings, causing the pre-push hook to misfire.

## Proposed changes:
* Increase the standard out stream buffer to four times its default value.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1722427972550539-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
* Run `node ./tools/js-tools/git-hooks/pre-push-hook.js` to make sure the hook works properly and doesn't report false positives.