### PR TITLE
tools: Improve speed of `tools/changelogger-release.sh`

### DIFF
--- a/tools/changelogger-release.sh
+++ b/tools/changelogger-release.sh
@@ -161,7 +161,6 @@ if $ANY; then
 fi
 
 # Release the projects, in build order so we can force a release of something if one of its deps got updated.
-declare -A RELEASED
 for SLUG in "${TO_RELEASE[@]}"; do
 	cd "$BASE/projects/$SLUG"
 
@@ -172,7 +171,6 @@ for SLUG in "${TO_RELEASE[@]}"; do
 	fi
 
 	info "Processing $SLUG..."
-	RELEASED[$SLUG]=1
 
 	# Avoid "There are no changes with content for this write. Proceed?" prompts and empty changelog entries.
 	ANY=false
@@ -224,6 +222,7 @@ for SLUG in "${TO_RELEASE[@]}"; do
 	if [[ -z "$OLDVER" ]] || is_major_bump "$OLDVER" "$VER"; then
 		debug "  Version bump ${OLDVER:-none} -> $VER looks like a major bump, adding a change entry to dependents without one"
 		for S in $( jq -r --arg slug "$SLUG" '.[$slug] // empty | .[]' <<<"$DEPTS" ); do
+			[[ "$S" == monorepo ]] && continue
 			cd "$BASE/projects/$S"
 			CHANGES_DIR=$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)
 			if [[ ! -d "$CHANGES_DIR" || -z "$(ls -- "$CHANGES_DIR")" ]]; then
@@ -251,25 +250,24 @@ done
 
 cd "$BASE"
 info "Updating dependencies..."
-SLUGS=()
-# Use a temp variable so pipefail works
-TMP="$(pnpm jetpack dependencies build-order --pretty)"
-mapfile -t SLUGS <<<"$TMP"
-
-TMPDIR="${TMPDIR:-/tmp}"
-TEMP=$(mktemp "${TMPDIR%/}/changelogger-release-XXXXXXXX")
-
-for DEPENDENCY_SLUG in "${SLUGS[@]}"; do
-	if [[ -n "${RELEASED[$DEPENDENCY_SLUG]}" ]]; then
-		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $RELEASEBRANCH -U $DEPENDENCY_SLUG"
-		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $RELEASEBRANCH -U "$DEPENDENCY_SLUG"
+debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $RELEASEBRANCH -U -P"
+"$BASE"/tools/check-intra-monorepo-deps.sh $VERBOSE $RELEASEBRANCH -U -P
+info "Adding changelog entries for unreleased projects..."
+for DS in $( git -c core.quotepath=off diff --name-only projects | sed -e 's!^projects/\([^/]\+/[^/]\+\)/.*$!\1!' | sort -u ); do
+	cd "$BASE/projects/$DS"
+	if ! git diff --quiet ./CHANGELOG.md; then
+		debug "  $DS is being released, no change entry needed"
+	elif ! git diff --quiet -- "./$( q -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json )/"; then
+		debug "  $DS already has an uncommitted change entry file, skipping"
+	elif ! git diff --quiet -- . ":!./composer.lock"; then
+		debug "  $DS has non-lockfile changes"
+		changelogger_add 'Updated package dependencies.'
 	else
-		debug "  tools/check-intra-monorepo-deps.sh $VERBOSE $RELEASEBRANCH -u $DEPENDENCY_SLUG"
-		PACKAGE_VERSIONS_CACHE="$TEMP" tools/check-intra-monorepo-deps.sh $VERBOSE $RELEASEBRANCH -u "$DEPENDENCY_SLUG"
+		debug "  $DS has lockfile changes only"
+		changelogger_add '' 'Updated composer.lock.'
 	fi
 done
-
-rm "$TEMP"
+cd "$BASE"
 
 debug "  Updating pnpm.lock..."
 pnpm install --silent

