### PR TITLE
Fix/translation issue

### DIFF
--- a/projects/packages/videopress/changelog/fix-translation-issue
+++ b/projects/packages/videopress/changelog/fix-translation-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix translation issue with VideoPress data

--- a/projects/packages/videopress/src/class-stats.php
+++ b/projects/packages/videopress/src/class-stats.php
@@ -137,6 +137,7 @@ class Stats {
 		 */
 		krsort( $dates );
 		$period_of_data = floor( $period_count / 2 );
+		$period         = $period === 'day' ? __( 'day', 'jetpack-videopress-pkg' ) : __( 'year', 'jetpack-videopress-pkg' );
 
 		// template for the response
 		$featured_stats = array(


### PR DESCRIPTION
## Proposed changes:

* This ensures the period in the label of data is translated

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack after connecting your user and site
3. Look at the jetpack initial state in the window by logging `myJetpackInitialState` and make sure the label and period look correct still
![image](https://github.com/user-attachments/assets/f6c1853f-6476-4cb6-961d-03d208aaa77d)

