### PR TITLE
Brief: Update empty helper text layout

### DIFF
--- a/projects/plugins/jetpack/changelog/update-brief-write-help-text
+++ b/projects/plugins/jetpack/changelog/update-brief-write-help-text
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Update empty help text for Brief

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/breve.scss
@@ -4,7 +4,7 @@
 	margin-bottom: 24px;
 
 	.components-checkbox-control {
-		&__input:not(:disabled) {
+		&__input:not( :disabled ) {
 			@include features-colors( ( 'border-color' ) );
 			&:checked {
 				@include features-colors( ( 'background-color' ) );
@@ -24,6 +24,11 @@
 	&__grade-label {
 		color: #757575;
 		margin-left: 12px;
+	}
+
+	&__help-text {
+		font-size: 12px;
+		color: #757575;
 	}
 
 	.feature-checkboxes-container {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.tsx
@@ -108,10 +108,8 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 				<BaseControl>
 					<div className="grade-level-container">
 						{ gradeLevel === null ? (
-							<p>
-								<em className="breve-help-text">
-									{ __( 'Write to see your grade level.', 'jetpack' ) }
-								</em>
+							<p className="jetpack-ai-proofread__help-text">
+								{ __( 'Write to see your grade level.', 'jetpack' ) }
 							</p>
 						) : (
 							<Tooltip text={ __( 'To make it easy to read, aim for level 8-12', 'jetpack' ) }>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes #39029 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update font-size and color for empty helper text.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
N/A

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open your editor with an empty post.
* It should show the `Write to see your grade level.` in gray with 12px as `font-size`. 

