### PR TITLE
tools: Fix incorrectly quoted `*` in bash scripts

### DIFF
--- a/tools/composer-update-monorepo.sh
+++ b/tools/composer-update-monorepo.sh
@@ -25,9 +25,9 @@ function check_dir {
 		return 1
 	elif [[ -d "$1" ]]; then
 		DIR="${1%/}"
-	elif [[ "$1" == "*/composer.json" && -f "$1" ]]; then # DWIM
+	elif [[ "$1" == */composer.json && -f "$1" ]]; then # DWIM
 		DIR="$(dirname "$1")"
-	elif [[ "$1" == "*/composer.lock" && -f "$1" ]]; then # DWIM
+	elif [[ "$1" == */composer.lock && -f "$1" ]]; then # DWIM
 		DIR="$(dirname "$1")"
 	else
 		error "Directory $1 does not exist."

--- a/tools/version-packages.sh
+++ b/tools/version-packages.sh
@@ -35,7 +35,7 @@ function check_dir {
 			error "$DIR does not contain composer.json."
 			return 1
 		fi
-	elif [[ "$1" == "*/composer.json" && -f "$1" ]]; then # DWIM
+	elif [[ "$1" == */composer.json && -f "$1" ]]; then # DWIM
 		DIR="$(dirname "$1")"
 	else
 		error "Directory $1 does not exist."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
In a few places, we do something like `[[ "$var" == "*/filename" ]]`, which checks for the variable being literally "*/filename" rather than interpreting the `*` as a glob as intended.

This removes the unnecessary quotes so it works right.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try running something like `tools/composer-update-monorepo.sh projects/plugins/beta/composer.lock` or `tools/version-packages.sh projects/plugins/beta/composer.json`, see if it works right rather than complaining that the directory doesn't exist.
