### PR TITLE
Jetpack AI: change sidebar usagePanel conditions

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-sidebar-hide-usage-panel-on-plans
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-sidebar-hide-usage-panel-on-plans
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: hide usagepanel when tier plans are disabled. Show QuotaExceededMessage instead of nudges

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -26,7 +26,7 @@ import clsx from 'clsx';
  */
 import UsagePanel from '../../plugins/ai-assistant-plugin/components/usage-panel';
 import { USAGE_PANEL_PLACEMENT_BLOCK_SETTINGS_SIDEBAR } from '../../plugins/ai-assistant-plugin/components/usage-panel/types';
-import { PLAN_TYPE_FREE, usePlanType } from '../../shared/use-plan-type';
+import { PLAN_TYPE_FREE, PLAN_TYPE_UNLIMITED, usePlanType } from '../../shared/use-plan-type';
 import ConnectPrompt from './components/connect-prompt';
 import FeedbackControl from './components/feedback-control';
 import QuotaExceededMessage from './components/quota-exceeded-message';
@@ -61,6 +61,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		requestsLimit,
 		currentTier,
 		loading: loadingAiFeature,
+		tierPlansEnabled,
 	} = useAiFeature();
 	const requestsRemaining = Math.max( requestsLimit - requestsCount, 0 );
 
@@ -360,11 +361,14 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 							{ __( 'Discover all features', 'jetpack' ) }
 						</ExternalLink>
 					</div>
-					<PanelBody initialOpen={ true }>
-						<PanelRow>
-							<UsagePanel placement={ USAGE_PANEL_PLACEMENT_BLOCK_SETTINGS_SIDEBAR } />
-						</PanelRow>
-					</PanelBody>
+					{ ( planType === PLAN_TYPE_FREE ||
+						( tierPlansEnabled && planType !== PLAN_TYPE_UNLIMITED ) ) && (
+						<PanelBody initialOpen={ true }>
+							<PanelRow>
+								<UsagePanel placement={ USAGE_PANEL_PLACEMENT_BLOCK_SETTINGS_SIDEBAR } />
+							</PanelRow>
+						</PanelBody>
+					) }
 					<PanelBody initialOpen={ true }>
 						<PanelRow>
 							<FeedbackControl />

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -22,14 +22,18 @@ export default function useAiFeature() {
 			usagePeriod,
 			requestsCount: allTimeRequestsCount,
 			requestsLimit: freeRequestsLimit,
+			tierPlansEnabled,
 		} = featureData;
 
 		const planType = getPlanType( currentTier );
 
+		// TODO: mind this hardcoded value (3000),
+		// maybe provide it from the backend but we'd be replacing the 9 Billion limit with 3k
+		const currentTierLimit = tierPlansEnabled ? currentTier?.limit || freeRequestsLimit : 3000;
+
 		const actualRequestsCount =
 			planType === PLAN_TYPE_TIERED ? usagePeriod?.requestsCount : allTimeRequestsCount;
