### PR TITLE
Boost: Update Page Cache notice for WP Cloud clients

### DIFF
--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -27,10 +27,10 @@ class Config {
 			'assetPath'       => plugins_url( $internal_path, JETPACK_BOOST_PATH ),
 			'canResizeImages' => wp_image_editor_supports( array( 'methods' => array( 'resize' ) ) ),
 			'site'            => array(
-				'url'      => get_home_url(),
-				'domain'   => ( new Status() )->get_site_suffix(),
-				'online'   => ! ( new Status() )->is_offline_mode(),
-				'isAtomic' => ( new Host() )->is_woa_site(),
+				'url'    => get_home_url(),
+				'domain' => ( new Status() )->get_site_suffix(),
+				'online' => ! ( new Status() )->is_offline_mode(),
+				'host'   => ( new Host() )->get_known_host_guess(),
 			),
 			'api'             => array(
 				'namespace' => JETPACK_BOOST_REST_NAMESPACE,

--- a/projects/plugins/boost/app/assets/src/js/features/activate-license/activate-license.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/activate-license/activate-license.tsx
@@ -1,10 +1,10 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import styles from './activate-license.module.scss';
+import { isWoaHosting } from '$lib/utils/hosting';
 
 const ActivateLicense = () => {
-	const { site } = Jetpack_Boost;
-	if ( site.isAtomic ) {
+	if ( isWoaHosting() ) {
 		return null;
 	}
 

--- a/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
@@ -4,6 +4,7 @@ import { useSingleModuleState } from './lib/stores';
 import styles from './module.module.scss';
 import ErrorBoundary from '$features/error-boundary/error-boundary';
 import { __ } from '@wordpress/i18n';
+import { isWoaHosting } from '$lib/utils/hosting';
 
 type ModuleProps = {
 	title: React.ReactNode;
@@ -37,6 +38,9 @@ const Module = ( {
 	} );
 	const isModuleActive = status?.active ?? false;
 	const isModuleAvailable = status?.available ?? false;
+	// Even though Page Cache is not available or running on WoA sites,
+	// they have their own caching and we use Page Cache to show that it's active.
+	const isFakeActive = isWoaHosting() && slug === 'page_cache';
 
 	const handleToggle = () => {
 		if ( onBeforeToggle ) {
@@ -64,7 +68,7 @@ const Module = ( {
 					<ToggleControl
 						className={ `jb-feature-toggle-${ slug }` }
 						size="small"
-						checked={ isModuleActive }
+						checked={ isModuleActive || isFakeActive }
 						disabled={ ! isModuleAvailable }
 						onChange={ handleToggle }
 					/>

--- a/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/module/module.tsx
@@ -38,9 +38,9 @@ const Module = ( {
 	} );
 	const isModuleActive = status?.active ?? false;
 	const isModuleAvailable = status?.available ?? false;
-	// Even though Page Cache is not available or running on WoA sites,
-	// they have their own caching and we use Page Cache to show that it's active.
-	const isFakeActive = isWoaHosting() && slug === 'page_cache';
+	// Page Cache is not available for WoA sites, but since WoA sites
+	// have their own caching, we want to show that Page Cache is active.
+	const isFakeActive = ! isModuleAvailable && isWoaHosting() && slug === 'page_cache';
 
 	const handleToggle = () => {
 		if ( onBeforeToggle ) {

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
@@ -9,6 +9,7 @@ import { Notice } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import { useSingleModuleState } from '$features/module/lib/stores';
 import styles from './page-cache.module.scss';
+import { isWpCloudClient, isWoaHosting } from '$lib/utils/hosting';
 
 const DismissableNotice = ( { title, children }: { title: string; children: ReactNode } ) => {
 	const [ dismissed, setDismissed ] = useState( false );
@@ -35,8 +36,6 @@ const PageCache = () => {
 	const showCacheEngineErrorNotice = useShowCacheEngineErrorNotice(
 		pageCacheSetup.isSuccess && !! moduleState?.active
 	);
-
-	const { site } = Jetpack_Boost;
 
 	const [ removePageCacheNotice ] = useMutationNotice(
 		'page-cache-setup',
@@ -97,17 +96,19 @@ const PageCache = () => {
 							'jetpack-boost'
 						) }
 					</p>
-					{ site.isAtomic && (
+					{ ( isWpCloudClient() || isWoaHosting() ) && (
 						<Notice
 							level="warning"
 							title={ __( 'Page Cache is unavailable', 'jetpack-boost' ) }
 							hideCloseButton={ true }
 						>
 							<p>
-								{ __(
-									'Your website already has a page cache running on it powered by WordPress.com.',
-									'jetpack-boost'
-								) }
+								{ isWoaHosting()
+									? __(
+											'Your website already has a page cache running on it powered by WordPress.com.',
+											'jetpack-boost'
+									  )
+									: __( 'Your hosting provider already provides page caching.', 'jetpack-boost' ) }
 							</p>
 						</Notice>
 					) }

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
@@ -99,7 +99,11 @@ const PageCache = () => {
 					{ ( isWpCloudClient() || isWoaHosting() ) && (
 						<Notice
 							level="warning"
-							title={ __( 'Page Cache is unavailable', 'jetpack-boost' ) }
+							title={
+								isWoaHosting()
+									? __( 'Page Cache is running', 'jetpack-boost' )
+									: __( 'Page Cache is unavailable', 'jetpack-boost' )
+							}
 							hideCloseButton={ true }
 						>
 							<p>

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
@@ -98,7 +98,7 @@ const PageCache = () => {
 					</p>
 					{ ( isWpCloudClient() || isWoaHosting() ) && (
 						<Notice
-							level="warning"
+							level={ isWoaHosting() ? 'success' : 'info' }
 							title={
 								isWoaHosting()
 									? __( 'Page Cache is running', 'jetpack-boost' )

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
@@ -96,26 +96,31 @@ const PageCache = () => {
 							'jetpack-boost'
 						) }
 					</p>
-					{ ( isWpCloudClient() || isWoaHosting() ) && (
-						<Notice
-							level={ isWoaHosting() ? 'success' : 'info' }
-							title={
-								isWoaHosting()
-									? __( 'Page Cache is running', 'jetpack-boost' )
-									: __( 'Page Cache is unavailable', 'jetpack-boost' )
-							}
-							hideCloseButton={ true }
-						>
-							<p>
-								{ isWoaHosting()
-									? __(
-											'Your website already has a page cache running on it powered by WordPress.com.',
-											'jetpack-boost'
-									  )
-									: __( 'Your hosting provider already provides page caching.', 'jetpack-boost' ) }
-							</p>
-						</Notice>
-					) }
+					{ ( isWpCloudClient() || isWoaHosting() ) &&
+						( isWoaHosting() ? (
+							<Notice
+								level="success"
+								title={ __( 'Page Cache is running', 'jetpack-boost' ) }
+								hideCloseButton={ true }
+							>
+								<p>
+									{ __(
+										'Your website already has a page cache running on it powered by WordPress.com.',
+										'jetpack-boost'
+									) }
+								</p>
+							</Notice>
+						) : (
+							<Notice
+								level="info"
+								title={ __( 'Page Cache is unavailable', 'jetpack-boost' ) }
+								hideCloseButton={ true }
+							>
+								<p>
+									{ __( 'Your hosting provider already provides page caching.', 'jetpack-boost' ) }
+								</p>
+							</Notice>
+						) ) }
 					<Health
 						error={ pageCacheError.data }
 						setError={ pageCacheErrorMutation.mutate }

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
@@ -36,6 +36,7 @@ const PageCache = () => {
 	const showCacheEngineErrorNotice = useShowCacheEngineErrorNotice(
 		pageCacheSetup.isSuccess && !! moduleState?.active
 	);
+	const showUnavailableNotice = ! moduleState?.available && ( isWoaHosting() || isWpCloudClient() );
 
 	const [ removePageCacheNotice ] = useMutationNotice(
 		'page-cache-setup',
@@ -96,7 +97,7 @@ const PageCache = () => {
 							'jetpack-boost'
 						) }
 					</p>
-					{ ( isWpCloudClient() || isWoaHosting() ) &&
+					{ showUnavailableNotice &&
 						( isWoaHosting() ? (
 							<Notice
 								level="success"

--- a/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/page-cache/page-cache.tsx
@@ -36,7 +36,8 @@ const PageCache = () => {
 	const showCacheEngineErrorNotice = useShowCacheEngineErrorNotice(
 		pageCacheSetup.isSuccess && !! moduleState?.active
 	);
-	const showUnavailableNotice = ! moduleState?.available && ( isWoaHosting() || isWpCloudClient() );
+	const showCacheFromHostingNotice =
+		! moduleState?.available && ( isWoaHosting() || isWpCloudClient() );
 
 	const [ removePageCacheNotice ] = useMutationNotice(
 		'page-cache-setup',
@@ -97,7 +98,7 @@ const PageCache = () => {
 							'jetpack-boost'
 						) }
 					</p>
-					{ showUnavailableNotice &&
+					{ showCacheFromHostingNotice &&
 						( isWoaHosting() ? (
 							<Notice
 								level="success"

--- a/projects/plugins/boost/app/assets/src/js/global.d.ts
+++ b/projects/plugins/boost/app/assets/src/js/global.d.ts
@@ -28,7 +28,7 @@ declare global {
 			domain: string;
 			url: string;
 			online: boolean;
-			isAtomic: boolean;
+			host: string;
 		};
 		assetPath: string;
 		pluginDirUrl: string;

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/hosting.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/hosting.ts
@@ -1,0 +1,17 @@
+/**
+ * Determine if this site is on a WP Cloud client.
+ *
+ * @return {boolean} True if the site is on a WP Cloud client, false otherwise.
+ */
+export const isWpCloudClient = (): boolean => {
+	return Jetpack_Boost.site.host === 'atomic';
+};
+
+/**
+ * Determine if this site is an WordPress.com on Atomic site.
+ *
+ * @return {boolean} True if the site is an WordPress.com on Atomic site, false otherwise.
+ */
+export const isWoaHosting = (): boolean => {
+	return Jetpack_Boost.site.host === 'woa';
+};

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/purchase-success.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/purchase-success.tsx
@@ -7,6 +7,7 @@ import { useSingleModuleState } from '$features/module/lib/stores';
 import { useNavigate } from 'react-router-dom';
 import CardPage from '$layout/card-page/card-page';
 import styles from './purchase-success.module.scss';
+import { isWoaHosting } from '$lib/utils/hosting';
 
 const PurchaseSuccess: React.FC = () => {
 	const [ , setCloudCssState ] = useSingleModuleState( 'cloud_css' );
@@ -14,7 +15,7 @@ const PurchaseSuccess: React.FC = () => {
 	const [ isaState ] = useSingleModuleState( 'image_size_analysis' );
 	const navigate = useNavigate();
 	const isaRequest = useImageAnalysisRequest();
-	const { site, canResizeImages } = Jetpack_Boost;
+	const { canResizeImages } = Jetpack_Boost;
 
 	useEffect( () => {
 		setCloudCssState( true );
@@ -97,7 +98,7 @@ const PurchaseSuccess: React.FC = () => {
 				</li>
 
 				<li>
-					{ site.isAtomic
+					{ isWoaHosting()
 						? createInterpolateElement(
 								__(
 									`Dedicated email support plus priority Live Chat if <link>your plan</link> includes <strong>Premium Support</strong>`,

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache.php
@@ -107,6 +107,10 @@ class Page_Cache implements Pluggable, Has_Deactivate, Optimization {
 		// Disable Page Cache on WoA and WP Cloud clients.
 		// They already have caching enabled.
 		if ( ( new Host() )->is_woa_site() || ( new Host() )->is_atomic_platform() ) {
+			if ( Page_Cache_Setup::can_run_cache() ) {
+				return true;
+			}
+
 			return false;
 		}
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache.php
@@ -104,9 +104,9 @@ class Page_Cache implements Pluggable, Has_Deactivate, Optimization {
 	}
 
 	public static function is_available() {
-		// Disable Page Cache on Atomic.
-		// It already has caching enabled.
-		if ( ( new Host() )->is_woa_site() ) {
+		// Disable Page Cache on WoA and WP Cloud clients.
+		// They already have caching enabled.
+		if ( ( new Host() )->is_woa_site() || ( new Host() )->is_atomic_platform() ) {
 			return false;
 		}
 

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -150,6 +150,15 @@ class Page_Cache_Setup {
 	}
 
 	/**
+	 * Get the path to the advanced-cache.php file.
+	 *
+	 * @return string The full path to the advanced-cache.php file.
+	 */
+	public static function get_advanced_cache_path() {
+		return WP_CONTENT_DIR . '/advanced-cache.php';
+	}
+
+	/**
 	 * Creates the advanced-cache.php file.
 	 *
 	 * Returns true if the files were setup correctly, or WP_Error if there was a problem.
@@ -157,7 +166,7 @@ class Page_Cache_Setup {
 	 * @return bool|\WP_Error
 	 */
 	private static function create_advanced_cache() {
-		$advanced_cache_filename = WP_CONTENT_DIR . '/advanced-cache.php';
+		$advanced_cache_filename = self::get_advanced_cache_path();
 
 		if ( file_exists( $advanced_cache_filename ) ) {
 			$content = file_get_contents( $advanced_cache_filename ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
@@ -265,6 +274,21 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 	}
 
 	/**
+	 * Checks if page cache can be run or not.
+	 *
+	 * @return bool True if the advanced-cache.php file doesn't exist or belongs to Boost, false otherwise.
+	 */
+	public static function can_run_cache() {
+		$advanced_cache_path = self::get_advanced_cache_path();
+		if ( ! file_exists( $advanced_cache_path ) ) {
+			return true;
+		}
+
+		$content = file_get_contents( $advanced_cache_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		return strpos( $content, Page_Cache::ADVANCED_CACHE_SIGNATURE ) !== false;
+	}
+
+	/**
 	 * Removes the advanced-cache.php file and the WP_CACHE define from wp-config.php
 	 * Fired when the plugin is deactivated.
 	 */
@@ -300,7 +324,7 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 	 * Deletes the file advanced-cache.php if it exists.
 	 */
 	public static function delete_advanced_cache() {
-		$advanced_cache_filename = WP_CONTENT_DIR . '/advanced-cache.php';
+		$advanced_cache_filename = self::get_advanced_cache_path();
 
 		if ( ! file_exists( $advanced_cache_filename ) ) {
 			return false;

--- a/projects/plugins/boost/changelog/update-page-cache-behavior-on-atomic
+++ b/projects/plugins/boost/changelog/update-page-cache-behavior-on-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Page Cache: Update notice for WP Cloud clients.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/39138.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove incorrectly named `isAtomic` property, referring to WoA sites;
* Add `host` property to refer to the host the website is running on;
* Add helpers to figure out whether the site is running on WoA or a WP Cloud client;
* Update Page Cache notice colors for WoA and WP Cloud client sites. Yellow indicated something's wrong and that it can't be fixed. In this case, nothing is wrong so we don't need to scare people;
* Update Page Cache UI to show as "running" (but still disabled) for WoA sites;
* Update Page Cache notice title to indicate that it's running on WoA sites;
* Update Page Cache UI toggle to be disabled for WP Cloud clients;
* Add a notice to Page Cache for WP Cloud clients, to indicate that they have their own caching running;
* Check if Page Cache can actually be run, despite the hosting showing as WoA or WP Cloud. This fixes an edge case with Jurassic Ninja (since it's a WP Cloud client site), where disabling drop-ins would show Page Cache as unavailable.

**Page Cache UI for Boost running on WoA:**

![CleanShot 2024-08-30 at 12 13 24](https://github.com/user-attachments/assets/6a30bcec-bcea-4d17-a40f-058580579a1a)

**Page Cache UI for Boost running on WP Cloud clients:**

![image](https://github.com/user-attachments/assets/0ec01a03-8f1f-4cf5-aad5-a8db7df2995a)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p9o2xV-4BQ-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**I don't know how to test on a WP Cloud client, so I only have instructions for WoA below. I tested what it would look like for WP Cloud locally by making Boost "think" that it's on WP Cloud by editing checks manually.**

* Deploy Boost on an Atomic site;
* Make sure that Page Cache is showing as "active", but can't be toggled;
* Make sure that the notice is as per the screenshots above.