### PR TITLE
Sync: Move check for IDC safe mode after check for connection

### DIFF
--- a/projects/packages/sync/changelog/update-move-in_safe_mode-after-checkif-connected
+++ b/projects/packages/sync/changelog/update-move-in_safe_mode-after-checkif-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Optimized performance by moving the IDC safe mode check after the connection check, reducing unnecessary get_option() requests for jetpack_sync_error_idc

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -304,15 +304,16 @@ class Actions {
 			return false;
 		}
 
-		if ( ( new Status() )->in_safe_mode() ) {
-			return false;
-		}
-
 		$connection = new Jetpack_Connection();
 		if ( ! $connection->is_connected() ) {
 			if ( ! doing_action( 'jetpack_site_registered' ) ) {
 				return false;
 			}
+		}
+
+		// By now, we know the site is connected, so we can return false if in safe mode.
+		if ( ( new Status() )->in_safe_mode() ) {
+			return false;
 		}
 
 		return true;


### PR DESCRIPTION
This saves an extra request for get_option() looking for `jetpack_sync_error_idc` when Jetpack is disconnected<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Automattic/vulcan#497

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Optimizes performance by moving the IDC safe mode check after the connection check, reducing an unnecessary get_option() requests for jetpack_sync_error_idc.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-QN-p2#comment-896

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

This saves an extra request for get_option() looking for `jetpack_sync_error_idc`