### PR TITLE
Contact Form: Prevent direct file access

### DIFF
--- a/projects/plugins/jetpack/changelog/add-contact-form-file-direct-access-prevention
+++ b/projects/plugins/jetpack/changelog/add-contact-form-file-direct-access-prevention
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Contact Form: Prevent direct file access.

--- a/projects/plugins/jetpack/modules/contact-form.php
+++ b/projects/plugins/jetpack/modules/contact-form.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 
 /**


### PR DESCRIPTION
Fixes p1724061704911039-slack-CBG1CP4EN 

## Proposed changes:

* This PR prevents direct file access to `modules/contact-form.php`. This may prevent some fatal errors caused by third parties attempting to visit the file directly.
* As was mentioned in Slack - p1724061704911039-slack-CBG1CP4EN - it may be possible to add a sniff to catch all other files that could be affected, but in the short-term this deals with this singular reported issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1724061704911039-slack-CBG1CP4EN

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Self-hosted:

* On trunk, visit the following page: `wp-content/plugins/jetpack/modules/contact-form.php`. You may see a fatal error showing on the page itself: `Fatal error: Uncaught Error: Class "Automattic\Jetpack\Forms\Jetpack_Forms" not found `...
* With this PR applied, directly accessing that page should result in a blank page instead.

