### PR TITLE
LaunchpadSaveModal: Update action href based on experiment variation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3764,6 +3764,9 @@ importers:
       '@automattic/jetpack-connection':
         specifier: workspace:*
         version: link:../../js-packages/connection
+      '@automattic/jetpack-explat':
+        specifier: workspace:*
+        version: link:../../packages/explat
       '@automattic/jetpack-licensing':
         specifier: workspace:*
         version: link:../../js-packages/licensing

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4009,9 +4009,6 @@ importers:
       '@types/jest':
         specifier: 29.5.12
         version: 29.5.12
-      '@types/node':
-        specifier: ^20.4.2
-        version: 20.14.15
       '@types/react':
         specifier: 18.3.3
         version: 18.3.3
@@ -4074,7 +4071,7 @@ importers:
         version: 10.4.1
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.14.15)
+        version: 29.7.0
       jest-environment-jsdom:
         specifier: 29.7.0
         version: 29.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4009,6 +4009,9 @@ importers:
       '@types/jest':
         specifier: 29.5.12
         version: 29.5.12
+      '@types/node':
+        specifier: ^20.4.2
+        version: 20.14.15
       '@types/react':
         specifier: 18.3.3
         version: 18.3.3
@@ -4071,7 +4074,7 @@ importers:
         version: 10.4.1
       jest:
         specifier: 29.7.0
-        version: 29.7.0
+        version: 29.7.0(@types/node@20.14.15)
       jest-environment-jsdom:
         specifier: 29.7.0
         version: 29.7.0

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -3,6 +3,11 @@
 ### This is a list detailing changes for all Jetpack releases.
 
 ## 13.8 - 2024-09-04
