### PR TITLE
Admin Page: remove extra link to activate Jetpack Stats

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -203,13 +203,10 @@ class SiteStatsComponent extends React.Component {
 								? __( 'Unavailable in Offline Mode', 'jetpack' )
 								: createInterpolateElement(
 										__(
-											'<Button>Activate Jetpack Stats</Button> to see page views, likes, followers, subscribers, and more! <a>Learn More</a>',
+											'Activate Jetpack Stats to see page views, likes, followers, subscribers, and more! <a>Learn More</a>',
 											'jetpack'
 										),
 										{
-											Button: (
-												<Button rna className="jp-link-button" onClick={ this.activateStats } />
-											),
 											a: (
 												<a
 													href={ getRedirectUrl( 'jetpack-support-wordpress-com-stats' ) }

--- a/projects/plugins/jetpack/changelog/update-stats-banner-activate
+++ b/projects/plugins/jetpack/changelog/update-stats-banner-activate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Dashboard: remove extra link in banner to invite admins to activate stats.


### PR DESCRIPTION
See #37616

## Proposed changes:

Including a button within the feature description isn't pretty, and doesn't bring any value when we already have a button on the right of the feature description.

**Before**

<img width="1111" alt="Screenshot 2024-08-22 at 14 47 04" src="https://github.com/user-attachments/assets/ca3f0ab7-23d7-4f62-9add-ab1523388059">

**After**

<img width="1107" alt="Screenshot 2024-08-22 at 14 48 11" src="https://github.com/user-attachments/assets/1e5448d1-a811-4dbd-a276-2cec6d7cc6b7">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Go to Jetpack > Settings > Modules
* Deactivate the Stats feature
* Go to Jetpack > Settings > Traffic
* Check the stats card, and note that you can activate the Stats feature from there.
