### PR TITLE
Social: Fix connection services list crash on simple sites

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-connection-services-list-crash-on-simple-sites
+++ b/projects/packages/publicize/changelog/fix-social-connection-services-list-crash-on-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed connection services list crash on simple sites

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -76,6 +76,7 @@ class Publicize_Script_Data {
 		$basic_data = array(
 			'is_publicize_enabled' => Utils::is_publicize_active(),
 			'feature_flags'        => self::get_feature_flags(),
+			'supported_services'   => array(),
 		);
 
 		if ( ! Utils::is_publicize_active() || ! Utils::is_connected() ) {


### PR DESCRIPTION
#38924 caused a slight regression...

![image](https://github.com/user-attachments/assets/3ef63a16-c94a-4879-9327-b25fa96979da)


This PR fixes the crash on Simple site post editor when Social connection test results finish

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fallback to an empty array of supported services for simple sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Simple site post editor
* Open Jetpack sidebar
* Wait for connection test results to finish
* Confirm that the editor doesn't crash

