### PR TITLE
Change design task for Writing and Free flows

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-design-done
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-launchpad-design-done
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Launchpad: Require a design is selected before marking the step as complete in both the Write and Free flows

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -52,7 +52,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'task_ids'            => array(
 				'plan_selected',
 				'setup_free',
-				'design_selected',
+				'design_completed',
 				'domain_upsell',
 				'first_post_published',
 				'design_edited',
@@ -120,7 +120,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'            => array(
 				'setup_write',
-				'design_selected',
+				'design_completed',
 				'plan_selected',
 				'first_post_published',
 				'site_launched',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/93901

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
The Write and Free launchpad checklists used the `design_selected` task in their launchpad definitions. This task is always marked as done, even if a design isn't actually selected, which is perfectly possible for both of these flows - even likely for the write flow, depending upon the precise path.
    
Now they use the `design_completed` task, which explicitly checks whether a design has been selected before being marked as completed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
 1. Use jetpack rsync to get this change onto wpcom sandbox
 2. Sandbox the public-api

### Write flow
 1. Go through the /start flow
 2. Choose write goal
 3. Choose to create post
 4. Write a post and publish
 5. In the post-publish dialog click "Next Steps"
 6. You should be back in Launchpad and there should be a "Select a design" related task that is left undone.
<img width="444" alt="Screenshot 2024-09-02 at 16 24 57" src="https://github.com/user-attachments/assets/b9f62ce2-9c36-441b-9462-eb9567110f6c">


### Free flow
1. Go through any of the CTAs on https://wordpress.com/free/
2. When you land on the design picker, don't pick a site
3. Instead get the site URL out of the url parameter
4. Go to wordpress.com/home/:siteURL
5. You should land in the launchpad with the "Select a design" left undone

<img width="444" alt="Screenshot 2024-09-02 at 16 23 25" src="https://github.com/user-attachments/assets/9ab959ec-7ac7-4e4a-a262-1ef043464426">

(does it feel ok to have both Select a design and Edit design? Logically it makes sense, but if the user wants to keep the design forever "Select a design" will be forever unchecked.
