### PR TITLE
Social: POC for adding social share log

### DIFF
--- a/projects/packages/publicize/changelog/add-social-share-log-poc
+++ b/projects/packages/publicize/changelog/add-social-share-log-poc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added the social share log cpt

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -250,6 +250,7 @@ abstract class Publicize_Base {
 		// Custom priority to ensure post type support is added prior to thumbnail support being added to the theme.
 		add_action( 'init', array( $this, 'add_post_type_support' ), 8 );
 		add_action( 'init', array( $this, 'register_post_meta' ), 20 );
+		add_action( 'init', array( new Social_Share_Log(), 'init' ), 20 );
 
 		// The custom priority for this action ensures that any existing code that
 		// removes post-thumbnails support during 'init' continues to work.

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -182,6 +182,10 @@ class REST_Controller {
 									'type'     => 'array',
 									'required' => true,
 								),
+								'share_log'         => array(
+									'type'     => 'array',
+									'required' => true,
+								),
 							),
 						),
 					),
@@ -638,6 +642,23 @@ class REST_Controller {
 		$post_id   = $request->get_param( 'id' );
 		$post_meta = $request_body['meta'];
 		$post      = get_post( $post_id );
+
+		$share_log = $post_meta['share_log'];
+
+		foreach ( $share_log as $share_meta ) {
+			$post_id = wp_insert_post(
+				array(
+					'post_title'  => $share_meta['post_title'],
+					'post_type'   => 'social_share_log',
+					'post_status' => 'publish',
+					'meta_input'  => $share_meta,
+				)
+			);
+		}
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
 
 		if ( $post && 'publish' === $post->post_status && isset( $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] ) ) {
 			update_post_meta( $post_id, self::SOCIAL_SHARES_POST_META_KEY, $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] );

--- a/projects/packages/publicize/src/class-social-share-log.php
+++ b/projects/packages/publicize/src/class-social-share-log.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Register the Social Share Log custom post type.
+ *
+ * @package automattic/jetpack-social-plugin
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+/**
+ * Register the Social Share Log custom post type.
+ *
+ * @package automattic/jetpack-social-plugin
+ */
+class Social_Share_Log {
+	const SOCIAL_SHARE_LOG_CPT = 'social_share_log';
+
+	/**
+	 * Initialize the custom post type for social share logs.
+	 */
+	public function init() {
+		self::register_cpt();
+		self::register_share_log_fields();
+	}
+
+	/**
+	 * Register the custom post type for social share logs.
+	 */
+	public function register_cpt() {
+		$args = array(
+			'public'       => false,
+			'show_ui'      => false,
+			'label'        => 'Share Logs',
+			'show_in_rest' => true,
+			'has_archive'  => true,
+			'supports'     => array( 'title', 'custom-fields' ),
+		);
+		register_post_type( self::SOCIAL_SHARE_LOG_CPT, $args );
+	}
+
+	/**
+	 * Registers the custom fields for the social share log.
+	 */
+	public function register_share_log_fields() {
+		$fields = array( 'status', 'message', 'timestamp', 'service', 'connection_id', 'external_name', 'profile_url', 'enabled' );
+
+		foreach ( $fields as $field ) {
+			register_rest_field(
+				self::SOCIAL_SHARE_LOG_CPT,
+				$field,
+				array(
+					'get_callback' => array( $this, 'get_share_log_meta' ),
+					'schema'       => null,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Get the meta for the social share log.
+	 *
+	 * @param array  $post_object The object.
+	 * @param string $field_name The field name.
+	 * @return mixed
+	 */
+	public function get_share_log_meta( $post_object, $field_name ) {
+		return get_post_meta( $post_object['id'], $field_name, true );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This is a POC for the Social Share log implementation using custom post types. Sandbox D158508-code for testing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With D158508-code sandboxed and this change checked out, create a new post with multiple connections to share to.
* Share the post
* After sharing the post you have to wait 5-20seconds for the JP endpoint to get called
* Go to `YOUR_SITE/wp-json/wp/v2/social_share_log` where you should see an entry for each share that was made, with the metadata filled out.
* If you want to see it on the UI you can change `public` and `show_ui` to true in the class PHP file.