### PR TITLE
Subscriptions: Render the Close button lower than the Marketing bar

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-welcome-overlay-close-button-fix
+++ b/projects/plugins/jetpack/changelog/fix-welcome-overlay-close-button-fix
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Subscriptions: Make the Close button render lower than the Marketing bar
+Subscriptions: Render the Close button lower than the Marketing bar

--- a/projects/plugins/jetpack/changelog/fix-welcome-overlay-close-button-fix
+++ b/projects/plugins/jetpack/changelog/fix-welcome-overlay-close-button-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Make the Close button render lower than the Marketing bar

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
@@ -44,7 +44,7 @@ body.admin-bar .jetpack-subscribe-overlay__close {
 }
 
 body.has-marketing-bar .jetpack-subscribe-overlay__close {
-	top: 74px;
+	top: 81px;
 }
 
 .jetpack-subscribe-overlay__to-content {

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
@@ -43,6 +43,10 @@ body.admin-bar .jetpack-subscribe-overlay__close {
 	top: 64px;
 }
 
+body.has-marketing-bar .jetpack-subscribe-overlay__close {
+	top: 74px;
+}
+
 .jetpack-subscribe-overlay__to-content {
 	display: none;
 	position: fixed;

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.css
@@ -47,6 +47,10 @@ body.has-marketing-bar .jetpack-subscribe-overlay__close {
 	top: 81px;
 }
 
+body.admin-bar.has-marketing-bar .jetpack-subscribe-overlay__close {
+	top: 114px;
+}
+
 .jetpack-subscribe-overlay__to-content {
 	display: none;
 	position: fixed;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/39063

## Proposed changes:

It renders the Welcome overlay Close button lower than the Marketing bar if visible.

### Before

<img width="1128" alt="Screenshot 2024-08-25 at 21 56 03" src="https://github.com/user-attachments/assets/60f0b93b-8f03-44b7-81cd-9f9f5a27ac59">

### After

<img width="1128" alt="Screenshot 2024-08-25 at 21 59 21" src="https://github.com/user-attachments/assets/1e3b12e9-4fab-41c8-8058-2d4080f7bfc3">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

