### PR TITLE
Subscriptions: Hook the Subscribe block only after single post content

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-subscription-after-post-content
+++ b/projects/plugins/jetpack/changelog/update-fix-subscription-after-post-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Hook the Subscribe block only after single post content

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/class-jetpack-subscription-site.php
@@ -111,6 +111,17 @@ class Jetpack_Subscription_Site {
 	}
 
 	/**
+	 * Returns true if context is recognized as a single post element.
+	 *
+	 * @param WP_Block_Template|WP_Post|array $context The block template, template part, or pattern the anchor block belongs to.
+	 *
+	 * @return bool
+	 */
+	protected function is_single_post_context( $context ) {
+		return $context instanceof WP_Block_Template && $context->slug === 'single';
+	}
+
+	/**
 	 * Handles Subscription block navigation placement.
 	 *
 	 * @return void
@@ -180,7 +191,7 @@ class Jetpack_Subscription_Site {
 				function ( $content ) {
 					// Check if we're inside the main loop in a single Post.
 					if (
-						is_singular() &&
+						is_single() &&
 						in_the_loop() &&
 						is_main_query() &&
 						$this->user_can_view_post()
@@ -227,10 +238,11 @@ HTML
 
 		add_filter(
 			'hooked_block_types',
-			function ( $hooked_blocks, $relative_position, $anchor_block ) {
+			function ( $hooked_blocks, $relative_position, $anchor_block, $context ) {
 				if (
 					$anchor_block === 'core/post-content' &&
 					$relative_position === 'after' &&
+					self::is_single_post_context( $context ) &&
 					$this->user_can_view_post()
 				) {
 					$hooked_blocks[] = 'jetpack/subscriptions';
@@ -239,7 +251,7 @@ HTML
 				return $hooked_blocks;
 			},
 			10,
-			3
+			4
 		);
 
 		add_filter(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

It fixes a bug where the Subscribe block was hooked not only after the single post content but also after, for example, page content.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the "Add the Subscribe Block at the end of each post" toggle from the Newsletter settings
* Make sure the Subscribe block is rendered only after the single post content and not after the page content
* Make sure it works for both, block and classic themes

