### PR TITLE
SSO: Show wp-admin login form if site has local users

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcom-sso-local-users
+++ b/projects/plugins/wpcomsh/changelog/update-wpcom-sso-local-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+SSO: Show wp-admin login form if site has local users

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -218,25 +218,36 @@ add_filter( 'jetpack_sso_auth_cookie_expiration', 'wpcomsh_jetpack_sso_auth_cook
 
 /**
  * Determine if users who are already logged in to WordPress.com are automatically logged in to wp-admin.
+ *
+ * Sites without local users:
+ * - Automatic login, always.
+ *
+ * Sites with local users:
+ * - If user comes from Calypso: Automatic login
+ * - Otherwise: Show the login form, so they can decide whether to use a WP.com account or a local account.
  */
 function wpcomsh_bypass_jetpack_sso_login() {
-	/**
-	 * Sites with the classic interface:
-	 * - Automatic login if they come from Calypso.
-	 * - Otherwise we display the login form, so they can decide whether to use a WP.com account or a local account.
-	 */
-	if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
-		$calypso_domains = array(
-			'https://wordpress.com/',
-			'https://horizon.wordpress.com/',
-			'https://wpcalypso.wordpress.com/',
-			'http://calypso.localhost:3000/',
-			'http://127.0.0.1:41050/', // Desktop App.
-		);
-		return in_array( wp_get_referer(), $calypso_domains, true );
+	$calypso_domains = array(
+		'https://wordpress.com/',
+		'https://horizon.wordpress.com/',
+		'https://wpcalypso.wordpress.com/',
+		'http://calypso.localhost:3000/',
+		'http://127.0.0.1:41050/', // Desktop App.
+	);
+	if ( in_array( wp_get_referer(), $calypso_domains, true ) ) {
+		return true;
 	}
 
-	// Users of sites with the default interface are always logged in automatically.
+	if ( class_exists( '\Automattic\Jetpack\Connection\Manager' ) ) {
+		$connection_manager = new \Automattic\Jetpack\Connection\Manager( 'jetpack' );
+		$users              = get_users( array( 'fields' => array( 'ID' ) ) );
+		foreach ( $users as $user ) {
+			if ( ! $connection_manager->is_user_connected( $user->ID ) ) {
+				return false;
+			}
+		}
+	}
+
 	return true;
 }
 add_filter( 'jetpack_sso_bypass_login_forward_wpcom', 'wpcomsh_bypass_jetpack_sso_login' );

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -217,14 +217,14 @@ function wpcomsh_jetpack_sso_auth_cookie_expiration( $seconds ) {
 add_filter( 'jetpack_sso_auth_cookie_expiration', 'wpcomsh_jetpack_sso_auth_cookie_expiration' );
 
 /**
- * Determine if users who are already logged in to WordPress.com are automatically logged in to wp-admin.
+ * Determine if users should be enforced to log in with their WP.com account.
  *
  * Sites without local users:
- * - Automatic login, always.
+ * - WP.com login, always.
  *
  * Sites with local users:
- * - If user comes from Calypso: Automatic login
- * - Otherwise: Show the login form, so they can decide whether to use a WP.com account or a local account.
+ * - If user comes from Calypso: WP.com login
+ * - Otherwise: Jetpack SSO login, so they can decide whether to use a WP.com account or a local account.
  */
 function wpcomsh_bypass_jetpack_sso_login() {
 	$calypso_domains = array(


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/39037

## Proposed changes:

Stops enforcing the WP.com login for Atomic sites with local users.

Before | After
--- | ---
<img width="1091" alt="Screenshot 2024-08-29 at 16 15 27" src="https://github.com/user-attachments/assets/0e325235-cebc-4d9a-a00d-1b83a9722061"> | <img width="1097" alt="Screenshot 2024-08-29 at 16 16 32" src="https://github.com/user-attachments/assets/699ee813-8738-4ef1-aec8-e995559c6b8d">

Previously, we were disabling the enforced WP.com login on sites with the classic interface (except for users coming from Calypso), and kept it on sites with the default interface.

However, sites with the default interface can have local users as well (users not connected to WP.com) who are unable to use their wp-admin credentials to log in into wp-admin.

This PR fixes that by changing who is enforced to log in with a WP.com account:

- Sites without local users:
  - WP.com login, always.
- Sites with local users:
  - If user comes from Calypso: WP.com login
  - Otherwise: Jetpack SSO login, so they can decide whether to use a WP.com account or a local account.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pc4f5j-4Ky-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Install Jetpack Beta on a WoA dev site
- Open Jetpack Beta and activate the branch of this PR in the WordPress.com Site Helper plugin (`wpcomsh`).
- Go to https://wordpress.com/settings/general and select your WoA dev site
- Activate the default admin interface
- Go to `/wp-admin/users.php`
- Create a new local user (**do not invite the user to WP.com**)
- Open an incognito/private window
- Go to `/wp-admin`
- Make sure the Jetpack SSO login form shows up which allows you to use either a WP.com account or a local account
- Go to wordpress.com
- Log in
- While in Calypso, switch to your WoA dev site
- Click on any menu that links to wp-admin (e.g. Settings > Media)
- Make sure you're automatically logged in
- Close the incognito/private window
- Remove all the local users from your site
- Open an incognito/private window
- Go to `/wp-admin`
- Make sure you're redirected to the WP.com login
- Close the incognito/private window
- Activate the classic admin interface now
- Repeat the steps above and confirm that you get the same results