### PR TITLE
Fix connection assets for WPCOM Simple sites

### DIFF
--- a/projects/packages/connection/actions.php
+++ b/projects/packages/connection/actions.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Action Hooks for Jetpack connection assets.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+// If WordPress's plugin API is available already, use it. If not,
+// drop data into `$wp_filter` for `WP_Hook::build_preinitialized_hooks()`.
+if ( function_exists( 'add_action' ) ) {
+	add_action(
+		'plugins_loaded',
+		array( Automattic\Jetpack\Connection\Connection_Assets::class, 'configure' ),
+		1
+	);
+} else {
+	global $wp_filter;
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$wp_filter['plugins_loaded'][1][] = array(
+		'accepted_args' => 0,
+		'function'      => array( Automattic\Jetpack\Connection\Connection_Assets::class, 'configure' ),
+	);
+}

--- a/projects/packages/connection/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/packages/connection/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed connection assets for wpcom simple sites

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -25,6 +25,9 @@
 		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
 	},
 	"autoload": {
+		"files": [
+			"actions.php"
+		],
 		"classmap": [
 			"legacy",
 			"src/",

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -155,8 +155,6 @@ class Manager {
 
 		// Initial Partner management.
 		Partner::init();
-
-		Connection_Assets::configure();
 	}
 
 	/**

--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -383,7 +383,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+                "reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -428,6 +428,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "legacy",
                     "src/",

--- a/projects/plugins/backup/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/backup/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -665,7 +665,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+                "reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -710,6 +710,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "legacy",
                     "src/",

--- a/projects/plugins/boost/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/boost/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -521,7 +521,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+                "reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -566,6 +566,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "legacy",
                     "src/",

--- a/projects/plugins/inspect/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/inspect/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -383,7 +383,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+                "reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -428,6 +428,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "legacy",
                     "src/",

--- a/projects/plugins/jetpack/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/jetpack/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -907,7 +907,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/connection",
-				"reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+				"reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -952,6 +952,9 @@
 				}
 			},
 			"autoload": {
+				"files": [
+					"actions.php"
+				],
 				"classmap": [
 					"legacy",
 					"src/",

--- a/projects/plugins/migration/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/migration/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/migration/composer.lock
+++ b/projects/plugins/migration/composer.lock
@@ -665,7 +665,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+                "reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -710,6 +710,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "legacy",
                     "src/",

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -494,7 +494,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+                "reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -539,6 +539,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "legacy",
                     "src/",

--- a/projects/plugins/protect/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/protect/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -578,7 +578,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+                "reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -623,6 +623,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "legacy",
                     "src/",

--- a/projects/plugins/search/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/search/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -521,7 +521,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+                "reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -566,6 +566,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "legacy",
                     "src/",

--- a/projects/plugins/social/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/social/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -521,7 +521,7 @@
 			"dist": {
 				"type": "path",
 				"url": "../../packages/connection",
-				"reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+				"reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
 			},
 			"require": {
 				"automattic/jetpack-a8c-mc-stats": "@dev",
@@ -566,6 +566,9 @@
 				}
 			},
 			"autoload": {
+				"files": [
+					"actions.php"
+				],
 				"classmap": [
 					"legacy",
 					"src/",

--- a/projects/plugins/starter-plugin/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/starter-plugin/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -521,7 +521,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+                "reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -566,6 +566,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "legacy",
                     "src/",

--- a/projects/plugins/videopress/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/videopress/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -521,7 +521,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+                "reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -566,6 +566,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "legacy",
                     "src/",

--- a/projects/plugins/wpcomsh/changelog/fix-connection-assets-for-wpcom-simple-sites
+++ b/projects/plugins/wpcomsh/changelog/fix-connection-assets-for-wpcom-simple-sites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -631,7 +631,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "61beeb1eadc51c94a4ba35310bed89a1f15702e3"
+                "reference": "dfb367ef9c0c15e8edbef55aaddec4d17a0881fc"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -676,6 +676,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "actions.php"
+                ],
                 "classmap": [
                     "legacy",
                     "src/",


### PR DESCRIPTION
Following #38877, the Jetpack sidebar doesn't load on simple sites because the `Manager` class is not initialized on Simple sites and thus the connection bundle never gets registered.



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR creates `actions.php` file and loads it via composer autoload to ensure the assets are registered.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Goto post editor for Jetpack, Simple and Atomic sites
* Confirm that the Jetpack sidebar laods

