### PR TITLE
Tiled Galleries: enqueue legacy script in footer and defer loading

### DIFF
--- a/projects/plugins/jetpack/changelog/update-tiled-galleries-enqueue
+++ b/projects/plugins/jetpack/changelog/update-tiled-galleries-enqueue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Tiled Galleries: defer loading of the Tiled Gallery script for improved performance.

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery.php
@@ -182,7 +182,10 @@ class Jetpack_Tiled_Gallery {
 			),
 			array(),
 			JETPACK__VERSION,
-			false
+			array(
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			)
 		);
 		wp_enqueue_style( 'tiled-gallery', plugins_url( 'tiled-gallery/tiled-gallery.css', __FILE__ ), array(), '2023-08-21' );
 		wp_style_add_data( 'tiled-gallery', 'rtl', 'replace' );


### PR DESCRIPTION
## Proposed changes:

This improves loading of the legacy tiled gallery script so it loads as late as possible on the page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related conversation: p55Cj4-3qL-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* On a site that's connected to WordPress.com, go to Jetpack > Settings > Performance
* Enable the site accelerator (this enables the legacy tiled gallery module behind the scenes).
* Go to Posts > Add New
* Add a new Classic block
* Create a gallery inside that classic block
* When picking the gallery type, pick tiled gallery
* Publish your post
* Visit your post on the frontend.
* View source, and ensure that the `tiled-gallery.js` (or `tiled-gallery.min.js`) script is loaded in the footer.
