### PR TITLE
Payment Buttons: ensure assets are loaded properly

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-load-assets-payment-buttons
+++ b/projects/plugins/jetpack/changelog/fix-load-assets-payment-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Payment Button Blocks: ensure that the buttons' stylesheet is properly loaded on the frontend.

--- a/projects/plugins/jetpack/changelog/fix-load-assets-payment-buttons#2
+++ b/projects/plugins/jetpack/changelog/fix-load-assets-payment-buttons#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Contact Info Block: ensure that the buttons' stylesheet is properly loaded on the frontend.

--- a/projects/plugins/jetpack/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
+++ b/projects/plugins/jetpack/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
@@ -22,7 +22,7 @@ class Jetpack_Contact_Info_Block {
 	 * @return string
 	 */
 	public static function render( $attr, $content ) {
-		Jetpack_Gutenberg::load_styles_as_required( __DIR__ );
+		Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 		return str_replace(
 			'class="wp-block-jetpack-contact-info', // Closing " intentionally ommited to that the user can also add the className as expected.
 			'itemprop="location" itemscope itemtype="http://schema.org/Organization" class="wp-block-jetpack-contact-info',

--- a/projects/plugins/jetpack/extensions/blocks/payment-buttons/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/payment-buttons/editor.scss
@@ -2,7 +2,7 @@
 	--jetpack-payment-buttons-gap: 0.5em;
 	&.is-layout-flex {
 		gap: var(--jetpack-payment-buttons-gap);
-		display: block;
+		display: flex;
 	}
 	&.is-layout-flex .is-layout-flex {
 		display:flex;

--- a/projects/plugins/jetpack/extensions/blocks/payment-buttons/payment-buttons.php
+++ b/projects/plugins/jetpack/extensions/blocks/payment-buttons/payment-buttons.php
@@ -61,7 +61,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  * @return string
  */
 function render_block( $attributes, $content ) {
-	\Jetpack_Gutenberg::load_styles_as_required( __DIR__ );
+	\Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
 	return $content;
 }


### PR DESCRIPTION
Fixes #38790

## Proposed changes:

See https://github.com/Automattic/jetpack/issues/38790#issuecomment-2303999388

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Posts > Add New
* Add a Payments button block
* Inside that block, add one or more payment blocks.
* Publish your post.
* Load the post on the frontend and view source.
* Look for `.wp-block-jetpack-payment-buttons`; you should see the style added inline on the page.
