### PR TITLE
Add/value to active state videopress card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/protect-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/protect-value-section.tsx
@@ -1,4 +1,5 @@
 import useProduct from '../../../data/products/use-product';
+import baseStyles from '../style.module.scss';
 import { AutoFirewallStatus } from './auto-firewall-status';
 import { InfoTooltip } from './info-tooltip';
 import { LoginsBlockedStatus } from './logins-blocked-status';
@@ -40,13 +41,13 @@ const ProtectValueSection = () => {
 					<ScanAndThreatStatus />
 				</div>
 				<div className="value-section__auto-firewall">
-					<div className="value-section__heading">Auto-Firewall</div>
+					<div className={ baseStyles.valueSectionHeading }>Auto-Firewall</div>
 					<div className="value-section__data">
 						<AutoFirewallStatus />
 					</div>
 				</div>
 				<div className="value-section__logins-blocked">
-					<div className="value-section__heading">Logins Blocked</div>
+					<div className={ baseStyles.valueSectionHeading }>Logins Blocked</div>
 					<div className="value-section__data">
 						<LoginsBlockedStatus />
 					</div>

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/scan-threats-status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/scan-threats-status.tsx
@@ -7,12 +7,13 @@ import useProduct from '../../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../../hooks/use-analytics';
 import useMyJetpackConnection from '../../../hooks/use-my-jetpack-connection';
+import baseStyles from '../style.module.scss';
 import ShieldOff from './assets/shield-off.svg';
 import ShieldPartial from './assets/shield-partial.svg';
 import ShieldSuccess from './assets/shield-success.svg';
 import { InfoTooltip } from './info-tooltip';
 import { useProtectTooltipCopy } from './use-protect-tooltip-copy';
-import type { ReactElement, PropsWithChildren } from 'react';
+import type { PropsWithChildren, ReactElement } from 'react';
 
 export const ScanAndThreatStatus = () => {
 	const slug = 'protect';
@@ -115,7 +116,9 @@ function ThreatStatus( {
 	if ( criticalThreatCount ) {
 		return (
 			<>
-				<div className="value-section__heading">{ __( 'Threats', 'jetpack-my-jetpack' ) }</div>
+				<div className={ baseStyles.valueSectionHeading }>
+					{ __( 'Threats', 'jetpack-my-jetpack' ) }
+				</div>
 				<div className="value-section__data">
 					<div className="scan-threats__critical-threats">
 						<div className="scan-threats__threat-count">{ numThreats }</div>
@@ -151,7 +154,9 @@ function ThreatStatus( {
 
 	return (
 		<>
-			<div className="value-section__heading">{ __( 'Threats', 'jetpack-my-jetpack' ) }</div>
+			<div className={ baseStyles.valueSectionHeading }>
+				{ __( 'Threats', 'jetpack-my-jetpack' ) }
+			</div>
 			<div className="value-section__data">
 				<div className="scan-threats__threat-count">{ numThreats }</div>
 			</div>
@@ -174,7 +179,9 @@ function ScanStatus( { status }: { status: 'success' | 'partial' | 'off' } ) {
 	if ( status === 'success' ) {
 		return (
 			<>
-				<div className="value-section__heading">{ __( 'Scan', 'jetpack-my-jetpack' ) }</div>
+				<div className={ baseStyles.valueSectionHeading }>
+					{ __( 'Scan', 'jetpack-my-jetpack' ) }
+				</div>
 				<div className="value-section__data">
 					<div>
 						<img
@@ -191,7 +198,9 @@ function ScanStatus( { status }: { status: 'success' | 'partial' | 'off' } ) {
 	if ( status === 'partial' ) {
 		return (
 			<>
-				<div className="value-section__heading">{ __( 'Scan', 'jetpack-my-jetpack' ) }</div>
+				<div className={ baseStyles.valueSectionHeading }>
+					{ __( 'Scan', 'jetpack-my-jetpack' ) }
+				</div>
 				<div className="value-section__data">
 					<div>
 						<img
@@ -223,7 +232,7 @@ function ScanStatus( { status }: { status: 'success' | 'partial' | 'off' } ) {
 	}
 	return (
 		<>
-			<div className="value-section__heading">{ __( 'Scan', 'jetpack-my-jetpack' ) }</div>
+			<div className={ baseStyles.valueSectionHeading }>{ __( 'Scan', 'jetpack-my-jetpack' ) }</div>
 			<div className="value-section__data">
 				<div>
 					<img

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/style.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/style.scss
@@ -8,15 +8,6 @@
         flex-direction: column;
     }
 
-    &__heading {
-        font-size: var(--font-body-extra-small);
-        color: var(--jp-gray-100);
-        font-weight: 500;
-        margin-bottom: calc(var(--spacing-base) + 2px);
-        line-height: var(--font-title-small);
-        text-align: center;
-    }
-
     &__last-scan {
         display: flex;
         align-items: center;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/style.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/protect-card/style.scss
@@ -6,6 +6,7 @@
     > div {
         display: flex;
         flex-direction: column;
+        align-items: flex-start;
     }
 
     &__last-scan {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/style.module.scss
@@ -58,6 +58,15 @@
 	}
 }
 
+.valueSectionHeading {
+	font-size: var(--font-body-extra-small);
+	color: var(--jp-gray-100);
+	font-weight: 500;
+	margin-bottom: calc(var(--spacing-base) + 2px);
+	line-height: var(--font-title-small);
+	text-align: center;
+}
+
 // Since we're adding so much info into the My Jetpack product cards, here we'll increase
 // the min-width of the cards to 300px, and otherwise wrap around.
 @media screen and (min-width: 599px) and (max-width: 1290px) {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/style.module.scss
@@ -64,7 +64,6 @@
 	font-weight: 500;
 	margin-bottom: calc(var(--spacing-base) + 2px);
 	line-height: var(--font-title-small);
-	text-align: center;
 }
 
 // Since we're adding so much info into the My Jetpack product cards, here we'll increase

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
@@ -3,6 +3,7 @@
  */
 import { Text } from '@automattic/jetpack-components';
 import { useCallback } from 'react';
+import { PRODUCT_STATUSES } from '../../../constants';
 import { PRODUCT_SLUGS } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
@@ -17,8 +18,11 @@ const slug = PRODUCT_SLUGS.VIDEOPRESS;
 
 const VideopressCard: ProductCardComponent = ( { admin } ) => {
 	const { detail } = useProduct( slug );
-	const { isPluginActive = false } = detail || {};
+	const { status } = detail || {};
 	const { videopress: data } = getMyJetpackWindowInitialState();
+
+	const isPluginActive =
+		status === PRODUCT_STATUSES.ACTIVE || status === PRODUCT_STATUSES.CAN_UPGRADE;
 
 	const descriptionText = useVideoPressCardDescription( {
 		isPluginActive,

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/style.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/style.scss
@@ -11,3 +11,21 @@ p.description {
     font-size: var( --font-body-small );
     margin: 0 0 1rem;
 }
+
+.videopress-card__value-section {
+    display: flex;
+
+    &__container {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+
+        width: 50%;
+    }
+
+    &__value {
+        font-size: calc( var( --font-headline-small ) - 4px );
+        color: var( --jp-gray-90 );
+        line-height: 1.125;       
+    }
+}

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
@@ -29,6 +29,10 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 	const currentViews = featuredStats?.data?.views?.current;
 	const currentWatchTime = featuredStats?.data?.watch_time?.current;
 
+	if ( currentViews === undefined || currentWatchTime === undefined ) {
+		return null;
+	}
+
 	return (
 		<div className="videopress-card__value-section">
 			<div className="videopress-card__value-section__container">

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
@@ -33,7 +33,7 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 		<div className="videopress-card__value-section">
 			<div className="videopress-card__value-section__container">
 				<span className={ baseStyles.valueSectionHeading }>
-					{ __( 'Monthly views', 'jetpack-my-jetpack' ) }
+					{ __( '30-Day views', 'jetpack-my-jetpack' ) }
 				</span>
 
 				<span className="videopress-card__value-section__value">

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
@@ -22,10 +22,10 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 		return <span className="videopress-card__video-count">{ videoCount }</span>;
 	}
 
-	const currentViews = featuredStats?.data?.views?.current;
-	const currentWatchTime = featuredStats?.data?.watch_time?.current;
+	if ( isPluginActive && videoCount ) {
+		const currentViews = featuredStats?.data?.views?.current;
+		const currentWatchTime = featuredStats?.data?.watch_time?.current;
 
-	if ( isPluginActive && ( currentViews > 0 || currentWatchTime > 0 ) ) {
 		return (
 			<div className="videopress-card__value-section">
 				<div className="videopress-card__value-section__container">

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
@@ -1,3 +1,7 @@
+import { __ } from '@wordpress/i18n';
+import formatNumber from '../../../utils/format-number';
+import formatTime from '../../../utils/format-time';
+import baseStyles from '../style.module.scss';
 import type { FC } from 'react';
 
 import './style.scss';
@@ -8,8 +12,43 @@ interface VideoPressValueSectionProps {
 }
 
 const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginActive, data } ) => {
-	if ( ! isPluginActive && data.videoCount ) {
-		return <span className="videopress-card__video-count">{ data.videoCount }</span>;
+	const { videoCount, featuredStats } = data || {};
+	const shortenedNumberConfig: Intl.NumberFormatOptions = {
+		maximumFractionDigits: 1,
+		notation: 'compact',
+	};
+
+	if ( ! isPluginActive && videoCount ) {
+		return <span className="videopress-card__video-count">{ videoCount }</span>;
+	}
+
+	const currentViews = featuredStats?.data?.views?.current;
+	const currentWatchTime = featuredStats?.data?.watch_time?.current;
+
+	if ( isPluginActive && ( currentViews > 0 || currentWatchTime > 0 ) ) {
+		return (
+			<div className="videopress-card__value-section">
+				<div className="videopress-card__value-section__container">
+					<span className={ baseStyles.valueSectionHeading }>
+						{ __( 'Monthly views', 'jetpack-my-jetpack' ) }
+					</span>
+
+					<span className="videopress-card__value-section__value">
+						{ formatNumber( currentViews, shortenedNumberConfig ) }
+					</span>
+				</div>
+
+				<div className="videopress-card__value-section__container">
+					<span className={ baseStyles.valueSectionHeading }>
+						{ __( 'Total time watched', 'jetpack-my-jetpack' ) }
+					</span>
+
+					<span className="videopress-card__value-section__value">
+						{ formatTime( currentWatchTime ) }
+					</span>
+				</div>
+			</div>
+		);
 	}
 
 	return null;

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
@@ -18,40 +18,40 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 		notation: 'compact',
 	};
 
-	if ( ! isPluginActive && videoCount ) {
+	if ( ! videoCount ) {
+		return null;
+	}
+
+	if ( ! isPluginActive ) {
 		return <span className="videopress-card__video-count">{ videoCount }</span>;
 	}
 
-	if ( isPluginActive && videoCount ) {
-		const currentViews = featuredStats?.data?.views?.current;
-		const currentWatchTime = featuredStats?.data?.watch_time?.current;
+	const currentViews = featuredStats?.data?.views?.current;
+	const currentWatchTime = featuredStats?.data?.watch_time?.current;
 
-		return (
-			<div className="videopress-card__value-section">
-				<div className="videopress-card__value-section__container">
-					<span className={ baseStyles.valueSectionHeading }>
-						{ __( 'Monthly views', 'jetpack-my-jetpack' ) }
-					</span>
+	return (
+		<div className="videopress-card__value-section">
+			<div className="videopress-card__value-section__container">
+				<span className={ baseStyles.valueSectionHeading }>
+					{ __( 'Monthly views', 'jetpack-my-jetpack' ) }
+				</span>
 
-					<span className="videopress-card__value-section__value">
-						{ formatNumber( currentViews, shortenedNumberConfig ) }
-					</span>
-				</div>
-
-				<div className="videopress-card__value-section__container">
-					<span className={ baseStyles.valueSectionHeading }>
-						{ __( 'Total time watched', 'jetpack-my-jetpack' ) }
-					</span>
-
-					<span className="videopress-card__value-section__value">
-						{ formatTime( currentWatchTime ) }
-					</span>
-				</div>
+				<span className="videopress-card__value-section__value">
+					{ formatNumber( currentViews, shortenedNumberConfig ) }
+				</span>
 			</div>
-		);
-	}
 
-	return null;
+			<div className="videopress-card__value-section__container">
+				<span className={ baseStyles.valueSectionHeading }>
+					{ __( 'Total time watched', 'jetpack-my-jetpack' ) }
+				</span>
+
+				<span className="videopress-card__value-section__value">
+					{ formatTime( currentWatchTime ) }
+				</span>
+			</div>
+		</div>
+	);
 };
 
 export default VideoPressValueSection;

--- a/projects/packages/my-jetpack/_inc/components/stats-section/count-comparison-card.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/count-comparison-card.jsx
@@ -1,18 +1,10 @@
-import { numberFormat } from '@automattic/jetpack-components';
 import { Card } from '@wordpress/components';
 import { arrowDown, arrowUp, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import React from 'react';
+import formatNumber from '../../utils/format-number';
 import styles from './style.module.scss';
-
-const formatNumber = ( number, config = {} ) => {
-	if ( number === null || ! Number.isFinite( number ) ) {
-		return '-';
-	}
-
-	return numberFormat( number, config );
-};
 
 const subtract = ( a, b ) => {
 	if ( typeof a !== 'number' || typeof b !== 'number' ) {

--- a/projects/packages/my-jetpack/_inc/utils/format-number.ts
+++ b/projects/packages/my-jetpack/_inc/utils/format-number.ts
@@ -1,0 +1,13 @@
+import { numberFormat } from '@automattic/jetpack-components';
+
+type FormatNumberFunction = ( number: number, config: Intl.NumberFormatOptions ) => string;
+
+const formatNumber: FormatNumberFunction = ( number, config = {} ) => {
+	if ( number === null || ! Number.isFinite( number ) ) {
+		return '-';
+	}
+
+	return numberFormat( number, config );
+};
+
+export default formatNumber;

--- a/projects/packages/my-jetpack/_inc/utils/format-time.ts
+++ b/projects/packages/my-jetpack/_inc/utils/format-time.ts
@@ -4,6 +4,11 @@ const formatTime: FormatTimeFunction = ( seconds: number ) => {
 	const minutes = Math.floor( seconds / 60 );
 	const hours = Math.floor( minutes / 60 );
 	const days = Math.floor( hours / 24 );
+	const years = Math.floor( days / 365 );
+
+	if ( years > 0 ) {
+		return `${ years }y ${ days % 365 }d`;
+	}
 
 	if ( days > 0 ) {
 		return `${ days }d ${ hours % 24 }h`;

--- a/projects/packages/my-jetpack/_inc/utils/format-time.ts
+++ b/projects/packages/my-jetpack/_inc/utils/format-time.ts
@@ -1,0 +1,23 @@
+type FormatTimeFunction = ( seconds: number ) => string;
+
+const formatTime: FormatTimeFunction = ( seconds: number ) => {
+	const minutes = Math.floor( seconds / 60 );
+	const hours = Math.floor( minutes / 60 );
+	const days = Math.floor( hours / 24 );
+
+	if ( days > 0 ) {
+		return `${ days }d ${ hours % 24 }h`;
+	}
+
+	if ( hours > 0 ) {
+		return `${ hours }h ${ minutes % 60 }m`;
+	}
+
+	if ( minutes > 0 ) {
+		return `${ minutes }m ${ seconds % 60 }s`;
+	}
+
+	return `${ seconds }s`;
+};
+
+export default formatTime;

--- a/projects/packages/my-jetpack/changelog/add-value-to-active-state-videopress-card
+++ b/projects/packages/my-jetpack/changelog/add-value-to-active-state-videopress-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add value to active card state on VideoPress My Jetpack card

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.32.2",
+	"version": "4.32.3-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -42,7 +42,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.32.2';
+	const PACKAGE_VERSION = '4.32.3-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -315,6 +315,13 @@ class Initializer {
 		}
 
 		$videopress_stats = new VideoPress_Stats();
+		$featured_stats   = $videopress_stats->get_featured_stats( 60 );
+
+		if ( is_wp_error( $featured_stats ) ) {
+			return array(
+				'videoCount' => $video_count,
+			);
+		}
 
 		return array(
 			'featuredStats' => $videopress_stats->get_featured_stats( 60 ),

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -63,7 +63,7 @@ class Initializer {
 	const MY_JETPACK_SITE_INFO_TRANSIENT_KEY             = 'my-jetpack-site-info';
 	const UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY = 'update-historically-active-jetpack-modules';
 	const MISSING_CONNECTION_NOTIFICATION_KEY            = 'missing-connection';
-	const VIDEOPRESS_STATS_KEY                           = 'videopress-stats';
+	const VIDEOPRESS_STATS_KEY                           = 'my-jetpack-videopress-stats';
 
 	/**
 	 * Holds info/data about the site (from the /sites/%d endpoint)

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -317,7 +317,7 @@ class Initializer {
 		$videopress_stats = new VideoPress_Stats();
 
 		return array(
-			'featuredStats' => $videopress_stats->get_featured_stats(),
+			'featuredStats' => $videopress_stats->get_featured_stats( 60 ),
 			'videoCount'    => $video_count,
 		);
 	}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -60,11 +60,10 @@ class Initializer {
 		'jetpack-search',
 	);
 
-	const MY_JETPACK_SITE_INFO_TRANSIENT_KEY = 'my-jetpack-site-info';
-
+	const MY_JETPACK_SITE_INFO_TRANSIENT_KEY             = 'my-jetpack-site-info';
 	const UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY = 'update-historically-active-jetpack-modules';
-
-	const MISSING_CONNECTION_NOTIFICATION_KEY = 'missing-connection';
+	const MISSING_CONNECTION_NOTIFICATION_KEY            = 'missing-connection';
+	const VIDEOPRESS_STATS_KEY                           = 'videopress-stats';
 
 	/**
 	 * Holds info/data about the site (from the /sites/%d endpoint)
@@ -314,17 +313,23 @@ class Initializer {
 			);
 		}
 
-		$videopress_stats = new VideoPress_Stats();
-		$featured_stats   = $videopress_stats->get_featured_stats( 60 );
+		$featured_stats = get_transient( self::VIDEOPRESS_STATS_KEY );
 
-		if ( is_wp_error( $featured_stats ) ) {
+		if ( ! $featured_stats ) {
+			$videopress_stats = new VideoPress_Stats();
+			$featured_stats   = $videopress_stats->get_featured_stats( 60 );
+		}
+
+		if ( is_wp_error( $featured_stats ) || ! $featured_stats ) {
 			return array(
 				'videoCount' => $video_count,
 			);
 		}
 
+		set_transient( self::VIDEOPRESS_STATS_KEY, $featured_stats, HOUR_IN_SECONDS );
+
 		return array(
-			'featuredStats' => $videopress_stats->get_featured_stats( 60 ),
+			'featuredStats' => $featured_stats,
 			'videoCount'    => $video_count,
 		);
 	}

--- a/projects/packages/videopress/changelog/add-value-to-active-state-videopress-card
+++ b/projects/packages/videopress/changelog/add-value-to-active-state-videopress-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add value to active card state on VideoPress My Jetpack card

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.24.0",
+	"version": "0.24.1-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.24.0';
+	const PACKAGE_VERSION = '0.24.1-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/class-stats.php
+++ b/projects/packages/videopress/src/class-stats.php
@@ -87,13 +87,15 @@ class Stats {
 	/**
 	 * Returns the featured stats for VideoPress.
 	 *
+	 * @param int $days (optional) The number of days to consider.
+	 *
 	 * @return array|WP_Error a list of stats, or WP_Error on failure.
 	 */
-	public static function get_featured_stats() {
+	public static function get_featured_stats( $days = 14 ) {
 		$response = self::fetch_video_plays(
 			array(
 				'period'         => 'day',
-				'num'            => 14,
+				'num'            => $days,
 				'complete_stats' => true,
 			)
 		);
@@ -115,16 +117,17 @@ class Stats {
 		$dates = $data['days'];
 
 		// Organize the data into the planned stats
-		return self::prepare_featured_stats( $dates );
+		return self::prepare_featured_stats( $dates, $days );
 	}
 
 	/**
 	 * Prepares the featured stats for VideoPress.
 	 *
 	 * @param array $dates The list of dates returned by the API.
+	 * @param int   $total_days The total number of days to consider.
 	 * @return array a list of stats.
 	 */
-	public static function prepare_featured_stats( $dates ) {
+	public static function prepare_featured_stats( $dates, $total_days ) {
 		/**
 		 * Ensure the sorting of the dates, recent ones first.
 		 * This way, the first 7 positions are from the last 7 days,
@@ -134,7 +137,8 @@ class Stats {
 
 		// template for the response
 		$featured_stats = array(
-			'label' => __( 'last 7 days', 'jetpack-videopress-pkg' ),
+			// translators: %d is the number of days
+			'label' => sprintf( __( 'last %d days', 'jetpack-videopress-pkg' ), floor( $total_days / 2 ) ),
 			'data'  => array(
 				'views'       => array(
 					'current'  => 0,
@@ -156,7 +160,7 @@ class Stats {
 		foreach ( $dates as $date_info ) {
 			$date_totals = $date_info['total'];
 
-			if ( $counter < 7 ) {
+			if ( $counter < floor( $total_days / 2 ) ) {
 
 				// the first 7 elements are for the current period
 				$featured_stats['data']['views']['current']       += $date_totals['views'];


### PR DESCRIPTION
## Proposed changes:

* Add optional `$days` arg to function in VideoPress package that returns stats. This arg allows us to customize the days returned for featured stats without having to duplicate functionality in My Jetpack. It also doesn't break any current usages of the function as the argument is optional and defaults to the old value of 14 days
* Add monthly views and watch-time to the active card state (if there is any)
* Hide value section if the module is active but no views or watch time has been recorded

NOTE: This PR does not intend to handle adding trends, tooltip, or context switching between monthly and all-time views. Those will be handled in separate PRs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-rb7-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. On a Jurassic Ninja site, enable sandbox access and checkout this branch on the main Jetpack plugin. 
2. Go to `/wp-admin/options-general.php?page=companion_settings` and enter your sandbox domain to enable sandboxed requests
3. Connect your user account
4. Add at least 1 video to your site
5. Go to My Jetpack and confirm you still see the inactive state showing 1 video you could be using VideoPress for
![image](https://github.com/user-attachments/assets/026ba521-c86f-4fe5-980a-d254f37bda24)
6. Now activate the VideoPress plugin with this branch. You probably won't have any video data on your test site as far as views or watch time goes, so you should see an active card with no content
![image](https://github.com/user-attachments/assets/381a7a25-4756-40bd-b73b-6f126a4952a7)
7. To mock some randomized data, go to fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qfgngf%2Qivqrb%2Qcynlf%2Qi1%2Q1%2Qraqcbvag.cuc%3Se%3Q210o65nn%26zb%3Q1199%26sv%3Q37%2350-og and replace all those zeros with something like `rand(0, 100)`. You can pick whatever numbers you'd like if you wanted to test out smaller or bigger numbers.
8. Now refresh My Jetpack and you should see some data
![image](https://github.com/user-attachments/assets/8fbb388d-72d3-4c1a-a059-44b3e4762d93)

Play around with the random numbers to make sure they scale well with the compacting number/time formatting.
Additionally make sure they match designs here: p1HpG7-rb7-p2

Note: There are some pending questions as far as the design goes (p1HpG7-rb7-p2#comment-73251), so the CSS is pending, but the functionality should remain the same so I think it is ready to review