### PR TITLE
Newsletter: Plugin: Add 'Post & Email - Post only' buttons

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-plugin-2
+++ b/projects/plugins/jetpack/changelog/update-newsletter-plugin-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+feature flagged 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -337,7 +337,7 @@ export function PreviewModal( { isOpen, onClose, postId } ) {
 						height: 'calc(100vh - 190px)',
 						backgroundColor: '#ddd',
 						paddingTop: selectedDevice !== 'desktop' ? '36px' : '0',
-						transition: 'padding 0.5s ease-in-out',
+						transition: 'padding 0.3s ease-in-out',
 					} }
 				>
 					{ isLoading ? (
@@ -350,7 +350,7 @@ export function PreviewModal( { isOpen, onClose, postId } ) {
 								maxWidth: '100%',
 								height: '100%',
 								border: 'none',
-								transition: 'width 0.5s ease-in-out',
+								transition: 'width 0.3s ease-in-out',
 							} }
 							title={ __( 'Email Preview', 'jetpack' ) }
 						/>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -5,6 +5,7 @@ import { PluginSidebar } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { useAccessLevel } from '../../shared/memberships/edit';
+import { NewsletterEmailDocumentSettings } from '../../shared/memberships/settings';
 import SubscribersAffirmation from '../../shared/memberships/subscribers-affirmation';
 import { PreviewModal, EmailPreview } from './email-preview';
 import { SendIcon } from './icons';
@@ -13,11 +14,13 @@ const NewsletterMenu = () => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ isEmailPreviewOpen, setIsEmailPreviewOpen ] = useState( false );
 
-	const { postId, postType, postStatus } = useSelect(
+	const { postId, postType, postStatus, isSendEmailEnabled } = useSelect(
 		select => ( {
 			postId: select( 'core/editor' ).getCurrentPostId(),
 			postType: select( 'core/editor' ).getCurrentPostType(),
 			postStatus: select( 'core/editor' ).getEditedPostAttribute( 'status' ),
+			isSendEmailEnabled:
+				! select( 'core/editor' ).getEditedPostAttribute( 'meta' )?.jetpack_dont_email_post_to_subs,
 		} ),
 		[]
 	);
@@ -40,39 +43,42 @@ const NewsletterMenu = () => {
 			icon={ <SendIcon /> }
 		>
 			<PanelBody>
-				{ isUserConnected ? (
+				<NewsletterEmailDocumentSettings />
+				<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
+				{ isSendEmailEnabled && ! isPublished && (
 					<>
-						<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
-						{ ! isPublished && (
-							<p>
-								{ __(
-									'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',
-									'jetpack'
-								) }
-							</p>
+						{ isUserConnected ? (
+							<>
+								<p>
+									{ __(
+										'Ensure your email looks perfect. Use the buttons below to view a preview or send a test email.',
+										'jetpack'
+									) }
+								</p>
+								<HStack wrap={ true }>
+									<Button onClick={ openModal } variant="secondary" disabled={ isPublished }>
+										{ __( 'Preview email', 'jetpack' ) }
+									</Button>
+									<Button onClick={ openEmailPreview } variant="secondary" disabled={ isPublished }>
+										{ __( 'Send test email', 'jetpack' ) }
+									</Button>
+								</HStack>
+								<PreviewModal isOpen={ isModalOpen } onClose={ closeModal } postId={ postId } />
+								<EmailPreview isModalOpen={ isEmailPreviewOpen } closeModal={ closeEmailPreview } />
+							</>
+						) : (
+							<>
+								<p>
+									{ __(
+										'To email your posts, build an audience, and use features like preview and test, connect to WordPress.com cloud.',
+										'jetpack'
+									) }
+								</p>
+								<Button variant="primary" href={ connectUrl } style={ { marginTop: '10px' } }>
+									{ __( 'Connect WordPress.com account', 'jetpack' ) }
+								</Button>
+							</>
 						) }
-						<HStack wrap={ true }>
-							<Button onClick={ openModal } variant="secondary" disabled={ isPublished }>
-								{ __( 'Preview email', 'jetpack' ) }
-							</Button>
-							<Button onClick={ openEmailPreview } variant="secondary" disabled={ isPublished }>
-								{ __( 'Send test email', 'jetpack' ) }
-							</Button>
-						</HStack>
-						<PreviewModal isOpen={ isModalOpen } onClose={ closeModal } postId={ postId } />
-						<EmailPreview isModalOpen={ isEmailPreviewOpen } closeModal={ closeEmailPreview } />
-					</>
-				) : (
-					<>
-						<p>
-							{ __(
-								'To email your posts, build an audience, and use features like preview and test, connect to WordPress.com cloud.',
-								'jetpack'
-							) }
-						</p>
-						<Button variant="primary" href={ connectUrl } style={ { marginTop: '10px' } }>
-							{ __( 'Connect WordPress.com account', 'jetpack' ) }
-						</Button>
 					</>
 				) }
 			</PanelBody>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -4,6 +4,7 @@ import { useSelect } from '@wordpress/data';
 import { PluginSidebar } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
+import { META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS } from '../../shared/memberships/constants';
 import { useAccessLevel } from '../../shared/memberships/edit';
 import { NewsletterEmailDocumentSettings } from '../../shared/memberships/settings';
 import SubscribersAffirmation from '../../shared/memberships/subscribers-affirmation';
@@ -14,19 +15,19 @@ const NewsletterMenu = () => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ isEmailPreviewOpen, setIsEmailPreviewOpen ] = useState( false );
 
-	const { postId, postType, postStatus, isSendEmailEnabled } = useSelect(
+	const { postId, postType, postStatus, meta } = useSelect(
 		select => ( {
 			postId: select( 'core/editor' ).getCurrentPostId(),
 			postType: select( 'core/editor' ).getCurrentPostType(),
 			postStatus: select( 'core/editor' ).getEditedPostAttribute( 'status' ),
-			isSendEmailEnabled:
-				! select( 'core/editor' ).getEditedPostAttribute( 'meta' )?.jetpack_dont_email_post_to_subs,
+			meta: select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
 		} ),
 		[]
 	);
 
 	const accessLevel = useAccessLevel( postType );
 	const isPublished = postStatus === 'publish';
+	const isSendEmailEnabled = ! meta?.[ META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS ];
 
 	const { isUserConnected } = useConnection();
 	const connectUrl = `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/connection`;
@@ -43,7 +44,7 @@ const NewsletterMenu = () => {
 			icon={ <SendIcon /> }
 		>
 			<PanelBody>
-				<NewsletterEmailDocumentSettings />
+				{ ! isPublished && <NewsletterEmailDocumentSettings /> }
 				<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
 				{ isSendEmailEnabled && ! isPublished && (
 					<>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add 'Post & Email - Post only' buttons

<img width="302" alt="Screenshot 2024-08-14 at 10 39 44 PM" src="https://github.com/user-attachments/assets/62de575d-6094-4ff3-bbb8-94fd4f8e3da8">

<img width="296" alt="Screenshot 2024-08-14 at 10 39 53 PM" src="https://github.com/user-attachments/assets/987b86e9-7579-4748-8c7d-2ee2b05dea34">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor and add `&showNewsletterMenu` to the url.
* Play with the Newsletter plugin, try different combinations.
* Please add any missing details to https://github.com/Automattic/jetpack-roadmap/issues/1761

