### PR TITLE
Monorepo tools: update wording in version check recommendations

### DIFF
--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -277,7 +277,7 @@ for SLUG in "${SLUGS[@]}"; do
 			if [[ -n "$CI" ]]; then
 				M="::error file=$FILE"
 				[[ -n "$LINE" ]] && M="$M,line=${LINE%%:*}"
-				echo "$M::Must depend on monorepo package $PKG version $VER%0APlease run \`tools/check-intra-monorepo-deps.sh -u\`, commit, and push the generated changes to fix this."
+				echo "$M::Must depend on monorepo package $PKG version $VER%0APlease run \`tools/check-intra-monorepo-deps.sh -u\`, commit, and push the generated changes to your branch to fix this."
 			else
 				M="$FILE"
 				[[ -n "$LINE" ]] && M="$M:${LINE%%:*}"
@@ -320,7 +320,7 @@ done
 spinclear
 
 if ! $UPDATE && [[ "$EXIT" != "0" ]]; then
-	jetpackGreen 'Please run `tools/check-intra-monorepo-deps.sh -u`, commit, and push the generated changes to fix these errors.'
+	jetpackGreen 'Before you can merge your PR, please run `tools/check-intra-monorepo-deps.sh -u`, commit, and push the generated changes to your branch to fix these errors.'
 fi
 
 if $RELEASEBRANCH && [[ "${#SKIPPED[@]}" -gt 0 && "$EXIT" == "0" ]]; then

--- a/tools/project-version.sh
+++ b/tools/project-version.sh
@@ -132,7 +132,7 @@ function sedver {
 		LINE=$(grep --line-number --max-count=1 -E "$2" "$1" || true)
 		if [[ -n "$CI" ]]; then
 			echo "---" # Bracket message containing newlines for better visibility in GH's logs.
-			echo "::error file=${1#$BASE/},line=${LINE%%:*}::Version mismatch, expected $3 but found $VER!%0APlease run \`tools/project-version.sh -f -u $VERSION $SLUG\` or \`tools/fixup-project-versions.sh\`, commit, and push the generated changes to fix this."
+			echo "::error file=${1#$BASE/},line=${LINE%%:*}::Version mismatch, expected $3 but found $VER!%0ABefore you can merge your PR, please run \`tools/fixup-project-versions.sh\`, commit, and push the generated changes to your branch to fix this."
 			echo "---"
 		else
 			error "${1#$BASE/}:${LINE%%:*}: Version mismatch, expected $3 but found $VER!"
@@ -178,7 +178,7 @@ function jsver {
 		LINE=$(grep --line-number --max-count=1 -E "^	{$N}\"${X##*.}\": $VE,?$" "$1" || true)
 		if [[ -n "$CI" ]]; then
 			echo "---" # Bracket message containing newlines for better visibility in GH's logs.
-			echo "::error file=${1#$BASE/},line=${LINE%%:*}::Version mismatch, expected $3 but found $VER!%0APlease run \`tools/project-version.sh -f -u $VERSION $SLUG\` or \`tools/fixup-project-versions.sh\`, commit, and push the generated changes to fix this."
+			echo "::error file=${1#$BASE/},line=${LINE%%:*}::Version mismatch, expected $3 but found $VER!%0ABefore you can merge your PR, please run \`tools/fixup-project-versions.sh\`, commit, and push the generated changes to your branch to fix this."
 			echo "---"
 		else
 			error "${1#$BASE/}:${LINE%%:*}: Version mismatch, expected $3 but found $VER!"
@@ -260,7 +260,7 @@ if $FIX_INTRA_MONOREPO_DEPS; then
 fi
 
 if $FIXHINT; then
-	green "Please run \`tools/project-version.sh -f -u $VERSION $SLUG\` or \`tools/fixup-project-versions.sh\`, commit, and push the generated changes to fix this."
+	green "Before you can merge your PR, please run \`tools/fixup-project-versions.sh\`, commit, and push the generated changes to your branch to fix this."
 fi
 
 exit $EXIT


### PR DESCRIPTION
## Proposed changes:

This is a follow-up to #38509, following discussions here:
p1723563421311809/1723563375.969809-slack-C4GAQ900P

Let's try to be more clear that this has to be done by the PR author, before the PR can be merged, so the CI check can pass.

I also removed the choice that was offered between 2 scripts, to simplify the message to PR authors. They do not immediately have the knowledge that would help them decide whether to use one script or another, so we can make things easier for them by removing one decision.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Check wording and typos
