### PR TITLE
Social: Fix initial state for simple sites that expected a user connection

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-url-initial-state-for-simple-sites
+++ b/projects/packages/publicize/changelog/fix-social-url-initial-state-for-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the initial state for simple sites that expected a user connection

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -75,6 +75,7 @@ class Publicize_Script_Data {
 		$basic_data = array(
 			'is_publicize_enabled' => Utils::is_publicize_active(),
 			'feature_flags'        => self::get_feature_flags(),
+			'urls'                 => self::get_urls(),
 		);
 
 		$is_wpcom = ( new Host() )->is_wpcom_platform();
@@ -84,7 +85,6 @@ class Publicize_Script_Data {
 			return array_merge(
 				$basic_data,
 				array(
-					'urls' => self::get_urls(),
 					/**
 					 * 'store'       => self::get_store_script_data(),
 					 * 'shares_data' => self::get_shares_data(),

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Publicize\Publicize_Utils as Utils;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Publicize_Script_Data class.
@@ -76,20 +77,23 @@ class Publicize_Script_Data {
 			'feature_flags'        => self::get_feature_flags(),
 		);
 
-		if ( ! Utils::is_publicize_active() || ! Utils::is_connected() ) {
-			return $basic_data;
+		$is_wpcom = ( new Host() )->is_wpcom_platform();
+
+		// We don't need a user connection for WPCOM sites.
+		if ( $is_wpcom || ( Utils::is_publicize_active() && Utils::is_connected() ) ) {
+			return array_merge(
+				$basic_data,
+				array(
+					'urls' => self::get_urls(),
+					/**
+					 * 'store'       => self::get_store_script_data(),
+					 * 'shares_data' => self::get_shares_data(),
+					 */
+				)
+			);
 		}
 
-		return array_merge(
-			$basic_data,
-			array(
-				'urls' => self::get_urls(),
-				/**
-				 * 'store'       => self::get_store_script_data(),
-				 * 'shares_data' => self::get_shares_data(),
-				 */
-			)
-		);
+		return $basic_data;
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -75,7 +75,7 @@ class Publicize_Script_Data {
 		$basic_data = array(
 			'is_publicize_enabled' => Utils::is_publicize_active(),
 			'feature_flags'        => self::get_feature_flags(),
-			'urls'                 => self::get_urls(),
+			'urls'                 => array(),
 		);
 
 		$is_wpcom = ( new Host() )->is_wpcom_platform();
@@ -85,6 +85,7 @@ class Publicize_Script_Data {
 			return array_merge(
 				$basic_data,
 				array(
+					'urls' => self::get_urls(),
 					/**
 					 * 'store'       => self::get_store_script_data(),
 					 * 'shares_data' => self::get_shares_data(),

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -78,10 +78,12 @@ class Publicize_Script_Data {
 			'urls'                 => array(),
 		);
 
-		$is_wpcom = ( new Host() )->is_wpcom_platform();
+		if ( ! Utils::is_publicize_active() ) {
+			return $basic_data;
+		}
 
-		// We don't need a user connection for WPCOM sites.
-		if ( $is_wpcom || ( Utils::is_publicize_active() && Utils::is_connected() ) ) {
+		// We don't need a user connection for Simple sites.
+		if ( ( new Host() )->is_wpcom_simple() || Utils::is_connected() ) {
 			return array_merge(
 				$basic_data,
 				array(

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -22,14 +22,7 @@ class Publicize_Script_Data {
 	 * @return Publicize
 	 */
 	public static function publicize() {
-		/**
-		 * Publicize instance.
-		 *
-		 * @var Publicize $publicize
-		 */
-		global $publicize;
-
-		return $publicize;
+		return publicize_init();
 	}
 
 	/**


### PR DESCRIPTION
#38855 introduced a regression that resulted in editor type error for `urls` being undefined on simple sites.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make initial state aware of the WPCOM platform

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On Simple, Atomic and Jetpack sites
* Goto post editor
* Open the Jetpack/social sidebar
* Confirm that there is no crash
* Confirm that the connections management link works as expected.

