### PR TITLE
Sync: Add subscription type for HPOS orders conditinionally

### DIFF
--- a/projects/packages/sync/changelog/update-sync-hpos-orders-add-subscription-type-conditinionally
+++ b/projects/packages/sync/changelog/update-sync-hpos-orders-add-subscription-type-conditinionally
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: Add subscription type for HPOS orders only if WooCommerce Subscriptions plugin exists

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -15,6 +15,11 @@ use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 class WooCommerce_HPOS_Orders extends Module {
 
 	/**
+	 * The slug of WooCommerce Subscriptions plugin.
+	 */
+	const WOOCOMMERCE_SUBSCRIPTIONS_PATH = 'woocommerce-subscriptions/woocommerce-subscriptions.php';
+
+	/**
 	 * Order table name. There are four order tables (order, addresses, operational_data and meta), but for sync purposes we only care about the main table since it has the order ID.
 	 *
 	 * @access private
@@ -65,7 +70,12 @@ class WooCommerce_HPOS_Orders extends Module {
 	 * @return array Order types to sync.
 	 */
 	public static function get_order_types_to_sync( $prefixed = false ) {
-		$types = array( 'order', 'order_refund', 'subscription' );
+		$types = array( 'order', 'order_refund' );
+
+		if ( is_plugin_active( self::WOOCOMMERCE_SUBSCRIPTIONS_PATH ) ) {
+			$types[] = 'subscription';
+		}
+
 		if ( $prefixed ) {
 			$types = array_map(
 				function ( $type ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes bug introduced in #39022 if there are orders with the shop_subscription type but the WooCommerce Subscriptions plugin is not active.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add subscription type for HPOS orders only if WooCommerce Subscriptions plugin exists

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow instructions in https://github.com/Automattic/jetpack/pull/39022. Make sure the fatal in the notes doesn't occur even if 
WooCommerce Subscriptions plugin is not active.