### PR TITLE
Add full sync default modules list filter.

### DIFF
--- a/projects/packages/sync/changelog/add-default-full-sync-config-filter
+++ b/projects/packages/sync/changelog/add-default-full-sync-config-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync: add a filter that allows modification of the default modules list used for full sync procedure.

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -81,7 +81,7 @@ class Full_Sync_Immediately extends Module {
 
 		if ( ! is_array( $full_sync_config ) ) {
 			/*
-			 * Filer defualt sync config to allow injecting custom configuration.
+			 * Filter default sync config to allow injecting custom configuration.
 			 *
 			 * @param array $full_sync_config Sync configuration for all sync modules.
 			 *

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -80,7 +80,14 @@ class Full_Sync_Immediately extends Module {
 		$this->reset_data();
 
 		if ( ! is_array( $full_sync_config ) ) {
-			$full_sync_config = Defaults::$default_full_sync_config;
+			/*
+			 * Filer defualt sync config to allow injecting custom configuration.
+			 *
+			 * @param array $full_sync_config Sync configuration for all sync modules.
+			 *
+			 * @since x.x.x
+			 */
+			$full_sync_config = apply_filters( 'jetpack_full_sync_config', Defaults::$default_full_sync_config );
 			if ( is_multisite() ) {
 				$full_sync_config['network_options'] = 1;
 			}

--- a/projects/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/projects/packages/sync/src/modules/class-full-sync-immediately.php
@@ -85,7 +85,7 @@ class Full_Sync_Immediately extends Module {
 			 *
 			 * @param array $full_sync_config Sync configuration for all sync modules.
 			 *
-			 * @since x.x.x
+			 * @since $$next-version$$
 			 */
 			$full_sync_config = apply_filters( 'jetpack_full_sync_config', Defaults::$default_full_sync_config );
 			if ( is_multisite() ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR adds a filter that allows modification of the default modules used for the full sync procedure.

### Other information:

~- [ ] Have you written new tests for your changes, if applicable?~
~- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?~
~- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?~

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://wp.me/pfKYZu-11k

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Not internal but it can be influenced by integrations that use this filter.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not using the filter should not influence any operations.

* Create a snippet that attaches to `jetpack_full_sync_config` and modifies the list of the default sync modules.
