### PR TITLE
Social: Hide notices and preview modal when module is off

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-hide-notices-with-module-off
+++ b/projects/js-packages/publicize-components/changelog/update-social-hide-notices-with-module-off
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Hid most of the actions and notices when sharing is off

--- a/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connections-list.tsx
@@ -17,7 +17,7 @@ export const ConnectionsList: React.FC = () => {
 	const { connections, toggleById } = useSocialMediaConnections();
 	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
 
-	const { needsUserConnection } = usePublicizeConfig();
+	const { needsUserConnection, isPublicizeEnabled } = usePublicizeConfig();
 
 	const toggleConnection = useCallback(
 		( connectionId: string, connection ) => () => {
@@ -52,10 +52,15 @@ export const ConnectionsList: React.FC = () => {
 					);
 				} ) }
 			</ul>
-			<MediaValidationNotices />
-			<BrokenConnectionsNotice />
-			<UnsupportedConnectionsNotice />
-			<EnabledConnectionsNotice />
+			{ isPublicizeEnabled ? (
+				<>
+					<MediaValidationNotices />
+					<BrokenConnectionsNotice />
+					<UnsupportedConnectionsNotice />
+					<EnabledConnectionsNotice />
+				</>
+			) : null }
+
 			{ ! needsUserConnection ? <SettingsButton variant="secondary" /> : null }
 		</div>
 	);

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -57,7 +57,7 @@ export default function PublicizeForm() {
 					<PanelRow>
 						<ConnectionsList />
 					</PanelRow>
-					{ featureFlags.useEditorPreview ? <SocialPostModal /> : null }
+					{ featureFlags.useEditorPreview && isPublicizeEnabled ? <SocialPostModal /> : null }
 					<ShareCountInfo />
 				</>
 			) : null }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/494

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Hid modal trigger and notices if Publicize is off

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor, have broken, and other notices
* Turn off sharing
* Only the connection management should be visible

![CleanShot 2024-08-09 at 13 39 15 png](https://github.com/user-attachments/assets/7fc2d6dd-d088-47ba-bbc8-3947b15587d9)


