### PR TITLE
Admin menu: update order of submenu items within the Jetpack menu.

### DIFF
--- a/projects/packages/admin-ui/changelog/update-jetpack-admin-menu-order
+++ b/projects/packages/admin-ui/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.4.2",
+	"version": "0.4.3-alpha",
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",
 	"bugs": {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack\Admin_UI;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.4.2';
+	const PACKAGE_VERSION = '0.4.3-alpha';
 
 	/**
 	 * Whether this class has been initialized
@@ -58,7 +58,14 @@ class Admin_Menu {
 					remove_action( 'admin_menu', array( 'Akismet_Admin', 'admin_menu' ), 5 );
 
 					// Add an Anti-spam menu item for Jetpack.
-					self::add_menu( __( 'Akismet Anti-spam', 'jetpack-admin-ui' ), __( 'Akismet Anti-spam', 'jetpack-admin-ui' ), 'manage_options', 'akismet-key-config', array( 'Akismet_Admin', 'display_page' ) );
+					self::add_menu(
+						__( 'Akismet Anti-spam', 'jetpack-admin-ui' ),
+						__( 'Akismet Anti-spam', 'jetpack-admin-ui' ),
+						'manage_options',
+						'akismet-key-config',
+						array( 'Akismet_Admin', 'display_page' ),
+						9
+					);
 				},
 				4
 			);

--- a/projects/packages/backup/changelog/update-jetpack-admin-menu-order
+++ b/projects/packages/backup/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -124,7 +124,8 @@ class Jetpack_Backup {
 			_x( 'VaultPress Backup', 'The Jetpack VaultPress Backup product name, without the Jetpack prefix', 'jetpack-backup-pkg' ),
 			'manage_options',
 			'jetpack-backup',
-			array( __CLASS__, 'plugin_settings_page' )
+			array( __CLASS__, 'plugin_settings_page' ),
+			10
 		);
 		add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
 

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.4.2';
+	const PACKAGE_VERSION = '3.4.3-alpha';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/my-jetpack/changelog/update-jetpack-admin-menu-order
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.32.0",
+	"version": "4.32.1-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-activitylog.php
+++ b/projects/packages/my-jetpack/src/class-activitylog.php
@@ -51,7 +51,7 @@ class Activitylog {
 			'manage_options',
 			esc_url( Redirect::get_url( 'cloud-activity-log-wp-menu', $args ) ),
 			null,
-			1
+			2
 		);
 	}
 }

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -41,7 +41,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.32.0';
+	const PACKAGE_VERSION = '4.32.1-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-jetpack-manage.php
+++ b/projects/packages/my-jetpack/src/class-jetpack-manage.php
@@ -49,7 +49,7 @@ class Jetpack_Manage {
 			'manage_options',
 			esc_url( Redirect::get_url( 'cloud-manage-dashboard-wp-menu', $args ) ),
 			null,
-			100
+			3
 		);
 	}
 

--- a/projects/packages/search/changelog/update-jetpack-admin-menu-order
+++ b/projects/packages/search/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-search",
-	"version": "0.44.14",
+	"version": "0.44.15-alpha",
 	"description": "Package for Jetpack Search products",
 	"main": "main.js",
 	"directories": {

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Search;
  * Search package general information
  */
 class Package {
-	const VERSION = '0.44.14';
+	const VERSION = '0.44.15-alpha';
 	const SLUG    = 'search';
 
 	/**

--- a/projects/packages/search/src/dashboard/class-dashboard.php
+++ b/projects/packages/search/src/dashboard/class-dashboard.php
@@ -102,7 +102,8 @@ class Dashboard {
 				_x( 'Search', 'product name shown in menu', 'jetpack-search-pkg' ),
 				'manage_options',
 				'jetpack-search',
-				array( $this, 'render' )
+				array( $this, 'render' ),
+				11
 			);
 		} else {
 			// always add the page, but hide it from the menu.

--- a/projects/packages/stats-admin/changelog/update-jetpack-admin-menu-order
+++ b/projects/packages/stats-admin/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.21.0",
+	"version": "0.21.1-alpha",
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",
 	"bugs": {

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -60,7 +60,8 @@ class Dashboard {
 			_x( 'Stats', 'product name shown in menu', 'jetpack-stats-admin' ),
 			'manage_options',
 			'stats',
-			array( $this, 'render' )
+			array( $this, 'render' ),
+			4
 		);
 
 		if ( $page_suffix ) {

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -22,7 +22,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.21.0';
+	const VERSION = '0.21.1-alpha';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/videopress/changelog/update-jetpack-admin-menu-order
+++ b/projects/packages/videopress/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.30",
+	"version": "0.23.31-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -39,7 +39,8 @@ class Admin_UI {
 			_x( 'VideoPress', 'The Jetpack VideoPress product name, without the Jetpack prefix', 'jetpack-videopress-pkg' ),
 			'manage_options',
 			self::ADMIN_PAGE_SLUG,
-			array( __CLASS__, 'plugin_settings_page' )
+			array( __CLASS__, 'plugin_settings_page' ),
+			6
 		);
 		add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
 

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.30';
+	const PACKAGE_VERSION = '0.23.31-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/wordads/changelog/update-jetpack-admin-menu-order
+++ b/projects/packages/wordads/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/packages/wordads/package.json
+++ b/projects/packages/wordads/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-wordads",
-	"version": "0.3.25",
+	"version": "0.3.26-alpha",
 	"description": "Earn income by allowing Jetpack to display high quality ads.",
 	"main": "main.js",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/wordads/#readme",

--- a/projects/packages/wordads/src/class-package.php
+++ b/projects/packages/wordads/src/class-package.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\WordAds;
  * WordAds package general information
  */
 class Package {
-	const VERSION = '0.3.25';
+	const VERSION = '0.3.26-alpha';
 	const SLUG    = 'wordads';
 
 	/**

--- a/projects/packages/wordads/src/dashboard/class-dashboard.php
+++ b/projects/packages/wordads/src/dashboard/class-dashboard.php
@@ -55,7 +55,8 @@ class Dashboard {
 			_x( 'WordAds', 'product name shown in menu', 'jetpack-wordads' ),
 			'manage_options',
 			'jetpack-wordads',
-			array( $this, 'render' )
+			array( $this, 'render' ),
+			15
 		);
 
 		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );

--- a/projects/plugins/beta/changelog/update-jetpack-admin-menu-order
+++ b/projects/plugins/beta/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/plugins/beta/src/class-admin.php
+++ b/projects/plugins/beta/src/class-admin.php
@@ -41,7 +41,8 @@ class Admin {
 			'Beta Tester',
 			'update_plugins',
 			'jetpack-beta',
-			array( self::class, 'render' )
+			array( self::class, 'render' ),
+			16
 		);
 
 		if ( false !== self::$hookname ) {

--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -53,7 +53,8 @@ class Admin {
 			$menu_label,
 			'manage_options',
 			JETPACK_BOOST_SLUG,
-			array( $this, 'render_settings' )
+			array( $this, 'render_settings' ),
+			5
 		);
 		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
 	}

--- a/projects/plugins/boost/changelog/update-jetpack-admin-menu-order
+++ b/projects/plugins/boost/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -1,5 +1,6 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
@@ -78,6 +79,21 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	}
 
 	/**
+	 * Remove the main Jetpack submenu if a site is in offline mode or connected.
+	 * At that point, admins can access the Jetpack Dashboard instead.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function remove_jetpack_menu() {
+		if (
+			( new Status() )->is_offline_mode()
+			|| Jetpack::is_connection_ready()
+		) {
+			remove_submenu_page( 'jetpack', 'jetpack' );
+		}
+	}
+
+	/**
 	 * Add Jetpack Dashboard sub-link and point it to AAG if the user can view stats, manage modules or if Protect is active.
 	 *
 	 * Works in Dev Mode or when user is connected.
@@ -85,9 +101,18 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @since 4.3.0
 	 */
 	public function jetpack_add_dashboard_sub_nav_item() {
-		if ( ( new Status() )->is_offline_mode() || Jetpack::is_connection_ready() ) {
-			add_submenu_page( 'jetpack', __( 'Dashboard', 'jetpack' ), __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'jetpack#/dashboard', '__return_null', 1 );
-			remove_submenu_page( 'jetpack', 'jetpack' );
+		if (
+			( new Status() )->is_offline_mode()
+			|| Jetpack::is_connection_ready()
+		) {
+			Admin_Menu::add_menu(
+				__( 'Dashboard', 'jetpack' ),
+				__( 'Dashboard', 'jetpack' ),
+				'jetpack_admin_page',
+				Jetpack::admin_url( array( 'page' => 'jetpack#/dashboard' ) ),
+				null,
+				12
+			);
 		}
 	}
 
@@ -165,7 +190,14 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 */
 	public function jetpack_add_settings_sub_nav_item() {
 		if ( $this->can_access_settings() ) {
-			add_submenu_page( 'jetpack', __( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'jetpack_admin_page', 'jetpack#/settings', '__return_null' );
+			Admin_Menu::add_menu(
+				__( 'Settings', 'jetpack' ),
+				__( 'Settings', 'jetpack' ),
+				'jetpack_admin_page',
+				Jetpack::admin_url( array( 'page' => 'jetpack#/settings' ) ),
+				null,
+				13
+			);
 		}
 	}
 

--- a/projects/plugins/jetpack/changelog/update-jetpack-admin-menu-order
+++ b/projects/plugins/jetpack/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -64,6 +64,7 @@ class Jetpack_Admin {
 
 		add_action( 'admin_init', array( $jetpack_react, 'react_redirects' ), 0 );
 		add_action( 'admin_menu', array( $jetpack_react, 'add_actions' ), 998 );
+		add_action( 'admin_menu', array( $jetpack_react, 'remove_jetpack_menu' ), 1000 );
 		add_action( 'jetpack_admin_menu', array( $jetpack_react, 'jetpack_add_dashboard_sub_nav_item' ) );
 		add_action( 'jetpack_admin_menu', array( $jetpack_react, 'jetpack_add_settings_sub_nav_item' ) );
 		add_action( 'jetpack_admin_menu', array( $this, 'admin_menu_debugger' ) );

--- a/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Scan;
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\My_Jetpack\Products\Backup;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status\Host;
@@ -68,22 +69,40 @@ class Admin_Sidebar_Link {
 		}
 
 		if ( $this->should_show_scan() ) {
-			$menu_label = __( 'Scan', 'jetpack' );
-			$url        = Redirect::get_url( 'calypso-scanner' );
-			add_submenu_page( 'jetpack', $menu_label, esc_html( $menu_label ) . ' <span class="dashicons dashicons-external"></span>', 'manage_options', esc_url( $url ), null, $this->get_link_offset() );
+			Admin_Menu::add_menu(
+				__( 'Scan', 'jetpack' ),
+				__( 'Scan', 'jetpack' ) . ' <span class="dashicons dashicons-external"></span>',
+				'manage_options',
+				esc_url( Redirect::get_url( 'calypso-scanner' ) ),
+				null,
+				10
+			);
 		}
 
-		// Add scan item which shows history page only. This is mutally exclusive from the scan item above and is only shown for Atomic sitse.
+		/*
+		 * Add scan item which shows history page only.
+		 * This is mutally exclusive from the scan item above and is only shown for Atomic sites.
+		 */
 		if ( $this->should_show_scan_history_only() ) {
-			$menu_label = __( 'Scan', 'jetpack' );
-			$url        = Redirect::get_url( 'cloud-scan-history-wp-menu' );
-			add_submenu_page( 'jetpack', $menu_label, esc_html( $menu_label ) . ' <span class="dashicons dashicons-external"></span>', 'manage_options', esc_url( $url ), null, $this->get_link_offset() );
+			Admin_Menu::add_menu(
+				__( 'Scan', 'jetpack' ),
+				__( 'Scan', 'jetpack' ) . ' <span class="dashicons dashicons-external"></span>',
+				'manage_options',
+				esc_url( Redirect::get_url( 'cloud-scan-history-wp-menu' ) ),
+				null,
+				10
+			);
 		}
 
 		if ( $this->should_show_backup() ) {
-			$menu_label = __( 'VaultPress', 'jetpack' );
-			$url        = Redirect::get_url( 'calypso-backups' );
-			add_submenu_page( 'jetpack', $menu_label, esc_html( $menu_label ) . ' <span class="dashicons dashicons-external"></span>', 'manage_options', esc_url( $url ), null, $this->get_link_offset() );
+			Admin_Menu::add_menu(
+				__( 'VaultPress', 'jetpack' ),
+				__( 'VaultPress', 'jetpack' ) . ' <span class="dashicons dashicons-external"></span>',
+				'manage_options',
+				esc_url( Redirect::get_url( 'calypso-backups' ) ),
+				null,
+				10
+			);
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -251,7 +251,14 @@ function stats_admin_menu() {
 	} else {
 		// Enable the new Odyssey Stats experience.
 		$stats_dashboard = new Stats_Dashboard();
-		$hook            = Admin_Menu::add_menu( __( 'Stats', 'jetpack' ), __( 'Stats', 'jetpack' ), 'view_stats', 'stats', array( $stats_dashboard, 'render' ) );
+		$hook            = Admin_Menu::add_menu(
+			__( 'Stats', 'jetpack' ),
+			__( 'Stats', 'jetpack' ),
+			'view_stats',
+			'stats',
+			array( $stats_dashboard, 'render' ),
+			4
+		);
 		add_action( "load-$hook", array( $stats_dashboard, 'admin_init' ) );
 	}
 }

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -15,6 +15,7 @@
 
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\XMLRPC_Async_Call;
 use Automattic\Jetpack\Redirect;
@@ -1031,13 +1032,13 @@ class Jetpack_Subscriptions {
 			array( 'site' => $blog_id ? $blog_id : $status->get_site_suffix() )
 		);
 
-		add_submenu_page(
-			'jetpack',
-			esc_attr__( 'Subscribers', 'jetpack' ),
+		Admin_Menu::add_menu(
+			__( 'Subscribers', 'jetpack' ),
 			__( 'Subscribers', 'jetpack' ) . ' <span class="dashicons dashicons-external"></span>',
 			'manage_options',
 			esc_url( $link ),
-			null
+			null,
+			14
 		);
 	}
 

--- a/projects/plugins/protect/changelog/update-jetpack-admin-menu-order
+++ b/projects/plugins/protect/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -153,7 +153,8 @@ class Jetpack_Protect {
 			$menu_label,
 			'manage_options',
 			'jetpack-protect',
-			array( $this, 'plugin_settings_page' )
+			array( $this, 'plugin_settings_page' ),
+			8
 		);
 
 		add_action( 'load-' . $page_suffix, array( $this, 'enqueue_admin_scripts' ) );

--- a/projects/plugins/social/changelog/update-jetpack-admin-menu-order
+++ b/projects/plugins/social/changelog/update-jetpack-admin-menu-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin menu: update the order of the different submenu items within the Jetpack menu.

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -52,7 +52,8 @@ class Jetpack_Social {
 			_x( 'Social', 'The Jetpack Social product name, without the Jetpack prefix', 'jetpack-social' ),
 			'manage_options',
 			'jetpack-social',
-			array( $this, 'plugin_settings_page' )
+			array( $this, 'plugin_settings_page' ),
+			7
 		);
 
 		add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );


### PR DESCRIPTION
## Proposed changes:

This changes the order of the different submenu items, like so:

1. **My Jetpack**
2. Activity Log (External)
3. **Jetpack Manage** (External)
4. **Stats**
5. **Boost**
6. **VideoPress**
7. **Social**
8. **Protect**
9. **Akismet Anti-spam**
10. **VaultPress Backup** / Scan / VaultPress (External) / VaultPress
11. Search
12. **Dashboard**
13. **Settings**
14. **Subscribers** (External)
15. WordAds
16. Beta Tester

> [!NOTE]
> This is not ready to be merged just yet. The logic to highlight the current submenu item will have to be updated:
> https://github.com/Automattic/jetpack/blob/e0ec75999fe35ab550e537fee45837fa50d4945d/projects/plugins/jetpack/_inc/client/main.jsx#L963-L968

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* 856-gh-jetpack-roadmap

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

You'll want to try this PR with our different standalones, with and without Jetpack, when connected to Jetpack, and when not connected.
