### PR TITLE
Jetpack AI: remove hardcoded value for request limit

### DIFF
--- a/projects/plugins/jetpack/changelog/change-ai-image-generation-unlimited-plan-hard-limit
+++ b/projects/plugins/jetpack/changelog/change-ai-image-generation-unlimited-plan-hard-limit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: remove hardcoded limit on image generation, it's handled by backend

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -22,14 +22,11 @@ export default function useAiFeature() {
 			usagePeriod,
 			requestsCount: allTimeRequestsCount,
 			requestsLimit: freeRequestsLimit,
-			tierPlansEnabled,
 		} = featureData;
 
 		const planType = getPlanType( currentTier );
 
-		// TODO: mind this hardcoded value (3000),
-		// maybe provide it from the backend but we'd be replacing the 9 Billion limit with 3k
-		const currentTierLimit = tierPlansEnabled ? currentTier?.limit || freeRequestsLimit : 3000;
+		const currentTierLimit = currentTier?.limit || freeRequestsLimit;
 
 		const actualRequestsCount =
 			planType === PLAN_TYPE_TIERED ? usagePeriod?.requestsCount : allTimeRequestsCount;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-feature/index.ts
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import {
-	PLAN_TYPE_FREE,
-	PLAN_TYPE_TIERED,
-	usePlanType as getPlanType,
-} from '../../../../shared/use-plan-type';
+import { PLAN_TYPE_FREE, usePlanType as getPlanType } from '../../../../shared/use-plan-type';
 import type { WordPressPlansSelectors } from 'extensions/store/wordpress-com';
 
 export default function useAiFeature() {
@@ -29,7 +25,7 @@ export default function useAiFeature() {
 		const currentTierLimit = currentTier?.limit || freeRequestsLimit;
 
 		const actualRequestsCount =
-			planType === PLAN_TYPE_TIERED ? usagePeriod?.requestsCount : allTimeRequestsCount;
+			planType === PLAN_TYPE_FREE ? allTimeRequestsCount : usagePeriod?.requestsCount;
 		const actualRequestsLimit = planType === PLAN_TYPE_FREE ? freeRequestsLimit : currentTierLimit;
 
 		return {


### PR DESCRIPTION
Image generation tries to make sure the user has enough requests left before attempting to generate a new one. With tier plans disabled this will be deprecated, even if the user would go over the limit with an image generation request.

Fixes #

## Proposed changes:
Remove the hardcoded limit of 3000, trust the currentTier limit or default to free requests limit

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1724868021650779/1724866663.901329-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Sandbox the public API. Disable the tier plans and set the licensed amount to somewhere near the fair usage limit, like 2995 (refer to D159560-code for filter setup).

Open one of the AI image generation modals (image block, featured image). Before this patch you'd get a warning about not having enough requests to perform the action. Apply this PR and reload. You should be able to generate an image even if you're too close to the limit.

Test other random scenarios (tiers plans enabled/disabled, free in range/over limit, tier in range/over limit) to see everything is still working