### PR TITLE
SSO: Automatic login for Calypso users on classic WP.com sites

### DIFF
--- a/projects/packages/connection/changelog/fix-jetpack-sso-wpcom-classic
+++ b/projects/packages/connection/changelog/fix-jetpack-sso-wpcom-classic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+SSO: Removed the ability to skip the automatic login if site uses the WP.com classic interface

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -447,13 +447,6 @@ class SSO {
 	}
 
 	/**
-	 * Checks to determine if the user has indicated they want to use the wp-admin interface.
-	 */
-	private function use_wp_admin_interface() {
-		return 'wp-admin' === get_option( 'wpcom_admin_interface' );
-	}
-
-	/**
 	 * Initialization for a SSO request.
 	 */
 	public function login_init() {
@@ -510,7 +503,7 @@ class SSO {
 			 * to the WordPress.com login page AND  that the request to wp-login.php
 			 * is not something other than login (Like logout!)
 			 */
-			if ( ! $this->use_wp_admin_interface() && Helpers::bypass_login_forward_wpcom() && $this->wants_to_login() ) {
+			if ( Helpers::bypass_login_forward_wpcom() && $this->wants_to_login() ) {
 				add_filter( 'allowed_redirect_hosts', array( Helpers::class, 'allowed_redirect_hosts' ) );
 				$reauth  = ! empty( $_GET['force_reauth'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$sso_url = $this->get_sso_url_or_die( $reauth );

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -640,7 +640,7 @@ class SSO {
 								'jetpack_sso_login_form_explanation_text',
 								sprintf(
 									/* Translators: %s is the name of the site. */
-									__( 'Test - You can now save time spent logging in by connecting your WordPress.com account to %s.', 'jetpack-connection' ),
+									__( 'You can now save time spent logging in by connecting your WordPress.com account to %s.', 'jetpack-connection' ),
 									esc_html( $site_name )
 								)
 							);

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -640,7 +640,7 @@ class SSO {
 								'jetpack_sso_login_form_explanation_text',
 								sprintf(
 									/* Translators: %s is the name of the site. */
-									__( 'You can now save time spent logging in by connecting your WordPress.com account to %s.', 'jetpack-connection' ),
+									__( 'Test - You can now save time spent logging in by connecting your WordPress.com account to %s.', 'jetpack-connection' ),
 									esc_html( $site_name )
 								)
 							);

--- a/projects/plugins/wpcomsh/changelog/fix-jetpack-sso-wpcom-classic
+++ b/projects/plugins/wpcomsh/changelog/fix-jetpack-sso-wpcom-classic
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+SSO: Automatic logic for Calypso users of classic sites

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -127,7 +127,7 @@
 			"composer/installers": true,
 			"roots/wordpress-core-installer": true
 		},
-		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_5_1_alpha"
+		"autoloader-suffix": "26841ac2064774301cbe06d174833bfc_wpcomshⓥ5_6_0_alpha"
 	},
 	"extra": {
 		"mirror-repo": "Automattic/wpcom-site-helper",

--- a/projects/plugins/wpcomsh/package.json
+++ b/projects/plugins/wpcomsh/package.json
@@ -3,7 +3,7 @@
 	"name": "@automattic/jetpack-wpcomsh",
 	"description": "A helper for connecting WordPress.com sites to external host infrastructure.",
 	"homepage": "https://jetpack.com",
-	"version": "5.5.1-alpha",
+	"version": "5.6.0-alpha",
 	"bugs": {
 		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Wpcomsh"
 	},

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -2,14 +2,14 @@
 /**
  * Plugin Name: WordPress.com Site Helper
  * Description: A helper for connecting WordPress.com sites to external host infrastructure.
- * Version: 5.5.1-alpha
+ * Version: 5.6.0-alpha
  * Author: Automattic
  * Author URI: http://automattic.com/
  *
  * @package wpcomsh
  */
 
-define( 'WPCOMSH_VERSION', '5.5.1-alpha' );
+define( 'WPCOMSH_VERSION', '5.6.0-alpha' );
 
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -217,9 +217,29 @@ function wpcomsh_jetpack_sso_auth_cookie_expiration( $seconds ) {
 add_filter( 'jetpack_sso_auth_cookie_expiration', 'wpcomsh_jetpack_sso_auth_cookie_expiration' );
 
 /**
- * If a user is logged in to WordPress.com, log him in automatically to wp-login
+ * Determine if users who are already logged in to WordPress.com are automatically logged in to wp-admin.
  */
-add_filter( 'jetpack_sso_bypass_login_forward_wpcom', '__return_true' );
+function wpcomsh_bypass_jetpack_sso_login() {
+	/**
+	 * Sites with the classic interface:
+	 * - Automatic login if they come from Calypso.
+	 * - Otherwise we display the login form, so they can decide whether to use a WP.com account or a local account.
+	 */
+	if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
+		$calypso_domains = array(
+			'https://wordpress.com/',
+			'https://horizon.wordpress.com/',
+			'https://wpcalypso.wordpress.com/',
+			'http://calypso.localhost:3000/',
+			'http://127.0.0.1:41050/', // Desktop App.
+		);
+		return in_array( wp_get_referer(), $calypso_domains, true );
+	}
+
+	// Users of sites with the default interface are always logged in automatically.
+	return true;
+}
+add_filter( 'jetpack_sso_bypass_login_forward_wpcom', 'wpcomsh_bypass_jetpack_sso_login' );
 
 /**
  * Overwrite the default value of SSO "Match by Email" setting.


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7953

## Proposed changes:

This PR adjusts the logic introduced in https://github.com/Automattic/jetpack/pull/33940 so users of WP.com sites with the classic interface are automatically logged in to wp-admin if they come from Calypso.

If they go directly to wp-admin, we will still display the login form so they can decide whether to use a WP.com account or a local account.

**Before**


https://github.com/user-attachments/assets/49133536-b87f-4014-819c-700563d3aac4

**After**

https://github.com/user-attachments/assets/f5a035de-96ef-43b7-9973-884a8469bc14

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Install Jetpack Beta on a WoA dev site
- Open Jetpack Beta and activate the branch of this PR in the following plugins:
  - Jetpack
  - WordPress.com Features (`jetpack-mu-wpcom`)
    - Also add `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` to your `wp-config.php` file.
  - WordPress.com Site Helper (`wpcomsh`)
- Activate the classic interface on your WoA dev site
- Open an incognito/private window
- Go to `/wp-admin`
- Make sure the login form shows up which allows you to use either a WP.com account or a local account
- Go to wordpress.com
- Log in
- While in Calypso, switch to your WoA dev site
- Click on any menu that links to wp-admin
- Make sure you're automatically logged in

