### PR TITLE
Social: Fix share modal trigger presence

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-share-modal-trigger-presence
+++ b/projects/js-packages/publicize-components/changelog/fix-social-share-modal-trigger-presence
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fixed a bug on when to show the share log modal trigger

--- a/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from 'react';
 import { store as socialStore } from '../../social-store';
@@ -16,8 +17,21 @@ type ModalTriggerProps = ButtonProps & {
 export const ModalTrigger = forwardRef(
 	( { withWrapper = false, ...props }: ModalTriggerProps, ref: unknown ) => {
 		const { openShareStatusModal } = useDispatch( socialStore );
-
 		const featureFlags = useSelect( select => select( socialStore ).featureFlags(), [] );
+		const { shareStatus } = useSelect( select => {
+			const store = select( socialStore );
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- `@wordpress/editor` is a nightmare to work with TypeScript
+			const _editorStore = select( editorStore ) as any;
+
+			return {
+				shareStatus: store.getPostShareStatus( _editorStore.getCurrentPostId() ),
+			};
+		}, [] );
+
+		// If the post is not shared anywhere, thus there is no share status or no shares, we don't need to show the trigger.
+		if ( ! shareStatus || ! shareStatus.shares || shareStatus.shares.length === 0 ) {
+			return null;
+		}
 
 		if ( ! featureFlags.useShareStatus ) {
 			return null;

--- a/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { forwardRef } from 'react';
 import { store as socialStore } from '../../social-store';
@@ -18,15 +17,7 @@ export const ModalTrigger = forwardRef(
 	( { withWrapper = false, ...props }: ModalTriggerProps, ref: unknown ) => {
 		const { openShareStatusModal } = useDispatch( socialStore );
 		const featureFlags = useSelect( select => select( socialStore ).featureFlags(), [] );
-		const { shareStatus } = useSelect( select => {
-			const store = select( socialStore );
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- `@wordpress/editor` is a nightmare to work with TypeScript
-			const _editorStore = select( editorStore ) as any;
-
-			return {
-				shareStatus: store.getPostShareStatus( _editorStore.getCurrentPostId() ),
-			};
-		}, [] );
+		const shareStatus = useSelect( select => select( socialStore ).getPostShareStatus(), [] );
 
 		// If the post is not shared anywhere, thus there is no share status or no shares, we don't need to show the trigger.
 		if ( ! shareStatus || ! shareStatus.shares || shareStatus.shares.length === 0 ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/553

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Only show the modal trigger if `shareStatus.shares` is present and length is not 0.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/553
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Publish a post without sharing.
* It should not have the modal trigger. Refresh, still should not have the trigger
* Publish a post with sharing, it should have the modal trigger.
* Open an already published post, it should have the modal trigger 

