### PR TITLE
Forms: render option field as a div in the editor

### DIFF
--- a/projects/packages/forms/changelog/fix-dropdown-failing-e2e-test
+++ b/projects/packages/forms/changelog/fix-dropdown-failing-e2e-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Render option field as a div in the editor
+
+

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-option.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-field-option.js
@@ -54,7 +54,7 @@ export const JetpackFieldOptionEdit = ( {
 			<RichText
 				{ ...blockProps }
 				identifier="label"
-				tagName="p"
+				tagName="div"
 				className="wp-block"
 				value={ attributes.label }
 				placeholder={ __( 'Add option…', 'jetpack-forms' ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
https://github.com/Automattic/jetpack/pull/38916 fails a Calypso e2e test, as it renders the option field block in an outer `p` element (in the editor), while a `div` is expected.

There are several possible fixes (see conversation linked below), but making sure we render a `div` is the quickest. This PR does that. We may reiterate on this later.

| Before | After |
|-|-|
|<img width="203" alt="Screenshot 2024-08-27 at 1 07 25 PM" src="https://github.com/user-attachments/assets/e4ca8bb8-7a28-4a02-9a5f-e00775705cbb">|<img width="191" alt="Screenshot 2024-08-27 at 1 07 29 PM" src="https://github.com/user-attachments/assets/55d7ce83-1fcc-4336-95c1-822f0bcc94ae">|


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1724766845302749-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Optionally, verify that the _Multiple Choice_ or _Single Choice_ fields behave as expected.