### PR TITLE
Social: Update custom message placeholder

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-custom-message-placeholder
+++ b/projects/js-packages/publicize-components/changelog/update-social-custom-message-placeholder
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated the custom message placeholder

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.59.0",
+	"version": "0.60.0-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/message-box-control/index.js
+++ b/projects/js-packages/publicize-components/src/components/message-box-control/index.js
@@ -45,7 +45,10 @@ export default function MessageBoxControl( {
 			onChange={ handleChange }
 			disabled={ disabled }
 			maxLength={ maxLength }
-			placeholder={ __( 'Write a message for your audience here.', 'jetpack' ) }
+			placeholder={ __(
+				'Write a custom message for your social audience here. This message will override your post content.',
+				'jetpack'
+			) }
 			rows={ 4 }
 			help={ sprintf(
 				/* translators: placeholder is a number. */

--- a/projects/js-packages/publicize-components/src/components/message-box-control/index.js
+++ b/projects/js-packages/publicize-components/src/components/message-box-control/index.js
@@ -46,7 +46,7 @@ export default function MessageBoxControl( {
 			disabled={ disabled }
 			maxLength={ maxLength }
 			placeholder={ __(
-				'Write a custom message for your social audience here. This message will override your post content.',
+				'Write a custom message for your social audience here. This message will override your social post content.',
 				'jetpack'
 			) }
 			rows={ 4 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/497

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updated placeholder message for custom message box

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the post editor
* Check that the custom message reflects what's it's set to.

![CleanShot 2024-08-08 at 14 41 13 png](https://github.com/user-attachments/assets/14d47ddb-21dd-4e28-aa21-4aa02bf08293)


