### PR TITLE
SSO: Automatic logic for Calypso users on classic WP.com sites

### DIFF
--- a/projects/packages/connection/changelog/fix-jetpack-sso-wpcom-classic
+++ b/projects/packages/connection/changelog/fix-jetpack-sso-wpcom-classic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+SSO: Removed the ability to skip the automatic login if site uses the WP.com classic interface

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -447,13 +447,6 @@ class SSO {
 	}
 
 	/**
-	 * Checks to determine if the user has indicated they want to use the wp-admin interface.
-	 */
-	private function use_wp_admin_interface() {
-		return 'wp-admin' === get_option( 'wpcom_admin_interface' );
-	}
-
-	/**
 	 * Initialization for a SSO request.
 	 */
 	public function login_init() {
@@ -510,7 +503,7 @@ class SSO {
 			 * to the WordPress.com login page AND  that the request to wp-login.php
 			 * is not something other than login (Like logout!)
 			 */
-			if ( ! $this->use_wp_admin_interface() && Helpers::bypass_login_forward_wpcom() && $this->wants_to_login() ) {
+			if ( Helpers::bypass_login_forward_wpcom() && $this->wants_to_login() ) {
 				add_filter( 'allowed_redirect_hosts', array( Helpers::class, 'allowed_redirect_hosts' ) );
 				$reauth  = ! empty( $_GET['force_reauth'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$sso_url = $this->get_sso_url_or_die( $reauth );

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -640,7 +640,7 @@ class SSO {
 								'jetpack_sso_login_form_explanation_text',
 								sprintf(
 									/* Translators: %s is the name of the site. */
-									__( 'You can now save time spent logging in by connecting your WordPress.com account to %s.', 'jetpack-connection' ),
+									__( 'Test - You can now save time spent logging in by connecting your WordPress.com account to %s.', 'jetpack-connection' ),
 									esc_html( $site_name )
 								)
 							);


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7953

## Proposed changes:
 TBD

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD

