### PR TITLE
Update Welcome Flow A/B experiment

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
@@ -1,5 +1,5 @@
 import { Col, Button, Text, TermsOfService } from '@automattic/jetpack-components';
-import { initializeExPlat, loadExperimentAssignment } from '@automattic/jetpack-explat';
+import { initializeExPlat } from '@automattic/jetpack-explat';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useContext } from 'react';
 import { NoticeContext } from '../../context/notices/noticeContext';
@@ -47,14 +47,10 @@ const ConnectionStep = ( {
 
 			initializeExPlat();
 
-			const { variationName } = await loadExperimentAssignment(
-				'jetpack_my_jetpack_post_connection_flow_202408'
-			);
-
-			if ( variationName !== 'treatment' ) {
-				// For control or default, we redirect to the connection page as described in the experiment.
-				window.location.href = 'admin.php?page=my-jetpack#/connection';
-			}
+			// const { variationName } = await loadExperimentAssignment(
+			// 	'jetpack_my_jetpack_post_connection_flow_202408'
+			// );
+			const variationName = 'treatment'; // hardcoding the variationName to 'treatment' for now
 
 			onUpdateWelcomeFlowExperiment( state => ( {
 				...state,

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
@@ -1,5 +1,5 @@
 import { Col, Button, Text, TermsOfService } from '@automattic/jetpack-components';
-import { initializeExPlat } from '@automattic/jetpack-explat';
+import { initializeExPlat, loadExperimentAssignment } from '@automattic/jetpack-explat';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useContext } from 'react';
 import { NoticeContext } from '../../context/notices/noticeContext';
@@ -47,10 +47,9 @@ const ConnectionStep = ( {
 
 			initializeExPlat();
 
-			// const { variationName } = await loadExperimentAssignment(
-			// 	'jetpack_my_jetpack_post_connection_flow_202408'
-			// );
-			const variationName = 'treatment'; // hardcoding the variationName to 'treatment' for now
+			const { variationName } = await loadExperimentAssignment(
+				'jetpack_my_jetpack_evaluation_recommendations_202409'
+			);
 
 			onUpdateWelcomeFlowExperiment( state => ( {
 				...state,

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
@@ -47,10 +47,10 @@ const WelcomeFlow: FC< PropsWithChildren > = ( { children } ) => {
 		} else if ( ! isProcessingEvaluation ) {
 			if (
 				! recommendedModules &&
-				( welcomeFlowExperiment.variation === 'control' || ! isJetpackUserNew() )
+				( welcomeFlowExperiment.variation === 'treatment' || ! isJetpackUserNew() )
 			) {
 				// If user is not new but doesn't have recommendations, we skip evaluation
-				// If user has recommendations, it means they were already in treatment group and they redo the evaluation
+				// If user has recommendations, it means they redo the evaluation
 				return null;
 			}
 

--- a/projects/packages/my-jetpack/changelog/update-welcome-flow-ab-test
+++ b/projects/packages/my-jetpack/changelog/update-welcome-flow-ab-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+We update Welcome Flow A/B experiment to test other things


### PR DESCRIPTION
## Proposed changes:
As the `treatment` version from our previous A/B experiment doesn't cause any drop in conversion rate, we make it become `control` version and establish new test where:

`control` - User sees evaluation recommendations
`treatment` - User doesn't see evaluation recommendations

## Testing instructions:

* Spin up a JN site with Jetpack Beta pointing to this branch and with sandbox access enabled
* Visit your site, go to Settings -> Jetpack Constants on `/wp-admin/options-general.php?page=companion_settings` and point JETPACK__SANDBOX_DOMAIN to your WPCOM sandbox
* Go to My Jetpack and open your browser's developer console on the network tab
* Click on "Activate Jetpack in one click"
<img width="1101" alt="image" src="https://github.com/user-attachments/assets/b5209b95-641d-49f1-a742-baded6fefe65">

* It'll then redirect show you evaluation survey, and once submitted present you with recommendations section
* Filter your network request by `assignment` and confirm you see a response like this:

```json
{
    "variations": {
        "jetpack_my_jetpack_evaluation_recommendations_202409": null
    },
    "ttl": 60,
    "debug": {
        "backend_aa_result": "request not sampled"
    }
}
```

* To test the treatment variation, disconnect your site by going back to My Jetpack, scrolling down to "Connection", clicking on "Manage" and then disconnecting; [new] then go to "Dashboard", scroll down and click "Reset Options (dev only)" in the footer.
<img width="547" alt="image" src="https://github.com/user-attachments/assets/8bc481f0-5632-4cd7-8846-90240673c7c7"> 

![CleanShot 2024-08-05 at 11 41 31@2x](https://github.com/user-attachments/assets/336de814-da3f-4e62-855d-593a622f6326)


* Then, follow the instructions on this page 21981-explat-experiment, hovering "Bookmarklet" for treatment in the Audience section 
