### PR TITLE
Add context switching to videopress card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
@@ -34,6 +34,7 @@ interface ConnectedProductCardProps {
 	primaryActionOverride?: Record< string, AdditionalAction >;
 	onMouseEnter?: () => void;
 	onMouseLeave?: () => void;
+	customLoadTracks?: Record< Lowercase< string >, unknown >;
 }
 
 const ConnectedProductCard: FC< ConnectedProductCardProps > = ( {
@@ -49,6 +50,7 @@ const ConnectedProductCard: FC< ConnectedProductCardProps > = ( {
 	primaryActionOverride,
 	onMouseEnter,
 	onMouseLeave,
+	customLoadTracks,
 } ) => {
 	const { isRegistered, isUserConnected } = useMyJetpackConnection();
 	const { recordEvent } = useAnalytics();
@@ -142,6 +144,7 @@ const ConnectedProductCard: FC< ConnectedProductCardProps > = ( {
 			upgradeInInterstitial={ upgradeInInterstitial }
 			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
+			customLoadTracks={ customLoadTracks }
 		>
 			{ children }
 		</ProductCard>

--- a/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/index.tsx
@@ -36,6 +36,7 @@ export type ProductCardProps = {
 	status: ProductStatus;
 	onMouseEnter?: MouseEventHandler< HTMLButtonElement >;
 	onMouseLeave?: MouseEventHandler< HTMLButtonElement >;
+	customLoadTracks?: Record< Lowercase< string >, unknown >;
 };
 
 // ProductCard component
@@ -63,6 +64,7 @@ const ProductCard: FC< ProductCardProps > = props => {
 		onMouseEnter,
 		onMouseLeave,
 		recommendation,
+		customLoadTracks,
 	} = props;
 
 	const { ownedProducts } = getMyJetpackWindowInitialState( 'lifecycleStats' );
@@ -147,8 +149,9 @@ const ProductCard: FC< ProductCardProps > = props => {
 		recordEvent( 'jetpack_myjetpack_product_card_load', {
 			product: slug,
 			status: status,
+			...customLoadTracks,
 		} );
-	}, [ recordEvent, slug, status ] );
+	}, [ recordEvent, slug, status, customLoadTracks ] );
 
 	return (
 		<Card

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
@@ -23,7 +23,7 @@ const VideopressCard: ProductCardComponent = ( { admin } ) => {
 	const { status } = detail || {};
 	const { videopress: data } = getMyJetpackWindowInitialState();
 	const { activeAndNoVideos } = useTooltipCopy();
-	const videoCount = data?.videoCount || 0;
+	const { videoCount = 0, featuredStats } = data || {};
 
 	const isPluginActive =
 		status === PRODUCT_STATUSES.ACTIVE || status === PRODUCT_STATUSES.CAN_UPGRADE;
@@ -32,6 +32,11 @@ const VideopressCard: ProductCardComponent = ( { admin } ) => {
 		isPluginActive,
 		videoCount,
 	} );
+
+	const customLoadTracks = {
+		stats_period: featuredStats?.period,
+		video_count: videoCount,
+	};
 
 	const Description = useCallback( () => {
 		return (
@@ -64,7 +69,13 @@ const VideopressCard: ProductCardComponent = ( { admin } ) => {
 	] );
 
 	return (
-		<ProductCard slug={ slug } showMenu admin={ admin } Description={ Description }>
+		<ProductCard
+			slug={ slug }
+			showMenu
+			admin={ admin }
+			Description={ Description }
+			customLoadTracks={ customLoadTracks }
+		>
 			<VideoPressValueSection isPluginActive={ isPluginActive } data={ data } />
 		</ProductCard>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
@@ -8,6 +8,8 @@ import useAnalytics from '../../../hooks/use-analytics';
 const useTooltipCopy = () => {
 	const { recordEvent } = useAnalytics();
 	const { videopress: data } = getMyJetpackWindowInitialState();
+	const { featuredStats, videoCount } = data || {};
+	const { period } = featuredStats || {};
 	const hostingRedirectLink = getRedirectUrl( 'jetpack-videopress-my-jetpack-tooltip' );
 
 	const recordHostingLinkClick = useCallback( () => {
@@ -27,10 +29,10 @@ const useTooltipCopy = () => {
 				_n(
 					'You have %d video in your Media Library that could benefit from VideoPress. Start <a>hosting</a> it today to unlock multiple benefits: enhanced quality add-free streaming, faster load times, customizable player controls.',
 					'You have %d videos in your Media Library that could benefit from VideoPress. Start <a>hosting</a> them today to unlock multiple benefits: enhanced quality add-free streaming, faster load times, customizable player controls.',
-					data?.videoCount,
+					videoCount,
 					'jetpack-my-jetpack'
 				),
-				data?.videoCount
+				videoCount
 			),
 			{
 				a: createElement( 'a', {
@@ -56,22 +58,44 @@ const useTooltipCopy = () => {
 		text: __( 'Success! 🌟 Your video is live and gathering views.', 'jetpack-my-jetpack' ),
 	};
 
+	const watchTimeTitle =
+		period === 'day' ? __( '30-Day', 'jetpack-my-jetpack' ) : __( 'Yearly', 'jetpack-my-jetpack' );
+
 	const viewsWithPlan = {
-		title: __( '30-Day views', 'jetpack-my-jetpack' ),
-		text: _n(
-			'This metric represents the total number of views your video has received on our platform over the past 30 days.',
-			'This metric represents the total number of views your videos have received on our platform over the past 30 days.',
-			data.videoCount,
-			'jetpack-my-jetpack'
+		title: sprintf(
+			// translators: %s is the period of time for which the views are counted. Example 30-Day or Yearly.
+			__( '%s views', 'jetpack-my-jetpack' ),
+			watchTimeTitle
 		),
+		text:
+			period === 'day'
+				? _n(
+						'This metric represents the total number of views your video has received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
+						'This metric represents the total number of views your videos have received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
+						videoCount,
+						'jetpack-my-jetpack'
+				  )
+				: _n(
+						'This metric represents the total number of views your videos have received on our platform over the past year.',
+						'This metric represents the total number of views your videos have received on our platform over the past year.',
+						videoCount,
+						'jetpack-my-jetpack'
+				  ),
 	};
 
 	const watchTime = {
-		title: __( '30-Day viewing time', 'jetpack-my-jetpack' ),
-		text: __(
-			'This metric shows total video viewing time for the last 30 days, comparing it with the performance of the previous 30 days.',
-			'jetpack-my-jetpack'
-		),
+		// translators: %s is the period of time for which the views are counted. Example 30-Day or Yearly.
+		title: sprintf( __( '%s viewing time', 'jetpack-my-jetpack' ), watchTimeTitle ),
+		text:
+			period === 'day'
+				? __(
+						'This metric shows total video viewing time for the last 30 days, comparing it with the performance of the previous 30 days.',
+						'jetpack-my-jetpack'
+				  )
+				: __(
+						'This metric shows total video viewing time for the last year.',
+						'jetpack-my-jetpack'
+				  ),
 	};
 
 	return {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
@@ -1,7 +1,7 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { createElement, useCallback } from 'react';
+import { createElement, useCallback, useMemo } from 'react';
 import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../../hooks/use-analytics';
 
@@ -58,44 +58,54 @@ const useTooltipCopy = () => {
 		text: __( 'Success! 🌟 Your video is live and gathering views.', 'jetpack-my-jetpack' ),
 	};
 
-	const watchTimeTitle =
-		period === 'day' ? __( '30-Day', 'jetpack-my-jetpack' ) : __( 'Yearly', 'jetpack-my-jetpack' );
+	const watchTimeTitle = useMemo( () => {
+		if ( period === 'day' ) {
+			return __( '30-Day views', 'jetpack-my-jetpack' );
+		}
+
+		return __( 'Yearly views', 'jetpack-my-jetpack' );
+	}, [ period ] );
+
+	const viewsWithPlanText = useMemo( () => {
+		if ( period === 'day' ) {
+			return _n(
+				'This metric represents the total number of views your video has received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
+				'This metric represents the total number of views your videos have received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
+				videoCount,
+				'jetpack-my-jetpack'
+			);
+		}
+
+		return _n(
+			'This metric represents the total number of views your videos have received on our platform over the past year.',
+			'This metric represents the total number of views your videos have received on our platform over the past year.',
+			videoCount,
+			'jetpack-my-jetpack'
+		);
+	}, [ period, videoCount ] );
 
 	const viewsWithPlan = {
-		title: sprintf(
-			// translators: %s is the period of time for which the views are counted. Example 30-Day or Yearly.
-			__( '%s views', 'jetpack-my-jetpack' ),
-			watchTimeTitle
-		),
-		text:
-			period === 'day'
-				? _n(
-						'This metric represents the total number of views your video has received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
-						'This metric represents the total number of views your videos have received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
-						videoCount,
-						'jetpack-my-jetpack'
-				  )
-				: _n(
-						'This metric represents the total number of views your videos have received on our platform over the past year.',
-						'This metric represents the total number of views your videos have received on our platform over the past year.',
-						videoCount,
-						'jetpack-my-jetpack'
-				  ),
+		title: watchTimeTitle,
+		text: viewsWithPlanText,
 	};
 
+	const watchTimeText = useMemo( () => {
+		if ( period === 'day' ) {
+			return __(
+				'This metric shows total video viewing time for the last 30 days, comparing it with the performance of the previous 30 days.',
+				'jetpack-my-jetpack'
+			);
+		}
+
+		return __(
+			'This metric shows total video viewing time for the last year.',
+			'jetpack-my-jetpack'
+		);
+	}, [ period ] );
+
 	const watchTime = {
-		// translators: %s is the period of time for which the views are counted. Example 30-Day or Yearly.
-		title: sprintf( __( '%s viewing time', 'jetpack-my-jetpack' ), watchTimeTitle ),
-		text:
-			period === 'day'
-				? __(
-						'This metric shows total video viewing time for the last 30 days, comparing it with the performance of the previous 30 days.',
-						'jetpack-my-jetpack'
-				  )
-				: __(
-						'This metric shows total video viewing time for the last year.',
-						'jetpack-my-jetpack'
-				  ),
+		title: watchTimeTitle,
+		text: watchTimeText,
 	};
 
 	return {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
@@ -68,7 +68,7 @@ const useTooltipCopy = () => {
 		'jetpack-my-jetpack'
 	);
 	const viewsWithPlanTextYear = _n(
-		'This metric represents the total number of views your videos have received on our platform over the past year.',
+		'This metric represents the total number of views your video have received on our platform over the past year.',
 		'This metric represents the total number of views your videos have received on our platform over the past year.',
 		videoCount,
 		'jetpack-my-jetpack'

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
@@ -1,7 +1,7 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { createElement, useCallback, useMemo } from 'react';
+import { createElement, useCallback } from 'react';
 import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../../hooks/use-analytics';
 
@@ -58,54 +58,39 @@ const useTooltipCopy = () => {
 		text: __( 'Success! 🌟 Your video is live and gathering views.', 'jetpack-my-jetpack' ),
 	};
 
-	const watchTimeTitle = useMemo( () => {
-		if ( period === 'day' ) {
-			return __( '30-Day views', 'jetpack-my-jetpack' );
-		}
+	const thirtyDayViews = __( '30-Day views', 'jetpack-my-jetpack' );
+	const yearlyViews = __( 'Yearly views', 'jetpack-my-jetpack' );
 
-		return __( 'Yearly views', 'jetpack-my-jetpack' );
-	}, [ period ] );
-
-	const viewsWithPlanText = useMemo( () => {
-		if ( period === 'day' ) {
-			return _n(
-				'This metric represents the total number of views your video has received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
-				'This metric represents the total number of views your videos have received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
-				videoCount,
-				'jetpack-my-jetpack'
-			);
-		}
-
-		return _n(
-			'This metric represents the total number of views your videos have received on our platform over the past year.',
-			'This metric represents the total number of views your videos have received on our platform over the past year.',
-			videoCount,
-			'jetpack-my-jetpack'
-		);
-	}, [ period, videoCount ] );
+	const viewsWithPlanTextDay = _n(
+		'This metric represents the total number of views your video has received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
+		'This metric represents the total number of views your videos have received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
+		videoCount,
+		'jetpack-my-jetpack'
+	);
+	const viewsWithPlanTextYear = _n(
+		'This metric represents the total number of views your videos have received on our platform over the past year.',
+		'This metric represents the total number of views your videos have received on our platform over the past year.',
+		videoCount,
+		'jetpack-my-jetpack'
+	);
 
 	const viewsWithPlan = {
-		title: watchTimeTitle,
-		text: viewsWithPlanText,
+		title: period === 'day' ? thirtyDayViews : yearlyViews,
+		text: period === 'day' ? viewsWithPlanTextDay : viewsWithPlanTextYear,
 	};
 
-	const watchTimeText = useMemo( () => {
-		if ( period === 'day' ) {
-			return __(
-				'This metric shows total video viewing time for the last 30 days, comparing it with the performance of the previous 30 days.',
-				'jetpack-my-jetpack'
-			);
-		}
-
-		return __(
-			'This metric shows total video viewing time for the last year.',
-			'jetpack-my-jetpack'
-		);
-	}, [ period ] );
+	const watchTimeTextDay = __(
+		'This metric shows total video viewing time for the last 30 days, comparing it with the performance of the previous 30 days.',
+		'jetpack-my-jetpack'
+	);
+	const watchTimeTextYear = __(
+		'This metric shows total video viewing time for the last year.',
+		'jetpack-my-jetpack'
+	);
 
 	const watchTime = {
-		title: watchTimeTitle,
-		text: watchTimeText,
+		title: period === 'day' ? thirtyDayViews : yearlyViews,
+		text: period === 'day' ? watchTimeTextDay : watchTimeTextYear,
 	};
 
 	return {

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
@@ -1,7 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { arrowUp, arrowDown, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useMemo } from 'react';
 import { PRODUCT_SLUGS } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
 import formatNumber from '../../../utils/format-number';
@@ -65,16 +64,6 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 		notation: 'compact',
 	};
 
-	const period = featuredStats?.period;
-
-	const watchTimeTitle = useMemo( () => {
-		if ( period === 'day' ) {
-			return __( '30-Day views', 'jetpack-my-jetpack' );
-		}
-
-		return __( 'Yearly views', 'jetpack-my-jetpack' );
-	}, [ period ] );
-
 	if ( ! videoCount ) {
 		return null;
 	}
@@ -115,6 +104,7 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 	const currentWatchTime = featuredStats?.data?.watch_time?.current;
 	const previousViews = featuredStats?.data?.views?.previous;
 	const previousWatchTime = featuredStats?.data?.watch_time?.previous;
+	const period = featuredStats?.period;
 
 	const viewsDifference = Math.abs( currentViews - previousViews );
 	const watchTimeDifference = Math.abs( currentWatchTime - previousWatchTime );
@@ -122,6 +112,9 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 	if ( currentViews === undefined || currentWatchTime === undefined ) {
 		return null;
 	}
+
+	const thirtyDayViews = __( '30-Day views', 'jetpack-my-jetpack' );
+	const yearlyViews = __( 'Yearly views', 'jetpack-my-jetpack' );
 
 	return (
 		<div className="videopress-card__value-section">
@@ -132,7 +125,7 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 						'videopress-card__value-section__heading'
 					) }
 				>
-					{ watchTimeTitle }
+					{ period === 'day' ? thirtyDayViews : yearlyViews }
 
 					<InfoTooltip
 						tracksEventName="videopress_card_tooltip_open"

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { arrowUp, arrowDown, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { PRODUCT_SLUGS } from '../../../data/constants';
@@ -12,9 +12,11 @@ import type { FC } from 'react';
 
 import './style.scss';
 
+type VideoPressWindowData = Window[ 'myJetpackInitialState' ][ 'videopress' ];
+
 interface VideoPressValueSectionProps {
 	isPluginActive: boolean;
-	data: Window[ 'myJetpackInitialState' ][ 'videopress' ];
+	data: VideoPressWindowData;
 }
 
 interface ValueSectionProps {
@@ -22,6 +24,7 @@ interface ValueSectionProps {
 	previousValue: number;
 	formattedValue: string;
 	formattedDifference: string;
+	period: VideoPressWindowData[ 'featuredStats' ][ 'period' ];
 }
 
 const ValueSection: FC< ValueSectionProps > = ( {
@@ -29,13 +32,14 @@ const ValueSection: FC< ValueSectionProps > = ( {
 	previousValue,
 	formattedValue,
 	formattedDifference,
+	period,
 } ) => {
 	const hasValueIncreased = value > previousValue;
 	return (
 		<div className="videopress-card__value-section__value-container">
 			<span className="videopress-card__value-section__value">{ formattedValue }</span>
 
-			{ value !== previousValue && (
+			{ value !== previousValue && period === 'day' && (
 				<div
 					className={ clsx(
 						'videopress-card__value-section__previous-value',
@@ -100,6 +104,7 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 	const currentWatchTime = featuredStats?.data?.watch_time?.current;
 	const previousViews = featuredStats?.data?.views?.previous;
 	const previousWatchTime = featuredStats?.data?.watch_time?.previous;
+	const period = featuredStats?.period;
 
 	const viewsDifference = Math.abs( currentViews - previousViews );
 	const watchTimeDifference = Math.abs( currentWatchTime - previousWatchTime );
@@ -107,6 +112,9 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 	if ( currentViews === undefined || currentWatchTime === undefined ) {
 		return null;
 	}
+
+	const watchTimeTitle =
+		period === 'day' ? __( '30-Day', 'jetpack-my-jetpack' ) : __( 'Yearly', 'jetpack-my-jetpack' );
 
 	return (
 		<div className="videopress-card__value-section">
@@ -117,7 +125,10 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 						'videopress-card__value-section__heading'
 					) }
 				>
-					{ __( '30-Day views', 'jetpack-my-jetpack' ) }
+					{
+						// translators: %s is the period of time for which the views are counted. Example 30-Day or Yearly.
+						sprintf( __( '%s views', 'jetpack-my-jetpack' ), watchTimeTitle )
+					}
 
 					<InfoTooltip
 						tracksEventName="videopress_card_tooltip_open"
@@ -125,6 +136,7 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 							location: 'views',
 							current_views: currentViews,
 							previous_views: previousViews,
+							period,
 							...tracksProps,
 						} }
 					>
@@ -147,6 +159,7 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 					previousValue={ previousViews }
 					formattedValue={ formatNumber( currentViews, shortenedNumberConfig ) }
 					formattedDifference={ formatNumber( viewsDifference, shortenedNumberConfig ) }
+					period={ period }
 				/>
 			</div>
 
@@ -165,6 +178,7 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 							location: 'watch_time',
 							current_watch_time: currentWatchTime,
 							previous_watch_time: previousWatchTime,
+							period,
 							...tracksProps,
 						} }
 					>
@@ -178,6 +192,7 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 					previousValue={ previousWatchTime }
 					formattedValue={ formatTime( currentWatchTime ) }
 					formattedDifference={ formatTime( watchTimeDifference ) }
+					period={ period }
 				/>
 			</div>
 		</div>

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/videopress-value-section.tsx
@@ -1,6 +1,7 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { arrowUp, arrowDown, Icon } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useMemo } from 'react';
 import { PRODUCT_SLUGS } from '../../../data/constants';
 import useProduct from '../../../data/products/use-product';
 import formatNumber from '../../../utils/format-number';
@@ -64,6 +65,16 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 		notation: 'compact',
 	};
 
+	const period = featuredStats?.period;
+
+	const watchTimeTitle = useMemo( () => {
+		if ( period === 'day' ) {
+			return __( '30-Day views', 'jetpack-my-jetpack' );
+		}
+
+		return __( 'Yearly views', 'jetpack-my-jetpack' );
+	}, [ period ] );
+
 	if ( ! videoCount ) {
 		return null;
 	}
@@ -104,7 +115,6 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 	const currentWatchTime = featuredStats?.data?.watch_time?.current;
 	const previousViews = featuredStats?.data?.views?.previous;
 	const previousWatchTime = featuredStats?.data?.watch_time?.previous;
-	const period = featuredStats?.period;
 
 	const viewsDifference = Math.abs( currentViews - previousViews );
 	const watchTimeDifference = Math.abs( currentWatchTime - previousWatchTime );
@@ -112,9 +122,6 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 	if ( currentViews === undefined || currentWatchTime === undefined ) {
 		return null;
 	}
-
-	const watchTimeTitle =
-		period === 'day' ? __( '30-Day', 'jetpack-my-jetpack' ) : __( 'Yearly', 'jetpack-my-jetpack' );
 
 	return (
 		<div className="videopress-card__value-section">
@@ -125,10 +132,7 @@ const VideoPressValueSection: FC< VideoPressValueSectionProps > = ( { isPluginAc
 						'videopress-card__value-section__heading'
 					) }
 				>
-					{
-						// translators: %s is the period of time for which the views are counted. Example 30-Day or Yearly.
-						sprintf( __( '%s views', 'jetpack-my-jetpack' ), watchTimeTitle )
-					}
+					{ watchTimeTitle }
 
 					<InfoTooltip
 						tracksEventName="videopress_card_tooltip_open"

--- a/projects/packages/my-jetpack/_inc/utils/format-time.ts
+++ b/projects/packages/my-jetpack/_inc/utils/format-time.ts
@@ -1,8 +1,9 @@
-type FormatTimeFunction = ( seconds: number ) => string;
+type FormatTimeFunction = ( hours: number ) => string;
 
-const formatTime: FormatTimeFunction = ( seconds: number ) => {
+const formatTime: FormatTimeFunction = ( hours: number ) => {
+	const seconds = Math.floor( hours * 3600 );
 	const minutes = Math.floor( seconds / 60 );
-	const hours = Math.floor( minutes / 60 );
+	hours = Math.floor( hours );
 	const days = Math.floor( hours / 24 );
 	const years = Math.floor( days / 365 );
 
@@ -22,7 +23,7 @@ const formatTime: FormatTimeFunction = ( seconds: number ) => {
 		return `${ minutes }m ${ seconds % 60 }s`;
 	}
 
-	return `${ seconds }s`;
+	return `${ Math.floor( seconds ) }s`;
 };
 
 export default formatTime;

--- a/projects/packages/my-jetpack/changelog/add-context-switching-to-videopress-card
+++ b/projects/packages/my-jetpack/changelog/add-context-switching-to-videopress-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add context switching to videopress card from yearly views to monthly views

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -243,7 +243,7 @@ interface Window {
 			};
 		};
 		videopress: {
-			featuredStats: {
+			featuredStats?: {
 				label: string;
 				period: 'day' | 'year';
 				data: {

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -245,6 +245,7 @@ interface Window {
 		videopress: {
 			featuredStats: {
 				label: string;
+				period: 'day' | 'year';
 				data: {
 					views: {
 						current: number;

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -321,7 +321,7 @@ class Initializer {
 
 		$featured_stats = get_transient( self::VIDEOPRESS_STATS_KEY );
 
-		if ( ! is_wp_error( $featured_stats ) && $featured_stats ) {
+		if ( $featured_stats ) {
 			return array(
 				'featuredStats' => $featured_stats,
 				'videoCount'    => $video_count,

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -318,11 +318,11 @@ class Initializer {
 			);
 		}
 
-		$featured_stats = get_transient( self::VIDEOPRESS_STATS_KEY );
+		$featured_stats   = get_transient( self::VIDEOPRESS_STATS_KEY );
+		$videopress_stats = new VideoPress_Stats();
 
 		if ( ! $featured_stats ) {
-			$videopress_stats = new VideoPress_Stats();
-			$featured_stats   = $videopress_stats->get_featured_stats( 60, 'day' );
+			$featured_stats = $videopress_stats->get_featured_stats( 60, 'day' );
 		}
 
 		if ( is_wp_error( $featured_stats ) || ! $featured_stats ) {
@@ -333,6 +333,12 @@ class Initializer {
 
 		if ( $featured_stats['data']['views']['current'] < 500 || $featured_stats['data']['views']['previous'] < 500 ) {
 			$featured_stats = $videopress_stats->get_featured_stats( 2, 'year' );
+		}
+
+		if ( is_wp_error( $featured_stats ) || ! $featured_stats ) {
+			return array(
+				'videoCount' => $video_count,
+			);
 		}
 
 		set_transient( self::VIDEOPRESS_STATS_KEY, $featured_stats, HOUR_IN_SECONDS );

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -322,13 +322,17 @@ class Initializer {
 
 		if ( ! $featured_stats ) {
 			$videopress_stats = new VideoPress_Stats();
-			$featured_stats   = $videopress_stats->get_featured_stats( 60 );
+			$featured_stats   = $videopress_stats->get_featured_stats( 60, 'day' );
 		}
 
 		if ( is_wp_error( $featured_stats ) || ! $featured_stats ) {
 			return array(
 				'videoCount' => $video_count,
 			);
+		}
+
+		if ( $featured_stats['data']['views']['current'] < 500 || $featured_stats['data']['views']['previous'] < 500 ) {
+			$featured_stats = $videopress_stats->get_featured_stats( 2, 'year' );
 		}
 
 		set_transient( self::VIDEOPRESS_STATS_KEY, $featured_stats, HOUR_IN_SECONDS );

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -332,7 +332,7 @@ class Initializer {
 		}
 
 		if ( $featured_stats['data']['views']['current'] < 500 || $featured_stats['data']['views']['previous'] < 500 ) {
-			$featured_stats = $videopress_stats->get_featured_stats( 1, 'year' );
+			$featured_stats = $videopress_stats->get_featured_stats( 2, 'year' );
 		}
 
 		set_transient( self::VIDEOPRESS_STATS_KEY, $featured_stats, HOUR_IN_SECONDS );

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -64,6 +64,7 @@ class Initializer {
 	const UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY = 'update-historically-active-jetpack-modules';
 	const MISSING_CONNECTION_NOTIFICATION_KEY            = 'missing-connection';
 	const VIDEOPRESS_STATS_KEY                           = 'my-jetpack-videopress-stats';
+	const VIDEOPRESS_PERIOD_KEY                          = 'my-jetpack-videopress-period';
 
 	/**
 	 * Holds info/data about the site (from the /sites/%d endpoint)
@@ -318,11 +319,36 @@ class Initializer {
 			);
 		}
 
-		$featured_stats   = get_transient( self::VIDEOPRESS_STATS_KEY );
+		$featured_stats = get_transient( self::VIDEOPRESS_STATS_KEY );
+
+		if ( ! is_wp_error( $featured_stats ) && $featured_stats ) {
+			return array(
+				'featuredStats' => $featured_stats,
+				'videoCount'    => $video_count,
+			);
+		}
+
+		$stats_period     = get_transient( self::VIDEOPRESS_PERIOD_KEY );
 		$videopress_stats = new VideoPress_Stats();
 
-		if ( ! $featured_stats ) {
+		// If the stats period exists, retrieve that information without checking the view count.
+		// If it does not, check the view count of monthly stats and determine if we want to show yearly or monthly stats.
+		if ( $stats_period ) {
+			if ( $stats_period === 'day' ) {
+				$featured_stats = $videopress_stats->get_featured_stats( 60, 'day' );
+			} else {
+				$featured_stats = $videopress_stats->get_featured_stats( 2, 'year' );
+			}
+		} else {
 			$featured_stats = $videopress_stats->get_featured_stats( 60, 'day' );
+
+			if (
+				! is_wp_error( $featured_stats ) &&
+				$featured_stats &&
+				( $featured_stats['data']['views']['current'] < 500 || $featured_stats['data']['views']['previous'] < 500 )
+			) {
+				$featured_stats = $videopress_stats->get_featured_stats( 2, 'year' );
+			}
 		}
 
 		if ( is_wp_error( $featured_stats ) || ! $featured_stats ) {
@@ -331,17 +357,8 @@ class Initializer {
 			);
 		}
 
-		if ( $featured_stats['data']['views']['current'] < 500 || $featured_stats['data']['views']['previous'] < 500 ) {
-			$featured_stats = $videopress_stats->get_featured_stats( 2, 'year' );
-		}
-
-		if ( is_wp_error( $featured_stats ) || ! $featured_stats ) {
-			return array(
-				'videoCount' => $video_count,
-			);
-		}
-
-		set_transient( self::VIDEOPRESS_STATS_KEY, $featured_stats, HOUR_IN_SECONDS );
+		set_transient( self::VIDEOPRESS_PERIOD_KEY, $featured_stats['period'], WEEK_IN_SECONDS );
+		set_transient( self::VIDEOPRESS_STATS_KEY, $featured_stats, DAY_IN_SECONDS );
 
 		return array(
 			'featuredStats' => $featured_stats,

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -332,7 +332,7 @@ class Initializer {
 		}
 
 		if ( $featured_stats['data']['views']['current'] < 500 || $featured_stats['data']['views']['previous'] < 500 ) {
-			$featured_stats = $videopress_stats->get_featured_stats( 2, 'year' );
+			$featured_stats = $videopress_stats->get_featured_stats( 1, 'year' );
 		}
 
 		set_transient( self::VIDEOPRESS_STATS_KEY, $featured_stats, HOUR_IN_SECONDS );

--- a/projects/packages/videopress/changelog/add-context-switching-to-videopress-card
+++ b/projects/packages/videopress/changelog/add-context-switching-to-videopress-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add context switching to videopress card from yearly views to monthly views

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.24.2",
+	"version": "0.24.3-alpha",
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",
 	"bugs": {

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.24.2';
+	const PACKAGE_VERSION = '0.24.3-alpha';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/packages/videopress/src/class-stats.php
+++ b/projects/packages/videopress/src/class-stats.php
@@ -141,7 +141,7 @@ class Stats {
 		// template for the response
 		$featured_stats = array(
 			// translators: %1$d is the number of units of time, %2$s is the period in which the units of time are measured ex. 'day' or 'year'.
-			'label'  => sprintf( _n( 'last %1$d %2$s', 'last %1$d %2$ss', $period_of_data, 'jetpack-videopress-pkg' ), $period_of_data, $period ),
+			'label'  => sprintf( _n( 'last %1$d %2$s', 'last %1$d %2$ss', (int) $period_of_data, 'jetpack-videopress-pkg' ), $period_of_data, $period ),
 			'period' => $period,
 			'data'   => array(
 				'views'       => array(

--- a/projects/packages/videopress/src/class-stats.php
+++ b/projects/packages/videopress/src/class-stats.php
@@ -87,15 +87,16 @@ class Stats {
 	/**
 	 * Returns the featured stats for VideoPress.
 	 *
-	 * @param int $days (optional) The number of days to consider.
+	 * @param int    $period_count (optional) The number of days to consider.
+	 * @param string $period (optional) The period to consider.
 	 *
 	 * @return array|WP_Error a list of stats, or WP_Error on failure.
 	 */
-	public static function get_featured_stats( $days = 14 ) {
+	public static function get_featured_stats( $period_count = 14, $period = 'day' ) {
 		$response = self::fetch_video_plays(
 			array(
-				'period'         => 'day',
-				'num'            => $days,
+				'period'         => $period,
+				'num'            => $period_count,
 				'complete_stats' => true,
 			)
 		);
@@ -117,29 +118,32 @@ class Stats {
 		$dates = $data['days'];
 
 		// Organize the data into the planned stats
-		return self::prepare_featured_stats( $dates, $days );
+		return self::prepare_featured_stats( $dates, $period_count, $period );
 	}
 
 	/**
 	 * Prepares the featured stats for VideoPress.
 	 *
-	 * @param array $dates The list of dates returned by the API.
-	 * @param int   $total_days The total number of days to consider.
+	 * @param array  $dates The list of dates returned by the API.
+	 * @param int    $period_count The total number of days to consider.
+	 * @param string $period The period to consider.
 	 * @return array a list of stats.
 	 */
-	public static function prepare_featured_stats( $dates, $total_days ) {
+	public static function prepare_featured_stats( $dates, $period_count, $period = 'day' ) {
 		/**
 		 * Ensure the sorting of the dates, recent ones first.
 		 * This way, the first 7 positions are from the last 7 days,
 		 * and the next 7 positions are from the 7 days before it.
 		 */
 		krsort( $dates );
+		$period_of_data = floor( $period_count / 2 );
 
 		// template for the response
 		$featured_stats = array(
-			// translators: %d is the number of days
-			'label' => sprintf( __( 'last %d days', 'jetpack-videopress-pkg' ), floor( $total_days / 2 ) ),
-			'data'  => array(
+			// translators: %1$d is the number of units of time, %2$s is the period in which the units of time are measured ex. 'day' or 'year'.
+			'label'  => sprintf( _n( 'last %1$d %2$s', 'last %1$d %2$ss', $period_of_data, 'jetpack-videopress-pkg' ), $period_of_data, $period ),
+			'period' => $period,
+			'data'   => array(
 				'views'       => array(
 					'current'  => 0,
 					'previous' => 0,
@@ -160,7 +164,7 @@ class Stats {
 		foreach ( $dates as $date_info ) {
 			$date_totals = $date_info['total'];
 
-			if ( $counter < floor( $total_days / 2 ) ) {
+			if ( $counter < floor( $period_count / 2 ) ) {
 
 				// the first 7 elements are for the current period
 				$featured_stats['data']['views']['current']       += $date_totals['views'];


### PR DESCRIPTION
## Proposed changes:

* Add functionality to show previous year of data if monthly data is not large enough
* Update time format function as I discovered that time is returned in hours not seconds

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-rb7-p2#comment-70687

## Does this pull request change what data or activity we track or use?

Yes, we are adding the time period in which stats are being shown to a few of the tracks events

## Testing instructions:

1. Check this branch out on your local environment (you can try this on jurassic tube as well, but switching contexts will be annoying because of the transient that keeps the data if you don't comment it out)
2. Go to [this line of code](https://github.com/Automattic/jetpack/pull/38979/files#diff-2be902912ee7edeeeed04156e4456f5966e480fea3067586ff451c63b2bf2624R321) and comment out the transient
3. Make sure your local environment is pointing to your sandbox
4. Make sure your testing site is User connected, has at least 1 video on it, and has VideoPress active
5. Now to go to this line of code on the backend: fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qfgngf%2Qivqrb%2Qcynlf%2Qi1%2Q1%2Qraqcbvag.cuc%3Se%3Q210o65nn%26zb%3Q1199%26sv%3Q37%2350-og and replace the 0's with
```php
'impressions' => wp_rand( 0, 300 ),
'views'       => wp_rand( 0, 300 ),
'watch_time'  => wp_rand( 0, 5 ),
```
6. Refresh My Jetpack and make sure it still shows monthly stats with the previous month comparisons
![image](https://github.com/user-attachments/assets/c2275a12-82b5-47f2-9c8d-8b8acc9f8fe5)
7. Now remove your changes on the backend
8. Now go to fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qfgngf%2Qivqrb%2Qcynlf%2Qi1%2Q1%2Qraqcbvag.cuc%3Se%3Q210o65nn%26zb%3Q1199%26sv%3Q37%2338-og and just above that line, insert the following line of code replacing the {site_id} with the id listed here: 3567b-pb/
```php
$site_id = {site_id};
```
9. Go to My Jetpack and see that the views are still shown as monthly stats
10. Go to [this line](https://github.com/Automattic/jetpack/pull/38979/files#diff-2be902912ee7edeeeed04156e4456f5966e480fea3067586ff451c63b2bf2624R331) and comment out the period transient. Go back to My Jetpack and see that the stats now show as yearly
![image](https://github.com/user-attachments/assets/9c20d46a-2509-4783-afce-f8ce826d366c)
![image](https://github.com/user-attachments/assets/0c79273c-d803-4dea-8c0c-feebb6520c02)
![image](https://github.com/user-attachments/assets/b0eded88-fbce-4540-a75f-6ef7d0177257)