### PR TITLE
Jetpack AI: Add fair usage message on Extension AI Control

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-add-fair-usage-message-on-extension-ai-control
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-add-fair-usage-message-on-extension-ai-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack AI: support fair usage messaging on the Extension AI Control component.

--- a/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/extension-ai-control.tsx
@@ -10,7 +10,12 @@ import React, { forwardRef } from 'react';
 /**
  * Internal dependencies
  */
-import { GuidelineMessage, ErrorMessage, UpgradeMessage } from '../message/index.js';
+import {
+	GuidelineMessage,
+	ErrorMessage,
+	UpgradeMessage,
+	FairUsageLimitMessage,
+} from '../message/index.js';
 import AIControl from './ai-control.js';
 import './style.scss';
 /**
@@ -31,6 +36,7 @@ type ExtensionAIControlProps = {
 	error?: RequestingErrorProps;
 	requestsRemaining?: number;
 	showUpgradeMessage?: boolean;
+	showFairUsageMessage?: boolean;
 	upgradeUrl?: string;
 	wrapperRef?: React.MutableRefObject< HTMLDivElement | null >;
 	onChange?: ( newValue: string ) => void;
@@ -62,6 +68,7 @@ export function ExtensionAIControl(
 		error,
 		requestsRemaining,
 		showUpgradeMessage = false,
+		showFairUsageMessage = false,
 		upgradeUrl,
 		wrapperRef,
 		onChange,
@@ -215,6 +222,8 @@ export function ExtensionAIControl(
 				upgradeUrl={ upgradeUrl }
 			/>
 		);
+	} else if ( showFairUsageMessage ) {
+		message = <FairUsageLimitMessage />;
 	} else if ( showUpgradeMessage ) {
 		message = (
 			<UpgradeMessage

--- a/projects/js-packages/ai-client/src/components/ai-control/stories/extension-ai-control.stories.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-control/stories/extension-ai-control.stories.tsx
@@ -112,6 +112,7 @@ const DefaultArgs = {
 	error: null,
 	requestsRemaining: null,
 	showUpgradeMessage: false,
+	showFairUsageMessage: false,
 	onChange: action( 'onChange' ),
 	onSend: action( 'onSend' ),
 	onStop: action( 'onStop' ),

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { ExternalLink, Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, arrowRight } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -112,6 +113,25 @@ export function GuidelineMessage(): React.ReactElement {
 			</ExternalLink>
 		</Message>
 	);
+}
+
+/**
+ * React component to render a fair usage limit message.
+ *
+ * @return {React.ReactElement } - Message component.
+ */
+export function FairUsageLimitMessage(): React.ReactElement {
+	const message = __(
+		"You've reached this month's request limit, per our <link>fair usage policy</link>.",
+		'jetpack-ai-client'
+	);
+	const element = createInterpolateElement( message, {
+		link: (
+			<ExternalLink href="https://jetpack.com/redirect/?source=ai-assistant-fair-usage-policy" />
+		),
+	} );
+
+	return <Message>{ element }</Message>;
 }
 
 /**

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -122,7 +122,7 @@ export function GuidelineMessage(): React.ReactElement {
  */
 export function FairUsageLimitMessage(): React.ReactElement {
 	const message = __(
-		"You've reached this month's request limit, per our <link>fair usage policy</link>.",
+		"You've reached this month's request limit, per our <link>fair usage policy</link>",
 		'jetpack-ai-client'
 	);
 	const element = createInterpolateElement( message, {

--- a/projects/js-packages/ai-client/src/components/message/index.tsx
+++ b/projects/js-packages/ai-client/src/components/message/index.tsx
@@ -131,7 +131,7 @@ export function FairUsageLimitMessage(): React.ReactElement {
 		),
 	} );
 
-	return <Message>{ element }</Message>;
+	return <Message severity={ MESSAGE_SEVERITY_WARNING }>{ element }</Message>;
 }
 
 /**

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-add-fair-usage-message-on-extension-ai-control
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-add-fair-usage-message-on-extension-ai-control
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: support fair usage messaging on the Extension AI Control component.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/components/ai-assistant-input/index.tsx
@@ -76,6 +76,13 @@ export default function AiAssistantInput( {
 		[ requireUpgrade, requestingState ]
 	);
 
+	/**
+	 * Show the fair usage message when the site is on the unlimited tier and was flagged as requireUpgrade.
+	 */
+	const showFairUsageMessage = useMemo( () => {
+		return requireUpgrade && currentTier?.value === 1;
+	}, [ requireUpgrade, currentTier ] );
+
 	const handleSend = useCallback( () => {
 		tracks.recordEvent( 'jetpack_ai_assistant_extension_generate', {
 			block_type: blockType,
@@ -165,6 +172,7 @@ export default function AiAssistantInput( {
 			error={ requestingError }
 			requestsRemaining={ requestsRemaining }
 			showUpgradeMessage={ showUpgradeMessage }
+			showFairUsageMessage={ showFairUsageMessage }
 			upgradeUrl={ checkoutUrl }
 			onChange={ setValue }
 			onSend={ handleSend }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create a simple FairUsageLimitMessage component on the AI Client package
* Show the FairUsageLimitMessage on the Extension AI Control component when the site has an unlimited plan but was flagged as requiring upgrade (the rule we created to simplify things, as per pe4Cmx-2FY-p2)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this branch on your testing site
* Sandbox the `public-api` domain and change the `0-sandbox.php` file to add the following filters, so we simulate an unlimited plan over the fair usage limit:

```
add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 1; } );
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 3001; } );
```

* Go to the block editor and add some text to a paragraph
* Look for the AI extension on the paragraph and click it to open the AI Control component
* Confirm you see the component with the fair usage message under it, containing a link to the fair usage policy (actually, a Jetpack redirect link still not pointing to a final page) and yellow background:

<img width="500" alt="Screenshot 2024-08-27 at 17 04 44" src="https://github.com/user-attachments/assets/d6cf94af-02b3-4d31-a67f-be403bc56dab">

* Confirm also that the extension is disabled, so you can't use it
* Confirm that clicking some of the quick actions on the extension menu will aslo trigger the AI Control component, disabled and with the fair usage message under it
* Bonus points for inserting a form block and confirming the AI extension there is also triggered disabled and with the yellow fair usage message under it

<img width="500" alt="Screenshot 2024-08-27 at 17 05 13" src="https://github.com/user-attachments/assets/3edd4fc4-2e53-41d7-9f0c-c8c867b1d95a">

* Confirm the UI you see matches the proposed design from p1HpG7-tUE-p2
* Go back to the `0-sandbox.php` file and change the filters to:

```

add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 1; } );
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 2900; } );
```

* Confirm the fair usage messages are gone on the AI Assistant extension, that it now shows the guidelines message and is enabled for use