### PR TITLE
Site Breadcrumbs: Copying module file to Classic Theme Helper package

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/add-site-breadcrumbs-to-classic-theme-helper-package
+++ b/projects/packages/classic-theme-helper/changelog/add-site-breadcrumbs-to-classic-theme-helper-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Site Breadcrumbs: Copying functionality file into Classic Theme Helper package.

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-classic-theme-helper",
-	"version": "0.4.5",
+	"version": "0.4.6-alpha",
 	"description": "Features used with classic themes",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/classic-theme-helper/#readme",
 	"bugs": {

--- a/projects/packages/classic-theme-helper/src/class-main.php
+++ b/projects/packages/classic-theme-helper/src/class-main.php
@@ -14,7 +14,7 @@ use WP_Error;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.4.5';
+	const PACKAGE_VERSION = '0.4.6-alpha';
 
 	/**
 	 * Modules to include.

--- a/projects/packages/classic-theme-helper/src/site-breadcrumbs.php
+++ b/projects/packages/classic-theme-helper/src/site-breadcrumbs.php
@@ -1,15 +1,10 @@
 <?php
 /**
- * Plugin Name: Site Breadcrumbs
- * Plugin URI: https://wordpress.com
- * Description: Quickly add breadcrumbs to the single view of a hierarchical post type or a hierarchical taxonomy.
- * Author: Automattic
- * Version: 1.0
- * Author URI: https://wordpress.com
- * License: GPL2 or later
- * Text Domain: jetpack
+ * Theme Tools: Site Breadcrumbs.
  *
- * @package automattic/jetpack
+ * Quickly add breadcrumbs to the single view of a hierarchical post type or a hierarchical taxonomy.
+ *
+ * @package automattic/jetpack-classic-theme-helper
  */
 
 if ( ! function_exists( 'jetpack_breadcrumbs' ) ) {
@@ -17,8 +12,6 @@ if ( ! function_exists( 'jetpack_breadcrumbs' ) ) {
 	 * Echos a set of breadcrumbs.
 	 *
 	 * Themes can call this function where the breadcrumbs should be outputted.
-	 *
-	 * @phan-suppress PhanRedefineFunction -- Covered by function_exists check.
 	 */
 	function jetpack_breadcrumbs() {
 		$taxonomy                 = is_category() ? 'category' : get_query_var( 'taxonomy' );
@@ -39,11 +32,11 @@ if ( ! function_exists( 'jetpack_breadcrumbs' ) ) {
 			$ancestors = array_reverse( get_post_ancestors( $post_id ) );
 			if ( $ancestors ) {
 				foreach ( $ancestors as $ancestor ) {
-					$breadcrumb .= '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_attr( $position ) . '"><a href="' . esc_url( get_permalink( $ancestor ) ) . '" itemprop="item"><span itemprop="name">' . esc_html( get_the_title( $ancestor ) ) . '</span></a></span>';
+					$breadcrumb .= '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_attr( (string) $position ) . '"><a href="' . esc_url( get_permalink( $ancestor ) ) . '" itemprop="item"><span itemprop="name">' . esc_html( get_the_title( $ancestor ) ) . '</span></a></span>';
 					++$position;
 				}
 			}
-			$breadcrumb .= '<span class="current-page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_attr( $position ) . '"><span itemprop="name">' . esc_html( get_the_title( $post_id ) ) . '</span></span>';
+			$breadcrumb .= '<span class="current-page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_attr( (string) $position ) . '"><span itemprop="name">' . esc_html( get_the_title( $post_id ) ) . '</span></span>';
 		} elseif ( $is_taxonomy_hierarchical ) {
 			$current = get_term( get_queried_object_id(), $taxonomy );
 
@@ -55,27 +48,24 @@ if ( ! function_exists( 'jetpack_breadcrumbs' ) ) {
 				$breadcrumb = jetpack_get_term_parents( $current->parent, $taxonomy );
 			}
 
-			$breadcrumb .= '<span class="current-category" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta property="position" content="' . esc_attr( $position ) . '"><span itemprop="name">' . esc_html( $current->name ) . '</span></span>';
+			$breadcrumb .= '<span class="current-category" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta property="position" content="' . esc_attr( (string) $position ) . '"><span itemprop="name">' . esc_html( $current->name ) . '</span></span>';
 		}
 
-		$home = '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_attr( $position ) . '"><meta itemprop="position" content="0"><a href="' . esc_url( home_url( '/' ) ) . '" class="home-link" itemprop="item" rel="home"><span itemprop="name">' . esc_html__( 'Home', 'jetpack' ) . '</span></a></span>';
+		$home = '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_attr( (string) $position ) . '"><meta itemprop="position" content="0"><a href="' . esc_url( home_url( '/' ) ) . '" class="home-link" itemprop="item" rel="home"><span itemprop="name">' . esc_html__( 'Home', 'jetpack-classic-theme-helper' ) . '</span></a></span>';
 
 		echo '<nav class="entry-breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">' . $home . $breadcrumb . '</nav>'; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
-
 }
 
 if ( ! function_exists( 'jetpack_get_term_parents' ) ) {
 	/**
 	 * Return the parents for a given taxonomy term ID.
 	 *
-	 * @phan-suppress PhanRedefineFunction -- Covered by function_exists check.
-	 *
 	 * @param int    $term Taxonomy term whose parents will be returned.
 	 * @param string $taxonomy Taxonomy name that the term belongs to.
 	 * @param array  $visited Terms already added to prevent duplicates.
 	 *
-	 * @return string A list of links to the term parents.
+	 * @return string|WP_Error A list of links to the term parents|WP_Error.
 	 */
 	function jetpack_get_term_parents( $term, $taxonomy, $visited = array() ) {
 		$parent = get_term( $term, $taxonomy );

--- a/projects/plugins/jetpack/changelog/add-site-breadcrumbs-to-classic-theme-helper-package
+++ b/projects/plugins/jetpack/changelog/add-site-breadcrumbs-to-classic-theme-helper-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Site Breadcrumbs: Wrapping functions in function_exists as part of functionality move to package


### PR DESCRIPTION

Fixes https://github.com/Automattic/vulcan/issues/453

## Proposed changes:

* Moved the main file `site-breadcrumbs.php` to the Classic Theme Helper package.
* Added `function_exists` checks in both module and package file versions. Not strictly required (no issues in testing), but I wanted to be safe with this.
* Added some string casts and an updated function comment to meet Phan test failures when moving the code, instead of commenting out those Phan issues. Will test more when requiring the package, and do any useful clean-up then.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/vulcan/issues/453

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* You shouldn't need to test this as it's technically just a copy-over of the file, but with added `function_exists` checks in both places.
* However if testing, with this PR checked out you can use the theme 'Sequential', add a new page, and on the front-end visit that page. Underneath the site title you'll see the site breadcrumbs.

