### PR TITLE
Help Center: fix 404 error loading languages

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/help-center-fix-language-script
+++ b/projects/packages/jetpack-mu-wpcom/changelog/help-center-fix-language-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Help Center: don't load english translations

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -105,16 +105,20 @@ class Help_Center {
 		}
 
 		if ( $variant !== 'wp-admin-disconnected' && $variant !== 'gutenberg-disconnected' ) {
-			// Load translations directly from widgets.wp.com.
-			wp_enqueue_script(
-				'help-center-translations',
-				'https://widgets.wp.com/help-center/languages/' . Common\determine_iso_639_locale() . '-v1.js',
-				array( 'wp-i18n' ),
-				$version,
-				true
-			);
+			$locale = Common\determine_iso_639_locale();
 
-			$script_dependencies[] = 'help-center-translations';
+			if ( 'en' !== $locale ) {
+				// Load translations directly from widgets.wp.com.
+				wp_enqueue_script(
+					'help-center-translations',
+					'https://widgets.wp.com/help-center/languages/' . Common\determine_iso_639_locale() . '-v1.js',
+					array( 'wp-i18n' ),
+					$version,
+					true
+				);
+
+				$script_dependencies[] = 'help-center-translations';
+			}
 		}
 
 		// If the user is not connected, the Help Center icon will link to the support page.

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -111,7 +111,7 @@ class Help_Center {
 				// Load translations directly from widgets.wp.com.
 				wp_enqueue_script(
 					'help-center-translations',
-					'https://widgets.wp.com/help-center/languages/' . Common\determine_iso_639_locale() . '-v1.js',
+					'https://widgets.wp.com/help-center/languages/' . $locale . '-v1.js',
 					array( 'wp-i18n' ),
 					$version,
 					true


### PR DESCRIPTION
## Proposed changes:

Only load translations if the language is not English.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1723727168367789/1723718483.180279-slack-C02T4NVL4JJ

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Start with a clean sandbox and run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin help-center/fix-language-script`.
2. Sandbox a test sites.
3. Go to any `wp-admin` page and check your console to make sure there is no 404 errors.
4. Make sure Help Center still works.