### PR TITLE
Fix/payments correct link to setup plans

### DIFF
--- a/projects/plugins/jetpack/_inc/client/earn/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/earn/index.jsx
@@ -129,7 +129,7 @@ function Earn( props ) {
 					featureName="payments"
 					title={ __( 'Collect payments', 'jetpack' ) }
 					supportLink={ getRedirectUrl( 'jetpack-support-jetpack-blocks-payments-block' ) }
-					infoLink={ getRedirectUrl( 'wpcom-earn-payments', {
+					infoLink={ getRedirectUrl( 'jetpack-earn-payments', {
 						site: blogID ?? siteRawUrl,
 					} ) }
 					infoDescription={ __(
@@ -143,7 +143,7 @@ function Earn( props ) {
 					featureName="donations"
 					title={ __( 'Accept donations and tips', 'jetpack' ) }
 					supportLink={ getRedirectUrl( 'jetpack-support-jetpack-blocks-donations-block' ) }
-					infoLink={ getRedirectUrl( 'wpcom-earn-payments', {
+					infoLink={ getRedirectUrl( 'jetpack-earn-payments', {
 						site: blogID ?? siteRawUrl,
 					} ) }
 					infoDescription={ __(

--- a/projects/plugins/jetpack/changelog/fix-payments-correct-link-to-setup-plans
+++ b/projects/plugins/jetpack/changelog/fix-payments-correct-link-to-setup-plans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Payment blocks: link to Jetpack Cloud for Jetpack sites

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -6,6 +6,8 @@ import {
 	JetpackEditorPanelLogo,
 	useAnalytics,
 	useModuleStatus,
+	isSimpleSite,
+	isAtomicSite,
 } from '@automattic/jetpack-shared-extension-utils';
 import { Button, ExternalLink, Flex, FlexItem, Notice, PanelRow } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -200,6 +202,9 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 		};
 	} );
 
+	const isJetpackSite = ! isAtomicSite() && ! isSimpleSite();
+	const monetizeRedirectUrl = isJetpackSite ? 'jetpack-monetize' : 'wpcom-earn';
+
 	return (
 		<>
 			<PluginPostPublishPanel
@@ -229,7 +234,7 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 						<Button
 							target="_blank"
 							variant="secondary"
-							href={ getRedirectUrl( 'wpcom-earn', {
+							href={ getRedirectUrl( monetizeRedirectUrl, {
 								site: getSiteFragment(),
 							} ) }
 						>

--- a/projects/plugins/jetpack/extensions/shared/memberships/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/utils.js
@@ -1,4 +1,9 @@
-import { isSimpleSite, isAtomicSite } from '@automattic/jetpack-shared-extension-utils';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import {
+	getSiteFragment,
+	isSimpleSite,
+	isAtomicSite,
+} from '@automattic/jetpack-shared-extension-utils';
 import { Button, ToolbarButton, Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { _x, __ } from '@wordpress/i18n';
@@ -25,15 +30,19 @@ export const encodeValueForShortcodeAttribute = value => {
 
 export const getPaidPlanLink = alreadyHasTierPlans => {
 	const isJetpackSite = ! isAtomicSite() && ! isSimpleSite();
-
-	const base = isJetpackSite
-		? 'https://cloud.jetpack.com/monetize/payments/'
-		: 'https://wordpress.com/earn/payments/';
-
-	const link = base + location.hostname;
+	const site = getSiteFragment();
+	let redirectUrl = isJetpackSite ? 'jetpack-earn-payments' : 'wpcom-earn-payments';
 
 	// We force the "Newsletters plan" link only if there is no plans already created
-	return alreadyHasTierPlans ? link : link + '#add-tier-plan';
+	if ( alreadyHasTierPlans ) {
+		redirectUrl = isJetpackSite
+			? 'jetpack-earn-payments-add-tier-plan'
+			: 'wpcom-earn-payments-add-tier-plan';
+	}
+
+	return getRedirectUrl( redirectUrl, {
+		site,
+	} );
 };
 
 export const getShowMisconfigurationWarning = ( postVisibility, accessLevel ) => {

--- a/projects/plugins/jetpack/extensions/shared/memberships/utils.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/utils.js
@@ -1,3 +1,4 @@
+import { isSimpleSite, isAtomicSite } from '@automattic/jetpack-shared-extension-utils';
 import { Button, ToolbarButton, Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { _x, __ } from '@wordpress/i18n';
@@ -23,7 +24,14 @@ export const encodeValueForShortcodeAttribute = value => {
 };
 
 export const getPaidPlanLink = alreadyHasTierPlans => {
-	const link = 'https://wordpress.com/earn/payments/' + location.hostname;
+	const isJetpackSite = ! isAtomicSite() && ! isSimpleSite();
+
+	const base = isJetpackSite
+		? 'https://cloud.jetpack.com/monetize/payments/'
+		: 'https://wordpress.com/earn/payments/';
+
+	const link = base + location.hostname;
+
 	// We force the "Newsletters plan" link only if there is no plans already created
 	return alreadyHasTierPlans ? link : link + '#add-tier-plan';
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves https://github.com/Automattic/jetpack/issues/38766

Links opening payment setup for Jetpack & WP.com sites now open to `wordpress.com/earn/` for everyone. This changes Jetpack sites to go for Jetpack Cloud version instead.

<img width="943" alt="image" src="https://github.com/user-attachments/assets/733ceaa4-b370-4e86-a792-95be83184130">

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Link to Jetpack Cloud for Monetize UI for Jetpack sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add subscribe block; "setup plan" should bring you to Jetpack Cloud from Jetpack site.
* Sync PR to WP.com, and try the block there. You should end up in Monetize dash in Calypso blue.
* See Jetpack -> Settings -> Earn, and all setup links now point to Jetpack Cloud. This UI is just for Jetpack sites.