### PR TITLE
Social: Improve polling for share status

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-improve-polling-for-share-status
+++ b/projects/js-packages/publicize-components/changelog/update-social-improve-polling-for-share-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Improved polling performance for share status

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/index.tsx
@@ -1,8 +1,9 @@
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginPostPublishPanel } from '@wordpress/edit-post';
 import { store as editorStore } from '@wordpress/editor';
 import { usePostMeta } from '../../hooks/use-post-meta';
 import { usePostPrePublishValue } from '../../hooks/use-post-pre-publish-value';
+import { usePostJustPublished } from '../../hooks/use-saving-post';
 import { store as socialStore } from '../../social-store';
 import { ShareStatus } from './share-status';
 
@@ -13,15 +14,14 @@ import { ShareStatus } from './share-status';
  */
 export function PostPublishShareStatus() {
 	const { isPublicizeEnabled } = usePostMeta();
-	const { featureFlags, postId, isPostPublised } = useSelect( select => {
+	const { pollForPostShareStatus } = useDispatch( socialStore );
+	const { featureFlags, isPostPublised } = useSelect( select => {
 		const store = select( socialStore );
 
 		const _editorStore = select( editorStore );
 
 		return {
 			featureFlags: store.featureFlags(),
-			// @ts-expect-error -- `@wordpress/editor` is a nightmare to work with TypeScript
-			postId: _editorStore.getCurrentPostId(),
 			// @ts-expect-error -- `@wordpress/editor` is a nightmare to work with TypeScript
 			isPostPublised: _editorStore.isCurrentPostPublished(),
 		};
@@ -33,13 +33,25 @@ export function PostPublishShareStatus() {
 
 	const willPostBeShared = isPublicizeEnabled && enabledConnections.length > 0;
 
-	if ( ! featureFlags.useShareStatus || ! willPostBeShared || ! isPostPublised ) {
+	const showStatus = featureFlags.useShareStatus && willPostBeShared && isPostPublised;
+
+	usePostJustPublished( () => {
+		if ( showStatus ) {
+			pollForPostShareStatus( {
+				isRequestComplete( { postShareStatus } ) {
+					return postShareStatus.done;
+				},
+			} );
+		}
+	}, [ showStatus ] );
+
+	if ( ! showStatus ) {
 		return null;
 	}
 
 	return (
 		<PluginPostPublishPanel id="publicize-share-status">
-			<ShareStatus postId={ postId } />
+			<ShareStatus />
 		</PluginPostPublishPanel>
 	);
 }

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
@@ -15,7 +15,7 @@ import styles from './styles.module.scss';
 export function ShareStatus() {
 	const shareStatus = useSelect( select => select( socialStore ).getPostShareStatus(), [] );
 
-	if ( shareStatus.loading ) {
+	if ( shareStatus.loading || ! shareStatus.done ) {
 		return (
 			<div className={ styles[ 'loading-block' ] }>
 				<Spinner />
@@ -50,10 +50,6 @@ export function ShareStatus() {
 				</ShareStatusModalTrigger>
 			</Notice>
 		);
-	}
-
-	if ( ! shareStatus.done ) {
-		return <span>{ __( 'The request to share your post is still in progress.', 'jetpack' ) }</span>;
 	}
 
 	if ( ! shareStatus.shares.length ) {

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
@@ -1,59 +1,19 @@
 import { Spinner } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { getDate, isInTheFuture } from '@wordpress/date';
-import { store as editorStore } from '@wordpress/editor';
-import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as socialStore } from '../../social-store';
 import Notice from '../notice';
 import { ShareStatusModalTrigger } from '../share-status';
 import styles from './styles.module.scss';
 
-export type ShareStatusProps = {
-	postId: number;
-};
-
-const ONE_MINUTE_IN_MS = 60 * 1000;
-
 /**
  * Share status component.
  *
- * @param {ShareStatusProps} props - Component props.
  *
  * @return {import('react').ReactNode} - Share status UI.
  */
-export function ShareStatus( { postId }: ShareStatusProps ) {
-	const shareStatus = useSelect(
-		select => select( socialStore ).getPostShareStatus( postId ),
-		[ postId ]
-	);
-
-	// Whether the post has been published more than one minute ago.
-	const hasBeenMoreThanOneMinute = useSelect( select => {
-		// @ts-expect-error -- `@wordpress/editor` is a nightmare to work with TypeScript
-		const date = select( editorStore ).getEditedPostAttribute( 'date' );
-
-		const oneMinuteAfterPostDate = new Date( Number( getDate( date ) ) + ONE_MINUTE_IN_MS );
-
-		// @ts-expect-error isInTheFuture is typed incorrectly as it should accept a Date object apart from a string.
-		return ! isInTheFuture( oneMinuteAfterPostDate );
-	}, [] );
-
-	// @ts-expect-error `invalidateResolution` exists in every store
-	const { invalidateResolution } = useDispatch( socialStore );
-
-	useEffect( () => {
-		if ( ! hasBeenMoreThanOneMinute && ! shareStatus.loading && ! shareStatus.done ) {
-			// Fire the next request as soon as the previous one is done but we are not done yet.
-			invalidateResolution( 'getPostShareStatus', [ postId ] );
-		}
-	}, [
-		hasBeenMoreThanOneMinute,
-		invalidateResolution,
-		postId,
-		shareStatus.loading,
-		shareStatus.done,
-	] );
+export function ShareStatus() {
+	const shareStatus = useSelect( select => select( socialStore ).getPostShareStatus(), [] );
 
 	if ( shareStatus.loading ) {
 		return (

--- a/projects/js-packages/publicize-components/src/social-store/actions/share-status.ts
+++ b/projects/js-packages/publicize-components/src/social-store/actions/share-status.ts
@@ -127,8 +127,11 @@ export function pollForPostShareStatus( {
 		let hasTimeoutPassed = false;
 
 		do {
-			// Invalidate the resolution to get the latest share status.
-			dispatch.invalidateResolution( 'getPostShareStatus', [ postId ] );
+			// Do not invalidate the resolution if the request is still loading.
+			if ( ! select.getPostShareStatus( postId ).loading ) {
+				// Invalidate the resolution to get the latest share status.
+				dispatch.invalidateResolution( 'getPostShareStatus', [ postId ] );
+			}
 
 			// Wait for the polling interval.
 			await new Promise( resolve => setTimeout( resolve, pollingInterval ) );

--- a/projects/js-packages/publicize-components/src/social-store/actions/share-status.ts
+++ b/projects/js-packages/publicize-components/src/social-store/actions/share-status.ts
@@ -1,4 +1,4 @@
-import { SocialStoreState } from '../types';
+import { PostShareStatus, SocialStoreState } from '../types';
 import {
 	FETCH_POST_SHARE_STATUS,
 	RECEIVE_POST_SHARE_STATUS,
@@ -69,4 +69,76 @@ export function openShareStatusModal() {
  */
 export function closeShareStatusModal() {
 	return toggleShareStatusModal( false );
+}
+
+type IsRequestComplete = ( options: {
+	lastTimestamp: number;
+	postShareStatus: PostShareStatus;
+} ) => boolean;
+
+/**
+ * Default implementation to check if the request is complete.
+ *
+ * @param {IsRequestComplete} options - Options.
+ *
+ * @return {boolean} - Whether the request is complete.
+ */
+export const defaultIsRequestComplete: IsRequestComplete = ( {
+	lastTimestamp,
+	postShareStatus,
+} ) => {
+	// If the last timestamp is present, check if there are newer timestamps.
+	// otherwise check if we have any shares.
+	return lastTimestamp
+		? postShareStatus.shares.some( share => share.timestamp > lastTimestamp )
+		: postShareStatus.shares.length > 0;
+};
+
+type PollForPostShareStatusOptions = {
+	postId?: number;
+	timeout?: number;
+	isRequestComplete?: IsRequestComplete;
+	pollingInterval?: number;
+};
+
+const ONE_MINUTE_IN_MS = 60 * 1000;
+
+const POLLING_INTERVAL = 3 * 1000; // milliseconds
+
+/**
+ * Poll for share status.
+ *
+ * @param {PollForPostShareStatusOptions} options - Options.
+ *
+ * @return {Promise<void>} - Function to start polling.
+ */
+export function pollForPostShareStatus( {
+	pollingInterval = POLLING_INTERVAL,
+	postId,
+	isRequestComplete = defaultIsRequestComplete,
+	timeout = ONE_MINUTE_IN_MS,
+}: PollForPostShareStatusOptions = {} ) {
+	return async function ( { dispatch, select } ) {
+		const startedAt = Date.now();
+
+		const lastTimestamp = select.getPostShareStatus( postId ).shares[ 0 ]?.timestamp || 0;
+
+		let isTheRequestComplete = false;
+		let hasTimeoutPassed = false;
+
+		do {
+			// Invalidate the resolution to get the latest share status.
+			dispatch.invalidateResolution( 'getPostShareStatus', [ postId ] );
+
+			// Wait for the polling interval.
+			await new Promise( resolve => setTimeout( resolve, pollingInterval ) );
+
+			isTheRequestComplete = isRequestComplete( {
+				lastTimestamp,
+				postShareStatus: select.getPostShareStatus( postId ),
+			} );
+
+			hasTimeoutPassed = Date.now() - startedAt > timeout;
+		} while ( ! isTheRequestComplete && ! hasTimeoutPassed );
+	};
 }

--- a/projects/js-packages/publicize-components/src/social-store/selectors/share-status.ts
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/share-status.ts
@@ -18,7 +18,7 @@ export const getPostShareStatus = createRegistrySelector(
 
 			return state.shareStatus?.[ id ] ?? { shares: [] };
 		}
-);
+) as ( state: SocialStoreState, postId?: number ) => PostShareStatus;
 
 /**
  * Whether the share status modal is open.

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -41,6 +41,7 @@ export type ShareStatusItem = Pick<
 	timestamp: number;
 	service: string;
 	external_name: string;
+	external_id: string;
 };
 
 export type PostShareStatus = {


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Create `pollForPostShareStatus` action to handle polling for share status
* Use the above action in post publish share status

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the share status feature - `define( 'JETPACK_SOCIAL_HAS_SHARE_STATUS', true );`
* Open Network tab
* Create a new post and publish it
* Confirm that you see the share status info in the sidebar in post publish panel
* Confirm that the share status polling happens every 3 seonnds
* Confirm that it ends after a timeout of 1 minute
