### PR TITLE
Social | Initial State: Migrate URLs

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-initial-state-migrate-urls
+++ b/projects/js-packages/publicize-components/changelog/update-social-initial-state-migrate-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrated social URLs to use the new script data (initial state)

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.60.0",
+	"version": "0.60.1-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/form/broken-connections-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/broken-connections-notice.tsx
@@ -25,7 +25,7 @@ export const BrokenConnectionsNotice: React.FC = () => {
 		);
 	} );
 
-	const { connectionsAdminUrl } = usePublicizeConfig();
+	const { connectionsPageUrl } = usePublicizeConfig();
 
 	const useAdminUiV1 = useSelect( select => select( store ).useAdminUiV1(), [] );
 	const { openConnectionsModal } = useDispatch( store );
@@ -37,7 +37,7 @@ export const BrokenConnectionsNotice: React.FC = () => {
 			className={ styles[ 'broken-connection-btn' ] }
 		/>
 	) : (
-		<ExternalLink href={ connectionsAdminUrl } />
+		<ExternalLink href={ connectionsPageUrl } />
 	);
 
 	const getServiceLabel = useServiceLabel();

--- a/projects/js-packages/publicize-components/src/components/form/connection-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/connection-notice.tsx
@@ -1,3 +1,4 @@
+import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { PanelRow } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
@@ -7,7 +8,7 @@ import styles from './styles.module.scss';
 
 export const ConnectionNotice: React.FC = () => {
 	const { hasConnections } = useSocialMediaConnections();
-	const { needsUserConnection, userConnectionUrl } = usePublicizeConfig();
+	const { needsUserConnection } = usePublicizeConfig();
 
 	if ( needsUserConnection ) {
 		return (
@@ -18,7 +19,7 @@ export const ConnectionNotice: React.FC = () => {
 						'jetpack'
 					) }
 					&nbsp;
-					<a href={ userConnectionUrl }>{ __( 'Connect now', 'jetpack' ) }</a>
+					<a href={ getMyJetpackUrl( '#/connection' ) }>{ __( 'Connect now', 'jetpack' ) }</a>
 				</p>
 			</PanelRow>
 		);

--- a/projects/js-packages/publicize-components/src/components/form/settings-button.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/settings-button.tsx
@@ -31,7 +31,7 @@ export function SettingsButton( { label, variant = 'primary' }: SettingsButtonPr
 		};
 	}, [] );
 	const { openConnectionsModal } = useDispatch( store );
-	const { connectionsAdminUrl } = usePublicizeConfig();
+	const { connectionsPageUrl } = usePublicizeConfig();
 
 	const text = label || __( 'Manage connections', 'jetpack' );
 	const hasConnections = connections.length > 0;
@@ -46,7 +46,7 @@ export function SettingsButton( { label, variant = 'primary' }: SettingsButtonPr
 			{ text }
 		</Button>
 	) : (
-		<ExternalLink className={ styles[ 'settings-button' ] } href={ connectionsAdminUrl }>
+		<ExternalLink className={ styles[ 'settings-button' ] } href={ connectionsPageUrl }>
 			{ text }
 		</ExternalLink>
 	);

--- a/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/unsupported-connections-notice.tsx
@@ -9,7 +9,7 @@ import { checkConnectionCode } from './utils';
 export const UnsupportedConnectionsNotice: React.FC = () => {
 	const { connections } = useSocialMediaConnections();
 
-	const { connectionsAdminUrl } = usePublicizeConfig();
+	const { connectionsPageUrl } = usePublicizeConfig();
 
 	const unsupportedConnections = connections.filter( connection =>
 		checkConnectionCode( connection, 'unsupported' )
@@ -24,7 +24,7 @@ export const UnsupportedConnectionsNotice: React.FC = () => {
 						'jetpack'
 					),
 					{
-						moreInfo: <ExternalLink href={ connectionsAdminUrl } />,
+						moreInfo: <ExternalLink href={ connectionsPageUrl } />,
 					}
 				) }
 			</Notice>

--- a/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
@@ -3,12 +3,11 @@ import {
 	getJetpackExtensionAvailability,
 	isUpgradable,
 	getJetpackData,
-	getSiteFragment,
 	isSimpleSite,
 } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { store as socialStore } from '../../social-store';
+import { getSocialScriptData } from '../../utils';
 import { usePostMeta } from '../use-post-meta';
 
 const republicizeFeatureName = 'republicize';
