### PR TITLE
Protect: Add ProgressBar wrapper background

### DIFF
--- a/projects/plugins/protect/changelog/add-protect-progress-bar-background
+++ b/projects/plugins/protect/changelog/add-protect-progress-bar-background
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Adds a background to the scan progress bar

--- a/projects/plugins/protect/composer.json
+++ b/projects/plugins/protect/composer.json
@@ -79,6 +79,6 @@
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true
 		},
-		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ3_0_0_beta"
+		"autoloader-suffix": "c4802e05bbcf59fd3b6350e8d3e5482c_protectⓥ3_0_1_alpha"
 	}
 }

--- a/projects/plugins/protect/jetpack-protect.php
+++ b/projects/plugins/protect/jetpack-protect.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Protect
  * Plugin URI: https://wordpress.org/plugins/jetpack-protect
  * Description: Security tools that keep your site safe and sound, from posts to plugins.
- * Version: 3.0.0-beta
+ * Version: 3.0.1-alpha
  * Author: Automattic - Jetpack Security team
  * Author URI: https://jetpack.com/protect/
  * License: GPLv2 or later
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'JETPACK_PROTECT_VERSION', '3.0.0-beta' );
+define( 'JETPACK_PROTECT_VERSION', '3.0.1-alpha' );
 define( 'JETPACK_PROTECT_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK_PROTECT_ROOT_FILE', __FILE__ );
 define( 'JETPACK_PROTECT_ROOT_FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );

--- a/projects/plugins/protect/src/js/components/progress-bar/style.module.scss
+++ b/projects/plugins/protect/src/js/components/progress-bar/style.module.scss
@@ -6,6 +6,8 @@
 
 	&__wrapper {
 		width: 100%;
+		border-radius: calc( var( --spacing-base ) * 3 ); // 24px
+		background-color: var( --jp-gray-5 );
 	}
 	
 	&__bar {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
When a scan has started but progress is 0, it is not clear that there is a progress bar.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a background to the wrapper element to make it clear the scan is progressing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1357

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch using the beta tester on a fresh JN instance with a scan upgrade
* View the scan progress bar and verify it is obvious throughout the entirety of the scan that progress is being made

## Screenshots

Before:
<img width="2100" alt="Screen Shot 2024-08-12 at 14 33 42" src="https://github.com/user-attachments/assets/d7a3772f-22c2-429c-81b3-9cc03aa5bc01">

After:
<img width="2116" alt="Screen Shot 2024-08-12 at 14 36 05" src="https://github.com/user-attachments/assets/9a21ccd7-b17d-4124-8b1c-c4eb17470b33">



