### PR TITLE
Fix/muwpcom sharing modal checkbox alignment

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-muwpcom-sharing-modal-checkbox-alignment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-muwpcom-sharing-modal-checkbox-alignment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+MU WPCOM: Fix Post Publish Modal checkbox alignment

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -253,7 +253,7 @@ const SharingModalInner: React.FC = () => {
 						<InlineSocialLogo icon="pinterest-alt" size={ 18 } />
 					</Button>
 					<div className="wpcom-block-editor-post-published-sharing-modal__checkbox-section">
-						<FormLabel htmlFor="toggle" className="is-checkbox">
+						<FormLabel htmlFor="toggle" className="is-checkbox" style={ { display: 'flex' } }>
 							<FormInputCheckbox
 								id="toggle"
 								onChange={ () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -253,7 +253,7 @@ const SharingModalInner: React.FC = () => {
 						<InlineSocialLogo icon="pinterest-alt" size={ 18 } />
 					</Button>
 					<div className="wpcom-block-editor-post-published-sharing-modal__checkbox-section">
-						<FormLabel htmlFor="toggle" className="is-checkbox" style={ { display: 'flex' } }>
+						<FormLabel htmlFor="toggle" className="is-checkbox">
 							<FormInputCheckbox
 								id="toggle"
 								onChange={ () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/style.scss
@@ -112,6 +112,10 @@
 		.wpcom-block-editor-post-published-sharing-modal__checkbox-section {
 			margin-top: 40px;
 			color: var(--studio-gray-60);
+
+			label {
+				display: flex;
+			}
 		}
 		.form-checkbox {
 			margin-top: 1px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8755

## Proposed changes:
This is my first PR in Jetpack and I mostly wanted to see the dev workflows. The change needs just some css and for now I just added it inline. 

What is the preferred method for such a change? Using a css file or something different? I also checked the existing `is-checkbox`  css class, but I didn't find any usage in the repo neither any rules applied (through dev tools). Is it used in some cases? Can it be removed?

## Screenshots

Before            |  After
:-------------------------:|:-------------------------:
<img width="760" alt="before" src="https://github.com/user-attachments/assets/01b23c9b-b70f-4aa8-8e21-3f6ac666f007"> | <img width="760" alt="after" src="https://github.com/user-attachments/assets/f021f0cd-b943-4029-9aa7-35ef1d6f3692">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?

Νο.

## Testing instructions:
1. Create a new post and publish
2. Observe that in the sharing modal that is shown the checkbox is properly aligned.

