### PR TITLE
Prevent PHP warning produced by the "Howdy" link rewrite

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-howdy-link-warning
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-howdy-link-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed PHP warning for accessing an undefined array key.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php
@@ -55,12 +55,12 @@ class WPCOM_Admin_Bar extends \WP_Admin_Bar {
 	 * }
 	 */
 	public function add_node( $args ) {
-		if ( ! is_array( $args ) || empty( $args['href'] ) || ! isset( $args['id'] ) ) {
+		if ( ! is_array( $args ) || empty( $args['href'] ) ) {
 			parent::add_node( $args );
 			return;
 		}
 
-		if ( $args['id'] === 'my-account' ) {
+		if ( isset( $args['id'] ) && $args['id'] === 'my-account' ) {
 			if ( ! is_user_member_of_blog() || get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
 				$args['href'] = 'https://wordpress.com/me';
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php
@@ -55,7 +55,7 @@ class WPCOM_Admin_Bar extends \WP_Admin_Bar {
 	 * }
 	 */
 	public function add_node( $args ) {
-		if ( ! is_array( $args ) || empty( $args['href'] ) ) {
+		if ( ! is_array( $args ) || empty( $args['href'] ) || ! isset( $args['id'] ) ) {
 			parent::add_node( $args );
 			return;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a PHP warning raised by the code introduced in #39113 for logged-in Automatticians in /wp-admin on a any WPCOM simple sites:

```
Warning: Undefined array key "id" in ...jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php on line 63
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The PR is adding an `isset( $args['id'] )` check to the conditional which is checking the value of the key.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Logged-in to WordPress.com as an Automattician, go to '/wp-admin' of a sandboxed WPCOM simple site
* Notice the PHP warning

