### PR TITLE
Test: PluginPreviewMenuItem

### DIFF
--- a/projects/plugins/jetpack/changelog/test-plugin-preview-dropdown-item
+++ b/projects/plugins/jetpack/changelog/test-plugin-preview-dropdown-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+just to share a proof of concept

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -1,7 +1,7 @@
 import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
-import { PluginPreviewDropdownItem } from '@wordpress/editor';
+import { PluginPreviewMenuItem } from '@wordpress/editor';
 import { addFilter } from '@wordpress/hooks';
 import { atSymbol, send } from '@wordpress/icons';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
@@ -81,10 +81,10 @@ registerJetpackPlugin( blockName, {
 				<SubscribePanels />
 				{ shouldShowNewsletterMenu() && <NewsletterMenu /> }
 				<CommandPalette />
-				<PluginPreviewDropdownItem onClick={ () => {} }>Custom Preview</PluginPreviewDropdownItem>
-				<PluginPreviewDropdownItem onClick={ () => {} } icon={ send }>
+				<PluginPreviewMenuItem onClick={ () => {} }>Custom Preview</PluginPreviewMenuItem>
+				<PluginPreviewMenuItem onClick={ () => {} } icon={ send }>
 					Email preview
-				</PluginPreviewDropdownItem>
+				</PluginPreviewMenuItem>
 			</>
 		);
 	},

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -3,7 +3,7 @@ import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 import { PluginPreviewDropdownItem } from '@wordpress/editor';
 import { addFilter } from '@wordpress/hooks';
-import { atSymbol } from '@wordpress/icons';
+import { atSymbol, send } from '@wordpress/icons';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
 import CommandPalette from './command-palette';
@@ -81,7 +81,10 @@ registerJetpackPlugin( blockName, {
 				<SubscribePanels />
 				{ shouldShowNewsletterMenu() && <NewsletterMenu /> }
 				<CommandPalette />
-				<PluginPreviewDropdownItem onClick={ () => {} }>My button title</PluginPreviewDropdownItem>
+				<PluginPreviewDropdownItem onClick={ () => {} }>Custom Preview</PluginPreviewDropdownItem>
+				<PluginPreviewDropdownItem onClick={ () => {} } icon={ send }>
+					Email preview
+				</PluginPreviewDropdownItem>
 			</>
 		);
 	},

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -1,6 +1,7 @@
 import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
+import { PluginPreviewDropdownItem } from '@wordpress/editor';
 import { addFilter } from '@wordpress/hooks';
 import { atSymbol } from '@wordpress/icons';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
@@ -80,6 +81,7 @@ registerJetpackPlugin( blockName, {
 				<SubscribePanels />
 				{ shouldShowNewsletterMenu() && <NewsletterMenu /> }
 				<CommandPalette />
+				<PluginPreviewDropdownItem onClick={ () => {} }>My button title</PluginPreviewDropdownItem>
 			</>
 		);
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

See: https://github.com/WordPress/gutenberg/pull/64644

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

