### PR TITLE
Notifications: Use profile locale to match menu language

### DIFF
--- a/projects/plugins/jetpack/changelog/update-notification-locale-source
+++ b/projects/plugins/jetpack/changelog/update-notification-locale-source
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Notifications: Use profile locale to match menu language

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -173,7 +173,7 @@ class Jetpack_Notifications {
 			return;
 		}
 
-		$wpcom_locale = get_locale();
+		$user_locale = get_user_locale();
 
 		if ( ! class_exists( 'GP_Locales' ) ) {
 			if ( defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) && file_exists( JETPACK__GLOTPRESS_LOCALES_PATH ) ) {
@@ -182,9 +182,9 @@ class Jetpack_Notifications {
 		}
 
 		if ( class_exists( 'GP_Locales' ) ) {
-			$wpcom_locale_object = GP_Locales::by_field( 'wp_locale', $wpcom_locale );
-			if ( $wpcom_locale_object instanceof GP_Locale ) {
-				$wpcom_locale = $wpcom_locale_object->slug;
+			$jetpack_locale_object = GP_Locales::by_field( 'slug', $user_locale );
+			if ( $jetpack_locale_object instanceof GP_Locale ) {
+				$user_locale = $jetpack_locale_object->slug;
 			}
 		}
 
@@ -196,7 +196,7 @@ class Jetpack_Notifications {
 				'id'     => 'notes',
 				'title'  => $title,
 				'meta'   => array(
-					'html'  => '<div id="wpnt-notes-panel2" class="intrinsic-ignore" style="display:none" lang="' . esc_attr( $wpcom_locale ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>' . $third_party_cookie_check_iframe,
+					'html'  => '<div id="wpnt-notes-panel2" class="intrinsic-ignore" style="display:none" lang="' . esc_attr( $user_locale ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>' . $third_party_cookie_check_iframe,
 					'class' => 'menupop',
 				),
 				'parent' => 'top-secondary',

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -196,7 +196,7 @@ class Jetpack_Notifications {
 				'id'     => 'notes',
 				'title'  => $title,
 				'meta'   => array(
-					'html'  => '<div id="wpnt-notes-panel2" class="intrinsic-ignore" style="display:none" lang="' . esc_attr( $user_locale ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>' . $third_party_cookie_check_iframe,
+					'html'  => '<div id="wpnt-notes-panel2" class="intrinsic-ignore" style="display:none" lang="' . esc_attr( strtolower( substr( $user_locale, 0, 2 ) ) ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>' . $third_party_cookie_check_iframe,
 					'class' => 'menupop',
 				),
 				'parent' => 'top-secondary',


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/8656

## Proposed changes:
We want to make the Notifications panel use the same locale as the menu, and it should be from `/wp-admin/profile.php` rather than the Site settings where it was used.

Site locale: Portuguese

| User Locale | Before | After |
| --- | --- | --- |
| Spanish | ![image](https://github.com/user-attachments/assets/0b8330e1-cbf2-4c39-9d8a-6451c38b4ebf) | ![image](https://github.com/user-attachments/assets/6f5b647b-bec4-4d9f-abec-ffdb8ea5f297) |
| Italian | ![image](https://github.com/user-attachments/assets/d3c9f4c7-3fcb-4703-86cf-f6368812e5ad) | ![image](https://github.com/user-attachments/assets/6306ecae-7e24-4732-97e4-3b741b791ddd) |

#### Pressable

Site locale: English
User Locale: Spanish

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c38e5e47-6d7d-400d-bf79-c8429d499ec0) | ![image](https://github.com/user-attachments/assets/6af86d53-36f1-4809-9ec6-e3733ca160ad) |

## Jetpack product discussion
-

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Follow the instructions from the first comment to apply this PR to your site.
* Go to '/wp-admin/profile.php'
* Select different locale than the site settings
* Click on the bell icon and check the notifications language.
* It should match the menu language
* Check for regressions

