### PR TITLE
Image Guide: Fix uncaught exception

### DIFF
--- a/projects/js-packages/image-guide/changelog/fix-uncaught-exception
+++ b/projects/js-packages/image-guide/changelog/fix-uncaught-exception
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix: Handle uncaught exception for images with empty or no src attributes.

--- a/projects/js-packages/image-guide/src/find-image-elements.ts
+++ b/projects/js-packages/image-guide/src/find-image-elements.ts
@@ -9,7 +9,16 @@ import { MeasurableImage, type FetchFn } from './MeasurableImage.js';
 export function findMeasurableElements( nodes: Element[] ): HTMLElement[] | HTMLImageElement[] {
 	return nodes.filter( ( el ): el is HTMLElement | HTMLImageElement => {
 		if ( el instanceof HTMLImageElement ) {
-			if ( isSvgUrl( el.src ) ) {
+			// Handle img tags with empty or no src attributes.
+			if ( ! el.src.trim() ) {
+				return false;
+			}
+
+			try {
+				if ( isSvgUrl( el.src ) ) {
+					return false;
+				}
+			} catch ( e ) {
 				return false;
 			}
 			return true;

--- a/projects/js-packages/image-guide/src/find-image-elements.ts
+++ b/projects/js-packages/image-guide/src/find-image-elements.ts
@@ -67,6 +67,13 @@ export function backgroundImageSource( node: HTMLElement ) {
 	return null;
 }
 
+/**
+ * Check if a URL is an SVG.
+ *
+ * @param {string} srcUrl - The URL to check
+ * @throws {Error} - If the URL is not valid.
+ * @return {boolean} - true if the URL is an SVG
+ */
 function isSvgUrl( srcUrl: string ): boolean {
 	const url = new URL( srcUrl );
 	return url.pathname.toLowerCase().endsWith( '.svg' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/boost-cloud/issues/564

This fix also affects the Image Size Analysis in the Boost Cloud, but it's a bit harder to test, so I just left instructions for the version in the Boost plugin. The equivalent of the bug in the cloud is that the ISA report gets stuck, because of the invalid payload sent to the cloud (check the related issue for more info). This PR adds a fix that skip images with invalid src attributes and handles the uncaught exception (in cases where the src value is not a valid URL).

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Handle uncaught exception when an img tag has an empty src attribute, or the src attribute is missing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1724223575633099-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Test that it breaks

* Use `trunk`;
* Setup Boost free;
* Add the following HTML to the body of a page on your test site:
   ```html
   <img style="display:none;" alt="This is an invalid image" role="presentation" />
   ```
* Enable Image Guide;
* Open the page with the image and check the console - there should be an Uncaught error `TypeError: Failed to construct 'URL': Invalid URL`.

### Test that it works

* Apply this branch;
* Use Boost free again;
* Make sure to have the HTML on a page;
* Enable Image Guide;
* Check the page - there shouldn't be an error in the console.