### PR TITLE
Launch Site-Level User Profile project

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/site-level-user-profile
+++ b/projects/packages/jetpack-mu-wpcom/changelog/site-level-user-profile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Enable Users -> Profile (profile.php) on all sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -166,39 +166,15 @@ add_action( 'admin_bar_menu', 'wpcom_add_reader_menu', 11 );
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
 function wpcom_maybe_replace_edit_profile_menu_to_me( $wp_admin_bar ) {
-	/**
-	 * The Edit Profile menu should point to /me, instead of the site's profile.php
-	 * if one of the following is true:
-	 * - the user is not a member of the current site
-	 * - the current site uses Default admin interface AND the site-level user profile is disabled
-	 */
-	$should_replace = ! is_user_member_of_blog() || ( empty( get_option( 'wpcom_site_level_user_profile' ) ) && get_option( 'wpcom_admin_interface' ) !== 'wp-admin' );
-
 	$edit_profile_node = $wp_admin_bar->get_node( 'user-info' );
 	if ( $edit_profile_node ) {
-		if ( $should_replace ) {
-			// Temporarily point to wpcalypso.wordpress.com for testing purposes.
-			$url = 'https://wordpress.com/me';
-			if ( ! empty( get_option( 'wpcom_site_level_user_profile' ) ) ) {
-				$url = 'https://wpcalypso.wordpress.com/me';
-			}
-
-			$edit_profile_node->href = maybe_add_origin_site_id_to_url( $url );
+		/**
+		 * The Edit Profile menu should point to /me, instead of the site's profile.php
+		 * if the user is not a member of the current site
+		 */
+		if ( ! is_user_member_of_blog() ) {
+			$edit_profile_node->href = maybe_add_origin_site_id_to_url( 'https://wordpress.com/me' );
 			$wp_admin_bar->add_node( (array) $edit_profile_node );
-		}
-	}
-
-	$my_account_node = $wp_admin_bar->get_node( 'my-account' );
-	if ( $my_account_node ) {
-		if ( $should_replace ) {
-			// Temporarily point to wpcalypso.wordpress.com for testing purposes.
-			$url = 'https://wordpress.com/me/account';
-			if ( ! empty( get_option( 'wpcom_site_level_user_profile' ) ) ) {
-				$url = 'https://wpcalypso.wordpress.com/me/account';
-			}
-
-			$my_account_node->href = maybe_add_origin_site_id_to_url( $url );
-			$wp_admin_bar->add_node( (array) $my_account_node );
 		}
 	}
 }
@@ -217,18 +193,12 @@ function wpcom_add_my_account_item_to_profile_menu( $wp_admin_bar ) {
 		$wp_admin_bar->remove_node( 'logout' );
 	}
 
-	// Temporarily point to wpcalypso.wordpress.com for testing purposes.
-	$url = 'https://wordpress.com/me/account';
-	if ( ! empty( get_option( 'wpcom_site_level_user_profile' ) ) ) {
-		$url = 'https://wpcalypso.wordpress.com/me/account';
-	}
-
 	$wp_admin_bar->add_node(
 		array(
 			'id'     => 'wpcom-profile',
 			'parent' => 'user-actions',
 			'title'  => __( 'My Account', 'jetpack-mu-wpcom' ),
-			'href'   => maybe_add_origin_site_id_to_url( $url ),
+			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/me/account' ),
 		)
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
@@ -35,30 +35,24 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 
 	$is_wpcom_atomic_classic = is_woa_site() && get_option( 'wpcom_admin_interface' ) === 'wp-admin';
 
-	// Temporarily point to wpcalypso.wordpress.com for testing purposes.
-	$wpcom_host = 'https://wordpress.com';
-	if ( get_option( 'wpcom_site_level_user_profile' ) === '1' ) {
-		$wpcom_host = 'https://wpcalypso.wordpress.com';
-	}
-
 	wp_localize_script(
 		'wpcom-profile-settings-link-to-wpcom',
 		'wpcomProfileSettingsLinkToWpcom',
 		array(
 			'language'             => array(
-				'link' => esc_url( $wpcom_host . '/me/account' ),
+				'link' => esc_url( 'https://wordpress.com/me/account' ),
 				'text' => __( 'Your admin interface language is managed on WordPress.com Account settings', 'jetpack-mu-wpcom' ),
 			),
 			'synced'               => array(
-				'link' => esc_url( $wpcom_host . '/me' ),
+				'link' => esc_url( 'https://wordpress.com/me' ),
 				'text' => __( 'You can manage your profile on WordPress.com Profile settings (First / Last / Display Names, Website, and Biographical Info)', 'jetpack-mu-wpcom' ),
 			),
 			'email'                => array(
-				'link' => esc_url( $wpcom_host . '/me/account' ),
+				'link' => esc_url( 'https://wordpress.com/me/account' ),
 				'text' => __( 'Your WordPress.com email is managed on WordPress.com Account settings', 'jetpack-mu-wpcom' ),
 			),
 			'password'             => array(
-				'link' => esc_url( $wpcom_host . '/me/security' ),
+				'link' => esc_url( 'https://wordpress.com/me/security' ),
 				'text' => __( 'Your WordPress.com password is managed on WordPress.com Security settings', 'jetpack-mu-wpcom' ),
 			),
 			'isWpcomAtomicClassic' => $is_wpcom_atomic_classic,

--- a/projects/packages/masterbar/changelog/site-level-user-profile
+++ b/projects/packages/masterbar/changelog/site-level-user-profile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Enable Users -> Profile (profile.php) on all sites

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -136,12 +136,6 @@ class Atomic_Admin_Menu extends Admin_Menu {
 			// The 'Subscribers' menu exists in the Jetpack menu for Classic wp-admin interface, so only add it for non-wp-admin interfaces.
 			// // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'users.php', esc_attr__( 'Subscribers', 'jetpack-masterbar' ), __( 'Subscribers', 'jetpack-masterbar' ), 'list_users', 'https://wordpress.com/subscribers/' . $this->domain, null );
-
-			if ( empty( get_option( 'wpcom_site_level_user_profile' ) ) ) {
-				remove_submenu_page( 'users.php', 'profile.php' );
-				// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-				add_submenu_page( 'users.php', esc_attr__( 'My Profile', 'jetpack-masterbar' ), __( 'My Profile', 'jetpack-masterbar' ), 'read', 'https://wordpress.com/me/', null );
-			}
 		}
 
 		// Users who can't 'list_users' will see "Profile" menu & "Profile > Account Settings" as submenu.

--- a/projects/packages/masterbar/tests/php/test-class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/tests/php/test-class-atomic-admin-menu.php
@@ -300,9 +300,9 @@ class Test_Atomic_Admin_Menu extends TestCase {
 		static::$admin_menu->add_users_menu();
 		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, $submenu['users.php'][0][2] );
 		$this->assertSame( 'user-new.php', $submenu['users.php'][2][2] );
+		$this->assertSame( 'profile.php', $submenu['users.php'][3][2] );
 		$this->assertSame( 'https://wordpress.com/subscribers/' . static::$domain, $submenu['users.php'][4][2] );
-		$this->assertSame( 'https://wordpress.com/me', $submenu['users.php'][5][2] );
-		$this->assertSame( 'https://wordpress.com/me/account', $submenu['users.php'][6][2] );
+		$this->assertSame( 'https://wordpress.com/me/account', $submenu['users.php'][5][2] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/slup-launch
+++ b/projects/plugins/jetpack/changelog/slup-launch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Enable Users -> Profile (profile.php) on all sites

--- a/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
+++ b/projects/plugins/jetpack/tests/php/modules/masterbar/test-class-atomic-admin-menu.php
@@ -269,9 +269,9 @@ class Test_Atomic_Admin_Menu extends WP_UnitTestCase {
 		static::$admin_menu->add_users_menu();
 		$this->assertSame( 'https://wordpress.com/people/team/' . static::$domain, $submenu['users.php'][0][2] );
 		$this->assertSame( 'user-new.php', $submenu['users.php'][2][2] );
+		$this->assertSame( 'profile.php', $submenu['users.php'][3][2] );
 		$this->assertSame( 'https://wordpress.com/subscribers/' . static::$domain, $submenu['users.php'][4][2] );
-		$this->assertSame( 'https://wordpress.com/me', $submenu['users.php'][5][2] );
-		$this->assertSame( 'https://wordpress.com/me/account', $submenu['users.php'][6][2] );
+		$this->assertSame( 'https://wordpress.com/me/account', $submenu['users.php'][5][2] );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/changelog/site-level-user-profile
+++ b/projects/plugins/wpcomsh/changelog/site-level-user-profile
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Enable Users -> Profile (profile.php) on all sites

--- a/projects/plugins/wpcomsh/feature-plugins/masterbar.php
+++ b/projects/plugins/wpcomsh/feature-plugins/masterbar.php
@@ -102,39 +102,6 @@ function wpcomsh_admin_color_scheme_picker_disabled() {
 }
 
 /**
- * Hides the "Admin Color Scheme" entry on /wp-admin/profile.php,
- * and adds an action that prints a calypso page link.
- * This applies only to WPCOM connected users.
- **/
-function wpcomsh_hide_color_schemes() {
-	// Do nothing if the admin interface is wp-admin.
-	if ( get_option( 'wpcom_admin_interface' ) === 'wp-admin' || ! empty( get_option( 'wpcom_site_level_user_profile' ) ) ) {
-		return false;
-	}
-
-	// Do nothing if we can't tell whether the User is connected.
-	if ( ! class_exists( 'Automattic\Jetpack\Connection\Manager' ) ) {
-		return false;
-	}
-	$connection_manager        = new Connection_Manager( 'jetpack' );
-	$user_id_from_query_string = $_GET['user_id'] ?? false; // phpcs:ignore WordPress.Security
-
-	if ( ! $connection_manager->is_user_connected( $user_id_from_query_string ) ) {
-		// If this is a local user, show the default UX.
-		return;
-	}
-
-	remove_action( 'admin_color_scheme_picker', 'admin_color_scheme_picker' );
-
-	if ( ! $user_id_from_query_string ) {
-		// Show Calypso page link only to a user editing their profile.
-		add_action( 'admin_color_scheme_picker', 'wpcomsh_admin_color_scheme_picker_disabled' );
-	}
-}
-add_action( 'load-profile.php', 'wpcomsh_hide_color_schemes' );
-add_action( 'load-user-edit.php', 'wpcomsh_hide_color_schemes' );
-
-/**
  * Gets data from the `wpcom.getUser` XMLRPC response and set it as user options. This is hooked
  * into the `setted_transient` action that is triggered everytime the XMLRPC response is read.
  *
@@ -333,10 +300,6 @@ add_filter( 'pre_option_wpcom_admin_interface', 'wpcomsh_get_wpcom_admin_interfa
  *    from wp-admin going forward.
  */
 function wpcomsh_unsync_color_schemes_on_save() {
-	if ( get_option( 'wpcom_admin_interface' ) !== 'wp-admin' && empty( get_option( 'wpcom_site_level_user_profile' ) ) ) {
-		return;
-	}
-
 	// Returns Calypso color scheme (if still exists),
 	// or wp-admin color scheme otherwise.
 	$maybe_synced_color_scheme = get_user_option( 'admin_color' );


### PR DESCRIPTION
Related to: https://github.com/Automattic/dotcom-forge/issues/8876

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

This PR launches pbxlJb-63Y-p2.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Simple Site

1. Sandbox a Simple site.
2. Patch this PR to your sandbox as per the instructions below.
3. Test on both Default and Classic interfaces:
    - Verify that the `Howdy` -> `Edit Profile` menu point to `profile.php`.
    - (to be able to actually access `profile.php`, you need to patch D160152-code)

#### Atomic Site

1. Prepare a WoA dev (important) site.
2. Install Jetpack Beta Tester
3. Patch this PR to Jetpack Beta Tester's `Jetpack`, `WordPress.com Features`, and `WordPress.com Site Helper`.
5. Test on both Default and Classic interfaces:
    - Verify that you can access Users -> Profile.
    - Verify that you can modify the admin color scheme.
    - Verify that your changes actually take effect.
    - Verify that the `Howdy` -> `Edit Profile` menu point to `profile.php`.