### PR TITLE
Newsletter: Email Preview: Hide Access selector accordingly 

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-email-preview-access-selector
+++ b/projects/plugins/jetpack/changelog/update-newsletter-email-preview-access-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Not yet released feature

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -154,7 +154,11 @@ const PreviewAccessSelector = ( { selectedAccess, setSelectedAccess } ) => {
 	const accessLevel = useAccessLevel( postType );
 	const { tracks } = useAnalytics();
 
-	const isPaidOptionDisabled = ! accessLevel || accessLevel !== accessOptions.paid_subscribers.key;
+	const isPaidAccess = accessLevel === accessOptions.paid_subscribers.key;
+
+	if ( ! isPaidAccess ) {
+		return null;
+	}
 
 	const accessOptionsList = [
 		{ label: accessOptions.subscribers.label, value: accessOptions.subscribers.key, icon: people },
@@ -162,20 +166,13 @@ const PreviewAccessSelector = ( { selectedAccess, setSelectedAccess } ) => {
 			label: accessOptions.paid_subscribers.label,
 			value: accessOptions.paid_subscribers.key,
 			icon: currencyDollar,
-			disabled: isPaidOptionDisabled,
 		},
 	];
 
 	const handleChange = value => {
-		if ( ! isPaidOptionDisabled ) {
-			tracks.recordEvent( 'jetpack_newsletter_preview_access_change', { access: value } );
-			setSelectedAccess( value );
-		}
+		tracks.recordEvent( 'jetpack_newsletter_preview_access_change', { access: value } );
+		setSelectedAccess( value );
 	};
-
-	if ( isSmall && isPaidOptionDisabled ) {
-		return null;
-	}
 
 	return (
 		<ToggleGroupControl
@@ -198,7 +195,6 @@ const PreviewAccessSelector = ( { selectedAccess, setSelectedAccess } ) => {
 						key={ access.value }
 						value={ access.value }
 						label={ access.label }
-						disabled={ access.disabled }
 					/>
 				)
 			) }


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Make the access selector in the Email Preview feature simpler
* show Paid Subscribers option only if access is set to paid.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check the email preview feature on a post with access set to all subscribers or paid subscribers.

