### PR TITLE
 Custom CSS: remove outdated link from admin menu  

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-remove-outdated-custom-css-menu-item
+++ b/projects/plugins/jetpack/changelog/fix-remove-outdated-custom-css-menu-item
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+ Custom CSS: remove outdated link from admin menu  

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -152,11 +152,6 @@ class Jetpack_Admin {
 			// Add in our new page slug that will redirect to the customizer.
 			$hook = add_theme_page( __( 'CSS', 'jetpack' ), __( 'Additional CSS', 'jetpack' ), 'edit_theme_options', 'editcss-customizer-redirect', array( __CLASS__, 'customizer_redirect' ) );
 			add_action( "load-{$hook}", array( __CLASS__, 'customizer_redirect' ) );
-		} elseif ( class_exists( 'Jetpack' ) && Jetpack::is_connection_ready() ) { // Link to the Jetpack Settings > Writing page, highlighting the Custom CSS setting.
-			add_submenu_page( '', __( 'CSS', 'jetpack' ), __( 'Additional CSS', 'jetpack' ), 'edit_theme_options', 'editcss', array( __CLASS__, 'theme_enhancements_redirect' ) );
-
-			$hook = add_theme_page( __( 'CSS', 'jetpack' ), __( 'Additional CSS', 'jetpack' ), 'edit_theme_options', 'editcss-theme-enhancements-redirect', array( __CLASS__, 'theme_enhancements_redirect' ) );
-			add_action( "load-{$hook}", array( __CLASS__, 'theme_enhancements_redirect' ) );
 		}
 	}
 
@@ -179,20 +174,6 @@ class Jetpack_Admin {
 					'return_url' => wp_get_referer(),
 				)
 			)
-		);
-		exit;
-	}
-
-	/**
-	 * Handle the Additional CSS redirect to the Jetpack settings Theme Enhancements section.
-	 *
-	 * @since 11.0
-	 *
-	 * @return never
-	 */
-	public static function theme_enhancements_redirect() {
-		wp_safe_redirect(
-			'admin.php?page=jetpack#/writing?term=custom-css'
 		);
 		exit;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/479

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The Custom CSS module was [removed from the Jetpack plugin](https://github.com/Automattic/jetpack/pull/38865) but, in the admin menu, there's a lingering link (labelled _Additional CSS_) to the Custom CSS section in the Jetpack settings, that no longer exists. This PR removes the link.

<img width="160" alt="Screenshot 2024-08-30 at 1 58 55 PM" src="https://github.com/user-attachments/assets/f92d0e6c-bce7-428f-b435-72997e4100b5">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Project thread: pfwV0U-4M-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test site with this branch
- Install a classic theme, such as Twenty-Eleven
- Notice the _Appearance_ menu has no _Additional CSS_ item