### PR TITLE
fix: Prevent undefined `get_current_screen` function errors

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-prevent-undefined-get-current-screen-function-errors
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-prevent-undefined-get-current-screen-function-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent undefined `get_current_screen` function errors resulting from invoking the function in contexts where it is undefined.

--- a/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/class-starter-page-templates.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/starter-page-templates/class-starter-page-templates.php
@@ -176,6 +176,10 @@ class Starter_Page_Templates {
 	 * Enqueue block editor assets.
 	 */
 	public function enqueue_assets() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return;
+		}
+
 		$screen      = get_current_screen();
 		$user_locale = Common\get_iso_639_locale( get_user_locale() );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Guard against invocations of an undefined `get_current_screen` function. 

This function is undefined in certain contexts -- e.g., a REST API
request that results in enqueueing assets. Referencing an undefined
function results in a fatal error. With the `get_current_screen`
function specifically, it is common practice to check the function's
existence prior to invoking the it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A, no product discussion occurred for this bug fix. 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. 

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Verify feature stability with testing instructions similar to https://github.com/Automattic/jetpack/pull/38475. 

1. [Apply these changes](https://github.com/Automattic/jetpack/pull/39228#issuecomment-2328828632) to your testing environment. 
2. Create a new page on your test site: `<site_domain>/wp-admin/post-new.php?post_type=page`. 
3. Verify the page templates displayed match those in production and function as expected (e.g., clicking one inserts the content into the block editor). 

