### PR TITLE
Site Breadcrumbs: Prevent creation of jetpack_breadcrumbs function unless host is not WP.com

### DIFF
--- a/projects/packages/classic-theme-helper/.phan/baseline.php
+++ b/projects/packages/classic-theme-helper/.phan/baseline.php
@@ -10,7 +10,7 @@
 return [
     // # Issue statistics:
     // PhanTypeMismatchArgumentInternal : 10+ occurrences
-    // PhanUndeclaredClassMethod : 9 occurrences
+    // PhanUndeclaredClassMethod : 10+ occurrences
     // PhanTypePossiblyInvalidDimOffset : 8 occurrences
     // PhanUndeclaredClassReference : 4 occurrences
     // PhanTypeMismatchArgumentProbablyReal : 3 occurrences
@@ -29,8 +29,8 @@ return [
         'src/content-options/featured-images-fallback.php' => ['PhanTypePossiblyInvalidDimOffset'],
         'src/custom-content-types.php' => ['PhanUndeclaredClassMethod'],
         'src/custom-post-types/class-jetpack-portfolio.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach'],
-		'src/site-breadcrumbs.php' => ['PhanUndeclaredClassMethod'],
-	],
+        'src/site-breadcrumbs.php' => ['PhanUndeclaredClassMethod'],
+    ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
 ];

--- a/projects/packages/classic-theme-helper/.phan/baseline.php
+++ b/projects/packages/classic-theme-helper/.phan/baseline.php
@@ -29,7 +29,8 @@ return [
         'src/content-options/featured-images-fallback.php' => ['PhanTypePossiblyInvalidDimOffset'],
         'src/custom-content-types.php' => ['PhanUndeclaredClassMethod'],
         'src/custom-post-types/class-jetpack-portfolio.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeSuspiciousNonTraversableForeach'],
-    ],
+		'src/site-breadcrumbs.php' => ['PhanUndeclaredClassMethod'],
+	],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)
 ];

--- a/projects/packages/classic-theme-helper/changelog/fix-site-breadcrumbs-prevent-wpcom-function-duplication
+++ b/projects/packages/classic-theme-helper/changelog/fix-site-breadcrumbs-prevent-wpcom-function-duplication
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Site Breadcrumbs: Ensure main function is not created when host is WordPress.com.

--- a/projects/packages/classic-theme-helper/src/site-breadcrumbs.php
+++ b/projects/packages/classic-theme-helper/src/site-breadcrumbs.php
@@ -7,7 +7,8 @@
  * @package automattic/jetpack-classic-theme-helper
  */
 
-if ( ! function_exists( 'jetpack_breadcrumbs' ) ) {
+$host = new Automattic\Jetpack\Status\Host();
+if ( ! function_exists( 'jetpack_breadcrumbs' ) && ! $host->is_wpcom_simple() ) {
 	/**
 	 * Echos a set of breadcrumbs.
 	 *


### PR DESCRIPTION
## Proposed changes:

* While testing https://github.com/Automattic/jetpack/pull/39210 on WordPress.com, I was encountering a fatal error related to Site Breadcrumbs, seemingly not replicable on trunk (possibly related to sun/moon and loading orders). It seems unrelated to the PR, but highlighted an issue that does need fixing - there is a mu-plugins file that also creates a `jetpack_breadcrumbs` function, so in the Classic Theme Helper package we should add a check to see if a site's host is WPcom and not create the function there, in that case.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* To test, follow the testing instructions here: https://github.com/Automattic/jetpack/pull/38931 - there should be no change to the functionality.
* You may be able to replicate the fatal error by testing https://github.com/Automattic/jetpack/pull/39210 on Simple sites (I tested with Dara and Sequential).

There is also an associated diff here that can be reviewed at the same time, it doesn't need to work with this PR but adds an additional safety net: D160507-code