### PR TITLE
A4A Dev Sites: Add `is_a4a_dev_site` attribute to sites API response.

### DIFF
--- a/projects/plugins/jetpack/changelog/site-is-a4a-dev-site
+++ b/projects/plugins/jetpack/changelog/site-is-a4a-dev-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add a4a_is_dev_site attribute to Sites API response.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -85,6 +85,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'wpcom_site_setup'            => '(string) The WP.com site setup identifier.',
 		'is_deleted'                  => '(bool) If the site flagged as deleted.',
 		'is_a4a_client'               => '(bool) If the site is an A4A client site.',
+		'is_a4a_dev_site'             => '(bool) If the site is an A4A dev site.',
 	);
 
 	/**
@@ -120,6 +121,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_wpcom_staging_site',
 		'is_deleted',
 		'is_a4a_client',
+		'is_a4a_dev_site',
 	);
 
 	/**
@@ -611,6 +613,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'is_a4a_client':
 				$response[ $key ] = $this->site->is_a4a_client();
+				break;
+			case 'is_a4a_dev_site':
+				$response[ $key ] = $this->site->is_a4a_dev_site();
 				break;
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -79,6 +79,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'was_hosting_trial'           => '(bool) If the site ever used a hosting trial.',
 		'is_deleted'                  => '(bool) If the site flagged as deleted.',
 		'is_a4a_client'               => '(bool) If the site is an A4A client site.',
+		'is_a4a_dev_site'             => '(bool) If the site is an A4A dev site.',
 	);
 
 	/**

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -424,6 +424,18 @@ abstract class SAL_Site {
 	abstract public function is_a4a_client();
 
 	/**
+	 * Indicates that a site is an A4A dev site.
+	 *
+	 * @return bool
+	 */
+	public function is_a4a_dev_site() {
+		if ( function_exists( 'has_blog_sticker' ) ) {
+			return has_blog_sticker( 'a4a-is-dev-site' );
+		}
+		return false;
+	}
+
+	/**
 	 * Return the user interactions with a site. Not used in Jetpack.
 	 *
 	 * @param string $role The capability to check.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related #https://github.com/Automattic/dotcom-forge/issues/8668

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `is_a4a_dev_site` attribute to sites API response.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `bin/jetpack-downloader test jetpack add/site-is-a4a-dev-site` on your sandbox.
* Go to https://developer.wordpress.com/docs/api/console/
* `WP.COM API` / `v1.2` / `GET` / `me/sites`
* You should see the new `is_a4a_dev_site` attribute.

Note: The `is-a4a-dev-site` blog sticker was only recently introduced so all your old dev sites will not have this blog sticker set to `true`. If you like, you can check it against a newly provisioned dev site. See D158724-code.

<img width="913" alt="image" src="https://github.com/user-attachments/assets/9d52404d-f1d3-4d68-a12e-95a261be5dde">