### PR TITLE
My Jetpack: fix infinite loading spinner when activating Jetpack with one click

### DIFF
--- a/projects/packages/my-jetpack/_inc/utils/side-load-tracks.ts
+++ b/projects/packages/my-jetpack/_inc/utils/side-load-tracks.ts
@@ -35,10 +35,13 @@ function getCurrentYearAndWeek() {
  * @returns {Promise<void>} A promise that resolves once the script has loaded.
  */
 function loadScript( src: string ): Promise< void > {
-	return new Promise( resolve => {
+	return new Promise( ( resolve, reject ) => {
 		const script = document.createElement( 'script' );
 		script.src = src;
 		script.onload = () => resolve();
+		script.onerror = () => {
+			reject( new Error( `Failed to load script: ${ src }` ) );
+		};
 		document.head.appendChild( script );
 	} );
 }

--- a/projects/packages/my-jetpack/changelog/fix-sideload-tracks-reject-onerror
+++ b/projects/packages/my-jetpack/changelog/fix-sideload-tracks-reject-onerror
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: fix a bug where a user would see and infinite loading spinner when trying to connect Jetpack with one click in the Welcome flow.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1723236824069459-slack-C01264051NE

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Calls `reject` an when `loadScript` can't load the script for some reason. This prevents the one-click connection flow from failing silently and send it to the `finally` block of `onConnectSiteClick`. Updating the UI to immediately represents that the new connection completed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN with Jetpack Beta pointing to this branch
* Load the site in a browser with ad-blockers enabled
* Click on "Activate Jetpack in one click"
<img width="931" alt="image" src="https://github.com/user-attachments/assets/ed8403b5-bc70-4f06-8700-e498373b7e4c">

* Confirm it finishes loading and the UI reflects the site-connection