### PR TITLE
Jetpack AI: fix extra spacing bug on the AI Assistant block inspector

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-block-inspector-bug
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-block-inspector-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: fix bug that showed extra spacing on the AI Assistant block inspector area.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -323,9 +323,8 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 		</>
 	);
 
-	const fairUsageNotice = (
-		<>{ isOverLimit && planType === PLAN_TYPE_UNLIMITED && <FairUsageNotice variant="muted" /> }</>
-	);
+	const fairUsageNotice =
+		isOverLimit && planType === PLAN_TYPE_UNLIMITED ? <FairUsageNotice variant="muted" /> : null;
 
 	const trackUpgradeClick = useCallback(
 		event => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change how the `fairUsageNotice` const is computed so it is truly null when no fair usage notice is necessary, preventing the addition of an empty div that was producing the extra spacing

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this branch on your testing site
* Sandbox the `public-api` domain and change the `0-sandbox.php` file to add the following filters, so we simulate an unlimited plan under the fair usage limit:

```
add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 1; } );
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 2999; } );
```

* Go to the block editor and add an AI Assistant block
* With the block selected, open the block inspector sidebar (on the post settings sidebar, go to the "block" tab)
* Confirm the spacing between the block description and the "Discover all features" link is correct:

| Before | After |
| --- | --- |
| <img width="257" alt="Screenshot 2024-08-28 at 18 38 49" src="https://github.com/user-attachments/assets/f99a8dd8-2c88-44f1-926b-cc75899af940"> | <img width="250" alt="Screenshot 2024-08-29 at 14 20 45" src="https://github.com/user-attachments/assets/5e9a8e30-aab3-44a3-943e-7d637bceba35"> |

* Go back to the `0-sandbox.php` file and change the filters to the values below, so we simulate the site is over the fair usage limit:

```

add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 1; } );
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 3001; } );
```

* Confirm the fair usage message is showing properly:

<img width="250" alt="Screenshot 2024-08-29 at 14 30 00" src="https://github.com/user-attachments/assets/2b5d2bef-a44a-4300-8694-da861e905672">