### PR TITLE
AI Assistant: Add spelling mistake detection to Breve

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3887,6 +3887,9 @@ importers:
       markdown-it-footnote:
         specifier: 3.0.3
         version: 3.0.3
+      nspell:
+        specifier: 2.1.5
+        version: 2.1.5
       photon:
         specifier: 4.0.0
         version: 4.0.0
@@ -10511,6 +10514,10 @@ packages:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
 
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
   is-builtin-module@3.2.1:
     resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
     engines: {node: '>=6'}
@@ -11733,6 +11740,9 @@ packages:
       - validate-npm-package-name
       - which
       - write-file-atomic
+
+  nspell@2.1.5:
+    resolution: {integrity: sha512-PSStyugKMiD9mHmqI/CR5xXrSIGejUXPlo88FBRq5Og1kO5QwQ5Ilu8D8O5I/SHpoS+mibpw6uKA8rd3vXd2Sg==}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -22682,6 +22692,8 @@ snapshots:
       call-bind: 1.0.7
       has-tostringtag: 1.0.2
 
+  is-buffer@2.0.5: {}
+
   is-builtin-module@3.2.1:
     dependencies:
       builtin-modules: 3.3.0
@@ -24292,6 +24304,10 @@ snapshots:
       path-key: 4.0.0
 
   npm@8.19.4: {}
