### PR TITLE
Fix: Don't show AI editing excerpt UI on patterns, templates/parts.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-dont-show-excerpt-ai-UI-on-patterns-templates-and-template-parts
+++ b/projects/plugins/jetpack/changelog/fix-dont-show-excerpt-ai-UI-on-patterns-templates-and-template-parts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix: Do not show Jetpack AI excerpt UI on patterns, templates, and template parts where it does not make sense.

--- a/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-content-lens/extend/ai-post-excerpt/index.tsx
@@ -298,14 +298,26 @@ ${ postContent }
 	);
 }
 
-export const PluginDocumentSettingPanelAiExcerpt = () => (
-	<PostTypeSupportCheck supportKeys="excerpt">
-		<PluginDocumentSettingPanel
-			className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }
-			name="ai-content-lens-plugin"
-			title={ __( 'Excerpt', 'jetpack' ) }
-		>
-			<AiPostExcerpt />
-		</PluginDocumentSettingPanel>
-	</PostTypeSupportCheck>
-);
+export const PluginDocumentSettingPanelAiExcerpt = () => {
+	const isExcerptUsedAsDescription = useSelect( select => {
+		const { getCurrentPostType } = select( editorStore ) as typeof EditorSelectors;
+		const postType = getCurrentPostType();
+		const isTemplateOrTemplatePart = postType === 'wp_template' || postType === 'wp_template_part';
+		const isPattern = postType === 'wp_block';
+		return isTemplateOrTemplatePart || isPattern;
+	}, [] );
+	if ( isExcerptUsedAsDescription ) {
+		return null;
+	}
+	return (
+		<PostTypeSupportCheck supportKeys="excerpt">
+			<PluginDocumentSettingPanel
+				className={ isBetaExtension( 'ai-content-lens' ) ? 'is-beta-extension inset-shadow' : '' }
+				name="ai-content-lens-plugin"
+				title={ __( 'Excerpt', 'jetpack' ) }
+			>
+				<AiPostExcerpt />
+			</PluginDocumentSettingPanel>
+		</PostTypeSupportCheck>
+	);
+};


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/39247


## Proposed changes:
Checks for the cases where the excerpt is used as a description and not a excerpt. In these cases the Jetpack Excerpt UI is not included.

This fixes a buggy behavior where when editing patterns or templates, we see an unexpected excerpt editing UI in sites with Jetpack installed and the AI module active.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
In the post editor, I added a paragraph.
I created a pattern with that paragraph.
I pressed manage patterns in the top right corner of the editor.
I opened the pattern I just created on the editor, and I verified the excerpt UI is not available, on trunk it is.
