### PR TITLE
Admin bar: use Help Center icon mask instead of svg so that it follows color scheme

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-icon-frontend
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-icon-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: fix the color of the Help Center icon on frontend

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -90,7 +90,7 @@ class Help_Center {
 					$wp_admin_bar->add_menu(
 						array(
 							'id'     => 'help-center',
-							'title'  => self::download_asset( 'widgets.wp.com/help-center/help-icon.svg', false ),
+							'title'  => '<span id="help-center-icon" class="ab-icon"></span><span id="help-center-icon-with-notification" class="ab-icon"></span>',
 							'parent' => 'top-secondary',
 							'href'   => $this->get_help_center_url(),
 							'meta'   => array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -96,16 +96,6 @@ CSS
 			}
 CSS
 	);
-
-	// Force wpcom icons to have consistent color.
-	wp_add_inline_style(
-		'wpcom-admin-bar',
-		<<<CSS
-			#wpadminbar .ab-icon {
-				color: $admin_icon_color;
-			}
-CSS
-	);
 }
 add_action( 'wp_enqueue_scripts', 'wpcom_enqueue_admin_bar_assets' );
 add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_admin_bar_assets' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -181,8 +181,25 @@
 				display: block !important;
 				width: 52px !important;
 				margin-right: 0 !important;
+
 				.ab-item {
-					width: 52px;
+					display: flex;
+					justify-content: center;
+
+					.ab-icon {
+						width: 30px;
+						height: 46px;
+
+						&:before {
+							background-position-y: bottom;
+							background-position-x: center;
+							top: 0 !important;
+							left: 0 !important;
+							width: 30px !important;
+							height: 46px !important;
+							background-size: contain;
+						}
+					}
 				}
 			}
 


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/8821

## Proposed changes:

This PR uses the new Help Center mask image from https://github.com/Automattic/wp-calypso/pull/93804, so that it follows the correct admin color scheme on both admin and frontend screens.

Previously, it always uses the admin color scheme even on frontend screens due to this hack:

https://github.com/Automattic/jetpack/blob/a6c16b2318275f612c91151c759b5d3bfd9767e5/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php#L100-L108

Now, in this PR, we removed the problematic CSS hack and uses the mask. It works because WordPress already styles icons with the correct color everywhere if the icon is presented as `.ab-icon:before`.

For example, on a Modern color scheme:

|||
|-|-|
|Before|<img width="284" alt="image" src="https://github.com/user-attachments/assets/92b30e83-c8e3-4e7c-b3db-246c3b36fd19">|
|After|<img width="284" alt="image" src="https://github.com/user-attachments/assets/822e15c6-3b3c-4590-bfcb-6f52b8b75480">|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. First, follow the instructions from https://github.com/Automattic/wp-calypso/pull/93804 to set up the new CSS on your sandbox.
2. Go to `wp-admin/profile.php` and set the color scheme to Modern.
3. Apply this to your sandbox: `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix-help-center-icon-frontend`
4. Go to site frontend; verify that the help center color is correct (see above screenshot)
5. Go to wp-admin screens; verify that the help center color is correct (following the Modern scheme)
6. Verify that the Help Center icon is still working as usual.

