### PR TITLE
Site Level User Profile: add /wpcom/v2/profile endpoint to get admin color and locale

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-profile.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-profile.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * REST API endpoint for user profile.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Profile
+ */
+class WPCOM_REST_API_V2_Endpoint_Profile extends WP_REST_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'profile';
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Checks if a given request has access to user profile.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! current_user_can( 'read' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to view your user profile on this site.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves the user profile.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_item( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return rest_ensure_response(
+			array(
+				'admin_color' => get_user_option( 'admin_color' ),
+				'locale'      => get_user_locale(),
+			)
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Profile' );

--- a/projects/plugins/jetpack/changelog/site-profile-language
+++ b/projects/plugins/jetpack/changelog/site-profile-language
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Add /wpcom/v2/profile endpoint that returns user profile: admin color and locale


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/7754

## Proposed changes:

This PR adds a new `/wpcom/v2/profile` endpoint which returns user profile data. Currently it consists of:

- `admin_color`
- `locale`

This endpoint is meant to be used in Calypso screens so that the correct translation is rendered.

This endpoint is meant to replace the existing `/wpcom/v2/admin-color`. Will clean up later.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the instructions on:

- https://github.com/Automattic/wp-calypso/pull/93369

