### PR TITLE
Protect: Disable ignore button when fixer in progress

### DIFF
--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/events.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/events.ts
@@ -97,7 +97,7 @@ async function handleMouseEnter( e: MouseEvent ) {
 			target: el,
 			virtual: virtual,
 		} as Anchor );
-	}, 500 ) as unknown as number;
+	}, 500 );
 }
 
 function handleMouseLeave() {
@@ -106,7 +106,7 @@ function handleMouseLeave() {
 
 	highlightTimeout = setTimeout( () => {
 		( dispatch( 'jetpack/ai-breve' ) as BreveDispatch ).setHighlightHover( false );
-	}, 100 ) as unknown as number;
+	}, 100 );
 }
 
 export default function registerEvents( clientId: string ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/events.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/events.ts
@@ -97,7 +97,7 @@ async function handleMouseEnter( e: MouseEvent ) {
 			target: el,
 			virtual: virtual,
 		} as Anchor );
-	}, 500 );
+	}, 500 ) as unknown as number;
 }
 
 function handleMouseLeave() {
@@ -106,7 +106,7 @@ function handleMouseLeave() {
 
 	highlightTimeout = setTimeout( () => {
 		( dispatch( 'jetpack/ai-breve' ) as BreveDispatch ).setHighlightHover( false );
-	}, 100 );
+	}, 100 ) as unknown as number;
 }
 
 export default function registerEvents( clientId: string ) {

--- a/projects/plugins/protect/changelog/update-protect-disable-ignore-button-when-fixer-in-progress
+++ b/projects/plugins/protect/changelog/update-protect-disable-ignore-button-when-fixer-in-progress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Disables the unignore threats button when a fixer is in progress

--- a/projects/plugins/protect/src/js/components/threats-list/paid-list.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/paid-list.jsx
@@ -151,6 +151,7 @@ const ThreatAccordionItem = ( {
 							isDestructive={ true }
 							variant="secondary"
 							onClick={ handleIgnoreThreatClick() }
+							disabled={ fixerInProgress }
 						>
 							{ __( 'Ignore threat', 'jetpack-protect' ) }
 						</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
When a fixer is in progress it is still possible to trigger the ignore threat button.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable the button when `fixerInProgress` is `true`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1350

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch on beta tester on a fresh JN install
* Add fixable threats, upgrade and detect them
* Trigger the fixer and ensure that both the `Ignore threat`, and `Fix threat` buttons become disabled while the fixer is in progress
* Ensure no regressions are introduced

