### PR TITLE
My Jetpack: Fix Jetpack AI product page cta on valid tier

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -208,15 +208,16 @@ export default function () {
 									'jetpack-my-jetpack'
 								) }
 							</div>
-							{ ! shouldContactUs && ! hasUnlimited && (
-								<Button
-									variant="primary"
-									onClick={ upgradeClickHandler }
-									className={ styles[ 'product-interstitial__hero-cta' ] }
-								>
-									{ __( 'Get more requests', 'jetpack-my-jetpack' ) }
-								</Button>
-							) }
+							{ ( ! shouldContactUs && ! hasUnlimited ) ||
+								( isFree && ! tierPlansEnabled && (
+									<Button
+										variant="primary"
+										onClick={ upgradeClickHandler }
+										className={ styles[ 'product-interstitial__hero-cta' ] }
+									>
+										{ __( 'Get more requests', 'jetpack-my-jetpack' ) }
+									</Button>
+								) ) }
 							{ shouldContactUs && (
 								<Button
 									variant="primary"

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -70,7 +70,8 @@ export default function () {
 	const isFree = currentTier?.value === 0;
 	const hasUnlimited = currentTier?.value === 1;
 	const hasPaidTier = ( ! isFree && ! hasUnlimited ) || ( hasUnlimited && ! tierPlansEnabled );
-	const shouldContactUs = ! hasUnlimited && hasPaidTier && ! nextTier && currentTier;
+	const shouldContactUs =
+		tierPlansEnabled && ! hasUnlimited && hasPaidTier && ! nextTier && currentTier;
 	const freeRequestsLeft = isFree && 20 - allTimeRequests >= 0 ? 20 - allTimeRequests : 0;
 	const showCurrentUsage = hasPaidTier && ! isFree && usage;
 	const showAllTimeUsage = hasPaidTier || hasUnlimited;

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -75,6 +75,8 @@ export default function () {
 	const freeRequestsLeft = isFree && 20 - allTimeRequests >= 0 ? 20 - allTimeRequests : 0;
 	const showCurrentUsage = hasPaidTier && ! isFree && usage;
 	const showAllTimeUsage = hasPaidTier || hasUnlimited;
+	const canUpgrade =
+		( tierPlansEnabled && ! hasUnlimited && ! shouldContactUs ) || ( ! tierPlansEnabled && isFree );
 	const contactHref = getRedirectUrl( 'jetpack-ai-tiers-more-requests-contact' );
 	const feedbackURL = getRedirectUrl( 'jetpack-ai-feedback' );
 	const videoLinkFeaturedImages = getRedirectUrl( 'jetpack-ai-product-page-featured-image-link' );
@@ -208,16 +210,15 @@ export default function () {
 									'jetpack-my-jetpack'
 								) }
 							</div>
-							{ ( ! shouldContactUs && ! hasUnlimited ) ||
-								( isFree && ! tierPlansEnabled && (
-									<Button
-										variant="primary"
-										onClick={ upgradeClickHandler }
-										className={ styles[ 'product-interstitial__hero-cta' ] }
-									>
-										{ __( 'Get more requests', 'jetpack-my-jetpack' ) }
-									</Button>
-								) ) }
+							{ canUpgrade && (
+								<Button
+									variant="primary"
+									onClick={ upgradeClickHandler }
+									className={ styles[ 'product-interstitial__hero-cta' ] }
+								>
+									{ __( 'Get more requests', 'jetpack-my-jetpack' ) }
+								</Button>
+							) }
 							{ shouldContactUs && (
 								<Button
 									variant="primary"

--- a/projects/packages/my-jetpack/changelog/fix-ai-product-page-CTA-on-valid-tier
+++ b/projects/packages/my-jetpack/changelog/fix-ai-product-page-CTA-on-valid-tier
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack AI product page: fix flags for showing/hiding upgrade/contact us button


### PR DESCRIPTION
On hold!

## Proposed changes:
Change the flags we use to determine if we need to show/hide the upgrade/contact us button

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1725305201319099-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Sandbox the public API, set your sandbox to mock a tier plan. Go to the product page `wp-admin/admin.php?page=my-jetpack#/jetpack-ai`

With tier plans enabled
- you should see the "Get more requests"
- if you set tier 1000 you should see the "Contact Us" button

With tier plans disabled
- you should see no button on the product page