### PR TITLE
Backport mu-wpcom-plugin 2.5.10 Changes

### DIFF
--- a/projects/js-packages/remove-asset-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/remove-asset-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.22] - 2024-08-30
+### Changed
+- Updated package dependencies. [#39111]
+
 ## [1.0.21] - 2023-12-03
 ### Changed
 - Updated package dependencies. [#34427]
@@ -99,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.0.22]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.21...v1.0.22
 [1.0.21]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.20...v1.0.21
 [1.0.20]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.19...v1.0.20
 [1.0.19]: https://github.com/Automattic/remove-asset-webpack-plugin/compare/v1.0.18...v1.0.19

--- a/projects/js-packages/remove-asset-webpack-plugin/package.json
+++ b/projects/js-packages/remove-asset-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/remove-asset-webpack-plugin",
-	"version": "1.0.21",
+	"version": "1.0.22",
 	"description": "A Webpack plugin to remove assets from the build.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/remove-asset-webpack-plugin/README.md#readme",
 	"bugs": {

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.8] - 2024-08-30
+### Changed
+- Updated package dependencies. [#39111]
+
 ## [0.22.7] - 2024-08-23
 ### Changed
 - Updated package dependencies. [#39004]
@@ -432,6 +436,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.22.8]: https://github.com/automattic/jetpack-blaze/compare/v0.22.7...v0.22.8
 [0.22.7]: https://github.com/automattic/jetpack-blaze/compare/v0.22.6...v0.22.7
 [0.22.6]: https://github.com/automattic/jetpack-blaze/compare/v0.22.5...v0.22.6
 [0.22.5]: https://github.com/automattic/jetpack-blaze/compare/v0.22.4...v0.22.5

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.22.7",
+	"version": "0.22.8",
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",
 	"bugs": {

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.22.7';
+	const PACKAGE_VERSION = '0.22.8';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/calypsoify/CHANGELOG.md
+++ b/projects/packages/calypsoify/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2024-08-30
+### Changed
+- Updated package dependencies. [#39111]
+
 ## [0.1.4] - 2024-08-23
 ### Changed
 - Updated package dependencies. [#39004]
@@ -33,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calypsoify: Load feature from the Calypsoify package. [#37375]
 - Updated package dependencies. [#37379]
 
+[0.1.5]: https://github.com/Automattic/jetpack-calypsoify/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/Automattic/jetpack-calypsoify/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/Automattic/jetpack-calypsoify/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/Automattic/jetpack-calypsoify/compare/v0.1.1...v0.1.2

--- a/projects/packages/calypsoify/package.json
+++ b/projects/packages/calypsoify/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-calypsoify",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "Calypsoify is designed to make sure specific wp-admin pages include navigation that prioritizes the Calypso navigation experience.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/calypsoify/#readme",
 	"bugs": {

--- a/projects/packages/calypsoify/src/class-jetpack-calypsoify.php
+++ b/projects/packages/calypsoify/src/class-jetpack-calypsoify.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Status;
  */
 class Jetpack_Calypsoify {
 
-	const PACKAGE_VERSION = '0.1.4';
+	const PACKAGE_VERSION = '0.1.5';
 
 	/**
 	 * Singleton instance of `Jetpack_Calypsoify`.

--- a/projects/packages/classic-theme-helper/CHANGELOG.md
+++ b/projects/packages/classic-theme-helper/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4] - 2024-08-30
+### Security
+- Social Menu: Switch to more appropriate method of calling the SVG icon file. [#39136]
+
+### Added
+- Classic Theme Helper: Adding Portfolio custom post type content [#39134]
+- Content Options: Moving content to Classic Theme Helper package. [#39028]
+
+### Changed
+- Updated package dependencies. [#39111]
+
 ## [0.5.3] - 2024-08-26
 ### Changed
 - Site Breadcrumbs: Requiring the feature from the Classic Theme Helper package [#38931]
@@ -86,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add wordpress folder on gitignore. [#37177]
 
+[0.5.4]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Automattic/jetpack-classic-theme-helper/compare/v0.5.0...v0.5.1

--- a/projects/packages/classic-theme-helper/changelog/add-content-options-to-classic-theme-helper-package
+++ b/projects/packages/classic-theme-helper/changelog/add-content-options-to-classic-theme-helper-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Content Options: Moving content to Classic Theme Helper package.

--- a/projects/packages/classic-theme-helper/changelog/add-portfolios-cpt-to-classic-theme-helper-package
+++ b/projects/packages/classic-theme-helper/changelog/add-portfolios-cpt-to-classic-theme-helper-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Classic Theme Helper: Adding Portfolio custom post type content

--- a/projects/packages/classic-theme-helper/changelog/update-svg-icon-inclusion-method
+++ b/projects/packages/classic-theme-helper/changelog/update-svg-icon-inclusion-method
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Social Menu: Switch to more appropriate method of calling the SVG icon file.

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-classic-theme-helper",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"description": "Features used with classic themes",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/classic-theme-helper/#readme",
 	"bugs": {

--- a/projects/packages/classic-theme-helper/src/class-main.php
+++ b/projects/packages/classic-theme-helper/src/class-main.php
@@ -14,7 +14,7 @@ use WP_Error;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.5.3';
+	const PACKAGE_VERSION = '0.5.4';
 
 	/**
 	 * Modules to include.

--- a/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
+++ b/projects/packages/jetpack-mu-wpcom/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.60.0] - 2024-08-30
+### Added
+- Add Meta crawler. [#39159]
+
+### Changed
+- Newspack blocks: Updated from 3.5 to 4.0.1 [#39033]
+- Updated package dependencies. [#39111]
+
+### Fixed
+- Always rewrite profile.php to /me on Default sites [#39113]
+
 ## [5.59.0] - 2024-08-26
 ### Added
 - Auto open Upload Theme dialog if query parameter is present [#39045]
@@ -1189,6 +1200,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Testing initial package release.
 
+[5.60.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.59.0...v5.60.0
 [5.59.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.58.0...v5.59.0
 [5.58.0]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.57.1...v5.58.0
 [5.57.1]: https://github.com/Automattic/jetpack-mu-wpcom/compare/v5.57.0...v5.57.1

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-meta-bot
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-meta-bot
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add Meta crawler.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-more-eslint-rules
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-more-eslint-rules
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Fix new eslint sniffs. Should be no change in functionality.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-howdy-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-howdy-link
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Always rewrite profile.php to /me on Default sites

--- a/projects/packages/jetpack-mu-wpcom/changelog/try-no-version-bumps-in-trunk
+++ b/projects/packages/jetpack-mu-wpcom/changelog/try-no-version-bumps-in-trunk
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Un-bump version numbers in trunk. The build will now update the version numbers as needed for mirrors.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-13.7-backport
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-13.7-backport
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Updated versions.
-
-

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-newspack-blocks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-newspack-blocks
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Newspack blocks: Updated from 3.5 to 4.0.1

--- a/projects/packages/jetpack-mu-wpcom/composer.json
+++ b/projects/packages/jetpack-mu-wpcom/composer.json
@@ -62,7 +62,7 @@
 		},
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "5.59.x-dev"
+			"dev-trunk": "5.60.x-dev"
 		},
 		"textdomain": "jetpack-mu-wpcom",
 		"version-constants": {

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom",
-	"version": "5.59.0",
+	"version": "5.60.0",
 	"description": "Enhances your site with features powered by WordPress.com",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/jetpack-mu-wpcom/#readme",
 	"bugs": {

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -15,7 +15,7 @@ define( 'WPCOM_ADMIN_BAR_UNIFICATION', true );
  * Jetpack_Mu_Wpcom main class.
  */
 class Jetpack_Mu_Wpcom {
-	const PACKAGE_VERSION = '5.59.0';
+	const PACKAGE_VERSION = '5.60.0';
 	const PKG_DIR         = __DIR__ . '/../';
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;

--- a/projects/packages/masterbar/CHANGELOG.md
+++ b/projects/packages/masterbar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2024-08-30
+### Changed
+- Updated package dependencies. [#39111]
+
 ## [0.8.0] - 2024-08-23
 ### Changed
 - Remove locale sync [#39009]
@@ -102,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies. [#37669]
 - Updated package dependencies. [#37706]
 
+[0.8.1]: https://github.com/Automattic/jetpack-masterbar/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/Automattic/jetpack-masterbar/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Automattic/jetpack-masterbar/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Automattic/jetpack-masterbar/compare/v0.6.0...v0.6.1

--- a/projects/packages/masterbar/changelog/try-no-version-bumps-in-trunk
+++ b/projects/packages/masterbar/changelog/try-no-version-bumps-in-trunk
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Un-bump version numbers in trunk. The build will now update the version numbers as needed for mirrors.
-
-

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",
 	"bugs": {

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.8.0';
+	const PACKAGE_VERSION = '0.8.1';
 
 	/**
 	 * Initializer.

--- a/projects/packages/sync/CHANGELOG.md
+++ b/projects/packages/sync/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.0] - 2024-08-30
+### Added
+- Add share status log modal to published posts [#39051]
+
 ## [3.8.1] - 2024-08-29
 ### Changed
 - Sync: Add subscription type for HPOS orders only if WooCommerce Subscriptions plugin exists [#39118]
@@ -1258,6 +1262,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Move sync to a classmapped package
 
+[3.9.0]: https://github.com/Automattic/jetpack-sync/compare/v3.8.1...v3.9.0
 [3.8.1]: https://github.com/Automattic/jetpack-sync/compare/v3.8.0...v3.8.1
 [3.8.0]: https://github.com/Automattic/jetpack-sync/compare/v3.7.1...v3.8.0
 [3.7.1]: https://github.com/Automattic/jetpack-sync/compare/v3.7.0...v3.7.1

--- a/projects/packages/sync/changelog/add-social-share-status-shares-modal
+++ b/projects/packages/sync/changelog/add-social-share-status-shares-modal
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add share status log modal to published posts

--- a/projects/packages/sync/composer.json
+++ b/projects/packages/sync/composer.json
@@ -59,7 +59,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "3.8.x-dev"
+			"dev-trunk": "3.9.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/sync/src/class-package-version.php
+++ b/projects/packages/sync/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Sync;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '3.8.1';
+	const PACKAGE_VERSION = '3.9.0';
 
 	const PACKAGE_SLUG = 'sync';
 

--- a/projects/plugins/automattic-for-agencies-client/changelog/prerelease
+++ b/projects/plugins/automattic-for-agencies-client/changelog/prerelease
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Remove Phan comment
+Comment: Updated composer.lock.
 
 

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -862,7 +862,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+                "reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -895,7 +895,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/backup/changelog/prerelease#2
+++ b/projects/plugins/backup/changelog/prerelease#2
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Fix Phan issue
+Comment: Updated composer.lock.
 
 

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1740,7 +1740,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+                "reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1773,7 +1773,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/boost/changelog/prerelease
+++ b/projects/plugins/boost/changelog/prerelease
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Updated composer.lock.
 
-Updated package dependencies.
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1791,7 +1791,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+                "reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1824,7 +1824,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2683,7 +2683,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+				"reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -2716,7 +2716,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "3.8.x-dev"
+					"dev-trunk": "3.9.x-dev"
 				},
 				"dependencies": {
 					"test-only": [

--- a/projects/plugins/migration/changelog/prerelease#4
+++ b/projects/plugins/migration/changelog/prerelease#4
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Updated composer.lock.
 
-Updated package dependencies.
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -1740,7 +1740,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+                "reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1773,7 +1773,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
+++ b/projects/plugins/mu-wpcom-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.5.10 - 2024-08-30
+### Changed
+- Internal updates.
+
 ## 2.5.9 - 2024-08-26
 ### Changed
 - Updated package dependencies. [#39004]

--- a/projects/plugins/mu-wpcom-plugin/composer.json
+++ b/projects/plugins/mu-wpcom-plugin/composer.json
@@ -46,6 +46,6 @@
 		]
 	},
 	"config": {
-		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_9"
+		"autoloader-suffix": "d9d132a783958a00a2c7cccff60ca42d_jetpack_mu_wpcom_pluginⓥ2_5_10"
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1005,7 +1005,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "7fc7349f067c70f35ec09b2028354537372ba24a"
+                "reference": "c08aeda80f1247f476847d3ce232d69c0094774e"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1039,7 +1039,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.59.x-dev"
+                    "dev-trunk": "5.60.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {
@@ -1506,7 +1506,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+                "reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1539,7 +1539,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -3,7 +3,7 @@
  *
  * Plugin Name: WordPress.com Features
  * Description: Test plugin for the jetpack-mu-wpcom package
- * Version: 2.5.9
+ * Version: 2.5.10
  * Author: Automattic
  * License: GPLv2 or later
  * Text Domain: jetpack-mu-wpcom-plugin

--- a/projects/plugins/mu-wpcom-plugin/package.json
+++ b/projects/plugins/mu-wpcom-plugin/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "@automattic/jetpack-mu-wpcom-plugin",
-	"version": "2.5.9",
+	"version": "2.5.10",
 	"description": "Test plugin for the jetpack-mu-wpcom package",
 	"homepage": "https://jetpack.com",
 	"bugs": {

--- a/projects/plugins/protect/changelog/prerelease
+++ b/projects/plugins/protect/changelog/prerelease
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Updated composer.lock.
 
-Updated package dependencies.
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1653,7 +1653,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+                "reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1686,7 +1686,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/search/changelog/prerelease#2
+++ b/projects/plugins/search/changelog/prerelease#2
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Updated composer.lock.
 
-Updated package dependencies.
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1745,7 +1745,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+                "reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1778,7 +1778,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/social/changelog/prerelease
+++ b/projects/plugins/social/changelog/prerelease
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Updated composer.lock.
 
-Updated package dependencies.
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1736,7 +1736,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/sync",
-				"reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+				"reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
 			},
 			"require": {
 				"automattic/jetpack-connection": "@dev",
@@ -1769,7 +1769,7 @@
 					"link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
 				},
 				"branch-alias": {
-					"dev-trunk": "3.8.x-dev"
+					"dev-trunk": "3.9.x-dev"
 				},
 				"dependencies": {
 					"test-only": [

--- a/projects/plugins/starter-plugin/changelog/prerelease#3
+++ b/projects/plugins/starter-plugin/changelog/prerelease#3
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Updated composer.lock.
 
-Updated package dependencies.
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1596,7 +1596,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+                "reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1629,7 +1629,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/videopress/changelog/prerelease
+++ b/projects/plugins/videopress/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1596,7 +1596,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+                "reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1629,7 +1629,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/wpcomsh/changelog/prerelease
+++ b/projects/plugins/wpcomsh/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1142,7 +1142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "7fc7349f067c70f35ec09b2028354537372ba24a"
+                "reference": "c08aeda80f1247f476847d3ce232d69c0094774e"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1176,7 +1176,7 @@
                 },
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "5.59.x-dev"
+                    "dev-trunk": "5.60.x-dev"
                 },
                 "textdomain": "jetpack-mu-wpcom",
                 "version-constants": {
@@ -1705,7 +1705,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "64ed9303f16e3377d99091c67842f3c4b07b71eb"
+                "reference": "526ab81e23c778c2c3462149febe2f7a9fd0df50"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1738,7 +1738,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "3.8.x-dev"
+                    "dev-trunk": "3.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for mu-wpcom-plugin 2.5.10

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.