### PR TITLE
Fix/tooltip for watch time videopress card

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
@@ -89,7 +89,7 @@ const useTooltipCopy = () => {
 	);
 
 	const watchTime = {
-		title: period === 'day' ? thirtyDayViews : yearlyViews,
+		title: __( 'Total time watched', 'jetpack-my-jetpack' ),
 		text: period === 'day' ? watchTimeTextDay : watchTimeTextYear,
 	};
 

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/use-tooltip-copy.ts
@@ -61,16 +61,12 @@ const useTooltipCopy = () => {
 	const thirtyDayViews = __( '30-Day views', 'jetpack-my-jetpack' );
 	const yearlyViews = __( 'Yearly views', 'jetpack-my-jetpack' );
 
-	const viewsWithPlanTextDay = _n(
-		'This metric represents the total number of views your video has received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
-		'This metric represents the total number of views your videos have received on our platform over the past 30 days, comparing it with the performance of the previous 30 days.',
-		videoCount,
+	const viewsWithPlanTextDay = __(
+		'This metric shows your total video views over the past 30 days, compared to the previous 30 days.',
 		'jetpack-my-jetpack'
 	);
-	const viewsWithPlanTextYear = _n(
-		'This metric represents the total number of views your video have received on our platform over the past year.',
-		'This metric represents the total number of views your videos have received on our platform over the past year.',
-		videoCount,
+	const viewsWithPlanTextYear = __(
+		'This metric shows your total video views over the past year.',
 		'jetpack-my-jetpack'
 	);
 
@@ -80,7 +76,7 @@ const useTooltipCopy = () => {
 	};
 
 	const watchTimeTextDay = __(
-		'This metric shows total video viewing time for the last 30 days, comparing it with the performance of the previous 30 days.',
+		'This metric shows your total video viewing time over the past 30 days, compared to the previous 30 days.',
 		'jetpack-my-jetpack'
 	);
 	const watchTimeTextYear = __(

--- a/projects/packages/my-jetpack/changelog/fix-tooltip-for-watch-time-videopress-card
+++ b/projects/packages/my-jetpack/changelog/fix-tooltip-for-watch-time-videopress-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix tooltip title for videopress card


### PR DESCRIPTION
## Proposed changes:

* Fix title for watch time tooltip on VideoPress card
* Make tooltips shorter (recommended by @ilonagl)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: p1HpG7-rb7-p2#comment-73468

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Check this branch out on your local environment (you can try this on jurassic tube as well, but switching contexts will be annoying because of the transient that keeps the data if you don't comment it out)
2. Go to [this line of code](https://github.com/Automattic/jetpack/pull/38979/files#diff-2be902912ee7edeeeed04156e4456f5966e480fea3067586ff451c63b2bf2624R321) and comment out the transient
3. Make sure your local environment is pointing to your sandbox
4. Make sure your testing site is User connected, has at least 1 video on it, and has VideoPress active
5. Now to go to this line of code on the backend: fbhepr%2Skers%2Sjcpbz%2Schoyvp.ncv%2Serfg%2Sjcpbz%2Qwfba%2Qraqcbvagf%2Spynff.jcpbz%2Qwfba%2Qncv%2Qfgngf%2Qivqrb%2Qcynlf%2Qi1%2Q1%2Qraqcbvag.cuc%3Se%3Q210o65nn%26zb%3Q1199%26sv%3Q37%2350-og and replace the 0's with
```php
'impressions' => wp_rand( 0, 300 ),
'views'       => wp_rand( 0, 300 ),
'watch_time'  => wp_rand( 0, 5 ),
```
6. Refresh My Jetpack and make sure the Watch time tooltip makes sense
![image](https://github.com/user-attachments/assets/2e406770-1ed4-45b6-85de-e67ed6ad6e8b)
