### PR TITLE
AI Assistant: Accept Breve typo suggestions

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-spelling-suggestion
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-spelling-suggestion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Accept Breve typo suggestions

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -79,7 +79,7 @@ const getContext = ( language: string ) => {
 	return context;
 };
 
-const getSpellchecker = ( { language = 'en' }: { language?: string } = {} ) => {
+export const getSpellchecker = ( { language = 'en' }: { language?: string } = {} ) => {
 	if ( spellcheckers[ language ] ) {
 		return spellcheckers[ language ];
 	}
@@ -113,16 +113,11 @@ export default function spellingMistakes( text: string ): Array< HighlightedText
 
 	words.forEach( ( word: string, index ) => {
 		if ( ! spellchecker.correct( word ) ) {
-			const suggestions = spellchecker.suggest( word );
-
-			if ( suggestions.length > 0 ) {
-				highlightedTexts.push( {
-					text: word,
-					startIndex: text.indexOf( word, index ),
-					endIndex: text.indexOf( word, index ) + word.length,
-					suggestions,
-				} );
-			}
+			highlightedTexts.push( {
+				text: word,
+				startIndex: text.indexOf( word, index ),
+				endIndex: text.indexOf( word, index ) + word.length,
+			} );
 		}
 	} );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -111,14 +111,21 @@ export default function spellingMistakes( text: string ): Array< HighlightedText
 		return highlightedTexts;
 	}
 
-	words.forEach( ( word: string, index ) => {
+	// To avoid highlighting the same word occurrence multiple times
+	let searchStartIndex = 0;
+
+	words.forEach( ( word: string ) => {
+		const wordIndex = text.indexOf( word, searchStartIndex );
+
 		if ( ! spellchecker.correct( word ) ) {
 			highlightedTexts.push( {
 				text: word,
-				startIndex: text.indexOf( word, index ),
-				endIndex: text.indexOf( word, index ) + word.length,
+				startIndex: wordIndex,
+				endIndex: wordIndex + word.length,
 			} );
 		}
+
+		searchStartIndex = wordIndex + word.length;
 	} );
 
 	return highlightedTexts;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -103,7 +103,7 @@ export default function spellingMistakes( text: string ): Array< HighlightedText
 	// Regex to match words, including contractions and hyphenated words
 	// \p{L} is a Unicode property that matches any letter in any language
 	// \p{M} is a Unicode property that matches any character intended to be combined with another character
-	const wordRegex = new RegExp( /[\p{L}\p{M}'-]+/, 'gu' );
+	const wordRegex = new RegExp( /[\p{L}\p{M}']+/, 'gu' );
 	const words = text.match( wordRegex ) || [];
 	const spellchecker = getSpellchecker();
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
@@ -109,7 +109,6 @@ export type BreveFeature = {
 export type HighlightedText = {
 	text: string;
 	suggestion?: string;
-	suggestions?: Array< string >;
 	startIndex: number;
 	endIndex: number;
 };

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-target-text.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/get-target-text.ts
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import { getNodeTextIndex } from './get-node-text-index';
+import { getNonLinkAncestor } from './get-non-link-ancestor';
+
+export default function getTargetText( anchor: HTMLElement ) {
+	const target = anchor?.innerText;
+	const parent = getNonLinkAncestor( anchor as HTMLElement );
+	// The text containing the target
+	const text = parent?.innerText as string;
+	// Get the index of the target in the parent
+	const startIndex = getNodeTextIndex( parent as HTMLElement, anchor as HTMLElement );
+	// Get the occurrences of the target in the sentence
+	const targetRegex = new RegExp( target, 'gi' );
+	const matches = Array.from( text.matchAll( targetRegex ) ).map( match => match.index );
+	// Get the right occurrence of the target in the sentence
+	const occurrence = Math.max( 1, matches.indexOf( startIndex ) + 1 );
+
+	return { target, parent, text, occurrence };
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/replace-occurrence.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/utils/replace-occurrence.ts
@@ -1,0 +1,18 @@
+export default function replaceOccurrence( {
+	text,
+	target,
+	occurrence,
+	replacement,
+}: {
+	text: string;
+	target: string;
+	occurrence: number;
+	replacement: string;
+} ) {
+	const targetRegex = new RegExp( target, 'gi' );
+	const matches = Array.from( text.matchAll( targetRegex ) ).map( match => match.index );
+	const startIndex = matches[ occurrence - 1 ];
+	const endIndex = startIndex + target.length;
+
+	return text.substring( 0, startIndex ) + replacement + text.substring( endIndex );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39006

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes a bug when more than one typo that is exactly the same happens at the same text, only the first was highlighted
* Removes `-` from the words regex, as the suggestions from nspell don't work well in hyphenated words
* Moves the suggestion computation to happen when the popover is opened for performance reasons
* Adds buttons with the suggestions that can be applied immediatelly 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and add some typos to a block, with the same typo happening at least twice
* Check that the two identical typos are highlighted
* Hover over a typo
* Check that suggestions are available (not all words have suggestions, in that case the only option is to dismiss the highlight)
* Check that the correct occurrence of a typo is fixed on click
