### PR TITLE
My jetpack: handle tiers enabled better

### DIFF
--- a/projects/packages/my-jetpack/changelog/my-jetpack-handle-tiers-enabled-better
+++ b/projects/packages/my-jetpack/changelog/my-jetpack-handle-tiers-enabled-better
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: AI product class to handle better disabling tiers

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -201,16 +201,16 @@ class Jetpack_Ai extends Product {
 	 * @return int
 	 */
 	public static function get_next_usage_tier() {
-		if ( ! self::is_site_connected() ) {
-			// without site connection we can't know if tiers are enabled or not,
-			// hence we can't know if the next tier is 100 or 1 (unlimited).
-			return 100;
-		}
+		// if ( ! self::is_site_connected() ) {
+		// without site connection we can't know if tiers are enabled or not,
+		// hence we can't know if the next tier is 100 or 1 (unlimited).
+		// return 100;
+		// }
 
 		$info = self::get_ai_assistant_feature();
 
 		// Bail early if it's not possible to fetch the feature data or if it's included in a plan.
-		if ( is_wp_error( $info ) || self::has_paid_plan_for_product() ) {
+		if ( self::has_paid_plan_for_product() || is_wp_error( $info ) || empty( $info ) ) {
 			return null;
 		}
 

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -201,14 +201,16 @@ class Jetpack_Ai extends Product {
 	 * @return int
 	 */
 	public static function get_next_usage_tier() {
-		if ( ! self::is_site_connected() || ! self::has_paid_plan_for_product() ) {
+		if ( ! self::is_site_connected() ) {
+			// without site connection we can't know if tiers are enabled or not,
+			// hence we can't know if the next tier is 100 or 1 (unlimited).
 			return 100;
 		}
 
 		$info = self::get_ai_assistant_feature();
 
-		// Bail early if it's not possible to fetch the feature data.
-		if ( is_wp_error( $info ) ) {
+		// Bail early if it's not possible to fetch the feature data or if it's included in a plan.
+		if ( is_wp_error( $info ) || self::has_paid_plan_for_product() ) {
 			return null;
 		}
 

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -93,6 +93,10 @@ class Jetpack_Ai extends Product {
 	 * @return string[] Slugs of the available tiers
 	 */
 	public static function get_tiers() {
+		if ( ! self::are_tier_plans_enabled() ) {
+			return parent::get_tiers();
+		}
+
 		return array(
 			self::UPGRADED_TIER_SLUG,
 			self::CURRENT_TIER_SLUG,
@@ -105,6 +109,10 @@ class Jetpack_Ai extends Product {
 	 * @return array[] Protect features comparison
 	 */
 	public static function get_features_by_tier() {
+		if ( ! self::are_tier_plans_enabled() ) {
+			return parent::get_features_by_tier();
+		}
+
 		$current_tier        = self::get_current_usage_tier();
 		$current_description = 0 === $current_tier
 			? __( 'Up to 20 requests', 'jetpack-my-jetpack' )
@@ -360,6 +368,18 @@ class Jetpack_Ai extends Product {
 	 * @return array Pricing details
 	 */
 	public static function get_pricing_for_ui() {
+		// no tiers
+		if ( ! self::are_tier_plans_enabled() ) {
+			return array_merge(
+				array(
+					'available'          => true,
+					'wpcom_product_slug' => static::get_wpcom_product_slug(),
+				),
+				// hardcoding 1 as next tier if tiers are not enabled
+				self::get_pricing_for_ui_by_usage_tier( 1 )
+			);
+		}
+
 		$next_tier              = self::get_next_usage_tier();
 		$current_tier           = self::get_current_usage_tier();
 		$current_call_to_action = $current_tier === 0
@@ -541,6 +561,19 @@ class Jetpack_Ai extends Product {
 		}
 
 		return \Jetpack_AI_Helper::get_ai_assistance_feature();
+	}
+
+	/**
+	 * Get the AI Assistant tiered plans status
+	 *
+	 * @return boolean
+	 */
+	public static function are_tier_plans_enabled() {
+		$info = self::get_ai_assistant_feature();
+		if ( ! empty( $info ) && isset( $info['tier-plans-enabled'] ) ) {
+			return boolval( $info['tier-plans-enabled'] );
+		}
+		return false;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -314,11 +314,7 @@ class Jetpack_Ai extends Product {
 			return array();
 		}
 
-		// get info about the feature.
-		$info = self::get_ai_assistant_feature();
-
-		// flag to indicate if the tiers are enabled, case the info is available.
-		$tier_plans_enabled = ( ! is_wp_error( $info ) && isset( $info['tier-plans-enabled'] ) ) ? boolval( $info['tier-plans-enabled'] ) : false;
+		$tier_plans_enabled = self::are_tier_plans_enabled();
 
 		/*
 		 * when tiers are enabled and the price tier list is empty,

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -263,14 +263,13 @@ class Jetpack_Ai extends Product {
 	 * @return string
 	 */
 	public static function get_features_by_usage_tier( $tier ) {
-		$features = array(
-			1 => array(
-				__( 'Artificial intelligence chatbot', 'jetpack-my-jetpack' ),
-				__( 'Generate text, tables, lists, and forms', 'jetpack-my-jetpack' ),
-				__( 'Refine the tone and content to your liking', 'jetpack-my-jetpack' ),
-				__( 'Get feedback about your post', 'jetpack-my-jetpack' ),
-				__( 'Seamless WordPress editor integration', 'jetpack-my-jetpack' ),
-			),
+		$is_tier_plan = $tier && intval( $tier ) > 1;
+		$features     = array(
+			__( 'Artificial intelligence chatbot', 'jetpack-my-jetpack' ),
+			__( 'Generate text, tables, lists, and forms', 'jetpack-my-jetpack' ),
+			__( 'Refine the tone and content to your liking', 'jetpack-my-jetpack' ),
+			__( 'Get feedback about your post', 'jetpack-my-jetpack' ),
+			__( 'Seamless WordPress editor integration', 'jetpack-my-jetpack' ),
 		);
 
 		$tiered_features = array(
@@ -284,7 +283,7 @@ class Jetpack_Ai extends Product {
 			sprintf( __( 'Up to %d requests per month', 'jetpack-my-jetpack' ), $tier ),
 		);
 
-		return isset( $features[ $tier ] ) ? $features[ $tier ] : $tiered_features;
+		return $is_tier_plan ? $tiered_features : $features;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -574,6 +574,12 @@ class Jetpack_Ai extends Product {
 	 */
 	public static function are_tier_plans_enabled() {
 		$info = self::get_ai_assistant_feature();
+		if ( is_wp_error( $info ) ) {
+			// this is another faulty default value, we'll assume disabled while
+			// production is enabled
+			return false;
+		}
+
 		if ( ! empty( $info ) && isset( $info['tier-plans-enabled'] ) ) {
 			return boolval( $info['tier-plans-enabled'] );
 		}

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -264,7 +264,14 @@ class Jetpack_Ai extends Product {
 	 */
 	public static function get_features_by_usage_tier( $tier ) {
 		$is_tier_plan = $tier && intval( $tier ) > 1;
-		$features     = array(
+
+		if ( $tier === 100 && ( ! self::is_site_connected() || ! self::has_paid_plan_for_product() ) ) {
+			// in these cases, get_next_usage_tier() will return 100
+			// 100 is fine as default when tiered plans are enabled, but not otherwise
+			$is_tier_plan = false;
+		}
+
+		$features = array(
 			__( 'Artificial intelligence chatbot', 'jetpack-my-jetpack' ),
 			__( 'Generate text, tables, lists, and forms', 'jetpack-my-jetpack' ),
 			__( 'Refine the tone and content to your liking', 'jetpack-my-jetpack' ),

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -201,16 +201,16 @@ class Jetpack_Ai extends Product {
 	 * @return int
 	 */
 	public static function get_next_usage_tier() {
-		// if ( ! self::is_site_connected() ) {
-		// without site connection we can't know if tiers are enabled or not,
-		// hence we can't know if the next tier is 100 or 1 (unlimited).
-		// return 100;
-		// }
+		if ( ! self::is_site_connected() || ! self::has_paid_plan_for_product() ) {
+			// without site connection we can't know if tiers are enabled or not,
+			// hence we can't know if the next tier is 100 or 1 (unlimited).
+			return 100;
+		}
 
 		$info = self::get_ai_assistant_feature();
 
 		// Bail early if it's not possible to fetch the feature data or if it's included in a plan.
-		if ( self::has_paid_plan_for_product() || is_wp_error( $info ) || empty( $info ) ) {
+		if ( is_wp_error( $info ) || empty( $info ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
Revert some of the changes done on #35910 to allow product class to handle both tiers enabled/disabled properly

## Proposed changes:
Add checks for Jetpack AI enabled filter on key product class helper methods, allowing for both states to be handled properly 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1724085510340989-slack-C02TQF5VAJD

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
You'll need to use local env and sandbox public-api, I find difficult to force JN instances to use the sandbox for internal requests.


**Site never connected**:
- **tiers enabled**:
  - [ ] My Jetpack card shows "Learn more" button, leading to the interstitial
  - [ ] interstitial shows tiered features, including the tier's request limit (100 by default), 9.95/mo paid yearly
- **tiers disabled**: 
  - [x] My Jetpack card shows "Learn more" button, leading to interstitial
  - [x] interstitial shows generic features, no mention to limit, 9.95/mo paid yearly

Connect the Jetpack site

**Site connected**:

- **tiers enabled**:
  - [x] My Jetpack card shows "Upgrade" and "View" buttons. Upgrade leads to interstitial (2 columns) and View leads to AI product page
  - [x] Jetpack dashboard card shows greyed out and an "Upgrade" button leading to the interstital (same as above)
- **tiers disabled**:
  - [x] My Jetpack card shows "Upgrade" and "View" buttons. Upgrade leads to interstitial with a single feature set and price 9.95/mo (current tier 100 cost). CTA is "Get Jetpack AI"
  - [x] Jetpack dashboard card shows greyed out and an "Upgrade" button leading to the interstital (same as above)

(upgrades will not work with tiers disabled)

Re enable tiers and get an upgrade.

**Once upgraded**:
- **tiers enabled**:
  - [x] My Jetpack card shows "Upgrade" and "View" buttons. Upgrade leads to interstitial, single column upgrade, and View leads to AI product page 
  - [x] Jetpack dashboard card shows a "All features" button leading to the product page
- **tiers disabled**:
  - [x] My Jetpack card shows "View" button leading to AI product page 
  - [x] Jetpack dashboard card shows a "All features" button leading to the product page