### PR TITLE
Jetpack: Fix REST API warnings from Comments endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-comment-endpoint-warnings
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-comment-endpoint-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+REST API: Avoid PHP warnings in comment endpoint when the parent comment does not exist.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-comment-endpoint.php
@@ -185,8 +185,8 @@ abstract class WPCOM_JSON_API_Comment_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$response[ $key ] = (string) $status;
 					break;
 				case 'parent': // May be object or false.
-					if ( $comment->comment_parent ) {
-						$parent           = get_comment( $comment->comment_parent );
+					$parent = $comment->comment_parent ? get_comment( $comment->comment_parent ) : null;
+					if ( $parent ) {
 						$response[ $key ] = (object) array(
 							'ID'   => (int) $parent->comment_ID,
 							'type' => (string) ( $parent->comment_type ? $parent->comment_type : 'comment' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
There are two bugs involved here:

* The Subscriptions block is trying to hide comments by returning empty-string from the 'get_comment' filter, but that filter must return a WP_Comment object. Not even null would be right.
* The REST API endpoint isn't checking for if `get_comment()` on the parent comment ID returns null.

This fixes the second; I don't know what would be correct to fix the first.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1724783930444699/1724774845.040969-slack-C02ECE3ML

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox public-api.wordpress.com
* In a private window, use https://developer.wordpress.com/docs/api/console/ to hit the `/sites/$site/posts/$post_ID/replies/` endpoint for site ID 233337427 and post 1783.