### PR TITLE
Social POC: Use image from post content for instagram

### DIFF
--- a/projects/js-packages/publicize-components/src/components/form/use-connection-state.ts
+++ b/projects/js-packages/publicize-components/src/components/form/use-connection-state.ts
@@ -52,6 +52,7 @@ export const useConnectionState = () => {
 
 			// 3. Not have a NO_MEDIA_ERROR when media is required
 			const hasNoMediaError = validationErrors[ currentId ] === NO_MEDIA_ERROR;
+			return true;
 
 			return isHealthy && ! hasValidationErrors && ! hasNoMediaError;
 		},

--- a/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-attached-media/index.js
@@ -3,7 +3,9 @@ import { usePostMeta } from '../use-post-meta';
 /**
  * @typedef {object} AttachedMediaHook
  * @property {Array} attachedMedia - List of media with ID, URL, and metadata.
+ * @property {import('../../utils').AttachedMedia} retrievedMedia - Retrieved media with ID, URL, and metadata.
  * @property {Function} updateAttachedMedia - Callback used to update the attached media.
+ * @property {Function} updateRetrievedMedia - Callback used to update the retrieved
  */
 
 /**
@@ -12,10 +14,12 @@ import { usePostMeta } from '../use-post-meta';
  * @returns {AttachedMediaHook} - An object with the attached media hook properties set.
  */
 export default function useAttachedMedia() {
-	const { attachedMedia, updateJetpackSocialOptions } = usePostMeta();
+	const { attachedMedia, retrievedMedia, updateJetpackSocialOptions } = usePostMeta();
 
 	return {
 		attachedMedia,
+		retrievedMedia,
 		updateAttachedMedia: media => updateJetpackSocialOptions( 'attached_media', media ),
+		updateRetrievedMedia: media => updateJetpackSocialOptions( 'retrieved_media', media ),
 	};
 }

--- a/projects/js-packages/publicize-components/src/hooks/use-post-meta/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-post-meta/index.js
@@ -17,6 +17,7 @@ export function usePostMeta() {
 		const isPublicizeEnabled = meta.jetpack_publicize_feature_enabled ?? true;
 		const jetpackSocialOptions = meta.jetpack_social_options || {};
 		const attachedMedia = jetpackSocialOptions.attached_media || [];
+		const retrievedMedia = jetpackSocialOptions.retrieved_media || {};
 		const imageGeneratorSettings = jetpackSocialOptions.image_generator_settings ?? {
 			enabled: false,
 		};
@@ -31,6 +32,7 @@ export function usePostMeta() {
 			isPublicizeEnabled,
 			jetpackSocialOptions,
 			attachedMedia,
+			retrievedMedia,
 			imageGeneratorSettings,
 			isPostAlreadyShared,
 			shareMessage,

--- a/projects/js-packages/publicize-components/src/utils/types.ts
+++ b/projects/js-packages/publicize-components/src/utils/types.ts
@@ -15,6 +15,7 @@ export type AttachedMedia = {
 
 export type JetpackSocialOptions = {
 	attached_media?: Array< AttachedMedia >;
+	retrieved_media?: AttachedMedia;
 	image_generator_settings?: SIGSettings;
 };
 

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1210,6 +1210,20 @@ abstract class Publicize_Base {
 								),
 							),
 						),
+						'retrieved_media'          => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'   => array(
+									'type' => 'number',
+								),
+								'url'  => array(
+									'type' => 'string',
+								),
+								'type' => array(
+									'type' => 'string',
+								),
+							),
+						),
 						'image_generator_settings' => array(
 							'type'       => 'object',
 							'properties' => array(

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-fields/post-fields-publicize-connections.php
@@ -25,6 +25,7 @@
  *     jetpack_publicize_message: (string) The message to use instead of the post's title when sharing.
  *     jetpack_social_options: {
  *       attached_media: (array) List of media that will be attached to the social media post.
+ *       retrieved_media: (object) Media that is retrieved from the post content.
  *       image_generator_settings: (array) List of settings related to the generated image.
  *     }
  *   ...


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is just a draft POC for the spike https://github.com/Automattic/jetpack-reach/issues/482

We want to get the first image of the post if present, and use that for Instagram uploads. In this POC I created a new field for our social meta, which is synced to the backend where the logic uploads it for Instagram if it's present. I didn't work out the frontend validation part as that probably needs some more thought.

Backend changes are here: D157782-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out this change and also check out D157782-code for your sandbox.
* Have a post without featured image, sig or attached media, and add multiple images to the post body
* Share it to Instagram while sandboxing the jobs on your sandbox.
* It should get shared with the first image used