### PR TITLE
My Jetpack: fix post checkout URL 

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-post-checkout-url
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-post-checkout-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: change Jetpack AI post checkout URL so the redirect works

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -499,7 +499,7 @@ class Jetpack_Ai extends Product {
 	 * @return ?string
 	 */
 	public static function get_post_checkout_url() {
-		return '/wp-admin/admin.php?page=my-jetpack#/jetpack-ai';
+		return 'admin.php?page=my-jetpack#/jetpack-ai';
 	}
 
 	/**


### PR DESCRIPTION
The checkout process would not redirect properly after purchasing Jetpack AI

## Proposed changes:
Fix post checkout URL 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1724961678448609-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Get an upgrade/purchase for Jetpack AI from My Jetpack interstitial or any other upgrade flow. Once the purchase is completed, you should be taken back to `wp-admin/admin.php?page=my-jetpack#/jetpack-ai`