### PR TITLE
Forms: fix block inserter collapsing in Firefox

### DIFF
--- a/projects/packages/forms/changelog/fix-firefox-contact-form
+++ b/projects/packages/forms/changelog/fix-firefox-contact-form
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix FF Block inserter issue

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -226,7 +226,6 @@ const FieldDefaults = {
 		],
 	},
 	save: () => null,
-	example: {},
 };
 
 const OptionFieldDefaults = {

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -56,15 +56,15 @@ export const settings = {
 		_x( 'contact form', 'block search term', 'jetpack-forms' ),
 	],
 	supports: {
-		color: {
-			link: true,
-			gradients: true,
-		},
+		// 	color: {
+		// 		link: true,
+		// 		gradients: true,
+		// 	},
 		html: false,
-		spacing: {
-			padding: true,
-			margin: true,
-		},
+		// 	spacing: {
+		// 		padding: true,
+		// 		margin: true,
+		// 	},
 		align: [ 'wide', 'full' ],
 	},
 	attributes: defaultAttributes,
@@ -77,30 +77,30 @@ export const settings = {
 			</div>
 		);
 	},
-	example: {
-		innerBlocks: [
-			{
-				name: 'jetpack/field-name',
-				attributes: { required: true, label: __( 'Name', 'jetpack-forms' ) },
-			},
-			{
-				name: 'jetpack/field-email',
-				attributes: { required: true, label: __( 'Email', 'jetpack-forms' ) },
-			},
-			{
-				name: 'jetpack/field-textarea',
-				attributes: { label: __( 'Message', 'jetpack-forms' ) },
-			},
-			{
-				name: 'jetpack/button',
-				attributes: {
-					text: __( 'Contact Us', 'jetpack-forms' ),
-					element: 'button',
-					lock: { remove: true },
-				},
-			},
-		],
-	},
+	// example: {
+	// 	innerBlocks: [
+	// 		{
+	// 			name: 'jetpack/field-name',
+	// 			attributes: { required: true, label: __( 'Name', 'jetpack-forms' ) },
+	// 		},
+	// 		{
+	// 			name: 'jetpack/field-email',
+	// 			attributes: { required: true, label: __( 'Email', 'jetpack-forms' ) },
+	// 		},
+	// 		{
+	// 			name: 'jetpack/field-textarea',
+	// 			attributes: { label: __( 'Message', 'jetpack-forms' ) },
+	// 		},
+	// 		{
+	// 			name: 'jetpack/button',
+	// 			attributes: {
+	// 				text: __( 'Contact Us', 'jetpack-forms' ),
+	// 				element: 'button',
+	// 				lock: { remove: true },
+	// 			},
+	// 		},
+	// 	],
+	// },
 	styles: [
 		{ name: 'default', label: 'Default', isDefault: true },
 		{ name: 'animated', label: 'Animated' },

--- a/projects/packages/forms/src/blocks/contact-form/index.js
+++ b/projects/packages/forms/src/blocks/contact-form/index.js
@@ -56,15 +56,7 @@ export const settings = {
 		_x( 'contact form', 'block search term', 'jetpack-forms' ),
 	],
 	supports: {
-		// 	color: {
-		// 		link: true,
-		// 		gradients: true,
-		// 	},
 		html: false,
-		// 	spacing: {
-		// 		padding: true,
-		// 		margin: true,
-		// 	},
 		align: [ 'wide', 'full' ],
 	},
 	attributes: defaultAttributes,
@@ -77,30 +69,6 @@ export const settings = {
 			</div>
 		);
 	},
-	// example: {
-	// 	innerBlocks: [
-	// 		{
-	// 			name: 'jetpack/field-name',
-	// 			attributes: { required: true, label: __( 'Name', 'jetpack-forms' ) },
-	// 		},
-	// 		{
-	// 			name: 'jetpack/field-email',
-	// 			attributes: { required: true, label: __( 'Email', 'jetpack-forms' ) },
-	// 		},
-	// 		{
-	// 			name: 'jetpack/field-textarea',
-	// 			attributes: { label: __( 'Message', 'jetpack-forms' ) },
-	// 		},
-	// 		{
-	// 			name: 'jetpack/button',
-	// 			attributes: {
-	// 				text: __( 'Contact Us', 'jetpack-forms' ),
-	// 				element: 'button',
-	// 				lock: { remove: true },
-	// 			},
-	// 		},
-	// 	],
-	// },
 	styles: [
 		{ name: 'default', label: 'Default', isDefault: true },
 		{ name: 'animated', label: 'Animated' },

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -34,8 +34,6 @@ class Jetpack_Forms {
 			add_action( 'current_screen', '\Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks' );
 		}
 
-		add_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Util::register_pattern' );
-
 		add_action( 'rest_api_init', array( new WPCOM_REST_API_V2_Endpoint_Forms(), 'register_rest_routes' ) );
 	}
 

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -34,6 +34,8 @@ class Jetpack_Forms {
 			add_action( 'current_screen', '\Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks' );
 		}
 
+		add_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Util::register_pattern' );
+
 		add_action( 'rest_api_init', array( new WPCOM_REST_API_V2_Endpoint_Forms(), 'register_rest_routes' ) );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/39144

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This draft PR explores fixing the issue linked above: in the latest versions of Firefox (reported in 129 and 128), the block inserter collapses when various actions are operated. For instance:
- when the user starts typing in the search box
- when the cursor hovers any Jetpack Forms block

This only happens with Jetpack Forms blocks. If we don't register those blocks, the inserter works seamlessly.

_Block inserter_
<img width="345" alt="Screenshot 2024-08-30 at 9 46 21 AM" src="https://github.com/user-attachments/assets/c1275513-1bae-4796-9a3c-362aabae55e2">

It's been hard to reproduce the issue consistently every time. At times, the inserter collapses immediately. Other times, it takes 5 to 10 times hovering it. No error is logged in the console.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin a test site with this branch
- Create a new post
- Open the block inserter by clicking the `+` button
- Ensure the search functionality works and the inserter does not collapse
- Hover various forms blocks: the inserter should not collapse
- Try hovering several times and at various speeds

