### PR TITLE
Update Quick Start instructions

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -164,7 +164,7 @@ If you're ready to start, you should see all green `SUCCESS` messages. If the sc
 
 Once you're all set here, you can continue developing. If you're setting up an local environment and want to start testing immediately, please ensure you build the projects you need.
 
-`jetpack build` will provide prompts to determine the project you need or you can pass it a complete command, like `jetpack build plugins/jetpack --with-deps`
+`jetpack build` will provide prompts to determine the project you need or you can pass it a complete command, like `jetpack build plugins/jetpack --deps`
 
 ### Testing Jetpack cloud features
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -102,7 +102,7 @@ Note: This is for Automattician use only. For other methods, check out [ngrok](.
 Once you have a local copy of Jetpack and all development tools installed, you can start developing.
 
 1. Make sure the plugin you're developing is activated on your WordPress site.
-2. [Build your project](#building-your-project) using `jetpack build [type/project]`, such as `jetpack build plugins/jetpack`
+2. [Build your project](development-environment.md#building-your-project) using `jetpack build [type/project]` and including its dependencies, such as `jetpack build plugins/jetpack --deps`
 3. Access the plugin's dashboard in your browser.
 
 By default the development build above will run once and if you change any of the files, you need to run `jetpack build` again to see the changes on the site. If you want to avoid that, you can run a continuous build that will rebuild anytime it sees any changes on your local filesystem. To run it, use:

--- a/projects/plugins/jetpack/changelog/fix-install-instructions
+++ b/projects/plugins/jetpack/changelog/fix-install-instructions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update Quick Start instructions

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -184,7 +184,7 @@ if ( is_readable( $jetpack_autoloader ) && is_readable( $jetpack_module_headings
 		$message = sprintf(
 			wp_kses(
 				/* translators: Placeholder is a link to a support document. */
-				__( 'Your installation of Jetpack is incomplete. If you installed Jetpack from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment. Jetpack must have Composer dependencies installed and built via the build command: <code>jetpack build plugins/jetpack --with-deps</code>', 'jetpack' ),
+				__( 'Your installation of Jetpack is incomplete. If you installed Jetpack from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment. Jetpack must have Composer dependencies installed and built via the build command: <code>jetpack build plugins/jetpack --deps</code>', 'jetpack' ),
 				array(
 					'a'    => array(
 						'href'   => array(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

While going through the Quick Start Guide, I noticed a few incorrect suggestions. This PR updates them so that anyone following these instructions doesn't encounter the same issues.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- `Building your project` link was broken.
- Clarify that project dependencies need to be installed.
- Running `jetpack docker install` isn't required after starting Docker containers.
- The suggested `--with-deps` argument for `jetpack build` doesn't exist.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The only visible code change appears when trying to activate Jetpack without building it first. To resolve this:

1. Clone the repository to a temporary folder.
2. Follow the installation instructions (e.g., via Docker), but do not build the plugin using `jetpack build`.
3. Activate Jetpack at `/wp-admin/plugins.php`.

The message `Your installation of Jetpack is incomplete` will be displayed on the same page.