### PR TITLE
Calipsoify: Remove legacy Calypso edit link redirects

### DIFF
--- a/projects/packages/connection/changelog/remove-calypso-redirect-code-from-jetpack__construct
+++ b/projects/packages/connection/changelog/remove-calypso-redirect-code-from-jetpack__construct
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Removed registering of Jetpack option edit_links_calypso_redirect

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -40,7 +40,6 @@ class Jetpack_Options {
 					'allowed_xsite_search_ids', // (array) Array of WP.com blog ids that are allowed to search the content of this site
 					'available_modules',
 					'do_activate',
-					'edit_links_calypso_redirect', // (bool) Whether post/page edit links on front end should point to Calypso.
 					'log',
 					'slideshow_background_color',
 					'widget_twitter',

--- a/projects/plugins/jetpack/_inc/lib/functions.wp-notify.php
+++ b/projects/plugins/jetpack/_inc/lib/functions.wp-notify.php
@@ -15,6 +15,8 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Redirect;
 
+_deprecated_file( __FILE__, 'jetpack-$$next-version$$' );
+
 // phpcs:disable WordPress.WP.I18n.MissingArgDomain --reason: Code copied from Core, so using Core strings.
 // phpcs:disable WordPress.Utils.I18nTextDomainFixer.MissingArgDomain --reason: Code copied from Core, so using Core strings.
 

--- a/projects/plugins/jetpack/_inc/lib/functions.wp-notify.php
+++ b/projects/plugins/jetpack/_inc/lib/functions.wp-notify.php
@@ -8,6 +8,8 @@
  *
  * In the past, we used to overwrite the whole pluggable function, but we started using filters to avoid having
  * to check for Jetpack::is_active() too early in the load flow.
+ *
+ * @deprecated $$next-version$$ File became unused.
  */
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;

--- a/projects/plugins/jetpack/changelog/remove-calypso-redirect-code-from-jetpack__construct
+++ b/projects/plugins/jetpack/changelog/remove-calypso-redirect-code-from-jetpack__construct
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -993,12 +993,16 @@ class Jetpack {
 	/**
 	 * Redirect edit post links to Calypso.
 	 *
+	 * @deprecated since $$next-version$$
+	 *
 	 * @param string $default_url Post edit URL.
 	 * @param int    $post_id Post ID.
 	 *
 	 * @return string
 	 */
 	public function point_edit_post_links_to_calypso( $default_url, $post_id ) {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
+
 		$post = get_post( $post_id );
 
 		if ( empty( $post ) ) {
@@ -1031,11 +1035,15 @@ class Jetpack {
 	/**
 	 * Redirect edit comment links to Calypso.
 	 *
+	 * @deprecated since $$next-version$$
+	 *
 	 * @param string $url Comment edit URL.
 	 *
 	 * @return string
 	 */
 	public function point_edit_comment_links_to_calypso( $url ) {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
+
 		// Take the `query` key value from the URL, and parse its parts to the $query_args. `amp;c` matches the comment ID.
 		$query_args = null;
 		wp_parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_args );

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -758,23 +758,6 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'filter_default_modules' ) );
 		add_filter( 'jetpack_get_default_modules', array( $this, 'handle_deprecated_modules' ), 99 );
 
-		/*
-		 * If enabled, point edit post, page, and comment links to Calypso instead of WP-Admin.
-		 * We should make sure to only do this for front end links.
-		 */
-		if ( self::get_option( 'edit_links_calypso_redirect' ) && ! is_admin() ) {
-			add_filter( 'get_edit_post_link', array( $this, 'point_edit_post_links_to_calypso' ), 1, 2 );
-			add_filter( 'get_edit_comment_link', array( $this, 'point_edit_comment_links_to_calypso' ), 1 );
-
-			/*
-			 * We'll shortcircuit wp_notify_postauthor and wp_notify_moderator pluggable functions
-			 * so they point moderation links on emails to Calypso.
-			 */
-			require_once JETPACK__PLUGIN_DIR . '_inc/lib/functions.wp-notify.php';
-			add_filter( 'comment_notification_recipients', 'jetpack_notify_postauthor', 1, 2 );
-			add_filter( 'notify_moderator', 'jetpack_notify_moderator', 1, 2 );
-		}
-
 		add_action(
 			'plugins_loaded',
 			function () {


### PR DESCRIPTION
We're not setting the `jetpack_edit_links_calypso_redirect` option anymore. 

 This saves an unnecessary call to `get_option()` when Jetpack is disconnected

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes code checking for `jetpack_edit_links_calypso_redirect` from `Jetpack::__construct()`
* Deprecated methods `Jetpack::point_edit_post_links_to_calypso` and `Jetpack::point_edit_comment_links_to_calypso` as they are no longer used.
* Deprecates file `functions.wp-notif.php` as it's not longer loaded

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-Qx-p2

## Does this pull request change what data or activity we track or use?
Noe

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Confirm there's no mention of `jetpack_edit_links_calypso_redirect` in dotcom, wpcomsh, or Jetpack anymore. 
* Confirm the file `function.wp-notify.php` is not loaded from anywhere other than the code removed in this PR
* Confirm that the methods `Jetpack::point_edit_post_links_to_calypso` and `Jetpack::point_edit_comment_links_to_calypso` as are no longer used anywhere else.
* Run this branch with the Jetpack Beta Tester plugin on a WoA site and check that nothing crashes. 

