### PR TITLE
Hide the Customizer link on Simple sites

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-menu.php
@@ -119,12 +119,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Menu extends WP_REST_Controller {
 
 			remove_action( 'customize_register', array( 'Jetpack_Fonts_Typekit', 'maybe_override_for_advanced_mode' ), 20 );
 
-			// TODO: Remove the conditional when we start using the package code on WPCOM.
-			if ( class_exists( 'Automattic\Jetpack\Masterbar' ) ) {
-				remove_action( 'customize_register', 'Automattic\Jetpack\Masterbar\register_css_nudge_control' );
-			} else {
-				remove_action( 'customize_register', 'Automattic\Jetpack\Dashboard_Customizations\register_css_nudge_control' );
-			}
+			remove_action( 'customize_register', 'Automattic\Jetpack\Masterbar\register_css_nudge_control' );
 
 			remove_action( 'customize_register', array( 'Jetpack_Custom_CSS_Enhancements', 'customize_register' ) );
 		}

--- a/projects/plugins/jetpack/changelog/fix-hide-customizer-menu-on-simple
+++ b/projects/plugins/jetpack/changelog/fix-hide-customizer-menu-on-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Hide the Customizer link on Simple site


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1723329013131409-slack-C029GN3KD

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR fixes the bug where the Customizer link is displayed on Simple sites even when the Block theme is active. 

Assuming the conditional check is no longer required because of this update: pfwV0U-3U-p2#comment-307

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Prepare a Simple site with Default Interface
* Have a Block theme active
* Observe the Customizer link is not shown in the sidebar of Dashboard or in Masterbar of frontend
	<img width="277" alt="Screenshot 2024-08-13 at 14 12 35" src="https://github.com/user-attachments/assets/e5e524aa-5bd9-4a36-9b20-564f4b848d03">
	<img width="415" alt="Screenshot 2024-08-13 at 14 12 41" src="https://github.com/user-attachments/assets/40383f1f-47a6-49a9-9a3b-c7cc21949d73">

* Confirm that there are no regression on Simple Classic, Atomic Default, Atomic Classic