### PR TITLE
My Jetpack: Fix the tooltip and active button of the boost card are overlapping

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/boost-speed-score.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/boost-speed-score.tsx
@@ -8,7 +8,7 @@ import { Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { arrowUp, Icon } from '@wordpress/icons';
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import { PRODUCT_STATUSES } from '../../../constants';
 import useProduct from '../../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
@@ -20,13 +20,14 @@ import type { SetStateAction } from 'react';
 
 import './style.scss';
 
-const BoostSpeedScore: BoostSpeedScoreType = ( { shouldShowTooltip } ) => {
+const BoostSpeedScore: BoostSpeedScoreType = () => {
 	const { recordEvent } = useAnalytics();
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ speedLetterGrade, setSpeedLetterGrade ] = useState( '' );
 	const [ currentSpeedScore, setCurrentSpeedScore ] = useState< number | null >( null );
 	const [ previousSpeedScore, setPreviousSpeedScore ] = useState< number | null >( null );
 	const [ isSpeedScoreError, setIsSpeedScoreError ] = useState( false );
+	const [ shouldShowTooltip, setShouldShowTooltip ] = useState( false );
 	const [ hasTooltipBeenViewed, setHasTooltipBeenViewed ] = useState( false );
 	const isMobileViewport: boolean = useViewportMatch( 'medium', '<' );
 
@@ -116,6 +117,14 @@ const BoostSpeedScore: BoostSpeedScoreType = ( { shouldShowTooltip } ) => {
 
 	const tooltipCopy = useBoostTooltipCopy( { speedLetterGrade, boostScoreIncrease } );
 
+	const handleEnter = useCallback( () => {
+		setShouldShowTooltip( true );
+	}, [ setShouldShowTooltip ] );
+
+	const handleOut = useCallback( () => {
+		setShouldShowTooltip( false );
+	}, [ setShouldShowTooltip ] );
+
 	useEffect( () => {
 		if ( latestBoostSpeedScores ) {
 			if ( isBoostActive ) {
@@ -152,7 +161,15 @@ const BoostSpeedScore: BoostSpeedScoreType = ( { shouldShowTooltip } ) => {
 
 	return (
 		! isSpeedScoreError && (
-			<div className="mj-boost-speed-score">
+			<div
+				className="mj-boost-speed-score"
+				role="presentation"
+				onMouseEnter={ handleEnter }
+				onMouseLeave={ handleOut }
+				onClick={ shouldShowTooltip ? handleOut : handleEnter }
+				onFocus={ handleEnter }
+				onBlur={ handleOut }
+			>
 				{ isLoading ? (
 					<Spinner color="#23282d" size={ 16 } />
 				) : (
@@ -161,7 +178,7 @@ const BoostSpeedScore: BoostSpeedScoreType = ( { shouldShowTooltip } ) => {
 							<span>{ __( 'Your website’s overall speed score:', 'jetpack-my-jetpack' ) }</span>
 							<span className="mj-boost-speed-score__grade--letter">
 								{ speedLetterGrade }
-								{ shouldShowTooltip && (
+								{ ! isLoading && shouldShowTooltip && (
 									<Popover
 										placement={ isMobileViewport ? 'top-end' : 'top-start' }
 										noArrow={ false }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/index.tsx
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import { useState, useCallback } from 'react';
 import { PRODUCT_STATUSES } from '../../../constants';
 import { PRODUCT_SLUGS } from '../../../data/constants';
 import ProductCard from '../../connected-product-card';
@@ -7,7 +6,6 @@ import BoostSpeedScore from './boost-speed-score';
 import type { ProductCardComponent } from '../types';
 
 const BoostCard: ProductCardComponent = props => {
-	const [ shouldShowTooltip, setShouldShowTooltip ] = useState( false );
 	// Override the primary action button to read "Boost your site" instead
 	// of the default text, "Lern more".
 	const primaryActionOverride = {
@@ -16,23 +14,13 @@ const BoostCard: ProductCardComponent = props => {
 		},
 	};
 
-	const handleMouseEnter = useCallback( () => {
-		setShouldShowTooltip( true );
-	}, [ setShouldShowTooltip ] );
-
-	const handleMouseLeave = useCallback( () => {
-		setShouldShowTooltip( false );
-	}, [ setShouldShowTooltip ] );
-
 	return (
 		<ProductCard
 			slug={ PRODUCT_SLUGS.BOOST }
 			primaryActionOverride={ primaryActionOverride }
-			onMouseEnter={ handleMouseEnter }
-			onMouseLeave={ handleMouseLeave }
 			{ ...props }
 		>
-			<BoostSpeedScore shouldShowTooltip={ shouldShowTooltip } />
+			<BoostSpeedScore />
 		</ProductCard>
 	);
 };

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/style.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/boost-card/style.scss
@@ -3,6 +3,13 @@
 $bar_height: 24px;
 $border_radius: math.div($bar-height, 2);
 
+.mj-boost-speed-score {
+    // Increase the area to trigger the hover.
+    padding: calc( var( --spacing-base ) ); // 8px;
+    margin: calc( var( --spacing-base ) * -1 );
+    margin-bottom: 0;
+}
+
 .mj-boost-speed-score__grade {
     font-size: var(--font-body-small);
     line-height: $bar_height;

--- a/projects/packages/my-jetpack/changelog/fix-boost-score-popover
+++ b/projects/packages/my-jetpack/changelog/fix-boost-score-popover
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Fix the popover and active button of the Bboost card are overlapping


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/39062

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Make the tooltip displays only when you hover on the grade of the performance section

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack
* Scroll down to see the Boost Card and make it close to the top of the window
* Hover the Boost Card or even the "Active" button
* Make sure the tooltip won't display immediately now
* Hover the Scroe
* Make sure the tooltip displays
