### PR TITLE
AI Client: add logo generator over quota notice

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-logo-ai-generator-over-quota-notice
+++ b/projects/js-packages/ai-client/changelog/add-logo-ai-generator-over-quota-notice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Logo generator: add over quota notice, handle disabling tiers on checkout

--- a/projects/js-packages/ai-client/src/logo-generator/components/fair-usage-notice.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/fair-usage-notice.tsx
@@ -1,0 +1,38 @@
+import { Notice } from '@wordpress/components';
+import useFairUsageNoticeMessage from '../hooks/use-fair-usage-notice-message.js';
+/**
+ * Types
+ */
+import type { ReactElement } from 'react';
+
+type FairUsageNoticeProps = {
+	variant?: 'error' | 'muted';
+};
+
+/**
+ * The fair usage notice component.
+ * @param {FairUsageNoticeProps}         props         - Fair usage notice component props.
+ * @param {FairUsageNoticeProps.variant} props.variant - The variant of the notice to render.
+ * @return {ReactElement} the Notice component with the fair usage message.
+ */
+export const FairUsageNotice = ( { variant = 'error' }: FairUsageNoticeProps ) => {
+	const useFairUsageNoticeMessageElement = useFairUsageNoticeMessage();
+
+	if ( variant === 'muted' ) {
+		return (
+			<span className="jetpack-ai-fair-usage-notice-muted-variant">
+				{ useFairUsageNoticeMessageElement }
+			</span>
+		);
+	}
+
+	if ( variant === 'error' ) {
+		return (
+			<Notice status="error" isDismissible={ false } className="jetpack-ai-fair-usage-notice">
+				{ useFairUsageNoticeMessageElement }
+			</Notice>
+		);
+	}
+
+	return null;
+};

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -68,7 +68,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		generateFirstPrompt,
 		generateLogo,
 		setContext,
-		requireUpgrade,
+		tierPlansEnabled,
 	} = useLogoGenerator();
 	const { featureFetchError, firstLogoPromptFetchError, clearErrors } = useRequestErrors();
 	const siteId = siteDetails?.ID;
