### PR TITLE
Protect: Hide IP list settings when list disabled

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-hide-allow-lists-when-disabled
+++ b/projects/plugins/protect/changelog/update-protect-hide-allow-lists-when-disabled
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Protect: hide IP list text controls when the list is disabled
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-scan-team/issues/1356

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When an IP list is disabled, and has no content in the list, hide the text input and related controls.
* When an IP list is disabled, but has content, show the list but keep it disabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack-scan-team/issues/1356

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test on both a site that supports and does not support the WAF module.
* Test assorted combinations of the firewall setting toggles:
  * Validate the IP list text boxes and related controls are hidden when disabled and empty.
  * Validate the IP list text boxes display but are disabled when disabled but has content.

## Screenshots

Lists disabled without content (default):

<img width="839" alt="Screenshot 2024-08-12 at 3 20 39 PM" src="https://github.com/user-attachments/assets/cbf4bc58-7146-441b-979c-66a01a2ed7d2">

Lists enabled:

<img width="831" alt="Screenshot 2024-08-12 at 3 21 29 PM" src="https://github.com/user-attachments/assets/618aab69-bb52-4bc2-8ff4-93d56ee01626">

List disabled with content:

<img width="878" alt="Screenshot 2024-08-12 at 3 21 06 PM" src="https://github.com/user-attachments/assets/deca5053-94e4-4c26-8c9c-a2b5bff21a02">



