### PR TITLE
Social Icons Widget: fix path to icons' SVG file.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-social-icons-wrong-path
+++ b/projects/plugins/jetpack/changelog/fix-social-icons-wrong-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social Icons Widget: ensure the social network icons are displayed properly.

--- a/projects/plugins/jetpack/modules/widgets/social-icons.php
+++ b/projects/plugins/jetpack/modules/widgets/social-icons.php
@@ -116,10 +116,10 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 	public function include_svg_icons() {
 		// Define SVG sprite file in Jetpack.
 		$svg_icons = dirname( __DIR__ ) . '/theme-tools/social-menu/social-menu.svg';
-		$svg_icons = class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Main' ) ? JETPACK__PLUGIN_DIR . 'jetpack-vendor/automattic/jetpack-classic-theme-helper/src/social-menu/social-menu.svg' : dirname( __DIR__ ) . '/theme-tools/social-menu/social-menu.svg';
+		$svg_icons = class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Main' ) ? JETPACK__PLUGIN_DIR . 'jetpack_vendor/automattic/jetpack-classic-theme-helper/src/social-menu/social-menu.svg' : dirname( __DIR__ ) . '/theme-tools/social-menu/social-menu.svg';
 		// Define SVG sprite file in WPCOM.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$svg_icons = class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Main' ) ? JETPACK__PLUGIN_DIR . 'jetpack-vendor/automattic/jetpack-classic-theme-helper/src/social-menu/social-menu.svg' : dirname( __DIR__ ) . '/social-menu/social-menu.svg';
+			$svg_icons = class_exists( 'Automattic\Jetpack\Classic_Theme_Helper\Main' ) ? JETPACK__PLUGIN_DIR . 'jetpack_vendor/automattic/jetpack-classic-theme-helper/src/social-menu/social-menu.svg' : dirname( __DIR__ ) . '/social-menu/social-menu.svg';
 		}
 
 		// If it exists, include it.


### PR DESCRIPTION
Fixes #38959

## Proposed changes:

Follow-up to #38297. Let's use the correct path to Automattic's package dependencies (`jetpack_vendor` instead of `jetpack-vendor`).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Appearance > Themes 
* Install and activate a classic theme like the Twenty Ten theme.
* Go to Plugins > Add New
* Install and activate the Classic Widgets plugin.
* Go to Appearance > Widgets
* Drag and add a Social Icons widget to your sidebar.
* Add a few social networks to the widget's settings: `https://twitter.com/jetpack/` for example, or `https://www.facebook.com/jetpackme`
* Save your changes
* Check the frontend
    * The icons should be displayed properly.
    
