### PR TITLE
Classic Helper Theme Plugin: Add Social Links to the plugin

### DIFF
--- a/projects/plugins/classic-theme-helper-plugin/changelog/update-classic-theme-helper-plugin-social-links
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/update-classic-theme-helper-plugin-social-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Classic Theme Helper: Ensure Social Links will load from the plugin.

--- a/projects/plugins/classic-theme-helper-plugin/classic-theme-helper-plugin.php
+++ b/projects/plugins/classic-theme-helper-plugin/classic-theme-helper-plugin.php
@@ -79,6 +79,7 @@ function init_packages_plugins_loaded() {
 	 */
 function init_packages_init() {
 	if ( class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Social_Links' ) ) {
+		// @phan-suppress-next-line PhanNoopNew
 		new Automattic\Jetpack\Classic_Theme_Helper\Social_Links();
 	}
 }

--- a/projects/plugins/classic-theme-helper-plugin/classic-theme-helper-plugin.php
+++ b/projects/plugins/classic-theme-helper-plugin/classic-theme-helper-plugin.php
@@ -52,19 +52,33 @@ add_filter(
 	}
 );
 
-	// Init Jetpack packages
-	add_action( 'plugins_loaded', 'init_packages', 1 );
+	// Init Jetpack packages that are hooked into plugins_loaded.
+	add_action( 'plugins_loaded', 'init_packages_plugins_loaded', 1 );
 
 	/**
-	 * Configure what Jetpack packages should get automatically initialized.
+	 * Configure what Jetpack packages should get automatically initialized, using the plugins_loaded hook.
 	 *
 	 * @return void
 	 */
-function init_packages() {
+function init_packages_plugins_loaded() {
 	if ( class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 		Automattic\Jetpack\Classic_Theme_Helper\Main::init();
 	}
 	if ( class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Featured_Content' ) ) {
 		Automattic\Jetpack\Classic_Theme_Helper\Featured_Content::setup();
+	}
+}
+
+	// Init Jetpack packages that are hooked into init.
+	add_action( 'init', 'init_packages_init', 30 );
+
+	/**
+	 * Configure what Jetpack packages should get automatically initialized, using the init hook.
+	 *
+	 * @return void
+	 */
+function init_packages_init() {
+	if ( class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Social_Links' ) ) {
+		new Automattic\Jetpack\Classic_Theme_Helper\Social_Links();
 	}
 }


### PR DESCRIPTION

Fixes https://github.com/Automattic/vulcan/issues/442

## Proposed changes:

* This PR ensures the classes that initialize Social Links from the Classic Theme Helper package are initialized in the plugin, so they can work even if Jetpack is not also initializing those classes.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/vulcan/issues/442

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Replicating the issue:

* If testing locally, make sure you have installed and built the Classic Helper Theme plugin:  `jetpack install plugins/classic-theme-helper-plugin`, `jetpack build plugins/classic-theme-helper-plugin`, then activate the plugin.
* Also if testing locally, remove `"automattic/jetpack-classic-theme-helper": "@dev",` from the Jetpack plugin `composer.json` file. Then run run `tools/fixup-project-versions.sh`, and then `jetpack install plugins/jetpack` and `jetpack build plugins/jetpack`.
* If testing using the Beta tester plugin, activate 'Bleeding Edge' for the Classic Theme Helper plugin.
* Comment out `theme-tools/social-links.php'` from `projects/plugins/jetpack/modules/module-extras.php` (via SFTP / SSH if using a test site and the Beta tester plugin)
* If testing using the Beta tester plugin,  delete the `jetpack-classic-theme-helper` package folder from `jetpack/jetpack-vendor/automattic`.
* Follow the steps in this PR to test Social Links (only on self-hosted): https://github.com/Automattic/jetpack/pull/38730
* It should not work.

To test the fix:

* Apply this PR if testing locally or using the Beta tester plugin (activating the branch for the Classic Theme Helper plugin).
* Follow the same steps as above (from 'comment out' if using the Beta tester plugin)
* Social Links should work as expected.