+
+  nspell@2.1.5:
+    dependencies:
+      is-buffer: 2.0.5
 
   nth-check@2.1.1:
     dependencies:

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-typo-local
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-typo-local
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add spelling mistake detection to Breve

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/_features.colors.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/_features.colors.scss
@@ -5,6 +5,7 @@ $features-colors: (
 	'complex-words': rgb( 240, 184, 73 ),
 	'unconfident-words': rgb( 9, 181, 133 ),
 	'long-sentences': rgb( 122, 0, 223 ),
+	'spelling-mistakes': rgb( 214, 54, 56 ),
 );
 
 @mixin properties( $feature, $color, $properties, $opacity: false ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/index.ts
@@ -5,8 +5,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Features
  */
+import { getFeatureAvailability } from '../../../../../blocks/ai-assistant/lib/utils/get-feature-availability';
 import complexWords, { COMPLEX_WORDS, dictionary as dicComplex } from './complex-words';
 import longSentences, { LONG_SENTENCES } from './long-sentences';
+import spellingMistakes, { SPELLING_MISTAKES } from './spelling-mistakes';
 import unconfidentWords, { UNCONFIDENT_WORDS } from './unconfident-words';
 /**
  * Types
@@ -32,5 +34,13 @@ const features: Array< BreveFeature > = [
 		description: __( 'Remove weasel words.', 'jetpack' ),
 	},
 ];
+
+if ( getFeatureAvailability( 'ai-breve-typo-support' ) ) {
+	features.unshift( {
+		config: SPELLING_MISTAKES,
+		highlight: spellingMistakes,
+		description: __( 'Fix spelling mistakes.', 'jetpack' ),
+	} );
+}
 
 export default features;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -61,7 +61,7 @@ export default function longSentences( text: string ): Array< HighlightedText > 
 		return highlightedTexts;
 	}
 
-	words.forEach( ( word, index ) => {
+	words.forEach( ( word: string, index ) => {
 		if ( ! spellchecker.correct( word ) ) {
 			const suggestions = spellchecker.suggest( word );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import nspell from 'nspell';
+/**
+ * Types
+ */
+import type { BreveFeatureConfig, HighlightedText, SpellChecker } from '../../types';
+
+export const SPELLING_MISTAKES: BreveFeatureConfig = {
+	name: 'spelling-mistakes',
+	title: __( 'Spelling mistakes', 'jetpack' ),
+	tagName: 'span',
+	className: 'jetpack-ai-breve__has-proofread-highlight--spelling-mistakes',
+	defaultEnabled: false,
+};
+
+const spellcheckers: { [ key: string ]: SpellChecker } = {};
+const spellingContexts: {
+	[ key: string ]: {
+		affix: string;
+		dictionary: string;
+	};
+} = {};
+
+const loadContext = ( language: string ) => {
+	// TODO: Load dictionaries dynamically and save on localStorage
+	return spellingContexts[ language ];
+};
+
+const getSpellchecker = ( { language = 'en' }: { language?: string } = {} ) => {
+	if ( spellcheckers[ language ] ) {
+		return spellcheckers[ language ];
+	}
+
+	// Cannot await here as the Rich Text function needs to be synchronous.
+	// Load of the dictionary in the background if necessary and re-trigger the highlights later.
+	const spellingContext = loadContext( language );
+
+	if ( ! spellingContext ) {
+		return null;
+	}
+
+	const { affix, dictionary } = spellingContext;
+	spellcheckers[ language ] = nspell( affix, dictionary );
+
+	return spellcheckers[ language ];
+};
+
+export default function longSentences( text: string ): Array< HighlightedText > {
+	const highlightedTexts: Array< HighlightedText > = [];
+	// Regex to match words, including contractions and hyphenated words
+	// \p{L} is a Unicode property that matches any letter in any language
+	// \p{M} is a Unicode property that matches any character intended to be combined with another character
+	const wordRegex = new RegExp( /[\p{L}\p{M}'-]+/, 'gu' );
+	const words = text.match( wordRegex ) || [];
+	const spellchecker = getSpellchecker();
+
+	if ( ! spellchecker ) {
+		return highlightedTexts;
+	}
+
+	words.forEach( ( word, index ) => {
+		if ( ! spellchecker.correct( word ) ) {
+			const suggestions = spellchecker.suggest( word );
+
+			if ( suggestions.length > 0 ) {
+				highlightedTexts.push( {
+					text: word,
+					startIndex: text.indexOf( word, index ),
+					endIndex: text.indexOf( word, index ) + word.length,
+					suggestions,
+				} );
+			}
+		}
+	} );
+
+	return highlightedTexts;
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/highlight/index.tsx
@@ -25,6 +25,7 @@ import { BREVE_FEATURE_NAME } from '../constants';
 import features from '../features';
 import registerEvents from '../features/events';
 import { LONG_SENTENCES } from '../features/long-sentences';
+import { SPELLING_MISTAKES } from '../features/spelling-mistakes';
 import getBreveAvailability from '../utils/get-availability';
 import { getNodeTextIndex } from '../utils/get-node-text-index';
 import { getNonLinkAncestor } from '../utils/get-non-link-ancestor';
@@ -231,7 +232,7 @@ export default function Highlight() {
 								<div className="jetpack-ai-breve__color" data-breve-type={ feature } />
 								<div>{ title }</div>
 							</div>
-							{ ! hasSuggestions && (
+							{ ! hasSuggestions && feature !== SPELLING_MISTAKES.name && (
 								<div className="jetpack-ai-breve__action">
 									{ loading ? (
 										<div className="jetpack-ai-breve__loading">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
@@ -105,6 +105,12 @@ export type BreveFeature = {
 export type HighlightedText = {
 	text: string;
 	suggestion?: string;
+	suggestions?: Array< string >;
 	startIndex: number;
 	endIndex: number;
+};
+
+export type SpellChecker = {
+	correct: ( word: string ) => boolean;
+	suggest: ( word: string ) => Array< string >;
 };

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -97,6 +97,7 @@
 		"mapbox-gl": "1.13.0",
 		"markdown-it": "14.0.0",
 		"markdown-it-footnote": "3.0.3",
+		"nspell": "2.1.5",
 		"photon": "4.0.0",
 		"postcss-custom-properties": "12.1.7",
 		"prop-types": "15.7.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of #38888 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds the `spelling-mistakes` feature with detection
* Does not include the fixes yet
* Does not include the dictionary async loading yet

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test this locally, as manual changes are necessary
* Go to the block editor and check that there are no regressions
* On the `spelling-mistakes/index.ts` file, add those lines:
```
6 - import affixEn from '../../assets/en.aff.js';
7 - import dictionaryEn from '../../assets/en.dic.js';
...
31-	spellingContexts[ language ] = {
32-		affix: affixEn,
33-		dictionary: dictionaryEn,
34	};
```
* Create the dictionary files with `export default `paste dictionary here`;
* Reload the editor
* If beta is enabled, check that you can see the typos, but the `Suggest` button is not included
* If beta is not enabled, check that the typos feature is not included

| Before | After |
| - | - |
| ![2024-08-15_21-20-46-before](https://github.com/user-attachments/assets/e0be0efe-150e-4233-a5d2-eaf871c9ac2e) | ![2024-08-15_21-17-49](https://github.com/user-attachments/assets/c95297db-239c-481f-80ca-548983a149a4) |
