### PR TITLE
Backport mu-wpcom-plugin 2.5.6, jetpack 13.8-a.1, wpcomsh 5.3.3 Changes

### DIFF
--- a/projects/js-packages/partner-coupon/CHANGELOG.md
+++ b/projects/js-packages/partner-coupon/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.84 - 2024-08-12
+### Removed
+- Tests: Removed react-test-renderer. [#38755]
+
 ## 0.2.83 - 2024-07-22
 ### Changed
 - Update dependencies. [#38402]

--- a/projects/js-packages/partner-coupon/changelog/fix-deprecated-react-test-renderer-usage
+++ b/projects/js-packages/partner-coupon/changelog/fix-deprecated-react-test-renderer-usage
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Tests: Removed react-test-renderer.

--- a/projects/js-packages/partner-coupon/package.json
+++ b/projects/js-packages/partner-coupon/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-partner-coupon",
-	"version": "0.2.84-alpha",
+	"version": "0.2.84",
 	"description": "This package aims to add components to make it easier to redeem partner coupons",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/partner-coupon/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/CHANGELOG.md
+++ b/projects/js-packages/publicize-components/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.60.0] - 2024-08-12
+### Changed
+- Hid most of the actions and notices when sharing is off [#38801]
+- Updated the position of connection notices in the editor [#38789]
+- Social: Updated intial state logic to use the new consolidated initial state [#38606]
+- Updated the custom message placeholder [#38784]
+
+### Fixed
+- Fixed a UI issue in the editor [#38829]
+- Fixed social post modal max-height [#38830]
+- Social post UI: Fix connection toggle and media notice [#38799]
+
 ## [0.59.0] - 2024-08-05
 ### Added
 - Added connection toggle to social post preview [#38686]
@@ -819,6 +831,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#24470]
 
+[0.60.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.59.0...v0.60.0
 [0.59.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.58.0...v0.59.0
 [0.58.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.57.0...v0.58.0
 [0.57.0]: https://github.com/Automattic/jetpack-publicize-components/compare/v0.56.2...v0.57.0

--- a/projects/js-packages/publicize-components/changelog/fix-social-editor-spacing
+++ b/projects/js-packages/publicize-components/changelog/fix-social-editor-spacing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed a UI issue in the editor

--- a/projects/js-packages/publicize-components/changelog/fix-social-post-connection-toggle-and-notice
+++ b/projects/js-packages/publicize-components/changelog/fix-social-post-connection-toggle-and-notice
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Social post UI: Fix connection toggle and media notice

--- a/projects/js-packages/publicize-components/changelog/fix-social-post-moda-height
+++ b/projects/js-packages/publicize-components/changelog/fix-social-post-moda-height
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed social post modal max-height

--- a/projects/js-packages/publicize-components/changelog/update-consolidate-social-state
+++ b/projects/js-packages/publicize-components/changelog/update-consolidate-social-state
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Social: Updated intial state logic to use the new consolidated initial state

--- a/projects/js-packages/publicize-components/changelog/update-social-custom-message-placeholder
+++ b/projects/js-packages/publicize-components/changelog/update-social-custom-message-placeholder
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Updated the custom message placeholder

--- a/projects/js-packages/publicize-components/changelog/update-social-hide-notices-with-module-off
+++ b/projects/js-packages/publicize-components/changelog/update-social-hide-notices-with-module-off
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Hid most of the actions and notices when sharing is off

--- a/projects/js-packages/publicize-components/changelog/update-social-move-notices-near-connections
+++ b/projects/js-packages/publicize-components/changelog/update-social-move-notices-near-connections
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Moved the connection notices in the editor

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.60.0-alpha",
+	"version": "0.60.0",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/script-data/CHANGELOG.md
+++ b/projects/js-packages/script-data/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2024-08-12
+### Fixed
+- Add npm auto-publish to script-data package [#38826]
+
 ## 0.1.0 - 2024-08-08
 ### Added
 - Added jetpack-script-data package to consolidate the logic for Jetpack Initial state [#38430]
+
+[0.1.1]: https://github.com/Automattic/jetpack-script-data/compare/v0.1.0...v0.1.1

--- a/projects/js-packages/script-data/changelog/update-npm-autopublish-script-data
+++ b/projects/js-packages/script-data/changelog/update-npm-autopublish-script-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Add npm auto-publish to script-data package

--- a/projects/js-packages/script-data/package.json
+++ b/projects/js-packages/script-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-script-data",
-	"version": "0.1.1-alpha",
+	"version": "0.1.1",
 	"description": "A library to provide data for script handles and the corresponding utility functions for Jetpack.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/script-data/#readme",
 	"bugs": {

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2024-08-12
+### Fixed
+- Fixed variable names. [#38606]
+
 ## [2.3.0] - 2024-08-08
 ### Added
-- Added jetpack-initial-state package to consolidate the logic for Initial state [#38430]
+- Added jetpack-initial-state package to consolidate the logic for Initial state. [#38430]
 
 ## [2.2.0] - 2024-07-23
 ### Added
@@ -466,6 +470,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[2.3.1]: https://github.com/Automattic/jetpack-assets/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/Automattic/jetpack-assets/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/Automattic/jetpack-assets/compare/v2.1.13...v2.2.0
 [2.1.13]: https://github.com/Automattic/jetpack-assets/compare/v2.1.12...v2.1.13

--- a/projects/packages/assets/changelog/update-consolidate-social-state
+++ b/projects/packages/assets/changelog/update-consolidate-social-state
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed variable names

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.8] - 2024-08-12
+### Added
+- React 19 compatibility: Making sure useRef includes an argument. [#38765]
+
 ## [0.32.7] - 2024-08-05
 ### Changed
 - React compatibility: Changing ReactDOM.render usage to be via ReactDOM.createRoot. [#38649]
@@ -619,6 +623,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[0.32.8]: https://github.com/automattic/jetpack-forms/compare/v0.32.7...v0.32.8
 [0.32.7]: https://github.com/automattic/jetpack-forms/compare/v0.32.6...v0.32.7
 [0.32.6]: https://github.com/automattic/jetpack-forms/compare/v0.32.5...v0.32.6
 [0.32.5]: https://github.com/automattic/jetpack-forms/compare/v0.32.4...v0.32.5

--- a/projects/packages/forms/changelog/update-react-compat-useref-requires-argument
+++ b/projects/packages/forms/changelog/update-react-compat-useref-requires-argument
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-React 19 compatibility: Making sure useRef includes an argument.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.32.8-alpha",
+	"version": "0.32.8",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.32.8-alpha';
+	const PACKAGE_VERSION = '0.32.8';
 
 	/**
 	 * Load the contact form module.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.55.0] - 2024-08-12
+### Added
+- WPCOM MU Plugin: Add dynamic script loader [#38819]
+
 ## [5.54.3] - 2024-08-12
 ### Fixed
 - MU WPCOM: Fix the “page-patterns” plugin has encountered an error and cannot be rendered" [#38823]
@@ -12,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.54.2] - 2024-08-09
 ### Fixed
 - Block Editor Nux: Temporary stop load feature from MU WPCOM [#38802]
-- Fixed CSSTidy loading in the test. [#37859]
+- Fixed CSSTidy loading in the test [#37859]
 
 ## [5.54.1] - 2024-08-08
 ### Fixed
@@ -1129,6 +1133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.55.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.54.3...v5.55.0
 [5.54.3]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.54.2...v5.54.3
 [5.54.2]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.54.1...v5.54.2
 [5.54.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.54.0...v5.54.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-dynamic-enqueue-script
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-dynamic-enqueue-script
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-WPCOM MU Plugin: add dynamic script loader

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -62,7 +62,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.55.x-dev"
+			"dev-trunk": "5.56.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.55.0-alpha",
+	"version": "5.55.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.55.0",
+	"version": "5.56.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.55.0-alpha';
+	const PACKAGE_VERSION = '5.55.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.55.0';
+	const PACKAGE_VERSION = '5.56.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.0] - 2024-08-12
+### Changed
+- Open Graph Meta Tags: Stopped handling Fediverse tags from Publicize package. [#38809]
+- Social: Updated intial state logic to use the new consolidated initial state. [#38606]
+
 ## [0.48.0] - 2024-08-05
 ### Added
 - Added endpoint to sync shares post meta back to the self-hosted site. [#38702]
@@ -640,6 +645,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.49.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.48.0...v0.49.0
 [0.48.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.47.4...v0.48.0
 [0.47.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.47.3...v0.47.4
 [0.47.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.47.2...v0.47.3

--- a/projects/packages/publicize/changelog/update-consolidate-social-state
+++ b/projects/packages/publicize/changelog/update-consolidate-social-state
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Social: Updated intial state logic to use the new consolidated initial state

--- a/projects/packages/publicize/changelog/update-fediverse-og-to-common
+++ b/projects/packages/publicize/changelog/update-fediverse-og-to-common
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Open Graph Meta Tags: do not handle Fediverse tags from Publicize package.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.49.0-alpha",
+	"version": "0.49.0",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.31] - 2024-08-12
+### Added
+- React 19 compatibility: Making sure useRef includes an argument. [#38765]
+
+### Removed
+- Tests: Removed react-test-renderer. [#38755]
+
 ## [0.23.30] - 2024-08-05
 ### Changed
 - Fixup versions [#38612]
@@ -1382,6 +1389,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.23.31]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.30...v0.23.31
 [0.23.30]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.29...v0.23.30
 [0.23.29]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.28...v0.23.29
 [0.23.28]: https://github.com/Automattic/jetpack-videopress/compare/v0.23.27...v0.23.28

--- a/projects/packages/videopress/changelog/fix-deprecated-react-test-renderer-usage
+++ b/projects/packages/videopress/changelog/fix-deprecated-react-test-renderer-usage
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Tests: Removed react-test-renderer.

--- a/projects/packages/videopress/changelog/update-react-compat-useref-requires-argument
+++ b/projects/packages/videopress/changelog/update-react-compat-useref-requires-argument
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-React 19 compatibility: Making sure useRef includes an argument.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.23.31-alpha",
+	"version": "0.23.31",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.23.31-alpha';
+	const PACKAGE_VERSION = '0.23.31';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 13.8-a.1 - 2024-08-12
+### Enhancements
+- Social: Display Fediverse creator meta tag when a post has an active Mastodon connection. [#38809]
+
+### Improved compatibility
+- Performance: Optimize the size of included image files. [#38573]
+
+### Bug fixes
+- AI Assistant: Disable Breve for free plan users when AI Assistant block is disabled [#38743]
+- Subscriptions: Prevent saave discussion settings from turning on the subscribe modal. [#38805]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- AI Assistant: Add namespace to Breve CSS classes. [#38795]
+- Code: Cleaning up usage of 'javascript:' in URLs. [#38783]
+- Code: Making sure useRef includes an argument. [#38765]
+- Components: React cleanup for React 19 compatibility. [#38762]
+- Contact Form: Remove deprecated functionality. [#38786]
+- Likes Block: Add keywords. [#38778]
+- Media: Support video and audio shortcodes in Media Extractor. [#38556]
+- Publicize: Fixed a warning with undefined variables. [#38781]
+- Security: Redirect to Protect dashboard for Firewall settings, when available. [#38655]
+- Social: Updated intial state logic to use the new consolidated initial state. [#38606]
+- Tests: Fixed CSSTidy loading in tests. [#37859]
+- Tests: Removed react-test-renderer as not in use. [#38755]
+
 ## 13.7-beta2 - 2024-08-06
 ### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
 - Internal updates.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-preview.php
@@ -136,7 +136,7 @@ class WPCOM_REST_API_V2_Endpoint_Email_Preview extends WP_REST_Controller {
 				/**
 				* Filters the generated email preview HTML.
 				*
-				* @since $$next-version$$
+				* @since 13.8
 				*
 				* @param string $html   The generated HTML for the email preview.
 				* @param WP_Post $post  The post object.

--- a/projects/plugins/jetpack/changelog/add-consolidate-initial-state
+++ b/projects/plugins/jetpack/changelog/add-consolidate-initial-state
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-extracting-video-audio-shortcodes
+++ b/projects/plugins/jetpack/changelog/add-extracting-video-audio-shortcodes
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Support video and audio shortcodes in Media Extractor

--- a/projects/plugins/jetpack/changelog/add-protect-threat-history
+++ b/projects/plugins/jetpack/changelog/add-protect-threat-history
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/jetpack/changelog/add-redirect-waf-settings-to-protect
+++ b/projects/plugins/jetpack/changelog/add-redirect-waf-settings-to-protect
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Security Settings: Redirect to Protect dashboard for Firewall settings, when available.

--- a/projects/plugins/jetpack/changelog/add-wpcomsh-tests-to-matrix
+++ b/projects/plugins/jetpack/changelog/add-wpcomsh-tests-to-matrix
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixed CSSTidy loading in tests.

--- a/projects/plugins/jetpack/changelog/fix-deprecated-react-test-renderer-usage
+++ b/projects/plugins/jetpack/changelog/fix-deprecated-react-test-renderer-usage
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Tests: Removed react-test-renderer as not in use.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-paid-plans
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-breve-paid-plans
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI Assistant: Disable Breve when AI Assistant block is disabled or on free plan

--- a/projects/plugins/jetpack/changelog/fix-social-initial-state-undefined-variable
+++ b/projects/plugins/jetpack/changelog/fix-social-initial-state-undefined-variable
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Fixed a warning with undefined variables

--- a/projects/plugins/jetpack/changelog/fix-sync-remove-waf-class-usage
+++ b/projects/plugins/jetpack/changelog/fix-sync-remove-waf-class-usage
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Updated tests
-
-

--- a/projects/plugins/jetpack/changelog/init-release-cycle
+++ b/projects/plugins/jetpack/changelog/init-release-cycle
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Init 13.8-a.0
-
-

--- a/projects/plugins/jetpack/changelog/remove-google-drive-helper
+++ b/projects/plugins/jetpack/changelog/remove-google-drive-helper
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Contact Form: Removing deprecated functionality

--- a/projects/plugins/jetpack/changelog/try-lossless-image-optmization-part-2
+++ b/projects/plugins/jetpack/changelog/try-lossless-image-optmization-part-2
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Lossless image optimization of most images in projects/plugins [a through social]

--- a/projects/plugins/jetpack/changelog/update-consolidate-social-state
+++ b/projects/plugins/jetpack/changelog/update-consolidate-social-state
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-Social: Updated intial state logic to use the new consolidated initial state

--- a/projects/plugins/jetpack/changelog/update-discussion-settings-modal
+++ b/projects/plugins/jetpack/changelog/update-discussion-settings-modal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Fix: Saving discussion settings shouldn't turn on subscribe modal.

--- a/projects/plugins/jetpack/changelog/update-email-preview-access-selector
+++ b/projects/plugins/jetpack/changelog/update-email-preview-access-selector
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Already in a previous changelog entry

--- a/projects/plugins/jetpack/changelog/update-email-preview-access-selector-disabled
+++ b/projects/plugins/jetpack/changelog/update-email-preview-access-selector-disabled
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-feature flaged feature

--- a/projects/plugins/jetpack/changelog/update-email-preview-styles
+++ b/projects/plugins/jetpack/changelog/update-email-preview-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-feature flag feature, not yet released

--- a/projects/plugins/jetpack/changelog/update-fediverse-og-to-common
+++ b/projects/plugins/jetpack/changelog/update-fediverse-og-to-common
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Jetpack Social: display Fediverse creator meta tag when a post has an active Mastodon connection.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-css-namespace
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-css-namespace
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI Assistant: Add namespace to Breve CSS classes

--- a/projects/plugins/jetpack/changelog/update-likes-keywords
+++ b/projects/plugins/jetpack/changelog/update-likes-keywords
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Likes Block: add keywords

--- a/projects/plugins/jetpack/changelog/update-preview-email
+++ b/projects/plugins/jetpack/changelog/update-preview-email
@@ -1,4 +1,0 @@
-Significance: minor
-Type: other
-
-there's already a changelog for this feature

--- a/projects/plugins/jetpack/changelog/update-react-compat-javascript-url
+++ b/projects/plugins/jetpack/changelog/update-react-compat-javascript-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Javascript: Cleaning up usage of javascript: in URLs

--- a/projects/plugins/jetpack/changelog/update-react-compat-useref-requires-argument
+++ b/projects/plugins/jetpack/changelog/update-react-compat-useref-requires-argument
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-React 19 compatibility: Making sure useRef includes an argument. 

--- a/projects/plugins/jetpack/changelog/update-react-compatibility-ref-cleanup
+++ b/projects/plugins/jetpack/changelog/update-react-compatibility-ref-cleanup
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Components: React cleanup, removing implicit returns from ref callbacks, to ensure compatibility with React 19.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_8_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_8_a_2",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_8_a_0",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ13_8_a_1",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -543,7 +543,7 @@ function jetpack_og_get_description( $description = '', $data = null ) {
  *
  * @see https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/
  *
- * @since $$next-version$$
+ * @since 13.8
  *
  * @param array $tags Current tags.
  *
@@ -643,7 +643,7 @@ function jetpack_add_fediverse_creator_open_graph_tag( $tags ) {
  * Update the markup for the Open Graph tag to match the expected output for Mastodon
  * (name instead of property).
  *
- * @since $$next-version$$
+ * @since 13.8
  *
  * @param string $og_tag A single OG tag.
  *

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.8-a.1
+ * Version: 13.8-a.2
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.5' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.8-a.1' );
+define( 'JETPACK__VERSION', '13.8-a.2' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 13.8-a.0
+ * Version: 13.8-a.1
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 define( 'JETPACK__MINIMUM_WP_VERSION', '6.5' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '7.0' );
-define( 'JETPACK__VERSION', '13.8-a.0' );
+define( 'JETPACK__VERSION', '13.8-a.1' );
 
 /**
  * Constant used to fetch the connection owner token

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.8.0-a.1",
+	"version": "13.8.0-a.2",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Jetpack",
-	"version": "13.8.0-a.0",
+	"version": "13.8.0-a.1",
 	"private": true,
 	"description": "[Jetpack](https://jetpack.com/) is a WordPress plugin that supercharges your self-hosted WordPress site with the awesome cloud power of [WordPress.com](https://wordpress.com).",
 	"homepage": "https://jetpack.com",

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,45 +326,16 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 13.7-beta - 2024-08-05
+### 13.8-a.1 - 2024-08-12
 #### Enhancements
-- AI Assistant: Add feedback link to the sidebar.
-- AI Assistant: Breve UI enhancements.
-- AI Assistant: Disable first Breve hover on mobile.
-- AI Assistant: Disable long sentences Breve feature by default.
-- AI Assistant: Enable Breve for 10% of production sites.
-- AI Assistant: Enable Breve for 20% of production sites.
-- AI Assistant: Make Jetpack Breve available to general public.
-- AI Assistant: The general purpose image generator is now available to all users.
-- Blocks: Add the EventCoutdown block.
-- Blocks: Add the Timeline block.
-- Dashboard: Add a dashboard card for AI Assistant.
-- General: Losslessly optimized PNG images.
-- Jetpack: Port additional Full Site Editing features from WP Cloud.
-- Jetpack AI: Enable the AI Logo generator extension.
-- Jetpack Newsletter: Add Jetpack Newsletter menu with preview option.
-- Newsletter: Improve the modal overlay.
-- Security: Add separate IP allow and block list toggles in Web Application Firewall settings.
-- Settings: Add a link to the AI assistant product page.
-- Site Editor: Remove extra site editor notices in favor of the ones provided by WordPress directly.
-- Social: Added recommendation steps for the Social plan.
-- Subscriptions: Add command palette commands for quickly changing post access.
-- Subscriptions: Implemented a more dynamic approach to displaying the modal.
-- Subscriptions: Improve the Subscribe block loading animation.
+- Social: Display Fediverse creator meta tag when a post has an active Mastodon connection.
 
 #### Improved compatibility
-- Blocks: Changed the use of default parameters in the Map block for React 19 compatibility.
-- Contact Form: Ensure checkboxes are properly displayed when using the Twenty Twenty or the Twenty Twenty One theme.
-- General: Remove code for compatibility with WordPress versions before 6.5.
-- General: Update WordPress version requirements to WordPress 6.5.
-- Masterbar: Always show the notification bell.
+- Performance: Optimize the size of included image files.
 
 #### Bug fixes
-- Blocks: Check if the fontFamily block attribute is a string before trying to format.
-- Donations Block: Fix undefined array key warnings with old/malformed blocks.
-- Jetpack Comments: Fix replying to comments in Chrome when logged in to both WordPress.com and Jetpack.
-- Like block: Fix warning displayed when trying to load the Like block on unsupported pages.
-- Sharing: Do not include Gravatar images in Open Graph Meta tags.
+- AI Assistant: Disable Breve for free plan users when AI Assistant block is disabled
+- Subscriptions: Prevent saave discussion settings from turning on the subscribe modal.
 
 --------
 

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.5.6 - 2024-08-12
+### Changed
+- Internal updates.
+
 ## 2.5.5 - 2024-08-08
 ### Changed
 - Internal updates.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-wpcom-dynamic-enqueue-script
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-wpcom-dynamic-enqueue-script
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_6_alpha"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_6"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_6"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_7_alpha"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1005,7 +1005,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "549c21965098fed38f1c3b908826de426c67bfa0"
+                "reference": "363f23c725cd3277f91f195b90199a3100175441"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1039,7 +1039,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.55.x-dev"
+                    "dev-trunk": "5.56.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.5.6-alpha
+ * Version: 2.5.6
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.5.6
+ * Version: 2.5.7-alpha
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.5.6-alpha",
+	"version": "2.5.6",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.5.6",
+	"version": "2.5.7-alpha",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/wpcomsh/CHANGELOG.md
+++ b/projects/plugins/wpcomsh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.3.3 - 2024-08-12
+### Changed
+- Internal updates.
+
 ## 5.3.2 - 2024-08-12
 ### Changed
 - Internal updates.

--- a/projects/plugins/wpcomsh/changelog/add-wpcom-dynamic-enqueue-script
+++ b/projects/plugins/wpcomsh/changelog/add-wpcom-dynamic-enqueue-script
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/wpcomsh/changelog/prerelease
+++ b/projects/plugins/wpcomsh/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -128,7 +128,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_3_3"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_3_4_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -128,7 +128,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_3_3_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_3_3"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1142,7 +1142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "549c21965098fed38f1c3b908826de426c67bfa0"
+                "reference": "363f23c725cd3277f91f195b90199a3100175441"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1176,7 +1176,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.55.x-dev"
+                    "dev-trunk": "5.56.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.3.3",
+	"version": "5.3.4-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.3.3-alpha",
+	"version": "5.3.3",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.3.3
+ * Version: 5.3.4-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.3.3' );
+define( 'WPCOMSH_VERSION', '5.3.4-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.3.3-alpha
+ * Version: 5.3.3
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.3.3-alpha' );
+define( 'WPCOMSH_VERSION', '5.3.3' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.5.6, jetpack 13.8-a.1, wpcomsh 5.3.3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.