### PR TITLE
Boost: Post 3.4.9 fixes

### DIFF
--- a/projects/plugins/boost/CHANGELOG.md
+++ b/projects/plugins/boost/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.9] - 2024-09-03
+### Fixed
+- Update `automattic/jetpack-image-cdn` package to resolve a PHP fatal error.
+
 ## [3.4.8] - 2024-09-02
 ### Changed
 - Admin menu: change order of Jetpack sub-menu items [#39095]
@@ -494,6 +498,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First public alpha release
 
+[3.4.9]: https://github.com/Automattic/jetpack-boost-production/compare/3.4.8...3.4.9
 [3.4.8]: https://github.com/Automattic/jetpack-boost-production/compare/3.4.7...3.4.8
 [3.4.7]: https://github.com/Automattic/jetpack-boost-production/compare/3.4.6...3.4.7
 [3.4.6]: https://github.com/Automattic/jetpack-boost-production/compare/3.4.4...3.4.6

--- a/projects/plugins/boost/changelog/prerelease
+++ b/projects/plugins/boost/changelog/prerelease
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/boost/changelog/prerelease#2
+++ b/projects/plugins/boost/changelog/prerelease#2
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Updated composer.lock.
-
-

--- a/projects/plugins/boost/changelog/update-boost-after-3.4.9
+++ b/projects/plugins/boost/changelog/update-boost-after-3.4.9
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated composer.lock.
+
+

--- a/projects/plugins/boost/changelog/update-boost-post-3-4-8-fixes
+++ b/projects/plugins/boost/changelog/update-boost-post-3-4-8-fixes
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Update Boost to 3.4.8 (post-release task).
-
-

--- a/projects/plugins/boost/changelog/update-page-cache-behavior-on-atomic
+++ b/projects/plugins/boost/changelog/update-page-cache-behavior-on-atomic
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Page Cache: Update notice for WP Cloud clients.

--- a/projects/plugins/boost/composer.json
+++ b/projects/plugins/boost/composer.json
@@ -3,7 +3,7 @@
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"version": "3.4.8",
+	"version": "3.4.9",
 	"authors": [
 		{
 			"name": "Automattic, Inc.",
@@ -74,7 +74,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_4_8",
+		"autoloader-suffix": "b1e77e6231d50e7663f84529b6a3dfda_jetpack_boostⓥ3_4_9",
 		"allow-plugins": {
 			"roots/wordpress-core-installer": true,
 			"automattic/jetpack-autoloader": true,

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85650c8a8ff4de68f5aac66412bc62b9",
+    "content-hash": "709f3a097b03b2e8817ed1b01ccd6942",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Jetpack Boost
  * Plugin URI:        https://jetpack.com/boost
  * Description:       Boost your WordPress site's performance, from the creators of Jetpack
- * Version: 3.4.8
+ * Version: 3.4.9
  * Author:            Automattic - Jetpack Site Speed team
  * Author URI:        https://jetpack.com/boost/
  * License:           GPL-2.0+
@@ -29,7 +29,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'JETPACK_BOOST_VERSION', '3.4.8' );
+define( 'JETPACK_BOOST_VERSION', '3.4.9' );
 define( 'JETPACK_BOOST_SLUG', 'jetpack-boost' );
 
 if ( ! defined( 'JETPACK_BOOST_CLIENT_NAME' ) ) {

--- a/projects/plugins/boost/package.json
+++ b/projects/plugins/boost/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jetpack-boost",
-	"version": "3.4.8",
+	"version": "3.4.9",
 	"description": "Boost your WordPress site's performance, from the creators of Jetpack",
 	"directories": {
 		"test": "tests"

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -5,7 +5,7 @@ Tags: performance, speed, web vitals, critical css, cache
 Requires at least: 5.5
 Tested up to: 6.6
 Requires PHP: 7.0
-Stable tag: 3.4.8
+Stable tag: 3.4.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -183,19 +183,9 @@ If you run into compatibility issues, please do let us know. You can drop us a l
 2. Jetpack Boost Speed Improvement
 
 == Changelog ==
-### 3.4.8 - 2024-09-02
-#### Changed
-- Admin menu: change order of Jetpack sub-menu items
-- Page Cache: Update notice for WP Cloud clients.
-- React: Changing global JSX namespace to React.JSX
-
+### 3.4.9 - 2024-09-03
 #### Fixed
-- Cloud CSS: Fixed not properly storing CSS returned from the cloud after a theme switch.
-- Lossless image optimization for images (should improve performance with no visible changes).
-- Misc: Fix PHP warning when generating critical css for some taxonomy pages.
-- Revert recent SVG image optimizations.
-- UI: Fix inconsistencies.
-- Updated package dependencies.
+- Update `automattic/jetpack-image-cdn` package to resolve a PHP fatal error.
 
 --------
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR cleans up after the 3.4.9 release that happened yesterday.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1725378834139999-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure readme.txt, changelog.md and versions are correct.