### PR TITLE
Site-Level User Profile: Inconsistent Color Scheme when previewing

### DIFF
--- a/projects/packages/masterbar/changelog/fix-admin-color-scheme-css-concat-issues
+++ b/projects/packages/masterbar/changelog/fix-admin-color-scheme-css-concat-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site-Level User Profile: Inconsistent Color Scheme when previewing

--- a/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
+++ b/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
@@ -31,11 +31,14 @@ class Admin_Color_Schemes {
 		if ( false === ( new Host() )->is_wpcom_simple() ) {
 			add_action( 'rest_api_init', array( $this, 'register_admin_color_meta' ) );
 		}
-
-		if ( ( defined( 'WPCOM_ADMIN_BAR_UNIFICATION' ) && WPCOM_ADMIN_BAR_UNIFICATION ) || get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) { // Classic sites.
-			add_filter( 'css_do_concat', array( $this, 'disable_css_concat_for_color_schemes' ), 10, 2 );
+		// Disable CSS concatenation to fix issues
+		add_filter( 'css_do_concat', array( $this, 'disable_css_concat_for_color_schemes' ), 10, 2 );
+		// Enqueue scripts
+		if ( ( defined( 'WPCOM_ADMIN_BAR_UNIFICATION' ) && WPCOM_ADMIN_BAR_UNIFICATION ) || get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+			// Classic sites.
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_color_scheme_for_sidebar_notice' ) );
-		} else { // Default and self-hosted sites.
+		} else {
+			// Default and self-hosted sites.
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_core_color_schemes_overrides' ) );
 		}
 	}
@@ -229,6 +232,8 @@ class Admin_Color_Schemes {
 	/**
 	 * Currently, the selected color scheme CSS (with id = "colors") is concatenated (by Jetpack Boost / Page Optimize),
 	 * and is output before the default color scheme CSS, making it lose in specificity.
+	 *
+	 * Another issue is that color schemes like Blue get wrong SASS color variables from Coffee, which affects the previews.
 	 *
 	 * To prevent this, we disable CSS concatenation for color schemes.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8498

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable CSS concatenation for all sites

>[!NOTE]
>A better approach might be to use `get_option( 'wpcom_site_level_user_profile' ) === '1'` to target Simple Default separately, rather than all sites. 

### **Context**

This bug is in the concatenated stylesheet with id `all-css-8-1`. In that stylesheet, some schemes get the wrong color value from the SASS variables of another scheme.

See in the following screenshot that the color brown from the Coffee scheme is leaked in the selector for the Blue scheme while the [variables](https://github.com/Automattic/jetpack/blob/c77c6acb14eed1d06ecdac8ffa5a2ba9de47560b/projects/packages/masterbar/src/admin-color-schemes/colors/blue/_variables.scss#L6) for the Blue scheme are correct.

![image](https://github.com/user-attachments/assets/d396cb08-5ee3-4270-9fcc-3707c8b08ff9)

I confirmed that disabling the CSS concatenation fixes it by using `define( 'FORCE_CONCAT', true );` on my sandbox, which is required to reproduce the issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add `define( 'FORCE_CONCAT', true );` to your `0-sandbox.php` file
* Patch this PR in your sandbox with `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/admin-color-scheme-css-concat-issues`
* Go to `/wp-admin/profile.php`
* Click on Coffee
* Save changes
* Click on Blue
* Expect to see the right colors
* Don't forget to reset your sandbox with `bin/jetpack-downloader reset jetpack-mu-wpcom-plugin`

