### PR TITLE
Boost: add plugin version meta to page

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/Generator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Generator.php
@@ -12,6 +12,7 @@ class Generator {
 		$generator = new static();
 		if ( static::is_generating_critical_css() ) {
 			add_action( 'wp_head', array( $generator, 'display_generate_meta' ), 0 );
+			add_action( 'wp_head', array( $generator, 'display_plugin_version_meta' ), 0 );
 			$generator->force_logged_out_render();
 		}
 	}
@@ -61,6 +62,16 @@ class Generator {
 	public function display_generate_meta() {
 		?>
 		<meta name="<?php echo esc_attr( self::GENERATE_QUERY_ACTION ); ?>" content="true"/>
+		<?php
+	}
+
+	/**
+	 * Displays the plugin version number as a meta tag.
+	 */
+	private function display_plugin_version_meta() {
+		$plugin_version = defined( 'JETPACK_BOOST_VERSION' ) ? JETPACK_BOOST_VERSION : 'unknown';
+		?>
+		<meta name="jetpack-boost-version" content="<?php echo esc_attr( $plugin_version ); ?>"/>
 		<?php
 	}
 }

--- a/projects/plugins/boost/app/lib/critical-css/Generator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Generator.php
@@ -68,7 +68,7 @@ class Generator {
 	/**
 	 * Displays the plugin version number as a meta tag.
 	 */
-	private function display_plugin_version_meta() {
+	public function display_plugin_version_meta() {
 		$plugin_version = defined( 'JETPACK_BOOST_VERSION' ) ? JETPACK_BOOST_VERSION : 'unknown';
 		?>
 		<meta name="jetpack-boost-version" content="<?php echo esc_attr( $plugin_version ); ?>"/>

--- a/projects/plugins/boost/app/lib/critical-css/Generator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Generator.php
@@ -6,7 +6,8 @@ use Automattic\Jetpack_Boost\Modules\Optimizations\Critical_CSS\CSS_Proxy;
 
 class Generator {
 
-	const GENERATE_QUERY_ACTION = 'jb-generate-critical-css';
+	const GENERATE_QUERY_ACTION   = 'jb-generate-critical-css';
+	const PLUGIN_VERSION_META_TAG = 'jb-version';
 
 	public static function init() {
 		$generator = new static();
@@ -71,7 +72,7 @@ class Generator {
 	public function display_plugin_version_meta() {
 		$plugin_version = defined( 'JETPACK_BOOST_VERSION' ) ? JETPACK_BOOST_VERSION : 'unknown';
 		?>
-		<meta name="jetpack-boost-version" content="<?php echo esc_attr( $plugin_version ); ?>"/>
+		<meta name="<?php echo esc_attr( self::PLUGIN_VERSION_META_TAG ); ?>" content="<?php echo esc_attr( $plugin_version ); ?>"/>
 		<?php
 	}
 }

--- a/projects/plugins/boost/app/lib/critical-css/Generator.php
+++ b/projects/plugins/boost/app/lib/critical-css/Generator.php
@@ -11,9 +11,9 @@ class Generator {
 
 	public static function init() {
 		$generator = new static();
+		add_action( 'wp_head', array( $generator, 'display_plugin_version_meta' ), 0 );
 		if ( static::is_generating_critical_css() ) {
 			add_action( 'wp_head', array( $generator, 'display_generate_meta' ), 0 );
-			add_action( 'wp_head', array( $generator, 'display_plugin_version_meta' ), 0 );
 			$generator->force_logged_out_render();
 		}
 	}

--- a/projects/plugins/boost/changelog/add-boost-version-meta-ccss
+++ b/projects/plugins/boost/changelog/add-boost-version-meta-ccss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Boost: add plugin version in meta field when generating critical css


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Display the plugin version number in the page html, to be used by the plugin backend when version checking a site.

Ref: https://github.com/Automattic/boost-cloud/issues/22


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a constant PLUGIN_VERSION_META_TAG to the Generator class
* Add a function `display_plugin_version_meta` to that class
* Use wp_head to call `display_plugin_version_meta` on every page load.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Apply PR.
* Reload your test site
* View source code
* You should see the string `<meta name="jetpack-boost-version" content="X"/>` where X is the version number of Boost running on your site.
