### PR TITLE
Hide re-tangled first/last/display names, bio, and website fields in profile.php

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/retangle-name-fields
+++ b/projects/packages/jetpack-mu-wpcom/changelog/retangle-name-fields
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Re-tangle first/last/display name, website, and bio fields in profile.php

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
@@ -39,6 +39,10 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 		'wpcom-profile-settings-link-to-wpcom',
 		'wpcomProfileSettingsLinkToWpcom',
 		array(
+			'synced'        => array(
+				'link' => esc_url( 'https://wordpress.com/me' ),
+				'text' => __( 'You can change your First / Last / Display Names, Website, and Biographical Info on WordPress.com Profile settings', 'jetpack-mu-wpcom' ),
+			),
 			'email'         => array(
 				'link' => esc_url( 'https://wordpress.com/me/account' ),
 				'text' => __( 'Your WordPress.com email is managed on WordPress.com Account settings', 'jetpack-mu-wpcom' ),
@@ -51,4 +55,4 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 		)
 	);
 }
-add_action( 'load-profile.php', 'wpcom_profile_settings_add_links_to_wpcom' );
+add_action( 'profile_personal_options', 'wpcom_profile_settings_add_links_to_wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -59,19 +59,26 @@ const wpcom_profile_settings_add_links_to_wpcom = () => {
 };
 
 /**
- * Remove the fields that are synced from /me.
+ * Hide the fields that are synced from /me.
  */
-const wpcom_profile_settings_remove_synced_fields = () => {
-	document.querySelector( '.user-first-name-wrap' )?.remove();
-	document.querySelector( '.user-last-name-wrap' )?.remove();
-	document.querySelector( '.user-nickname-wrap' )?.remove();
-	document.querySelector( '.user-display-name-wrap' )?.remove();
-	document.querySelector( '.user-url-wrap' )?.remove();
-	document.querySelector( '.user-description-wrap' )?.remove();
+const wpcom_profile_settings_hide_synced_fields = () => {
+	[
+		'.user-first-name-wrap',
+		'.user-last-name-wrap',
+		'.user-nickname-wrap',
+		'.user-display-name-wrap',
+		'.user-url-wrap',
+		'.user-description-wrap',
+	].forEach( selector => {
+		const field = document.querySelector( selector );
+		if ( field ) {
+			field.classList.add( 'hidden' );
+		}
+	} );
 };
 
 document.addEventListener( 'DOMContentLoaded', () => {
 	wpcom_profile_settings_add_links_to_wpcom();
 	wpcom_profile_settings_disable_email_field();
-	wpcom_profile_settings_remove_synced_fields();
+	wpcom_profile_settings_hide_synced_fields();
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -18,6 +18,7 @@ const wpcom_profile_settings_disable_email_field = () => {
  * Add a link to the WordPress.com profile settings page.
  */
 const wpcom_profile_settings_add_links_to_wpcom = () => {
+	const usernameSection = document.querySelector( '.user-user-login-wrap' )?.querySelector( 'td' );
 	const emailSection = document.querySelector( '.user-email-wrap' )?.querySelector( 'td' );
 	const newPasswordSection = document.getElementById( 'password' )?.querySelector( 'td' );
 	const userSessionSection = document.querySelector( '.user-sessions-wrap' );
@@ -46,9 +47,31 @@ const wpcom_profile_settings_add_links_to_wpcom = () => {
 		notice.innerHTML = `<a href="${ passwordSettingsLink }">${ passwordSettingsLinkText }</a>.`;
 		newPasswordSection.appendChild( notice );
 	}
+
+	const syncedSettingsLink = window.wpcomProfileSettingsLinkToWpcom?.synced?.link;
+	const syncedSettingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.synced?.text;
+	if ( usernameSection && syncedSettingsLink && syncedSettingsLinkText ) {
+		const notice = document.createElement( 'p' );
+		notice.className = 'description';
+		notice.innerHTML = `<a href="${ syncedSettingsLink }">${ syncedSettingsLinkText }</a>.`;
+		usernameSection.appendChild( notice );
+	}
+};
+
+/**
+ * Remove the fields that are synced from /me.
+ */
+const wpcom_profile_settings_remove_synced_fields = () => {
+	document.querySelector( '.user-first-name-wrap' )?.remove();
+	document.querySelector( '.user-last-name-wrap' )?.remove();
+	document.querySelector( '.user-nickname-wrap' )?.remove();
+	document.querySelector( '.user-display-name-wrap' )?.remove();
+	document.querySelector( '.user-url-wrap' )?.remove();
+	document.querySelector( '.user-description-wrap' )?.remove();
 };
 
 document.addEventListener( 'DOMContentLoaded', () => {
 	wpcom_profile_settings_add_links_to_wpcom();
 	wpcom_profile_settings_disable_email_field();
+	wpcom_profile_settings_remove_synced_fields();
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/8645

## Proposed changes:

This PR hides the fields that we want to re-tangle back to wpcom (`/me`):

- First / Last / Display name
- Website
- Biographical Info

Please refer to the linked issue above for the discussion.

|Before|After|
|-|-|
|<img width="944" alt="image" src="https://github.com/user-attachments/assets/58b4be86-f23d-4ad3-a69a-1c0e7bcb8124">|<img width="1062" alt="image" src="https://github.com/user-attachments/assets/5ac8f94c-ce1d-40f5-a050-2b14ce176e77">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this to an Atomic Classic site.
2. Verify `profile.php` as shown above.
3. Patch this to your Simple Classic site sandbox.
4. Verify `profile.php` as shown above.

