### PR TITLE
Repo gardening: update PR review flow explanation to be clearer

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-description-pr-flow-message
+++ b/projects/github-actions/repo-gardening/changelog/update-description-pr-flow-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Check PR description: update PR review workflow explanation to be clearer.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -494,9 +494,22 @@ The e2e test report can be found [here](https://automattic.github.io/jetpack-e2e
 	if ( statusChecks.isFromContributor ) {
 		comment += `
 
-Once your PR is ready for review, check one last time that all required checks appearing at the bottom of this PR are passing or skipped.
-Then, add the "[Status] Needs Team Review" label and ask someone from your team review the code. Once reviewed, it can then be merged.
-If you need an extra review from someone familiar with the codebase, you can update the labels from "[Status] Needs Team Review" to "[Status] Needs Review", and in that case Jetpack Approvers will do a final review of your PR.`;
+**Follow this PR Review Process:**
+
+1. Ensure all required checks appearing at the bottom of this PR are passing.
+2. Choose a review path based on your changes:
+    A. Team Review: add the https://github.com/Automattic/jetpack/labels/%5BStatus%5D%20Needs%20Team%20Review label
+      - For most changes, including minor cross-team impacts.
+      - Example: Updating a team-specific component or a small change to a shared library.
+    B. Crew Review: add the "https://github.com/Automattic/jetpack/labels/%5BStatus%5D%20Needs%20Review" label
+      - For significant changes to core functionality.
+      - Example: Major updates to a shared library or complex features.
+    C. Both: Start with Team, then request Crew
+      - For complex changes or when you need extra confidence.
+      - Example: Refactor affecting multiple systems.
+3. Get at least one approval before merging.
+
+Still unsure? Reach out in #jetpack-developers for guidance!`;
 	}
 
 	// Gather info about the next release for that plugin.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -498,10 +498,10 @@ The e2e test report can be found [here](https://automattic.github.io/jetpack-e2e
 
 1. Ensure all required checks appearing at the bottom of this PR are passing.
 2. Choose a review path based on your changes:
-    A. Team Review: add the https://github.com/Automattic/jetpack/labels/%5BStatus%5D%20Needs%20Team%20Review label
+    A. Team Review: add the [ [Status] Needs Team Review](https://github.com/Automattic/jetpack/labels/%5BStatus%5D%20Needs%20Team%20Review) label
       - For most changes, including minor cross-team impacts.
       - Example: Updating a team-specific component or a small change to a shared library.
-    B. Crew Review: add the "https://github.com/Automattic/jetpack/labels/%5BStatus%5D%20Needs%20Review" label
+    B. Crew Review: add the [ [Status] Needs Review](https://github.com/Automattic/jetpack/labels/%5BStatus%5D%20Needs%20Review) label
       - For significant changes to core functionality.
       - Example: Major updates to a shared library or complex features.
     C. Both: Start with Team, then request Crew

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -498,10 +498,10 @@ The e2e test report can be found [here](https://automattic.github.io/jetpack-e2e
 
 1. Ensure all required checks appearing at the bottom of this PR are passing.
 2. Choose a review path based on your changes:
-    A. Team Review: add the [ [Status] Needs Team Review](https://github.com/Automattic/jetpack/labels/%5BStatus%5D%20Needs%20Team%20Review) label
+    A. Team Review: add the "[Status] Needs Team Review" label
       - For most changes, including minor cross-team impacts.
       - Example: Updating a team-specific component or a small change to a shared library.
-    B. Crew Review: add the [ [Status] Needs Review](https://github.com/Automattic/jetpack/labels/%5BStatus%5D%20Needs%20Review) label
+    B. Crew Review: add the "[Status] Needs Review" label
       - For significant changes to core functionality.
       - Example: Major updates to a shared library or complex features.
     C. Both: Start with Team, then request Crew


### PR DESCRIPTION
## Proposed changes:

Let's iterate on the explanations we provide to PR authors when they open a PR in this repo. We can turn the explanation into a list, which may be easier to quickly parse and visualize.

I was hoping I could automatically format the label mentions too. In theory, simply linking to 

```
https://github.com/Automattic/jetpack/labels/%5BStatus%5D%20Needs%20Review
```

Should turn into a link formatted to look just like in the PR sidebar:

[ [Status] Needs Review](https://github.com/Automattic/jetpack/labels/%5BStatus%5D%20Needs%20Review)

That didn't work in my tests though.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* Related conversation: p1723620319635249/1723563375.969809-slack-C4GAQ900P

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

You won't be able to test this in this repo before it's merged. Here is how it will look after it's merged:

<img width="609" alt="Screenshot 2024-08-14 at 16 50 30" src="https://github.com/user-attachments/assets/eb3376b4-430b-4478-a5d4-9024550426b1">
