### PR TITLE
Warnings: Handle missing odie-last-chat-id

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-null-fallback-odie-chat-id
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-null-fallback-odie-chat-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-odie.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-odie.php
@@ -204,7 +204,7 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 
 		$projected_response = array(
 			'odie_chat_id'      => $response->odie_chat_id,
-			'odie_last_chat_id' => $response->odie_last_chat_id,
+			'odie_last_chat_id' => $response->odie_last_chat_id ?? null,
 		);
 
 		return rest_ensure_response( $projected_response );


### PR DESCRIPTION
This handle missing `odie_last_chat_id` (it doesn't always exist, by design) in WPCOM API response. 

Fixes: p1723111575744999-slack-C029S5LLB7D

## Proposed changes:
Add null-coalescing. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
1. Checkout this branch.
2. go to `projects/packages/jetpack-mu-wpcom`
3. run `jetpack rsync mu-wpcom-plugin wpcom-atomic:htdocs/wp-content/plugins/jetpack-mu-wpcom-plugin-dev`.
4. Go to your WoA site wp-admin and open the Help Center. 
5. Go to Wapuu, it should work.