### PR TITLE
Add: Incompatible plugin one-click-ssl to the incompatible plugin list

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-incompatible-plugin-one-click-ssl
+++ b/projects/plugins/wpcomsh/changelog/add-incompatible-plugin-one-click-ssl
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Incompatible Plugins: Added one-click-ssl

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -116,6 +116,7 @@ class Jetpack_Plugin_Compatibility {
 		'disable-xml-rpc-unset-x-pingback/index.php'       => '"disable-xml-rpc-unset-x-pingback" has been deactivated, XML-RPC is required for your Jetpack Connection on WordPress.com.',
 		'disable-xml-rpc/disable-xml-rpc.php'              => '"disable-xml-rpc" has been deactivated, XML-RPC is required for your Jetpack Connection on WordPress.com.',
 		'manage-xml-rpc/manage-xml-rpc.php'                => '"manage-xml-rpc" has been deactivated, XML-RPC is required for your Jetpack Connection on WordPress.com.',
+		'one-click-ssl/ssl.php'                            => '"one-click-ssl" has been deactivated, because it is not supported on WordPress.com.',
 		'really-simple-ssl-pro/really-simple-ssl-pro.php'  => '"really-simple-ssl-pro" is not supported on WordPress.com.',
 		'sg-security/sg-security.php'                      => '"sg-security" has been deactivated, "security" related plugins may break your site or cause performance issues for your site and are not supported on WordPress.com.',
 		'simple-xml-rpc-disabler/simple-xml-rpc-disabler.php' => '"simple-xml-rpc-disabler" has been deactivated, XML-RPC is required for your Jetpack Connection on WordPress.com.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds incompatible plugin `one-click-ssl` to the incompatible plugins array in wpcomsh. Once set up, the plugin can cause conflicts with WordPress.com hosted site's provisioned SSL and cause critical errors. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Reported in p1723743499816259-slack-C03TY6J1A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the steps to test this branch (should be a comment posted by the bot below)
* On your WoA dev site, Install `one-click-ssl` by running wp-cli `wp install one-click-ssl --activate`
* Navigate to `/wp-admin/plugins.php` and confirm that the plugin is automatically disabled by wpcomsh.