### PR TITLE
My Jetpack: add link to fair usage on limit renewal notice for Jetpack AI

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -11,6 +11,7 @@ import {
 	Notice,
 } from '@automattic/jetpack-components';
 import { Button, Card, ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, plus, help, check } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -109,27 +110,45 @@ export default function () {
 
 	const currentUsageLabel = __( 'Requests this month', 'jetpack-my-jetpack' );
 	const currentRemainingLabel = __( 'Requests for this month', 'jetpack-my-jetpack' );
-
+	// You've reached this month's request limit, per our fair usage policy. Requests will reset on
 	const renewalNoticeTitle = __(
 		"You've reached your request limit for this month",
 		'jetpack-my-jetpack'
 	);
 	const upgradeNoticeTitle = __( "You've used all your free requests", 'jetpack-my-jetpack' );
 
-	const renewalNoticeBodyInfo = sprintf(
+	const renewalNoticeBodyTeaser = sprintf(
 		// translators: %d is the number of days left in the month.
-		__( 'Wait for %d days to reset your limit', 'jetpack-my-jetpack' ),
+		__(
+			'Wait for %d days to reset your limit, or upgrade now to a higher tier for additional requests and keep your work moving forward.',
+			'jetpack-my-jetpack'
+		),
 		Math.floor( ( new Date( usage?.nextStart || null ) - new Date() ) / ( 1000 * 60 * 60 * 24 ) )
 	);
 
-	const renewalNoticeBodyTeaser = __(
-		', or upgrade now to a higher tier for additional requests and keep your work moving forward.',
-		'jetpack-my-jetpack'
+	const renewalNoticeBodyFairUsage = createInterpolateElement(
+		sprintf(
+			// translators: %d is the number of days left in the month.
+			__(
+				'Wait for %d days to reset your limit, per our <link>fair usage</link> policy.',
+				'jetpack-my-jetpack'
+			),
+			Math.floor( ( new Date( usage?.nextStart || null ) - new Date() ) / ( 1000 * 60 * 60 * 24 ) )
+		),
+		{
+			link: (
+				<a
+					href={ getRedirectUrl( 'ai-product-page-fair-usage-policy' ) }
+					target="_blank"
+					rel="noreferrer"
+				/>
+			),
+		}
 	);
 
 	const renewalNoticeBody = ! tierPlansEnabled
-		? renewalNoticeBodyInfo + '.'
-		: renewalNoticeBodyInfo + renewalNoticeBodyTeaser;
+		? renewalNoticeBodyFairUsage
+		: renewalNoticeBodyTeaser;
 
 	const upgradeNoticeBody = __(
 		'Reach for More with Jetpack AI! Upgrade now for additional requests and keep your momentum going.',

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-fair-usage-link
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-product-page-fair-usage-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack AI product page: add fair usage link on over quota notice


### PR DESCRIPTION

## Proposed changes:
The notice shown when the fair usage limit is reached was lacking a link to more information about it. For now we link to AI guidelines.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-2Hp-p2#comment-1376

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
Sandbox the public api. Disable tier plans and mock an over fair usage case:
```
add_filter( 'jetpack_ai_tier_plans_enabled', '__return_false' );
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 3001; } );
```

Visit Jetpack AI product page at `wp-admin/admin.php?page=my-jetpack#/jetpack-ai`. You should see a notice including a link to AI guidelines:

<img width="729" alt="image" src="https://github.com/user-attachments/assets/acfaabed-e5be-4d9a-a6ce-4d61efbd48ba">
