### PR TITLE
MU WPCOM: Replace @wordpress/react-i18n with @wordpress/i18n

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-block-editor-nux-error
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-block-editor-nux-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+MU WPCOM: Fix the “page-patterns” plugin has encountered an error and cannot be rendered"

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.54.2",
+	"version": "5.54.3-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.54.2';
+	const PACKAGE_VERSION = '5.54.3-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -174,7 +174,7 @@ class Jetpack_Mu_Wpcom {
 		define( 'MU_WPCOM_STARTER_PAGE_TEMPLATES', true );
 		define( 'MU_WPCOM_TAGS_EDUCATION', true );
 		define( 'MU_WPCOM_BLOCK_DESCRIPTION_LINKS', true );
-		define( 'MU_WPCOM_BLOCK_EDITOR_NUX', false );
+		define( 'MU_WPCOM_BLOCK_EDITOR_NUX', true );
 		define( 'MU_WPCOM_POSTS_LIST_BLOCK', true );
 		define( 'MU_WPCOM_JETPACK_COUNTDOWN_BLOCK', true );
 		define( 'MU_WPCOM_JETPACK_TIMELINE_BLOCK', true );
@@ -218,6 +218,7 @@ class Jetpack_Mu_Wpcom {
 			require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';
 			require_once __DIR__ . '/features/tags-education/tags-education.php';
 			require_once __DIR__ . '/features/wpcom-block-description-links/wpcom-block-description-links.php';
+			require_once __DIR__ . '/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php';
 			require_once __DIR__ . '/features/wpcom-blocks/a8c-posts-list/a8c-posts-list.php';
 			require_once __DIR__ . '/features/wpcom-blocks/event-countdown/event-countdown.php';
 			require_once __DIR__ . '/features/wpcom-blocks/timeline/timeline.php';

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-minimized.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-minimized.tsx
@@ -1,8 +1,7 @@
 import { Button, Flex } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon, close } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import maximize from '../icons/maximize';
 import type { MinimizedTourRendererProps } from '../../../types';
 
@@ -12,7 +11,6 @@ const WpcomTourKitMinimized: React.FunctionComponent< MinimizedTourRendererProps
 	onDismiss,
 	currentStepIndex,
 } ) => {
-	const { __ } = useI18n();
 	const lastStepIndex = steps.length - 1;
 	const page = currentStepIndex + 1;
 	const numberOfPages = lastStepIndex + 1;

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-rating.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-rating.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useTourKitContext } from '../../../index';
 import thumbsDown from '../icons/thumbs_down';
@@ -12,7 +12,6 @@ const WpcomTourKitRating: React.FunctionComponent = () => {
 	const context = useTourKitContext();
 	const config = context.config as unknown as WpcomConfig;
 	const tourRating = config.options?.tourRating?.useTourRating?.() ?? tempRating;
-	const { __ } = useI18n();
 
 	let isDisabled = false;
 

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-step-card-navigation.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
+import { __ } from '@wordpress/i18n';
 import WpcomTourKitPaginationControl from './wpcom-tour-kit-pagination-control';
 import type { WpcomTourStepRendererProps } from '../../../types';
 
@@ -14,7 +14,6 @@ const WpcomTourKitStepCardNavigation: React.FunctionComponent< Props > = ( {
 	setInitialFocusedElement,
 	steps,
 } ) => {
-	const { __ } = useI18n();
 	const isFirstStep = currentStepIndex === 0;
 	const lastStepIndex = steps.length - 1;
 

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-step-card-overlay-controls.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-step-card-overlay-controls.tsx
@@ -1,6 +1,6 @@
 import { Button, Flex } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import minimize from '../icons/minimize';
 import type { TourStepRendererProps } from '../../../types';
 
@@ -13,8 +13,6 @@ const WpcomTourKitStepCardOverlayControls: React.FunctionComponent< Props > = ( 
 	onMinimize,
 	onDismiss,
 } ) => {
-	const { __ } = useI18n();
-
 	return (
 		<div className="wpcom-tour-kit-step-card-overlay-controls">
 			<Flex>

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/variants/wpcom/components/wpcom-tour-kit-step-card.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, CardBody, CardFooter, CardMedia } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import WpcomTourKitRating from './wpcom-tour-kit-rating';
 import WpcomTourKitStepCardNavigation from './wpcom-tour-kit-step-card-navigation';
@@ -18,7 +18,6 @@ const WpcomTourKitStepCard: React.FunctionComponent< WpcomTourStepRendererProps 
 	onPreviousStep,
 	setInitialFocusedElement,
 } ) => {
-	const { __ } = useI18n();
 	const lastStepIndex = steps.length - 1;
 	const { descriptions, heading, imgSrc, imgLink } = steps[ currentStepIndex ].meta;
 	const isLastStep = currentStepIndex === lastStepIndex;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -1,9 +1,9 @@
 import { Modal, Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { Icon, globe, link as linkIcon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
-import { useI18n } from '@wordpress/react-i18n';
 import clsx from 'clsx';
 import React from 'react';
 import postPublishedImage from '../../../../assets/images/illo-share.svg';
@@ -42,7 +42,6 @@ const SharingModalInner: React.FC = () => {
 	const isDismissedDefault = window?.sharingModalOptions?.isDismissed || false;
 	const { launchpadScreenOption } = window?.launchpadOptions || {};
 	const { isDismissed, updateIsDismissed } = useSharingModalDismissed( isDismissedDefault );
-	const { __ } = useI18n();
 	const isPrivateBlog = window?.wpcomGutenberg?.blogPublic === '-1';
 
 	const {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -3,8 +3,8 @@ import { Button, FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { __, _n } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useI18n } from '@wordpress/react-i18n';
 import * as React from 'react';
 import { wpcomTrackEvent } from '../../../../common/tracks';
 import useAddTagsToPost from './use-add-tags-to-post';
@@ -37,7 +37,6 @@ type SuggestedTagsProps = {
  * @param props - The props of the component.
  */
 function SuggestedTags( props: SuggestedTagsProps ) {
-	const { __, _n } = useI18n();
 	const localeSlug = useLocale();
 	const { id: postId, meta: postMeta } = useSelect(
 		select => ( select( 'core/editor' ) as CoreEditorPlaceholder ).getCurrentPost(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/83654, p9F6qB-fSH-p2, p1723186454644719-slack-C02FMH4G8

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace `@wordpress/react-i18n` with `@wordpress/i18n` to get rid of the `@wordpress/react-i18n` to avoid the error because the `wp-react-i18n` dependency was missing without the active Gutenberg plugin

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disable Gutenberg plugin
* Create/Edit a page
* Make sure you can see the following error
  ```
  The “page-patterns” plugin has encountered an error and cannot be rendered"
  ```
* Apply changes to your atomic site
* Create/Edit a page again
* Make sure the error is gone

