### PR TITLE
Readymade Templates: Use `setup_general` task in Launchpad

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-rt-launchpad
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-rt-launchpad
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Minor change to replace a launchpad task of the RT flow
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -263,7 +263,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'task_ids'            => array(
 				'verify_domain_email',
 				'design_selected',
-				'setup_free',
+				'site_title',
 				'generate_content',
 				'plan_completed',
 				'domain_upsell',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -263,7 +263,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'task_ids'            => array(
 				'verify_domain_email',
 				'design_selected',
-				'site_title',
+				'setup_general',
 				'generate_content',
 				'plan_completed',
 				'domain_upsell',


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/8588

## Proposed changes:

Replaces the `setup_free` launchpad task with the `setup_general` one for the Readymade Template flow. 

Before | After
--- | ---
<img width="399" alt="Screenshot 2024-08-07 at 11 03 48" src="https://github.com/user-attachments/assets/cd1c423b-1fa2-4b40-a69a-035e705b4013"> | <img width="387" alt="Screenshot 2024-08-07 at 11 04 26" src="https://github.com/user-attachments/assets/f3cce032-0f1b-4816-a902-a6afb0fcffe3">
<img width="1337" alt="Screenshot 2024-08-07 at 11 04 12" src="https://github.com/user-attachments/assets/5f90104d-445a-4d7c-9033-bc7c868db7eb"> | <img width="1248" alt="Screenshot 2024-08-07 at 11 26 23" src="https://github.com/user-attachments/assets/28aaf3ea-3391-4f08-9dd5-85ca6d8eeed9">


This way, users have a way to go back to the Launchpad.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WP.com sandbox
- Sandbox the API
- Go to https://wpcalypso.wordpress.com/patterns
- Scroll down to the "Site layouts" sections
- Pick a layout
- Once the site is created, check the Launchpad tasks
- Make sure there is a "Give your site a name" task
- Select it
- Make sure you update your site title and tagline there.
- Make sure you can go back to the Launchpad

