### PR TITLE
Allows requests to the v1.1 of the campaigns endpoints for Blaze

### DIFF
--- a/projects/packages/blaze/changelog/update-blaze-campaigns-controller
+++ b/projects/packages/blaze/changelog/update-blaze-campaigns-controller
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allows request to the v1.1 endpoints of Blaze campaigns

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.22.3",
+	"version": "0.22.4-alpha",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -135,7 +135,7 @@ class Dashboard_REST_Controller {
 		// WordAds DSP API Campaigns routes
 		register_rest_route(
 			static::$namespace,
-			sprintf( '/sites/%d/wordads/dsp/api/v1/campaigns(?P<sub_path>[a-zA-Z0-9-_\/]*)(\?.*)?', $site_id ),
+			sprintf( '/sites/%d/wordads/dsp/api/(?P<api_version>v[0-9]+\.?[0-9]*)/campaigns(?P<sub_path>[a-zA-Z0-9-_\/]*)(\?.*)?', $site_id ),
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_dsp_campaigns' ),
@@ -525,7 +525,8 @@ class Dashboard_REST_Controller {
 	 * @return array|WP_Error
 	 */
 	public function get_dsp_campaigns( $req ) {
-		return $this->get_dsp_generic( 'v1/campaigns', $req );
+		$version = $req->get_param( 'api_version' ) ?? 'v1';
+		return $this->get_dsp_generic( "{$version}/campaigns", $req );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.22.3';
+	const PACKAGE_VERSION = '0.22.4-alpha';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.


### PR DESCRIPTION
## Proposed changes:
Changes the `register_rest_route` we have for the `/campaigns` endpoint in Blaze, to also support calls to the v1.1 version of the same controller.

### Other information:

Jetpack Blaze supports setting campaign objectives as part of the campaign creation flow. We want to dynamize the list of campaigns, so we created a WPCOM endpoint to retrieve them (WP Rest API `sites/{ID}/wordads/dsp/api/v1.1/campaigns/objectives`) . 

We are working on changing the Blaze Create campaign widget to start using this new endpoint, but we need to first allow it in Jetpack based sites. This PR aims to do that.

This will be the expected behavior of the new campaign/objectives endpoint:
https://github.com/user-attachments/assets/29feaab1-9bcd-45ab-9ad4-4ef80c40b103

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1722496349588369-slack-C069RG07W6S

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Unless you have access to the DSP Widget repository, you won't be able to test the new v1.1 endpoint. However, we can test that the compatibility with the campaigns v1 endpoint still works fine.

* Go to Tools->Advertising
* Click on the Campaigns tab
* Verify that you get the correct list of campaigns (no errors should be shown)