### PR TITLE
Add WordAds WoA post transfer action

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-woa-transfer-wordads
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-woa-transfer-wordads
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+WOA: add WordAds post transfer action

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -250,31 +250,10 @@ function wpcomsh_woa_post_process_maybe_enable_wordads( $args, $assoc_args ) {
 		return;
 	}
 
-	$allowed_options = array(
-		'wordads_display_front_page',
-		'wordads_display_post',
-		'wordads_display_page',
-		'wordads_display_archive',
-		'enable_header_ad',
-		'wordads_second_belowpost',
-		'wordads_inline_enabled',
-		'wordads_ccpa_enabled',
-		'wordads_ccpa_privacy_policy_url',
-		'wordads_active',
-		'wordads_approved',
-		'wordads_house',
-		'wordads_unsafe',
-		'wordads_custom_adstxt',
-		'wordads_custom_adstxt_enabled',
-		'wordads_cmp_enabled',
-	);
-
 	foreach ( $options_decoded as $option => $value ) {
-		if ( in_array( $option, $allowed_options, true ) ) {
-			// Convert boolean options to string first to work around update_option not setting the option if the value is false.
-			// This sets the option to either '1' if true or '' if false.
-			update_option( $option, is_bool( $value ) ? (string) $value : $value );
-		}
+		// Convert boolean options to string first to work around update_option not setting the option if the value is false.
+		// This sets the option to either '1' if true or '' if false.
+		update_option( $option, is_bool( $value ) ? (string) $value : $value );
 	}
 
 	if ( ! defined( 'JETPACK__VERSION' ) || ! class_exists( 'Jetpack' ) ) {

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -228,7 +228,7 @@ function wpcomsh_woa_post_transfer_install_marketplace_software( $args, $assoc_a
 add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_transfer_install_marketplace_software', 10, 2 );
 
 /**
- * Enables the WordAds Jetpack module if required.
+ * Sets WordAds options and enables the WordAds Jetpack module if required.
  *
  * @param array $args Arguments.
  * @param array $assoc_args Associated arguments.
@@ -237,17 +237,29 @@ add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_transfer_install_mark
  */
 function wpcomsh_woa_post_process_maybe_enable_wordads( $args, $assoc_args ) {
 
-	$wordads_enabled = WP_CLI\Utils\get_flag_value( $assoc_args, 'wordads-enabled', false );
-	if ( ! $wordads_enabled ) {
+	// wordads-options is expected to be a JSON object with option name=>value pairs.
+	$wordads_options = WP_CLI\Utils\get_flag_value( $assoc_args, 'wordads-options', false );
+
+	if ( false === $wordads_options ) {
 		return;
 	}
 
-	WP_CLI::runcommand(
-		'jetpack module activate wordads',
-		array(
-			'launch'     => false,
-			'exit_error' => false,
-		)
-	);
+	$options_decoded = json_decode( $wordads_options );
+
+	if ( ! is_array( $options_decoded ) ) {
+		return;
+	}
+
+	foreach ( $options_decoded as $option => $value ) {
+		update_option( $option, $value );
+	}
+
+	if ( ! defined( 'JETPACK__VERSION' ) || ! class_exists( 'Jetpack' ) ) {
+		return;
+	}
+
+	if ( ! Jetpack::is_module_active( 'wordads' ) ) {
+		Jetpack::activate_module( 'wordads', false, false );
+	}
 }
 add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_process_maybe_enable_wordads', 10, 2 );

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -244,7 +244,7 @@ function wpcomsh_woa_post_process_maybe_enable_wordads( $args, $assoc_args ) {
 		return;
 	}
 
-	$options_decoded = json_decode( $wordads_options );
+	$options_decoded = json_decode( $wordads_options, true );
 
 	if ( ! is_array( $options_decoded ) ) {
 		return;

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -250,8 +250,31 @@ function wpcomsh_woa_post_process_maybe_enable_wordads( $args, $assoc_args ) {
 		return;
 	}
 
+	$allowed_options = array(
+		'wordads_display_front_page',
+		'wordads_display_post',
+		'wordads_display_page',
+		'wordads_display_archive',
+		'enable_header_ad',
+		'wordads_second_belowpost',
+		'wordads_inline_enabled',
+		'wordads_ccpa_enabled',
+		'wordads_ccpa_privacy_policy_url',
+		'wordads_active',
+		'wordads_approved',
+		'wordads_house',
+		'wordads_unsafe',
+		'wordads_custom_adstxt',
+		'wordads_custom_adstxt_enabled',
+		'wordads_cmp_enabled',
+	);
+
 	foreach ( $options_decoded as $option => $value ) {
-		update_option( $option, $value );
+		if ( in_array( $option, $allowed_options, true ) ) {
+			// Convert boolean options to string first to work around update_option not setting the option if the value is false.
+			// This sets the option to either '1' if true or '' if false.
+			update_option( $option, is_bool( $value ) ? (string) $value : $value );
+		}
 	}
 
 	if ( ! defined( 'JETPACK__VERSION' ) || ! class_exists( 'Jetpack' ) ) {

--- a/projects/plugins/wpcomsh/woa.php
+++ b/projects/plugins/wpcomsh/woa.php
@@ -226,3 +226,28 @@ function wpcomsh_woa_post_transfer_install_marketplace_software( $args, $assoc_a
 	}
 }
 add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_transfer_install_marketplace_software', 10, 2 );
+
+/**
+ * Enables the WordAds Jetpack module if required.
+ *
+ * @param array $args Arguments.
+ * @param array $assoc_args Associated arguments.
+ *
+ * @return void
+ */
+function wpcomsh_woa_post_process_maybe_enable_wordads( $args, $assoc_args ) {
+
+	$wordads_enabled = WP_CLI\Utils\get_flag_value( $assoc_args, 'wordads-enabled', false );
+	if ( ! $wordads_enabled ) {
+		return;
+	}
+
+	WP_CLI::runcommand(
+		'jetpack module activate wordads',
+		array(
+			'launch'     => false,
+			'exit_error' => false,
+		)
+	);
+}
+add_action( 'wpcomsh_woa_post_transfer', 'wpcomsh_woa_post_process_maybe_enable_wordads', 10, 2 );


### PR DESCRIPTION
## Proposed changes:
- Adds an action to WoA post-transfer to activate the Jetpack WordAds module if the pre-transfer site was enrolled in WordAds.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Initiate a transfer for a site enrolled in WordAds
- After transfer, verify that the WordAds Jetpack module is activated

## Does this pull request change what data or activity we track or use?

No

