### PR TITLE
My Jetpack: avoid PHP warning when is_silent is not set

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-notice-my-jetpack-bubble
+++ b/projects/packages/my-jetpack/changelog/fix-notice-my-jetpack-bubble
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Notification bubbles: avoid PHP warning when information is missing.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -768,7 +768,7 @@ class Initializer {
 			self::get_red_bubble_alerts(),
 			function ( $alert ) {
 				// We don't want to show silent alerts
-				return isset( $alert['is_silent'] ) && ! $alert['is_silent'];
+				return empty( $alert['is_silent'] );
 			}
 		);
 

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -768,7 +768,7 @@ class Initializer {
 			self::get_red_bubble_alerts(),
 			function ( $alert ) {
 				// We don't want to show silent alerts
-				return ! $alert['is_silent'];
+				return isset( $alert['is_silent'] ) && ! $alert['is_silent'];
 			}
 		);
 


### PR DESCRIPTION
Follow-up to #38534

## Proposed changes:

This should avoid warnings like this one:

```
PHP Warning:  Undefined array key "is_silent" in /srv/htdocs/wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-my-jetpack/src/class-initializer.php on line 759
```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Install the Jetpack plugin.
* Go to My Jetpack
* Connect your site (not your WordPress.com account) to WordPress.com.
* Check the error logs
    * You should not see any error.
