### PR TITLE
OG Tags / Fediverse: check for active integration instead of class

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fediverse-og-better-compat-check
+++ b/projects/plugins/jetpack/changelog/update-fediverse-og-better-compat-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+OG Tags: check if the Open Graph integration in the ActivityPub plugin is active instead of checking for the class.

--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -550,16 +550,9 @@ function jetpack_og_get_description( $description = '', $data = null ) {
  * @return array
  */
 function jetpack_add_fediverse_creator_open_graph_tag( $tags ) {
-	/*
-	 * Let's not add any tags when the ActivityPub plugin already adds its own.
-	 * On WordPress.com simple, let's check if the plugin is active.
-	 * On self-hosted, let's just check if the class exists.
-	 */
-	$is_activitypub_active = function_exists( 'wpcom_activitypub_is_active' )
-		? wpcom_activitypub_is_active()
-		: class_exists( '\Activitypub\Integration\Opengraph' );
-
-	if ( $is_activitypub_active ) {
+	// Let's not add any tags when the ActivityPub plugin already adds its own.
+	$is_activitypub_opengraph_integration_active = get_option( 'activitypub_use_opengraph' );
+	if ( $is_activitypub_opengraph_integration_active ) {
 		return $tags;
 	}
 

--- a/projects/plugins/jetpack/functions.opengraph.php
+++ b/projects/plugins/jetpack/functions.opengraph.php
@@ -613,7 +613,7 @@ function jetpack_add_fediverse_creator_open_graph_tag( $tags ) {
 				'user_id'       => (int) $connection_user_id,
 				'connection_id' => (int) $connection_id,
 				'handle'        => $mastodon_handle,
-				'global'        => 0 === $connection_user_id,
+				'global'        => 0 === (int) $connection_user_id,
 			);
 		}
 	}


### PR DESCRIPTION
Follow-up to #38809

## Proposed changes:

Let's not check if the `Activitypub\Integration\Opengraph` class exists:

- This can be problematic in an autoloaded environment.
- The ActivityPub plugin actually offers an option allowing you to not require the class:
https://github.com/Automattic/wordpress-activitypub/blob/0bbd715d05fc8b2c399529872715605cffa613b1/integration/load.php#L41-L51

**Unchecking that option actually causes a Fatal Error on the site**, because of https://github.com/Automattic/wordpress-activitypub/blob/0bbd715d05fc8b2c399529872715605cffa613b1/activitypub.php#L126-L129

> [!NOTE]
> This was reported here:
> https://macaw.social/@andypiper/112955494627919377

We now fully rely on the option instead. This has the inconvenient that if one deactivates and deletes the ActivityPub plugin, the option may stick around. This may be fixed if this issue gets fixed:
https://github.com/Automattic/wordpress-activitypub/issues/855

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Sharing
* Enable Jetpack Social, and connect your site to a test Mastodon account.
* Go to Posts > Add New
* Write a post and publish it. In the post sidebar, ensure the post is shared to Mastodon.
* Check the source of the post on the frontend: you should see this: `<meta name="fediverse:creator" content="@tests@fedi.jeremy.hu" />`
* Now install and activate the ActivityPub plugin on your site.
* Check that same post again ; the meta tag added by Jetpack should be gone.
* Now go to Settings > ActivityPub > Settings
* Disable the Open Graph option at the bottom of the page
* Go back to the frontend ; the tag added by Jetpack should be back.
