### PR TITLE
Shared Extension Utils: Add needsUserConnection function

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/add-needs-user-connection-shared-extension-utils
+++ b/projects/js-packages/shared-extension-utils/changelog/add-needs-user-connection-shared-extension-utils
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+New utility function `needsUserConnection` to determine if a user connection is required based on the current user's connection status and site type.

--- a/projects/js-packages/shared-extension-utils/index.js
+++ b/projects/js-packages/shared-extension-utils/index.js
@@ -21,3 +21,4 @@ export { getBlockIconComponent, getBlockIconProp } from './src/get-block-icon-fr
 export { default as getJetpackBlocksVariation } from './src/get-jetpack-blocks-variation';
 export * from './src/modules-state';
 export { default as isMyJetpackAvailable } from './src/is-my-jetpack-available';
+export { default as needsUserConnection } from './src/needs-user-connection';

--- a/projects/js-packages/shared-extension-utils/src/needs-user-connection.js
+++ b/projects/js-packages/shared-extension-utils/src/needs-user-connection.js
@@ -1,0 +1,13 @@
+import isCurrentUserConnected from './is-current-user-connected';
+import { isSimpleSite } from './site-type-utils';
+
+/**
+ * Returns true if the current user is not connected to WP.com and the site is not a simple site.
+ *
+ * @return {boolean} Whether the current user is not connected to WP.com and the site is not a simple site.
+ */
+const needsUserConnection = () => {
+	return ! isCurrentUserConnected() && ! isSimpleSite();
+};
+
+export default needsUserConnection;


### PR DESCRIPTION
Introduces a new utility function `needsUserConnection` in the shared-extension-utils package. This function helps determine if a user connection is required based on two conditions:

1. The current user is not connected
2. The site is not a simple site


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Adds `needsUserConnection` function in `needs-user-connection.js`
- Imports and uses `isCurrentUserConnected` and `isSimpleSite` utility functions

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None, but see how we needed something like this again in https://github.com/Automattic/jetpack/pull/39064 

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

