### PR TITLE
Protect: Fix globalStats access

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-global-stats-access
+++ b/projects/plugins/protect/changelog/fix-protect-global-stats-access
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Makes globalStats always accessible"

--- a/projects/plugins/protect/changelog/fix-protect-global-stats-access
+++ b/projects/plugins/protect/changelog/fix-protect-global-stats-access
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Makes globalStats always accessible"
+Makes globalStats always accessible

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -233,6 +233,7 @@ class Jetpack_Protect {
 				'isUpdating'          => false,
 				'config'              => Waf_Runner::get_config(),
 				'stats'               => self::get_waf_stats(),
+				'globalStats'         => Waf_Stats::get_global_stats(),
 			),
 		);
 
@@ -455,7 +456,6 @@ class Jetpack_Protect {
 			'ipAllowListCount'          => Waf_Stats::get_ip_allow_list_count(),
 			'ipBlockListCount'          => Waf_Stats::get_ip_block_list_count(),
 			'automaticRulesLastUpdated' => Waf_Stats::get_automatic_rules_last_updated(),
-			'globalStats'               => Waf_Stats::get_global_stats(),
 		);
 	}
 }

--- a/projects/plugins/protect/src/js/components/scan-footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/scan-footer/index.jsx
@@ -75,8 +75,7 @@ const ProductPromotion = () => {
 
 const FooterInfo = () => {
 	const { hasRequiredPlan } = useProtectData();
-	const { stats } = useWafData();
-	const { globalStats } = stats;
+	const { globalStats } = useWafData();
 	const totalVulnerabilities = parseInt( globalStats?.totalVulnerabilities );
 	const totalVulnerabilitiesFormatted = isNaN( totalVulnerabilities )
 		? '50,000'

--- a/projects/plugins/protect/src/js/routes/scan/index.jsx
+++ b/projects/plugins/protect/src/js/routes/scan/index.jsx
@@ -74,8 +74,7 @@ const ErrorSection = ( { errorMessage, errorCode } ) => {
 
 const ScanningSection = ( { currentProgress } ) => {
 	const { hasRequiredPlan } = useProtectData();
-	const { stats } = useWafData();
-	const { globalStats } = stats;
+	const { globalStats } = useWafData();
 	const totalVulnerabilities = parseInt( globalStats?.totalVulnerabilities );
 	const totalVulnerabilitiesFormatted = isNaN( totalVulnerabilities )
 		? '50,000'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
`Jetpack_Protect::get_stats` returns false in an unsupported environment (in any case where `Waf_Runner::is_enabled` is false), we need `globalStats` always.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the inclusion from `get_stats` and add a dedicated property to the initial state.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1362

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout the branch and fire up Jurassic Tube
* Manually update `Waf_Runner::is_supported_environment` to `false`
* Verify that the `globalStats.totalVulnerabilities` is always accessible in the initial state
* Revert changes to `Waf_Runner` method
* Ensure that no regressions are introduced

