### PR TITLE
Social: Rename review sharing status to 'View sharing history'

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-rename-share-status-trigger-button
+++ b/projects/js-packages/publicize-components/changelog/update-rename-share-status-trigger-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social: Renamed review sharing status to 'View sharing history'

--- a/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/modal-trigger.tsx
@@ -25,7 +25,7 @@ export const ModalTrigger = forwardRef(
 
 		const trigger = (
 			<Button variant="secondary" onClick={ openShareStatusModal } { ...props } ref={ ref }>
-				{ props.children || __( 'Review sharing status', 'jetpack' ) }
+				{ props.children || __( 'View sharing history', 'jetpack' ) }
 			</Button>
 		);
 


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*Rename review sharing status trigger from 'Review sharing status' to 'View sharing history'

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post
* Publish it and share to some social media connections
* Wait for sharing status to reflect
* Confirm that the share status button is renamed to 'View sharing history'
* Open the Jetpack sidebar
* Confirm that the share status button is renamed to 'View sharing history'

| BEFORE | AFTER |
|--------|--------|
| <img width="293" alt="Screenshot 2024-08-30 at 10 08 22 AM" src="https://github.com/user-attachments/assets/40911b96-cf7e-4d8e-94c6-7127d73c8b8b"> | <img width="281" alt="Screenshot 2024-08-30 at 10 20 10 AM" src="https://github.com/user-attachments/assets/4490a41b-54fd-43ac-ac79-2c4298e465a1"> | 