### PR TITLE
WAF: Avoid using Waf_Rules_Manager from Waf_Runner::initialize()

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-no-waf-rules-manager-call-in-standalone-mode
+++ b/projects/packages/waf/changelog/fix-waf-no-waf-rules-manager-call-in-standalone-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WAF: reduce amount of classes autoloaded during standalone mode execution

--- a/projects/packages/waf/src/class-waf-cli.php
+++ b/projects/packages/waf/src/class-waf-cli.php
@@ -159,7 +159,7 @@ class CLI extends WP_CLI_Command {
 			sprintf(
 				/* translators: %1$s is the name of the mode that was just switched to. */
 				__( 'Jetpack WAF rules successfully created to: "%1$s".', 'jetpack-waf' ),
-				Waf_Runner::get_waf_file_path( Waf_Rules_Manager::RULES_ENTRYPOINT_FILE )
+				Waf_Runner::get_waf_file_path( Waf_Runner::ENTRYPOINT_FILE )
 			)
 		);
 	}

--- a/projects/packages/waf/src/class-waf-cli.php
+++ b/projects/packages/waf/src/class-waf-cli.php
@@ -142,6 +142,7 @@ class CLI extends WP_CLI_Command {
 	 */
 	public function generate_rules() {
 		try {
+			Waf_Constants::define_entrypoint();
 			Waf_Rules_Manager::generate_automatic_rules();
 			Waf_Rules_Manager::generate_rules();
 		} catch ( \Exception $e ) {
@@ -159,7 +160,7 @@ class CLI extends WP_CLI_Command {
 			sprintf(
 				/* translators: %1$s is the name of the mode that was just switched to. */
 				__( 'Jetpack WAF rules successfully created to: "%1$s".', 'jetpack-waf' ),
-				Waf_Runner::get_waf_file_path( Waf_Runner::ENTRYPOINT_FILE )
+				Waf_Runner::get_waf_file_path( JETPACK_WAF_ENTRYPOINT )
 			)
 		);
 	}

--- a/projects/packages/waf/src/class-waf-constants.php
+++ b/projects/packages/waf/src/class-waf-constants.php
@@ -22,6 +22,7 @@ class Waf_Constants {
 		self::define_waf_directory();
 		self::define_wpconfig_path();
 		self::define_killswitch();
+		self::define_entrypoint();
 	}
 
 	/**
@@ -77,6 +78,15 @@ class Waf_Constants {
 		if ( ! defined( 'JETPACK_WAF_MODE' ) ) {
 			$mode_option = get_option( Waf_Runner::MODE_OPTION_NAME );
 			define( 'JETPACK_WAF_MODE', $mode_option );
+		}
+	}
+
+	/**
+	 * Set the entrypoint definition if it has not been set.
+	 */
+	public static function define_entrypoint() {
+		if ( ! defined( 'JETPACK_WAF_ENTRYPOINT' ) ) {
+			define( 'JETPACK_WAF_ENTRYPOINT', 'rules/rules.php' );
 		}
 	}
 

--- a/projects/packages/waf/src/class-waf-rules-manager.php
+++ b/projects/packages/waf/src/class-waf-rules-manager.php
@@ -39,10 +39,9 @@ class Waf_Rules_Manager {
 	const IP_LISTS_ENABLED_OPTION_NAME = 'jetpack_waf_ip_list';
 
 	// Rule Files
-	const RULES_ENTRYPOINT_FILE = '/rules/rules.php';
-	const AUTOMATIC_RULES_FILE  = '/rules/automatic-rules.php';
-	const IP_ALLOW_RULES_FILE   = '/rules/allow-ip.php';
-	const IP_BLOCK_RULES_FILE   = '/rules/block-ip.php';
+	const AUTOMATIC_RULES_FILE = '/rules/automatic-rules.php';
+	const IP_ALLOW_RULES_FILE  = '/rules/allow-ip.php';
+	const IP_BLOCK_RULES_FILE  = '/rules/block-ip.php';
 
 	/**
 	 * Whether automatic rules are enabled.
@@ -223,7 +222,7 @@ class Waf_Rules_Manager {
 		Waf_Runner::initialize_filesystem();
 
 		$rules                = "<?php\n";
-		$entrypoint_file_path = Waf_Runner::get_waf_file_path( self::RULES_ENTRYPOINT_FILE );
+		$entrypoint_file_path = Waf_Runner::get_waf_file_path( Waf_Runner::ENTRYPOINT_FILE );
 
 		// Ensure that the folder exists
 		if ( ! $wp_filesystem->is_dir( dirname( $entrypoint_file_path ) ) ) {
@@ -231,7 +230,7 @@ class Waf_Rules_Manager {
 		}
 
 		// Ensure all potentially required rule files exist
-		$rule_files = array( self::RULES_ENTRYPOINT_FILE, self::AUTOMATIC_RULES_FILE, self::IP_ALLOW_RULES_FILE, self::IP_BLOCK_RULES_FILE );
+		$rule_files = array( Waf_Runner::ENTRYPOINT_FILE, self::AUTOMATIC_RULES_FILE, self::IP_ALLOW_RULES_FILE, self::IP_BLOCK_RULES_FILE );
 		foreach ( $rule_files as $rule_file ) {
 			$rule_file = Waf_Runner::get_waf_file_path( $rule_file );
 			if ( ! $wp_filesystem->is_file( $rule_file ) ) {

--- a/projects/packages/waf/src/class-waf-rules-manager.php
+++ b/projects/packages/waf/src/class-waf-rules-manager.php
@@ -220,9 +220,10 @@ class Waf_Rules_Manager {
 	public static function generate_rules() {
 		global $wp_filesystem;
 		Waf_Runner::initialize_filesystem();
+		Waf_Constants::define_entrypoint();
 
 		$rules                = "<?php\n";
-		$entrypoint_file_path = Waf_Runner::get_waf_file_path( Waf_Runner::ENTRYPOINT_FILE );
+		$entrypoint_file_path = Waf_Runner::get_waf_file_path( JETPACK_WAF_ENTRYPOINT );
 
 		// Ensure that the folder exists
 		if ( ! $wp_filesystem->is_dir( dirname( $entrypoint_file_path ) ) ) {
@@ -230,7 +231,7 @@ class Waf_Rules_Manager {
 		}
 
 		// Ensure all potentially required rule files exist
-		$rule_files = array( Waf_Runner::ENTRYPOINT_FILE, self::AUTOMATIC_RULES_FILE, self::IP_ALLOW_RULES_FILE, self::IP_BLOCK_RULES_FILE );
+		$rule_files = array( JETPACK_WAF_ENTRYPOINT, self::AUTOMATIC_RULES_FILE, self::IP_ALLOW_RULES_FILE, self::IP_BLOCK_RULES_FILE );
 		foreach ( $rule_files as $rule_file ) {
 			$rule_file = Waf_Runner::get_waf_file_path( $rule_file );
 			if ( ! $wp_filesystem->is_file( $rule_file ) ) {

--- a/projects/packages/waf/src/class-waf-rules-manager.php
+++ b/projects/packages/waf/src/class-waf-rules-manager.php
@@ -44,6 +44,13 @@ class Waf_Rules_Manager {
 	const IP_BLOCK_RULES_FILE  = '/rules/block-ip.php';
 
 	/**
+	 * Rules Entrypoint File
+	 *
+	 * @deprecated $$next-version$$ Use JETPACK_WAF_ENTRYPOINT instead.
+	 */
+	const RULES_ENTRYPOINT_FILE = '/rules/rules.php';
+
+	/**
 	 * Whether automatic rules are enabled.
 	 *
 	 * @return bool

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -257,7 +257,7 @@ class Waf_Runner {
 			$waf = new Waf_Runtime( new Waf_Transforms(), new Waf_Operators() );
 
 			// execute waf rules.
-			$rules_file_path = self::get_waf_file_path( self::RULES_ENTRYPOINT_FILE );
+			$rules_file_path = self::get_waf_file_path( self::ENTRYPOINT_FILE );
 			if ( file_exists( $rules_file_path ) ) {
 				// phpcs:ignore
 				include $rules_file_path;

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -20,6 +20,7 @@ class Waf_Runner {
 	const MODE_OPTION_NAME             = 'jetpack_waf_mode';
 	const SHARE_DATA_OPTION_NAME       = 'jetpack_waf_share_data';
 	const SHARE_DEBUG_DATA_OPTION_NAME = 'jetpack_waf_share_debug_data';
+	const ENTRYPOINT_FILE              = '/rules/rules.php';
 
 	/**
 	 * Run the WAF
@@ -256,7 +257,7 @@ class Waf_Runner {
 			$waf = new Waf_Runtime( new Waf_Transforms(), new Waf_Operators() );
 
 			// execute waf rules.
-			$rules_file_path = self::get_waf_file_path( Waf_Rules_Manager::RULES_ENTRYPOINT_FILE );
+			$rules_file_path = self::get_waf_file_path( self::RULES_ENTRYPOINT_FILE );
 			if ( file_exists( $rules_file_path ) ) {
 				// phpcs:ignore
 				include $rules_file_path;
@@ -368,12 +369,12 @@ class Waf_Runner {
 		self::initialize_filesystem();
 
 		// If the rules file doesn't exist, there's nothing else to do.
-		if ( ! $wp_filesystem->exists( self::get_waf_file_path( Waf_Rules_Manager::RULES_ENTRYPOINT_FILE ) ) ) {
+		if ( ! $wp_filesystem->exists( self::get_waf_file_path( self::ENTRYPOINT_FILE ) ) ) {
 			return;
 		}
 
 		// Empty the rules entrypoint file.
-		if ( ! $wp_filesystem->put_contents( self::get_waf_file_path( Waf_Rules_Manager::RULES_ENTRYPOINT_FILE ), "<?php\n" ) ) {
+		if ( ! $wp_filesystem->put_contents( self::get_waf_file_path( self::ENTRYPOINT_FILE ), "<?php\n" ) ) {
 			throw new File_System_Exception( 'Failed to empty rules.php file.' );
 		}
 	}

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -319,6 +319,11 @@ class Waf_Runner {
 			add_option( Waf_Rules_Manager::VERSION_OPTION_NAME, Waf_Rules_Manager::RULES_VERSION );
 		}
 
+		$mode = get_option( self::MODE_OPTION_NAME );
+		if ( ! $mode ) {
+			add_option( self::MODE_OPTION_NAME, 'normal' );
+		}
+
 		add_option( self::SHARE_DATA_OPTION_NAME, true );
 
 		self::initialize_filesystem();

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -319,11 +319,6 @@ class Waf_Runner {
 			add_option( Waf_Rules_Manager::VERSION_OPTION_NAME, Waf_Rules_Manager::RULES_VERSION );
 		}
 
-		$mode = get_option( self::MODE_OPTION_NAME );
-		if ( ! $mode ) {
-			add_option( self::MODE_OPTION_NAME, 'normal' );
-		}
-
 		add_option( self::SHARE_DATA_OPTION_NAME, true );
 
 		self::initialize_filesystem();

--- a/projects/packages/waf/src/class-waf-runner.php
+++ b/projects/packages/waf/src/class-waf-runner.php
@@ -20,7 +20,6 @@ class Waf_Runner {
 	const MODE_OPTION_NAME             = 'jetpack_waf_mode';
 	const SHARE_DATA_OPTION_NAME       = 'jetpack_waf_share_data';
 	const SHARE_DEBUG_DATA_OPTION_NAME = 'jetpack_waf_share_debug_data';
-	const ENTRYPOINT_FILE              = '/rules/rules.php';
 
 	/**
 	 * Run the WAF
@@ -32,6 +31,7 @@ class Waf_Runner {
 			return;
 		}
 		Waf_Constants::define_mode();
+		Waf_Constants::define_entrypoint();
 		Waf_Constants::define_share_data();
 
 		if ( ! self::is_allowed_mode( JETPACK_WAF_MODE ) ) {
@@ -257,7 +257,7 @@ class Waf_Runner {
 			$waf = new Waf_Runtime( new Waf_Transforms(), new Waf_Operators() );
 
 			// execute waf rules.
-			$rules_file_path = self::get_waf_file_path( self::ENTRYPOINT_FILE );
+			$rules_file_path = self::get_waf_file_path( JETPACK_WAF_ENTRYPOINT );
 			if ( file_exists( $rules_file_path ) ) {
 				// phpcs:ignore
 				include $rules_file_path;
@@ -367,14 +367,15 @@ class Waf_Runner {
 
 		global $wp_filesystem;
 		self::initialize_filesystem();
+		Waf_Constants::define_entrypoint();
 
 		// If the rules file doesn't exist, there's nothing else to do.
-		if ( ! $wp_filesystem->exists( self::get_waf_file_path( self::ENTRYPOINT_FILE ) ) ) {
+		if ( ! $wp_filesystem->exists( self::get_waf_file_path( JETPACK_WAF_ENTRYPOINT ) ) ) {
 			return;
 		}
 
 		// Empty the rules entrypoint file.
-		if ( ! $wp_filesystem->put_contents( self::get_waf_file_path( self::ENTRYPOINT_FILE ), "<?php\n" ) ) {
+		if ( ! $wp_filesystem->put_contents( self::get_waf_file_path( JETPACK_WAF_ENTRYPOINT ), "<?php\n" ) ) {
 			throw new File_System_Exception( 'Failed to empty rules.php file.' );
 		}
 	}

--- a/projects/packages/waf/src/class-waf-standalone-bootstrap.php
+++ b/projects/packages/waf/src/class-waf-standalone-bootstrap.php
@@ -154,6 +154,7 @@ class Waf_Standalone_Bootstrap {
 			. sprintf( "define( 'JETPACK_WAF_SHARE_DEBUG_DATA', %s );\n", var_export( $share_debug_data_option, true ) )
 			. sprintf( "define( 'JETPACK_WAF_DIR', %s );\n", var_export( JETPACK_WAF_DIR, true ) )
 			. sprintf( "define( 'JETPACK_WAF_WPCONFIG', %s );\n", var_export( JETPACK_WAF_WPCONFIG, true ) )
+			. sprintf( "define( 'JETPACK_WAF_ENTRYPOINT', %s );\n", var_export( JETPACK_WAF_ENTRYPOINT, true ) )
 			. 'require_once ' . var_export( $autoloader_file, true ) . ";\n"
 			. "Automattic\Jetpack\Waf\Waf_Runner::initialize();\n";
 		// phpcs:enable

--- a/projects/packages/waf/tests/php/integration/test-waf-activation.php
+++ b/projects/packages/waf/tests/php/integration/test-waf-activation.php
@@ -90,7 +90,7 @@ final class WafActivationTest extends WorDBless\BaseTestCase {
 		$this->assertSame( false, get_option( Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME ) );
 
 		// Ensure the rule files were generated.
-		$this->assertFileExists( Waf_Runner::get_waf_file_path( Waf_Rules_Manager::RULES_ENTRYPOINT_FILE ) );
+		$this->assertFileExists( Waf_Runner::get_waf_file_path( Waf_Runner::ENTRYPOINT_FILE ) );
 		$this->assertFileExists( Waf_Runner::get_waf_file_path( Waf_Rules_Manager::AUTOMATIC_RULES_FILE ) );
 		$this->assertFileExists( Waf_Runner::get_waf_file_path( Waf_Rules_Manager::IP_ALLOW_RULES_FILE ) );
 		$this->assertFileExists( Waf_Runner::get_waf_file_path( Waf_Rules_Manager::IP_BLOCK_RULES_FILE ) );
@@ -116,7 +116,7 @@ final class WafActivationTest extends WorDBless\BaseTestCase {
 		$this->assertSame( false, get_option( Waf_Runner::MODE_OPTION_NAME ) );
 
 		// Ensure the rules entrypoint file was emptied.
-		$this->assertSame( "<?php\n", file_get_contents( Waf_Runner::get_waf_file_path( Waf_Rules_Manager::RULES_ENTRYPOINT_FILE ) ) );
+		$this->assertSame( "<?php\n", file_get_contents( Waf_Runner::get_waf_file_path( Waf_Runner::ENTRYPOINT_FILE ) ) );
 	}
 
 	/**

--- a/projects/packages/waf/tests/php/integration/test-waf-activation.php
+++ b/projects/packages/waf/tests/php/integration/test-waf-activation.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Waf\Waf_Constants;
 use Automattic\Jetpack\Waf\Waf_Initializer;
 use Automattic\Jetpack\Waf\Waf_Rules_Manager;
 use Automattic\Jetpack\Waf\Waf_Runner;
@@ -75,6 +76,9 @@ final class WafActivationTest extends WorDBless\BaseTestCase {
 	 * Test WAF activation.
 	 */
 	public function testActivation() {
+		// Ensure the JETPACK_WAF_ENTRYPOINT is defined.
+		Waf_Constants::define_entrypoint();
+
 		// Mock the WPCOM request for retrieving the automatic rules.
 		add_filter( 'pre_http_request', array( $this, 'return_sample_response' ) );
 
@@ -90,7 +94,7 @@ final class WafActivationTest extends WorDBless\BaseTestCase {
 		$this->assertSame( false, get_option( Waf_Rules_Manager::AUTOMATIC_RULES_ENABLED_OPTION_NAME ) );
 
 		// Ensure the rule files were generated.
-		$this->assertFileExists( Waf_Runner::get_waf_file_path( Waf_Runner::ENTRYPOINT_FILE ) );
+		$this->assertFileExists( Waf_Runner::get_waf_file_path( JETPACK_WAF_ENTRYPOINT ) );
 		$this->assertFileExists( Waf_Runner::get_waf_file_path( Waf_Rules_Manager::AUTOMATIC_RULES_FILE ) );
 		$this->assertFileExists( Waf_Runner::get_waf_file_path( Waf_Rules_Manager::IP_ALLOW_RULES_FILE ) );
 		$this->assertFileExists( Waf_Runner::get_waf_file_path( Waf_Rules_Manager::IP_BLOCK_RULES_FILE ) );
@@ -106,6 +110,9 @@ final class WafActivationTest extends WorDBless\BaseTestCase {
 	 * Test WAF deactivation.
 	 */
 	public function testDeactivation() {
+		// Ensure the JETPACK_WAF_ENTRYPOINT is defined.
+		Waf_Constants::define_entrypoint();
+
 		$deactivated = Waf_Initializer::on_waf_deactivation();
 
 		// Ensure the WAF was deactivated successfully.
@@ -116,7 +123,7 @@ final class WafActivationTest extends WorDBless\BaseTestCase {
 		$this->assertSame( false, get_option( Waf_Runner::MODE_OPTION_NAME ) );
 
 		// Ensure the rules entrypoint file was emptied.
-		$this->assertSame( "<?php\n", file_get_contents( Waf_Runner::get_waf_file_path( Waf_Runner::ENTRYPOINT_FILE ) ) );
+		$this->assertSame( "<?php\n", file_get_contents( Waf_Runner::get_waf_file_path( JETPACK_WAF_ENTRYPOINT ) ) );
 	}
 
 	/**

--- a/projects/plugins/debug-helper/changelog/fix-waf-no-waf-rules-manager-call-in-standalone-mode
+++ b/projects/plugins/debug-helper/changelog/fix-waf-no-waf-rules-manager-call-in-standalone-mode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated constant for compatibility with latest waf package version.
+
+

--- a/projects/plugins/debug-helper/modules/class-waf-helper.php
+++ b/projects/plugins/debug-helper/modules/class-waf-helper.php
@@ -223,7 +223,7 @@ class Waf_Helper {
 		<hr>
 
 		<h2>Rules Entrypoint</h2>
-		<?php $this->render_waf_file( Waf_Runner::ENTRYPOINT_FILE ); ?>
+		<?php $this->render_waf_file( defined( 'JETPACK_WAF_ENTRYPOINT' ) && JETPACK_WAF_ENTRYPOINT ); ?>
 
 		<hr>
 

--- a/projects/plugins/debug-helper/modules/class-waf-helper.php
+++ b/projects/plugins/debug-helper/modules/class-waf-helper.php
@@ -5,6 +5,7 @@
  * @package automattic/jetpack-debug-helper
  */
 
+use Automattic\Jetpack\Waf\Waf_Constants;
 use Automattic\Jetpack\Waf\Waf_Rules_Manager;
 use Automattic\Jetpack\Waf\Waf_Runner;
 
@@ -223,7 +224,8 @@ class Waf_Helper {
 		<hr>
 
 		<h2>Rules Entrypoint</h2>
-		<?php $this->render_waf_file( defined( 'JETPACK_WAF_ENTRYPOINT' ) && JETPACK_WAF_ENTRYPOINT ); ?>
+		<?php Waf_Constants::define_entrypoint(); ?>
+		<?php defined( 'JETPACK_WAF_ENTRYPOINT' ) ? $this->render_waf_file( (string) JETPACK_WAF_ENTRYPOINT ) : 'Not set'; ?>
 
 		<hr>
 

--- a/projects/plugins/debug-helper/modules/class-waf-helper.php
+++ b/projects/plugins/debug-helper/modules/class-waf-helper.php
@@ -223,7 +223,7 @@ class Waf_Helper {
 		<hr>
 
 		<h2>Rules Entrypoint</h2>
-		<?php $this->render_waf_file( Waf_Rules_Manager::RULES_ENTRYPOINT_FILE ); ?>
+		<?php $this->render_waf_file( Waf_Runner::ENTRYPOINT_FILE ); ?>
 
 		<hr>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Related to https://github.com/Automattic/jpop-issues/issues/9175

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Migrates `Waf_Rules_Manager::RULES_ENTRYPOINT_FILE` to a new `JETPACK_WAF_ENTRYPOINT` constant, to avoid autoloading the `Waf_Rules_Manager` class during standalone mode firewall execution.
* Deprecates the `Waf_Rules_Manager::RULES_ENTRYPOINT_FILE` constant.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

peb6dq-2HL-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up automatic firewall rules.
* Verify the firewall blocks a request in both the default and standalone mode.
* Test updating various firewall settings.