### PR TITLE
MU WPCOM: Stop loading wpcom block editor nux feature

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-pagte-patterns-error
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-pagte-patterns-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Block Editor Nux: Temporary stop load feature from MU WPCOM

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -174,7 +174,7 @@ class Jetpack_Mu_Wpcom {
 		define( 'MU_WPCOM_STARTER_PAGE_TEMPLATES', true );
 		define( 'MU_WPCOM_TAGS_EDUCATION', true );
 		define( 'MU_WPCOM_BLOCK_DESCRIPTION_LINKS', true );
-		define( 'MU_WPCOM_BLOCK_EDITOR_NUX', true );
+		define( 'MU_WPCOM_BLOCK_EDITOR_NUX', false );
 		define( 'MU_WPCOM_POSTS_LIST_BLOCK', true );
 		define( 'MU_WPCOM_JETPACK_COUNTDOWN_BLOCK', true );
 		define( 'MU_WPCOM_JETPACK_TIMELINE_BLOCK', true );
@@ -218,6 +218,7 @@ class Jetpack_Mu_Wpcom {
 			require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';
 			require_once __DIR__ . '/features/tags-education/tags-education.php';
 			require_once __DIR__ . '/features/wpcom-block-description-links/wpcom-block-description-links.php';
+			require_once __DIR__ . '/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php';
 			require_once __DIR__ . '/features/wpcom-blocks/a8c-posts-list/a8c-posts-list.php';
 			require_once __DIR__ . '/features/wpcom-blocks/event-countdown/event-countdown.php';
 			require_once __DIR__ . '/features/wpcom-blocks/timeline/timeline.php';

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -218,7 +218,6 @@ class Jetpack_Mu_Wpcom {
 			require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';
 			require_once __DIR__ . '/features/tags-education/tags-education.php';
 			require_once __DIR__ . '/features/wpcom-block-description-links/wpcom-block-description-links.php';
-			require_once __DIR__ . '/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php';
 			require_once __DIR__ . '/features/wpcom-blocks/a8c-posts-list/a8c-posts-list.php';
 			require_once __DIR__ . '/features/wpcom-blocks/event-countdown/event-countdown.php';
 			require_once __DIR__ . '/features/wpcom-blocks/timeline/timeline.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
@@ -30,7 +30,7 @@ type CoreNuxPlaceholder = {
  */
 export function PagePatternsPlugin( props: PagePatternsPluginProps ) {
 	const { setOpenState } = useDispatch( pageLayoutStore );
-	const { setUsedPageOrPatternsModal } = useDispatch( 'automattic/wpcom-welcome-guide' );
+	//const { setUsedPageOrPatternsModal } = useDispatch( 'automattic/wpcom-welcome-guide' );
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 	const { editPost } = useDispatch( 'core/editor' );
 	const { toggleFeature } = useDispatch( 'core/edit-post' );
@@ -118,8 +118,8 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ) {
 
 	const handleClose = useCallback( () => {
 		setOpenState( 'CLOSED' );
-		setUsedPageOrPatternsModal?.();
-	}, [ setOpenState, setUsedPageOrPatternsModal ] );
+		//setUsedPageOrPatternsModal?.();
+	}, [ setOpenState /*setUsedPageOrPatternsModal*/ ] );
 
 	return (
 		<PagePatternModal

--- a/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/page-patterns-plugin.tsx
@@ -30,7 +30,7 @@ type CoreNuxPlaceholder = {
  */
 export function PagePatternsPlugin( props: PagePatternsPluginProps ) {
 	const { setOpenState } = useDispatch( pageLayoutStore );
-	//const { setUsedPageOrPatternsModal } = useDispatch( 'automattic/wpcom-welcome-guide' );
+	const { setUsedPageOrPatternsModal } = useDispatch( 'automattic/wpcom-welcome-guide' );
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 	const { editPost } = useDispatch( 'core/editor' );
 	const { toggleFeature } = useDispatch( 'core/edit-post' );
@@ -118,8 +118,8 @@ export function PagePatternsPlugin( props: PagePatternsPluginProps ) {
 
 	const handleClose = useCallback( () => {
 		setOpenState( 'CLOSED' );
-		//setUsedPageOrPatternsModal?.();
-	}, [ setOpenState /*setUsedPageOrPatternsModal*/ ] );
+		setUsedPageOrPatternsModal?.();
+	}, [ setOpenState, setUsedPageOrPatternsModal ] );
 
 	return (
 		<PagePatternModal


### PR DESCRIPTION
Fixes the regression that has been escalated in p1723186454644719-slack-C02FMH4G8
Reverts https://github.com/Automattic/jetpack/pull/38674

## Proposed changes:

Apparently, the `automattic/wpcom-welcome-guide` store is not available when the Gutenberg plugin is disabled and that causes a failure to the `starter-page-templates` feature.

It looks like a regression introduced after moving the wpcom block editor nux feature from ETK to jetpack-mu-wpcom (https://github.com/Automattic/jetpack/pull/38674), so as a temporary solution this PR stops loading the feature from jetpack-mu-wpcom.

Before | After
--- | ---
<img width="1279" alt="Screenshot 2024-08-09 at 14 00 37" src="https://github.com/user-attachments/assets/d801728c-4970-452b-b1fd-aa7df9e33863"> | <img width="1277" alt="Screenshot 2024-08-09 at 13 55 36" src="https://github.com/user-attachments/assets/65160700-479f-49e1-b953-73910ecb443d">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to your WoA dev site
- Disable the Gutenberg plugin
- Go to `/wp-admin/post-new.php?post_type=page`
- Make sure the "Add a page" modal shows up successfully 