### PR TITLE
Adding ithemes-security-pro to $incompatible_plugins

### DIFF
--- a/projects/plugins/wpcomsh/changelog/projects/plugins/wpcomsh/changelog/add-incompatible-plugin-ithemes-security-pro
+++ b/projects/plugins/wpcomsh/changelog/projects/plugins/wpcomsh/changelog/add-incompatible-plugin-ithemes-security-pro
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Incompatible Plugins: Added ithemes-security-pro

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -32,6 +32,7 @@ class Jetpack_Plugin_Compatibility {
 		'file-manager-advanced/file_manager_advanced.php'  => '"file-manager-advanced" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'file-manager/file-manager.php'                    => '"file-manager" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'hide-my-wp/index.php'                             => '"hide-my-wp" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
+		'ithemes-security-pro/ithemes-security-pro.php'    => '"ithemes-security-pro" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'plugins-garbage-collector/plugins-garbage-collector.php' => '"plugins-garbage-collector" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'post-type-switcher/post-type-switcher.php'        => '"post-type-switcher" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'reset-wp/reset-wp.php'                            => '"reset-wp" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',


### PR DESCRIPTION
Although our [Incompatible Plugins doc](https://wordpress.com/support/plugins/incompatible-plugins/) mentions iThemes Security, we block only the free version slug (better-wp-security). I'm adding the Pro version by adding ithemes-security-pro to the file.

Slack Convo: p1723230754250609-slack-C03TY6J1A