### PR TITLE
Social: Fix initial state undefined variable

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-social-initial-state-undefined-variable
+++ b/projects/plugins/jetpack/changelog/fix-social-initial-state-undefined-variable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed a warning with undefined variables

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -771,9 +771,9 @@ class Jetpack_Gutenberg {
 
 				$initial_state['social']['connectionRefreshPath'] = $social_initial_state['connectionRefreshPath'];
 			}
-		}
 
-		$initial_state['social']['featureFlags'] = $social_initial_state['featureFlags'];
+			$initial_state['social']['featureFlags'] = $social_initial_state['featureFlags'];
+		}
 
 		wp_localize_script(
 			'jetpack-blocks-editor',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an undefined variable warning that could happen after https://github.com/Automattic/jetpack/pull/38669

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Moved the problematic line inside the condition for Social, as the `social` prop is only added to the initial state in that case

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In Gutenberg with Publicize off, you could see the warning
* Turn off Publicize in Jetpack Settings
* Open Gutenberg for a new post
* Check docker logs with jetpack docker logs
* With this change it should go away