@@ -103,7 +103,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	const initializeModal = useCallback( async () => {
 		try {
 			const hasHistory = ! isLogoHistoryEmpty( String( siteId ) );
-			const tierPlansEnabled = feature?.tierPlansEnabled;
+
 			const logoCost = feature?.costs?.[ 'jetpack-ai-logo-generator' ]?.logo ?? DEFAULT_LOGO_COST;
 			const promptCreationCost = 1;
 			const currentLimit = feature?.currentTier?.value || 0;

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -24,6 +24,7 @@ import useLogoGenerator from '../hooks/use-logo-generator.js';
 import useRequestErrors from '../hooks/use-request-errors.js';
 import { isLogoHistoryEmpty, clearDeletedMedia } from '../lib/logo-storage.js';
 import { STORE_NAME } from '../store/index.js';
+import { FairUsageNotice } from './fair-usage-notice.js';
 import { FeatureFetchFailureScreen } from './feature-fetch-failure-screen.js';
 import { FirstLoadScreen } from './first-load-screen.js';
 import { HistoryCarousel } from './history-carousel.js';
@@ -61,8 +62,14 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	const requestedFeatureData = useRef< boolean >( false );
 	const [ needsFeature, setNeedsFeature ] = useState( false );
 	const [ needsMoreRequests, setNeedsMoreRequests ] = useState( false );
-	const { selectedLogo, getAiAssistantFeature, generateFirstPrompt, generateLogo, setContext } =
-		useLogoGenerator();
+	const {
+		selectedLogo,
+		getAiAssistantFeature,
+		generateFirstPrompt,
+		generateLogo,
+		setContext,
+		requireUpgrade,
+	} = useLogoGenerator();
 	const { featureFetchError, firstLogoPromptFetchError, clearErrors } = useRequestErrors();
 	const siteId = siteDetails?.ID;
 	const [ logoAccepted, setLogoAccepted ] = useState( false );
@@ -227,6 +234,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		body = (
 			<>
 				{ ! logoAccepted && <Prompt initialPrompt={ initialPrompt } /> }
+				{ requireUpgrade && <FairUsageNotice /> }
 				<LogoPresenter
 					logo={ selectedLogo }
 					onApplyLogo={ handleApplyLogo }

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -103,11 +103,12 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	const initializeModal = useCallback( async () => {
 		try {
 			const hasHistory = ! isLogoHistoryEmpty( String( siteId ) );
+			const tierPlansEnabled = feature?.tierPlansEnabled;
 			const logoCost = feature?.costs?.[ 'jetpack-ai-logo-generator' ]?.logo ?? DEFAULT_LOGO_COST;
 			const promptCreationCost = 1;
 			const currentLimit = feature?.currentTier?.value || 0;
 			const currentUsage = feature?.usagePeriod?.requestsCount || 0;
-			const isUnlimited = currentLimit === 1;
+			const isUnlimited = ! tierPlansEnabled ? currentLimit > 0 : currentLimit === 1;
 			const hasNoNextTier = ! feature?.nextTier; // If there is no next tier, the user cannot upgrade.
 
 			// The user needs an upgrade immediately if they have no logos and not enough requests remaining for one prompt and one logo generation.

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -24,7 +24,7 @@ import useLogoGenerator from '../hooks/use-logo-generator.js';
 import useRequestErrors from '../hooks/use-request-errors.js';
 import { isLogoHistoryEmpty, clearDeletedMedia } from '../lib/logo-storage.js';
 import { STORE_NAME } from '../store/index.js';
-import { FairUsageNotice } from './fair-usage-notice.js';
+// import { FairUsageNotice } from './fair-usage-notice.js';
 import { FeatureFetchFailureScreen } from './feature-fetch-failure-screen.js';
 import { FirstLoadScreen } from './first-load-screen.js';
 import { HistoryCarousel } from './history-carousel.js';
@@ -235,7 +235,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		body = (
 			<>
 				{ ! logoAccepted && <Prompt initialPrompt={ initialPrompt } /> }
-				{ requireUpgrade && <FairUsageNotice /> }
+
 				<LogoPresenter
 					logo={ selectedLogo }
 					onApplyLogo={ handleApplyLogo }

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -116,12 +116,15 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 				! isUnlimited &&
 				! hasNoNextTier &&
 				! hasHistory &&
-				currentLimit - currentUsage < logoCost + promptCreationCost;
+				( tierPlansEnabled
+					? currentLimit - currentUsage < logoCost + promptCreationCost
+					: currentLimit < currentUsage );
 
 			// If the site requires an upgrade, show the upgrade screen immediately.
-			setNeedsFeature( ! feature?.hasFeature ?? true );
+			setNeedsFeature( currentLimit === 0 );
 			setNeedsMoreRequests( siteNeedsMoreRequests );
-			if ( ! feature?.hasFeature || siteNeedsMoreRequests ) {
+
+			if ( currentLimit === 0 || siteNeedsMoreRequests ) {
 				setLoadingState( null );
 				return;
 			}

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -20,6 +20,7 @@ import {
 import { useCheckout } from '../hooks/use-checkout.js';
 import useLogoGenerator from '../hooks/use-logo-generator.js';
 import useRequestErrors from '../hooks/use-request-errors.js';
+import { FairUsageNotice } from './fair-usage-notice.js';
 import { UpgradeNudge } from './upgrade-nudge.js';
 import './prompt.scss';
 
@@ -44,6 +45,7 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 		getAiAssistantFeature,
 		requireUpgrade,
 		context,
+		tierPlansEnabled,
 	} = useLogoGenerator();
 
 	const enhancingLabel = __( 'Enhancing…', 'jetpack-ai-client' );
@@ -194,7 +196,8 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 						</Tooltip>
 					</div>
 				) }
-				{ ! isUnlimited && requireUpgrade && <UpgradeNudge /> }
+				{ requireUpgrade && tierPlansEnabled && <UpgradeNudge /> }
+				{ requireUpgrade && ! tierPlansEnabled && <FairUsageNotice /> }
 				{ enhancePromptFetchError && (
 					<div className="jetpack-ai-logo-generator__prompt-error">
 						{ __( 'Error enhancing prompt. Please try again.', 'jetpack-ai-client' ) }

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-checkout.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-checkout.ts
@@ -20,10 +20,11 @@ import type { Selectors } from '../store/types.js';
 const debug = debugFactory( 'ai-client:logo-generator:use-checkout' );
 
 export const useCheckout = () => {
-	const { nextTier } = useSelect( select => {
+	const { nextTier, tierPlansEnabled } = useSelect( select => {
 		const selectors: Selectors = select( STORE_NAME );
 		return {
 			nextTier: selectors.getAiAssistantFeature().nextTier,
+			tierPlansEnabled: selectors.getAiAssistantFeature().tierPlansEnabled,
 		};
 	}, [] );
 
@@ -33,7 +34,11 @@ export const useCheckout = () => {
 	const wpcomCheckoutUrl = new URL( `https://jetpack.com/redirect/` );
 	wpcomCheckoutUrl.searchParams.set( 'source', 'jetpack-ai-yearly-tier-upgrade-nudge' );
 	wpcomCheckoutUrl.searchParams.set( 'site', getSiteFragment() as string );
-	wpcomCheckoutUrl.searchParams.set( 'path', `jetpack_ai_yearly:-q-${ nextTier?.limit }` );
+
+	wpcomCheckoutUrl.searchParams.set(
+		'path',
+		tierPlansEnabled ? `jetpack_ai_yearly:-q-${ nextTier?.limit }` : 'jetpack_ai_yearly'
+	);
 
 	/**
 	 * Open the product interstitial page

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-fair-usage-notice-message.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-fair-usage-notice-message.tsx
@@ -1,0 +1,68 @@
+import { useSelect } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME } from '../store/index.js';
+/**
+ * Types
+ */
+import type { Selectors } from '../store/types.js';
+
+const useFairUsageNoticeMessage = () => {
+	const { usagePeriod } = useSelect( select => {
+		const selectors: Selectors = select( STORE_NAME );
+		return {
+			usagePeriod: selectors.getAiAssistantFeature().nextTier,
+		};
+	}, [] );
+	const getFormattedUsagePeriodStartDate = planUsagePeriod => {
+		if ( ! planUsagePeriod?.nextStart ) {
+			return null;
+		}
+
+		const nextUsagePeriodStartDate = new Date( planUsagePeriod.nextStart );
+		return (
+			nextUsagePeriodStartDate.toLocaleString( 'default', { month: 'long' } ) +
+			' ' +
+			nextUsagePeriodStartDate.getDate()
+		);
+	};
+
+	const getFairUsageNoticeMessage = resetDateString => {
+		const fairUsageMessage = __(
+			"You've reached this month's request limit, per our <link>fair usage policy</link>.",
+			'jetpack-ai-client'
+		);
+
+		if ( ! resetDateString ) {
+			return fairUsageMessage;
+		}
+
+		// Translators: %s is the date when the requests will reset.
+		const dateMessage = __( 'Requests will reset on %s.', 'jetpack-ai-client' );
+		const formattedDateMessage = sprintf( dateMessage, resetDateString );
+
+		return `${ fairUsageMessage } ${ formattedDateMessage }`;
+	};
+
+	const nextUsagePeriodStartDateString = getFormattedUsagePeriodStartDate( usagePeriod );
+
+	// Get the proper template based on the presence of the next usage period start date.
+	const fairUsageNoticeMessage = getFairUsageNoticeMessage( nextUsagePeriodStartDateString );
+
+	const fairUsageNoticeMessageElement = createInterpolateElement( fairUsageNoticeMessage, {
+		link: (
+			<a
+				href="https://jetpack.com/redirect/?source=ai-logo-generator-fair-usage-policy"
+				target="_blank"
+				rel="noreferrer"
+			/>
+		),
+	} );
+
+	return fairUsageNoticeMessageElement;
+};
+
+export default useFairUsageNoticeMessage;

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -46,6 +46,7 @@ const useLogoGenerator = () => {
 		getAiAssistantFeature,
 		requireUpgrade,
 		context,
+		tierPlansEnabled,
 	} = useSelect( select => {
 		const selectors: Selectors = select( STORE_NAME );
 
@@ -62,6 +63,7 @@ const useLogoGenerator = () => {
 			getAiAssistantFeature: selectors.getAiAssistantFeature,
 			requireUpgrade: selectors.getRequireUpgrade(),
 			context: selectors.getContext(),
+			tierPlansEnabled: selectors.getTierPlansEnabled(),
 		};
 	}, [] );
 
@@ -383,6 +385,7 @@ User request:${ prompt }`;
 		getAiAssistantFeature,
 		requireUpgrade,
 		context,
+		tierPlansEnabled,
 	};
 };
 

--- a/projects/js-packages/ai-client/src/logo-generator/store/selectors.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/selectors.ts
@@ -121,6 +121,10 @@ const selectors = {
 	 */
 	getRequireUpgrade( state: LogoGeneratorStateProp ): boolean {
 		const feature = state.features.aiAssistantFeature;
+
+		if ( ! feature?.tierPlansEnabled ) {
+			return feature?.requireUpgrade;
+		}
 		const logoCost = feature?.costs?.[ 'jetpack-ai-logo-generator' ]?.logo ?? DEFAULT_LOGO_COST;
 		const currentLimit = feature?.currentTier?.value || 0;
 		const currentUsage = feature?.usagePeriod?.requestsCount || 0;

--- a/projects/js-packages/ai-client/src/logo-generator/store/selectors.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/selectors.ts
@@ -200,6 +200,16 @@ const selectors = {
 	getContext( state: LogoGeneratorStateProp ): string {
 		return state._meta?.context ?? '';
 	},
+
+	/**
+	 * Get tier plans enabled status.
+	 *
+	 * @param {LogoGeneratorStateProp} state - The app state tree.
+	 * @return {boolean}                      The tier plans enabled status.
+	 */
+	getTierPlansEnabled( state: LogoGeneratorStateProp ): boolean {
+		return state.features.aiAssistantFeature?.tierPlansEnabled ?? false;
+	},
 };
 
 export default selectors;

--- a/projects/js-packages/ai-client/src/logo-generator/store/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/types.ts
@@ -181,6 +181,7 @@ export type Selectors = {
 	getSaveToLibraryError(): RequestError;
 	getLogoUpdateError(): RequestError;
 	getContext(): string;
+	getTierPlansEnabled(): boolean;
 };
 
 /*


### PR DESCRIPTION
## Proposed changes:
Add over quota notice for AI Logo generator
Handle some cases when tier plans are disabled
Fix checkout URL for non tiered plans

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1724958837365959/1724866663.901329-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Sandbox the public API. Purchase a tier plan (you need to have tier plans enabled for this), otherwise the AI logo generator doesn't work.

Once you have a tiered plan, disable tiers and setup as unlimited plan over fair usage:
```
add_filter( 'jetpack_ai_tier_plans_enabled', '__return_false' );
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 3001; } );
add_filter( 'jetpack_ai_all_time_requests_count', function() { return 4040; } );
add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 1; } );
```

Open the editor and insert a logo block, use the AI button to open the AI generator modal. The modal should show an error notice with a link to AI guidelines.

Test by changing the current period request count below 3k and reload the editor, you should be able to use the AI logo generator.

Test a couple other scenarios as well to confirm functionality.