--- a/tools/check-intra-monorepo-deps.sh
+++ b/tools/check-intra-monorepo-deps.sh
@@ -12,7 +12,7 @@ BASE=$PWD
 # Print help and exit.
 function usage {
 	cat <<-EOH
-		usage: $0 [-a] [-n <name>] [-v] [-R] [-U|-u] [<slug> ...]
+		usage: $0 [-a] [-n <name>] [-v] [-R] [-P] [-U|-u] [<slug> ...]
 
 		Check that all composer and pnpm dependencies between monorepo projects are up to date.
 
@@ -28,6 +28,7 @@ function usage {
 		 -n: Set changelogger filename.
 		 -v: Output debug information.
 		 -R: When on a release branch, skip updating the corresponding plugins.
+		 -P: Skip updating pnpm lockfile. Automatically skipped if <slug> is passed.
 	EOH
 	exit 1
 }
@@ -39,7 +40,8 @@ DOCL_EVER=true
 AUTO_SUFFIX=false
 CL_FILENAME=
 RELEASEBRANCH=false
-while getopts ":uUvhHRan:" opt; do
+DO_PNPM_LOCK=true
+while getopts ":uUvhHRPan:" opt; do
 	case ${opt} in
 		u)
 			UPDATE=true
@@ -60,6 +62,9 @@ while getopts ":uUvhHRan:" opt; do
 		H|R)
 			# -H is an old name, kept for back compat.
 			RELEASEBRANCH=true
+			;;
+		P)
+			DO_PNPM_LOCK=false
 			;;
 		h)
 			usage
@@ -123,23 +128,15 @@ function get_packages {
 	else
 		PKGS=()
 	fi
-	if [[ "$PACKAGES" == '{}' && -n "$PACKAGE_VERSIONS_CACHE" && -s "$PACKAGE_VERSIONS_CACHE" ]]; then
-		PACKAGES="$(<"$PACKAGE_VERSIONS_CACHE")"
-	else
-		for PKG in "${PKGS[@]}"; do
-			PACKAGES=$(jq -c --argjson packages "$PACKAGES"  --arg ver "$(cd "${PKG%/composer.json}" && changelogger version current --default-first-version)" '.name as $k | $packages | .[$k] |= { rel: $ver, dep: ( "^" + $ver ) }' "$PKG")
-		done
-		if [[ -n "$PACKAGE_VERSIONS_CACHE" ]]; then
-			echo "$PACKAGES" > "$PACKAGE_VERSIONS_CACHE"
-		fi
-	fi
+	for PKG in "${PKGS[@]}"; do
+		PACKAGES=$(jq -c --argjson packages "$PACKAGES"  --arg ver "$(cd "${PKG%/composer.json}" && changelogger version current --default-first-version)" '.name as $k | $packages | .[$k] |= { rel: $ver, dep: ( "^" + $ver ) }' "$PKG")
+	done
 
 	JSPACKAGES=$(jq -nc 'reduce inputs as $in ({}; if $in.name then .[$in.name] |= [ "workspace:*" ] else . end )' "$BASE"/projects/js-packages/*/package.json)
 }
 
 get_packages
 
-DO_PNPM_LOCK=true
 SLUGS=()
 if [[ $# -le 0 ]]; then
 	# Use a temp variable so pipefail works


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The script has gotten a bit slow, since it was running `check-intra-monorepo-deps.sh` individually for each project to pass either `-u` or `-U` depending on whether the project was included in the release or not.

We can speed it up by running `check-intra-monorepo-deps.sh -U` just once, and then looking at the git diff to see whether any changelog entries seem to be needed.

Also, we can then drop the `PACKAGE_VERSIONS_CACHE` thing from `check-intra-monorepo-deps.sh` that was done in a prior speedup attempt.

And finally, skip trying to handle the "monorepo" pseudo-package, it won't work and prevents releases of projects depended on by the monorepo root.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try it out. I did so myself to create #39145, FWIW.
