### PR TITLE
Boost: Update Boost pricing text

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/upgrade-cta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/upgrade-cta.tsx
@@ -39,7 +39,7 @@ const UpgradeCTA = ( {
 				<p className={ styles[ 'action-line' ] }>
 					{ sprintf(
 						/* translators: %s is the price including the currency symbol in front. */
-						__( `Upgrade now only %s`, 'jetpack-boost' ),
+						__( `Upgrade now only %s per month`, 'jetpack-boost' ),
 						priceString
 					) }
 				</p>

--- a/projects/plugins/boost/changelog/update-boost-pricing-text
+++ b/projects/plugins/boost/changelog/update-boost-pricing-text
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated pricing text for clarity
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added "per month" next to pricing CTAs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1725300024027529-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The pricing CTAs should contain "per month" at the end.
![image](https://github.com/user-attachments/assets/44b56cf3-e935-4630-95f1-e46fc7d0a1ae)
