### PR TITLE
My Jetpack: Change Jetpack AI product page limit handling

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -68,8 +68,8 @@ export default function () {
 	} = aiAssistantFeature || {};
 
 	const isFree = currentTier?.value === 0;
-	const hasUnlimited = currentTier?.value === 1 || ( ! tierPlansEnabled && ! isFree );
-	const hasPaidTier = ! isFree && ! hasUnlimited;
+	const hasUnlimited = currentTier?.value === 1;
+	const hasPaidTier = ( ! isFree && ! hasUnlimited ) || ( hasUnlimited && ! tierPlansEnabled );
 	const shouldContactUs = ! hasUnlimited && hasPaidTier && ! nextTier && currentTier;
 	const freeRequestsLeft = isFree && 20 - allTimeRequests >= 0 ? 20 - allTimeRequests : 0;
 	const showCurrentUsage = hasPaidTier && ! isFree && usage;
@@ -100,10 +100,15 @@ export default function () {
 	const showRenewalNotice = isOverLimit && hasPaidTier;
 	const showUpgradeNotice = isOverLimit && isFree;
 
-	const currentTierValue = currentTier?.value || 0;
-	const currentUsage = usage?.[ 'requests-count' ] || 0;
+	const currentTierLimit = currentTier?.limit || 0;
+	const currentUsage = usage?.requestsCount || 0;
+
 	const tierRequestsLeft =
-		currentTierValue - currentUsage >= 0 ? currentTierValue - currentUsage : 0;
+		currentTierLimit - currentUsage >= 0 ? currentTierLimit - currentUsage : 0;
+	const requestCardNumber = tierPlansEnabled ? tierRequestsLeft : currentUsage;
+
+	const currentUsageLabel = __( 'Requests this month', 'jetpack-my-jetpack' );
+	const currentRemainingLabel = __( 'Requests for this month', 'jetpack-my-jetpack' );
 
 	const renewalNoticeTitle = __(
 		"You've reached your request limit for this month",
@@ -111,14 +116,20 @@ export default function () {
 	);
 	const upgradeNoticeTitle = __( "You've used all your free requests", 'jetpack-my-jetpack' );
 
-	const renewalNoticeBody = sprintf(
+	const renewalNoticeBodyInfo = sprintf(
 		// translators: %d is the number of days left in the month.
-		__(
-			'Wait for %d days to reset your limit, or upgrade now to a higher tier for additional requests and keep your work moving forward.',
-			'jetpack-my-jetpack'
-		),
+		__( 'Wait for %d days to reset your limit', 'jetpack-my-jetpack' ),
 		Math.floor( ( new Date( usage?.nextStart || null ) - new Date() ) / ( 1000 * 60 * 60 * 24 ) )
 	);
+
+	const renewalNoticeBodyTeaser = __(
+		', or upgrade now to a higher tier for additional requests and keep your work moving forward.',
+		'jetpack-my-jetpack'
+	);
+
+	const renewalNoticeBody = ! tierPlansEnabled
+		? renewalNoticeBodyInfo + '.'
+		: renewalNoticeBodyInfo + renewalNoticeBodyTeaser;
 
 	const upgradeNoticeBody = __(
 		'Reach for More with Jetpack AI! Upgrade now for additional requests and keep your momentum going.',
@@ -222,10 +233,10 @@ export default function () {
 									<AiIcon />
 									<div>
 										<div className={ styles[ 'product-interstitial__stats-card-text' ] }>
-											{ __( 'Requests for this month', 'jetpack-my-jetpack' ) }
+											{ tierPlansEnabled ? currentRemainingLabel : currentUsageLabel }
 										</div>
 										<div className={ styles[ 'product-interstitial__stats-card-value' ] }>
-											{ tierRequestsLeft }
+											{ requestCardNumber }
 										</div>
 									</div>
 								</Card>
@@ -264,11 +275,15 @@ export default function () {
 						{ showNotice && (
 							<div className={ styles[ 'product-interstitial__ai-notice' ] }>
 								<Notice
-									actions={ [
-										<Button isPrimary onClick={ upgradeClickHandler }>
-											{ showRenewalNotice ? renewalNoticeCta : upgradeNoticeCta }
-										</Button>,
-									] }
+									actions={
+										tierPlansEnabled
+											? [
+													<Button isPrimary onClick={ upgradeClickHandler }>
+														{ showRenewalNotice ? renewalNoticeCta : upgradeNoticeCta }
+													</Button>,
+											  ]
+											: {}
+									}
 									onClose={ onNoticeClose }
 									level={ showRenewalNotice ? 'warning' : 'error' }
 									title={ showRenewalNotice ? renewalNoticeTitle : upgradeNoticeTitle }

--- a/projects/packages/my-jetpack/changelog/change-jetpack-ai-product-page-limit-handling
+++ b/projects/packages/my-jetpack/changelog/change-jetpack-ai-product-page-limit-handling
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+My Jetpack: show over quota notice and period usage counter for unlimited plans


### PR DESCRIPTION
## Proposed changes:
Add a notice for unlimited plans over fair usage on Jetpack AI product page
Show current period request count alongside the already all time requests count on Jetpack AI product page
Remove unnecessary conditional to determine if user is on unlimited plan

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1724872002295049/1724866663.901329-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Sandbox the public API. Disable the tier plans and set the licensed amount above the usage limit (refer to D159560-code for setting up an unlimited plan over limit). 

Go to My Jetpack and user the "View" button on Jetpack AI card to get to the product page.
There should be new card showing current period request count
There should be a notice stating when the next period reset will happen and inviting to upgrade

Enabling tier plans again should show **remaining** requests (default) instead of current period usage.

Exception to unlimited plans: there should be no upgrade button.
