### PR TITLE
MU WPCOM: Replace the link of the additional CSS

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-additional-css-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/mu-wpcom-additional-css-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+MU WPCOM: Replace the link of the additional CSS

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-documentation-links/wpcom-documentation-links.ts
@@ -52,6 +52,9 @@ function overrideCoreDocumentationLinksToWpcom( translation: string, text: strin
 		'https://wordpress.org/documentation/article/styles-overview/':
 			'https://wordpress.com/support/using-styles/',
 
+		'https://developer.wordpress.org/advanced-administration/wordpress/css/':
+			'https://wordpress.com/support/editing-css/',
+
 		/**
 		 * Embed Block
 		 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/83942

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace the link of the additional CSS with the dotcom one

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Wait for https://github.com/WordPress/gutenberg/pull/64603
* Go to Appearance → Editor
* Click on Styles
* Click the three dots
* Select Additional CSS
* Click 'Learn more about CSS'
* Make sure it points to `https://wordpress.com/support/editing-css/`