@@ -22,7 +21,6 @@ const republicizeFeatureName = 'republicize';
  */
 export default function usePublicizeConfig() {
 	const sharesData = getJetpackData()?.social?.sharesData ?? {};
-	const blogID = getJetpackData()?.wpcomBlogId;
 	const isShareLimitEnabled = sharesData.is_share_limit_enabled;
 	const isRePublicizeFeatureAvailable =
 		getJetpackExtensionAvailability( republicizeFeatureName )?.available || isShareLimitEnabled;
@@ -30,9 +28,7 @@ export default function usePublicizeConfig() {
 	const currentPostType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	const { isUserConnected } = useConnection();
 
-	const connectionsRootUrl =
-		getJetpackData()?.social?.publicizeConnectionsUrl ??
-		'https://wordpress.com/marketing/connections/';
+	const { urls } = getSocialScriptData();
 
 	/*
 	 * isPublicizeEnabledMeta:
@@ -105,8 +101,6 @@ export default function usePublicizeConfig() {
 
 	const needsUserConnection = ! isUserConnected && ! isSimpleSite();
 
-	const userConnectionUrl = useSelect( select => select( socialStore ).userConnectionUrl(), [] );
-
 	return {
 		isPublicizeEnabledMeta,
 		isPublicizeEnabled,
@@ -124,11 +118,8 @@ export default function usePublicizeConfig() {
 		isSocialImageGeneratorAvailable:
 			!! getJetpackData()?.social?.isSocialImageGeneratorAvailable && ! isJetpackSocialNote,
 		isSocialImageGeneratorEnabled: !! getJetpackData()?.social?.isSocialImageGeneratorEnabled,
-		connectionsAdminUrl: connectionsRootUrl + ( blogID ?? getSiteFragment() ),
-		adminUrl: getJetpackData()?.social?.adminUrl,
-		jetpackSharingSettingsUrl: getJetpackData()?.social?.jetpackSharingSettingsUrl,
+		connectionsPageUrl: urls.connectionsManagementPage,
 		isJetpackSocialNote,
 		needsUserConnection,
-		userConnectionUrl,
 	};
 }

--- a/projects/js-packages/publicize-components/src/social-store/reducer/index.js
+++ b/projects/js-packages/publicize-components/src/social-store/reducer/index.js
@@ -12,7 +12,6 @@ const reducer = combineReducers( {
 	jetpackSettings,
 	socialImageGeneratorSettings,
 	hasPaidPlan: ( state = false ) => state,
-	userConnectionUrl: ( state = '' ) => state,
 	useAdminUiV1: ( state = false ) => state,
 	featureFlags: ( state = false ) => state,
 	hasPaidFeatures: ( state = false ) => state,

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.js
@@ -36,15 +36,6 @@ export function getConnectionsByService( state, serviceName ) {
 }
 
 /**
- * Returns the connections admin URL from the store.
- * @param {import("../types").SocialStoreState} state - State object.
- * @returns {string|null} The connections admin URL.
- */
-export function getConnectionsAdminUrl( state ) {
-	return state.connectionData?.adminUrl ?? null;
-}
-
-/**
  * Returns whether there are connections in the store.
  * @param {import("../types").SocialStoreState} state - State object.
  * @returns {boolean} Whether there are connections.

--- a/projects/js-packages/publicize-components/src/social-store/selectors/index.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/index.js
@@ -10,7 +10,6 @@ const selectors = {
 	...jetpackSettingSelectors,
 	...sharesData,
 	...socialImageGeneratorSettingsSelectors,
-	userConnectionUrl: state => state.userConnectionUrl,
 	useAdminUiV1: state => state.useAdminUiV1,
 	featureFlags: state => state.featureFlags,
 	hasPaidFeatures: state => state.hasPaidFeatures,

--- a/projects/js-packages/publicize-components/src/social-store/selectors/site-data.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/site-data.js
@@ -1,5 +1,4 @@
 const siteDataSelectors = {
-	getAdminUrl: state => state.siteData?.adminUrl ?? null,
 	getAPIRootUrl: state => state.siteData?.apiRoot ?? null,
 	getAPINonce: state => state.siteData?.apiNonce ?? null,
 	getRegistrationNonce: state => state.siteData?.registrationNonce ?? null,

--- a/projects/js-packages/publicize-components/src/social-store/selectors/test/connection-data.test.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/test/connection-data.test.js
@@ -1,6 +1,5 @@
 import {
 	getConnections,
-	getConnectionsAdminUrl,
 	hasConnections,
 	getFailedConnections,
 	getMustReauthConnections,
@@ -11,7 +10,6 @@ import {
 
 const state = {
 	connectionData: {
-		adminUrl: 'https://wordpress.com/some-url',
 		connections: [
 			{
 				id: '123456789',
@@ -61,17 +59,6 @@ describe( 'Social store selectors: connectionData', () => {
 		it( 'should return connections', () => {
 			const connections = getConnections( state );
 			expect( connections ).toEqual( state.connectionData.connections );
-		} );
-	} );
-
-	describe( 'getConnectionsAdminUrl', () => {
-		it( 'should return null if no adminUrl', () => {
-			expect( getConnectionsAdminUrl( {} ) ).toBeNull();
-		} );
-
-		it( 'should return adminUrl', () => {
-			const adminUrl = getConnectionsAdminUrl( state );
-			expect( adminUrl ).toEqual( state.connectionData.adminUrl );
 		} );
 	} );
 

--- a/projects/js-packages/publicize-components/src/types/types.ts
+++ b/projects/js-packages/publicize-components/src/types/types.ts
@@ -2,9 +2,14 @@ export interface FeatureFlags {
 	useAdminUiV1: boolean;
 }
 
+export interface SocialUrls {
+	connectionsManagementPage: string;
+}
+
 export interface SocialScriptData {
 	is_publicize_enabled: boolean;
 	feature_flags: FeatureFlags;
+	urls: SocialUrls;
 }
 
 type JetpackSettingsSelectors = {

--- a/projects/js-packages/publicize-components/src/types/types.ts
+++ b/projects/js-packages/publicize-components/src/types/types.ts
@@ -27,7 +27,6 @@ type JetpackSettingsSelectors = {
 type ConnectionDataSelectors = {
 	getConnections: () => Array< object >;
 	getServices: () => Array< object >;
-	getConnectionsAdminUrl: () => string;
 	hasConnections: () => boolean;
 };
 

--- a/projects/js-packages/publicize-components/src/utils/index.js
+++ b/projects/js-packages/publicize-components/src/utils/index.js
@@ -2,3 +2,4 @@ export * from './get-share-message-max-length';
 export * from './get-supported-additional-connections';
 export * from './request-external-access';
 export * from './types';
+export * from './script-data';

--- a/projects/js-packages/publicize-components/src/utils/script-data.ts
+++ b/projects/js-packages/publicize-components/src/utils/script-data.ts
@@ -1,0 +1,11 @@
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { SocialScriptData } from '../types/types';
+
+/**
+ * Get the social script data from the window object.
+ *
+ * @returns {SocialScriptData} The social script data.
+ */
+export function getSocialScriptData(): SocialScriptData {
+	return getScriptData().social;
+}

--- a/projects/js-packages/script-data/changelog/update-social-initial-state-migrate-urls
+++ b/projects/js-packages/script-data/changelog/update-social-initial-state-migrate-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrated social URLs to use the new script data (initial state)

--- a/projects/js-packages/script-data/package.json
+++ b/projects/js-packages/script-data/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-script-data",
-	"version": "0.1.1",
+	"version": "0.1.2-alpha",
 	"description": "A library to provide data for script handles and the corresponding utility functions for Jetpack.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/script-data/#readme",
 	"bugs": {

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -57,3 +57,14 @@ export function getMyJetpackUrl( section = '' ) {
 export function getActiveFeatures() {
 	return getScriptData().site.plan?.features?.active ?? [];
 }
+
+/**
+ * Check if the site has a specific feature.
+ *
+ * @param {string} feature - The feature to check.
+ *
+ * @returns {boolean} Whether the site has the feature.
+ */
+export function siteHasFeature( feature: string ) {
+	return getActiveFeatures().includes( feature );
+}

--- a/projects/packages/publicize/changelog/update-social-initial-state-migrate-urls
+++ b/projects/packages/publicize/changelog/update-social-initial-state-migrate-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrated social URLs to use the new script data (initial state)

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.49.0",
+	"version": "0.49.1-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -47,7 +47,7 @@ class Publicize_Script_Data {
 
 		$data['social'] = self::get_admin_script_data();
 
-		if ( empty( $data['site']['plan'] ) ) {
+		if ( empty( $data['site']['plan']['product_slug'] ) ) {
 			$data['site']['plan'] = Current_Plan::get();
 		}
 
@@ -83,9 +83,9 @@ class Publicize_Script_Data {
 		return array_merge(
 			$basic_data,
 			array(
+				'urls' => self::get_urls(),
 				/**
 				 * 'store'       => self::get_store_script_data(),
-				 * 'urls'        => self::get_urls(),
 				 * 'shares_data' => self::get_shares_data(),
 				 */
 			)
@@ -132,5 +132,24 @@ class Publicize_Script_Data {
 		}
 
 		return Current_Plan::supports( 'social-' . $feature );
+	}
+
+	/**
+	 * Get the URLs.
+	 *
+	 * @return array
+	 */
+	public static function get_urls() {
+
+		$urls = array(
+			'connectionsManagementPage' => self::publicize()->publicize_connections_url(
+				'jetpack-social-connections-admin-page'
+			),
+		);
+
+		// Escape the URLs.
+		array_walk( $urls, 'esc_url_raw' );
+
+		return $urls;
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-social-initial-state-migrate-urls
+++ b/projects/plugins/jetpack/changelog/update-social-initial-state-migrate-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fixed unit test

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.js
@@ -71,6 +71,12 @@ beforeEach( () => {
 	setGradient.mockClear();
 	setTextColor.mockClear();
 	setButtonBackgroundColor.mockClear();
+
+	global.JetpackScriptData = {
+		social: {
+			urls: {},
+		},
+	};
 } );
 
 describe( 'Inspector controls', () => {

--- a/projects/plugins/social/changelog/update-social-initial-state-migrate-urls
+++ b/projects/plugins/social/changelog/update-social-initial-state-migrate-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrated social URLs to use the new script data (initial state)

--- a/projects/plugins/social/src/js/components/admin-page/header/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/header/index.jsx
@@ -1,4 +1,5 @@
 import { SOCIAL_STORE_ID } from '@automattic/jetpack-publicize-components';
+import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -11,7 +12,7 @@ const AdminPageHeader = () => {
 
 		return {
 			showPricingPage: store.showPricingPage(),
-			activateLicenseUrl: `${ store.getAdminUrl() }admin.php?page=my-jetpack#/add-license`,
+			activateLicenseUrl: getMyJetpackUrl( '#/add-license' ),
 		};
 	} );
 

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -12,8 +12,9 @@ import {
 	ShareLimitsBar,
 	store as socialStore,
 	useShareLimits,
+	getSocialScriptData,
 } from '@automattic/jetpack-publicize-components';
-import { getScriptData } from '@automattic/jetpack-script-data';
+import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, postList } from '@wordpress/icons';
@@ -21,29 +22,28 @@ import StatCards from '../stat-cards';
 import styles from './styles.module.scss';
 
 const Header = () => {
-	const connectionData = window.jetpackSocialInitialState.connectionData ?? {};
 	const {
-		connectionsAdminUrl,
+		// TODO replace some of these from script data (initial state)
 		hasConnections,
 		isModuleEnabled,
-		newPostUrl,
 		postsCount,
 		totalShareCount,
 		showShareLimits,
 	} = useSelect( select => {
 		const store = select( socialStore );
 		return {
-			connectionsAdminUrl: connectionData.adminUrl,
 			hasConnections: store.getConnections().length > 0,
 			isModuleEnabled: store.isModuleEnabled(),
-			newPostUrl: `${ store.getAdminUrl() }post-new.php`,
 			postsCount: store.getSharedPostsCount(),
 			totalShareCount: store.getTotalSharesCount(),
 			showShareLimits: store.showShareLimits(),
 		};
 	} );
-	// TODO - Replace this with a utility function like `getSocialFeatureFlags` when available
-	const { useAdminUiV1 } = getScriptData().social.feature_flags;
+
+	const {
+		feature_flags: { useAdminUiV1 },
+		urls,
+	} = getSocialScriptData();
 
 	const { hasConnectionError } = useConnectionErrorNotice();
 
@@ -79,13 +79,16 @@ const Header = () => {
 										{ __( 'Connect accounts', 'jetpack-social' ) }
 									</Button>
 								) : (
-									<Button href={ connectionsAdminUrl } isExternalLink={ true }>
+									<Button href={ urls.connectionsManagementPage } isExternalLink={ true }>
 										{ __( 'Connect accounts', 'jetpack-social' ) }
 									</Button>
 								) }
 							</>
 						) }
-						<Button href={ newPostUrl } variant={ hasConnections ? 'primary' : 'secondary' }>
+						<Button
+							href={ getAdminUrl( 'post-new.php' ) }
+							variant={ hasConnections ? 'primary' : 'secondary' }
+						>
 							{ __( 'Write a post', 'jetpack-social' ) }
 						</Button>
 					</div>

--- a/projects/plugins/social/src/js/components/social-module-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-module-toggle/index.tsx
@@ -5,8 +5,11 @@ import {
 	getRedirectUrl,
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
-import { ConnectionManagement, SOCIAL_STORE_ID } from '@automattic/jetpack-publicize-components';
-import { getScriptData } from '@automattic/jetpack-script-data';
+import {
+	ConnectionManagement,
+	SOCIAL_STORE_ID,
+	getSocialScriptData,
+} from '@automattic/jetpack-publicize-components';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -19,7 +22,6 @@ import styles from './styles.module.scss';
 const SocialModuleToggle: React.FC = () => {
 	const {
 		// TODO - replace some of these with values from initial state
-		connectionsAdminUrl,
 		isModuleEnabled,
 		isUpdating,
 		siteSuffix,
@@ -30,14 +32,15 @@ const SocialModuleToggle: React.FC = () => {
 		return {
 			isModuleEnabled: store.isModuleEnabled(),
 			isUpdating: store.isUpdatingJetpackSettings(),
-			connectionsAdminUrl: store.getConnectionsAdminUrl(),
 			siteSuffix: store.getSiteSuffix(),
 			blogID: store.getBlogID(),
 			hasPaidFeatures: store.hasPaidFeatures(),
 		};
 	}, [] );
 
-	const { useAdminUiV1 } = getScriptData().social.feature_flags;
+	const { urls, feature_flags } = getSocialScriptData();
+
+	const useAdminUiV1 = feature_flags.useAdminUiV1;
 
 	const updateOptions = useDispatch( SOCIAL_STORE_ID ).updateJetpackSettings;
 
@@ -62,13 +65,13 @@ const SocialModuleToggle: React.FC = () => {
 			) : null;
 		}
 
-		return connectionsAdminUrl ? (
+		return urls.connectionsManagementPage ? (
 			<Button
 				fullWidth={ isSmall }
 				className={ styles.button }
 				variant="secondary"
 				isExternalLink={ true }
-				href={ connectionsAdminUrl }
+				href={ urls.connectionsManagementPage }
 				disabled={ isUpdating || ! isModuleEnabled }
 				target="_blank"
 			>

--- a/projects/plugins/social/src/js/components/social-notes-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-notes-toggle/index.tsx
@@ -1,5 +1,6 @@
 import { Text, Button, useBreakpointMatch } from '@automattic/jetpack-components';
 import { store as socialStore } from '@automattic/jetpack-publicize-components';
+import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { ExternalLink, SelectControl, ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
@@ -34,7 +35,7 @@ const SocialNotesToggle: React.FC< SocialNotesToggleProps > = ( { disabled } ) =
 		return {
 			isEnabled: store.isSocialNotesEnabled(),
 			notesConfig: store.getSocialNotesConfig(),
-			newNoteUrl: `${ store.getAdminUrl() }post-new.php?post_type=jetpack-social-note`,
+			newNoteUrl: getAdminUrl( 'post-new.php?post_type=jetpack-social-note' ),
 			// Temporarily we disable forever after action to wait for the page to reload.
 			// isUpdating: store.isSocialNotesSettingsUpdating(),
 		};

--- a/projects/plugins/social/src/js/components/types/types.ts
+++ b/projects/plugins/social/src/js/components/types/types.ts
@@ -14,7 +14,6 @@ type JetpackSettingsSelectors = {
 
 type ConnectionDataSelectors = {
 	getConnections: () => Array< object >;
-	getConnectionsAdminUrl: () => string;
 	hasConnections: () => boolean;
 };
 


### PR DESCRIPTION
As a part of consolidating our initial state started in #38606, we need to migrate the way we pass/compute the URLs that we need in Social JS code 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `urls` to the social script data (initial state)
* Use those URLs in place of existing ones
* Remove the unused URLs
* Update some URLs to use the client-side utility functions to generate the URLs 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test the following on Jetpack, Simple and Atomic sites

* Go to editor
* Simulate some broken connections
* Confirm that the fix link in broken connection notice works as expected
* When there is no user connection
    * Confirm that the "Connect now" link in the editor points to the correct URL
    * Confirm that the connect user account link on Social admin page works as expected
* Confirm that the "Manage connections" link/butotn in the editor works as expected
* On social admin page, when a new plan is purchased without activating it, confirm that the licence activation link points to the correct location
* On social admin page, confirm that "Write a post" and "Create a note" links point to the correct location. Also confirm that the "Connect accounts" link/button works as expected.


