### PR TITLE
AI Assistant: Recompute Breve highlights when dictionary is loaded

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-recompute-highlights
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-recompute-highlights
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Recompute Breve highlights when dictionary is loaded

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import nspell from 'nspell';
@@ -16,6 +17,7 @@ import type {
 	SpellingDictionaryContext,
 	HighlightedText,
 	SpellChecker,
+	BreveDispatch,
 } from '../../types';
 
 const debug = debugFactory( 'jetpack-ai-breve:spelling-mistakes' );
@@ -36,6 +38,10 @@ const contextRequests: {
 const fetchContext = async ( language: string ) => {
 	debug( 'Fetching spelling context from the server' );
 
+	const { setDictionaryLoading } = dispatch( 'jetpack/ai-breve' ) as BreveDispatch;
+
+	setDictionaryLoading( SPELLING_MISTAKES.name, true );
+
 	try {
 		contextRequests[ language ] = { loading: true, loaded: false, failed: false };
 		const data = await getDictionary( SPELLING_MISTAKES.name, language );
@@ -51,6 +57,8 @@ const fetchContext = async ( language: string ) => {
 		debug( 'Failed to fetch spelling context', error );
 		contextRequests[ language ] = { loading: false, loaded: false, failed: true };
 		// TODO: Handle retries
+	} finally {
+		setDictionaryLoading( SPELLING_MISTAKES.name, false );
 	}
 };
 
@@ -90,7 +98,7 @@ const getSpellchecker = ( { language = 'en' }: { language?: string } = {} ) => {
 	return spellcheckers[ language ];
 };
 
-export default function longSentences( text: string ): Array< HighlightedText > {
+export default function spellingMistakes( text: string ): Array< HighlightedText > {
 	const highlightedTexts: Array< HighlightedText > = [];
 	// Regex to match words, including contractions and hyphenated words
 	// \p{L} is a Unicode property that matches any letter in any language

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/index.ts
@@ -11,5 +11,6 @@ import { BreveControls } from './types';
 const Breve = Controls as BreveControls;
 
 export { Breve };
-export { default as Highlight, registerBreveHighlights } from './highlight';
+export { default as Highlight } from './highlight';
+export { registerBreveHighlights } from './utils/register-format';
 export { store };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/actions.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/actions.ts
@@ -50,6 +50,14 @@ export function toggleFeature( feature: string, force?: boolean ) {
 	};
 }
 
+export function setDictionaryLoading( feature: string, loading: boolean ) {
+	return {
+		type: 'SET_DICTIONARY_LOADING',
+		feature,
+		loading,
+	};
+}
+
 export function setBlockMd5( blockId: string, md5: string ) {
 	return {
 		type: 'SET_BLOCK_MD5',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/reducer.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/reducer.ts
@@ -27,7 +27,7 @@ const initialConfiguration = {
 
 export function configuration(
 	state: BreveState[ 'configuration' ] = initialConfiguration,
-	action: { type: string; enabled?: boolean; feature?: string }
+	action: { type: string; enabled?: boolean; feature?: string; loading?: boolean }
 ) {
 	switch ( action.type ) {
 		case 'SET_PROOFREAD_ENABLED': {
@@ -63,6 +63,17 @@ export function configuration(
 			return {
 				...state,
 				disabled,
+			};
+		}
+
+		case 'SET_DICTIONARY_LOADING': {
+			const loading = action.loading
+				? [ ...( state.loading ?? [] ), action.feature ]
+				: [ ...( state.loading ?? [] ) ].filter( feature => feature !== action.feature );
+
+			return {
+				...state,
+				loading,
 			};
 		}
 	}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/selectors.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/selectors.ts
@@ -3,7 +3,7 @@
  */
 import type { Anchor, BreveState } from '../types';
 
-// POPOVER
+// Popover
 
 export function isHighlightHover( state: BreveState ) {
 	return state.popover?.isHighlightHover;
@@ -21,7 +21,7 @@ export function getPopoverLevel( state: BreveState ) {
 	return state.popover?.level;
 }
 
-// CONFIGURATION
+// Configuration
 
 export function isProofreadEnabled( state: BreveState ) {
 	return state.configuration?.enabled;
@@ -29,6 +29,10 @@ export function isProofreadEnabled( state: BreveState ) {
 
 export function isFeatureEnabled( state: BreveState, feature: string ) {
 	return ! state.configuration?.disabled?.includes( feature );
+}
+
+export function isFeatureDictionaryLoading( state: BreveState, feature: string ) {
+	return state.configuration?.loading?.includes( feature );
 }
 
 export function getDisabledFeatures( state: BreveState ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
@@ -18,6 +18,7 @@ export type BreveState = {
 	configuration?: {
 		enabled?: boolean;
 		disabled?: Array< string >;
+		loading?: Array< string >;
 	};
 	suggestions?: {
 		[ key: string ]: {
@@ -41,6 +42,7 @@ export type BreveSelect = {
 	getPopoverLevel: () => number;
 	isProofreadEnabled: () => boolean;
 	isFeatureEnabled: ( feature: string ) => boolean;
+	isFeatureDictionaryLoading: ( feature: string ) => boolean;
 	getDisabledFeatures: () => Array< string >;
 	getBlockMd5: ( blockId: string ) => string;
 	getSuggestionsLoading: ( {
@@ -73,6 +75,7 @@ export type BreveDispatch = {
 	setPopoverAnchor: ( anchor: Anchor ) => void;
 	toggleProofread: ( force?: boolean ) => void;
 	toggleFeature: ( feature: string, force?: boolean ) => void;
+	setDictionaryLoading( feature: string, loading: boolean ): void;
 	invalidateSuggestions: ( blockId: string ) => void;
 	invalidateSingleSuggestion: ( feature: string, blockId: string, id: string ) => void;
 	ignoreSuggestion: ( blockId: string, id: string ) => void;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/register-format.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/register-format.ts
@@ -1,0 +1,131 @@
+/**
+ * External dependencies
+ */
+import { getBlockContent } from '@wordpress/blocks';
+import { dispatch, select } from '@wordpress/data';
+import { registerFormatType, removeFormat, RichTextValue } from '@wordpress/rich-text';
+import md5 from 'crypto-js/md5';
+/**
+ * Internal dependencies
+ */
+import features from '../features';
+import registerEvents from '../features/events';
+import highlight from '../highlight/highlight';
+import getBreveAvailability from '../utils/get-availability';
+/**
+ * Types
+ */
+import type { BreveDispatch, BreveFeature, BreveSelect } from '../types';
+import type { Block } from '@automattic/jetpack-ai-client';
+import type { WPFormat } from '@wordpress/rich-text/build-types/register-format-type';
+import type { RichTextFormatList } from '@wordpress/rich-text/build-types/types';
+
+type CoreBlockEditorSelect = {
+	getBlock: ( clientId: string ) => Block;
+};
+
+export function getFormatName( featureName: string ) {
+	return `jetpack/ai-proofread-${ featureName }`;
+}
+
+export function registerBreveHighlight( feature: BreveFeature ) {
+	if ( ! feature ) {
+		return;
+	}
+
+	const { highlight: featureHighlight, config } = feature;
+	const { name, ...configSettings } = config;
+	const formatName = getFormatName( name );
+
+	const settings = {
+		name: formatName,
+		interactive: false,
+
+		edit: () => {},
+		...configSettings,
+
+		__experimentalGetPropsForEditableTreePreparation( _select, { blockClientId } ) {
+			const {
+				getIgnoredSuggestions,
+				isFeatureEnabled,
+				isProofreadEnabled,
+				isFeatureDictionaryLoading,
+			} = select( 'jetpack/ai-breve' ) as BreveSelect;
+
+			const { getAiAssistantFeature } = select( 'wordpress-com/plans' );
+			const isFreePlan = getAiAssistantFeature().currentTier?.value === 0;
+
+			return {
+				isProofreadEnabled: isProofreadEnabled() && getBreveAvailability( isFreePlan ),
+				isFeatureEnabled: isFeatureEnabled( config.name ),
+				ignored: getIgnoredSuggestions( { blockId: blockClientId } ),
+				isFeatureDictionaryLoading: isFeatureDictionaryLoading( config.name ),
+			};
+		},
+
+		__experimentalCreatePrepareEditableTree(
+			{ isProofreadEnabled, isFeatureEnabled, ignored, isFeatureDictionaryLoading },
+			{ blockClientId, richTextIdentifier }
+		) {
+			return ( formats: Array< RichTextFormatList >, text: string ) => {
+				const { getBlock } = select( 'core/block-editor' ) as CoreBlockEditorSelect;
+				const { getBlockMd5 } = select( 'jetpack/ai-breve' ) as BreveSelect;
+				const { invalidateSuggestions, setBlockMd5 } = dispatch(
+					'jetpack/ai-breve'
+				) as BreveDispatch;
+
+				const record = { formats, text } as RichTextValue;
+				const type = formatName;
+
+				// Ignored suggestions
+				let ignoredList = ignored;
+
+				// Has to be defined here, as adding it to __experimentalGetPropsForEditableTreePreparation
+				// causes an issue with the block inserter. ref p1721746774569699-slack-C054LN8RNVA
+				const currentMd5 = getBlockMd5( blockClientId );
+
+				if ( text && isProofreadEnabled && isFeatureEnabled && ! isFeatureDictionaryLoading ) {
+					const block = getBlock( blockClientId );
+					// Only use block content for complex blocks like tables
+					const blockContent = richTextIdentifier === 'content' ? text : getBlockContent( block );
+					const textMd5 = md5( blockContent ).toString();
+
+					if ( currentMd5 !== textMd5 ) {
+						ignoredList = [];
+						invalidateSuggestions( blockClientId );
+						setBlockMd5( blockClientId, textMd5 );
+					}
+
+					const highlights = featureHighlight( text );
+					const applied = highlight( {
+						ignored: ignoredList,
+						content: record,
+						type,
+						indexes: highlights,
+						attributes: {
+							'data-breve-type': config.name,
+							'data-identifier': richTextIdentifier ?? 'none',
+							'data-block': blockClientId,
+						},
+					} );
+
+					setTimeout( () => {
+						registerEvents( blockClientId );
+					}, 100 );
+
+					return applied.formats;
+				}
+
+				return removeFormat( record, type, 0, record.text.length ).formats;
+			};
+		},
+	} as WPFormat;
+
+	registerFormatType( formatName, settings );
+}
+
+export function registerBreveHighlights() {
+	features.forEach( feature => {
+		registerBreveHighlight( feature );
+	} );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #38888 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Refactors the rich text registering function to a separate file
* Adds a `loading` state to the store for features that have their dictionary loaded async (only spelling mistakes for now)
* Recomputes the highlights once the feature is properly loaded

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor
* Delete the `jetpack-ai-breve-spelling-context-en` localStorage entry
* Reload the page
* Check that the dictionary is loaded from the CDN and the highlights are added when that is done
