### PR TITLE
WPCOM MU PLUGIN: update block description links

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-embed-documentaion-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-embed-documentaion-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WPCOM Block Description Links: add links for embed variations

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
@@ -90,10 +90,14 @@ const addBlockSupportLinks = (
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				description: string | ReactElement< string | JSXElementConstructor< any > >;
 			} ) => {
-				const link = blockInfoWithVariations[ name ][ variation.name ]?.link;
-				const postId = blockInfoWithVariations[ name ][ variation.name ]?.postId;
+				let link = blockInfoWithVariations[ name ][ variation.name ]?.link;
+				let postId = blockInfoWithVariations[ name ][ variation.name ]?.postId;
 
-				if ( ! link ) {
+				// Set the default link for all embed variations that don't have a specific guide.
+				if ( ! link && name === 'core/embed' ) {
+					link = 'https://wordpress.com/support/wordpress-editor/blocks/embed-block/';
+					postId = 150644;
+				} else if ( ! link ) {
 					return variation;
 				}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
@@ -187,6 +187,9 @@ const blockInfoMapping: { [ key: string ]: { link: string; postId: number } } = 
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/syntax-highlighter-code-block/',
 		postId: 4743,
 	},
+	/**
+	 * Automattic Blocks
+	 */
 	'crowdsignal-forms/vote': {
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/vote-block/',
 		postId: 174824,
@@ -215,6 +218,9 @@ const blockInfoMapping: { [ key: string ]: { link: string; postId: number } } = 
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/blog-posts-block/',
 		postId: 158419,
 	},
+	/**
+	 * Jetpack Blocks
+	 */
 	'jetpack/send-a-message': {
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/whatsapp-button-block/',
 		postId: 169728,
@@ -352,6 +358,12 @@ export const blockInfoWithVariations: {
 		'group-stack': {
 			link: 'https://wordpress.com/support/wordpress-editor/blocks/row-block/',
 			postId: 190036,
+		},
+	},
+	'core/embed': {
+		twitter: {
+			link: 'https://wordpress.com/support/wordpress-editor/blocks/twitter-block/',
+			postId: 150413,
 		},
 	},
 };

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
@@ -361,9 +361,21 @@ export const blockInfoWithVariations: {
 		},
 	},
 	'core/embed': {
+		soundcloud: {
+			link: 'https://wordpress.com/support/soundcloud-audio-player/',
+			postId: 4213,
+		},
 		twitter: {
 			link: 'https://wordpress.com/support/wordpress-editor/blocks/twitter-block/',
 			postId: 150413,
+		},
+		vimeo: {
+			link: 'https://wordpress.com/support/videos/vimeo/',
+			postId: 1235,
+		},
+		youtube: {
+			link: 'https://wordpress.com/support/wordpress-editor/blocks/youtube-block/',
+			postId: 150414,
 		},
 	},
 };

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
@@ -51,6 +51,12 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 		 */
 		'https://wordpress.org/documentation/article/styles-overview/':
 			'https://wordpress.com/support/using-styles/',
+
+		/**
+		 * Embed Block
+		 */
+		'https://wordpress.org/documentation/article/embeds/':
+			'https://wordpress.com/support/wordpress-editor/blocks/embed-block/',
 	};
 
 	const url = documentLinksMap[ text ] ?? '';


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/86688

## Proposed changes:

Add WordPress.com support links to embed variation blocks. I accounted for some of the major ones that we have guides for and added the default guide for every other variation.

<img width="494" alt="Screen Shot 2024-08-12 at 17 50 23" src="https://github.com/user-attachments/assets/7df0c73e-d407-442b-b5d9-a8270e1d36c0">

This also adds a rewrite for the "learn more" link in the embed block. Now you should receive a WordPress.com link rather than a WordPress.org link.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
*More detailed testing steps here...* PCYsg-Osp-p2

1. Pull branch
2. Run `jetpack build packages/jetpack-mu-wpcom plugins/mu-wpcom-plugin && jetpack rsync mu-wpcom-plugin [YOUR-ATOMIC-SSH]:htdocs/wp-content/plugins/jetpack-mu-wpcom-plugin-dev`
3. Make sure you have these two defined: `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` & `define( 'JETPACK_AUTOLOAD_DEV', true );` in your `wp-config.php`.
4. Go to the post editor and add any embed block.
5. The Block Guide link under the description should link you to either the specific variation guide or the default embed block.