### PR TITLE
Update/email preview improvements

### DIFF
--- a/projects/plugins/jetpack/changelog/update-email-preview-improvements-2
+++ b/projects/plugins/jetpack/changelog/update-email-preview-improvements-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+featured flagged feature

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -1,4 +1,3 @@
-import { Text } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
 import { Button, PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -42,12 +41,12 @@ const NewsletterMenu = () => {
 					<>
 						<SubscribersAffirmation accessLevel={ accessLevel } />
 						{ ! isPublished && (
-							<Text>
+							<p>
 								{ __(
 									'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',
 									'jetpack'
 								) }
-							</Text>
+							</p>
 						) }
 						<Button
 							onClick={ openModal }
@@ -64,15 +63,12 @@ const NewsletterMenu = () => {
 					</>
 				) : (
 					<>
-						<Text variant="title-small" mb={ 2 }>
-							{ __( 'Newsletter', 'jetpack' ) }
-						</Text>
-						<Text mb={ 3 }>
+						<p>
 							{ __(
 								'To email your posts, build an audience, and use features like preview and test, connect to WordPress.com cloud.',
 								'jetpack'
 							) }
-						</Text>
+						</p>
 						<Button variant="primary" href={ connectUrl } style={ { marginTop: '10px' } }>
 							{ __( 'Connect WordPress.com account', 'jetpack' ) }
 						</Button>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -1,3 +1,5 @@
+import { Text } from '@automattic/jetpack-components';
+import { useConnection } from '@automattic/jetpack-connection';
 import { Button, PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { PluginSidebar } from '@wordpress/edit-post';
@@ -23,40 +25,61 @@ const NewsletterMenu = () => {
 	const accessLevel = useAccessLevel( postType );
 	const isPublished = postStatus === 'publish';
 
+	const { isUserConnected } = useConnection();
+	const connectUrl = `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/connection`;
+
 	const openModal = () => setIsModalOpen( true );
 	const closeModal = () => setIsModalOpen( false );
 
 	return (
-		<>
-			<PluginSidebar
-				name="newsletter-settings-sidebar"
-				title={ __( 'Newsletter', 'jetpack' ) }
-				icon={ <SendIcon /> }
-			>
-				<PanelBody>
-					<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
-					{ ! isPublished && (
-						<p>
+		<PluginSidebar
+			name="newsletter-settings-sidebar"
+			title={ __( 'Newsletter', 'jetpack' ) }
+			icon={ <SendIcon /> }
+		>
+			<PanelBody>
+				{ isUserConnected ? (
+					<>
+						<SubscribersAffirmation accessLevel={ accessLevel } />
+						{ ! isPublished && (
+							<Text>
+								{ __(
+									'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',
+									'jetpack'
+								) }
+							</Text>
+						) }
+						<Button
+							onClick={ openModal }
+							style={ {
+								marginRight: '18px',
+								marginTop: '10px',
+							} }
+							variant="secondary"
+							disabled={ isPublished }
+						>
+							{ __( 'Preview email', 'jetpack' ) }
+						</Button>
+						<PreviewModal isOpen={ isModalOpen } onClose={ closeModal } postId={ postId } />
+					</>
+				) : (
+					<>
+						<Text variant="title-small" mb={ 2 }>
+							{ __( 'Newsletter', 'jetpack' ) }
+						</Text>
+						<Text mb={ 3 }>
 							{ __(
-								'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',
+								'To email your posts, build an audience, and use features like preview and test, connect to WordPress.com cloud.',
 								'jetpack'
 							) }
-						</p>
-					) }
-					<Button
-						onClick={ openModal }
-						style={ {
-							marginRight: '18px',
-						} }
-						variant="secondary"
-						disabled={ isPublished }
-					>
-						{ __( 'Preview email', 'jetpack' ) }
-					</Button>
-				</PanelBody>
-			</PluginSidebar>
-			<PreviewModal isOpen={ isModalOpen } onClose={ closeModal } postId={ postId } />
-		</>
+						</Text>
+						<Button variant="primary" href={ connectUrl } style={ { marginTop: '10px' } }>
+							{ __( 'Connect WordPress.com account', 'jetpack' ) }
+						</Button>
+					</>
+				) }
+			</PanelBody>
+		</PluginSidebar>
 	);
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Preview Modal works only for connected users. Don't show the buttons and instead show a `Connect WordPress.com account` button.

<img width="303" alt="Screenshot 2024-08-14 at 12 59 44 PM" src="https://github.com/user-attachments/assets/32cf6b65-8de1-42b2-80ec-ab3b3723ffd1">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* add `&showNewsletterMenu` to the editor.

