### PR TITLE
Social: Fix resharing not shown when only social plugin is active

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-republicize-not-shown
+++ b/projects/js-packages/publicize-components/changelog/fix-social-republicize-not-shown
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed resharing for jetpack sites when only social plugin is active

--- a/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
@@ -5,6 +5,7 @@ import {
 	getJetpackData,
 	getSiteFragment,
 	isSimpleSite,
+	isAtomicSite,
 } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -21,9 +22,10 @@ const republicizeFeatureName = 'republicize';
  * for toggling support for the current post.
  */
 export default function usePublicizeConfig() {
+	const isJetpackSite = ! isAtomicSite() && ! isSimpleSite();
 	const blogID = getJetpackData()?.wpcomBlogId;
 	const isRePublicizeFeatureAvailable =
-		getJetpackExtensionAvailability( republicizeFeatureName )?.available;
+		isJetpackSite || getJetpackExtensionAvailability( republicizeFeatureName )?.available;
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 	const currentPostType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	const { isUserConnected } = useConnection();


### PR DESCRIPTION
#38904 caused a regression that caused the issue of resharing in post editor not shown when only Social plugin is active.

Slack conversation: p1725385931580259-slack-C02JJ910CNL

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix resharing not shown when only social plugin is active

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* For Jetpack sites with only Social active (not Jetpack), goto post editor
* Open Social sidebar
* Confirm that the resharing is visible for both free and paid plan
* Now activate Jetpack
* Confirm that resharing is visible in Jetpack sidebar for both free and paid plan
* For a simple sites, confirm that resharing is not visible on free plan but is visible on paid plan
* For Atomic sites, confirm that resharing is always visible

| BEFORE | AFTER |
|--------|--------|
| <img width="350" alt="image" src="https://github.com/user-attachments/assets/3402695e-c156-4c7d-aed1-d153de4e684b">  | <img width="350" alt="image" src="https://github.com/user-attachments/assets/f71331c1-d3e9-460e-8468-5e4513ee6d91"> |

