### PR TITLE
Title Optimization: Add feedback link on the footer section

### DIFF
--- a/projects/plugins/jetpack/changelog/update-title-optimization-add-feedback-link
+++ b/projects/plugins/jetpack/changelog/update-title-optimization-add-feedback-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Title Optimization: Include feedback link on the footer.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
@@ -3,7 +3,7 @@
  */
 import { useAiSuggestions } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { Button, Spinner } from '@wordpress/components';
+import { Button, Spinner, ExternalLink } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -238,6 +238,11 @@ export default function TitleOptimization( {
 							</div>
 						</>
 					) }
+					<div className="jetpack-ai-title-optimization__footer">
+						<ExternalLink href="https://jetpack.com/redirect/?source=jetpack-ai-feedback">
+							{ __( 'Provide feedback', 'jetpack' ) }
+						</ExternalLink>
+					</div>
 				</AiAssistantModal>
 			) }
 		</div>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/style.scss
@@ -20,4 +20,16 @@
 		align-items: center;
 		margin-top: 16px;
 	}
+
+	&__footer {
+		display: flex;
+		justify-content: flex-start;
+		margin-right: -32px;
+		margin-left: -32px;
+		margin-top: 32px;
+		margin-bottom: -32px;
+		padding: 20px 32px;
+		border-top: solid 1px #dcdcde;
+		height: 60px;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a footer section to the title optmization modal and include a "Provide feedback" link there

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With beta extensions enabled, go to the block editor and add some content to it
* Look for the "Improve title for SEO" button and click it
* Confirm that:
   * the title optimization modal now has a footer section
   * there is a "Provide feedback" link on it
   * clicking the link will open the Jetpack feedback form on a new tab

<img width="500" alt="Screenshot 2024-08-16 at 17 35 59" src="https://github.com/user-attachments/assets/f074dede-6bc2-45c1-b6a4-35d6d3677748">

---

Notes:

- we are not hiding the footer using the beta flag since it is useful for the current implementation too, so there is no issue on adding it there
- the style is slightly different from the proposed design because it is following the default style for the `ExternalLink` component on the block editor; we already have some links using the same style on the sidebar, so we can keep the consistency and also keep the code simple:

<img width="300" alt="Screenshot 2024-08-16 at 17 35 20" src="https://github.com/user-attachments/assets/f8b916b8-00e1-4cda-a2d6-16107bdae8ea">