### PR TITLE
MU WPCOM: Add Support Links for Recent Blocks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-blocks-support-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-blocks-support-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Gutenberg: Include links to support docs for recent blocks.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
@@ -341,6 +341,18 @@ const blockInfoMapping: { [ key: string ]: { link: string; postId: number } } = 
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/subscriber-login-block/',
 		postId: 380451,
 	},
+	'jetpack/blog-stats': {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/blog-stats-block/',
+		postId: 382010,
+	},
+	'jetpack/top-posts': {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/top-posts-pages-block/',
+		postId: 381536,
+	},
+	'jetpack/goodreads': {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/goodreads-block/',
+		postId: 382051,
+	},
 };
 
 export const blockInfoWithVariations: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/wp-calypso#93391
Fixes Automattic/wp-calypso#93387
Fixes Automattic/wp-calypso#93284

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the support doc links for the Goodreads, Top Posts and Pages, and Blog Stats block. 

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I'm having issues building the plugin, so I haven't actually been able to test this. Once the plugin has been built though, you should theoretically be able to see a link to the support document under the description for the Blog Stats, Goodreads, and Top Posts and Pages block, which should appear in the block sidebar. Verify that all of these links are correct. 