### PR TITLE
i18n loader script: load script in the footer and defer it.

### DIFF
--- a/projects/packages/assets/changelog/update-i18n-loader-footer
+++ b/projects/packages/assets/changelog/update-i18n-loader-footer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+i18n loader script: load script in the footer and defer it.

--- a/projects/packages/assets/changelog/update-i18n-loader-footer
+++ b/projects/packages/assets/changelog/update-i18n-loader-footer
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-i18n loader script: load script in the footer and defer it.
+i18n loader script & React JSX runtime: load scripts in the footer.

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -510,24 +510,32 @@ class Assets {
 		}
 		$url = self::normalize_path( plugins_url( $path, __FILE__ ) );
 		$url = add_query_arg( 'minify', 'true', $url );
-		$wp_scripts->add( 'wp-jp-i18n-loader', $url, $asset['dependencies'], $asset['version'] );
+
+		$handle = 'wp-jp-i18n-loader';
+
+		$wp_scripts->add( $handle, $url, $asset['dependencies'], $asset['version'] );
+
+		// Ensure the script is loaded in the footer and deferred.
+		$wp_scripts->add_data( $handle, 'group', 1 );
+		$wp_scripts->add_data( $handle, 'strategy', 'defer' );
+
 		if ( ! is_array( $data ) ||
 			! isset( $data['baseUrl'] ) || ! ( is_string( $data['baseUrl'] ) || false === $data['baseUrl'] ) ||
 			! isset( $data['locale'] ) || ! is_string( $data['locale'] ) ||
 			! isset( $data['domainMap'] ) || ! is_array( $data['domainMap'] ) ||
 			! isset( $data['domainPaths'] ) || ! is_array( $data['domainPaths'] )
 		) {
-			$wp_scripts->add_inline_script( 'wp-jp-i18n-loader', 'console.warn( "I18n state deleted by jetpack_i18n_state hook" );' );
+			$wp_scripts->add_inline_script( $handle, 'console.warn( "I18n state deleted by jetpack_i18n_state hook" );' );
 		} elseif ( ! $data['baseUrl'] ) {
-			$wp_scripts->add_inline_script( 'wp-jp-i18n-loader', 'console.warn( "Failed to determine languages base URL. Is WP_LANG_DIR in the WordPress root?" );' );
+			$wp_scripts->add_inline_script( $handle, 'console.warn( "Failed to determine languages base URL. Is WP_LANG_DIR in the WordPress root?" );' );
 		} else {
 			$data['domainMap']   = (object) $data['domainMap']; // Ensure it becomes a json object.
 			$data['domainPaths'] = (object) $data['domainPaths']; // Ensure it becomes a json object.
-			$wp_scripts->add_inline_script( 'wp-jp-i18n-loader', 'wp.jpI18nLoader.state = ' . wp_json_encode( $data, JSON_UNESCAPED_SLASHES ) . ';' );
+			$wp_scripts->add_inline_script( $handle, 'wp.jpI18nLoader.state = ' . wp_json_encode( $data, JSON_UNESCAPED_SLASHES ) . ';' );
 		}
 
 		// Deprecated state module: Depend on wp-i18n to ensure global `wp` exists and because anything needing this will need that too.
-		$wp_scripts->add( 'wp-jp-i18n-state', false, array( 'wp-deprecated', 'wp-jp-i18n-loader' ) );
+		$wp_scripts->add( 'wp-jp-i18n-state', false, array( 'wp-deprecated', $handle ) );
 		$wp_scripts->add_inline_script( 'wp-jp-i18n-state', 'wp.deprecated( "wp-jp-i18n-state", { alternative: "wp-jp-i18n-loader" } );' );
 		$wp_scripts->add_inline_script( 'wp-jp-i18n-state', 'wp.jpI18nState = wp.jpI18nLoader.state;' );
 

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -542,6 +542,7 @@ class Assets {
 		// @todo Remove this when we drop support for WordPress 6.5, as well as the script inclusion in test_wp_default_scripts_hook.
 		$jsx_url = self::normalize_path( plugins_url( '../build/react-jsx-runtime.js', __FILE__ ) );
 		$wp_scripts->add( 'react-jsx-runtime', $jsx_url, array( 'react' ), '18.3.1', true );
+		$wp_scripts->add_data( 'react-jsx-runtime', 'group', 1 );
 	}
 
 	// endregion .

--- a/projects/packages/assets/src/class-assets.php
+++ b/projects/packages/assets/src/class-assets.php
@@ -517,7 +517,6 @@ class Assets {
 
 		// Ensure the script is loaded in the footer and deferred.
 		$wp_scripts->add_data( $handle, 'group', 1 );
-		$wp_scripts->add_data( $handle, 'strategy', 'defer' );
 
 		if ( ! is_array( $data ) ||
 			! isset( $data['baseUrl'] ) || ! ( is_string( $data['baseUrl'] ) || false === $data['baseUrl'] ) ||

--- a/projects/packages/assets/tests/php/test-assets.php
+++ b/projects/packages/assets/tests/php/test-assets.php
@@ -785,6 +785,13 @@ class AssetsTest extends TestCase {
 					array( 'wp-jp-i18n-state', 'wp.jpI18nState = wp.jpI18nLoader.state;' )
 				)
 			);
+		$mock->expects( $this->exactly( 2 ) )->method( 'add_data' )
+			->with(
+				...$with_consecutive(
+					array( 'wp-jp-i18n-loader', 'group', 1 ),
+					array( 'react-jsx-runtime', 'group', 1 )
+				)
+			);
 
 		// @phan-suppress-next-line PhanTypeMismatchArgument -- We don't have a WP_Scripts definition to create a mock from. 🤷
 		Assets::wp_default_scripts_hook( $mock );

--- a/projects/packages/assets/tests/php/test-assets.php
+++ b/projects/packages/assets/tests/php/test-assets.php
@@ -729,7 +729,7 @@ class AssetsTest extends TestCase {
 
 		// @phan-suppress-next-line PhanDeprecatedFunction -- Keep using setMethods until we drop PHP 7.0 support.
 		$mock = $this->getMockBuilder( \stdClass::class )
-			->setMethods( array( 'add', 'add_inline_script' ) )
+			->setMethods( array( 'add', 'add_inline_script', 'add_data' ) )
 			->getMock();
 
 		// Unfortunately PHPUnit deprecated withConsecutive with no replacement, so we have to roll our own version.


### PR DESCRIPTION
## Proposed changes:

Let's load that script in the footer of the page to improve performance.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Related conversation: p55Cj4-3qL-p2

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start by switching your site's language to French in Settings > General.
* Go to Dashboard > Updates and ensure that there are no pending translation updates.
* Go to Jetpack > Dashboard > My Plans
* Purchase a Jetpack Search Plan
* Back on the site, go to Jetpack > Settings > Performance
* Enable Search and Instant Search
* Go to Appearance > Editor
* Add a Search block somewhere on your homepage.
* Load your site's frontend.
* Click on the search field and launch a search.
* The Instant Search modal should pop up.
* The different UI elements in the modal should be in French.
* Now check the site's source code, and search for `wp-jp-i18n-loader`
* The script should be loaded close to the footer of the page.

To test the changes to `react-jsx-runtime`, you'll need to run through the testing instructions in #38428.