### PR TITLE
Site Level User Profile: expose all relevant fields on profile.php

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/atomic-default-profile
+++ b/projects/packages/jetpack-mu-wpcom/changelog/atomic-default-profile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Site Level User Profile: expose all relevant fields on profile.php

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
@@ -8,16 +8,16 @@
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
 /**
- * Check if the site is a WordPress.com Simple site.
+ * Check if the site is a WordPress.com Atomic site.
  *
  * @return bool
  */
-function is_wpcom_simple() {
+function is_woa_site() {
 	if ( ! class_exists( 'Automattic\Jetpack\Status\Host' ) ) {
 		return false;
 	}
 	$host = new Automattic\Jetpack\Status\Host();
-	return $host->is_wpcom_simple();
+	return $host->is_woa_site();
 }
 
 /**
@@ -33,7 +33,7 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 		true
 	);
 
-	$is_wpcom_simple = is_wpcom_simple();
+	$is_wpcom_atomic_classic = is_woa_site() && get_option( 'wpcom_admin_interface' ) === 'wp-admin';
 
 	// Temporarily point to wpcalypso.wordpress.com for testing purposes.
 	$wpcom_host = 'https://wordpress.com';
@@ -45,19 +45,19 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 		'wpcom-profile-settings-link-to-wpcom',
 		'wpcomProfileSettingsLinkToWpcom',
 		array(
-			'synced'        => array(
+			'synced'               => array(
 				'link' => esc_url( $wpcom_host . '/me' ),
 				'text' => __( 'You can manage your profile on WordPress.com Profile settings (First / Last / Display Names, Website, and Biographical Info)', 'jetpack-mu-wpcom' ),
 			),
-			'email'         => array(
+			'email'                => array(
 				'link' => esc_url( $wpcom_host . '/me/account' ),
 				'text' => __( 'Your WordPress.com email is managed on WordPress.com Account settings', 'jetpack-mu-wpcom' ),
 			),
-			'password'      => array(
+			'password'             => array(
 				'link' => esc_url( $wpcom_host . '/me/security' ),
 				'text' => __( 'Your WordPress.com password is managed on WordPress.com Security settings', 'jetpack-mu-wpcom' ),
 			),
-			'isWpcomSimple' => $is_wpcom_simple,
+			'isWpcomAtomicClassic' => $is_wpcom_atomic_classic,
 		)
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -1,8 +1,8 @@
 /**
- * Disable the email field on Simple sites.
+ * Disable the email field except on Atomic Classic sites.
  */
 const wpcom_profile_settings_disable_email_field = () => {
-	if ( ! window.wpcomProfileSettingsLinkToWpcom?.isWpcomSimple ) {
+	if ( window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomicClassic ) {
 		return;
 	}
 	const emailField = document.getElementById( 'email' ) as HTMLInputElement;
@@ -25,8 +25,8 @@ const wpcom_profile_settings_add_links_to_wpcom = () => {
 
 	userSessionSection?.remove();
 
-	// Simple sites cannot set a password in wp-admin.
-	if ( window.wpcomProfileSettingsLinkToWpcom?.isWpcomSimple && newPasswordSection ) {
+	// We cannot set a password in wp-admin except on Atomic Classic sites.
+	if ( ! window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomicClassic && newPasswordSection ) {
 		newPasswordSection.innerHTML = '';
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/types.d.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/types.d.ts
@@ -9,7 +9,7 @@ declare global {
 				link: string;
 				text: string;
 			};
-			isWpcomSimple: boolean;
+			isWpcomAtomicClassic: boolean;
 		};
 	}
 }

--- a/projects/packages/masterbar/changelog/atomic-default-profile
+++ b/projects/packages/masterbar/changelog/atomic-default-profile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Site Level User Profile: expose all relevant fields on profile.php

--- a/projects/packages/masterbar/composer.json
+++ b/projects/packages/masterbar/composer.json
@@ -63,7 +63,7 @@
 	"extra": {
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.6.x-dev"
+			"dev-trunk": "0.7.x-dev"
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.6.1-alpha",
+	"version": "0.7.0-alpha",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -137,10 +137,11 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			// // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null );
 
-			// When the interface is not set to wp-admin, we replace the Profile submenu.
-			remove_submenu_page( 'users.php', 'profile.php' );
-			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-			add_submenu_page( 'users.php', esc_attr__( 'My Profile', 'jetpack-masterbar' ), __( 'My Profile', 'jetpack-masterbar' ), 'read', 'https://wordpress.com/me/', null );
+			if ( empty( get_option( 'wpcom_site_level_user_profile' ) ) ) {
+				remove_submenu_page( 'users.php', 'profile.php' );
+				// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+				add_submenu_page( 'users.php', esc_attr__( 'My Profile', 'jetpack-masterbar' ), __( 'My Profile', 'jetpack-masterbar' ), 'read', 'https://wordpress.com/me/', null );
+			}
 		}
 
 		// Users who can't 'list_users' will see "Profile" menu & "Profile > Account Settings" as submenu.

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.6.1-alpha';
+	const PACKAGE_VERSION = '0.7.0-alpha';
 
 	/**
 	 * Initializer.

--- a/projects/packages/masterbar/src/profile-edit/bootstrap.php
+++ b/projects/packages/masterbar/src/profile-edit/bootstrap.php
@@ -9,7 +9,6 @@ namespace Automattic\Jetpack\Masterbar;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
-require_once __DIR__ . '/profile-edit.php';
 require_once __DIR__ . '/class-wpcom-user-profile-fields-revert.php';
 
 /**

--- a/projects/plugins/jetpack/changelog/atomic-default-profile
+++ b/projects/plugins/jetpack/changelog/atomic-default-profile
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1665,7 +1665,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/masterbar",
-				"reference": "9f21b1d7607b21df7becfcdb49002d310d891440"
+				"reference": "39a207e6ee97aa176b4198439f5b7e8bc911ef87"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1693,7 +1693,7 @@
 			"extra": {
 				"autotagger": true,
 				"branch-alias": {
-					"dev-trunk": "0.6.x-dev"
+					"dev-trunk": "0.7.x-dev"
 				},
 				"changelogger": {
 					"link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/plugins/mu-wpcom-plugin/changelog/atomic-default-profile
+++ b/projects/plugins/mu-wpcom-plugin/changelog/atomic-default-profile
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -926,7 +926,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "9f21b1d7607b21df7becfcdb49002d310d891440"
+                "reference": "39a207e6ee97aa176b4198439f5b7e8bc911ef87"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -954,7 +954,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.6.x-dev"
+                    "dev-trunk": "0.7.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/plugins/wpcomsh/changelog/atomic-default-profile
+++ b/projects/plugins/wpcomsh/changelog/atomic-default-profile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Site Level User Profile: expose all relevant fields on profile.php

--- a/projects/plugins/wpcomsh/changelog/atomic-default-profile#2
+++ b/projects/plugins/wpcomsh/changelog/atomic-default-profile#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -128,7 +128,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_4_1_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_5_0_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1063,7 +1063,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "9f21b1d7607b21df7becfcdb49002d310d891440"
+                "reference": "39a207e6ee97aa176b4198439f5b7e8bc911ef87"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1091,7 +1091,7 @@
             "extra": {
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.6.x-dev"
+                    "dev-trunk": "0.7.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-masterbar/compare/v${old}...v${new}"

--- a/projects/plugins/wpcomsh/feature-plugins/masterbar.php
+++ b/projects/plugins/wpcomsh/feature-plugins/masterbar.php
@@ -108,7 +108,7 @@ function wpcomsh_admin_color_scheme_picker_disabled() {
  **/
 function wpcomsh_hide_color_schemes() {
 	// Do nothing if the admin interface is wp-admin.
-	if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) {
+	if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' || ! empty( get_option( 'wpcom_site_level_user_profile' ) ) ) {
 		return false;
 	}
 
@@ -333,7 +333,7 @@ add_filter( 'pre_option_wpcom_admin_interface', 'wpcomsh_get_wpcom_admin_interfa
  *    from wp-admin going forward.
  */
 function wpcomsh_unsync_color_schemes_on_save() {
-	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
+	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' && empty( get_option( 'wpcom_site_level_user_profile' ) ) ) {
 		return;
 	}
 

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.4.1-alpha",
+	"version": "5.5.0-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.4.1-alpha
+ * Version: 5.5.0-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.4.1-alpha' );
+define( 'WPCOMSH_VERSION', '5.5.0-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:

- https://github.com/Automattic/dotcom-forge/issues/8511

## Proposed changes:

This PR exposes all allowed fields on `profile.php` on Atomic Default sites, under the site option `wpcom_site_level_user_profile`.

Previously on Atomic Default sites, we don't expose `profile.php` at all because we replace the link with `Users` -> `My Profile`, pointing to `/me`. Now, we expose that Core page again, and:

- Enable the color scheme field again.
- Remove various duplicated notices around profile fields that are manageable on `/me`. 

|Before|After|
|-|-|
|<img width="1118" alt="image" src="https://github.com/user-attachments/assets/d82353a2-1043-4813-a068-96023ef61468">|<img width="898" alt="image" src="https://github.com/user-attachments/assets/7f8cac0c-ab86-4ac5-ab0c-61b7e0a7f92f">|

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare a WoA dev blog (so that we can patch wpcomsh)
2. Set the admin interface style to Default.
3. Install the Jetpack Beta Tester plugin.
4. Don't forget to add `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` to your site's `wp-config.php`.
5. Set the WordPress.com Features branch to Bleeding Edge (so that we can see the [new profile notices](https://github.com/Automattic/jetpack/pull/38854))
6. Go to `/profile.php`.
7. Verify that you see the page as per the screenshot (`Before` column).
8. Now, apply this branch to Jetpack Beta Tester to both:
    - WordPress.com Features
    - WordPress.com Site Helper
9. Go to `/profile.php` again.
10. Verify that you still see no changes.
11. Go to `/_cli`, then run `wp option update wpcom_site_level_user_profile 1`
12. Go to `/profile.php` again.
7. Verify that you see the page as per the screenshot (`After` column).
8. Verify that you can actually modify things there (including the admin color scheme).
    - Note that Calypso pages still won't respect admin color changes. It is being handled in https://github.com/Automattic/wp-calypso/pull/93369.