### PR TITLE
image-cdn: Avoid fatal on bad img width/height

### DIFF
--- a/projects/packages/image-cdn/changelog/fix-image-cdn-fatal
+++ b/projects/packages/image-cdn/changelog/fix-image-cdn-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid a fatal error if an `<img>` tag has width or height that's not an integer or percentage.

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -449,11 +449,11 @@ final class Image_CDN {
 
 				// First, check the image tag. Note we only check for pixel sizes now; HTML4 percentages have never been correctly
 				// supported, so we stopped pretending to support them in JP 9.1.0.
-				if ( ! is_string( $width ) || str_contains( $width, '%' ) ) {
+				if ( ! is_string( $width ) || ! ctype_digit( $width ) ) {
 					$width = false;
 				}
 
-				if ( ! is_string( $height ) || str_contains( $height, '%' ) ) {
+				if ( ! is_string( $height ) || ! ctype_digit( $height ) ) {
 					$height = false;
 				}
 

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn.php
@@ -1221,6 +1221,48 @@ class WP_Test_Image_CDN extends Image_CDN_Attachment_Test_Case {
 	}
 
 	/**
+	 * Tests that Photon ignores empty dimensions. It should fall back to e.g. a "size-foo" class.
+	 *
+	 * @covers Image_CDN::filter_the_content
+	 */
+	public function test_image_cdn_filter_the_content_empty_width_and_height() {
+		$sample_html      = '<img src="http://example.com/test.png" class="test size-large" width="" height="" />';
+		$filtered_content = Image_CDN::filter_the_content( $sample_html );
+		$attributes       = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
+		$query_str        = wp_parse_url( $attributes['src']['value'], PHP_URL_QUERY );
+		parse_str( $query_str, $query_params );
+
+		$this->assertArrayHasKey( 'width', $attributes );
+		$this->assertSame( '1024', $attributes['width']['value'] );
+		$this->assertArrayHasKey( 'height', $attributes );
+		$this->assertSame( '768', $attributes['height']['value'] );
+
+		$this->assertArrayHasKey( 'fit', $query_params );
+		$this->assertEquals( '1024,768', $query_params['fit'] );
+	}
+
+	/**
+	 * Tests that Photon ignores bogus dimensions. It should fall back to e.g. a "size-foo" class.
+	 *
+	 * @covers Image_CDN::filter_the_content
+	 */
+	public function test_image_cdn_filter_the_content_bogus_width_and_height() {
+		$sample_html      = '<img src="http://example.com/test.png" class="test size-large" width="1vh" height="1vh" />';
+		$filtered_content = Image_CDN::filter_the_content( $sample_html );
+		$attributes       = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
+		$query_str        = wp_parse_url( $attributes['src']['value'], PHP_URL_QUERY );
+		parse_str( $query_str, $query_params );
+
+		$this->assertArrayHasKey( 'width', $attributes );
+		$this->assertSame( '1024', $attributes['width']['value'] );
+		$this->assertArrayHasKey( 'height', $attributes );
+		$this->assertSame( '768', $attributes['height']['value'] );
+
+		$this->assertArrayHasKey( 'fit', $query_params );
+		$this->assertEquals( '1024,768', $query_params['fit'] );
+	}
+
+	/**
 	 * Tests that Photon will filter for an AMP response.
 	 *
 	 * @author westonruter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If the `<img>` tag has a value for `width` or `height` that's neither an integer nor a percentage, this will cause a fatal error when the value is attempted to be used as an integer. Add validation to avoid this.

This was introduced in #32700, the implicit validation included in the parameter extraction regex was lost when it was switched to use the HTML API.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1725378345801409/1725375599.111769-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 