### PR TITLE
Protect: Fix ScanHistoryDetails fixedOn property

### DIFF
--- a/projects/plugins/protect/changelog/fix-scan-history-details-fixed-on-date
+++ b/projects/plugins/protect/changelog/fix-scan-history-details-fixed-on-date
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixes the fixedOn prop in the ScanHistoryDetails component

--- a/projects/plugins/protect/src/js/components/paid-accordion/index.jsx
+++ b/projects/plugins/protect/src/js/components/paid-accordion/index.jsx
@@ -11,15 +11,15 @@ import styles from './styles.module.scss';
 
 const PaidAccordionContext = React.createContext();
 
-const ScanHistoryDetails = ( { detectedAt, fixedOn, status } ) => {
+const ScanHistoryDetails = ( { firstDetected, fixedOn, status } ) => {
 	return (
 		<>
-			{ detectedAt && (
+			{ firstDetected && (
 				<Text className={ styles[ 'accordion-header-status' ] }>
 					{ sprintf(
 						/* translators: %s: First detected date */
 						__( 'Threat found %s', 'jetpack-protect' ),
-						dateI18n( 'M j, Y', detectedAt )
+						dateI18n( 'M j, Y', firstDetected )
 					) }
 					{ 'fixed' === status && (
 						<>
@@ -109,9 +109,9 @@ export const PaidAccordionItem = ( {
 					</Text>
 					{ ( 'fixed' === status || 'ignored' === status ) && (
 						<ScanHistoryDetails
-							detectedAt={ firstDetected }
+							firstDetected={ firstDetected }
 							status={ status }
-							fixedAt={ fixedOn }
+							fixedOn={ fixedOn }
 						/>
 					) }
 				</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Fixes
There is mismatching `fixedAt` property passed in the usage of the `ScanHistoryDetails` component in the `PaidAccordion`. Because of this, `undefined` is passed and we display todays date.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the property to `fixedOn`
* Rename properties for better clarity

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jpop-issues/issues/9202

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* View a site w/ the latest Protect version, a scan upgrade, and historical fixed threats
* Verify that the `Threat fixed` date in the history details is today's date
* Install the Jetpack Beta Tester plugin and upgrade Protect to this branch
* Reload the History and ensure that the date rendered is correct, and corresponds with the results in Calyspo