-		const actualRequestsLimit =
-			planType === PLAN_TYPE_FREE ? freeRequestsLimit : currentTier?.limit;
+		const actualRequestsLimit = planType === PLAN_TYPE_FREE ? freeRequestsLimit : currentTierLimit;
 
 		return {
 			data: featureData,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -20,7 +20,7 @@ import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import useAiProductPage from '../../../../blocks/ai-assistant/hooks/use-ai-product-page';
 import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/utils/get-feature-availability';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
-import { PLAN_TYPE_FREE, usePlanType } from '../../../../shared/use-plan-type';
+import { PLAN_TYPE_FREE, PLAN_TYPE_UNLIMITED, usePlanType } from '../../../../shared/use-plan-type';
 import { FeaturedImage } from '../ai-image';
 import { Breve, registerBreveHighlights, Highlight } from '../breve';
 import useBreveAvailability from '../breve/hooks/use-breve-availability';
@@ -177,8 +177,9 @@ export default function AiAssistantPluginSidebar() {
 		tracks.recordEvent( 'jetpack_ai_panel_open', { placement } );
 	};
 
-	const showUsagePanel = planType === PLAN_TYPE_FREE;
-	const showQuotaExceeded = ! tierPlansEnabled && isOverLimit;
+	const showUsagePanel =
+		planType === PLAN_TYPE_FREE || ( tierPlansEnabled && planType !== PLAN_TYPE_UNLIMITED );
+	const showQuotaExceeded = planType === PLAN_TYPE_UNLIMITED && isOverLimit;
 
 	return (
 		<>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -14,11 +14,13 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import QuotaExceededMessage from '../../../../blocks/ai-assistant/components/quota-exceeded-message';
 import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout';
 import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import useAiProductPage from '../../../../blocks/ai-assistant/hooks/use-ai-product-page';
 import { getFeatureAvailability } from '../../../../blocks/ai-assistant/lib/utils/get-feature-availability';
 import JetpackPluginSidebar from '../../../../shared/jetpack-plugin-sidebar';
+import { PLAN_TYPE_FREE, usePlanType } from '../../../../shared/use-plan-type';
 import { FeaturedImage } from '../ai-image';
 import { Breve, registerBreveHighlights, Highlight } from '../breve';
 import useBreveAvailability from '../breve/hooks/use-breve-availability';
@@ -63,6 +65,8 @@ const JetpackAndSettingsContent = ( {
 	placement,
 	requireUpgrade,
 	upgradeType,
+	showUsagePanel,
+	showQuotaExceeded,
 }: JetpackSettingsContentProps ) => {
 	const { checkoutUrl } = useAICheckout();
 	const { productPageUrl } = useAiProductPage();
@@ -109,9 +113,15 @@ const JetpackAndSettingsContent = ( {
 					<Upgrade placement={ placement } type={ upgradeType } upgradeUrl={ checkoutUrl } />
 				</PanelRow>
 			) }
-			{ isUsagePanelAvailable && (
+			{ isUsagePanelAvailable && showUsagePanel && (
 				<PanelRow className="jetpack-ai-sidebar__feature-section">
 					<UsagePanel placement={ placement } />
+				</PanelRow>
+			) }
+
+			{ showQuotaExceeded && (
+				<PanelRow>
+					<QuotaExceededMessage />
 				</PanelRow>
 			) }
 
@@ -137,7 +147,8 @@ const JetpackAndSettingsContent = ( {
 };
 
 export default function AiAssistantPluginSidebar() {
-	const { requireUpgrade, upgradeType, currentTier } = useAiFeature();
+	const { requireUpgrade, upgradeType, currentTier, tierPlansEnabled, isOverLimit } =
+		useAiFeature();
 	const { checkoutUrl } = useAICheckout();
 	const { tracks } = useAnalytics();
 	const isBreveAvailable = useBreveAvailability();
@@ -152,6 +163,8 @@ export default function AiAssistantPluginSidebar() {
 		return postTypeObject?.viewable;
 	}, [] );
 
+	const planType = usePlanType( currentTier );
+
 	// If the post type is not viewable, do not render my plugin.
 	if ( ! isViewable ) {
 		return null;
@@ -163,6 +176,9 @@ export default function AiAssistantPluginSidebar() {
 		debug( placement );
 		tracks.recordEvent( 'jetpack_ai_panel_open', { placement } );
 	};
+
+	const showUsagePanel = planType === PLAN_TYPE_FREE;
+	const showQuotaExceeded = ! tierPlansEnabled && isOverLimit;
 
 	return (
 		<>
@@ -180,6 +196,8 @@ export default function AiAssistantPluginSidebar() {
 						placement={ PLACEMENT_JETPACK_SIDEBAR }
 						requireUpgrade={ requireUpgrade }
 						upgradeType={ upgradeType }
+						showUsagePanel={ showUsagePanel }
+						showQuotaExceeded={ showQuotaExceeded }
 					/>
 				</PanelBody>
 			</JetpackPluginSidebar>
@@ -193,6 +211,8 @@ export default function AiAssistantPluginSidebar() {
 					placement={ PLACEMENT_DOCUMENT_SETTINGS }
 					requireUpgrade={ requireUpgrade }
 					upgradeType={ upgradeType }
+					showUsagePanel={ showUsagePanel }
+					showQuotaExceeded={ showQuotaExceeded }
 				/>
 			</PluginDocumentSettingPanel>
 
@@ -214,7 +234,7 @@ export default function AiAssistantPluginSidebar() {
 						busy={ false }
 						disabled={ requireUpgrade }
 					/>
-					{ requireUpgrade && (
+					{ requireUpgrade && tierPlansEnabled && (
 						<Upgrade
 							placement={ PLACEMENT_PRE_PUBLISH }
 							type={ upgradeType }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/types.ts
@@ -4,6 +4,8 @@ export type JetpackSettingsContentProps = {
 	placement: typeof PLACEMENT_JETPACK_SIDEBAR | typeof PLACEMENT_DOCUMENT_SETTINGS;
 	requireUpgrade: boolean;
 	upgradeType: string;
+	showUsagePanel: boolean;
+	showQuotaExceeded: boolean;
 };
 
 export type CoreSelect = {


### PR DESCRIPTION
Consider tier plans enabled for showing the usage panel

Fixes #39084

## Proposed changes:
When tier plans are disabled, there should be no upgrade nudges unless user is free. Going over fair usage should provide some information.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1724704408576139-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply D159560-code on your sandbox.

We'll be testing several cases and scenarios, feel free to pick a delimited set.
For setup, sandbox public api and follow the instructions on D159560-code to mock the case using the filters on your sandbox.

**Overall, the idea is that, with tier plans are enabled, UI hasn't changed**

**Free user within limit, both tier plans disabled and enabled:**
- [x] show the UsagePanel with Upgrade button on Document and Jetpack sidebar
- [x] insert an AI Assistant block, the block inspector sidebar should show the UsagePanel with Upgrade button

**Free user over limit, both tier plans disabled and enabled:**
- [x] show the UsagePanel with Upgrade button on Document and Jetpack sidebar
- [x] the excerpt panel should show an upgrade nudge
- [x] insert an AI Assistant block, the block inspector sidebar should show the UsagePanel with Upgrade button
- [x] the AI Assistant block should show an upgrade nudge when active
- [x] other AI tools are disabled on the sidebars

**Tier plan user within limit:**
- Tier plans enabled:
  - [x] show the UsagePanel with Upgrade button on Document and Jetpack sidebar
  - [x] insert an AI Assistant block, the block inspector sidebar should show the UsagePanel with Upgrade button
- Tier plans disabled:
  - [x] sidebars don't show the UsagePanel
  - [x] AI Assistant block inspector doesn't show the UsagePanel

**Tier plan user over limit:**
- Tier plans enabled:
  - [x] show the UsagePanel with Upgrade button on Document and Jetpack sidebar
  - [x] the excerpt panel should show an upgrade nudge
  - [x] insert an AI Assistant block, the block inspector sidebar should show the UsagePanel with Upgrade button
  - [x] the AI Assistant block should show an upgrade nudge when active
- Tier plans disabled:
  - [x] sidebars don't show the UsagePanel
  - [x] AI Assistant block inspector doesn't show the UsagePanel

**Unlimited plan within fair usage limit:**
- Tier plans both enabled and disabled:
  - [x] sidebars don't show the UsagePanel
  - [x] AI Assistant block inspector doesn't show the UsagePanel

**Unlimited plan over fair limit:**
- Tier plans both enabled and disabled:
  - [x] sidebars don't show the UsagePanel
  - [x] an _over quota_ notification can be seen on the Document and Jetpack sidebars 
  - [x] AI Assistant block inspector doesn't show the UsagePanel
  - [x] AI Assistant block shows the _over quota_ notification within the block when active
  - [x] Excerpt panel shows the _over quota_ notification

NOTE: the _over quota_ notification is still a WIP, needs clarification