### PR TITLE
Replace the language selector with a link to WPCOM

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-locale-to-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-locale-to-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Replace language selector with a link to WPCOM

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -62,7 +62,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.57.x-dev"
+			"dev-trunk": "5.58.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.57.2-alpha",
+	"version": "5.58.0-alpha",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -13,7 +13,7 @@ namespace Automattic\Jetpack;
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.57.2-alpha';
+	const PACKAGE_VERSION = '5.58.0-alpha';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
@@ -45,6 +45,10 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 		'wpcom-profile-settings-link-to-wpcom',
 		'wpcomProfileSettingsLinkToWpcom',
 		array(
+			'language'             => array(
+				'link' => esc_url( $wpcom_host . '/me/account' ),
+				'text' => __( 'Your admin interface language is managed on WordPress.com Account settings', 'jetpack-mu-wpcom' ),
+			),
 			'synced'               => array(
 				'link' => esc_url( $wpcom_host . '/me' ),
 				'text' => __( 'You can manage your profile on WordPress.com Profile settings (First / Last / Display Names, Website, and Biographical Info)', 'jetpack-mu-wpcom' ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -18,18 +18,28 @@ const wpcom_profile_settings_disable_email_field = () => {
  * Add a link to the WordPress.com profile settings page.
  */
 const wpcom_profile_settings_add_links_to_wpcom = () => {
-	const usernameSection = document.querySelector( '.user-user-login-wrap' )?.querySelector( 'td' );
-	const emailSection = document.querySelector( '.user-email-wrap' )?.querySelector( 'td' );
-	const newPasswordSection = document.getElementById( 'password' )?.querySelector( 'td' );
 	const userSessionSection = document.querySelector( '.user-sessions-wrap' );
-
 	userSessionSection?.remove();
 
 	// We cannot set a password in wp-admin except on Atomic Classic sites.
+	const newPasswordSection = document.getElementById( 'password' )?.querySelector( 'td' );
 	if ( ! window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomicClassic && newPasswordSection ) {
 		newPasswordSection.innerHTML = '';
 	}
 
+	const languageSection = document.querySelector( '.user-language-wrap' )?.querySelector( 'td' );
+	const languageSelect = document.getElementById( 'locale' );
+	const languageSettingsLink = window.wpcomProfileSettingsLinkToWpcom?.language?.link;
+	const languageSettingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.language?.text;
+	if ( languageSettingsLink && languageSettingsLinkText ) {
+		const notice = document.createElement( 'p' );
+		notice.className = 'description';
+		notice.innerHTML = `<a href="${ languageSettingsLink }">${ languageSettingsLinkText }</a>.`;
+		languageSection?.appendChild( notice );
+		languageSelect?.remove();
+	}
+
+	const emailSection = document.querySelector( '.user-email-wrap' )?.querySelector( 'td' );
 	const emailSettingsLink = window.wpcomProfileSettingsLinkToWpcom?.email?.link;
 	const emailSettingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.email?.text;
 	if ( emailSection && emailSettingsLink && emailSettingsLinkText ) {
@@ -48,6 +58,7 @@ const wpcom_profile_settings_add_links_to_wpcom = () => {
 		newPasswordSection.appendChild( notice );
 	}
 
+	const usernameSection = document.querySelector( '.user-user-login-wrap' )?.querySelector( 'td' );
 	const syncedSettingsLink = window.wpcomProfileSettingsLinkToWpcom?.synced?.link;
 	const syncedSettingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.synced?.text;
 	if ( usernameSection && syncedSettingsLink && syncedSettingsLinkText ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/types.d.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/types.d.ts
@@ -1,6 +1,14 @@
 declare global {
 	interface Window {
 		wpcomProfileSettingsLinkToWpcom: {
+			language: {
+				link: string;
+				text: string;
+			};
+			synced: {
+				link: string;
+				text: string;
+			};
 			email: {
 				link: string;
 				text: string;

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-locale-to-wpcom
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-locale-to-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1005,7 +1005,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "022350b06a2d6341c35415ada223184263b916e8"
+                "reference": "acaaab4c89fce8ed6ad2ea4986cf3e1e6f127b14"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1039,7 +1039,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.57.x-dev"
+                    "dev-trunk": "5.58.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/changelog/update-locale-to-wpcom
+++ b/projects/plugins/wpcomsh/changelog/update-locale-to-wpcom
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1142,7 +1142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "022350b06a2d6341c35415ada223184263b916e8"
+                "reference": "acaaab4c89fce8ed6ad2ea4986cf3e1e6f127b14"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1176,7 +1176,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.57.x-dev"
+                    "dev-trunk": "5.58.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

> [!WARNING]  
> This PR should be merged after https://github.com/Automattic/jetpack/pull/39009

This PR replaces the language selector in profile.php with a link to /me/account. Please see https://github.com/Automattic/dotcom-forge/issues/8835 for more context. 

also close https://github.com/Automattic/dotcom-forge/issues/8496

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test the following in Simple Default/Atomic Default/Simple Classic/Atomic Classic

* Go to wp-admin/profile.php
* Observe the locale selector is replaced with a link to /me/account



