### PR TITLE
Site Settings API: Include is_fully_managed_agency site option

### DIFF
--- a/projects/plugins/jetpack/changelog/update-incl-is-fully-managed-agency-site-prop-in-site-settings-api
+++ b/projects/plugins/jetpack/changelog/update-incl-is-fully-managed-agency-site-prop-in-site-settings-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Site Settings API: Include is_fully_managed_agency_site site option in the response, and allow for its modification

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -496,6 +496,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'jetpack_waf_share_data'           => (bool) get_option( 'jetpack_waf_share_data' ),
 						'jetpack_waf_share_debug_data'     => (bool) get_option( 'jetpack_waf_share_debug_data' ),
 						'jetpack_waf_automatic_rules_last_updated_timestamp' => (int) get_option( 'jetpack_waf_automatic_rules_last_updated_timestamp' ),
+						'is_fully_managed_agency_site'     => (bool) get_option( 'is_fully_managed_agency_site' ),
 					);
 
 					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -1172,6 +1173,13 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 					update_option( 'migration_source_site_domain', $value );
 					$updated[ $key ] = $value;
+					break;
+
+				case 'is_fully_managed_agency_site':
+					$coerce_value = (int) (bool) $value;
+					if ( update_option( $key, $coerce_value ) ) {
+						$updated[ $key ] = (bool) $coerce_value;
+					}
 					break;
 
 				default:

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -145,6 +145,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint(
 			'enable_blocks_comments'                  => '(bool) Whether blocks comments are enabled',
 			'highlander_comment_form_prompt'          => '(string) The prompt for the comment form',
 			'jetpack_comment_form_color_scheme'       => '(string) The color scheme for the comment form',
+			'is_fully_managed_agency_site'            => '(bool) Whether the site is a fully managed agency site',
 		),
 
 		'response_format' => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8922

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Include the `is_fully_managed_agency` prop in the site settings API response. The prop is meant to directly reflect the value of the `is_fully_managed_agency` site option. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the PR build to your sandbox.
* Sandbox the `public-api.wordpress.com` domain
* Test the GET settings API either by (ensure the` is_fully_managed_agency` prop is included and has the expected value):
  * Inspecting the network request response when visitng https://wordpress.com/settings/general
  * Inspecting the response to a request made via WPCOM API developer console, to `WP.COM API`, `V 1.4`, `GET`, `sites/$site/settings`

