### PR TITLE
Fix script data not available in block editor iframe

### DIFF
--- a/projects/packages/assets/changelog/fix-script-data-not-available-in-editor-iframe
+++ b/projects/packages/assets/changelog/fix-script-data-not-available-in-editor-iframe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed script data not available in block editor iframe

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -17,6 +17,13 @@ class Script_Data {
 	const SCRIPT_HANDLE = 'jetpack-script-data';
 
 	/**
+	 * Whether the script data has been rendered.
+	 *
+	 * @var bool
+	 */
+	private static $did_render_script_data = false;
+
+	/**
 	 * Configure.
 	 */
 	public static function configure() {
@@ -69,11 +76,12 @@ class Script_Data {
 	 * @return void
 	 */
 	public static function render_script_data() {
-
-		// Avoid rendering the script data multiple times.
-		if ( current_filter() !== 'enqueue_block_editor_assets' && did_action( 'enqueue_block_editor_assets' ) ) {
+		// In case of 'enqueue_block_editor_assets' action, this can be called multiple times.
+		if ( self::$did_render_script_data ) {
 			return;
 		}
+
+		self::$did_render_script_data = true;
 
 		$script_data = is_admin() ? self::get_admin_script_data() : self::get_public_script_data();
 

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -40,6 +40,7 @@ class Script_Data {
 		 */
 		$hook = is_admin() ? 'admin_print_scripts' : 'wp_print_scripts';
 		add_action( $hook, array( self::class, 'render_script_data' ), 1 );
+		add_action( 'enqueue_block_editor_assets', array( self::class, 'render_script_data' ), 1 );
 	}
 
 	/**
@@ -68,6 +69,11 @@ class Script_Data {
 	 * @return void
 	 */
 	public static function render_script_data() {
+
+		// Avoid rendering the script data multiple times.
+		if ( current_filter() !== 'enqueue_block_editor_assets' && did_action( 'enqueue_block_editor_assets' ) ) {
+			return;
+		}
 
 		$script_data = is_admin() ? self::get_admin_script_data() : self::get_public_script_data();
 


### PR DESCRIPTION
Currently the script data is rendered via `admin_print_scripts` which doesn't make it available in block editor ifram thus the connection js store shows this warning about initial state not being available:

![image](https://github.com/user-attachments/assets/0035baaf-9493-4935-b33a-e484b5e8dcec)

Slack conversation: p1725370272662889-slack-C05PV073SG3

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Render script data via `enqueue_block_editor_assets` when inside block editor

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Activate ONLY Jetpack Social standalone, i.e. deactivate Jetpack and other standalone plugins
- Run `jetpack build packages/connection packages/assets plugins/social`
- Goto the post editor
- Confirm that you don't see the warning about initial state being missing