### PR TITLE
Fix inconsistent admin color scheme when previewing on Simple Default

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-simple-default-admin-color
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-simple-default-admin-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Inconsistent Color Scheme when previewing on Simple Default

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -9,6 +9,8 @@
 
 namespace Automattic\Jetpack;
 
+define( 'WPCOM_ADMIN_BAR_UNIFICATION', true );
+
 /**
  * Jetpack_Mu_Wpcom main class.
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/admin-color-schemes/admin-color-schemes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/admin-color-schemes/admin-color-schemes.php
@@ -11,6 +11,6 @@ use Automattic\Jetpack\Status\Host;
 // @TODO Ideally we should remove this feature entirely and update Jetpack_Mu_Wpcom::load_features to initialize
 // Masterbar for both WoA and Simple sites.
 // This would require removing the relevant Masterbar code on WPCOM and rely on the package only.
-if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' && ( new Host() )->is_wpcom_simple() ) {
+if ( ( new Host() )->is_wpcom_simple() ) {
 	new Admin_Color_Schemes();
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -10,8 +10,6 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
-define( 'WPCOM_ADMIN_BAR_UNIFICATION', true );
-
 // The $icon-color variable for admin color schemes.
 // See: https://github.com/WordPress/wordpress-develop/blob/679cc0c4a261a77bd8fdb140cd9b0b2ff80ebf37/src/wp-admin/css/colors/_variables.scss#L9
 // Only the ones different from the "fresh" scheme are listed.

--- a/projects/packages/masterbar/changelog/fix-simple-default-admin-color
+++ b/projects/packages/masterbar/changelog/fix-simple-default-admin-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Inconsistent Color Scheme when previewing on Simple Default

--- a/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
+++ b/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
@@ -32,10 +32,10 @@ class Admin_Color_Schemes {
 			add_action( 'rest_api_init', array( $this, 'register_admin_color_meta' ) );
 		}
 
-		if ( ( defined( 'WPCOM_ADMIN_BAR_UNIFICATION' ) && WPCOM_ADMIN_BAR_UNIFICATION ) || get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) { // Classic sites.
+		if ( ( defined( 'WPCOM_ADMIN_BAR_UNIFICATION' ) && WPCOM_ADMIN_BAR_UNIFICATION ) || get_option( 'wpcom_admin_interface' ) === 'wp-admin' ) { // Simple and Atomic sites.
 			add_filter( 'css_do_concat', array( $this, 'disable_css_concat_for_color_schemes' ), 10, 2 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_color_scheme_for_sidebar_notice' ) );
-		} else { // Default and self-hosted sites.
+		} else { // self-hosted sites.
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_core_color_schemes_overrides' ) );
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8498

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR fixes inconsistent admin color schemes when previewing on Simple Default sites: https://github.com/Automattic/dotcom-forge/issues/8498.

- Removed the `get_option( 'wpcom_admin_interface' ) === 'wp-admin'` gating from `admin-color-schemes.php` for it to be run on Simple Default.
- Lifted up where `define( 'WPCOM_ADMIN_BAR_UNIFICATION', true );` is defined. Because;
	- The issue happened since `enqueue_core_color_schemes_overrides` **was executed** on Simple Default (this `enqueue_core_color_schemes_overrides` should not be needed): https://github.com/Automattic/jetpack/blob/4e77ad40683cd2ba67c864dc6968fd67c6447e8f/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php#L35-L40
	- Since `wpcom-admin-bar.php` was executed after `admin-color-schemes.php`, `WPCOM_ADMIN_BAR_UNIFICATION` was not defined at the ⬆️ point. (Atomic Default had no problem since [Admin_Color_Schemes](https://github.com/Automattic/jetpack/blob/aa1579ee202d1d547887b756e81fa2622c643513/projects/packages/masterbar/src/class-main.php#L30) was [initialized](https://github.com/Automattic/jetpack/blob/aa1579ee202d1d547887b756e81fa2622c643513/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php#L155-L159) after `wpcom-admin-bar.php`.)

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Prepare a Simple Default site
* Set `wpcom_site_level_user_profile`
	* wpsh
	* switch_to_blog(YOURBLOG)
	* update_option("wpcom_site_level_user_profile", 1)
* Go to /wp-admin/profile.php
* Set Blue for Admin Color Scheme and save it
* Preview other admin color schemes
* Observe the issue occurs
* **Now, patch this PR to your sandbox**: https://github.com/Automattic/jetpack/pull/39048#issuecomment-2306321835
* Preview other admin color schemes
* Observe the issue no longer occurs

Regression Testing:

* Preview admin color schemes on Simple Classic, Atomic Classic, Atomic Default