### PR TITLE
Fix/my jetpack currency

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-currency
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-currency
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+allow user currency in My Jetpack pricing

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -82,7 +82,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "4.32.x-dev"
+			"dev-trunk": "4.33.x-dev"
 		},
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "4.32.4-alpha",
+	"version": "4.33.0-alpha",
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",
 	"bugs": {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -42,7 +42,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.32.4-alpha';
+	const PACKAGE_VERSION = '4.33.0-alpha';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/plugins/backup/changelog/fix-my-jetpack-currency
+++ b/projects/plugins/backup/changelog/fix-my-jetpack-currency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1160,7 +1160,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
+                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1198,7 +1198,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.32.x-dev"
+                    "dev-trunk": "4.33.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1160,7 +1160,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
+                "reference": "6b23d8933ae1026ffd3d3015bc60afba30a45930"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",

--- a/projects/plugins/boost/changelog/fix-my-jetpack-currency
+++ b/projects/plugins/boost/changelog/fix-my-jetpack-currency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1079,7 +1079,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
+                "reference": "6b23d8933ae1026ffd3d3015bc60afba30a45930"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1079,7 +1079,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
+                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1117,7 +1117,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.32.x-dev"
+                    "dev-trunk": "4.33.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/changelog/fix-my-jetpack-currency
+++ b/projects/plugins/jetpack/changelog/fix-my-jetpack-currency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1744,7 +1744,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "661b9575e9a137bbfa69319abe670453181a1449"
+				"reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1782,7 +1782,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.32.x-dev"
+					"dev-trunk": "4.33.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1744,7 +1744,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
+				"reference": "6b23d8933ae1026ffd3d3015bc60afba30a45930"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",

--- a/projects/plugins/migration/changelog/fix-my-jetpack-currency
+++ b/projects/plugins/migration/changelog/fix-my-jetpack-currency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1160,7 +1160,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
+                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1198,7 +1198,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.32.x-dev"
+                    "dev-trunk": "4.33.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1160,7 +1160,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
+                "reference": "6b23d8933ae1026ffd3d3015bc60afba30a45930"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",

--- a/projects/plugins/protect/changelog/fix-my-jetpack-currency
+++ b/projects/plugins/protect/changelog/fix-my-jetpack-currency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1073,7 +1073,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
+                "reference": "6b23d8933ae1026ffd3d3015bc60afba30a45930"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1073,7 +1073,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
+                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1111,7 +1111,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.32.x-dev"
+                    "dev-trunk": "4.33.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/search/changelog/fix-my-jetpack-currency
+++ b/projects/plugins/search/changelog/fix-my-jetpack-currency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
+                "reference": "6b23d8933ae1026ffd3d3015bc60afba30a45930"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
+                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1054,7 +1054,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.32.x-dev"
+                    "dev-trunk": "4.33.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/social/changelog/fix-my-jetpack-currency
+++ b/projects/plugins/social/changelog/fix-my-jetpack-currency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1016,7 +1016,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
+				"reference": "6b23d8933ae1026ffd3d3015bc60afba30a45930"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1016,7 +1016,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/my-jetpack",
-				"reference": "661b9575e9a137bbfa69319abe670453181a1449"
+				"reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
 			},
 			"require": {
 				"automattic/jetpack-admin-ui": "@dev",
@@ -1054,7 +1054,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "4.32.x-dev"
+					"dev-trunk": "4.33.x-dev"
 				},
 				"version-constants": {
 					"::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/starter-plugin/changelog/fix-my-jetpack-currency
+++ b/projects/plugins/starter-plugin/changelog/fix-my-jetpack-currency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
+                "reference": "6b23d8933ae1026ffd3d3015bc60afba30a45930"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
+                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1054,7 +1054,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.32.x-dev"
+                    "dev-trunk": "4.33.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"

--- a/projects/plugins/videopress/changelog/fix-my-jetpack-currency
+++ b/projects/plugins/videopress/changelog/fix-my-jetpack-currency
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
+                "reference": "6b23d8933ae1026ffd3d3015bc60afba30a45930"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1016,7 +1016,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "661b9575e9a137bbfa69319abe670453181a1449"
+                "reference": "50ec17690d0b787c2ba6b4219fb697ab0e0ca9aa"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1054,7 +1054,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "4.32.x-dev"
+                    "dev-trunk": "4.33.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This diff specifies the connected user's currency when getting prices for My Jetpack.
* It also sets up a way to reset the product cache whenever the user connects or the currency changes
* Product cache is shortened from 7 days to 1 day

Companion WPCOM diff: D158895-code

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D158895-code on your sandbox
* Obtain a test Jetpack site where the API can be sandboxed
* Check out this branch with the Jetpack beta plugin
* Visit My Jetpack and connect your user account.
* Check prices for the products on My Jetpack by clicking "Learn More"
* Prices should be in the currency that's set for your user
* Now, change your user currency preference on WPCOM
* Disconnect and re-connect Jetpack 
* Prices on My Jetpack should now show in the second currency
* Disconnect Jetpack again
* Prices should continue to show in the second currency after the site is disconnected since they cannot be re-fetched without the site connection.