### PR TITLE
Forms: update child blocks to Block API v3

### DIFF
--- a/projects/packages/forms/changelog/update-contact-form-block-api
+++ b/projects/packages/forms/changelog/update-contact-form-block-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: update child blocks to Block API v3

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-forms",
-	"version": "0.32.11",
+	"version": "0.32.12-alpha",
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",
 	"bugs": {

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -1,4 +1,4 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { createBlock, getBlockType } from '@wordpress/blocks';
 import { Path } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
@@ -17,6 +17,7 @@ import { useFormWrapper } from './util/form';
 import renderMaterialIcon from './util/render-material-icon';
 
 const FieldDefaults = {
+	apiVersion: 3,
 	category: 'contact-form',
 	supports: {
 		reusable: false,
@@ -229,6 +230,7 @@ const FieldDefaults = {
 };
 
 const OptionFieldDefaults = {
+	apiVersion: 3,
 	category: 'contact-form',
 	edit: JetpackFieldOptionEdit,
 	attributes: {
@@ -675,7 +677,15 @@ export const childBlocks = [
 				/>
 			),
 			edit: editMultiField( 'checkbox' ),
-			save: () => <InnerBlocks.Content />,
+			save: () => {
+				const blockProps = useBlockProps.save();
+
+				return (
+					<div { ...blockProps }>
+						<InnerBlocks.Content />
+					</div>
+				);
+			},
 			attributes: {
 				...FieldDefaults.attributes,
 				label: {
@@ -713,7 +723,15 @@ export const childBlocks = [
 				</Fragment>
 			),
 			edit: editMultiField( 'radio' ),
-			save: () => <InnerBlocks.Content />,
+			save: () => {
+				const blockProps = useBlockProps.save();
+
+				return (
+					<div { ...blockProps }>
+						<InnerBlocks.Content />
+					</div>
+				);
+			},
 			attributes: {
 				...FieldDefaults.attributes,
 				label: {

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -3,6 +3,7 @@ import {
 	InspectorControls,
 	PanelColorSettings,
 	BlockControls,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
@@ -27,6 +28,11 @@ function JetpackFieldCheckbox( props ) {
 	} = props;
 
 	const { blockStyle } = useJetpackFieldStyles( attributes );
+	const blockProps = useBlockProps( {
+		id: `jetpack-field-checkbox-${ instanceId }`,
+		className: 'jetpack-field jetpack-field-checkbox',
+		style: blockStyle,
+	} );
 
 	return (
 		<>
@@ -37,11 +43,7 @@ function JetpackFieldCheckbox( props ) {
 				/>
 			</BlockControls>
 
-			<div
-				id={ `jetpack-field-checkbox-${ instanceId }` }
-				className="jetpack-field jetpack-field-checkbox"
-				style={ blockStyle }
-			>
+			<div { ...blockProps }>
 				<input
 					className="jetpack-field-checkbox__checkbox"
 					type="checkbox"

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-consent.js
@@ -1,4 +1,4 @@
-import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
+import { InspectorControls, PanelColorSettings, useBlockProps } from '@wordpress/block-editor';
 import { BaseControl, PanelBody, SelectControl, ToggleControl } from '@wordpress/components';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
@@ -16,11 +16,13 @@ const JetpackFieldConsent = ( {
 	setAttributes,
 	attributes,
 } ) => {
+	const blockProps = useBlockProps( {
+		id: `jetpack-field-consent-${ instanceId }`,
+		className: 'jetpack-field jetpack-field-consent',
+	} );
+
 	return (
-		<div
-			id={ `jetpack-field-consent-${ instanceId }` }
-			className="jetpack-field jetpack-field-consent"
-		>
+		<div { ...blockProps }>
 			{ consentType === 'explicit' && (
 				<input className="jetpack-field-consent__checkbox" type="checkbox" disabled />
 			) }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-datepicker.js
@@ -1,3 +1,4 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { SelectControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -40,15 +41,17 @@ const JetpackDatePicker = props => {
 
 	const { blockStyle, fieldStyle } = useJetpackFieldStyles( attributes );
 	const formStyle = useFormStyle( clientId );
-
-	const classes = clsx( 'jetpack-field', {
-		'is-selected': isSelected,
-		'has-placeholder': !! placeholder,
+	const blockProps = useBlockProps( {
+		className: clsx( 'jetpack-field', {
+			'is-selected': isSelected,
+			'has-placeholder': !! placeholder,
+		} ),
+		style: blockStyle,
 	} );
 
 	return (
 		<>
-			<div className={ classes } style={ blockStyle }>
+			<div { ...blockProps }>
 				<JetpackFieldLabel
 					attributes={ attributes }
 					label={ label }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dropdown.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dropdown.js
@@ -1,4 +1,4 @@
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -16,10 +16,12 @@ const JetpackDropdown = ( { attributes, clientId, isSelected, name, setAttribute
 	const { id, label, options, required, requiredText, toggleLabel, width } = attributes;
 	const optionsWrapper = useRef( undefined );
 	const formStyle = useFormStyle( clientId );
-
-	const classes = clsx( 'jetpack-field jetpack-field-dropdown', {
-		'is-selected': isSelected,
-		'has-placeholder': ! isEmpty( toggleLabel ),
+	const blockProps = useBlockProps( {
+		className: clsx( 'jetpack-field jetpack-field-dropdown', {
+			'is-selected': isSelected,
+			'has-placeholder': ! isEmpty( toggleLabel ),
+		} ),
+		style: blockStyle,
 	} );
 
 	useFormWrapper( { attributes, clientId, name } );
@@ -115,7 +117,7 @@ const JetpackDropdown = ( { attributes, clientId, isSelected, name, setAttribute
 	const { blockStyle } = useJetpackFieldStyles( attributes );
 
 	return (
-		<div className={ classes } style={ blockStyle }>
+		<div { ...blockProps }>
 			<div className="jetpack-field-dropdown__wrapper">
 				<JetpackFieldLabel
 					required={ required }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dropdown.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-dropdown.js
@@ -16,6 +16,7 @@ const JetpackDropdown = ( { attributes, clientId, isSelected, name, setAttribute
 	const { id, label, options, required, requiredText, toggleLabel, width } = attributes;
 	const optionsWrapper = useRef( undefined );
 	const formStyle = useFormStyle( clientId );
+	const { blockStyle } = useJetpackFieldStyles( attributes );
 	const blockProps = useBlockProps( {
 		className: clsx( 'jetpack-field jetpack-field-dropdown', {
 			'is-selected': isSelected,
@@ -113,8 +114,6 @@ const JetpackDropdown = ( { attributes, clientId, isSelected, name, setAttribute
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
-
-	const { blockStyle } = useJetpackFieldStyles( attributes );
 
 	return (
 		<div { ...blockProps }>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-multiple.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-multiple.js
@@ -1,4 +1,4 @@
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
@@ -41,14 +41,15 @@ function JetpackFieldMultiple( props ) {
 	} );
 
 	const { blockStyle } = useJetpackFieldStyles( attributes );
+	const blockProps = useBlockProps( {
+		id: `jetpack-field-multiple-${ instanceId }`,
+		className: classes,
+		style: blockStyle,
+	} );
 
 	return (
 		<>
-			<div
-				id={ `jetpack-field-multiple-${ instanceId }` }
-				className={ classes }
-				style={ blockStyle }
-			>
+			<div { ...blockProps }>
 				<JetpackFieldLabel
 					required={ required }
 					requiredText={ requiredText }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-option.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-option.js
@@ -1,17 +1,14 @@
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { first } from 'lodash';
-import { useEffect } from 'react';
 import { supportsParagraphSplitting } from '../util/block-support';
 import { useParentAttributes } from '../util/use-parent-attributes';
 import { useJetpackFieldStyles } from './use-jetpack-field-styles';
 
 export const JetpackFieldOptionEdit = ( {
-	isSelected,
 	attributes,
 	clientId,
 	name,
@@ -30,7 +27,6 @@ export const JetpackFieldOptionEdit = ( {
 		[ clientId ]
 	);
 	const blockProps = useBlockProps();
-	const labelRef = useRef( null );
 
 	const handleSplit = label => {
 		return createBlock( name, {
@@ -48,33 +44,15 @@ export const JetpackFieldOptionEdit = ( {
 		removeBlock( clientId );
 	};
 
-	const onFocus = () => {
-		// TODO: move cursor to end
-	};
-
-	useEffect( () => {
-		const element = labelRef.current;
-
-		element?.addEventListener( 'focus', onFocus );
-
-		if ( isSelected ) {
-			// Timeout is necessary for the focus to be effective
-			setTimeout( () => element?.focus(), 0 );
-		}
-
-		return () => {
-			element?.removeEventListener( 'focus', onFocus );
-		};
-	}, [ isSelected, labelRef ] );
-
 	const supportsSplitting = supportsParagraphSplitting();
 	const type = name.replace( 'jetpack/field-option-', '' );
 	const classes = clsx( 'jetpack-field-option', `field-option-${ type }` );
 
 	return (
-		<div { ...( supportsSplitting ? blockProps : {} ) } className={ classes } style={ optionStyle }>
+		<div className={ classes } style={ optionStyle }>
 			<input type={ type } className="jetpack-option__type" tabIndex="-1" />
 			<RichText
+				{ ...blockProps }
 				identifier="label"
 				tagName="p"
 				className="wp-block"
@@ -82,11 +60,10 @@ export const JetpackFieldOptionEdit = ( {
 				placeholder={ __( 'Add option…', 'jetpack-forms' ) }
 				allowedFormats={ [] }
 				onChange={ val => setAttributes( { label: val } ) }
-				onReplace={ onReplace }
 				onRemove={ handleDelete }
+				onReplace={ onReplace }
 				preserveWhiteSpace={ false }
 				withoutInteractiveFormatting
-				ref={ labelRef }
 				{ ...( supportsSplitting ? {} : { onSplit: handleSplit } ) }
 			/>
 		</div>

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-textarea.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-textarea.js
@@ -1,3 +1,4 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { useEffect } from '@wordpress/element';
 import clsx from 'clsx';
@@ -21,12 +22,15 @@ const JetpackFieldTextarea = props => {
 		placeholder,
 		width,
 	} = props;
+
 	const formStyle = useFormStyle( clientId );
 	const { blockStyle, fieldStyle } = useJetpackFieldStyles( attributes );
-
-	const classes = clsx( 'jetpack-field jetpack-field-textarea', {
-		'is-selected': isSelected,
-		'has-placeholder': ! isEmpty( placeholder ),
+	const blockProps = useBlockProps( {
+		className: clsx( 'jetpack-field jetpack-field-textarea', {
+			'is-selected': isSelected,
+			'has-placeholder': ! isEmpty( placeholder ),
+		} ),
+		style: blockStyle,
 	} );
 
 	useEffect( () => {
@@ -38,7 +42,7 @@ const JetpackFieldTextarea = props => {
 
 	return (
 		<>
-			<div className={ classes } style={ blockStyle }>
+			<div { ...blockProps }>
 				<JetpackFieldLabel
 					clientId={ clientId }
 					required={ required }

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field.js
@@ -1,3 +1,4 @@
+import { useBlockProps } from '@wordpress/block-editor';
 import { createHigherOrderComponent, compose } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
 import clsx from 'clsx';
@@ -24,15 +25,17 @@ const JetpackField = props => {
 
 	const { blockStyle, fieldStyle } = useJetpackFieldStyles( attributes );
 	const formStyle = useFormStyle( clientId );
-
-	const classes = clsx( 'jetpack-field', {
-		'is-selected': isSelected,
-		'has-placeholder': ! isEmpty( placeholder ),
+	const blockProps = useBlockProps( {
+		className: clsx( 'jetpack-field', {
+			'is-selected': isSelected,
+			'has-placeholder': ! isEmpty( placeholder ),
+		} ),
+		style: blockStyle,
 	} );
 
 	return (
 		<>
-			<div className={ classes } style={ blockStyle }>
+			<div { ...blockProps }>
 				<JetpackFieldLabel
 					attributes={ attributes }
 					label={ label }

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -88,7 +88,6 @@ export const JetpackContactFormEdit = forwardRef(
 			variations,
 			defaultVariation,
 			canUserInstallPlugins,
-			style,
 		},
 		ref
 	) => {
@@ -342,7 +341,7 @@ export const JetpackContactFormEdit = forwardRef(
 						) }
 					</InspectorControls>
 
-					<div className={ formClassnames } style={ style } ref={ ref }>
+					<div className={ formClassnames } ref={ ref }>
 						<InnerBlocks
 							allowedBlocks={ ALLOWED_BLOCKS }
 							prioritizedInserterBlocks={ PRIORITIZED_INSERTER_BLOCKS }

--- a/projects/packages/forms/src/blocks/contact-form/edit.js
+++ b/projects/packages/forms/src/blocks/contact-form/edit.js
@@ -88,6 +88,7 @@ export const JetpackContactFormEdit = forwardRef(
 			variations,
 			defaultVariation,
 			canUserInstallPlugins,
+			style,
 		},
 		ref
 	) => {
@@ -341,7 +342,7 @@ export const JetpackContactFormEdit = forwardRef(
 						) }
 					</InspectorControls>
 
-					<div className={ formClassnames } ref={ ref }>
+					<div className={ formClassnames } style={ style } ref={ ref }>
 						<InnerBlocks
 							allowedBlocks={ ALLOWED_BLOCKS }
 							prioritizedInserterBlocks={ PRIORITIZED_INSERTER_BLOCKS }

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -41,14 +41,14 @@
 		}
 	}
 
-	> .block-editor-inner-blocks > .block-editor-block-list__layout {
+	.block-editor-inner-blocks .block-editor-block-list__layout {
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: flex-start;
 		flex-direction: row;
 		gap: var(--wp--style--block-gap, 1.5rem);
 
-		> .wp-block {
+		.wp-block {
 			flex: 0 0 100%;
 			margin: 0;
 
@@ -593,7 +593,7 @@
 	.jetpack-contact-form {
 		padding: 16px;
 
-		> .block-editor-inner-blocks > .block-editor-block-list__layout {
+		.block-editor-inner-blocks .block-editor-block-list__layout {
 			margin: 0;
 		}
 	}

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -43,6 +43,7 @@ const icon = renderMaterialIcon(
 );
 
 export const settings = {
+	apiVersion: 3,
 	title: __( 'Form', 'jetpack-forms' ),
 	description: __(
 		'Create forms to collect data from site visitors and manage their responses.',

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard_View_Switch;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '0.32.11';
+	const PACKAGE_VERSION = '0.32.12-alpha';
 
 	/**
 	 * Load the contact form module.

--- a/projects/plugins/jetpack/changelog/update-contact-form-block-api
+++ b/projects/plugins/jetpack/changelog/update-contact-form-block-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Button Block: update to Block API v3

--- a/projects/plugins/jetpack/extensions/blocks/button/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/edit.js
@@ -3,6 +3,7 @@ import {
 	RichText,
 	__experimentalUseGradient as useGradient, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	withColors,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -36,7 +37,9 @@ export function ButtonEdit( props ) {
 		: {};
 	/* eslint-enable react-hooks/rules-of-hooks */
 
-	const blockClasses = clsx( 'wp-block-button', className );
+	const blockProps = useBlockProps( {
+		className: clsx( 'wp-block-button', className ),
+	} );
 
 	const buttonClasses = clsx( 'wp-block-button__link', {
 		'has-background': backgroundColor.color || gradientValue,
@@ -61,7 +64,7 @@ export function ButtonEdit( props ) {
 	};
 
 	return (
-		<div className={ blockClasses }>
+		<div { ...blockProps }>
 			<RichText
 				allowedFormats={ 'input' === element ? [] : undefined }
 				className={ buttonClasses }

--- a/projects/plugins/jetpack/extensions/blocks/button/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/index.js
@@ -8,6 +8,7 @@ import save from './save';
 export const name = 'button';
 
 export const settings = {
+	apiVersion: 3,
 	title: __( 'Button', 'jetpack' ),
 	icon,
 	category: getCategoryWithFallbacks( 'design', 'layout' ),

--- a/projects/plugins/jetpack/extensions/blocks/button/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/button/save.js
@@ -2,6 +2,7 @@ import {
 	getColorClassName,
 	__experimentalGetGradientClass as getGradientClass, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	RichText,
+	useBlockProps,
 } from '@wordpress/block-editor';
 import clsx from 'clsx';
 import { IS_GRADIENT_AVAILABLE } from './constants';
@@ -27,13 +28,21 @@ export default function ButtonSave( { attributes, blockName, uniqueId } ) {
 		return null;
 	}
 
+	const blockProps = useBlockProps.save();
+
 	const backgroundClass = getColorClassName( 'background-color', backgroundColor );
 	const gradientClass = IS_GRADIENT_AVAILABLE ? getGradientClass( gradient ) : undefined;
 	const textClass = getColorClassName( 'color', textColor );
 
-	const blockClasses = clsx( 'wp-block-button', 'jetpack-submit-button', className, {
-		[ `wp-block-jetpack-${ blockName }` ]: blockName,
-	} );
+	const blockClasses = clsx(
+		'wp-block-button',
+		'jetpack-submit-button',
+		className,
+		blockProps?.className,
+		{
+			[ `wp-block-jetpack-${ blockName }` ]: blockName,
+		}
+	);
 
 	const buttonClasses = clsx( 'wp-block-button__link', {
 		'has-text-color': textColor || customTextColor,
@@ -58,7 +67,7 @@ export default function ButtonSave( { attributes, blockName, uniqueId } ) {
 	};
 
 	return (
-		<div className={ blockClasses }>
+		<div { ...blockProps } className={ blockClasses }>
 			<RichText.Content
 				className={ buttonClasses }
 				data-id-attr={ uniqueId || 'placeholder' }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/410

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the child blocks in the `forms` package to the Block API version 3. This is to prevent warnings in the logs and make the blocks more future-proof.

What the PR does in detail:
- Update the API version of the form and its field components to v3
- Update the API version of the `button` block that lives in the Jetpack plugin to v3
- Update the `edit` (and `save` if needed) functions to make the upgrade effective
- Update `jetpack-field-option.js` to ensure the `splitting` feature still works

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jetpack test site
- Create a new post
- Add a form
- Add all types of fields
<img width="334" alt="Screenshot 2024-08-22 at 2 03 04 PM" src="https://github.com/user-attachments/assets/fd13273f-3474-4229-9e8e-782a8bad9fe0">


- Check they work like they do on `trunk`
- Open the preview
- Check the form works

