### PR TITLE
wpcomsh: rum: Record if woocommerce is active

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-rum
+++ b/projects/plugins/wpcomsh/changelog/update-rum
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+rum data: include WooCommerce active status

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -128,7 +128,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_3_4_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_4_0_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.3.4-alpha",
+	"version": "5.4.0-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -522,13 +522,49 @@ function wpcomsh_footer_rum_js() {
 		}
 	}
 
+	$rum_kv = array();
+	$rum_kv = wpcomsh_get_woo_rum_data( $rum_kv );
+
+	if ( count( $rum_kv ) > 0 ) {
+		$rum_kv = wp_json_encode( $rum_kv, JSON_FORCE_OBJECT );
+		if ( is_string( $rum_kv ) ) {
+			$rum_kv = 'data-customproperties="' . esc_attr( $rum_kv ) . '"';
+		} else {
+			$rum_kv = '';
+		}
+	} else {
+		$rum_kv = '';
+	}
+
 	printf(
-		'<script defer id="bilmur" data-provider="wordpress.com" data-service="%1$s" %2$s src="%3$s"></script>' . "\n", //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		'<script defer id="bilmur" %1$s data-provider="wordpress.com" data-service="%2$s" %3$s src="%4$s"></script>' . "\n", //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$rum_kv, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		esc_attr( $service ),
 		wp_kses_post( $allow_iframe ),
 		esc_url( 'https://s0.wp.com/wp-content/js/bilmur.min.js?m=' . gmdate( 'YW' ) )
 	);
 }
+
+/**
+ * Adds WooCommerce-related data to the Real User Monitoring (RUM) array.
+ *
+ * This function checks if WooCommerce is active on the site and adds
+ * this information to the provided RUM data array. It's designed to be
+ * used as part of the RUM data collection process for Atomic sites.
+ *
+ * @param array $rum_kv An array of existing RUM key-value pairs.
+ *                      If not provided, an empty array will be used.
+ *
+ * @return array The input array with added WooCommerce data.
+ *               The 'woo_active' key will be added with a boolean value
+ *               indicating whether WooCommerce is active.
+ */
+function wpcomsh_get_woo_rum_data( $rum_kv = array() ) {
+	$woo_active           = class_exists( 'WooCommerce' ) ? '1' : '0';
+	$rum_kv['woo_active'] = $woo_active;
+	return $rum_kv;
+}
+
 add_action( 'wp_footer', 'wpcomsh_footer_rum_js' );
 add_action( 'admin_footer', 'wpcomsh_footer_rum_js' );
 

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.3.4-alpha
+ * Version: 5.4.0-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.3.4-alpha' );
+define( 'WPCOMSH_VERSION', '5.4.0-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
## Proposed changes:

* In the RUM (real user monitoring) data rendered in the footer, note if WooCommerce is active

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* View source and look for the element with id=bilmur
* Verify it now has customproperties set and matches the same form used on simple sites when they decide to render rum data

```
<script defer id="bilmur" data-customproperties="{&quot;woo_active&quot;:&quot;1&quot;}" data-provider="wordpress.com" data-service="atomic"  src="https://s0.wp.com/wp-content/js/bilmur.min.js?m=202433"></script>
```

