### PR TITLE
Newsletter: Email preview: Access Selector improvementes

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_
 use Automattic\Jetpack\Status\Host;
 
 require_once __DIR__ . '/trait-wpcom-rest-api-proxy-request-trait.php';
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Email_Preview
@@ -135,7 +136,7 @@ class WPCOM_REST_API_V2_Endpoint_Email_Preview extends WP_REST_Controller {
 				/**
 				* Filters the generated email preview HTML.
 				*
-				* @since $$next_version$$
+				* @since $$next-version$$
 				*
 				* @param string $html   The generated HTML for the email preview.
 				* @param WP_Post $post  The post object.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php
@@ -132,6 +132,15 @@ class WPCOM_REST_API_V2_Endpoint_Email_Preview extends WP_REST_Controller {
 		$post    = get_post( $post_id );
 		return rest_ensure_response(
 			array(
+				/**
+				* Filters the generated email preview HTML.
+				*
+				* @since $$next_version$$
+				*
+				* @param string $html   The generated HTML for the email preview.
+				* @param WP_Post $post  The post object.
+				* @param string $access The access level.
+				*/
 				'html' => apply_filters( 'jetpack_generate_email_preview_html', '', $post, $access ),
 			)
 		);

--- a/projects/plugins/jetpack/changelog/update-email-preview-access-selector
+++ b/projects/plugins/jetpack/changelog/update-email-preview-access-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Already in a previous changelog entry

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -8,8 +8,9 @@ import {
 	Modal,
 	TextControl,
 	Icon,
-	SelectControl,
-	ButtonGroup,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 	Spinner,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -125,30 +126,22 @@ const devices = [
 ];
 
 const DevicePicker = ( { selectedDevice, setSelectedDevice } ) => (
-	<ButtonGroup>
+	<ToggleGroupControl
+		__nextHasNoMarginBottom
+		onChange={ setSelectedDevice }
+		value={ selectedDevice }
+	>
 		{ devices.map( device => (
-			<Button
-				key={ device.name }
-				label={ device.label }
+			<ToggleGroupControlOptionIcon
 				icon={ device.icon }
-				isSmall
-				isPressed={ selectedDevice === device.name }
-				onClick={ () => setSelectedDevice( device.name ) }
-				style={ {
-					width: '36px',
-					height: '36px',
-				} }
+				value={ device.name }
+				label={ device.label }
 			/>
 		) ) }
-	</ButtonGroup>
+	</ToggleGroupControl>
 );
 
-const HeaderActions = ( {
-	selectedAccess,
-	setSelectedAccess,
-	selectedDevice,
-	setSelectedDevice,
-} ) => {
+const AccessPicker = ( { selectedAccess, setSelectedAccess } ) => {
 	const filteredAccessOptions = {
 		subscribers: accessOptions.subscribers,
 		paid_subscribers: accessOptions.paid_subscribers,
@@ -157,18 +150,30 @@ const HeaderActions = ( {
 		label: option.label,
 		value: option.key,
 	} ) );
-
 	return (
-		<HStack alignment="center" spacing={ 6 }>
+		<ToggleGroupControl
+			__nextHasNoMarginBottom
+			onChange={ setSelectedAccess }
+			value={ selectedAccess }
+			isBlock
+		>
+			{ accessOptionsList.map( access => (
+				<ToggleGroupControlOption value={ access.value } label={ access.label } />
+			) ) }
+		</ToggleGroupControl>
+	);
+};
+
+const HeaderActions = ( {
+	selectedAccess,
+	setSelectedAccess,
+	selectedDevice,
+	setSelectedDevice,
+} ) => {
+	return (
+		<HStack alignment="center" spacing={ 6 } style={ { width: '100%' } }>
 			<DevicePicker selectedDevice={ selectedDevice } setSelectedDevice={ setSelectedDevice } />
-			<SelectControl
-				prefix={ __( 'Access:', 'jetpack' ) }
-				value={ selectedAccess }
-				options={ accessOptionsList }
-				onChange={ value => setSelectedAccess( value ) }
-				className="jetpack-email-preview-select-control"
-				__nextHasNoMarginBottom
-			/>
+			<AccessPicker selectedAccess={ selectedAccess } setSelectedAccess={ setSelectedAccess } />
 		</HStack>
 	);
 };

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -149,7 +149,11 @@ const HeaderActions = ( {
 	selectedDevice,
 	setSelectedDevice,
 } ) => {
-	const accessOptionsList = Object.values( accessOptions ).map( option => ( {
+	const filteredAccessOptions = {
+		subscribers: accessOptions.subscribers,
+		paid_subscribers: accessOptions.paid_subscribers,
+	};
+	const accessOptionsList = Object.values( filteredAccessOptions ).map( option => ( {
 		label: option.label,
 		value: option.key,
 	} ) );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -8,8 +8,11 @@ import {
 	Modal,
 	TextControl,
 	Icon,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 	Spinner,
 } from '@wordpress/components';

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -176,7 +176,7 @@ const HeaderActions = ( {
 export function PreviewModal( { isOpen, onClose, postId } ) {
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ previewCache, setPreviewCache ] = useState( {} );
-	const [ selectedAccess, setSelectedAccess ] = useState( accessOptions.everybody.key );
+	const [ selectedAccess, setSelectedAccess ] = useState( accessOptions.subscribers.key );
 	const [ selectedDevice, setSelectedDevice ] = useState( 'desktop' );
 
 	const fetchPreview = useCallback(
@@ -217,7 +217,7 @@ export function PreviewModal( { isOpen, onClose, postId } ) {
 	);
 
 	useEffect( () => {
-		if ( isOpen && ! previewCache[ selectedAccess ] ) {
+		if ( isOpen && ! previewCache.hasOwnProperty( selectedAccess ) ) {
 			fetchPreview( selectedAccess );
 		} else if ( isOpen ) {
 			setIsLoading( false );
@@ -257,7 +257,7 @@ export function PreviewModal( { isOpen, onClose, postId } ) {
 						<Spinner />
 					) : (
 						<iframe
-							srcDoc={ previewCache[ selectedAccess ] }
+							srcDoc={ previewCache?.[ selectedAccess ] }
 							style={ {
 								width: deviceWidth,
 								height: '100%',

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -130,6 +130,7 @@ const DevicePicker = ( { selectedDevice, setSelectedDevice } ) => (
 		__nextHasNoMarginBottom
 		onChange={ setSelectedDevice }
 		value={ selectedDevice }
+		isBlock
 	>
 		{ devices.map( device => (
 			<ToggleGroupControlOptionIcon
@@ -142,20 +143,23 @@ const DevicePicker = ( { selectedDevice, setSelectedDevice } ) => (
 );
 
 const AccessPicker = ( { selectedAccess, setSelectedAccess } ) => {
-	const filteredAccessOptions = {
-		subscribers: accessOptions.subscribers,
-		paid_subscribers: accessOptions.paid_subscribers,
-	};
-	const accessOptionsList = Object.values( filteredAccessOptions ).map( option => ( {
-		label: option.label,
-		value: option.key,
-	} ) );
+	const accessOptionsList = [
+		{
+			label: __( 'Subscribers', 'jetpack' ),
+			value: accessOptions.subscribers.key,
+		},
+		{
+			label: __( 'Paid Subscribers', 'jetpack' ),
+			value: accessOptions.paid_subscribers.key,
+		},
+	];
 	return (
 		<ToggleGroupControl
 			__nextHasNoMarginBottom
 			onChange={ setSelectedAccess }
 			value={ selectedAccess }
 			isBlock
+			isAdaptiveWidth
 		>
 			{ accessOptionsList.map( access => (
 				<ToggleGroupControlOption value={ access.value } label={ access.label } />

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.scss
@@ -62,13 +62,6 @@
 }
 
 .jetpack-preview-email-modal-overlay {
-  .components-modal__header-heading {
-    font-size: 20px;
-    font-weight: 400;
-    line-height: 28px;
-    white-space: nowrap;
-  }
-
   .jetpack-email-preview-select-control .components-input-control__prefix {
     margin-left: 18px;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<img width="1512" alt="Screenshot 2024-08-07 at 12 30 22 PM" src="https://github.com/user-attachments/assets/8ad275bb-3cd4-4a22-a11e-29a223f869d9">

<img width="1512" alt="Screenshot 2024-08-07 at 12 30 37 PM" src="https://github.com/user-attachments/assets/eabf8dcc-d6dd-461f-938e-456b60abf090">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D157745-code.
* Sync this branch to your sandbox.
* Point `JETPACK__SANDBOX_DOMAIN` to your sandbox.
* Add paywall block.
* Use different combinations of post access and preview access.
* Set the feature flag by adding `&showNewsletterMenu` to the url.