### PR TITLE
Social: Fix editor spacing issue

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-editor-spacing
+++ b/projects/js-packages/publicize-components/changelog/fix-social-editor-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a UI issue in the editor

--- a/projects/js-packages/publicize-components/src/components/form/connection-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connection-notice.tsx
@@ -1,0 +1,44 @@
+import { PanelRow } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import usePublicizeConfig from '../../hooks/use-publicize-config';
+import useSocialMediaConnections from '../../hooks/use-social-media-connections';
+import { SettingsButton } from './settings-button';
+import styles from './styles.module.scss';
+
+export const ConnectionNotice: React.FC = () => {
+	const { hasConnections } = useSocialMediaConnections();
+	const { needsUserConnection, userConnectionUrl } = usePublicizeConfig();
+
+	if ( needsUserConnection ) {
+		return (
+			<PanelRow>
+				<p>
+					{ __(
+						'You must connect your WordPress.com account to be able to add social media connections.',
+						'jetpack'
+					) }
+					&nbsp;
+					<a href={ userConnectionUrl }>{ __( 'Connect now', 'jetpack' ) }</a>
+				</p>
+			</PanelRow>
+		);
+	}
+
+	if ( ! hasConnections ) {
+		return (
+			<PanelRow>
+				<p>
+					<span className={ styles[ 'no-connections-text' ] }>
+						{ __(
+							'Sharing is disabled because there are no social media accounts connected.',
+							'jetpack'
+						) }
+					</span>
+					<SettingsButton label={ __( 'Connect an account', 'jetpack' ) } />
+				</p>
+			</PanelRow>
+		);
+	}
+
+	return null;
+};

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -9,18 +9,16 @@
 import { Disabled, PanelRow } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { usePublicizeConfig } from '../../..';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { store as socialStore } from '../../social-store';
 import { ThemedConnectionsModal as ManageConnectionsModal } from '../manage-connections-modal';
 import { SocialPostModal } from '../social-post-modal/modal';
 import { AdvancedPlanNudge } from './advanced-plan-nudge';
+import { ConnectionNotice } from './connection-notice';
 import { ConnectionsList } from './connections-list';
-import { SettingsButton } from './settings-button';
 import { ShareCountInfo } from './share-count-info';
 import { SharePostForm } from './share-post-form';
-import styles from './styles.module.scss';
 
 /**
  * The Publicize form component. It contains the connection list, and the message box.
@@ -29,12 +27,7 @@ import styles from './styles.module.scss';
  */
 export default function PublicizeForm() {
 	const { hasConnections, hasEnabledConnections } = useSocialMediaConnections();
-	const {
-		isPublicizeEnabled,
-		isPublicizeDisabledBySitePlan,
-		needsUserConnection,
-		userConnectionUrl,
-	} = usePublicizeConfig();
+	const { isPublicizeEnabled, isPublicizeDisabledBySitePlan } = usePublicizeConfig();
 
 	const { useAdminUiV1, featureFlags } = useSelect( select => {
 		const store = select( socialStore );
@@ -61,43 +54,7 @@ export default function PublicizeForm() {
 					<ShareCountInfo />
 				</>
 			) : null }
-			{
-				// Use IIFE make it more readable and avoid nested ternary operators.
-				( () => {
-					if ( needsUserConnection ) {
-						return (
-							<PanelRow>
-								<p>
-									{ __(
-										'You must connect your WordPress.com account to be able to add social media connections.',
-										'jetpack'
-									) }
-									&nbsp;
-									<a href={ userConnectionUrl }>{ __( 'Connect now', 'jetpack' ) }</a>
-								</p>
-							</PanelRow>
-						);
-					}
-
-					if ( ! hasConnections ) {
-						return (
-							<PanelRow>
-								<p>
-									<span className={ styles[ 'no-connections-text' ] }>
-										{ __(
-											'Sharing is disabled because there are no social media accounts connected.',
-											'jetpack'
-										) }
-									</span>
-									<SettingsButton label={ __( 'Connect an account', 'jetpack' ) } />
-								</p>
-							</PanelRow>
-						);
-					}
-
-					return null;
-				} )()
-			}
+			<ConnectionNotice />
 
 			{ ! isPublicizeDisabledBySitePlan && (
 				<Fragment>

--- a/projects/js-packages/publicize-components/src/components/form/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/index.tsx
@@ -61,12 +61,12 @@ export default function PublicizeForm() {
 					<ShareCountInfo />
 				</>
 			) : null }
-			<PanelRow>
-				{
-					// Use IIFE make it more readable and avoid nested ternary operators.
-					( () => {
-						if ( needsUserConnection ) {
-							return (
+			{
+				// Use IIFE make it more readable and avoid nested ternary operators.
+				( () => {
+					if ( needsUserConnection ) {
+						return (
+							<PanelRow>
 								<p>
 									{ __(
 										'You must connect your WordPress.com account to be able to add social media connections.',
@@ -75,11 +75,13 @@ export default function PublicizeForm() {
 									&nbsp;
 									<a href={ userConnectionUrl }>{ __( 'Connect now', 'jetpack' ) }</a>
 								</p>
-							);
-						}
+							</PanelRow>
+						);
+					}
 
-						if ( ! hasConnections ) {
-							return (
+					if ( ! hasConnections ) {
+						return (
+							<PanelRow>
 								<p>
 									<span className={ styles[ 'no-connections-text' ] }>
 										{ __(
@@ -89,13 +91,13 @@ export default function PublicizeForm() {
 									</span>
 									<SettingsButton label={ __( 'Connect an account', 'jetpack' ) } />
 								</p>
-							);
-						}
+							</PanelRow>
+						);
+					}
 
-						return null;
-					} )()
-				}
-			</PanelRow>
+					return null;
+				} )()
+			}
 
 			{ ! isPublicizeDisabledBySitePlan && (
 				<Fragment>

--- a/projects/js-packages/publicize-components/src/components/form/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/form/styles.module.scss
@@ -49,7 +49,7 @@
 
 .enabled-connections-notice {
 	color: var(--jp-gray-50);
-	margin-bottom: 0.5rem;
+	margin-bottom: 0.25rem;
 }
 
 p.auto-share-title {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/489
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixed an issue where PanelRow was rendered when the content was not due to it's condition

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/489
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor and check that you do not see the extra Panelrow

| Before | After |
|--------|--------|
| ![CleanShot 2024-08-12 at 10 41 16 png](https://github.com/user-attachments/assets/ccd47ca9-fdb5-4d89-9c1e-ed37fd3c6768) | ![CleanShot 2024-08-12 at 10 37 34 png](https://github.com/user-attachments/assets/81825781-64ee-4431-8228-35ce501b358a) | 

