### PR TITLE
Jetpack: Show correct product name for "VaultPress Backup" in sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-saying-vaultpress-not-vaultpress-backup
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-saying-vaultpress-not-vaultpress-backup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sidebar: Show correct product name for "VaultPress Backup".

--- a/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
+++ b/projects/plugins/jetpack/modules/scan/class-admin-sidebar-link.php
@@ -93,8 +93,8 @@ class Admin_Sidebar_Link {
 
 		if ( $this->should_show_backup() ) {
 			Admin_Menu::add_menu(
-				__( 'VaultPress', 'jetpack' ),
-				__( 'VaultPress', 'jetpack' ) . ' <span class="dashicons dashicons-external"></span>',
+				__( 'VaultPress Backup', 'jetpack' ),
+				__( 'VaultPress Backup', 'jetpack' ) . ' <span class="dashicons dashicons-external"></span>',
 				'manage_options',
 				esc_url( Redirect::get_url( 'calypso-backups' ) ),
 				null,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This matches what is displayed when the Jetpack Backup plugin is installed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #39165

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a site with a Backup plan.
* Ensure the Jetpack Backup plugin is not active.
* Check the sidebar (see https://github.com/Automattic/jetpack/issues/39165#issuecomment-2325055812 for screenshots).
