### PR TITLE
Social: Add Social Share status component and cleanup panels

### DIFF
--- a/projects/js-packages/publicize-components/changelog/refactor-social-post-publish-panel
+++ b/projects/js-packages/publicize-components/changelog/refactor-social-post-publish-panel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Moved PostPublishPanels component to publicize-components package

--- a/projects/js-packages/publicize-components/index.ts
+++ b/projects/js-packages/publicize-components/index.ts
@@ -16,8 +16,7 @@ export { default as SocialImageGeneratorToggle } from './src/components/social-i
 export { default as TemplatePickerButton } from './src/components/social-image-generator/template-picker/button';
 export { default as PublicizePanel } from './src/components/panel';
 export { default as ReviewPrompt } from './src/components/review-prompt';
-export { default as PostPublishReviewPrompt } from './src/components/post-publish-review-prompt';
-export { default as PostPublishManualSharing } from './src/components/post-publish-manual-sharing';
+export { default as PostPublishPanels } from './src/components/post-publish-panels';
 export { default as RefreshJetpackSocialSettingsWrapper } from './src/components/refresh-jetpack-social-settings';
 export { default as ConnectionManagement } from './src/components/connection-management';
 

--- a/projects/js-packages/publicize-components/src/components/manual-sharing/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/manual-sharing/styles.module.scss
@@ -1,5 +1,4 @@
 .wrapper {
-	margin-top: 1rem;
 	padding-block: 1rem;
 	display: flex;
 	flex-direction: column;

--- a/projects/js-packages/publicize-components/src/components/panel/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.jsx
@@ -12,10 +12,10 @@ import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useRefreshConnections from '../../hooks/use-refresh-connections';
 import { usePostJustPublished } from '../../hooks/use-saving-post';
 import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
-import { store as socialStore } from '../../social-store';
 import PublicizeForm from '../form';
 import { ManualSharing } from '../manual-sharing';
 import { SharePostRow } from '../share-post';
+import { ShareStatusModal } from '../share-status-modal';
 import styles from './styles.module.scss';
 import './global.scss';
 
@@ -25,13 +25,6 @@ const PublicizePanel = ( { prePublish, children } ) => {
 	const refreshConnections = useRefreshConnections();
 
 	const { isPublicizeEnabled, hidePublicizeFeature, togglePublicizeFeature } = usePublicizeConfig();
-
-	const { featureFlags } = useSelect( select => {
-		const store = select( socialStore );
-		return {
-			featureFlags: store.featureFlags(),
-		};
-	}, [] );
 
 	// Refresh connections when the post is just published.
 	usePostJustPublished(
@@ -81,8 +74,8 @@ const PublicizePanel = ( { prePublish, children } ) => {
 			) }
 			{ isPostPublished && (
 				<>
+					<ShareStatusModal />
 					<ManualSharing />
-					{ featureFlags?.useShareStatus && 'Share status modal comes here' }
 				</>
 			) }
 		</PanelWrapper>

--- a/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.jsx
@@ -9,7 +9,7 @@ import styles from './styles.module.scss';
 /**
  * Post Publish Manual Sharing component.
  *
- * @return {import('react').ReactNode} Post Publish Manual Sharing component.
+ * @return {import('react').JSX.Element} Post Publish Manual Sharing component.
  */
 export default function PostPublishManualSharing() {
 	const { isCurrentPostPublished } = useSelect( select => select( editorStore ), [] );

--- a/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.jsx
@@ -1,4 +1,3 @@
-import { ThemeProvider } from '@automattic/jetpack-components';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
@@ -26,10 +25,8 @@ export default function PostPublishManualSharing() {
 			id="publicize-manual-sharing"
 			icon={ <JetpackEditorPanelLogo /> }
 		>
-			<ThemeProvider>
-				<ManualSharingInfo className={ styles.description } variant="body-small" />
-				<ShareButtons />
-			</ThemeProvider>
+			<ManualSharingInfo className={ styles.description } variant="body-small" />
+			<ShareButtons />
 		</PluginPostPublishPanel>
 	);
 }

--- a/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-manual-sharing/index.jsx
@@ -4,7 +4,6 @@ import { useSelect } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-import { store as socialStore } from '../../social-store';
 import { ManualSharingInfo } from '../manual-sharing/info';
 import { ShareButtons } from '../share-buttons/share-buttons';
 import styles from './styles.module.scss';
@@ -15,13 +14,6 @@ import styles from './styles.module.scss';
  */
 export default function PostPublishManualSharing() {
 	const { isCurrentPostPublished } = useSelect( select => select( editorStore ), [] );
-
-	const { featureFlags } = useSelect( select => {
-		const store = select( socialStore );
-		return {
-			featureFlags: store.featureFlags(),
-		};
-	}, [] );
 
 	if ( ! isCurrentPostPublished() ) {
 		return null;
@@ -37,7 +29,6 @@ export default function PostPublishManualSharing() {
 			<ThemeProvider>
 				<ManualSharingInfo className={ styles.description } variant="body-small" />
 				<ShareButtons />
-				{ featureFlags?.useShareStatus && 'Share status modal comes here' }
 			</ThemeProvider>
 		</PluginPostPublishPanel>
 	);

--- a/projects/js-packages/publicize-components/src/components/post-publish-panels/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-panels/index.tsx
@@ -5,7 +5,7 @@ import { PostPublishShareStatus } from '../post-publish-share-status';
 
 const PostPublishPanels = () => {
 	return (
-		<ThemeProvider>
+		<ThemeProvider targetDom={ document.body }>
 			<PostPublishShareStatus />
 			<PostPublishManualSharing />
 			<PostPublishReviewPrompt />

--- a/projects/js-packages/publicize-components/src/components/post-publish-panels/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-panels/index.tsx
@@ -1,12 +1,13 @@
+import { ThemeProvider } from '@automattic/jetpack-components';
 import PostPublishManualSharing from '../post-publish-manual-sharing';
 import PostPublishReviewPrompt from '../post-publish-review-prompt';
 
 const PostPublishPanels = () => {
 	return (
-		<>
+		<ThemeProvider>
 			<PostPublishManualSharing />
 			<PostPublishReviewPrompt />
-		</>
+		</ThemeProvider>
 	);
 };
 

--- a/projects/js-packages/publicize-components/src/components/post-publish-panels/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-panels/index.tsx
@@ -1,10 +1,12 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
 import PostPublishManualSharing from '../post-publish-manual-sharing';
 import PostPublishReviewPrompt from '../post-publish-review-prompt';
+import { PostPublishShareStatus } from '../post-publish-share-status';
 
 const PostPublishPanels = () => {
 	return (
 		<ThemeProvider>
+			<PostPublishShareStatus />
 			<PostPublishManualSharing />
 			<PostPublishReviewPrompt />
 		</ThemeProvider>

--- a/projects/js-packages/publicize-components/src/components/post-publish-panels/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-panels/index.tsx
@@ -1,7 +1,5 @@
-import {
-	PostPublishManualSharing,
-	PostPublishReviewPrompt,
-} from '@automattic/jetpack-publicize-components';
+import PostPublishManualSharing from '../post-publish-manual-sharing';
+import PostPublishReviewPrompt from '../post-publish-review-prompt';
 
 const PostPublishPanels = () => {
 	return (

--- a/projects/js-packages/publicize-components/src/components/post-publish-review-prompt/index.js
+++ b/projects/js-packages/publicize-components/src/components/post-publish-review-prompt/index.js
@@ -8,7 +8,7 @@ import { usePostStartedPublishing } from '../../hooks/use-saving-post';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import ReviewPrompt from '../review-prompt';
 
-const PostPublishReviewPropmpt = () => {
+const PostPublishReviewPrompt = () => {
 	const [ isReviewRequestDismissed, setIsReviewRequestDismissed ] = useState(
 		getJetpackData()?.social?.reviewRequestDismissed ?? true
 	);
@@ -54,4 +54,4 @@ const PostPublishReviewPropmpt = () => {
 	);
 };
 
-export default PostPublishReviewPropmpt;
+export default PostPublishReviewPrompt;

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
@@ -1,4 +1,6 @@
+import { useSelect } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { store as socialStore } from '../../social-store';
 import { ShareStatusModal } from '../share-status-modal';
 
 /**
@@ -7,6 +9,17 @@ import { ShareStatusModal } from '../share-status-modal';
  * @return {import('react').ReactNode} - Post publish share status component.
  */
 export function PostPublishShareStatus() {
+	const { featureFlags } = useSelect( select => {
+		const store = select( socialStore );
+		return {
+			featureFlags: store.featureFlags(),
+		};
+	}, [] );
+
+	if ( ! featureFlags.useShareStatus ) {
+		return null;
+	}
+
 	return (
 		<PluginPostPublishPanel id="publicize-share-status">
 			Your post was successfully shared in 4 connections.

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
@@ -1,0 +1,16 @@
+import { PluginPostPublishPanel } from '@wordpress/edit-post';
+import { ShareStatusModal } from '../share-status-modal';
+
+/**
+ * Post publish share status component.
+ *
+ * @return {import('react').ReactNode} - Post publish share status component.
+ */
+export function PostPublishShareStatus() {
+	return (
+		<PluginPostPublishPanel id="publicize-share-status">
+			Your post was successfully shared in 4 connections.
+			<ShareStatusModal />
+		</PluginPostPublishPanel>
+	);
+}

--- a/projects/js-packages/publicize-components/src/components/share-status-modal/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status-modal/index.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as socialStore } from '../../social-store';
+import styles from './styles.module.scss';
+
+/**
+ * Share status modal component.
+ *
+ * @return {import('react').ReactNode} - Share status modal component.
+ */
+export function ShareStatusModal() {
+	const { featureFlags } = useSelect( select => {
+		const store = select( socialStore );
+		return {
+			featureFlags: store.featureFlags(),
+		};
+	}, [] );
+
+	if ( ! featureFlags.useShareStatus ) {
+		return null;
+	}
+
+	return (
+		<div className={ styles.wrapper }>
+			<Button variant="secondary">{ __( 'Review sharing status', 'jetpack' ) }</Button>{ ' ' }
+		</div>
+	);
+}

--- a/projects/js-packages/publicize-components/src/components/share-status-modal/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/share-status-modal/styles.module.scss
@@ -1,0 +1,4 @@
+.wrapper {
+	margin-top: 1rem;
+	padding-block: 1rem;
+}

--- a/projects/plugins/jetpack/changelog/refactor-social-post-publish-panel
+++ b/projects/plugins/jetpack/changelog/refactor-social-post-publish-panel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Moved PostPublishPanels component to publicize-coomponents package

--- a/projects/plugins/jetpack/extensions/plugins/publicize/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/publicize/index.js
@@ -11,6 +11,7 @@ import {
 	PublicizePanel,
 	SocialImageGeneratorPanel,
 	usePublicizeConfig,
+	PostPublishPanels,
 } from '@automattic/jetpack-publicize-components';
 import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import { PostTypeSupportCheck } from '@wordpress/editor';
@@ -18,7 +19,6 @@ import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import { PublicizePlaceholder } from './components/placeholder';
 import PublicizeSkeletonLoader from './components/skeleton-loader';
 import UpsellNotice from './components/upsell';
-import PostPublishPanels from './post-publish';
 import PrePublishPanels from './pre-publish';
 
 import './editor.scss';

--- a/projects/plugins/social/changelog/refactor-social-post-publish-panel
+++ b/projects/plugins/social/changelog/refactor-social-post-publish-panel
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Moved PostPublishPanels component to publicize-components package

--- a/projects/plugins/social/src/js/editor.js
+++ b/projects/plugins/social/src/js/editor.js
@@ -6,9 +6,8 @@ import {
 	usePublicizeConfig,
 	useSocialMediaConnections,
 	PublicizePanel,
-	PostPublishReviewPrompt,
-	PostPublishManualSharing,
 	useSyncPostDataToStore,
+	PostPublishPanels,
 } from '@automattic/jetpack-publicize-components';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils';
 import { PanelBody } from '@wordpress/components';
@@ -113,8 +112,7 @@ const JetpackSocialSidebar = () => {
 				<SocialPreviewsPanel openModal={ openModal } />
 			</PluginPrePublishPanel>
 
-			<PostPublishManualSharing />
-			<PostPublishReviewPrompt />
+			<PostPublishPanels />
 		</PostTypeSupportCheck>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/pull/39015/files#r1728449882

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* refactored the component to be in the publicize components package

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Do this with JP and Social only too
* Publish a post
* Check the post-publish panel that appears, you should see the manual sharing as before
* Go to a published post and check the editor, you should see the panels there too
* You should see the new button for share status
* Use `wp.data.dispatch('core/edit-post').togglePublishSidebar();` to toggle the post-publish panel

![CleanShot 2024-08-23 at 10 26 10 png](https://github.com/user-attachments/assets/6e942688-3387-4e68-8d93-5cd5d0495a55)