### PR TITLE
Debug Helper: fix WPCOM request counter for repeated requests

### DIFF
--- a/projects/plugins/debug-helper/changelog/fix-jetpack-debug-request-counter
+++ b/projects/plugins/debug-helper/changelog/fix-jetpack-debug-request-counter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix WPCOM request counter for repeated requests.

--- a/projects/plugins/debug-helper/modules/inc/class-wpcom-api-request-tracker.php
+++ b/projects/plugins/debug-helper/modules/inc/class-wpcom-api-request-tracker.php
@@ -60,7 +60,7 @@ class WPCOM_API_Request_Tracker {
 		$url_host = wp_parse_url( $url, PHP_URL_HOST );
 
 		if ( 'public-api.wordpress.com' === $url_host ) {
-			$this->requests[ $url ] = array_key_exists( $url, $this->requests ) ? $this->requests[ $url ]++ : 1;
+			$this->requests[ $url ] = array_key_exists( $url, $this->requests ) ? $this->requests[ $url ] + 1 : 1;
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes:
* Make WPCOM API request counter properly count repeated requests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Go to Jetpack Debug, activate WPCOM request counter.
2. Go to a Jetpack page, confirm the number of requests shows up in the top right corner.