### PR TITLE
JPO: Do not check if the user is onboarding when loading modules

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-jetpack_onboarding-get_option-from-frontend
+++ b/projects/plugins/jetpack/changelog/remove-jetpack_onboarding-get_option-from-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated to not check for onboarding option from the frontend

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -1730,16 +1730,9 @@ class Jetpack {
 	public static function load_modules() {
 		$status = new Status();
 
-		if ( method_exists( $status, 'is_onboarding' ) ) {
-			$is_onboarding = $status->is_onboarding();
-		} else {
-			$is_onboarding = self::is_onboarding();
-		}
-
 		if (
 			! self::is_connection_ready()
 			&& ! $status->is_offline_mode()
-			&& ! $is_onboarding
 			&& (
 				! is_multisite()
 				|| ! get_site_option( 'jetpack_protect_active' )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Jetpack Onboarding flows were [removed 2019 from Calypso](https://github.com/Automattic/wp-calypso/pull/38000) and the whole JPO subsystem will be removed from Jetpack in #39229

This saves an extra request for get_option() looking for`jetpack_onboarding` when Jetpack is disconnected



Fixes Automattic/vulcan#502

## Proposed changes:

* Removes LOC checking for is_onboarding unnecessarily as the subsystem hasn't been in user for years
<!--- Explain what functional changes your PR includes -->


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-QN-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* [Launch a Jetpack site with this branch, query monitor, and no cache plugins](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=remove/jetpack_onboarding-get_option-from-frontend&wp-debug-log&cache-drop-in=false&query-monitor). 
* Enable the Query monitor Authentication cookie in Plugins -> Settings for query monitor
* Sign out. 
* Load the frontend. 
* Check Database Queries -> By Component -> jetpack_dev
* Confirm you do not see a query for loading the option `jetpack_onboarding`