### PR TITLE
ci: Check that React-using projects use react eslint rules

### DIFF
--- a/.github/files/lint-project-structure.sh
+++ b/.github/files/lint-project-structure.sh
@@ -222,6 +222,14 @@ for PROJECT in projects/*/*; do
 		fi
 	fi
 
+	# - If a project uses react, it should include the react linting rules too.
+	if [[ -e "$PROJECT/package.json" ]] && jq -e '.dependencies.react // .devDependencies.react' "$PROJECT/package.json" >/dev/null && ! git grep eslintrc/react "$PROJECT"/.eslintrc.* &>/dev/null; then
+		EXIT=1
+		TMP=$( git ls-files "$PROJECT"/.eslintrc.* | head -n 1 ) || true
+		[[ -n "$TMP" ]] && TMP=" file=$TMP"
+		echo "::error${TMP}::Project $SLUG appears to use React but does not extend jetpack-js-tools/eslintrc/react in its eslint config. Please add that."
+	fi
+
 	# - composer.json must exist.
 	if [[ ! -e "$PROJECT/composer.json" ]]; then
 		EXIT=1

--- a/projects/js-packages/ai-client/.eslintrc.cjs
+++ b/projects/js-packages/ai-client/.eslintrc.cjs
@@ -1,4 +1,6 @@
 module.exports = {
+	// @todo Uncomment this:
+	// extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	rules: {
 		// Enforce use of the correct textdomain.
 		'@wordpress/i18n-text-domain': [

--- a/projects/js-packages/ai-client/changelog/add-structure-lint-eslint-react
+++ b/projects/js-packages/ai-client/changelog/add-structure-lint-eslint-react
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add `@todo` comment about enabling jetpack-js-tools/eslintrc/react.
+
+

--- a/projects/js-packages/react-data-sync-client/.eslintrc.cjs
+++ b/projects/js-packages/react-data-sync-client/.eslintrc.cjs
@@ -1,5 +1,8 @@
 module.exports = {
-	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/typescript' ) ],
+	extends: [
+		require.resolve( 'jetpack-js-tools/eslintrc/react' ),
+		require.resolve( 'jetpack-js-tools/eslintrc/typescript' ),
+	],
 	rules: {
 		'jsdoc/check-alignment': 0,
 		'jsdoc/check-examples': 0,

--- a/projects/js-packages/react-data-sync-client/changelog/add-structure-lint-eslint-react
+++ b/projects/js-packages/react-data-sync-client/changelog/add-structure-lint-eslint-react
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Enable `jetpack-js-tools/eslintrc/react` eslint ruleset.
+
+

--- a/projects/js-packages/scan/.eslintrc.cjs
+++ b/projects/js-packages/scan/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	rules: {
 		// Enforce use of the correct textdomain.
 		'@wordpress/i18n-text-domain': [

--- a/projects/js-packages/scan/changelog/add-structure-lint-eslint-react
+++ b/projects/js-packages/scan/changelog/add-structure-lint-eslint-react
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Enable `jetpack-js-tools/eslintrc/react` eslint ruleset.
+
+

--- a/projects/js-packages/social-logos/.eslintrc.cjs
+++ b/projects/js-packages/social-logos/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
+};

--- a/projects/js-packages/social-logos/changelog/add-structure-lint-eslint-react
+++ b/projects/js-packages/social-logos/changelog/add-structure-lint-eslint-react
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Address React usage issues found by eslint in example.tsx.

--- a/projects/js-packages/social-logos/src/react/example.tsx
+++ b/projects/js-packages/social-logos/src/react/example.tsx
@@ -1,8 +1,31 @@
 /* eslint-disable no-alert -- ok for demo */
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { SocialLogo } from './social-logo';
 import { SocialLogoData } from './social-logo-data';
 import '../css/example.css';
