### PR TITLE
Social: Add share status feature flag

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-social-share-status-feature-flag
+++ b/projects/js-packages/publicize-components/changelog/add-social-share-status-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added the new feature flag for the social share status

--- a/projects/js-packages/publicize-components/package.json
+++ b/projects/js-packages/publicize-components/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize-components",
-	"version": "0.62.1-alpha",
+	"version": "0.63.0-alpha",
 	"description": "A library of JS components required by the Publicize editor plugin",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/publicize-components/#readme",
 	"bugs": {

--- a/projects/js-packages/publicize-components/src/components/panel/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.jsx
@@ -12,6 +12,7 @@ import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useRefreshConnections from '../../hooks/use-refresh-connections';
 import { usePostJustPublished } from '../../hooks/use-saving-post';
 import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
+import { store as socialStore } from '../../social-store';
 import PublicizeForm from '../form';
 import { ManualSharing } from '../manual-sharing';
 import { SharePostRow } from '../share-post';
@@ -24,6 +25,13 @@ const PublicizePanel = ( { prePublish, children } ) => {
 	const refreshConnections = useRefreshConnections();
 
 	const { isPublicizeEnabled, hidePublicizeFeature, togglePublicizeFeature } = usePublicizeConfig();
+
+	const { featureFlags } = useSelect( select => {
+		const store = select( socialStore );
+		return {
+			featureFlags: store.featureFlags(),
+		};
+	}, [] );
 
 	// Refresh connections when the post is just published.
 	usePostJustPublished(
@@ -71,7 +79,12 @@ const PublicizePanel = ( { prePublish, children } ) => {
 					<SharePostRow />
 				</Fragment>
 			) }
-			{ isPostPublished && <ManualSharing /> }
+			{ isPostPublished && (
+				<>
+					<ManualSharing />
+					{ featureFlags?.useShareStatus && 'Share status modal comes here' }
+				</>
+			) }
 		</PanelWrapper>
 	);
 };

--- a/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.jsx
@@ -4,6 +4,7 @@ import { useSelect } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
+import { store as socialStore } from '../../social-store';
 import { ManualSharingInfo } from '../manual-sharing/info';
 import { ShareButtons } from '../share-buttons/share-buttons';
 import styles from './styles.module.scss';
@@ -14,6 +15,13 @@ import styles from './styles.module.scss';
  */
 export default function PostPublishManualSharing() {
 	const { isCurrentPostPublished } = useSelect( select => select( editorStore ), [] );
+
+	const { featureFlags } = useSelect( select => {
+		const store = select( socialStore );
+		return {
+			featureFlags: store.featureFlags(),
+		};
+	}, [] );
 
 	if ( ! isCurrentPostPublished() ) {
 		return null;
@@ -29,6 +37,7 @@ export default function PostPublishManualSharing() {
 			<ThemeProvider>
 				<ManualSharingInfo className={ styles.description } variant="body-small" />
 				<ShareButtons />
+				{ featureFlags?.useShareStatus && 'Share status modal comes here' }
 			</ThemeProvider>
 		</PluginPostPublishPanel>
 	);

--- a/projects/packages/publicize/changelog/add-social-share-status-feature-flag
+++ b/projects/packages/publicize/changelog/add-social-share-status-feature-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added the new feature flag for the social share status

--- a/projects/packages/publicize/composer.json
+++ b/projects/packages/publicize/composer.json
@@ -68,7 +68,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.49.x-dev"
+			"dev-trunk": "0.50.x-dev"
 		}
 	},
 	"config": {

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.49.3-alpha",
+	"version": "0.50.0-alpha",
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",
 	"bugs": {

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -52,6 +52,11 @@ class Settings {
 			'feature_name'  => 'editor-preview',
 			'variable_name' => 'useEditorPreview',
 		),
+		array(
+			'flag_name'     => 'share_status',
+			'feature_name'  => 'share-status',
+			'variable_name' => 'useShareStatus',
+		),
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-social-share-status-feature-flag
+++ b/projects/plugins/jetpack/changelog/add-social-share-status-feature-flag
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2222,7 +2222,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/publicize",
-				"reference": "da20bd94a839a28d9d718d79246f35edf5e33567"
+				"reference": "a93a6a56a70e7f1aa7fc965efaecd0000804f0f4"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -2250,7 +2250,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.49.x-dev"
+					"dev-trunk": "0.50.x-dev"
 				}
 			},
 			"autoload": {

--- a/projects/plugins/social/changelog/add-social-share-status-feature-flag
+++ b/projects/plugins/social/changelog/add-social-share-status-feature-flag
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1494,7 +1494,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/publicize",
-				"reference": "da20bd94a839a28d9d718d79246f35edf5e33567"
+				"reference": "a93a6a56a70e7f1aa7fc965efaecd0000804f0f4"
 			},
 			"require": {
 				"automattic/jetpack-assets": "@dev",
@@ -1522,7 +1522,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-publicize/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "0.49.x-dev"
+					"dev-trunk": "0.50.x-dev"
 				}
 			},
 			"autoload": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/530

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/530
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to editor. You should not see the `Share status modal comes here` span below manual sharing.
* Run `jetpack docker wp option update jetpack_social_has_share_status true` and refresh the editor.
* You should see the `Share status modal comes here` span below the manual sharing.
* The same should happen in the post-publish panel.
