### PR TITLE
Newsletter: Plugin: Fixsend test email modal layout

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-send-test-email-modal-layout
+++ b/projects/plugins/jetpack/changelog/fix-send-test-email-modal-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Email preview: ensure the email is visible

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -3,6 +3,7 @@ import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import {
 	Button,
+	__experimentalGrid as Grid, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	Modal,
@@ -82,12 +83,11 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 								'jetpack'
 							) }
 						</p>
-						<HStack wrap={ true }>
+						<Grid alignment="bottom" columns={ 2 } gap={ 2 } templateColumns="2fr auto;">
 							<InputControl
 								value={ window?.Jetpack_Editor_Initial_State?.tracksUserData?.email }
 								disabled
 								__next40pxDefaultSize={ true }
-								size="__unstable-large"
 							/>
 							<Button
 								variant="primary"
@@ -98,7 +98,7 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 								{ __( 'Send', 'jetpack' ) }
 								<Icon icon={ SendIcon } />
 							</Button>
-						</HStack>
+						</Grid>
 					</>
 				) }
 			</VStack>


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/pull/38725

The modal to send the email preview wasn't rendering the input properly.
I used `Grid` instead `HStack`, so we can use grid-template-columns.

## Proposed changes:
### Current

<img width="582" alt="Screenshot 2024-08-16 at 16 56 33" src="https://github.com/user-attachments/assets/bd57f7d8-dec7-4122-838c-0a0703a47d84">


### Updated

<img width="565" alt="Screenshot 2024-08-16 at 16 57 14" src="https://github.com/user-attachments/assets/cd2067e3-066a-41b4-adeb-b7540c544135">


Mobile version:
<img width="498" alt="Screenshot 2024-08-16 at 16 57 34" src="https://github.com/user-attachments/assets/aefa58cc-d808-4e46-a5b4-864c423b37ec">


## Testing instructions:

* In the editor add showNewsletterMenu query arg to see the Newsletter plugin icon.
* Click "Send test email"

