### PR TITLE
Remove unnecessary WAF dependency in My Jetpack

### DIFF
--- a/projects/packages/my-jetpack/.phan/baseline.php
+++ b/projects/packages/my-jetpack/.phan/baseline.php
@@ -24,11 +24,12 @@ return [
     // PhanTypeMismatchArgumentProbablyReal : 2 occurrences
     // PhanPluginMixedKeyNoKey : 1 occurrence
     // PhanTypeMismatchArgumentNullableInternal : 1 occurrence
+    // PhanUndeclaredClassMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-activitylog.php' => ['PhanTypeMismatchArgumentProbablyReal'],
-        'src/class-initializer.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable'],
+        'src/class-initializer.php' => ['PhanImpossibleCondition', 'PhanNoopNew', 'PhanRedundantCondition', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnNullable', 'PhanUndeclaredClassMethod'],
         'src/class-jetpack-manage.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         'src/class-products.php' => ['PhanNonClassMethodCall'],
         'src/class-rest-products.php' => ['PhanParamTooMany', 'PhanPluginMixedKeyNoKey', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-protect-card-waf-dependency
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-protect-card-waf-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Removed unnecessary WAF dependency in My Jetpack.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -18,8 +18,7 @@
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-sync": "@dev",
-		"automattic/jetpack-protect-status": "@dev",
-		"automattic/jetpack-waf": "@dev"
+		"automattic/jetpack-protect-status": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "1.1.0",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -64,6 +64,7 @@ class Initializer {
 	const UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY = 'update-historically-active-jetpack-modules';
 	const MISSING_CONNECTION_NOTIFICATION_KEY            = 'missing-connection';
 	const VIDEOPRESS_STATS_KEY                           = 'my-jetpack-videopress-stats';
+	const WAF_AUTOMATIC_RULES_ENABLED_OPTION_NAME        = 'jetpack_waf_automatic_rules';
 
 	/**
 	 * Holds info/data about the site (from the /sites/%d endpoint)
@@ -219,6 +220,11 @@ class Initializer {
 		$scan_data                      = Protect_Status::get_status();
 		self::update_historically_active_jetpack_modules();
 
+		$waf_config = new \stdClass();
+		if ( class_exists( 'Automattic\Jetpack\Waf\Waf_Runner' ) ) {
+			$waf_config = Waf_Runner::get_config();
+		}
+
 		wp_localize_script(
 			'my_jetpack_main_app',
 			'myJetpackInitialState',
@@ -273,7 +279,7 @@ class Initializer {
 				'protect'                => array(
 					'scanData'  => $scan_data,
 					'wafConfig' => array_merge(
-						Waf_Runner::get_config(),
+						$waf_config,
 						array( 'blocked_logins' => (int) get_site_option( 'jetpack_protect_blocked_attempts', 0 ) )
 					),
 				),

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -220,7 +220,7 @@ class Initializer {
 		$scan_data                      = Protect_Status::get_status();
 		self::update_historically_active_jetpack_modules();
 
-		$waf_config = new \stdClass();
+		$waf_config = array();
 		if ( class_exists( 'Automattic\Jetpack\Waf\Waf_Runner' ) ) {
 			$waf_config = Waf_Runner::get_config();
 		}

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -64,7 +64,6 @@ class Initializer {
 	const UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY = 'update-historically-active-jetpack-modules';
 	const MISSING_CONNECTION_NOTIFICATION_KEY            = 'missing-connection';
 	const VIDEOPRESS_STATS_KEY                           = 'my-jetpack-videopress-stats';
-	const WAF_AUTOMATIC_RULES_ENABLED_OPTION_NAME        = 'jetpack_waf_automatic_rules';
 
 	/**
 	 * Holds info/data about the site (from the /sites/%d endpoint)

--- a/projects/plugins/backup/changelog/update-my-jetpack-protect-card-waf-dependency
+++ b/projects/plugins/backup/changelog/update-my-jetpack-protect-card-waf-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lock file

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1160,7 +1160,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2c06449483ed175f949e69ba407e6e92363c3b84"
+                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1177,7 +1177,6 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
-                "automattic/jetpack-waf": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {
@@ -1809,128 +1808,6 @@
             "transport-options": {
                 "relative": true
             }
-        },
-        {
-            "name": "automattic/jetpack-waf",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/waf",
-                "reference": "6e2fd903a4dc024db95b51904989506f65013e0e"
-            },
-            "require": {
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-ip": "@dev",
-                "automattic/jetpack-status": "@dev",
-                "php": ">=7.0",
-                "wikimedia/aho-corasick": "^1.0"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
-                "automattic/wordbless": "@dev",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-waf",
-                "textdomain": "jetpack-waf",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "cli.php"
-                ],
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "phpunit": [
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/integration/phpunit.xml.dist --colors=always",
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/unit/phpunit.xml.dist --colors=always"
-                ],
-                "post-install-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "post-update-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "test-coverage-html": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/integration/phpunit.xml.dist",
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/unit/phpunit.xml.dist"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Tools to assist with the Jetpack Web Application Firewall",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "wikimedia/aho-corasick",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wikimedia/AhoCorasick.git",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/AhoCorasick/zipball/2f3a1bd765913637a66eade658d11d82f0e551be",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "jakub-onderka/php-console-highlighter": "0.3.2",
-                "jakub-onderka/php-parallel-lint": "1.0.0",
-                "mediawiki/mediawiki-codesniffer": "18.0.0",
-                "mediawiki/minus-x": "0.3.1",
-                "phpunit/phpunit": "4.8.36 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Ori Livneh",
-                    "email": "ori@wikimedia.org"
-                }
-            ],
-            "description": "An implementation of the Aho-Corasick string matching algorithm.",
-            "homepage": "https://gerrit.wikimedia.org/g/AhoCorasick",
-            "keywords": [
-                "ahocorasick",
-                "matcher"
-            ],
-            "support": {
-                "source": "https://github.com/wikimedia/AhoCorasick/tree/v1.0.1"
-            },
-            "time": "2018-05-01T18:13:32+00:00"
         }
     ],
     "packages-dev": [

--- a/projects/plugins/boost/changelog/update-my-jetpack-protect-card-waf-dependency
+++ b/projects/plugins/boost/changelog/update-my-jetpack-protect-card-waf-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lock file

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1079,7 +1079,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2c06449483ed175f949e69ba407e6e92363c3b84"
+                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1096,7 +1096,6 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
-                "automattic/jetpack-waf": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {
@@ -1795,77 +1794,6 @@
             }
         },
         {
-            "name": "automattic/jetpack-waf",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/waf",
-                "reference": "6e2fd903a4dc024db95b51904989506f65013e0e"
-            },
-            "require": {
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-ip": "@dev",
-                "automattic/jetpack-status": "@dev",
-                "php": ">=7.0",
-                "wikimedia/aho-corasick": "^1.0"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
-                "automattic/wordbless": "@dev",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-waf",
-                "textdomain": "jetpack-waf",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "cli.php"
-                ],
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "phpunit": [
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/integration/phpunit.xml.dist --colors=always",
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/unit/phpunit.xml.dist --colors=always"
-                ],
-                "post-install-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "post-update-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "test-coverage-html": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/integration/phpunit.xml.dist",
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/unit/phpunit.xml.dist"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Tools to assist with the Jetpack Web Application Firewall",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/jetpack-wp-js-data-sync",
             "version": "dev-trunk",
             "dist": {
@@ -2112,57 +2040,6 @@
                 "source": "https://github.com/tubalmartin/YUI-CSS-compressor-PHP-port"
             },
             "time": "2018-01-15T15:26:51+00:00"
-        },
-        {
-            "name": "wikimedia/aho-corasick",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wikimedia/AhoCorasick.git",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/AhoCorasick/zipball/2f3a1bd765913637a66eade658d11d82f0e551be",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "jakub-onderka/php-console-highlighter": "0.3.2",
-                "jakub-onderka/php-parallel-lint": "1.0.0",
-                "mediawiki/mediawiki-codesniffer": "18.0.0",
-                "mediawiki/minus-x": "0.3.1",
-                "phpunit/phpunit": "4.8.36 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Ori Livneh",
-                    "email": "ori@wikimedia.org"
-                }
-            ],
-            "description": "An implementation of the Aho-Corasick string matching algorithm.",
-            "homepage": "https://gerrit.wikimedia.org/g/AhoCorasick",
-            "keywords": [
-                "ahocorasick",
-                "matcher"
-            ],
-            "support": {
-                "source": "https://github.com/wikimedia/AhoCorasick/tree/v1.0.1"
-            },
-            "time": "2018-05-01T18:13:32+00:00"
         }
     ],
     "packages-dev": [

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-protect-card-waf-dependency
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-protect-card-waf-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update lock file

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1744,7 +1744,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "2c06449483ed175f949e69ba407e6e92363c3b84"
+				"reference": "661b9575e9a137bbfa69319abe670453181a1449"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1761,7 +1761,6 @@
 				"automattic/jetpack-redirect": "@dev",
 				"automattic/jetpack-status": "@dev",
 				"automattic/jetpack-sync": "@dev",
-				"automattic/jetpack-waf": "@dev",
 				"php": ">=7.0"
 			},
 			"require-dev": {

--- a/projects/plugins/migration/changelog/update-my-jetpack-protect-card-waf-dependency
+++ b/projects/plugins/migration/changelog/update-my-jetpack-protect-card-waf-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lock file

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1160,7 +1160,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2c06449483ed175f949e69ba407e6e92363c3b84"
+                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1177,7 +1177,6 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
-                "automattic/jetpack-waf": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {
@@ -1809,128 +1808,6 @@
             "transport-options": {
                 "relative": true
             }
-        },
-        {
-            "name": "automattic/jetpack-waf",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/waf",
-                "reference": "6e2fd903a4dc024db95b51904989506f65013e0e"
-            },
-            "require": {
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-ip": "@dev",
-                "automattic/jetpack-status": "@dev",
-                "php": ">=7.0",
-                "wikimedia/aho-corasick": "^1.0"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
-                "automattic/wordbless": "@dev",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-waf",
-                "textdomain": "jetpack-waf",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "cli.php"
-                ],
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "phpunit": [
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/integration/phpunit.xml.dist --colors=always",
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/unit/phpunit.xml.dist --colors=always"
-                ],
-                "post-install-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "post-update-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "test-coverage-html": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/integration/phpunit.xml.dist",
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/unit/phpunit.xml.dist"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Tools to assist with the Jetpack Web Application Firewall",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "wikimedia/aho-corasick",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wikimedia/AhoCorasick.git",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/AhoCorasick/zipball/2f3a1bd765913637a66eade658d11d82f0e551be",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "jakub-onderka/php-console-highlighter": "0.3.2",
-                "jakub-onderka/php-parallel-lint": "1.0.0",
-                "mediawiki/mediawiki-codesniffer": "18.0.0",
-                "mediawiki/minus-x": "0.3.1",
-                "phpunit/phpunit": "4.8.36 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Ori Livneh",
-                    "email": "ori@wikimedia.org"
-                }
-            ],
-            "description": "An implementation of the Aho-Corasick string matching algorithm.",
-            "homepage": "https://gerrit.wikimedia.org/g/AhoCorasick",
-            "keywords": [
-                "ahocorasick",
-                "matcher"
-            ],
-            "support": {
-                "source": "https://github.com/wikimedia/AhoCorasick/tree/v1.0.1"
-            },
-            "time": "2018-05-01T18:13:32+00:00"
         }
     ],
     "packages-dev": [

--- a/projects/plugins/protect/changelog/update-my-jetpack-protect-card-waf-dependency
+++ b/projects/plugins/protect/changelog/update-my-jetpack-protect-card-waf-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lock file

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1073,7 +1073,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2c06449483ed175f949e69ba407e6e92363c3b84"
+                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1090,7 +1090,6 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
-                "automattic/jetpack-waf": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {

--- a/projects/plugins/search/changelog/update-my-jetpack-protect-card-waf-dependency
+++ b/projects/plugins/search/changelog/update-my-jetpack-protect-card-waf-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lock file

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2c06449483ed175f949e69ba407e6e92363c3b84"
+                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1033,7 +1033,6 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
-                "automattic/jetpack-waf": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {
@@ -1814,128 +1813,6 @@
             "transport-options": {
                 "relative": true
             }
-        },
-        {
-            "name": "automattic/jetpack-waf",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/waf",
-                "reference": "6e2fd903a4dc024db95b51904989506f65013e0e"
-            },
-            "require": {
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-ip": "@dev",
-                "automattic/jetpack-status": "@dev",
-                "php": ">=7.0",
-                "wikimedia/aho-corasick": "^1.0"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
-                "automattic/wordbless": "@dev",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-waf",
-                "textdomain": "jetpack-waf",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "cli.php"
-                ],
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "phpunit": [
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/integration/phpunit.xml.dist --colors=always",
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/unit/phpunit.xml.dist --colors=always"
-                ],
-                "post-install-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "post-update-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "test-coverage-html": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/integration/phpunit.xml.dist",
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/unit/phpunit.xml.dist"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Tools to assist with the Jetpack Web Application Firewall",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "wikimedia/aho-corasick",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wikimedia/AhoCorasick.git",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/AhoCorasick/zipball/2f3a1bd765913637a66eade658d11d82f0e551be",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "jakub-onderka/php-console-highlighter": "0.3.2",
-                "jakub-onderka/php-parallel-lint": "1.0.0",
-                "mediawiki/mediawiki-codesniffer": "18.0.0",
-                "mediawiki/minus-x": "0.3.1",
-                "phpunit/phpunit": "4.8.36 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Ori Livneh",
-                    "email": "ori@wikimedia.org"
-                }
-            ],
-            "description": "An implementation of the Aho-Corasick string matching algorithm.",
-            "homepage": "https://gerrit.wikimedia.org/g/AhoCorasick",
-            "keywords": [
-                "ahocorasick",
-                "matcher"
-            ],
-            "support": {
-                "source": "https://github.com/wikimedia/AhoCorasick/tree/v1.0.1"
-            },
-            "time": "2018-05-01T18:13:32+00:00"
         }
     ],
     "packages-dev": [

--- a/projects/plugins/social/changelog/update-my-jetpack-protect-card-waf-dependency
+++ b/projects/plugins/social/changelog/update-my-jetpack-protect-card-waf-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lock file

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1016,7 +1016,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "2c06449483ed175f949e69ba407e6e92363c3b84"
+				"reference": "661b9575e9a137bbfa69319abe670453181a1449"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1033,7 +1033,6 @@
 				"automattic/jetpack-redirect": "@dev",
 				"automattic/jetpack-status": "@dev",
 				"automattic/jetpack-sync": "@dev",
-				"automattic/jetpack-waf": "@dev",
 				"php": ">=7.0"
 			},
 			"require-dev": {
@@ -1805,128 +1804,6 @@
 			"transport-options": {
 				"relative": true
 			}
-		},
-		{
-			"name": "automattic/jetpack-waf",
-			"version": "dev-trunk",
-			"dist": {
-				"type": "path",
-				"url": "../../packages/waf",
-				"reference": "6e2fd903a4dc024db95b51904989506f65013e0e"
-			},
-			"require": {
-				"automattic/jetpack-connection": "@dev",
-				"automattic/jetpack-constants": "@dev",
-				"automattic/jetpack-ip": "@dev",
-				"automattic/jetpack-status": "@dev",
-				"php": ">=7.0",
-				"wikimedia/aho-corasick": "^1.0"
-			},
-			"require-dev": {
-				"automattic/jetpack-changelogger": "@dev",
-				"automattic/wordbless": "@dev",
-				"yoast/phpunit-polyfills": "1.1.0"
-			},
-			"suggest": {
-				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-			},
-			"type": "jetpack-library",
-			"extra": {
-				"autotagger": true,
-				"mirror-repo": "Automattic/jetpack-waf",
-				"textdomain": "jetpack-waf",
-				"changelogger": {
-					"link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
-				},
-				"branch-alias": {
-					"dev-trunk": "0.18.x-dev"
-				}
-			},
-			"autoload": {
-				"files": [
-					"cli.php"
-				],
-				"classmap": [
-					"src/"
-				]
-			},
-			"scripts": {
-				"phpunit": [
-					"./vendor/phpunit/phpunit/phpunit --configuration tests/php/integration/phpunit.xml.dist --colors=always",
-					"./vendor/phpunit/phpunit/phpunit --configuration tests/php/unit/phpunit.xml.dist --colors=always"
-				],
-				"post-install-cmd": [
-					"WorDBless\\Composer\\InstallDropin::copy"
-				],
-				"post-update-cmd": [
-					"WorDBless\\Composer\\InstallDropin::copy"
-				],
-				"test-coverage-html": [
-					"php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/integration/phpunit.xml.dist",
-					"php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/unit/phpunit.xml.dist"
-				],
-				"test-php": [
-					"@composer phpunit"
-				]
-			},
-			"license": [
-				"GPL-2.0-or-later"
-			],
-			"description": "Tools to assist with the Jetpack Web Application Firewall",
-			"transport-options": {
-				"relative": true
-			}
-		},
-		{
-			"name": "wikimedia/aho-corasick",
-			"version": "v1.0.1",
-			"source": {
-				"type": "git",
-				"url": "https://github.com/wikimedia/AhoCorasick.git",
-				"reference": "2f3a1bd765913637a66eade658d11d82f0e551be"
-			},
-			"dist": {
-				"type": "zip",
-				"url": "https://api.github.com/repos/wikimedia/AhoCorasick/zipball/2f3a1bd765913637a66eade658d11d82f0e551be",
-				"reference": "2f3a1bd765913637a66eade658d11d82f0e551be",
-				"shasum": ""
-			},
-			"require": {
-				"php": ">=5.5.9"
-			},
-			"require-dev": {
-				"jakub-onderka/php-console-highlighter": "0.3.2",
-				"jakub-onderka/php-parallel-lint": "1.0.0",
-				"mediawiki/mediawiki-codesniffer": "18.0.0",
-				"mediawiki/minus-x": "0.3.1",
-				"phpunit/phpunit": "4.8.36 || ^6.5"
-			},
-			"type": "library",
-			"autoload": {
-				"classmap": [
-					"src/"
-				]
-			},
-			"notification-url": "https://packagist.org/downloads/",
-			"license": [
-				"Apache-2.0"
-			],
-			"authors": [
-				{
-					"name": "Ori Livneh",
-					"email": "ori@wikimedia.org"
-				}
-			],
-			"description": "An implementation of the Aho-Corasick string matching algorithm.",
-			"homepage": "https://gerrit.wikimedia.org/g/AhoCorasick",
-			"keywords": [
-				"ahocorasick",
-				"matcher"
-			],
-			"support": {
-				"source": "https://github.com/wikimedia/AhoCorasick/tree/v1.0.1"
-			},
-			"time": "2018-05-01T18:13:32+00:00"
 		}
 	],
 	"packages-dev": [

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-protect-card-waf-dependency
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-protect-card-waf-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lock file

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2c06449483ed175f949e69ba407e6e92363c3b84"
+                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1033,7 +1033,6 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
-                "automattic/jetpack-waf": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {
@@ -1665,128 +1664,6 @@
             "transport-options": {
                 "relative": true
             }
-        },
-        {
-            "name": "automattic/jetpack-waf",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/waf",
-                "reference": "6e2fd903a4dc024db95b51904989506f65013e0e"
-            },
-            "require": {
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-ip": "@dev",
-                "automattic/jetpack-status": "@dev",
-                "php": ">=7.0",
-                "wikimedia/aho-corasick": "^1.0"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
-                "automattic/wordbless": "@dev",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-waf",
-                "textdomain": "jetpack-waf",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "cli.php"
-                ],
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "phpunit": [
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/integration/phpunit.xml.dist --colors=always",
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/unit/phpunit.xml.dist --colors=always"
-                ],
-                "post-install-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "post-update-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "test-coverage-html": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/integration/phpunit.xml.dist",
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/unit/phpunit.xml.dist"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Tools to assist with the Jetpack Web Application Firewall",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "wikimedia/aho-corasick",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wikimedia/AhoCorasick.git",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/AhoCorasick/zipball/2f3a1bd765913637a66eade658d11d82f0e551be",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "jakub-onderka/php-console-highlighter": "0.3.2",
-                "jakub-onderka/php-parallel-lint": "1.0.0",
-                "mediawiki/mediawiki-codesniffer": "18.0.0",
-                "mediawiki/minus-x": "0.3.1",
-                "phpunit/phpunit": "4.8.36 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Ori Livneh",
-                    "email": "ori@wikimedia.org"
-                }
-            ],
-            "description": "An implementation of the Aho-Corasick string matching algorithm.",
-            "homepage": "https://gerrit.wikimedia.org/g/AhoCorasick",
-            "keywords": [
-                "ahocorasick",
-                "matcher"
-            ],
-            "support": {
-                "source": "https://github.com/wikimedia/AhoCorasick/tree/v1.0.1"
-            },
-            "time": "2018-05-01T18:13:32+00:00"
         }
     ],
     "packages-dev": [

--- a/projects/plugins/videopress/changelog/update-my-jetpack-protect-card-waf-dependency
+++ b/projects/plugins/videopress/changelog/update-my-jetpack-protect-card-waf-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lock file

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "2c06449483ed175f949e69ba407e6e92363c3b84"
+                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1033,7 +1033,6 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
-                "automattic/jetpack-waf": "@dev",
                 "php": ">=7.0"
             },
             "require-dev": {
@@ -1745,128 +1744,6 @@
             "transport-options": {
                 "relative": true
             }
-        },
-        {
-            "name": "automattic/jetpack-waf",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/waf",
-                "reference": "6e2fd903a4dc024db95b51904989506f65013e0e"
-            },
-            "require": {
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-ip": "@dev",
-                "automattic/jetpack-status": "@dev",
-                "php": ">=7.0",
-                "wikimedia/aho-corasick": "^1.0"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
-                "automattic/wordbless": "@dev",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-waf",
-                "textdomain": "jetpack-waf",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-waf/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.18.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "cli.php"
-                ],
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "phpunit": [
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/integration/phpunit.xml.dist --colors=always",
-                    "./vendor/phpunit/phpunit/phpunit --configuration tests/php/unit/phpunit.xml.dist --colors=always"
-                ],
-                "post-install-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "post-update-cmd": [
-                    "WorDBless\\Composer\\InstallDropin::copy"
-                ],
-                "test-coverage-html": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/integration/phpunit.xml.dist",
-                    "php -dpcov.directory=. ./vendor/bin/phpunit --coverage-html ./coverage --configuration tests/php/unit/phpunit.xml.dist"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Tools to assist with the Jetpack Web Application Firewall",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "wikimedia/aho-corasick",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wikimedia/AhoCorasick.git",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/AhoCorasick/zipball/2f3a1bd765913637a66eade658d11d82f0e551be",
-                "reference": "2f3a1bd765913637a66eade658d11d82f0e551be",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9"
-            },
-            "require-dev": {
-                "jakub-onderka/php-console-highlighter": "0.3.2",
-                "jakub-onderka/php-parallel-lint": "1.0.0",
-                "mediawiki/mediawiki-codesniffer": "18.0.0",
-                "mediawiki/minus-x": "0.3.1",
-                "phpunit/phpunit": "4.8.36 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Ori Livneh",
-                    "email": "ori@wikimedia.org"
-                }
-            ],
-            "description": "An implementation of the Aho-Corasick string matching algorithm.",
-            "homepage": "https://gerrit.wikimedia.org/g/AhoCorasick",
-            "keywords": [
-                "ahocorasick",
-                "matcher"
-            ],
-            "support": {
-                "source": "https://github.com/wikimedia/AhoCorasick/tree/v1.0.1"
-            },
-            "time": "2018-05-01T18:13:32+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This PR removes the unnecessary WAF package dependency in My Jetpack that was initially added in https://github.com/Automattic/jetpack/pull/38332.  Prior to this PR, the WAF package and all it's dependencies were being loaded into My Jetpack (for use in the Protect product card), and hence getting shipped to all our standalone plugins, which is not optimal.

See also Slack discussion: p1723736483790589-slack-C02LK1W8T4Z

Fixes: https://github.com/Automattic/jetpack-marketing/issues/932

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removed the WAF package from the My Jetpack package composer.json file.
* Conditionally call WAF_Runner::get_config() only if the WAF_Runner class exists (via the Protect plugin or Jetpack plugin).
    * If the WAF_Runner class does not exist, we can safely assume the Auto-firewall feature is off/disabled for the purposes of the Protect product card.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

The WAF package was initially added in PR https://github.com/Automattic/jetpack/pull/38332 as part of the PT: Add value to the Protect product card in My Jetpack: pbNhbs-aP6-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a Jurassic Ninja site, checkout this branch using the Jetpack Beta Tester plugin on the Boost stand-alone plugin (Don't include Jetpack, we want only a stand-alone plugin (that is not Jetpack Protect) to be active).
* Go to the My Jetpack page.
* Open the browser developer console.
* View the value of `window.myJetpackInitialState`. (in the console, type `window.myJetpackInitialState` and press enter).
* Verify that the protect-->wafConfig object (in myJetpackInitialState) only shows a `blocked_logins:` property and does not include other properties (it does not include the WAF config data); See screenshot:
<img width="1760" alt="Screen Shot 2024-08-17 at 10 09 39" src="https://github.com/user-attachments/assets/32bcf6fb-78e9-4959-8feb-727d06793f09">
* Now open the Beta tester plugin and checkout this branch on the Jetpack plugin.
* Open the My Jetpack page again and open the developer console.
* Again view the value of `window.myJetpackInitialState`.
* Verify that the protect-->wafConfig object now shows many other WAF related properties and values; See screenshot:
<img width="1756" alt="Screen Shot 2024-08-17 at 10 14 11" src="https://github.com/user-attachments/assets/d56b97bb-484d-4c04-9b37-ca44c6d12673">
    * (This is expected because the Jetpack plugin does include the WAF package in it's dependencies (which is fine)).
* Now remove Jetpack (Open Plugins page, deactivate/remove Jetpack), and checkout this branch on the Protect plugin (using the Beta Tester plugin).
* Open the My Jetpack page again and open the developer console.
* Again view the value of `window.myJetpackInitialState`.
* Verify that the protect-->wafConfig object still shows all the WAF related properties and values; See screenshot:
<img width="1756" alt="Screen Shot 2024-08-17 at 10 14 11" src="https://github.com/user-attachments/assets/d56b97bb-484d-4c04-9b37-ca44c6d12673">
* Connect Jetpack. (Site connection is enough, but you can user connect too, if you want)
* Open the Protect page. Click the "Firewall" tab to open the firewall settings.
* Click the "Upgrade to enable automatic firewall protection" link.
* Using credits, go ahead and purchase the Jetpack Scan Daily product. Once purchased, you should be redirected back to the Protect firewall page.
* Toggle On the Automatic Firewall Protection.
* Open the My Jetpack page.
* View the Protect product card, the Auto-firewall column should be showing "On". See Screenshot:
<img width="748" alt="Screen Shot 2024-08-17 at 10 53 52" src="https://github.com/user-attachments/assets/76261220-199a-48c3-bf48-42f0d4e93cf8">
* Open the developer console and view the value of `window.myJetpackInitialState`.
* Verify that the protect-->wafConfig object still shows all the WAF related properties and values and that `automatic_rules_available` is `true` and `jetpack_waf_automatic_rules` is `true`.  : See screenshot:
<img width="1156" alt="Screen Shot 2024-08-17 at 10 59 21" src="https://github.com/user-attachments/assets/79a2c97d-59fc-4f00-b3ad-5cb3dc752f01">
