### PR TITLE
Newsletter: Remove Subscribe Modal from Settings -> Discussion

### DIFF
--- a/projects/plugins/jetpack/changelog/update-discussion-settings-modal
+++ b/projects/plugins/jetpack/changelog/update-discussion-settings-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix: Saving discussion settings shouldn't turn on subscribe modal.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -369,21 +369,6 @@ class Jetpack_Subscriptions {
 			'stc_enabled'
 		);
 
-		/** Enable Subscribe Modal */
-
-		add_settings_field(
-			'jetpack_subscriptions_comment_subscribe',
-			__( 'Enable Subscribe Modal', 'jetpack' ),
-			array( $this, 'subscribe_modal_setting' ),
-			'discussion',
-			'jetpack_subscriptions'
-		);
-
-		register_setting(
-			'discussion',
-			'sm_enabled'
-		);
-
 		/** Email me whenever: Someone subscribes to my blog */
 		/* @since 8.1 */
 
@@ -461,22 +446,6 @@ class Jetpack_Subscriptions {
 				array( 'em' => array() )
 			);
 			?>
-		</p>
-
-		<?php
-	}
-
-	/**
-	 * Subscribe Modal Toggle.
-	 */
-	public function subscribe_modal_setting() {
-
-		$sm_enabled = get_option( 'sm_enabled', 1 );
-		?>
-
-		<p class="description">
-			<input type="checkbox" name="sm_enabled" id="jetpack-subscribe-modal" value="1" <?php checked( $sm_enabled, 1 ); ?> />
-			<?php esc_html_e( 'Show a popup subscribe modal to readers.', 'jetpack' ); ?>
 		</p>
 
 		<?php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Removes duplicate setting; the setting is available at Settings -> Newsletter.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Before:
<img width="643" alt="Screenshot 2024-08-09 at 10 52 06 AM" src="https://github.com/user-attachments/assets/acc98b2b-50f5-40fe-b3e6-4e890c2c1562">

* After:
<img width="670" alt="Screenshot 2024-08-09 at 10 45 53 AM" src="https://github.com/user-attachments/assets/f19dd5f5-972b-4039-9e98-54bb5a39ae27">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Settings -> Discussions
* Check that saving works.

