### PR TITLE
Subscriptions: Fix Subscribe Modal spacing

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-subscribe-modal-spacing
+++ b/projects/plugins/jetpack/changelog/update-fix-subscribe-modal-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Fix Subscribe Modal spacing

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -186,13 +186,13 @@ class Jetpack_Subscribe_Modal {
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"15px"},"spacing":{"margin":{"top":"4px","bottom":"0px"}}}} -->
-		<p class='has-text-align-center' style='margin-top:4px;margin-bottom:0px;font-size:15px'>$subscribe_text</p>
+		<p class='has-text-align-center' style='margin-top:4px;margin-bottom:1em;font-size:15px'>$subscribe_text</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:jetpack/subscriptions {"borderRadius":50,"className":"is-style-compact","appSource":"subscribe-modal"} /-->
 
 		<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"20px"}},"typography":{"fontSize":"14px"}},"className":"jetpack-subscribe-modal__close"} -->
-		<p class="has-text-align-center jetpack-subscribe-modal__close" style="margin-top:20px;font-size:14px"><a href="#">$continue_reading</a></p>
+		<p class="has-text-align-center jetpack-subscribe-modal__close" style="margin-top:20px;font-size:14px;margin-bottom:0"><a href="#">$continue_reading</a></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -192,7 +192,7 @@ class Jetpack_Subscribe_Modal {
 		<!-- wp:jetpack/subscriptions {"borderRadius":50,"className":"is-style-compact","appSource":"subscribe-modal"} /-->
 
 		<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"20px"}},"typography":{"fontSize":"14px"}},"className":"jetpack-subscribe-modal__close"} -->
-		<p class="has-text-align-center jetpack-subscribe-modal__close" style="margin-top:20px;font-size:14px;margin-bottom:0"><a href="#">$continue_reading</a></p>
+		<p class="has-text-align-center jetpack-subscribe-modal__close" style="margin-top:20px;margin-bottom:0;font-size:14px;"><a href="#">$continue_reading</a></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -192,7 +192,7 @@ class Jetpack_Subscribe_Modal {
 		<!-- wp:jetpack/subscriptions {"borderRadius":50,"className":"is-style-compact","appSource":"subscribe-modal"} /-->
 
 		<!-- wp:paragraph {"align":"center","style":{"spacing":{"margin":{"top":"20px"}},"typography":{"fontSize":"14px"}},"className":"jetpack-subscribe-modal__close"} -->
-		<p class="has-text-align-center jetpack-subscribe-modal__close" style="margin-top:20px;margin-bottom:0;font-size:14px;"><a href="#">$continue_reading</a></p>
+		<p class="has-text-align-center jetpack-subscribe-modal__close" style="margin-top:20px;margin-bottom:0;font-size:14px"><a href="#">$continue_reading</a></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:

It fixes some spacing for the Subscribe Modal by:
- adding some bottom margin after the "Subscribe now to keep reading and get access to the full archive." text (when the element below has some top margin, those margins would collapse, that's why in some cases there should be no difference, which is good)
- remove bottom margin from the "Continue reading" link (we don't need it since it's the last element)

In most themes there should be no difference:

| Before | After |
|--------|--------|
| <img width="615" alt="Screenshot 2024-09-03 at 11 52 16" src="https://github.com/user-attachments/assets/bf2d1587-8fdc-42a6-a8be-5347740ceb3b"> | <img width="615" alt="Screenshot 2024-09-03 at 11 53 18" src="https://github.com/user-attachments/assets/cd93f5b2-1b66-42e5-8d63-85174cf9f52a"> |
| <img width="615" alt="Screenshot 2024-09-03 at 11 55 48" src="https://github.com/user-attachments/assets/14f4f3ec-1853-4635-89e0-c7bcd1aef3b0"> | <img width="615" alt="Screenshot 2024-09-03 at 11 56 38" src="https://github.com/user-attachments/assets/acd98b23-6b66-4fbf-b9fc-f3106428a399"> |


But for some other themes, it makes it look a bit better:

| Before | After |
|--------|--------|
| <img width="615" alt="Screenshot 2024-09-03 at 11 54 36" src="https://github.com/user-attachments/assets/37b6ffd4-ea90-4a48-a034-95793ecaa915"> | <img width="615" alt="Screenshot 2024-09-03 at 11 55 08" src="https://github.com/user-attachments/assets/97829bfc-bdc4-470b-84a0-3a8a2f3f2596"> |
| <img width="613" alt="Screenshot 2024-09-03 at 12 04 47" src="https://github.com/user-attachments/assets/7ee62252-316f-476b-958a-f797b94d83fb"> | <img width="613" alt="Screenshot 2024-09-03 at 12 04 41" src="https://github.com/user-attachments/assets/dad395f2-b68f-4414-b089-b9828f16d604"> |


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the "Show subscription pop-up when scrolling a post" option from the Newsletter settings
* Open the post
* Scroll a bit making sure the popup appears and looks as expected

