### PR TITLE
Log out Atomic users from WPCOM when logging out of the local site

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/logout-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/logout-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Whem Atomic users log out of wp-admin they are also logged out of WPCOM

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -62,7 +62,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.56.x-dev"
+			"dev-trunk": "5.57.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.56.0",
+	"version": "5.57.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.56.0';
+	const PACKAGE_VERSION = '5.57.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -105,6 +105,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-admin-dashboard/wpcom-admin-dashboard.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';
+		require_once __DIR__ . '/features/wpcom-logout/wpcom-logout.php';
 		require_once __DIR__ . '/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php';
 		require_once __DIR__ . '/features/wpcom-profile-settings/profile-settings-notices.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-theme-fixes.php';
@@ -139,7 +140,6 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-admin-interface/wpcom-admin-interface.php';
 		require_once __DIR__ . '/features/wpcom-admin-menu/wpcom-admin-menu.php';
 		require_once __DIR__ . '/features/wpcom-command-palette/wpcom-command-palette.php';
-		require_once __DIR__ . '/features/wpcom-logout/wpcom-logout.php';
 		require_once __DIR__ . '/features/wpcom-plugins/wpcom-plugins.php';
 		require_once __DIR__ . '/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php';
 		require_once __DIR__ . '/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php';

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -139,6 +139,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-admin-interface/wpcom-admin-interface.php';
 		require_once __DIR__ . '/features/wpcom-admin-menu/wpcom-admin-menu.php';
 		require_once __DIR__ . '/features/wpcom-command-palette/wpcom-command-palette.php';
+		require_once __DIR__ . '/features/wpcom-logout/wpcom-logout.php';
 		require_once __DIR__ . '/features/wpcom-plugins/wpcom-plugins.php';
 		require_once __DIR__ . '/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php';
 		require_once __DIR__ . '/features/wpcom-site-management-widget/class-wpcom-site-management-widget.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-logout/wpcom-logout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-logout/wpcom-logout.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Logout customizations for WordPress.com.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
+/**
+ * Maybe log out from WordPress.com when logging out of the local site.
+ */
+function maybe_logout_atomic_user_from_wpcom() {
+	$user_id            = get_current_user_id();
+	$is_atomic          = defined( 'IS_ATOMIC' ) && IS_ATOMIC;
+	$connection_manager = new Connection_Manager( 'jetpack' );
+
+	// If this is a WordPress.com user connected to an Atomic site, log them out of wpcom.
+	if ( $is_atomic && $connection_manager->is_user_connected( $user_id ) ) {
+		do_action( 'wp_masterbar_logout', $user_id );
+	}
+}
+add_action( 'clear_auth_cookie', 'maybe_logout_atomic_user_from_wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-logout/wpcom-logout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-logout/wpcom-logout.php
@@ -5,19 +5,13 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-
 /**
- * Maybe log out from WordPress.com when logging out of the local site.
+ * Log out from WordPress.com when logging out of the local site.
  */
-function maybe_logout_atomic_user_from_wpcom() {
-	$user_id            = get_current_user_id();
-	$is_atomic          = defined( 'IS_ATOMIC' ) && IS_ATOMIC;
-	$connection_manager = new Connection_Manager( 'jetpack' );
-
+function logout_atomic_user_from_wpcom() {
 	// If this is a WordPress.com user connected to an Atomic site, log them out of wpcom.
-	if ( $is_atomic && $connection_manager->is_user_connected( $user_id ) ) {
-		do_action( 'wp_masterbar_logout', $user_id );
+	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+		do_action( 'wp_masterbar_logout', get_current_user_id() );
 	}
 }
-add_action( 'clear_auth_cookie', 'maybe_logout_atomic_user_from_wpcom' );
+add_action( 'clear_auth_cookie', 'logout_atomic_user_from_wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-logout/wpcom-logout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-logout/wpcom-logout.php
@@ -5,13 +5,20 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+
 /**
- * Log out from WordPress.com when logging out of the local site.
+ * Log out Atomic WordPress.com users from WPCOM when they logout from a local site.
  */
 function logout_atomic_user_from_wpcom() {
-	// If this is a WordPress.com user connected to an Atomic site, log them out of wpcom.
-	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
-		do_action( 'wp_masterbar_logout', get_current_user_id() );
+	$connection_manager = new Connection_Manager();
+	$wpcom_user_data    = $connection_manager->get_connected_user_data( get_current_user_id() );
+	$has_wpcom_account  = isset( $wpcom_user_data['ID'] );
+
+	if ( $has_wpcom_account && defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+		// In some circustances get_current_user_id() returns the local user ID.
+		// The $wpcom_user_data['ID'] is always the WordPress.com user ID.
+		do_action( 'wp_masterbar_logout', $wpcom_user_data['ID'] );
 	}
 }
 add_action( 'clear_auth_cookie', 'logout_atomic_user_from_wpcom' );

--- a/projects/plugins/mu-wpcom-plugin/changelog/try-logout-wpcom
+++ b/projects/plugins/mu-wpcom-plugin/changelog/try-logout-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1005,7 +1005,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "363f23c725cd3277f91f195b90199a3100175441"
+                "reference": "40f80a23ff55774f2832fd091074341992238dae"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1039,7 +1039,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.56.x-dev"
+                    "dev-trunk": "5.57.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/changelog/try-logout-wpcom
+++ b/projects/plugins/wpcomsh/changelog/try-logout-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -128,7 +128,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_4_0"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_4_1_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1142,7 +1142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "363f23c725cd3277f91f195b90199a3100175441"
+                "reference": "40f80a23ff55774f2832fd091074341992238dae"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1176,7 +1176,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.56.x-dev"
+                    "dev-trunk": "5.57.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.4.0",
+	"version": "5.4.1-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.4.0
+ * Version: 5.4.1-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.4.0' );
+define( 'WPCOMSH_VERSION', '5.4.1-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8221

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR logs Atomic users out of WPCOM when they logout of their site locally in wp-admin.
* It uses the `clear_auth_cookie` hook since this action occurs right before the `wp_logout` hook, and we still have the required user ID.
* It triggers the `wp_masterbar_logout` action which makes use of the following function on WPCOM: fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Szh%2Qcyhtvaf%2Snqzva%2Qone.cuc%3Se%3Qn9q448nq%231908%2Q1930-og
* Note that Simple sites and Calypso views (both the Default admin interface and the Hosting pages for the Classic admin interface) already log the user out of WPCOM when they log out locally. Therefore, this PR only applies to Atomic wp-admin pages.

<img width="383" alt="Screenshot 2024-08-12 at 5 38 53 PM" src="https://github.com/user-attachments/assets/7cda9dbc-a264-4791-aea2-ebe199423d63">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load this PR on an Atomic site using the [instructions below](https://github.com/Automattic/jetpack/pull/38850#issuecomment-2285008151).
* On your Atomic test site, click "Log out" in the admin bar (as seen in the picture above)
* Clicking this link should have logged you out of your current site, as well as WordPress.com. You can confirm this by going to WordPress.com/sites, refreshing, and seeing you're no longer logged in.
--
* This PR does not apply to "local only" users. You can test this by creating a "local only" user on your Atomic site.
* Open up an Incognito window and login to your test site using the "local only" user.
* Open up a new tab and login to WordPress.com as your main account.
* Back on your test site, with your local user, click "Log out".
* You should still be logged in as your main account on WordPress.com.
--
* This PR does not apply to Simple sites. You can test for regressions by applying this PR to a local test site using the [instructions below](https://github.com/Automattic/jetpack/pull/38850#issuecomment-2285008151).
* Try logging out. It should log you out of WPCOM just like production.