### PR TITLE
Add Meta's AI crawler to robots.txt when opted out of data sharing.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-meta-bot
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-meta-bot
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Meta crawler.

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -44,6 +44,7 @@ function robots_txt( string $output, $public ): string {
 			'FacebookBot',
 			'Google-Extended',
 			'GPTBot',
+			'meta-externalagent',
 			'omgili',
 			'omgilibot',
 			'PerplexityBot',

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/blog-privacy/class-blog-privacy-test.php
@@ -58,6 +58,9 @@ Disallow: /
 User-agent: GPTBot
 Disallow: /
 
+User-agent: meta-externalagent
+Disallow: /
+
 User-agent: omgili
 Disallow: /
 


### PR DESCRIPTION
Context: p1724975395679439-slack-C03P4DG8BT4 

## Proposed changes:

- Add Meta's AI crawler to robots.txt when opted out of data sharing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Code review.