### PR TITLE
Simple Classic: Remove the experiment gating for the Admin Interface Style setting 

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-wpcom-admin-interface-setting-field-gating
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-wpcom-admin-interface-setting-field-gating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Removed gating logic for wpcom_admin_interface_settings_field

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -31,14 +31,7 @@ function wpcom_admin_interface_display() {
 	echo '<label><input type="radio" name="wpcom_admin_interface" value="calypso" ' . checked( 'calypso', $value, false ) . '/> <span>' . esc_html__( 'Default style', 'jetpack-mu-wpcom' ) . '</span></label><p>' . esc_html__( 'Use WordPress.com’s legacy dashboard to manage your site.', 'jetpack-mu-wpcom' ) . '</p><br>';
 	echo '</fieldset>';
 }
-
-if (
-	// The option should always be available on atomic sites.
-	! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ||
-	// The option will be shown if the simple site has already changed to Classic which means they should have already passed the experiment gate.
-	( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) ) {
-	add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );
-}
+add_action( 'admin_init', 'wpcomsh_wpcom_admin_interface_settings_field' );
 
 /**
  * Track the wpcom_admin_interface_changed event.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/pull/93358

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR removes the conditional logic that determines whether the Admin Interface Style should be displayed or not. Now that we intend to make this setting available to all Simple and Atomic sites, there's no need to gate this setting.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

No.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR in your Simple site.
* With a Simple Default site, head to /settings/general/SITE_SLUG, and switch to the Classic View via the view switcher in the top-right corner of the screen. Ensure that the setting is there.
* With a Simple Classic site, head to /wp-admin/options-general.php and ensure that the setting is there.
* Also ensure that the Admin Interface Style setting is still displayed in Atomic sites.

