### PR TITLE
AI Assistant: Change Breve type markup and restrict types

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-type-detection
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-type-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Change Breve type markup and restrict types

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.js
@@ -134,7 +134,7 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 							<CheckboxControl
 								className={ isProofreadEnabled ? '' : 'is-disabled' }
 								disabled={ ! isProofreadEnabled }
-								data-type={ feature.config.name }
+								data-breve-type={ feature.config.name }
 								key={ feature.config.name }
 								label={ feature.config.title }
 								checked={ ! disabledFeatures.includes( feature.config.name ) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/_features.colors.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/_features.colors.scss
@@ -8,7 +8,7 @@ $features-colors: (
 );
 
 @mixin properties( $feature, $color, $properties, $opacity: false ) {
-	&[data-type='#{$feature}'] {
+	&[data-breve-type='#{$feature}'] {
 		@each $property in $properties {
 			@if $opacity {
 				#{$property}: rgba( $color, $opacity );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/events.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/events.ts
@@ -19,12 +19,15 @@ let anchorTimeout: number;
 
 let isFirstHover = ! localStorage.getItem( 'jetpack-ai-breve-first-hover' );
 
-function getHighlightEl( el: HTMLElement ) {
-	if ( el === document.body ) {
+function getHighlightEl( el: HTMLElement | null ) {
+	if ( el === document.body || el === null ) {
 		return null;
 	}
 
-	if ( el.getAttribute( 'data-type' ) === null ) {
+	const breveType = el.getAttribute( 'data-breve-type' );
+	const featureTypes: Array< string | null > = features.map( ( { config } ) => config.name );
+
+	if ( ! featureTypes.includes( breveType ) ) {
 		return getHighlightEl( el.parentElement );
 	}
 
@@ -59,9 +62,13 @@ async function handleMouseEnter( e: MouseEvent ) {
 		}
 
 		const el = getHighlightEl( e.target as HTMLElement );
-		let virtual = el;
 
-		const shouldPointToCursor = el.getAttribute( 'data-type' ) === LONG_SENTENCES.name;
+		if ( ! el ) {
+			return;
+		}
+
+		let virtual = el;
+		const shouldPointToCursor = el.getAttribute( 'data-breve-type' ) === LONG_SENTENCES.name;
 
 		if ( shouldPointToCursor ) {
 			const rect = el.getBoundingClientRect();
@@ -109,7 +116,7 @@ export default function registerEvents( clientId: string ) {
 
 	features.forEach( ( { config } ) => {
 		const items: NodeListOf< HTMLElement > | undefined = block?.querySelectorAll?.(
-			`[data-type='${ config.name }']`
+			`[data-breve-type='${ config.name }']`
 		);
 
 		if ( items && items?.length > 0 ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
@@ -79,7 +79,7 @@ export default function Highlight() {
 		const defaultAnchor = { target: null, virtual: null };
 		const { target: anchorEl, virtual: virtualEl } =
 			breveSelect.getPopoverAnchor() ?? defaultAnchor;
-		const anchorFeature = anchorEl?.getAttribute?.( 'data-type' ) as string;
+		const anchorFeature = anchorEl?.getAttribute?.( 'data-breve-type' ) as string;
 		const anchorId = anchorEl?.getAttribute?.( 'data-id' ) as string;
 		const anchorBlockId = anchorEl?.getAttribute?.( 'data-block' ) as string;
 
@@ -228,7 +228,7 @@ export default function Highlight() {
 					>
 						<div className="jetpack-ai-breve__header-container">
 							<div className="jetpack-ai-breve__title">
-								<div className="jetpack-ai-breve__color" data-type={ feature } />
+								<div className="jetpack-ai-breve__color" data-breve-type={ feature } />
 								<div>{ title }</div>
 							</div>
 							{ ! hasSuggestions && (
@@ -335,7 +335,7 @@ export function registerBreveHighlights() {
 							type,
 							indexes: highlights,
 							attributes: {
-								'data-type': config.name,
+								'data-breve-type': config.name,
 								'data-identifier': richTextIdentifier ?? 'none',
 								'data-block': blockClientId,
 							},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38866 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes `data-type` to `data-breve-type`
* Restricts the values to those defined in the config files

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check that there is no regression on Breve highlights by asking and accepting a change
* Check that the events are sent with the correct type
* Edit the `data-breve-type` value of a highlight in the browser inspector to something that is not a valid type
* Check that its highlight turns black, but hovering it does not invoke a popover
