### PR TITLE
jetpack-mu-wpcom: Sync newspack blocks on build, not install

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -45,6 +45,14 @@ fi
 # Don't symlink, it breaks when copied later.
 export COMPOSER_MIRROR_PATH_REPOS=true
 
+# HACK: wpcomsh tests need the jetpack-mu-wpcom package built.
+# @todo Create a way to do this that's not a hack.
+if [[ "${CHANGED-<unset>}" == '<unset>' ]] || jq -e '.["plugins/wpcomsh"] // false' <<<"$CHANGED"; then
+	echo "::group::HACK: Build packages/jetpack-mu-wpcom for plugins/wpcomsh"
+	pnpm jetpack build -v packages/jetpack-mu-wpcom
+	echo "::endgroup::"
+fi
+
 BASE="$(pwd)"
 PKGVERSIONS="$(jq -nc 'reduce inputs as $in ({}; .[$in.name] |= ( $in.extra["branch-alias"]["dev-trunk"] // "dev-trunk" ) )' projects/packages/*/composer.json)"
 EXIT=0

--- a/projects/packages/jetpack-mu-wpcom/.gitignore
+++ b/projects/packages/jetpack-mu-wpcom/.gitignore
@@ -1,4 +1,5 @@
 .cache/
+bin/
 src/build/
 vendor/
 node_modules/

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-only-sync-newspack-blocks-on-build
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-only-sync-newspack-blocks-on-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Only sync newspack-blocks on build, not on install, so everyone in the monorepo not working on mu-wpcom doesn't have to download it.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -16,10 +16,9 @@
 	"author": "Automattic",
 	"scripts": {
 		"build": "echo 'Not implemented.'",
-		"build-js": "pnpm clean && webpack",
+		"build-js": "pnpm clean && pnpm run sync:newspack-blocks && webpack",
 		"build-production": "echo 'Not implemented.'",
 		"build-production-js": "NODE_ENV=production BABEL_ENV=production pnpm build-js",
-		"postinstall": "pnpm run sync:newspack-blocks",
 		"lint": "eslint --ext .js,.jsx,.cjs,.mjs,.ts,.tsx .",
 		"clean": "rm -rf src/build/",
 		"watch": "pnpm run build-production-js && pnpm webpack watch",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If you do it on install, everyone everywhere in the monorepo has to have this downloaded and installed even if they're not working on mu-wpcom at all.

Instead, save the syncing for the actual build. And also, as a (hopefully temporary) hack, build the package when plugins/wpcomsh is going to be tested too.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* No relevant change to the build artifact?
