### PR TITLE
Social: Fix modal dynamic toggle

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-modal-dynamic-toggle
+++ b/projects/js-packages/publicize-components/changelog/fix-social-modal-dynamic-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a ui issue with the toggle naming

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -2,7 +2,7 @@ import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { TabPanel } from '@wordpress/components';
 import { ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { store as socialStore } from '../../social-store';
 import ConnectionIcon from '../connection-icon';
@@ -93,7 +93,7 @@ export function PreviewSection() {
 									<ToggleControl
 										label={
 											isEnabled
-												? __( 'Connection enabled', 'jetpack' )
+												? _x( 'Connection enabled', '', 'jetpack' )
 												: __( 'Connection disabled', 'jetpack' )
 										}
 										checked={ isEnabled }

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -88,7 +88,11 @@ export function PreviewSection() {
 							// in that case we won't show the toggle
 							! shouldBeDisabled( tab ) ? (
 								<ToggleControl
-									label={ __( 'Connection enabled', 'jetpack' ) }
+									label={
+										tab.enabled
+											? __( 'Connection enabled', 'jetpack' )
+											: __( 'Connection disabled', 'jetpack' )
+									}
 									checked={ canBeTurnedOn( tab ) && tab.enabled }
 									onChange={ toggleConnection( tab.connection_id, tab ) }
 								/>

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/preview-section.tsx
@@ -79,28 +79,32 @@ export function PreviewSection() {
 	return (
 		<div className={ styles[ 'preview-section' ] }>
 			<TabPanel tabs={ connections }>
-				{ ( tab: ( typeof connections )[ number ] ) => (
-					<div className={ styles[ 'preview-content' ] }>
-						{
-							// If the connection should be disabled
-							// it means that there is some validation error
-							// or the connection is broken
-							// in that case we won't show the toggle
-							! shouldBeDisabled( tab ) ? (
-								<ToggleControl
-									label={
-										tab.enabled
-											? __( 'Connection enabled', 'jetpack' )
-											: __( 'Connection disabled', 'jetpack' )
-									}
-									checked={ canBeTurnedOn( tab ) && tab.enabled }
-									onChange={ toggleConnection( tab.connection_id, tab ) }
-								/>
-							) : null
-						}
-						<PostPreview connection={ tab } />
-					</div>
-				) }
+				{ ( tab: ( typeof connections )[ number ] ) => {
+					const isEnabled = canBeTurnedOn( tab ) && tab.enabled;
+
+					return (
+						<div className={ styles[ 'preview-content' ] }>
+							{
+								// If the connection should be disabled
+								// it means that there is some validation error
+								// or the connection is broken
+								// in that case we won't show the toggle
+								! shouldBeDisabled( tab ) ? (
+									<ToggleControl
+										label={
+											isEnabled
+												? __( 'Connection enabled', 'jetpack' )
+												: __( 'Connection disabled', 'jetpack' )
+										}
+										checked={ isEnabled }
+										onChange={ toggleConnection( tab.connection_id, tab ) }
+									/>
+								) : null
+							}
+							<PostPreview connection={ tab } />
+						</div>
+					);
+				} }
 			</TabPanel>
 		</div>
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/527

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Made the toggle dynamic

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the modal and toggle a connection to check the fix
![CleanShot 2024-08-16 at 10 25 58 png](https://github.com/user-attachments/assets/12f4644e-31b9-48c7-8e8d-518d2a9c9539)


