### PR TITLE
Social: Change publicize endpoint to handle async

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-social-publicize-endpoint-async-option
+++ b/projects/js-packages/publicize-components/changelog/add-social-publicize-endpoint-async-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Made resharing async

--- a/projects/js-packages/publicize-components/src/components/share-post/index.js
+++ b/projects/js-packages/publicize-components/src/components/share-post/index.js
@@ -33,7 +33,7 @@ function showErrorNotice( message = __( 'Unable to share the Post', 'jetpack' ) 
  */
 function showSuccessNotice() {
 	const { createSuccessNotice } = dispatch( noticesStore );
-	createSuccessNotice( __( 'Your post will be shared on the selected accounts.', 'jetpack' ), {
+	createSuccessNotice( __( 'Your post will be shared soon.', 'jetpack' ), {
 		id: 'publicize-post-share-message',
 		type: 'snackbar',
 	} );

--- a/projects/js-packages/publicize-components/src/components/share-post/index.js
+++ b/projects/js-packages/publicize-components/src/components/share-post/index.js
@@ -33,7 +33,7 @@ function showErrorNotice( message = __( 'Unable to share the Post', 'jetpack' ) 
  */
 function showSuccessNotice() {
 	const { createSuccessNotice } = dispatch( noticesStore );
-	createSuccessNotice( __( 'Post shared', 'jetpack' ), {
+	createSuccessNotice( __( 'Your post will be shared on the selected accounts.', 'jetpack' ), {
 		id: 'publicize-post-share-message',
 		type: 'snackbar',
 	} );

--- a/projects/js-packages/publicize-components/src/hooks/use-share-post/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-share-post/index.js
@@ -111,6 +111,7 @@ export default function useSharePost( postId ) {
 				data: {
 					message,
 					skipped_connections,
+					async: true,
 				},
 			} )
 				.then( ( result = {} ) => {

--- a/projects/packages/publicize/changelog/add-social-publicize-endpoint-async-option
+++ b/projects/packages/publicize/changelog/add-social-publicize-endpoint-async-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Made resharing async

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -454,9 +454,7 @@ class REST_Controller {
 		$post_id             = $request->get_param( 'postId' );
 		$message             = trim( $request->get_param( 'message' ) );
 		$skip_connection_ids = $request->get_param( 'skipped_connections' );
-		$async               = $request->get_param( 'async' );
-
-		$is_async_share = isset( $async ) && true === $async;
+		$async               = (bool) $request->get_param( 'async' );
 
 		/*
 		 * Publicize endpoint on WPCOM:
@@ -480,7 +478,7 @@ class REST_Controller {
 			array(
 				'message'             => $message,
 				'skipped_connections' => $skip_connection_ids,
-				'async'               => $is_async_share,
+				'async'               => $async,
 			)
 		);
 

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -454,6 +454,9 @@ class REST_Controller {
 		$post_id             = $request->get_param( 'postId' );
 		$message             = trim( $request->get_param( 'message' ) );
 		$skip_connection_ids = $request->get_param( 'skipped_connections' );
+		$async               = $request->get_param( 'async' );
+
+		$is_async_share = isset( $async ) && true === $async;
 
 		/*
 		 * Publicize endpoint on WPCOM:
@@ -477,6 +480,7 @@ class REST_Controller {
 			array(
 				'message'             => $message,
 				'skipped_connections' => $skip_connection_ids,
+				'async'               => $is_async_share,
 			)
 		);
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
@@ -110,7 +110,7 @@ class WPCOM_REST_API_V2_Endpoint_Publicize_Share_Post extends WP_REST_Controller
 		$skip_connection_ids = $request->get_param( 'skipped_connections' );
 		$async               = $request->get_param( 'async' );
 
-		$is_async_share = isset( $async ) && 'true' === $async;
+		$is_async_share = isset( $async ) && true === $async;
 
 		if ( $this->is_wpcom ) {
 			$post = get_post( $post_id );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
@@ -108,6 +108,9 @@ class WPCOM_REST_API_V2_Endpoint_Publicize_Share_Post extends WP_REST_Controller
 		$post_id             = $request->get_param( 'postId' );
 		$message             = trim( $request->get_param( 'message' ) );
 		$skip_connection_ids = $request->get_param( 'skipped_connections' );
+		$async               = $request->get_param( 'async' );
+
+		$is_async_share = isset( $async ) && 'true' === $async;
 
 		if ( $this->is_wpcom ) {
 			$post = get_post( $post_id );
@@ -120,14 +123,14 @@ class WPCOM_REST_API_V2_Endpoint_Publicize_Share_Post extends WP_REST_Controller
 			}
 
 			$publicize = publicize_init();
-			$result    = $publicize->republicize_post( (int) $post_id, $message, $skip_connection_ids, true );
+			$result    = $publicize->republicize_post( (int) $post_id, $message, $skip_connection_ids, true, ! $is_async_share );
 			if ( false === $result ) {
 				return new WP_Error( 'not_found', 'Cannot find that post', array( 'status' => 404 ) );
 			}
 
 			return $result;
 		} else {
-			$response = $this->proxy_request( $post_id, $message, $skip_connection_ids );
+			$response = $this->proxy_request( $post_id, $message, $skip_connection_ids, $is_async_share );
 			if ( is_wp_error( $response ) ) {
 				return rest_ensure_response( $response );
 			}
@@ -142,10 +145,11 @@ class WPCOM_REST_API_V2_Endpoint_Publicize_Share_Post extends WP_REST_Controller
 	 * @param int    $post_id             The post ID being shared.
 	 * @param string $message             The custom message to be used.
 	 * @param array  $skip_connection_ids An array of connection IDs where the post shouldn't be shared.
+	 * @param bool   $async               Whether to share the post asynchronously.
 	 *
 	 * @return array|WP_Error $response Response data, else WP_Error on failure.
 	 */
-	public function proxy_request( $post_id, $message, $skip_connection_ids ) {
+	public function proxy_request( $post_id, $message, $skip_connection_ids, $async = false ) {
 		/*
 		 * Publicize endpoint on WPCOM:
 		 * [POST] wpcom/v2/sites/{$siteId}/posts/{$postId}/publicize
@@ -168,6 +172,7 @@ class WPCOM_REST_API_V2_Endpoint_Publicize_Share_Post extends WP_REST_Controller
 			array(
 				'message'             => $message,
 				'skipped_connections' => $skip_connection_ids,
+				'async'               => $async,
 			)
 		);
 	}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-publicize-share-post.php
@@ -108,9 +108,7 @@ class WPCOM_REST_API_V2_Endpoint_Publicize_Share_Post extends WP_REST_Controller
 		$post_id             = $request->get_param( 'postId' );
 		$message             = trim( $request->get_param( 'message' ) );
 		$skip_connection_ids = $request->get_param( 'skipped_connections' );
-		$async               = $request->get_param( 'async' );
-
-		$is_async_share = isset( $async ) && true === $async;
+		$async               = (bool) $request->get_param( 'async' );
 
 		if ( $this->is_wpcom ) {
 			$post = get_post( $post_id );
@@ -123,14 +121,14 @@ class WPCOM_REST_API_V2_Endpoint_Publicize_Share_Post extends WP_REST_Controller
 			}
 
 			$publicize = publicize_init();
-			$result    = $publicize->republicize_post( (int) $post_id, $message, $skip_connection_ids, true, ! $is_async_share );
+			$result    = $publicize->republicize_post( (int) $post_id, $message, $skip_connection_ids, true, ! $async );
 			if ( false === $result ) {
 				return new WP_Error( 'not_found', 'Cannot find that post', array( 'status' => 404 ) );
 			}
 
 			return $result;
 		} else {
-			$response = $this->proxy_request( $post_id, $message, $skip_connection_ids, $is_async_share );
+			$response = $this->proxy_request( $post_id, $message, $skip_connection_ids, $async );
 			if ( is_wp_error( $response ) ) {
 				return rest_ensure_response( $response );
 			}

--- a/projects/plugins/jetpack/changelog/add-social-publicize-endpoint-async-option
+++ b/projects/plugins/jetpack/changelog/add-social-publicize-endpoint-async-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Added a way to reshare in async way


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/533

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Made the resharing async

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* You need to sandbox this change onto your wpcom sandbox to be able to test this, run `bin/jetpack-downloader test jetpack add/social-publicize-endpoint-async-option` on your Sandbox, and point your JT site to it.
* In your sandbox run the watcher, and watch the logs. Also add `async_reshare_post_sandboxed` to your `0-sandbox` file
* Go to an already published post, choose a connection, then click share post.
* You should see `Your post will be shared on the selected accounts.` in the bottom left
* In your watcher you should see `async_reshare_post_sandboxed` being queued.
* Check that the share is successful on the social media site.

