### PR TITLE
Boost: Check if queried object is null before using it

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Taxonomy_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/Taxonomy_Provider.php
@@ -72,6 +72,10 @@ class Taxonomy_Provider extends Provider {
 			return array();
 		}
 
+		if ( ! get_queried_object() ) {
+			return array();
+		}
+
 		// For example: "taxonomy_category".
 		return array( self::$name . '_' . get_queried_object()->taxonomy );
 	}

--- a/projects/plugins/boost/changelog/fix-querying-null-object
+++ b/projects/plugins/boost/changelog/fix-querying-null-object
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Misc: Fix PHP warning when generating critical css for some taxonomy pages.


### PR DESCRIPTION
Fixes https://github.com/Automattic/jpop-issues/issues/9164

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* It is possible for `get_queried_object` to [return null](https://github.com/WordPress/wordpress-develop/blob/6.6/src/wp-includes/class-wp-query.php#L3871), which will yield a PHP warning.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jpop-issues/issues/9164

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

*  I couldn't reproduce the issue, but if you take a look at the source code for [`get_queried_object`](https://github.com/WordPress/wordpress-develop/blob/6.6/src/wp-includes/class-wp-query.php#L3866) you can see that it can return `null`.