### PR TITLE
Social: Fix social post modal height and Mastodon preview

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-post-moda-height
+++ b/projects/js-packages/publicize-components/changelog/fix-social-post-moda-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed social post modal max-height

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/post-preview.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/post-preview.tsx
@@ -112,14 +112,11 @@ export function PostPreview( { connection }: PostPreviewProps ) {
 			const firstMediaItem = media?.[ 0 ];
 
 			const customImage = firstMediaItem?.type.startsWith( 'image/' ) ? firstMediaItem.url : null;
-			const desc = message
-				? message
-				: `${ title && excerpt ? `${ title }\n\n${ excerpt }` : title }`;
 
 			return (
 				<MastodonPostPreview
 					{ ...commonProps }
-					description={ desc }
+					description={ excerpt }
 					siteName={ siteName }
 					user={ {
 						avatarUrl: user.profileImage,

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/styles.module.scss
@@ -12,6 +12,7 @@
 
     @include break-large {
         width: calc(#{$break-large} - 40px);
+        max-height: calc(100% - 120px);
     }
 
     :global(.components-modal__content.hide-header) {


### PR DESCRIPTION

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Increase social post modal max-height to whatever makes the content fit
* Fix duplicated title for Mastodon preview when there is no custom message

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->



* Enable the editor preview feature - `define( 'JETPACK_SOCIAL_HAS_EDITOR_PREVIEW', true );`
* Goto post editor
* Open Jetpack or Social sidebar
* Under "Share this post" section, click on "Create custom posts"
* Add a custom image that has height greater than its width to make the modal scroll
* Confirm that the max-height of the modal has been increased
* Confirm that the duplicated title for Mastodon preview when there is no custom message is fixed


| BEFORE | AFTER |
|--------|--------|
| <img width="1167" alt="Screenshot 2024-08-12 at 2 18 44 PM" src="https://github.com/user-attachments/assets/e42de9f8-44e6-45d7-8530-8aafff507193"> | <img width="1169" alt="Screenshot 2024-08-12 at 2 17 33 PM" src="https://github.com/user-attachments/assets/a9566d1d-22b7-438e-9b22-7cdd03bcc091"> |