+
+/**
+ * An example React component that displays a single social logo.
+ *
+ * @param {object}  props               - The properties.
+ * @param {string}  props.name          - Logo name.
+ * @param {number}  props.iconSize      - Icon size.
+ * @param {boolean} props.showIconNames - Whether to show icon names.
+ * @return {React.Component} The `SocialLogoItemExample` component.
+ */
+function SocialLogoItemExample( { name, iconSize, showIconNames } ) {
+	const handleClick = useCallback( () => {
+		const code = `<SocialLogo icon="${ name }" size="${ iconSize }" />`;
+		window.prompt( 'Copy component code:', code );
+	}, [ iconSize, name ] );
+
+	return (
+		<div key={ name }>
+			<SocialLogo icon={ name } size={ iconSize } onClick={ handleClick } />
+			{ showIconNames && <p>{ name }</p> }
+		</div>
+	);
+}
 
 /**
  * An example React component that displays all the social logos.
@@ -15,31 +38,27 @@ function SocialLogosExample() {
 
 	const iconSize = useSmallIcons ? 24 : 48;
 
-	const handleClick = name => {
-		const code = `<SocialLogo icon="${ name }" size="${ iconSize }" />`;
-		window.prompt( 'Copy component code:', code );
-	};
+	const handleSmallIconsToggle = useCallback(
+		e => {
+			setUseSmallIcons( e.target.checked );
+		},
+		[ setUseSmallIcons ]
+	);
 
-	const handleSmallIconsToggle = e => {
-		setUseSmallIcons( e.target.checked );
-	};
+	const handleIconNamesToggle = useCallback(
+		e => {
+			setShowIconNames( e.target.checked );
+		},
+		[ setShowIconNames ]
+	);
 
-	const handleIconNamesToggle = e => {
-		setShowIconNames( e.target.checked );
-	};
-
-	const allSocialLogos = SocialLogoData.map( logo => {
-		return (
-			<div key={ logo.name }>
-				<SocialLogo
-					icon={ logo.name }
-					size={ iconSize }
-					onClick={ handleClick.bind( this, logo.name ) }
-				/>
-				{ showIconNames && <p>{ logo.name }</p> }
-			</div>
-		);
-	} );
+	const allSocialLogos = SocialLogoData.map( logo => (
+		<SocialLogoItemExample
+			name={ logo.name }
+			iconSize={ iconSize }
+			showIconNames={ showIconNames }
+		/>
+	) );
 
 	return (
 		<div className="social-logos-example">

--- a/projects/packages/assets/.eslintrc.cjs
+++ b/projects/packages/assets/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
+};

--- a/projects/packages/assets/changelog/add-structure-lint-eslint-react
+++ b/projects/packages/assets/changelog/add-structure-lint-eslint-react
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Enable `jetpack-js-tools/eslintrc/react` eslint ruleset.
+
+

--- a/projects/packages/blaze/.eslintrc.js
+++ b/projects/packages/blaze/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/packages/blaze/changelog/add-structure-lint-eslint-react
+++ b/projects/packages/blaze/changelog/add-structure-lint-eslint-react
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Address React usage errors found by eslint.

--- a/projects/packages/blaze/src/js/editor.js
+++ b/projects/packages/blaze/src/js/editor.js
@@ -43,7 +43,7 @@ const BlazePostPublishPanel = () => {
 	const blazeUrl = blazeUrlTemplate.link.replace( '__POST_ID__', postId );
 
 	// Decide when the panel should appear, and be tracked.
-	const shouldDisplayPanel = () => {
+	const shouldDisplayPanel = useCallback( () => {
 		// Only show the panel for Posts, Pages, and Products.
 		if ( ! [ 'page', 'post', 'product' ].includes( postType ) ) {
 			return false;
@@ -55,7 +55,7 @@ const BlazePostPublishPanel = () => {
 		}
 
 		return true;
-	};
+	}, [ postType, isPostPublished, postVisibility ] );
 
 	// Tracks event for the display of the panel.
 	useEffect( () => {
@@ -72,7 +72,7 @@ const BlazePostPublishPanel = () => {
 		}
 
 		tracks.recordEvent( 'jetpack_editor_blaze_post_publish_panel_view' );
-	}, [ tracks, isPublishingPost, isPostPublished, wasPublishing ] );
+	}, [ tracks, isPublishingPost, isPostPublished, wasPublishing, shouldDisplayPanel ] );
 
 	if ( ! shouldDisplayPanel() ) {
 		return null;

--- a/projects/packages/connection/.eslintrc.cjs
+++ b/projects/packages/connection/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
+};

--- a/projects/packages/connection/changelog/add-structure-lint-eslint-react
+++ b/projects/packages/connection/changelog/add-structure-lint-eslint-react
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Enable `jetpack-js-tools/eslintrc/react` eslint ruleset.
+
+

--- a/projects/packages/videopress/.eslintrc.js
+++ b/projects/packages/videopress/.eslintrc.js
@@ -2,6 +2,8 @@
  * @type {import("eslint").Linter.Config}
  */
 module.exports = {
+	// @todo: Uncomment this:
+	// extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	rules: {
 		// Enforce use of the correct textdomain.
 		'@wordpress/i18n-text-domain': [

--- a/projects/packages/videopress/changelog/add-structure-lint-eslint-react
+++ b/projects/packages/videopress/changelog/add-structure-lint-eslint-react
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add `@todo` comment about enabling jetpack-js-tools/eslintrc/react.
+
+

--- a/projects/packages/yoast-promo/.eslintrc.js
+++ b/projects/packages/yoast-promo/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+	extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	parserOptions: {
 		babelOptions: {
 			configFile: require.resolve( './babel.config.js' ),

--- a/projects/packages/yoast-promo/changelog/add-structure-lint-eslint-react
+++ b/projects/packages/yoast-promo/changelog/add-structure-lint-eslint-react
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Address React usage errors found by eslint.

--- a/projects/packages/yoast-promo/src/js/index.jsx
+++ b/projects/packages/yoast-promo/src/js/index.jsx
@@ -3,7 +3,7 @@ import { getSiteFragment, isSimpleSite } from '@automattic/jetpack-shared-extens
 import { PanelRow, ExternalLink, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
-import { useState } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Gridicon from 'gridicons';
 import { JetpackYoastLogos } from './JetpackYoastLogos';
@@ -38,10 +38,10 @@ export const YoastPromo = () => {
 			[ isDismissed ]
 		) || {};
 
-	const handleDismiss = () => {
+	const handleDismiss = useCallback( () => {
 		setIsDismissed( true );
 		dismissedStore.set( 'true' );
-	};
+	}, [ setIsDismissed ] );
 
 	const getContent = () => {
 		if ( ! isYoastFreeActive && ! isYoastPremiumActive ) {

--- a/projects/plugins/boost/.eslintrc.cjs
+++ b/projects/plugins/boost/.eslintrc.cjs
@@ -5,6 +5,8 @@ module.exports = {
 	root: true,
 	extends: [
 		require.resolve( 'jetpack-js-tools/eslintrc/base' ),
+		// @todo: Uncomment this:
+		// require.resolve( 'jetpack-js-tools/eslintrc/react' ),
 		require.resolve( 'jetpack-js-tools/eslintrc/wp-eslint-plugin/recommended' ),
 	],
 	ignorePatterns: [ '**/stories/*.stories.tsx', ...loadIgnorePatterns( __dirname ) ],

--- a/projects/plugins/boost/changelog/add-structure-lint-eslint-react
+++ b/projects/plugins/boost/changelog/add-structure-lint-eslint-react
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add `@todo` comment about enabling jetpack-js-tools/eslintrc/react.
+
+

--- a/projects/plugins/crm/.eslintrc.js
+++ b/projects/plugins/crm/.eslintrc.js
@@ -1,4 +1,6 @@
 module.exports = {
+	// @todo: Uncomment this:
+	// extends: [ require.resolve( 'jetpack-js-tools/eslintrc/react' ) ],
 	rules: {
 		// Enforce the use of the zero-bs-crm textdomain.
 		'@wordpress/i18n-text-domain': [

--- a/projects/plugins/crm/changelog/add-structure-lint-eslint-react
+++ b/projects/plugins/crm/changelog/add-structure-lint-eslint-react
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add `@todo` comment about enabling jetpack-js-tools/eslintrc/react.
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
I noticed that several of our projects are using React but did not have our `jetpack-js-tools/eslintrc/react` eslint ruleset enabled. This adds a linting check for that, and enables it on most of the projects where it was not enabled.

For a few I instead added a `@todo` comment about turning it on, due to a lot of cleanup being needed in order to successfully do so. I hope people more familiar with React and these projects will follow up on that.

* js-packages/ai-client: 32 × react/jsx-no-bind 33 × react-hooks/exhaustive-deps
* packages/videopress: 8 × react-hooks/rules-of-hooks 69 × react-hooks/exhaustive-deps 157 × react/jsx-no-bind
* plugins/boost: 1 × react/no-danger 81 × react/jsx-no-bind
* plugins/crm: 1 × react-hooks/rules-of-hooks 2 × react/jsx-no-bind 3 × react-hooks/exhaustive-deps

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* Try removing the `extends` added here. Does `.github/files/lint-project-structure.sh` catch it?