### PR TITLE
AI Assistant: Add A8c dictionary

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-a8c-dictionary
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-breve-a8c-dictionary
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Add A8c dictionary

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/a8c.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/a8c.ts
@@ -1,0 +1,18 @@
+export default `Automattic
+Tumblr
+WooCommerce
+Jetpack
+Simplenote
+WPScan
+Crowdsignal
+Cloudup
+Akismet
+Longreads
+Newspack
+Gravatar
+BuddyPress
+bbPress
+WordCamp
+Automatticians
+Automattician
+Mullenweg`;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -9,7 +9,7 @@ import nspell from 'nspell';
  * Internal dependencies
  */
 import getDictionary from '../../utils/get-dictionary';
-import a8c from './a8c.ts';
+import a8c from './a8c';
 /**
  * Types
  */

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -158,8 +158,13 @@ export const suggestSpellingFixes = (
 ) => {
 	const spellChecker = getSpellChecker( { language } );
 
-	if ( ! spellChecker ) {
+	if ( ! spellChecker || ! text ) {
 		return [];
+	}
+
+	// capital_P_dangit
+	if ( text.toLocaleLowerCase() === 'wordpress' ) {
+		return [ 'WordPress' ];
 	}
 
 	const suggestions = spellChecker.suggest( text );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -9,6 +9,7 @@ import nspell from 'nspell';
  * Internal dependencies
  */
 import getDictionary from '../../utils/get-dictionary';
+import a8c from './a8c.ts';
 /**
  * Types
  */
@@ -104,6 +105,9 @@ export const getSpellChecker = ( { language = 'en' }: { language?: string } = {}
 		)
 	);
 	exceptions.forEach( exception => spellChecker.add( exception ) );
+
+	// Add the Automattic dictionary
+	spellChecker.personal( a8c );
 
 	spellCheckers[ language ] = spellChecker;
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
@@ -118,6 +118,7 @@ export type SpellChecker = {
 	correct: ( word: string ) => boolean;
 	suggest: ( word: string ) => Array< string >;
 	add: ( word: string ) => void;
+	personal: ( dic: string ) => void;
 };
 
 export type SpellingDictionaryContext = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39099 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds A8c products dictionary
* capital_P_dangit

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor
* Add a text containing the words in the dictionary
```
Wordpress wordpress WordPress Matt Mullenweg Automattic Tumblr Twitter WooCommerce Woo Jetpack Simplenote WPScan Crowdsignal Cloudup Akismet Longreads Newspack Gravatar BuddyPress bbPress WordCamp Automatticians Automattician 
```
* Check that only `Wordpress` and `wordpress` are highlighted
* Check that the suggestion for them is `WordPress`
