### PR TITLE
Newsletter: Gutenberg Plugin: Add Send test email button

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-plugin
+++ b/projects/plugins/jetpack/changelog/update-newsletter-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+featured flagged feature

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -27,7 +27,7 @@ import { accessOptions } from '../../shared/memberships/constants';
 import { useAccessLevel } from '../../shared/memberships/edit';
 import illustration from './email-preview-illustration.svg';
 
-export default function EmailPreview( { isModalOpen, closeModal } ) {
+export function EmailPreview( { isModalOpen, closeModal } ) {
 	const [ emailSent, setEmailSent ] = useState( false );
 	const [ emailSending, setEmailSending ] = useState( false );
 	const [ errorMessage, setErrorMessage ] = useState( false );
@@ -360,3 +360,5 @@ export function PreviewModal( { isOpen, onClose, postId } ) {
 		)
 	);
 }
+
+export default EmailPreview;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -42,7 +42,7 @@ const NewsletterMenu = () => {
 			<PanelBody>
 				{ isUserConnected ? (
 					<>
-						<SubscribersAffirmation accessLevel={ accessLevel } />
+						<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
 						{ ! isPublished && (
 							<p>
 								{ __(
@@ -51,7 +51,7 @@ const NewsletterMenu = () => {
 								) }
 							</p>
 						) }
-						<HStack>
+						<HStack wrap={ true }>
 							<Button onClick={ openModal } variant="secondary" disabled={ isPublished }>
 								{ __( 'Preview email', 'jetpack' ) }
 							</Button>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -1,16 +1,17 @@
 import { useConnection } from '@automattic/jetpack-connection';
-import { Button, PanelBody } from '@wordpress/components';
+import { Button, PanelBody, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useSelect } from '@wordpress/data';
 import { PluginSidebar } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { useAccessLevel } from '../../shared/memberships/edit';
 import SubscribersAffirmation from '../../shared/memberships/subscribers-affirmation';
-import { PreviewModal } from './email-preview';
+import { PreviewModal, EmailPreview } from './email-preview';
 import { SendIcon } from './icons';
 
 const NewsletterMenu = () => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+	const [ isEmailPreviewOpen, setIsEmailPreviewOpen ] = useState( false );
 
 	const { postId, postType, postStatus } = useSelect(
 		select => ( {
@@ -29,6 +30,8 @@ const NewsletterMenu = () => {
 
 	const openModal = () => setIsModalOpen( true );
 	const closeModal = () => setIsModalOpen( false );
+	const openEmailPreview = () => setIsEmailPreviewOpen( true );
+	const closeEmailPreview = () => setIsEmailPreviewOpen( false );
 
 	return (
 		<PluginSidebar
@@ -48,18 +51,16 @@ const NewsletterMenu = () => {
 								) }
 							</p>
 						) }
-						<Button
-							onClick={ openModal }
-							style={ {
-								marginRight: '18px',
-								marginTop: '10px',
-							} }
-							variant="secondary"
-							disabled={ isPublished }
-						>
-							{ __( 'Preview email', 'jetpack' ) }
-						</Button>
+						<HStack>
+							<Button onClick={ openModal } variant="secondary" disabled={ isPublished }>
+								{ __( 'Preview email', 'jetpack' ) }
+							</Button>
+							<Button onClick={ openEmailPreview } variant="secondary" disabled={ isPublished }>
+								{ __( 'Send test email', 'jetpack' ) }
+							</Button>
+						</HStack>
 						<PreviewModal isOpen={ isModalOpen } onClose={ closeModal } postId={ postId } />
+						<EmailPreview isModalOpen={ isEmailPreviewOpen } closeModal={ closeEmailPreview } />
 					</>
 				) : (
 					<>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Add Send test email button

<img width="343" alt="Screenshot 2024-08-14 at 5 24 11 PM" src="https://github.com/user-attachments/assets/208a8c5e-260c-4f04-8741-e8a49ef3c254">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add `&showNewsletterMenu` to the editor url

