### PR TITLE
Classic Theme Helper: Remove Settings link and add Jetpack version checks

### DIFF
--- a/projects/plugins/classic-theme-helper-plugin/changelog/update-classic-theme-helper-add-version-checks
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/update-classic-theme-helper-add-version-checks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Classic Theme Helper Plugin: Removed unused Settings page and added Jetpack version checks to class loaders.

--- a/projects/plugins/classic-theme-helper-plugin/classic-theme-helper-plugin.php
+++ b/projects/plugins/classic-theme-helper-plugin/classic-theme-helper-plugin.php
@@ -41,44 +41,35 @@ define( 'CLASSIC_THEME_HELPER_PLUGIN_NAME', 'Classic Theme Helper Plugin' );
 define( 'CLASSIC_THEME_HELPER_PLUGIN_URI', 'https://jetpack.com' );
 define( 'CLASSIC_THEME_HELPER_PLUGIN_FOLDER', dirname( plugin_basename( __FILE__ ) ) );
 
-// Add "Settings" link to plugins page.
-add_filter(
-	'plugin_action_links_' . CLASSIC_THEME_HELPER_PLUGIN_FOLDER . '/classic-theme-helper-plugin.php',
-	function ( $actions ) {
-		$settings_link = '<a href="' . esc_url( admin_url( 'admin.php?page=classic-theme-helper-plugin' ) ) . '">' . __( 'Settings', 'classic-theme-helper-plugin' ) . '</a>';
-		array_unshift( $actions, $settings_link );
+// Init Jetpack packages that are hooked into plugins_loaded.
+add_action( 'plugins_loaded', 'init_packages_plugins_loaded', 1 );
 
-		return $actions;
-	}
-);
-
-	// Init Jetpack packages that are hooked into plugins_loaded.
-	add_action( 'plugins_loaded', 'init_packages_plugins_loaded', 1 );
-
-	/**
-	 * Configure what Jetpack packages should get automatically initialized, using the plugins_loaded hook.
-	 *
-	 * @return void
-	 */
+/**
+ * Configure what Jetpack packages should get automatically initialized, using the plugins_loaded hook.
+ *
+ * @return void
+ */
 function init_packages_plugins_loaded() {
+	$jp_plugin_version = Constants::get_constant( 'JETPACK__VERSION' );
 	if ( class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Main' ) ) {
 		Automattic\Jetpack\Classic_Theme_Helper\Main::init();
 	}
-	if ( class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Featured_Content' ) ) {
+	if ( $jp_plugin_version && version_compare( $jp_plugin_version, '13.6-a.2', '>=' ) && class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Featured_Content' ) ) {
 		Automattic\Jetpack\Classic_Theme_Helper\Featured_Content::setup();
 	}
 }
 
-	// Init Jetpack packages that are hooked into init.
-	add_action( 'init', 'init_packages_init', 30 );
+// Init Jetpack packages that are hooked into init.
+add_action( 'init', 'init_packages_init', 30 );
 
-	/**
-	 * Configure what Jetpack packages should get automatically initialized, using the init hook.
-	 *
-	 * @return void
-	 */
+/**
+ * Configure what Jetpack packages should get automatically initialized, using the init hook.
+ *
+ * @return void
+ */
 function init_packages_init() {
-	if ( class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Social_Links' ) ) {
+	$jp_plugin_version = Constants::get_constant( 'JETPACK__VERSION' );
+	if ( $jp_plugin_version && version_compare( $jp_plugin_version, '13.6-a.2', '>=' ) && class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Social_Links' ) ) {
 		// @phan-suppress-next-line PhanNoopNew
 		new Automattic\Jetpack\Classic_Theme_Helper\Social_Links();
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/vulcan/issues/388

## Proposed changes:
* Remove the placeholder Settings page link as we will not use a settings page on the initial release of this plugin.
* Added example Jetpack version checking to the feature class loaders. These will be updated with appropriate versions before release.
* Cleaned up whitespace in main plugin file.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [X] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [X] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Details about these changes can be found in this issue: https://github.com/Automattic/vulcan/issues/388

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Verify that the placeholder settings page link is no longer present on the Classic Theme Helper Plugin's listing in the WordPress admin plugins' page.
* Review the version checks added to the feature class loaders in `classic-theme-helper-plugin.php` and verify that they will work to only initialize each class when the Jetpack version is high enough.