### PR TITLE
AI Assistant: Remove Breve highlight popover when feature is disabled

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-remove-popover-on-disable
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-remove-popover-on-disable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Remove Breve highlight popover when feature is disabled

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
@@ -35,7 +35,8 @@ export const useInit = init => {
 
 const Controls = ( { blocks, disabledFeatures } ) => {
 	const [ gradeLevel, setGradeLevel ] = useState( null );
-	const { toggleFeature, toggleProofread } = useDispatch( 'jetpack/ai-breve' );
+	const { toggleFeature, toggleProofread, setPopoverHover, setHighlightHover, setPopoverAnchor } =
+		useDispatch( 'jetpack/ai-breve' );
 	const { tracks } = useAnalytics();
 
 	const isProofreadEnabled = useSelect(
@@ -81,6 +82,19 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 
 	// Update the grade level immediately on first load.
 	useInit( updateGradeLevel );
+
+	// Disable the popover when proofread or a feature is disabled.
+	useEffect( () => {
+		setPopoverHover( false );
+		setHighlightHover( false );
+		setPopoverAnchor( { target: null, virtual: null } );
+	}, [
+		setPopoverHover,
+		setHighlightHover,
+		setPopoverAnchor,
+		isProofreadEnabled,
+		disabledFeatures,
+	] );
 
 	return (
 		<div className="jetpack-ai-proofread">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38796

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reacts to changes on feature availability, removing the popover

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Click on the button to disable Breve to have it focused, re-enable Breve
* Hover over a highlight
* With the popover visible, press space to toggle the feature
* Check that the popover is gone and it is not in the upper left corner of the screen
* Repeat the test with any feature type
