### PR TITLE
fix: Handle possible `null` return from `get_current_screen`

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-handle-get-current-screen-null-return
+++ b/projects/plugins/jetpack/changelog/fix-handle-get-current-screen-null-return
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Gutenberg: Handle potential `null` return from `get_current_screen`

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -697,7 +697,8 @@ class Jetpack_Gutenberg {
 
 		$screen_base = null;
 		if ( function_exists( 'get_current_screen' ) ) {
-			$screen_base = get_current_screen()->base;
+			$current_screen = get_current_screen();
+			$screen_base    = $current_screen ? $current_screen->base : null;
 		}
 
 		$modules = array();

--- a/projects/plugins/jetpack/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/tests/php/general/test-class.jetpack-gutenberg.php
@@ -306,4 +306,32 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 		$this->assertFalse( $validated_url );
 	}
+
+	public function test_enqueue_block_editor_assets_handles_null_current_screen() {
+		// Simulate a context with null current_screen.
+		global $current_screen;
+		$previous_current_screen = $current_screen;
+		$current_screen          = null;
+		// Ensure that the block editor scripts and styles are loaded.
+		add_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
+
+		Jetpack_Gutenberg::enqueue_block_editor_assets();
+
+		// Check that the method did not throw an error.
+		$this->assertTrue( true );
+
+		$current_screen = $previous_current_screen;
+	}
+
+	public function test_enqueue_block_editor_assets_handles_defined_current_screen() {
+		// Simulate context with defined current_screen.
+		set_current_screen( 'edit-post' );
+		// Ensure that the block editor scripts and styles are loaded.
+		add_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
+
+		Jetpack_Gutenberg::enqueue_block_editor_assets();
+
+		// Check that the method did not throw an error.
+		$this->assertTrue( true );
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Handle the scenario where WordPress core's [`get_current_screen`](https://developer.wordpress.org/reference/functions/get_current_screen/) returns a `null` value. This is an unlikely scenario in the context of the editor loaded in WP Admin, but can occur in other contexts. E.g., within execution of an API endpoint request. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No conversations occurred leading up to this change. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

TBD

