### PR TITLE
AI Assistant: Remove autofocus on extended blocks while previewing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-preview-focus
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-preview-focus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Remove autofocus on extended blocks while previewing

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/inline-extensions/with-ai-extension.tsx
@@ -69,7 +69,8 @@ type CoreEditorSelect = { getCurrentPostId: () => number };
 // HOC to populate the block's edit component with the AI Assistant control inpuit and toolbar button.
 const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 	return props => {
-		const { clientId, isSelected, name: blockName } = props;
+		// Block props. isSelectionEnabled is used to determine if the block is in the editor or in the preview.
+		const { clientId, isSelected, name: blockName, isSelectionEnabled } = props;
 		// Ref to the control wrapper, its height and its ResizeObserver, for positioning adjustments.
 		const controlRef: React.MutableRefObject< HTMLDivElement | null > = useRef( null );
 		const controlHeight = useRef< number >( 0 );
@@ -390,13 +391,14 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 		// Focus the input when the AI Control is displayed and set the ownerDocument.
 		useEffect( () => {
-			if ( inputRef.current ) {
+			// Do not focus the input if the block is a preview.
+			if ( inputRef.current && isSelectionEnabled ) {
 				// Save the block's ownerDocument to use it later, as the editor can be in an iframe.
 				ownerDocument.current = inputRef.current.ownerDocument;
 				// Focus the input when the AI Control is displayed.
 				focusInput();
 			}
-		}, [ showAiControl, focusInput ] );
+		}, [ showAiControl, focusInput, isSelectionEnabled ] );
 
 		// Adjusts the input position in the editor by increasing the block's bottom-padding
 		// and setting the control's margin-top, "wrapping" the input with the block.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39144 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Uses the extended blocks' `isSelectionEnabled` value to determine if autofocus should happen or not

The issue is caused by autofocus happening within the preview block. We want to keep the behavior on blocks added to the editor, but not for preview blocks.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test using Firefox
* Go to the block editor
* Open the block inserter in the sidebar (The + button on the top left, after the site logo)
* Type "contact form"
* Check that the block inserter works as expected and the search input is not unfocused
* In the editor, add a Form block
* Check that the input is focused immediately
* Add a paragraph
* On the paragraph's block toolbar, click on the AI icon > "Ask AI Assistant"
* Check that the input is focused as well

| Before | After
| - | -
| <video src="https://github.com/user-attachments/assets/2de5981c-d1d0-4e57-8d9e-f8eb6848faa4" /> | <video src="https://github.com/user-attachments/assets/15f04234-0c15-4ad6-a878-d24ab710b430" />
