### PR TITLE
Forms: check for private and password-protected posts when handling the contact form submissions

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-feedback-parsing
+++ b/projects/packages/forms/changelog/fix-contact-form-feedback-parsing
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Add a safeguard against shortcode handling in contact form feedback.
+Check for private and password-protected posts when handling the contact form submissions.

--- a/projects/packages/forms/changelog/fix-contact-form-feedback-parsing
+++ b/projects/packages/forms/changelog/fix-contact-form-feedback-parsing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add a safeguard against shortcode handling in contact form feedback.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -686,6 +686,10 @@ class Contact_Form_Plugin {
 			// It's a form embedded in a post
 			$post = get_post( $id );
 
+			if ( $post->post_type === 'feedback' ) {
+				return false;
+			}
+
 			// Process the content to populate Contact_Form::$last
 			if ( $post ) {
 				/** This filter is already documented in core. wp-includes/post-template.php */

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -697,10 +697,6 @@ class Contact_Form_Plugin {
 
 			$post = get_post( $id );
 
-			if ( $post->post_type === 'feedback' ) {
-				return false;
-			}
-
 			// Process the content to populate Contact_Form::$last
 			if ( $post ) {
 				/** This filter is already documented in core. wp-includes/post-template.php */

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -684,6 +684,17 @@ class Contact_Form_Plugin {
 			do_blocks( '<!-- wp:template-part ' . wp_json_encode( $attributes ) . ' /-->' );
 		} else {
 			// It's a form embedded in a post
+
+			if ( ! is_post_publicly_viewable( $id ) && ! current_user_can( 'read_post', $id ) ) {
+				// The user can't see the post.
+				return false;
+			}
+
+			if ( post_password_required( $id ) ) {
+				// The post is password-protected and the password is not provided.
+				return false;
+			}
+
 			$post = get_post( $id );
 
 			if ( $post->post_type === 'feedback' ) {


### PR DESCRIPTION
## Proposed changes:
* Add a safeguard to prevent shortcode handling in contact form feedback.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/470

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
We just need to make sure the contact form works as expected.

1. Connect Jetpack.
2. Add the "Contact Form" block to a page or a post.
3. Try to send a message using the form. Confirm it shows up in the "Feedback" section.