### PR TITLE
My Jetpack: optimize repeated requests for failed WPCOM requests

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-repeated-requests
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-repeated-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Optimize repeated requests for unavailable WPCOM.

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -36,6 +36,13 @@ class Wpcom_Products {
 	const MY_JETPACK_PURCHASES_TRANSIENT_KEY = 'my-jetpack-purchases';
 
 	/**
+	 * Store the data on failed WPCOM requests.
+	 *
+	 * @var array
+	 */
+	private static $wpcom_request_failures = array();
+
+	/**
 	 * Fetches the list of products from WPCOM
 	 *
 	 * @return Object|WP_Error
@@ -49,13 +56,19 @@ class Wpcom_Products {
 		);
 
 		if ( $blog_id ) {
+			$request_label   = 'get_products_from_wpcom_blog_' . $blog_id;
+			$request_failure = static::get_request_failure( $request_label );
+			if ( null !== $request_failure ) {
+				return $request_failure;
+			}
+
 			// If has a blog id, use connected endpoint.
 			$endpoint = sprintf( '/sites/%d/products/?_locale=%s&type=jetpack', $blog_id, get_user_locale() );
 
 			// If available in the user data, set the user's currency as one of the params
 			if ( $connection->is_user_connected() ) {
 				$user_details = $connection->get_connected_user_data();
-				if ( $user_details['user_currency'] && $user_details['user_currency'] !== 'USD' ) {
+				if ( ! empty( $user_details['user_currency'] ) && $user_details['user_currency'] !== 'USD' ) {
 					$endpoint .= sprintf( '&currency=%s', $user_details['user_currency'] );
 				}
 			}
@@ -69,6 +82,12 @@ class Wpcom_Products {
 				)
 			);
 		} else {
+			$request_label   = 'get_products_from_wpcom';
+			$request_failure = static::get_request_failure( $request_label );
+			if ( null !== $request_failure ) {
+				return $request_failure;
+			}
+
 			$endpoint = 'https://public-api.wordpress.com/rest/v1.1/products?locale=' . get_user_locale() . '&type=jetpack';
 
 			$wpcom_request = wp_remote_get(
@@ -84,11 +103,13 @@ class Wpcom_Products {
 		if ( 200 === $response_code ) {
 			return json_decode( wp_remote_retrieve_body( $wpcom_request ) );
 		} else {
-			return new WP_Error(
+			$error = new WP_Error(
 				'failed_to_fetch_wpcom_products',
 				esc_html__( 'Unable to fetch the products list from WordPress.com', 'jetpack-my-jetpack' ),
 				array( 'status' => $response_code )
 			);
+			static::set_request_failure( $request_label, $error );
+			return $error;
 		}
 	}
 
@@ -99,6 +120,8 @@ class Wpcom_Products {
 	 * @return string
 	 */
 	private static function build_check_hash() {
+		static $has_user_data_fetch_error = false;
+
 		$hash_string = 'check_hash_';
 		$connection  = new Connection_Manager();
 
@@ -109,8 +132,11 @@ class Wpcom_Products {
 		if ( $connection->is_user_connected() ) {
 			$hash_string .= 'user_connected';
 			// Add the user's currency
-			$user_details = $connection->get_connected_user_data();
-			if ( $user_details['user_currency'] ) {
+			$user_details = $has_user_data_fetch_error ? false : $connection->get_connected_user_data();
+
+			if ( $user_details === false ) {
+				$has_user_data_fetch_error = true;
+			} elseif ( ! empty( $user_details['user_currency'] ) ) {
 				$hash_string .= '_' . $user_details['user_currency'];
 			}
 		}
@@ -295,6 +321,11 @@ class Wpcom_Products {
 			return $stored_purchases;
 		}
 
+		$request_failure = static::get_request_failure( 'get_site_current_purchases' );
+		if ( null !== $request_failure ) {
+			return $request_failure;
+		}
+
 		$site_id = Jetpack_Options::get_option( 'id' );
 
 		$response = Client::wpcom_json_api_request_as_blog(
@@ -305,7 +336,9 @@ class Wpcom_Products {
 			)
 		);
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return new WP_Error( 'purchases_state_fetch_failed' );
+			$error = new WP_Error( 'purchases_state_fetch_failed' );
+			static::set_request_failure( 'get_site_current_purchases', $error );
+			return $error;
 		}
 
 		$body      = wp_remote_retrieve_body( $response );
@@ -314,5 +347,32 @@ class Wpcom_Products {
 		set_transient( self::MY_JETPACK_PURCHASES_TRANSIENT_KEY, $purchases, 5 );
 
 		return $purchases;
+	}
+
+	/**
+	 * Record the request failure to prevent repeated requests.
+	 *
+	 * @param string   $request_label The request label.
+	 * @param WP_Error $error The error.
+	 *
+	 * @return void
+	 */
+	private static function set_request_failure( $request_label, WP_Error $error ) {
+		static::$wpcom_request_failures[ $request_label ] = $error;
+	}
+
+	/**
+	 * Get the pre-saved request failure if exists.
+	 *
+	 * @param string $request_label The request label.
+	 *
+	 * @return null|WP_Error
+	 */
+	private static function get_request_failure( $request_label ) {
+		if ( array_key_exists( $request_label, static::$wpcom_request_failures ) ) {
+			return static::$wpcom_request_failures[ $request_label ];
+		}
+
+		return null;
 	}
 }

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -350,6 +350,15 @@ class Wpcom_Products {
 	}
 
 	/**
+	 * Reset the request failures to retry the API requests.
+	 *
+	 * @return void
+	 */
+	public static function reset_request_failures() {
+		static::$wpcom_request_failures = array();
+	}
+
+	/**
 	 * Record the request failure to prevent repeated requests.
 	 *
 	 * @param string   $request_label The request label.

--- a/projects/packages/my-jetpack/src/products/class-backup.php
+++ b/projects/packages/my-jetpack/src/products/class-backup.php
@@ -184,7 +184,8 @@ class Backup extends Hybrid_Product {
 		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 2 ), null, 'wpcom' );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return new WP_Error( 'rewind_state_fetch_failed' );
+			$status = new WP_Error( 'rewind_state_fetch_failed' );
+			return $status;
 		}
 
 		$body   = wp_remote_retrieve_body( $response );

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -200,7 +200,8 @@ abstract class Product {
 		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/features', $site_id ), '1.1' );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return new WP_Error( 'site_features_fetch_failed' );
+			$features = new WP_Error( 'site_features_fetch_failed' );
+			return $features;
 		}
 
 		$body           = wp_remote_retrieve_body( $response );

--- a/projects/packages/my-jetpack/src/products/class-scan.php
+++ b/projects/packages/my-jetpack/src/products/class-scan.php
@@ -126,7 +126,8 @@ class Scan extends Module_Product {
 		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/scan', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 2 ), null, 'wpcom' );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return new WP_Error( 'scan_state_fetch_failed' );
+			$status = new WP_Error( 'scan_state_fetch_failed' );
+			return $status;
 		}
 
 		$body   = wp_remote_retrieve_body( $response );

--- a/projects/packages/my-jetpack/src/products/class-search.php
+++ b/projects/packages/my-jetpack/src/products/class-search.php
@@ -237,7 +237,7 @@ class Search extends Hybrid_Product {
 			// If available in the user data, set the user's currency as one of the params
 			if ( $connection->is_user_connected() ) {
 				$user_details = $connection->get_connected_user_data();
-				if ( $user_details['user_currency'] && $user_details['user_currency'] !== 'USD' ) {
+				if ( ! empty( $user_details['user_currency'] ) && $user_details['user_currency'] !== 'USD' ) {
 					$endpoint .= sprintf( '&currency=%s', $user_details['user_currency'] );
 				}
 			}

--- a/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
+++ b/projects/packages/my-jetpack/tests/php/test-wpcom-products.php
@@ -128,6 +128,8 @@ class Test_Wpcom_Products extends TestCase {
 
 		unset( $_SERVER['REQUEST_METHOD'] );
 		$_GET = array();
+
+		Wpcom_Products::reset_request_failures();
 	}
 
 	/**
@@ -189,6 +191,26 @@ class Test_Wpcom_Products extends TestCase {
 		remove_filter( 'pre_http_request', array( $this, 'mock_error_response' ) );
 
 		$this->assertEquals( $this->get_mock_products_data(), $products );
+	}
+
+	/**
+	 * Test that we get data from cache if a request fails.
+	 * Second request succeeds, but we'll never know because we don't retry it.
+	 */
+	public function test_get_products_error_norepeat() {
+		$this->create_user_and_login();
+
+		add_filter( 'pre_http_request', array( $this, 'mock_error_response' ) );
+		$products = Wpcom_Products::get_products();
+		remove_filter( 'pre_http_request', array( $this, 'mock_error_response' ) );
+
+		$this->assertTrue( is_wp_error( $products ) );
+
+		add_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
+		$products = Wpcom_Products::get_products();
+		remove_filter( 'pre_http_request', array( $this, 'mock_success_response' ) );
+
+		$this->assertTrue( is_wp_error( $products ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-my-jetpack-repeated-requests
+++ b/projects/plugins/jetpack/changelog/fix-my-jetpack-repeated-requests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: optimize repeated requests for unavailable WPCOM.


### PR DESCRIPTION
## Proposed changes:
My Jetpack will keep sending repeated requests to the same endpoints for each product if:
- Connection is broken or WPCOM is unavailable
- and there's no data cached for for those endpoints.

The PR will temporarily store API errors so there wouldn't be repeated API requests during the same PHP execution flow.
That brings down the number of WPCOM requests from about 300 to about a dozen.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pdWQjU-Sf-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Don't checkout the branch, but do checkout the `trunk` (Bleeding Edge) for Jetpack.

You will need a clean site with no cache.
The easiest way to achieve that without waiting for it to expire is to create a new JN site and randomize the tokens instead of properly connecting Jetpack.

1. Go to "Jetpack Debug", activate "Broken Token".
2. Go to Broken Token and click "Set invalid blog token", "Set invalid user token (current user)", "Set current user as primary user" and "Randomize blog ID". That will make Jetpack think the site is connected.
3. Use Jetpack Debug to activate the "WPCOM API Request Tracker".
4. Visit "Jetpack -> My Jetpack". The page will take some time to load. Check the number of requests in the top right corner, it should be about 300.
5. Checkout the branch.
6. Reload My Jetpack. It should load considerably faster, and the tracker should show about 10-15 API requests.
7. Confirm My Jetpack displays more or less fine, considering that connection is broken.
8. Disconnect Jetpack, connect again. Check My Jetpack and Jetpack Dashboard, confirm they work fine.