### PR TITLE
Jetpack Connection: Restrict handling verified errors on admin pages only

### DIFF
--- a/projects/packages/connection/changelog/update-connection-handle-verified-errors-on-admin-init
+++ b/projects/packages/connection/changelog/update-connection-handle-verified-errors-on-admin-init
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Jetpack Connection: Restrict handling verified errors on admin pages only

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -136,8 +136,6 @@ class Error_Handler {
 
 		add_action( 'rest_api_init', array( $this, 'register_verify_error_endpoint' ) );
 
-		$this->handle_verified_errors();
-
 		// If the site gets reconnected, clear errors.
 		add_action( 'jetpack_site_registered', array( $this, 'delete_all_errors' ) );
 		add_action( 'jetpack_get_site_data_success', array( $this, 'delete_all_api_errors' ) );
@@ -145,6 +143,7 @@ class Error_Handler {
 		add_filter( 'jetpack_connection_delete_all_tokens', array( $this, 'delete_all_errors_and_return_unfiltered_value' ) );
 		add_action( 'jetpack_unlinked_user', array( $this, 'delete_all_errors' ) );
 		add_action( 'jetpack_updated_user_token', array( $this, 'delete_all_errors' ) );
+		add_action( 'admin_init', array( $this, 'handle_verified_errors' ) );
 	}
 
 	/**

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -136,6 +136,9 @@ class Error_Handler {
 
 		add_action( 'rest_api_init', array( $this, 'register_verify_error_endpoint' ) );
 
+		// Handle verified errors on admin pages.
+		add_action( 'admin_init', array( $this, 'handle_verified_errors' ) );
+
 		// If the site gets reconnected, clear errors.
 		add_action( 'jetpack_site_registered', array( $this, 'delete_all_errors' ) );
 		add_action( 'jetpack_get_site_data_success', array( $this, 'delete_all_api_errors' ) );
@@ -143,7 +146,6 @@ class Error_Handler {
 		add_filter( 'jetpack_connection_delete_all_tokens', array( $this, 'delete_all_errors_and_return_unfiltered_value' ) );
 		add_action( 'jetpack_unlinked_user', array( $this, 'delete_all_errors' ) );
 		add_action( 'jetpack_updated_user_token', array( $this, 'delete_all_errors' ) );
-		add_action( 'admin_init', array( $this, 'handle_verified_errors' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

There's no need to handle Jetpack Connection errors outside of `wp-admin`, since we only display corresponding notices in `wp-admin` pages.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Connection\Error_Handler`: Instead of calling `handle_verified_errors` from the constructor we are adding it as a callback for the `admin_init` hook.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pdWQjU-QN-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Pre-requisites: A JP connected site
* Using the Jetpack Debug Helper plugin create a verified Connection Error (Jetpack Debug -> Enable Broken token Utilities -> Connection Errors)
* Visit the Jetpack Dashboard and confirm you see a Connection Error notice (same as on trunk)
* Visit My Jetpack and confirm you see a Connection Error notice (same as on trunk)