### PR TITLE
Content Options: Adding back an erroneously removed value from a get_post_metadata filter

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/fix-content-options-package-featured-image-filter
+++ b/projects/packages/classic-theme-helper/changelog/fix-content-options-package-featured-image-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Content Options: Add back value to filter in package version of Content Options file.

--- a/projects/packages/classic-theme-helper/src/content-options/featured-images.php
+++ b/projects/packages/classic-theme-helper/src/content-options/featured-images.php
@@ -85,7 +85,7 @@ if ( ! function_exists( 'jetpack_featured_images_remove_post_thumbnail' ) ) {
 			return $metadata;
 		}
 	}
-	add_filter( 'get_post_metadata', 'jetpack_featured_images_remove_post_thumbnail', true, 3 ); // @phan-suppress-current-line PhanTypeMismatchArgument -- Converting to an int results in the int being auto-removed via lint, which results in a PHP fatal error when the file is in use.
+	add_filter( 'get_post_metadata', 'jetpack_featured_images_remove_post_thumbnail', 1, 3 ); // @phan-suppress-current-line PhanTypeMismatchArgument -- Converting to an int results in the int being auto-removed via lint, which results in a PHP fatal error when the file is in use.
 
 }
 

--- a/projects/packages/classic-theme-helper/src/content-options/featured-images.php
+++ b/projects/packages/classic-theme-helper/src/content-options/featured-images.php
@@ -85,7 +85,7 @@ if ( ! function_exists( 'jetpack_featured_images_remove_post_thumbnail' ) ) {
 			return $metadata;
 		}
 	}
-	add_filter( 'get_post_metadata', 'jetpack_featured_images_remove_post_thumbnail', 3 );
+	add_filter( 'get_post_metadata', 'jetpack_featured_images_remove_post_thumbnail', true, 3 );
 
 }
 

--- a/projects/packages/classic-theme-helper/src/content-options/featured-images.php
+++ b/projects/packages/classic-theme-helper/src/content-options/featured-images.php
@@ -85,7 +85,7 @@ if ( ! function_exists( 'jetpack_featured_images_remove_post_thumbnail' ) ) {
 			return $metadata;
 		}
 	}
-	add_filter( 'get_post_metadata', 'jetpack_featured_images_remove_post_thumbnail', 1, 3 ); // @phan-suppress-current-line PhanTypeMismatchArgument -- Converting to an int results in the int being auto-removed via lint, which results in a PHP fatal error when the file is in use.
+	add_filter( 'get_post_metadata', 'jetpack_featured_images_remove_post_thumbnail', true, 3 ); // @phan-suppress-current-line PhanTypeMismatchArgument.
 
 }
 

--- a/projects/packages/classic-theme-helper/src/content-options/featured-images.php
+++ b/projects/packages/classic-theme-helper/src/content-options/featured-images.php
@@ -85,7 +85,7 @@ if ( ! function_exists( 'jetpack_featured_images_remove_post_thumbnail' ) ) {
 			return $metadata;
 		}
 	}
-	add_filter( 'get_post_metadata', 'jetpack_featured_images_remove_post_thumbnail', true, 3 );
+	add_filter( 'get_post_metadata', 'jetpack_featured_images_remove_post_thumbnail', true, 3 ); // @phan-suppress-current-line PhanTypeMismatchArgument -- Converting to an int results in the int being auto-removed via lint, which results in a PHP fatal error when the file is in use.
 
 }
 


### PR DESCRIPTION
## Proposed changes:

* This PR adds back the value 'true' to the values passed through the `get_post_metadata` filter within the `featured-images.php` file in the Classic Theme Helper package: `add_filter( 'get_post_metadata', 'jetpack_featured_images_remove_post_thumbnail', true, 3 );`. It also adds a Phan suppression to allow that bool.
* The file contents were copied over to the package previously, but somehow the bool value did not remain. I recall the Phan error initially, and recall changing the value to an int, but either the change didn't stick or was auto-removed at some stage.
* The omission of the bool resulted in a fatal error when attempting to require Content Options via the CTH package.
* The value could be changed to an int - eg 1 - but needs more testing, which I can do when requiring the package. This just makes sure we have parity initially.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* This shouldn't need to be tested, as we're copying what existed in the existing module file (and the package is not being required yet): https://github.com/Automattic/jetpack/blob/90657ba1859a7f9d1710b13dc231fa0af77dfb62/projects/plugins/jetpack/modules/theme-tools/content-options/featured-images.php#L88

