### PR TITLE
Admin bar: fix icon colors on site frontend

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-frontend-icon-color
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-frontend-icon-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: fix icon colors on site frontend

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -83,7 +83,7 @@ CSS
 		);
 	}
 
-	$admin_color      = get_user_option( 'admin_color' );
+	$admin_color      = is_admin() ? get_user_option( 'admin_color' ) : 'fresh';
 	$admin_icon_color = WPCOM_ADMIN_ICON_COLORS[ $admin_color ] ?? WPCOM_ADMIN_ICON_COLORS['fresh'];
 
 	// Force the icon colors to have desktop color even on mobile viewport.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -179,11 +179,8 @@
 
 			#wp-admin-bar-help-center {
 				display: block !important;
-				width: 52px !important;
+				width: 49px !important;
 				margin-right: 0 !important;
-				.ab-item {
-					width: 52px;
-				}
 			}
 
 			#wp-admin-bar-notes {


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/8821

## Proposed changes:

This PR fixes the logic that make wpcom icons have the correct color scheme.

There are multiple subtle things that are being fixed here due to the inconsistency of how HTML structure of the wpcom icons in the admin bar:

- Help Center uses `<svg>`.
- All other icons uses `.ab-icon:before` with a `mask-image`.

The bug is as follows:

- On site frontend on Desktop, the Help Center icon previously always use the admin color scheme, instead of the default color.
- On site frontend on Mobile, all icons previously always use the admin color scheme, instead of the default color.

This PR fixes all the above cases.

### Site frontend, Desktop

|||
|-|-|
|Before|<img width="284" alt="image" src="https://github.com/user-attachments/assets/92b30e83-c8e3-4e7c-b3db-246c3b36fd19">|
|After|<img width="284" alt="image" src="https://github.com/user-attachments/assets/822e15c6-3b3c-4590-bfcb-6f52b8b75480">|


### Site frontend, Mobile

|||
|-|-|
|Before|<img width="364" alt="image" src="https://github.com/user-attachments/assets/5974d6c6-33f8-4515-a3e8-4d2326d304fa">|
|After|<img width="364" alt="image" src="https://github.com/user-attachments/assets/e5c5b167-b7fa-41b2-92d4-c9f011d078e2">|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare an Atomic Classic site.
1. Patch this to your Beta Tester.
2. Go to `wp-admin/profile.php` and set the color scheme to Modern.
3. Verify the cases in the above screenshots.