+### Enhancements
+- Launchpad modal: Apply experiment [#81287]
+
+## 13.8-beta - 2024-09-02
+>>>>>>> 798545c838 (Add changelog manually)
 ### Major Enhancements
 - Custom CSS: Remove feature in favor of WordPress core implementation. [#38865]
 - Embeds: Remove YouTube and Vimeo embeds in favor of WordPress core implementation. [#39096]

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -3,11 +3,6 @@
 ### This is a list detailing changes for all Jetpack releases.
 
 ## 13.8 - 2024-09-04
-### Enhancements
-- Launchpad modal: Apply experiment [#81287]
-
-## 13.8-beta - 2024-09-02
->>>>>>> 798545c838 (Add changelog manually)
 ### Major Enhancements
 - Custom CSS: Remove feature in favor of WordPress core implementation. [#38865]
 - Embeds: Remove YouTube and Vimeo embeds in favor of WordPress core implementation. [#39096]

--- a/projects/plugins/jetpack/changelog/update-wpcom-launchpad-setup-redirection
+++ b/projects/plugins/jetpack/changelog/update-wpcom-launchpad-setup-redirection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+LaunchpadSaveModal: support launchpad experiment

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -40,10 +40,9 @@ const updateLaunchpadSaveModalBrowserConfig = config => {
 };
 
 export const settings = {
-	render: async function LaunchpadSaveModal() {
-		const experiment = await loadExperimentAssignment(
-			'calypso_onboarding_launchpad_removal_test_2024_08'
-		);
+	render: function LaunchpadSaveModal() {
+		const [ variationName, setVariationName ] = useState();
+
 		const { isSavingSite, isSavingPost, isCurrentPostPublished, postLink, postType } = useSelect(
 			select => {
 				const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } = select( coreStore );
@@ -63,8 +62,19 @@ export const settings = {
 			}
 		);
 
-		console.log( 'experiment', experiment );
-		alert( 'variationName', experiment?.variationName );
+		// Fetch the experiment data once when the component mounts
+		useEffect( () => {
+			loadExperimentAssignment( 'calypso_onboarding_launchpad_removal_test_2024_08' )
+				.then( experiment => {
+					console.log( 'experiment', experiment );
+					setVariationName( experiment.variationName );
+				} )
+				.catch( error => {
+					console.error( 'Error loading experiment assignment:', error );
+				} );
+		}, [] );
+
+		console.log( 'experimentName', variationName );
 
 		const prevIsSavingSite = usePrevious( isSavingSite );
 		const prevIsSavingPost = usePrevious( isSavingPost );

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -1,6 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { getSiteFragment, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { loadExperimentAssignment } from '@automattic/jetpack-explat';
+import { getSiteFragment, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import { Modal, Button, CheckboxControl } from '@wordpress/components';
 import { usePrevious } from '@wordpress/compose';
@@ -40,8 +40,10 @@ const updateLaunchpadSaveModalBrowserConfig = config => {
 };
 
 export const settings = {
-	render: function LaunchpadSaveModal() {
-		const { variationName } = await loadExperimentAssignment( 'calypso_onboarding_launchpad_removal_test_2024_08' );
+	render: async function LaunchpadSaveModal() {
+		const { variationName } = await loadExperimentAssignment(
+			'calypso_onboarding_launchpad_removal_test_2024_08'
+		);
 		const { isSavingSite, isSavingPost, isCurrentPostPublished, postLink, postType } = useSelect(
 			select => {
 				const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } = select( coreStore );

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -42,7 +42,9 @@ const updateLaunchpadSaveModalBrowserConfig = config => {
 export const settings = {
 	render: function LaunchpadSaveModal() {
 		const [ experimentVariationName, setExperimentVariationName ] = useState();
-		const sessionVariationName = window.sessionStorage.getItem( 'launchpad_experiment_variation' );
+		const sessionVariationName = window.sessionStorage.getItem(
+			'launchpad_removal_2024_experiment_variation'
+		);
 
 		const { isSavingSite, isSavingPost, isCurrentPostPublished, postLink, postType } = useSelect(
 			select => {

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -41,7 +41,7 @@ const updateLaunchpadSaveModalBrowserConfig = config => {
 
 export const settings = {
 	render: function LaunchpadSaveModal() {
-		const [ variationName, setVariationName ] = useState();
+		const [ experimentVariationName, setExperimentVariationName ] = useState();
 
 		const { isSavingSite, isSavingPost, isCurrentPostPublished, postLink, postType } = useSelect(
 			select => {
@@ -67,14 +67,12 @@ export const settings = {
 			loadExperimentAssignment( 'calypso_onboarding_launchpad_removal_test_2024_08' )
 				.then( experiment => {
 					console.log( 'experiment', experiment );
-					setVariationName( experiment.variationName );
+					setExperimentVariationName( experiment.variationName );
 				} )
 				.catch( error => {
 					console.error( 'Error loading experiment assignment:', error );
 				} );
 		}, [] );
-
-		console.log( 'experimentName', variationName );
 
 		const prevIsSavingSite = usePrevious( isSavingSite );
 		const prevIsSavingPost = usePrevious( isSavingPost );
@@ -106,6 +104,10 @@ export const settings = {
 			path: siteIntentOption,
 			query: `siteSlug=${ siteFragment }`,
 		} );
+		const calypsoHomeUrl = getRedirectUrl( 'calypso-home', {
+			site: siteFragment,
+		} );
+		const primaryActionHref = experimentVariationName === 'control' ? launchPadUrl : calypsoHomeUrl;
 		const { tracks } = useAnalytics();
 
 		const recordTracksEvent = eventName =>
@@ -123,7 +125,7 @@ export const settings = {
 					'You are one step away from bringing your site to life. Check out the next steps that will help you to launch your site.',
 					'jetpack'
 				),
-				actionButtonHref: launchPadUrl,
+				actionButtonHref: primaryActionHref,
 				actionButtonTracksEvent: 'jetpack_launchpad_save_modal_next_steps',
 				actionButtonText: 'Bogdan Test',
 			};

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -1,5 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { getSiteFragment, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { loadExperimentAssignment } from '@automattic/jetpack-explat';
 import apiFetch from '@wordpress/api-fetch';
 import { Modal, Button, CheckboxControl } from '@wordpress/components';
 import { usePrevious } from '@wordpress/compose';
@@ -40,6 +41,7 @@ const updateLaunchpadSaveModalBrowserConfig = config => {
 
 export const settings = {
 	render: function LaunchpadSaveModal() {
+		const { variationName } = await loadExperimentAssignment( 'calypso_onboarding_launchpad_removal_test_2024_08' );
 		const { isSavingSite, isSavingPost, isCurrentPostPublished, postLink, postType } = useSelect(
 			select => {
 				const { __experimentalGetDirtyEntityRecords, isSavingEntityRecord } = select( coreStore );
@@ -58,6 +60,8 @@ export const settings = {
 				};
 			}
 		);
+
+		console.log( 'variationName', variationName );
 
 		const prevIsSavingSite = usePrevious( isSavingSite );
 		const prevIsSavingPost = usePrevious( isSavingPost );

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -41,7 +41,7 @@ const updateLaunchpadSaveModalBrowserConfig = config => {
 
 export const settings = {
 	render: async function LaunchpadSaveModal() {
-		const { variationName } = await loadExperimentAssignment(
+		const experiment = await loadExperimentAssignment(
 			'calypso_onboarding_launchpad_removal_test_2024_08'
 		);
 		const { isSavingSite, isSavingPost, isCurrentPostPublished, postLink, postType } = useSelect(
@@ -63,7 +63,8 @@ export const settings = {
 			}
 		);
 
-		console.log( 'variationName', variationName );
+		console.log( 'experiment', experiment );
+		alert( 'variationName', experiment?.variationName );
 
 		const prevIsSavingSite = usePrevious( isSavingSite );
 		const prevIsSavingPost = usePrevious( isSavingPost );
@@ -77,6 +78,8 @@ export const settings = {
 			hideFSENextStepsModal,
 			siteIntentOption,
 		} = window?.Jetpack_LaunchpadSaveModal || {};
+
+		console.log( 'Jetpack_LaunchpadSaveModal', window?.Jetpack_LaunchpadSaveModal );
 
 		const hideFSENextStepsModalBool = !! hideFSENextStepsModal;
 
@@ -112,7 +115,7 @@ export const settings = {
 				),
 				actionButtonHref: launchPadUrl,
 				actionButtonTracksEvent: 'jetpack_launchpad_save_modal_next_steps',
-				actionButtonText: __( 'Next Steps', 'jetpack' ),
+				actionButtonText: 'Bogdan Test',
 			};
 
 			if ( siteIntentOption === 'newsletter' ) {

--- a/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
+++ b/projects/plugins/jetpack/extensions/plugins/launchpad-save-modal/index.js
@@ -42,6 +42,7 @@ const updateLaunchpadSaveModalBrowserConfig = config => {
 export const settings = {
 	render: function LaunchpadSaveModal() {
 		const [ experimentVariationName, setExperimentVariationName ] = useState();
+		const sessionVariationName = window.sessionStorage.getItem( 'launchpad_experiment_variation' );
 
 		const { isSavingSite, isSavingPost, isCurrentPostPublished, postLink, postType } = useSelect(
 			select => {
@@ -64,15 +65,14 @@ export const settings = {
 
 		// Fetch the experiment data once when the component mounts
 		useEffect( () => {
-			loadExperimentAssignment( 'calypso_onboarding_launchpad_removal_test_2024_08' )
-				.then( experiment => {
-					console.log( 'experiment', experiment );
-					setExperimentVariationName( experiment.variationName );
-				} )
-				.catch( error => {
-					console.error( 'Error loading experiment assignment:', error );
-				} );
-		}, [] );
+			loadExperimentAssignment( 'calypso_onboarding_launchpad_removal_test_2024_08' ).then(
+				experiment => {
+					sessionVariationName
+						? setExperimentVariationName( sessionVariationName )
+						: setExperimentVariationName( experiment.variationName );
+				}
+			);
+		}, [ sessionVariationName ] );
 
 		const prevIsSavingSite = usePrevious( isSavingSite );
 		const prevIsSavingPost = usePrevious( isSavingPost );
@@ -86,8 +86,6 @@ export const settings = {
 			hideFSENextStepsModal,
 			siteIntentOption,
 		} = window?.Jetpack_LaunchpadSaveModal || {};
-
-		console.log( 'Jetpack_LaunchpadSaveModal', window?.Jetpack_LaunchpadSaveModal );
 
 		const hideFSENextStepsModalBool = !! hideFSENextStepsModal;
 
@@ -107,7 +105,8 @@ export const settings = {
 		const calypsoHomeUrl = getRedirectUrl( 'calypso-home', {
 			site: siteFragment,
 		} );
-		const primaryActionHref = experimentVariationName === 'control' ? launchPadUrl : calypsoHomeUrl;
+		const primaryActionHref =
+			experimentVariationName === 'treatment' ? calypsoHomeUrl : launchPadUrl;
 		const { tracks } = useAnalytics();
 
 		const recordTracksEvent = eventName =>
@@ -127,7 +126,7 @@ export const settings = {
 				),
 				actionButtonHref: primaryActionHref,
 				actionButtonTracksEvent: 'jetpack_launchpad_save_modal_next_steps',
-				actionButtonText: 'Bogdan Test',
+				actionButtonText: __( 'Next Steps', 'jetpack' ),
 			};
 
 			if ( siteIntentOption === 'newsletter' ) {

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -133,6 +133,7 @@
 		"@testing-library/react": "15.0.7",
 		"@testing-library/user-event": "14.5.2",
 		"@types/jest": "29.5.12",
+		"@types/node": "^20.4.2",
 		"@types/react": "18.3.3",
 		"@types/wordpress__block-editor": "11.5.15",
 		"@types/wordpress__editor": "13.6.8",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -52,6 +52,7 @@
 		"@automattic/jetpack-boost-score-api": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
+		"@automattic/jetpack-explat": "workspace:*",
 		"@automattic/jetpack-licensing": "workspace:*",
 		"@automattic/jetpack-my-jetpack": "workspace:*",
 		"@automattic/jetpack-partner-coupon": "workspace:*",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -133,7 +133,6 @@
 		"@testing-library/react": "15.0.7",
 		"@testing-library/user-event": "14.5.2",
 		"@types/jest": "29.5.12",
-		"@types/node": "^20.4.2",
 		"@types/react": "18.3.3",
 		"@types/wordpress__block-editor": "11.5.15",
 		"@types/wordpress__editor": "13.6.8",

--- a/tools/js-tools/types/global.d.ts
+++ b/tools/js-tools/types/global.d.ts
@@ -4,6 +4,13 @@ declare module '*.module.scss' {
 	export default classes;
 }
 
+// Add the process declaration
+declare const process: {
+	env: {
+		NODE_ENV: 'development' | 'production' | 'test';
+	};
+};
+
 type AvailableBlockProps =
 	| {
 			available?: boolean;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:

The `LaunchpadSaveModal` component has hardcoded redirection to the fullscreen Launchpad onboarding step. With this change, we dynamically decide the redirection href based on the experiment or session storage item information.

The default behavior will remain the same if the experiment has not started.

Related Pull Request: https://github.com/Automattic/wp-calypso/pull/93205

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Related document: pbxNRc-3Yh-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new site or take an existing {SITE_SLUG}
* Apply PR changes to your sandbox and proxy your {SITE_SLUG}
* Go to `{SITE_SLUG}/wp-admin/site-editor.php?calypso_origin=http%3A%2F%2Fcalypso.localhost%3A3000&canvas=edit&assembler=1&showLaunchpad=true`
* In the developer tool, execute the command: `window.sessionStorage.setItem( 'launchpad_removal_2024_experiment_variation', 'treatment' );`
* Make any content change
* Press "Save" button
* In "Great progress!" modal, press on the "Next steps" button
* Check if the "Next steps" button has href: `https://jetpack.com/redirect/?source=calypso-home&site=launchpadtesting1.wordpress.com`

<img width="1006" alt="Screenshot 2024-09-06 at 17 43 23" src="https://github.com/user-attachments/assets/41ad9dc9-181d-4763-99d8-e7efe7c67441">