### PR TITLE
AI Assistant: Add flag for Breve typo detection support

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-typo-flag
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-typo-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add flag for Breve typo detection support

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -187,6 +187,18 @@ add_action(
 );
 
 /**
+ * Register the `ai-breve-typo-support` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		if ( apply_filters( 'jetpack_ai_enabled', true ) && apply_filters( 'breve_enabled', true ) ) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-breve-typo-support' );
+		}
+	}
+);
+
+/**
  * Register the `ai-assistant-site-logo-support` extension.
  */
 add_action(

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -80,7 +80,8 @@
 		"videopress/video-chapters",
 		"ai-assistant-backend-prompts",
 		"ai-assistant-extensions-support",
-		"ai-title-optimization-keywords-support"
+		"ai-title-optimization-keywords-support",
+		"ai-breve-typo-support"
 	],
 	"experimental": [ "ai-image", "ai-paragraph" ],
 	"no-post-editor": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38894

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the `ai-breve-typo-support` beta flag to ensure the typo detection feature is not partially implemented on any release

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Almost the same as the instructions from https://github.com/Automattic/jetpack/pull/38891, changing `ai-title-optimization-keywords-support` to `ai-breve-typo-support`. DRY principle in action.

- After checking the flag, use a code snippet to explicitly disable `breve_enabled`: `add_filter( 'breve_enabled', '__return_false' );`
- Reload the editor
- Check that the flag is disabled:

![2024-08-14_17-53-55](https://github.com/user-attachments/assets/a04acfe4-3d7b-4e3b-8cf7-613accf964ad)
