### PR TITLE
Add `usePostPrePublishValue` hook

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-use-post-pre-publish-value-hook
+++ b/projects/js-packages/publicize-components/changelog/add-use-post-pre-publish-value-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added usePostPrePublishValue hook

--- a/projects/js-packages/publicize-components/src/hooks/use-post-pre-publish-value/index.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-post-pre-publish-value/index.ts
@@ -1,0 +1,35 @@
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+/**
+ * Preserve a value from the post pre-publish state.
+ *
+ * The value will stop updating after the post is published.
+ *
+ * @template V
+ * @param {V} value - The value to preserve.
+ *
+ * @return {V} The preserved value.
+ */
+export function usePostPrePublishValue< V >( value: V ) {
+	const isPublishing = useSelect( select => select( editorStore ).isPublishingPost(), [] );
+
+	const [ currentValue, setCurrentValue ] = useState( value );
+
+	const valueFrozen = useRef( false );
+
+	useEffect( () => {
+		// Freeze the value after publishing starts.
+		if ( isPublishing ) {
+			valueFrozen.current = true;
+		}
+
+		// Since the value is not frozen yet, update the current value.
+		if ( ! valueFrozen.current ) {
+			setCurrentValue( value );
+		}
+	}, [ isPublishing, value ] );
+
+	return currentValue;
+}

--- a/projects/js-packages/publicize-components/src/hooks/use-post-pre-publish-value/index.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-post-pre-publish-value/index.ts
@@ -13,7 +13,11 @@ import { useEffect, useRef, useState } from '@wordpress/element';
  * @return {V} The preserved value.
  */
 export function usePostPrePublishValue< V >( value: V ) {
-	const isPublishing = useSelect( select => select( editorStore ).isPublishingPost(), [] );
+	const isPublishing = useSelect(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- `@wordpress/editor` is a nightmare to work with TypeScript
+		select => ( select( editorStore ) as any ).isPublishingPost(),
+		[]
+	);
 
 	const [ currentValue, setCurrentValue ] = useState( value );
 

--- a/projects/js-packages/publicize-components/src/hooks/use-post-pre-publish-value/test/index.test.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-post-pre-publish-value/test/index.test.js
@@ -1,0 +1,79 @@
+import { act, renderHook } from '@testing-library/react';
+import { RegistryProvider } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { usePostPrePublishValue } from '../';
+import {
+	connections as connectionsList,
+	createRegistryWithStores,
+} from '../../../utils/test-utils';
+
+const connections = connectionsList.map( connection => ( { ...connection, enabled: true } ) );
+
+const post = {
+	jetpack_publicize_connections: [ connections[ 0 ] ],
+};
+
+describe( 'usePostPrePublishValue', () => {
+	it( 'should return the value by default', async () => {
+		const registry = createRegistryWithStores( post );
+
+		const { result } = renderHook( () => usePostPrePublishValue( 'test-value' ), {
+			wrapper: ( { children } ) => (
+				<RegistryProvider value={ registry }>{ children }</RegistryProvider>
+			),
+		} );
+
+		expect( result.current ).toBe( 'test-value' );
+	} );
+
+	it( 'should return the updated value when the post is not being published', async () => {
+		const registry = createRegistryWithStores( post );
+
+		const { rerender, result } = renderHook(
+			( initialValue = 'first-value' ) => usePostPrePublishValue( initialValue ),
+			{
+				wrapper: ( { children } ) => (
+					<RegistryProvider value={ registry }>{ children }</RegistryProvider>
+				),
+			}
+		);
+
+		rerender( 'second-value' );
+
+		await act( async () => {
+			await registry.dispatch( editorStore ).editPost( {
+				status: 'draft',
+				content: 'Some test content',
+			} );
+		} );
+
+		expect( result.current ).toBe( 'second-value' );
+	} );
+
+	it( 'should preserve the pre-publish value', async () => {
+		const registry = createRegistryWithStores( post );
+
+		const { rerender, result } = renderHook(
+			( initialValue = 'first-value' ) => usePostPrePublishValue( initialValue ),
+			{
+				wrapper: ( { children } ) => (
+					<RegistryProvider value={ registry }>{ children }</RegistryProvider>
+				),
+			}
+		);
+
+		rerender( 'second-value' );
+
+		await act( async () => {
+			registry.dispatch( editorStore ).editPost( {
+				status: 'publish',
+				content: 'Some test content',
+			} );
+			registry.dispatch( editorStore ).savePost();
+		} );
+
+		rerender( 'third-value' );
+
+		expect( result.current ).toBe( 'second-value' );
+	} );
+} );


### PR DESCRIPTION
In a task like [#550](https://github.com/Automattic/jetpack-reach/issues/550), we need to preserve some value before the post is publish, to avoid the value being updated after the post is published.

This PR creates a hook named `usePostPrePublishValue`, which watches for a passed value until the post is published and freezes the value after that.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create `usePostPrePublishValue` hook
* Extract re-usable test logic from the tests for `useSyncPostDataToStore` to common utilities
* Add unit tests for `usePostPrePublishValue` hook

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Since the hook is not used yet, just verify that tests pass and CI is happy
* You may test it via #39120

