### PR TITLE
Replace `E_USER_ERROR` for PHP 8.4

### DIFF
--- a/projects/packages/stub-generator/changelog/fix-e_user_error-deprecated-in-php-8.4
+++ b/projects/packages/stub-generator/changelog/fix-e_user_error-deprecated-in-php-8.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Downgrade `E_USER_ERROR` to `E_USER_WARNING` in a test.
+
+

--- a/projects/packages/stub-generator/tests/php/IntegrationTest.php
+++ b/projects/packages/stub-generator/tests/php/IntegrationTest.php
@@ -53,7 +53,7 @@ class IntegrationTest extends TestCase {
 
 					public function stream_open( $path, $mode, $options ) {
 						if ( $options & STREAM_REPORT_ERRORS ) {
-							trigger_error( 'Open fail from dummy stream wrapper', E_USER_ERROR );
+							trigger_error( 'Open fail from dummy stream wrapper', E_USER_WARNING );
 						}
 						return false;
 					}

--- a/projects/plugins/jetpack/changelog/fix-e_user_error-deprecated-in-php-8.4
+++ b/projects/plugins/jetpack/changelog/fix-e_user_error-deprecated-in-php-8.4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Replace a `trigger_error( ..., E_USER_ERROR )` with a thrown exception for PHP 8.4 compatibility.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3290,6 +3290,7 @@ p {
 	 * This function artificially throws errors for such cases (per a specific list).
 	 *
 	 * @param string $plugin The activated plugin.
+	 * @throws RuntimeException If a conflicting plugin is detected.
 	 */
 	public function throw_error_on_activate_plugin( $plugin ) {
 		$active_modules = self::get_active_modules();
@@ -3313,7 +3314,7 @@ p {
 
 			if ( $throw ) {
 				/* translators: Plugin name to deactivate. */
-				trigger_error( sprintf( esc_html__( 'Jetpack contains the most recent version of the old &#8220;%1$s&#8221; plugin.', 'jetpack' ), 'WordPress.com Stats' ), E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				throw new RuntimeException( sprintf( __( 'Jetpack contains the most recent version of the old “%1$s” plugin.', 'jetpack' ), 'WordPress.com Stats' ) );
 			}
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
It seems they've decided to deprecate using `E_USER_ERROR` in favor of either dying or exceptions. The PHPCompatibility dev-branch run has added a sniff for this, so we may as well fix it.

One instance, in a test, is downgraded to `E_USER_WARNING`. The other is changed to a throw.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1725287899277359/1725284467.403089-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Changes make sense?