### PR TITLE
Jetpack AI: Update sidebar fair usage messaging

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-update-sidebar-fair-usage-messaging
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-update-sidebar-fair-usage-messaging
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: update fair usage messaging on the sidebar.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quota-exceeded-message/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quota-exceeded-message/index.tsx
@@ -266,17 +266,36 @@ const VIPUpgradePrompt = ( {
 	);
 };
 
+type FairUsageNoticeProps = {
+	variant?: 'error' | 'muted';
+};
+
 /**
  * The fair usage notice component.
+ * @param {FairUsageNoticeProps}         props         - Fair usage notice component props.
+ * @param {FairUsageNoticeProps.variant} props.variant - The variant of the notice to render.
  * @return {ReactElement} the Notice component with the fair usage message.
  */
-export const FairUsageNotice = () => {
+export const FairUsageNotice = ( { variant = 'error' }: FairUsageNoticeProps ) => {
 	const useFairUsageNoticeMessageElement = useFairUsageNoticeMessage();
-	return (
-		<Notice status="error" isDismissible={ false } className="jetpack-ai-fair-usage-notice">
-			{ useFairUsageNoticeMessageElement }
-		</Notice>
-	);
+
+	if ( variant === 'muted' ) {
+		return (
+			<span className="jetpack-ai-fair-usage-notice-muted-variant">
+				{ useFairUsageNoticeMessageElement }
+			</span>
+		);
+	}
+
+	if ( variant === 'error' ) {
+		return (
+			<Notice status="error" isDismissible={ false } className="jetpack-ai-fair-usage-notice">
+				{ useFairUsageNoticeMessageElement }
+			</Notice>
+		);
+	}
+
+	return null;
 };
 
 const QuotaExceededMessage = props => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quota-exceeded-message/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quota-exceeded-message/index.tsx
@@ -270,7 +270,7 @@ const VIPUpgradePrompt = ( {
  * The fair usage notice component.
  * @return {ReactElement} the Notice component with the fair usage message.
  */
-const FairUsageNotice = () => {
+export const FairUsageNotice = () => {
 	const useFairUsageNoticeMessageElement = useFairUsageNoticeMessage();
 	return (
 		<Notice status="error" isDismissible={ false } className="jetpack-ai-fair-usage-notice">

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quota-exceeded-message/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quota-exceeded-message/style.scss
@@ -19,5 +19,17 @@
     text-wrap: pretty;
     font-size: calc(13px);
     font-weight: normal;
-    color: var(--jp-gray-40);
+    color: #757575;
+
+    a {
+        color: #757575;
+    }
+}
+
+.jetpack-ai-fair-usage-notice {
+    color: #1E1E1E;
+
+    a {
+        color: #1E1E1E;
+    }
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quota-exceeded-message/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/components/quota-exceeded-message/style.scss
@@ -12,3 +12,12 @@
         }
     }
 }
+
+.jetpack-ai-fair-usage-notice-muted-variant {
+    line-height: 1.4;
+    margin: 0px;
+    text-wrap: pretty;
+    font-size: calc(13px);
+    font-weight: normal;
+    color: var(--jp-gray-40);
+}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -324,7 +324,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 	);
 
 	const fairUsageNotice = (
-		<>{ isOverLimit && planType === PLAN_TYPE_UNLIMITED && <FairUsageNotice /> }</>
+		<>{ isOverLimit && planType === PLAN_TYPE_UNLIMITED && <FairUsageNotice variant="muted" /> }</>
 	);
 
 	const trackUpgradeClick = useCallback(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -29,7 +29,7 @@ import { USAGE_PANEL_PLACEMENT_BLOCK_SETTINGS_SIDEBAR } from '../../plugins/ai-a
 import { PLAN_TYPE_FREE, PLAN_TYPE_UNLIMITED, usePlanType } from '../../shared/use-plan-type';
 import ConnectPrompt from './components/connect-prompt';
 import FeedbackControl from './components/feedback-control';
-import QuotaExceededMessage from './components/quota-exceeded-message';
+import QuotaExceededMessage, { FairUsageNotice } from './components/quota-exceeded-message';
 import ToolbarControls from './components/toolbar-controls';
 import { getStoreBlockId } from './extensions/ai-assistant/with-ai-assistant';
 import useAIAssistant from './hooks/use-ai-assistant';
@@ -323,6 +323,10 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		</>
 	);
 
+	const fairUsageNotice = (
+		<>{ isOverLimit && planType === PLAN_TYPE_UNLIMITED && <FairUsageNotice /> }</>
+	);
+
 	const trackUpgradeClick = useCallback(
 		event => {
 			event.preventDefault();
@@ -354,6 +358,12 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 					</div>
 				) }
 				<InspectorControls>
+					{ fairUsageNotice && (
+						<div className="block-editor-block-card" style={ { paddingTop: 0 } }>
+							<span className="block-editor-block-icon"></span>
+							{ fairUsageNotice }
+						</div>
+					) }
 					{ /* Mock BlockCard component styles to keep alignment */ }
 					<div className="block-editor-block-card" style={ { paddingTop: 0 } }>
 						<span className="block-editor-block-icon"></span>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -81,8 +81,10 @@ const JetpackAndSettingsContent = ( {
 	return (
 		<>
 			{ showFairUsageNotice && (
-				<PanelRow>
-					<FairUsageNotice />
+				<PanelRow className="jetpack-ai-sidebar__feature-section">
+					<BaseControl>
+						<FairUsageNotice variant="muted" />
+					</BaseControl>
 				</PanelRow>
 			) }
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -80,6 +80,12 @@ const JetpackAndSettingsContent = ( {
 
 	return (
 		<>
+			{ showFairUsageNotice && (
+				<PanelRow>
+					<FairUsageNotice />
+				</PanelRow>
+			) }
+
 			{ isBreveAvailable && (
 				<PanelRow>
 					<BaseControl label={ __( 'Write Brief with AI (BETA)', 'jetpack' ) }>
@@ -116,12 +122,6 @@ const JetpackAndSettingsContent = ( {
 			{ isUsagePanelAvailable && showUsagePanel && (
 				<PanelRow className="jetpack-ai-sidebar__feature-section">
 					<UsagePanel placement={ placement } />
-				</PanelRow>
-			) }
-
-			{ showFairUsageNotice && (
-				<PanelRow>
-					<FairUsageNotice />
 				</PanelRow>
 			) }
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import QuotaExceededMessage from '../../../../blocks/ai-assistant/components/quota-exceeded-message';
+import { FairUsageNotice } from '../../../../blocks/ai-assistant/components/quota-exceeded-message';
 import useAICheckout from '../../../../blocks/ai-assistant/hooks/use-ai-checkout';
 import useAiFeature from '../../../../blocks/ai-assistant/hooks/use-ai-feature';
 import useAiProductPage from '../../../../blocks/ai-assistant/hooks/use-ai-product-page';
@@ -66,7 +66,7 @@ const JetpackAndSettingsContent = ( {
 	requireUpgrade,
 	upgradeType,
 	showUsagePanel,
-	showQuotaExceeded,
+	showFairUsageNotice,
 }: JetpackSettingsContentProps ) => {
 	const { checkoutUrl } = useAICheckout();
 	const { productPageUrl } = useAiProductPage();
@@ -119,9 +119,9 @@ const JetpackAndSettingsContent = ( {
 				</PanelRow>
 			) }
 
-			{ showQuotaExceeded && (
+			{ showFairUsageNotice && (
 				<PanelRow>
-					<QuotaExceededMessage />
+					<FairUsageNotice />
 				</PanelRow>
 			) }
 
@@ -179,7 +179,7 @@ export default function AiAssistantPluginSidebar() {
 
 	const showUsagePanel =
 		planType === PLAN_TYPE_FREE || ( tierPlansEnabled && planType !== PLAN_TYPE_UNLIMITED );
-	const showQuotaExceeded = planType === PLAN_TYPE_UNLIMITED && isOverLimit;
+	const showFairUsageNotice = planType === PLAN_TYPE_UNLIMITED && isOverLimit;
 
 	return (
 		<>
@@ -198,7 +198,7 @@ export default function AiAssistantPluginSidebar() {
 						requireUpgrade={ requireUpgrade }
 						upgradeType={ upgradeType }
 						showUsagePanel={ showUsagePanel }
-						showQuotaExceeded={ showQuotaExceeded }
+						showFairUsageNotice={ showFairUsageNotice }
 					/>
 				</PanelBody>
 			</JetpackPluginSidebar>
@@ -213,7 +213,7 @@ export default function AiAssistantPluginSidebar() {
 					requireUpgrade={ requireUpgrade }
 					upgradeType={ upgradeType }
 					showUsagePanel={ showUsagePanel }
-					showQuotaExceeded={ showQuotaExceeded }
+					showFairUsageNotice={ showFairUsageNotice }
 				/>
 			</PluginDocumentSettingPanel>
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/types.ts
@@ -5,7 +5,7 @@ export type JetpackSettingsContentProps = {
 	requireUpgrade: boolean;
 	upgradeType: string;
 	showUsagePanel: boolean;
-	showQuotaExceeded: boolean;
+	showFairUsageNotice: boolean;
 };
 
 export type CoreSelect = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the AI Assistant sidebar fair usage message up, at the top of the sidebar
* Add fair usage message to the AI Assistant block inspector (design proposed it over the block description, but I think we can only show it under the description, so I proceeded this way)
* Change sidebar fair usage message style to a "muted" version (plan text, greyed style), as per proposed design
* Fix the colors of the links on the fair usage message so they follow the same color as the text around them

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1HpG7-tUE-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this branch on your testing site
* Sandbox the `public-api` domain and change the `0-sandbox.php` file to add the following filters, so we simulate an unlimited plan over the fair usage limit:

```
add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 1; } );
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 3001; } );
```

* On all test cases below, confirm the UI you see matches the proposed design from p1HpG7-tUE-p2 and the links on the messages are using the same color of the text
* Go to the block editor
* Confirm the fair usage message is showing correctly on the Jetpack sidebar and the post sidebar, following the proposed design:

<img width="250" alt="Screenshot 2024-08-28 at 13 52 56" src="https://github.com/user-attachments/assets/0f055e93-5d16-461b-b1c1-d90266d157a2">

* Add an AI Assistant block
* Confirm the fair usage message is showing correctly on block inspector, following the proposed design:

<img width="250" alt="Screenshot 2024-08-28 at 13 53 12" src="https://github.com/user-attachments/assets/a8204aec-efe2-44da-918b-951fdf50316a">

* Now let's confirm the link colors on already existing messages
* Add an image block and click the "Generate with AI" button; confirm the link on the fair usage limit message is in the same color as the message text:

<img width="500" alt="Screenshot 2024-08-28 at 13 52 08" src="https://github.com/user-attachments/assets/fff4ac14-49fe-4d95-afa5-455bd99cfe1d">

* Add an AI Assistant block; confirm the link on the fair usage limit message above it is in the same color as the message text

<img width="500" alt="Screenshot 2024-08-28 at 13 52 00" src="https://github.com/user-attachments/assets/6da39b8c-295c-4220-bffe-252e3e4a7f16">

* Go to the post settings sidebar and look for the excerpt tool; confirm the link on the fair usage limit message is in the same color as the message text

<img width="250" alt="Screenshot 2024-08-28 at 13 52 26" src="https://github.com/user-attachments/assets/197e70e0-dd90-43f1-b461-2bd82afd2b85">

* Go back to the `0-sandbox.php` file and change the filters to:

```

add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 1; } );
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 2900; } );
```

* Confirm the fair usage messages are gone