### PR TITLE
MU WPCOM: Disable the Open Graph Tags according to the privacy of the site

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-disable-seo-tag-by-privacy
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-disable-seo-tag-by-privacy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+MU WPCOM: Disable the Open Graph Tags according to the privacy of the site

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -61,3 +61,23 @@ function robots_txt( string $output, $public ): string {
 }
 
 add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 12, 2 );
+
+/**
+ * Disable the Open Graph Tags based on the value of either wpcom_public_coming_soon and wpcom_data_sharing_opt_out option.
+ */
+function remove_og_tags() {
+	if ( ! (bool) get_option( 'wpcom_public_coming_soon ' ) && ! (bool) get_option( 'wpcom_data_sharing_opt_out' ) ) {
+		return;
+	}
+
+	// Disable Jetpack Open Graph Tags.
+	remove_action( 'wp_head', 'jetpack_og_tags' );
+
+	// Disable Yoast SEO. See https://developer.yoast.com/customization/yoast-seo/disabling-yoast-seo/.
+	if ( function_exists( 'YoastSEO' ) ) {
+		$front_end = \YoastSEO()->classes->get( \Yoast\WP\SEO\Integrations\Front_End_Integration::class );
+		remove_action( 'wpseo_head', array( $front_end, 'present_head' ), -9999 );
+	}
+}
+
+add_action( 'init', __NAMESPACE__ . '\remove_og_tags' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -70,12 +70,17 @@ function remove_og_tags() {
 		return;
 	}
 
-	/** This filter is documented in class.jetpack.php */
-	$jetpack_enable_open_graph = apply_filters( 'jetpack_enable_open_graph', false );
 	// Disable Jetpack Open Graph Tags.
-	if ( $jetpack_enable_open_graph && function_exists( 'jetpack_og_tags' ) ) {
+	if ( function_exists( 'jetpack_og_tags' ) ) {
 		// @phan-suppress-next-line PhanUndeclaredFunctionInCallable
 		remove_action( 'wp_head', 'jetpack_og_tags' );
+	}
+
+	// Avoid calling check_open_graph as it registers the jetpack_og_tags function when running wp_head action.
+	if ( class_exists( '\Jetpack', false ) ) {
+		// @phan-suppress-next-line PhanUndeclaredFunction, PhanUndeclaredClassReference
+		$jetpack = \Jetpack::init();
+		remove_action( 'wp_head', array( $jetpack, 'check_open_graph' ), 1 );
 	}
 
 	// Disable Yoast SEO. See https://developer.yoast.com/customization/yoast-seo/disabling-yoast-seo/.
@@ -86,4 +91,4 @@ function remove_og_tags() {
 	}
 }
 
-add_action( 'init', __NAMESPACE__ . '\remove_og_tags' );
+add_action( 'wp_head', __NAMESPACE__ . '\remove_og_tags', 0 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -77,8 +77,9 @@ function remove_og_tags() {
 	}
 
 	// Avoid calling check_open_graph as it registers the jetpack_og_tags function when running wp_head action.
-	if ( class_exists( '\Jetpack', false ) ) {
-		// @phan-suppress-next-line PhanUndeclaredFunction, PhanUndeclaredClassReference
+	// @phan-suppress-next-line PhanUndeclaredClassInCallable
+	if ( class_exists( '\Jetpack', false ) && is_callable( 'Jetpack::init' ) ) {
+		// @phan-suppress-next-line PhanUndeclaredClassMethod
 		$jetpack = \Jetpack::init();
 		remove_action( 'wp_head', array( $jetpack, 'check_open_graph' ), 1 );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -66,7 +66,7 @@ add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 12, 2 );
  * Disable the Open Graph Tags based on the value of either wpcom_public_coming_soon and wpcom_data_sharing_opt_out option.
  */
 function remove_og_tags() {
-	if ( ! (bool) get_option( 'wpcom_public_coming_soon ' ) && ! (bool) get_option( 'wpcom_data_sharing_opt_out' ) ) {
+	if ( ! (bool) get_option( 'wpcom_public_coming_soon' ) && ! (bool) get_option( 'wpcom_data_sharing_opt_out' ) ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -71,18 +71,7 @@ function remove_og_tags() {
 	}
 
 	// Disable Jetpack Open Graph Tags.
-	if ( function_exists( 'jetpack_og_tags' ) ) {
-		// @phan-suppress-next-line PhanUndeclaredFunctionInCallable
-		remove_action( 'wp_head', 'jetpack_og_tags' );
-	}
-
-	// Avoid calling check_open_graph as it registers the jetpack_og_tags function when running wp_head action.
-	// @phan-suppress-next-line PhanUndeclaredClassInCallable
-	if ( class_exists( '\Jetpack', false ) && is_callable( 'Jetpack::init' ) ) {
-		// @phan-suppress-next-line PhanUndeclaredClassMethod
-		$jetpack = \Jetpack::init();
-		remove_action( 'wp_head', array( $jetpack, 'check_open_graph' ), 1 );
-	}
+	add_filter( 'jetpack_enable_open_graph', '__return_false', 99 );
 
 	// Disable Yoast SEO. See https://developer.yoast.com/customization/yoast-seo/disabling-yoast-seo/.
 	if ( function_exists( 'YoastSEO' ) && class_exists( 'Yoast\WP\SEO\Integrations\Front_End_Integration', false ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -63,7 +63,7 @@ function robots_txt( string $output, $public ): string {
 add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 12, 2 );
 
 /**
- * Disable the Open Graph Tags based on the value of either wpcom_public_coming_soon and wpcom_data_sharing_opt_out option.
+ * Disable the Open Graph Tags based on the value of either wpcom_public_coming_soon option.
  */
 function remove_og_tags() {
 	if ( ! (bool) get_option( 'wpcom_public_coming_soon' ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -70,8 +70,10 @@ function remove_og_tags() {
 		return;
 	}
 
+	/** This filter is documented in class.jetpack.php */
+	$jetpack_enable_open_graph = apply_filters( 'jetpack_enable_open_graph', false );
 	// Disable Jetpack Open Graph Tags.
-	if ( function_exists( 'jetpack_og_tags' ) ) {
+	if ( $jetpack_enable_open_graph && function_exists( 'jetpack_og_tags' ) ) {
 		// @phan-suppress-next-line PhanUndeclaredFunctionInCallable
 		remove_action( 'wp_head', 'jetpack_og_tags' );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -71,10 +71,14 @@ function remove_og_tags() {
 	}
 
 	// Disable Jetpack Open Graph Tags.
-	remove_action( 'wp_head', 'jetpack_og_tags' );
+	if ( function_exists( 'jetpack_og_tags' ) ) {
+		// @phan-suppress-next-line PhanUndeclaredFunctionInCallable
+		remove_action( 'wp_head', 'jetpack_og_tags' );
+	}
 
 	// Disable Yoast SEO. See https://developer.yoast.com/customization/yoast-seo/disabling-yoast-seo/.
-	if ( function_exists( 'YoastSEO' ) ) {
+	if ( function_exists( 'YoastSEO' ) && class_exists( 'Yoast\WP\SEO\Integrations\Front_End_Integration', false ) ) {
+		// @phan-suppress-next-line PhanUndeclaredFunction, PhanUndeclaredClassReference
 		$front_end = \YoastSEO()->classes->get( \Yoast\WP\SEO\Integrations\Front_End_Integration::class );
 		remove_action( 'wpseo_head', array( $front_end, 'present_head' ), -9999 );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -66,7 +66,7 @@ add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 12, 2 );
  * Disable the Open Graph Tags based on the value of either wpcom_public_coming_soon and wpcom_data_sharing_opt_out option.
  */
 function remove_og_tags() {
-	if ( ! (bool) get_option( 'wpcom_public_coming_soon' ) && ! (bool) get_option( 'wpcom_data_sharing_opt_out' ) ) {
+	if ( ! (bool) get_option( 'wpcom_public_coming_soon' ) ) {
 		return;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/92385

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add filter to disable the action to print OG tags by either Jetpack or YoastSEO

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes as below
  * On simple sites, apply changes to wpcom and sandbox your site
  * On atomic sites, apply changes to your site directly
* Go to https://wordpress.com/settings/general/:site
* Set the Privacy to one of the below
  * Coming Soon
  * Public & Prevent third-party sharing
* Open your site with the Incognito mode
* Make sure the OG tags are removed
* If your site is an atomic site, then install YoastSEO and make sure the OG tags of YoastSEO are removed either

