### PR TITLE
VideoPress: update tus JS client lib

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2876,8 +2876,8 @@ importers:
         specifier: ^5.3.4
         version: 5.3.4(react@18.3.1)
       tus-js-client:
-        specifier: 2.3.0
-        version: 2.3.0
+        specifier: 4.1.0
+        version: 4.1.0
     devDependencies:
       '@automattic/calypso-color-schemes':
         specifier: 3.1.3
@@ -11202,6 +11202,9 @@ packages:
   js-base64@2.6.4:
     resolution: {integrity: sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==}
 
+  js-base64@3.7.7:
+    resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -12650,6 +12653,11 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
 
@@ -12697,6 +12705,9 @@ packages:
   proper-lockfile@2.0.1:
     resolution: {integrity: sha512-rjaeGbsmhNDcDInmwi4MuI6mRwJu6zq8GjYCLuSuE7GF+4UjgzkL69sVKKJ2T2xH61kK7rXvGYpvaTu909oXaQ==}
     engines: {node: '>=4.0.0'}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   properties@1.2.1:
     resolution: {integrity: sha512-qYNxyMj1JeW54i/EWEFsM1cVwxJbtgPp8+0Wg9XjNaK6VE/c4oRi6PNu5p7w1mNXEIQIjV5Wwn8v8Gz82/QzdQ==}
@@ -13212,6 +13223,10 @@ packages:
 
   retry@0.10.1:
     resolution: {integrity: sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ==}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -14069,6 +14084,10 @@ packages:
 
   tus-js-client@2.3.0:
     resolution: {integrity: sha512-I4cSwm6N5qxqCmBqenvutwSHe9ntf81lLrtf6BmLpG2v4wTl89atCQKqGgqvkodE6Lx+iKIjMbaXmfvStTg01g==}
+
+  tus-js-client@4.1.0:
+    resolution: {integrity: sha512-e/nC/kJahvNYBcnwcqzuhFIvVELMMpbVXIoOOKdUn74SdQCvJd2JjqV2jZLv2EFOVbV4qLiO0lV7BxBXF21b6Q==}
+    engines: {node: '>=18'}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -17680,7 +17699,7 @@ snapshots:
       node-fetch: 2.6.7
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier-fallback: prettier@3.3.2
+      prettier-fallback: prettier@3.3.3
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.5.2
@@ -17715,7 +17734,7 @@ snapshots:
       node-fetch: 2.6.7
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier-fallback: prettier@3.3.2
+      prettier-fallback: prettier@3.3.3
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.5.2
@@ -17750,7 +17769,7 @@ snapshots:
       node-fetch: 2.6.7
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier-fallback: prettier@3.3.2
+      prettier-fallback: prettier@3.3.3
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.5.2
@@ -17787,7 +17806,7 @@ snapshots:
       node-fetch: 2.6.7
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier-fallback: prettier@3.3.2
+      prettier-fallback: prettier@3.3.3
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.5.2
@@ -24241,6 +24260,8 @@ snapshots:
 
   js-base64@2.6.4: {}
 
+  js-base64@3.7.7: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -25857,6 +25878,8 @@ snapshots:
 
   prettier@3.3.2: {}
 
+  prettier@3.3.3: {}
+
   pretty-error@4.0.0:
     dependencies:
       lodash: 4.17.21
@@ -25909,6 +25932,12 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       retry: 0.10.1
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
 
   properties@1.2.1: {}
 
@@ -26535,6 +26564,8 @@ snapshots:
       signal-exit: 3.0.7
 
   retry@0.10.1: {}
+
+  retry@0.12.0: {}
 
   retry@0.13.1: {}
 
@@ -27469,6 +27500,16 @@ snapshots:
       js-base64: 2.6.4
       lodash.throttle: 4.1.1
       proper-lockfile: 2.0.1
+      url-parse: 1.5.10
+
+  tus-js-client@4.1.0:
+    dependencies:
+      buffer-from: 1.1.2
+      combine-errors: 3.0.3
+      is-stream: 2.0.1
+      js-base64: 3.7.7
+      lodash.throttle: 4.1.1
+      proper-lockfile: 4.1.2
       url-parse: 1.5.10
 
   type-check@0.4.0:

--- a/projects/packages/videopress/changelog/update-videopress-tus-client-lib
+++ b/projects/packages/videopress/changelog/update-videopress-tus-client-lib
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+VideoPress: update tus client library to 4.1.0

--- a/projects/packages/videopress/composer.json
+++ b/projects/packages/videopress/composer.json
@@ -66,7 +66,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.23.x-dev"
+			"dev-trunk": "0.24.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -84,6 +84,6 @@
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"react-router-dom": "^5.3.4",
-		"tus-js-client": "2.3.0"
+		"tus-js-client": "4.1.0"
 	}
 }

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.31-alpha",
+	"version": "0.24.0-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.31-alpha';
+	const PACKAGE_VERSION = '0.24.0-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/client/lib/resumable-file-uploader/index.ts
+++ b/projects/packages/videopress/src/client/lib/resumable-file-uploader/index.ts
@@ -18,6 +18,7 @@ declare module 'tus-js-client' {
 	}
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type VPUploadHttpRequest = tus.HttpRequest & {
 	_method: string;
 	_url: string;

--- a/projects/plugins/jetpack/changelog/update-videopress-tus-client-lib
+++ b/projects/plugins/jetpack/changelog/update-videopress-tus-client-lib
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2758,7 +2758,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/videopress",
-				"reference": "ccd2cd04dcc11555bdd85d6e317b5d66a52ee1aa"
+				"reference": "a2141cef5a8cad5d00f4040f6474f08538d0d1d2"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -2785,7 +2785,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.23.x-dev"
+					"dev-trunk": "0.24.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-package-version.php"

--- a/projects/plugins/videopress/changelog/update-videopress-tus-client-lib
+++ b/projects/plugins/videopress/changelog/update-videopress-tus-client-lib
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1672,7 +1672,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/videopress",
-                "reference": "ccd2cd04dcc11555bdd85d6e317b5d66a52ee1aa"
+                "reference": "a2141cef5a8cad5d00f4040f6474f08538d0d1d2"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1699,7 +1699,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-videopress/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.23.x-dev"
+                    "dev-trunk": "0.24.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-package-version.php"


### PR DESCRIPTION
This is part of a bigger change in an attempt to address https://github.com/Automattic/videopress/issues/1038

## Proposed changes:
The PR updates the tus-js-client lib to its latest stable version 4.1.0. It should not change any current functionality.
It also adds proper types for less wiggly lines on the linter.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1723222978644229-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test video uploads on the VideoPress dashboard, the block editor and the media library. They should function as usual.
This is better tested on a JN instance as the task to make it work properly on the sandbox is a bit more frustrating, we'll get to that on next iterations.