### PR TITLE
Simple Classic: make Users -> Profile -> Email input readonly instead of disabled

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-disabled-email-address
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-disabled-email-address
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Simple Classic: make Users -> Profile -> Email input readonly instead of disabled

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -7,7 +7,7 @@ const wpcom_profile_settings_disable_email_field = () => {
 	}
 	const emailField = document.getElementById( 'email' ) as HTMLInputElement;
 	if ( emailField ) {
-		emailField.disabled = true;
+		emailField.readOnly = true;
 	}
 
 	const emailDescription = document.getElementById( 'email-description' ) as HTMLInputElement;


### PR DESCRIPTION
## Proposed changes:

#38638 broke Simple Classic: we can no longer save anything on the profile.php as we will get this error 🤦‍♂️ 

<img width="319" alt="image" src="https://github.com/user-attachments/assets/1dcd22d9-8f06-435c-901c-914487d30b62">

This is because the Email input is disabled, which will prevent the form from submitting the value.

With this PR, we make it as readonly instead, so that the value is still submitted (but still not editable).

|Before|After|
|-|-|
|<img width="744" alt="image" src="https://github.com/user-attachments/assets/baaa2136-5451-44ea-b602-83ce51c51c21">|<img width="744" alt="image" src="https://github.com/user-attachments/assets/151b5bac-0a02-4a24-9660-6d5673fb4cde">|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

1. Patch this to your sandbox.
2. Sandbox a Simple Classic site.
3. Go to Users -> Profile.
4. Verify you can save anything.

