### PR TITLE
Protect: Remove firewall upgrade prompt when the WAF module is unsupported

### DIFF
--- a/projects/plugins/protect/changelog/remove-protect-waf-upgrade-when-unsupported
+++ b/projects/plugins/protect/changelog/remove-protect-waf-upgrade-when-unsupported
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Firewall Dashboard: removed upgrade prompt when running in environments that does not support the feature.
+
+

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -79,6 +79,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ3_0_0_beta"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ3_0_1_alpha"
 	}
 }

--- a/projects/plugins/protect/jetpack-protect.php
+++ b/projects/plugins/protect/jetpack-protect.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Protect
  * Plugin URI: https://wordpress.org/plugins/jetpack-protect
  * Description: Security tools that keep your site safe and sound, from posts to plugins.
- * Version: 3.0.0-beta
+ * Version: 3.0.1-alpha
  * Author: Automattic - Jetpack Security team
  * Author URI: https://jetpack.com/protect/
  * License: GPLv2 or later
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'JETPACK_PROTECT_VERSION', '3.0.0-beta' );
+define( 'JETPACK_PROTECT_VERSION', '3.0.1-alpha' );
 define( 'JETPACK_PROTECT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_PROTECT_ROOT_FILE', __FILE__ );
 define( 'JETPACK_PROTECT_ROOT_FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );

--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -149,7 +149,7 @@ const FirewallSubheading = ( {
 					/>
 				) }
 			</div>
-			{ ! hasRequiredPlan && <UpgradePrompt /> }
+			{ ! hasRequiredPlan && wafSupported && <UpgradePrompt /> }
 		</>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-scan-team/issues/1349

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `wafSupported` to conditional that renders the upgrade prompt in the firewall header.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack-scan-team/issues/1349

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use Pressable or add a `DISABLE_JETPACK_WAF` constant 
* Get started with the free version of Protect
* Go to the firewall dashboard in Jetpack Protect
* Verify no upgrade prompt is displayed 
* Use JN or remove your `DISABLE_JETPACK_WAF` constant
* Repeat the test, ensure the upgrade prompt is displayed
