### PR TITLE
Newsletter: Email Menu: Don't prompt for connection on simple sites.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-simple-sites-prompts-connection
+++ b/projects/plugins/jetpack/changelog/fix-simple-sites-prompts-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+wpcom only

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -32,6 +32,7 @@ const NewsletterMenu = () => {
 
 	const { isUserConnected } = useConnection();
 	const connectUrl = `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/connection`;
+	const shouldPromptForConnection = ! isSimpleSite() && ! isUserConnected;
 
 	const openPreviewModal = () => setIsPreviewModalOpen( true );
 	const closePreviewModal = () => setIsPreviewModalOpen( false );
@@ -49,7 +50,7 @@ const NewsletterMenu = () => {
 				<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
 				{ isSendEmailEnabled && ! isPublished && (
 					<>
-						{ isUserConnected || isSimpleSite() ? (
+						{ ! shouldPromptForConnection ? (
 							<>
 								<p>
 									{ __(

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -1,4 +1,5 @@
 import { useConnection } from '@automattic/jetpack-connection';
+import { isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import { Button, PanelBody, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useSelect } from '@wordpress/data';
 import { PluginSidebar } from '@wordpress/edit-post';
@@ -48,7 +49,7 @@ const NewsletterMenu = () => {
 				<SubscribersAffirmation accessLevel={ accessLevel } prePublish={ ! isPublished } />
 				{ isSendEmailEnabled && ! isPublished && (
 					<>
-						{ isUserConnected ? (
+						{ isUserConnected || isSimpleSite() ? (
 							<>
 								<p>
 									{ __(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Connection prompt showing up on Simple sites:

<img width="281" alt="Screenshot 2024-08-25 at 10 58 49 AM" src="https://github.com/user-attachments/assets/ffd78716-b818-4d03-81de-be822ad4ba21">


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test this PR on a Simple site.
* Confirm that connection button doesn't show up anymore.

