### PR TITLE
MU WPCOM: Fix sharing modal "recommended tags" feature

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-add-tags-endpoint
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-add-tags-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use the correct endpoint route for adding suggested tags on new posts.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/suggested-tags.tsx
@@ -2,7 +2,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { Button, FormTokenField } from '@wordpress/components';
 import { TokenItem } from '@wordpress/components/build-types/form-token-field/types';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __, _n } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import * as React from 'react';
@@ -77,6 +77,7 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 		props.setShouldShowSuggestedTags( false );
 	};
 	const { saveTags } = useAddTagsToPost( postId, selectedTags, onAddTagsButtonClick );
+	const [ isSavingTags, setIsSavingTags ] = useState( false );
 
 	useEffect( () => {
 		if ( origSuggestedTags?.length === 0 ) {
@@ -119,8 +120,13 @@ function SuggestedTags( props: SuggestedTagsProps ) {
 			<p>{ __( 'Adding tags can help drive more traffic to your post.', 'jetpack-mu-wpcom' ) }</p>
 			<Button
 				className="wpcom-block-editor-post-published-sharing-modal__save-tags"
-				onClick={ saveTags }
+				onClick={ async () => {
+					setIsSavingTags( true );
+					await saveTags();
+					setIsSavingTags( false );
+				} }
 				variant="primary"
+				isBusy={ isSavingTags }
 			>
 				{ __( 'Add these tags', 'jetpack-mu-wpcom' ) }
 			</Button>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
@@ -1,4 +1,4 @@
-import wpcomRequest from 'wpcom-proxy-request';
+import apiFetch from '@wordpress/api-fetch';
 
 type HasAddedTagsResult = {
 	added_tags: number;
@@ -13,11 +13,10 @@ const useAddTagsToPost = ( postId: number, tags: string[], onSaveTags: OnSaveTag
 	async function saveTags() {
 		let addedTags = 0;
 		try {
-			const result = await wpcomRequest< HasAddedTagsResult >( {
+			const result: HasAddedTagsResult = await apiFetch( {
 				method: 'POST',
-				path: `read/sites/${ postId }/tags/add`,
-				apiNamespace: 'wpcom/v2',
-				body: { tags },
+				path: `/wpcom/v2/read/sites/${ window._currentSiteId }/posts/${ postId }/tags/add`,
+				data: { tags },
 			} );
 			addedTags = result.added_tags ?? 0;
 		} catch ( error ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/sharing-modal/use-add-tags-to-post.ts
@@ -1,4 +1,4 @@
-import apiFetch from '@wordpress/api-fetch';
+import wpcomRequest from 'wpcom-proxy-request';
 
 type HasAddedTagsResult = {
 	added_tags: number;
@@ -13,10 +13,11 @@ const useAddTagsToPost = ( postId: number, tags: string[], onSaveTags: OnSaveTag
 	async function saveTags() {
 		let addedTags = 0;
 		try {
-			const result: HasAddedTagsResult = await apiFetch( {
+			const result = await wpcomRequest< HasAddedTagsResult >( {
 				method: 'POST',
-				path: `/wpcom/v2/read/posts/${ postId }/tags/add`,
-				data: { tags },
+				path: `read/sites/${ postId }/tags/add`,
+				apiNamespace: 'wpcom/v2',
+				body: { tags },
 			} );
 			addedTags = result.added_tags ?? 0;
 		} catch ( error ) {


### PR DESCRIPTION
Fixes #39110.

## Proposed changes:
Fixes the endpoint used for the recommended tags on the sharing modal for new posts. Also adds the `isBusy` prop to its button. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
N/A.
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No.
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

- Apply this branch on your sandbox by running `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/add-tags-endpoint`;
- Try to create a new post on your site - add some content to it so it can get some tag recommendations;
- Publish it;
- Ensure adding the recommended tags works.

## Preview
### Before
https://github.com/user-attachments/assets/bbc876af-e715-40db-be39-eddb8236bc57

### After
https://github.com/user-attachments/assets/d7186a15-8340-4116-8aea-87e0ab460ffc