### PR TITLE
Sync: Enable full sync immediately for woocommerce module

### DIFF
--- a/projects/packages/sync/changelog/updates-sync-woo-commerce-module-enable-full-sync-immediately
+++ b/projects/packages/sync/changelog/updates-sync-woo-commerce-module-enable-full-sync-immediately
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync: Enable Full Sync Immediately for woocommerce module

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -1329,6 +1329,10 @@ class Defaults {
 			'chunk_size' => 100,
 			'max_chunks' => 10,
 		),
+		'woocommerce'        => array(
+			'chunk_size' => 100,
+			'max_chunks' => 10,
+		),
 	);
 
 	/**

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -42,9 +42,23 @@ class Comments extends Module {
 	 * @access public
 	 *
 	 * @return string
+	 * @deprecated since $$next-version$$ Use table() instead.
 	 */
 	public function table_name() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Sync\\Comments->table' );
 		return 'comments';
+	}
+
+	/**
+	 * The table in the database with the prefix.
+	 *
+	 * @access public
+	 *
+	 * @return string|bool
+	 */
+	public function table() {
+		global $wpdb;
+		return $wpdb->comments;
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-comments.php
+++ b/projects/packages/sync/src/modules/class-comments.php
@@ -37,7 +37,7 @@ class Comments extends Module {
 	}
 
 	/**
-	 * The table in the database.
+	 * The table name.
 	 *
 	 * @access public
 	 *

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Sync\Modules;
 
+use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Functions;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Replicastore;
@@ -381,7 +382,12 @@ abstract class Module {
 			$status['last_sent'] = $this->get_initial_last_sent();
 		}
 
-		$limits = Settings::get_setting( 'full_sync_limits' )[ $this->name() ];
+		$limits = Settings::get_setting( 'full_sync_limits' )[ $this->name() ] ??
+			Defaults::get_default_setting( 'full_sync_limits' )[ $this->name() ] ??
+			array(
+				'max_chunks' => 10,
+				'chunk_size' => 100,
+			);
 
 		$chunks_sent = 0;
 

--- a/projects/packages/sync/src/modules/class-module.php
+++ b/projects/packages/sync/src/modules/class-module.php
@@ -54,21 +54,22 @@ abstract class Module {
 	 * @access public
 	 *
 	 * @return string|bool
+	 * @deprecated since $$next-version$$ Use table() instead.
 	 */
 	public function table_name() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Sync\\Module->table' );
 		return false;
 	}
 
 	/**
-	 * The table in the database. This can be overridden to allow tables not present in the $wpdb global.
+	 * The table in the database with the prefix.
 	 *
 	 * @access public
 	 *
 	 * @return string|bool
 	 */
 	public function table() {
-		global $wpdb;
-		return $wpdb->{$this->table_name()};
+		return false;
 	}
 
 	/**
@@ -595,7 +596,7 @@ abstract class Module {
 	 */
 	public function get_min_max_object_ids_for_batches( $batch_size, $where_sql = false ) {
 
-		if ( ! $this->table_name() ) {
+		if ( ! $this->table() ) {
 			return false;
 		}
 

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -106,7 +106,7 @@ class Posts extends Module {
 	}
 
 	/**
-	 * The table in the database.
+	 * The table name.
 	 *
 	 * @access public
 	 *

--- a/projects/packages/sync/src/modules/class-posts.php
+++ b/projects/packages/sync/src/modules/class-posts.php
@@ -111,9 +111,23 @@ class Posts extends Module {
 	 * @access public
 	 *
 	 * @return string
+	 * @deprecated since $$next-version$$ Use table() instead.
 	 */
 	public function table_name() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Sync\\Posts->table' );
 		return 'posts';
+	}
+
+	/**
+	 * The table in the database with the prefix.
+	 *
+	 * @access public
+	 *
+	 * @return string|bool
+	 */
+	public function table() {
+		global $wpdb;
+		return $wpdb->posts;
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-term-relationships.php
+++ b/projects/packages/sync/src/modules/class-term-relationships.php
@@ -61,9 +61,23 @@ class Term_Relationships extends Module {
 	 * @access public
 	 *
 	 * @return string
+	 * @deprecated since $$next-version$$ Use table() instead.
 	 */
 	public function table_name() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Sync\\Term_Relationships->table' );
 		return 'term_relationships';
+	}
+
+	/**
+	 * The table in the database with the prefix.
+	 *
+	 * @access public
+	 *
+	 * @return string|bool
+	 */
+	public function table() {
+		global $wpdb;
+		return $wpdb->term_relationships;
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-term-relationships.php
+++ b/projects/packages/sync/src/modules/class-term-relationships.php
@@ -56,7 +56,7 @@ class Term_Relationships extends Module {
 	}
 
 	/**
-	 * The table in the database.
+	 * The table name.
 	 *
 	 * @access public
 	 *

--- a/projects/packages/sync/src/modules/class-terms.php
+++ b/projects/packages/sync/src/modules/class-terms.php
@@ -38,7 +38,7 @@ class Terms extends Module {
 	}
 
 	/**
-	 * The table in the database.
+	 * The table name.
 	 *
 	 * @access public
 	 *

--- a/projects/packages/sync/src/modules/class-terms.php
+++ b/projects/packages/sync/src/modules/class-terms.php
@@ -43,9 +43,23 @@ class Terms extends Module {
 	 * @access public
 	 *
 	 * @return string
+	 * @deprecated since $$next-version$$ Use table() instead.
 	 */
 	public function table_name() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Sync\\Terms->table' );
 		return 'term_taxonomy';
+	}
+
+	/**
+	 * The table in the database with the prefix.
+	 *
+	 * @access public
+	 *
+	 * @return string|bool
+	 */
+	public function table() {
+		global $wpdb;
+		return $wpdb->term_taxonomy;
 	}
 
 	/**
@@ -284,7 +298,7 @@ class Terms extends Module {
 	 * @return array $args The expanded hook parameters.
 	 */
 	public function expand_term_taxonomy_id( $args ) {
-		list( $term_taxonomy_ids,  $previous_end ) = $args;
+		list( $term_taxonomy_ids, $previous_end ) = $args;
 
 		return array(
 			'terms'        => get_terms(

--- a/projects/packages/sync/src/modules/class-users.php
+++ b/projects/packages/sync/src/modules/class-users.php
@@ -58,7 +58,7 @@ class Users extends Module {
 	}
 
 	/**
-	 * The table in the database.
+	 * The table name.
 	 *
 	 * @access public
 	 *

--- a/projects/packages/sync/src/modules/class-users.php
+++ b/projects/packages/sync/src/modules/class-users.php
@@ -63,9 +63,23 @@ class Users extends Module {
 	 * @access public
 	 *
 	 * @return string
+	 * @deprecated since $$next-version$$ Use table() instead.
 	 */
 	public function table_name() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Sync\\Users->table' );
 		return 'usermeta';
+	}
+
+	/**
+	 * The table in the database with the prefix.
+	 *
+	 * @access public
+	 *
+	 * @return string|bool
+	 */
+	public function table() {
+		global $wpdb;
+		return $wpdb->usermeta;
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -45,8 +45,21 @@ class WooCommerce_HPOS_Orders extends Module {
 	 * @access public
 	 *
 	 * @return string
+	 * @deprecated since $$next-version$$ Use table() instead.
 	 */
 	public function table_name() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Sync\\WooCOmmerce_HPOS_Orders->table' );
+		return $this->order_table_name;
+	}
+
+	/**
+	 * The table in the database with the prefix.
+	 *
+	 * @access public
+	 *
+	 * @return string|bool
+	 */
+	public function table() {
 		return $this->order_table_name;
 	}
 
@@ -403,7 +416,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	public function estimate_full_sync_actions( $config ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- We return all order count for full sync, so confit is not required.
 		global $wpdb;
 
-		$query = "SELECT count(*) FROM {$this->table_name()} WHERE {$this->get_where_sql( $config ) }";
+		$query = "SELECT count(*) FROM {$this->table()} WHERE {$this->get_where_sql( $config ) }";
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Hardcoded query, no user variable
 		$count = (int) $wpdb->get_var( $query );
 
@@ -421,7 +434,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	 * @return array Number of actions enqueued, and next module state.
 	 */
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $state ) {
-		return $this->enqueue_all_ids_as_action( 'full_sync_orders', $this->table_name(), 'id', $this->get_where_sql( $config ), $max_items_to_enqueue, $state );
+		return $this->enqueue_all_ids_as_action( 'full_sync_orders', $this->table(), 'id', $this->get_where_sql( $config ), $max_items_to_enqueue, $state );
 	}
 
 	/**

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -48,7 +48,7 @@ class WooCommerce_HPOS_Orders extends Module {
 	 * @deprecated since $$next-version$$ Use table() instead.
 	 */
 	public function table_name() {
-		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Sync\\WooCOmmerce_HPOS_Orders->table' );
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Sync\\WooCommerce_HPOS_Orders->table' );
 		return $this->order_table_name;
 	}
 

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -66,13 +66,15 @@ class WooCommerce extends Module {
 	 * @access public
 	 *
 	 * @return string
+	 * @deprecated since $$next-version$$ Use table() instead.
 	 */
 	public function table_name() {
+		_deprecated_function( __METHOD__, '$$next-version$$', 'Automattic\\Jetpack\\Sync\\WooCommerce->table' );
 		return $this->order_item_table_name;
 	}
 
 	/**
-	 * The table in the database. This can be overridden to allow tables not present in the $wpdb global.
+	 * The table in the database with the prefix.
 	 *
 	 * @access public
 	 *

--- a/projects/packages/sync/src/modules/class-woocommerce.php
+++ b/projects/packages/sync/src/modules/class-woocommerce.php
@@ -61,7 +61,7 @@ class WooCommerce extends Module {
 	private $order_item_table_name;
 
 	/**
-	 * The table in the database.
+	 * The table name.
 	 *
 	 * @access public
 	 *
@@ -69,6 +69,40 @@ class WooCommerce extends Module {
 	 */
 	public function table_name() {
 		return $this->order_item_table_name;
+	}
+
+	/**
+	 * The table in the database. This can be overridden to allow tables not present in the $wpdb global.
+	 *
+	 * @access public
+	 *
+	 * @return string|bool
+	 */
+	public function table() {
+		global $wpdb;
+		return $wpdb->prefix . 'woocommerce_order_items';
+	}
+
+	/**
+	 * The id field in the database.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
+	public function id_field() {
+		return 'order_item_id';
+	}
+
+	/**
+	 * The full sync action name for this module.
+	 *
+	 * @access public
+	 *
+	 * @return string
+	 */
+	public function full_sync_action_name() {
+		return 'jetpack_full_sync_woocommerce_order_items';
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/vulcan/issues/491

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes in the `module` class so that the `table` method is used when building the queries. This allows modules which tables are not present in the `$wpdb` object like the ones for woocommerce to override the value by using the prefix instead.
* Also extracted the full_sync_action_name so modules can override it and the actions are not fixed to the module name.
* Added default sync limits for woocommerce module

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Added steps for testing in the task https://github.com/Automattic/vulcan/issues/491#issuecomment-2331894471
