### PR TITLE
OG Tags: do not display Fediverse creator tag on wpcom simple

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fediverse-og-no-simple
+++ b/projects/plugins/jetpack/changelog/update-fediverse-og-no-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Open Graph Meta Tags: do not display Fediverse tag on WordPress.com Simple.

--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -11,6 +11,8 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Status\Host;
+
 add_action( 'wp_head', 'jetpack_og_tags' );
 add_action( 'web_stories_story_head', 'jetpack_og_tags' );
 
@@ -550,6 +552,15 @@ function jetpack_og_get_description( $description = '', $data = null ) {
  * @return array
  */
 function jetpack_add_fediverse_creator_open_graph_tag( $tags ) {
+	/*
+	 * Let's not do this on WordPress.com Simple for now,
+	 * because of its performance impact.
+	 * See p1723574138779019/1723572983.803009-slack-C01U2KGS2PQ
+	 */
+	if ( ( new Host() )->is_wpcom_simple() ) {
+		return $tags;
+	}
+
 	/*
 	 * Let's not add any tags when the ActivityPub plugin already adds its own.
 	 * On WordPress.com simple, let's check if the plugin is active.


### PR DESCRIPTION
Follow-up to #38809

## Proposed changes:

On wpcom simple, it was making uncached queries on the frontend.

See p1723574138779019/1723572983.803009-slack-C01U2KGS2PQ

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Sharing
* Enable Jetpack Social, and connect your site to a test Mastodon account.
* Go to Posts > Add New
* Write a post and publish it. In the post sidebar, ensure the post is shared to Mastodon.
* Check the source of the post on the frontend: you should see this: `<meta name="fediverse:creator" content="@tests@fedi.jeremy.hu" />`
    * > On WordPress.com Simple, you should not see anything.
* Disable Jetpack Social
* Ensure the meta tag is gone, and that there are no errors on your site
* Enable Jetpack Social again.
* Now install and activate the ActivityPub plugin on your site.
    * > On WordPress.com Simple, you'll want to go to Tools > Marketing > Connections, and flip the toggle to "enter the fediverse".
* Check that same post again ; the meta tag added by Jetpack should be gone.
