### PR TITLE
Beta Tester: Use blog url if the site title is literally "Site Title" 

### DIFF
--- a/projects/plugins/beta/changelog/update-beta-plugin-use-site-title-if-blog-name-is-Site-Title
+++ b/projects/plugins/beta/changelog/update-beta-plugin-use-site-title-if-blog-name-is-Site-Title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use site url in email subject if the site title exists and is equale to "Site Title"

--- a/projects/plugins/beta/src/class-hooks.php
+++ b/projects/plugins/beta/src/class-hooks.php
@@ -517,8 +517,15 @@ class Hooks {
 			return;
 		}
 
-		$site_title = get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : get_site_url();
-		// translators: %s: The site title.
+		$site_title = get_bloginfo( 'name' );
+		$site_url   = get_site_url();
+
+		// Check if the site title is empty or literally 'Site Title', then use the site URL instead.
+		if ( empty( $site_title ) || $site_title === 'Site Title' ) {
+			$site_title = $site_url;
+		}
+
+		// translators: %s: The site title or URL.
 		$subject = sprintf( __( '[%s] Jetpack Beta Tester auto-updates', 'jetpack-beta' ), $site_title );
 
 		$message = sprintf(


### PR DESCRIPTION
Site Title as it is a default value in some installations and provides no information on the subject of email messages coming from the Jetpack Beta Tester plugin

#### After

![image](https://github.com/user-attachments/assets/b36c1b38-810e-43cd-b411-74450f40087b)


#### Before

![image](https://github.com/user-attachments/assets/77f47d3e-1ce4-42e5-b796-0c8ff1529b7e)


## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Updates `send_autoupdate_email` to use the site url in the email subject if the title matches the string `"Site TItle"`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
Noe

## Testing instructions:

