### PR TITLE
Admin bar: use user language even on frontend screens

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/frontend-user-language
+++ b/projects/packages/jetpack-mu-wpcom/changelog/frontend-user-language
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin bar: always use user language even on frontend screens

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -109,6 +109,29 @@ add_action( 'wp_enqueue_scripts', 'wpcom_enqueue_admin_bar_assets' );
 add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_admin_bar_assets' );
 
 /**
+ * Render the admin bar in user locale even on frontend screens.
+ */
+function wpcom_always_use_user_locale() {
+	if ( is_admin() || ! is_admin_bar_showing() ) {
+		return;
+	}
+
+	$site_locale = get_locale();
+	$user_locale = get_user_locale();
+
+	if ( $site_locale !== $user_locale ) {
+		switch_to_locale( $user_locale );
+		add_action(
+			'wp_after_admin_bar_render',
+			function () use ( $site_locale ) {
+				switch_to_locale( $site_locale );
+			}
+		);
+	}
+}
+add_action( 'admin_bar_menu', 'wpcom_always_use_user_locale', -1 );
+
+/**
  * Replaces the WP logo as a link to /sites.
  *
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/dotcom-forge/issues/8723

## Proposed changes:

In Core, the site frontend screens will show the admin bar using the site's language. However, for Dotcom users, this behavior could be confusing. This is because we are using a single user language setting (set at /me/account) for various related screens, such as global Calypso view, notifications, help center, etc., and even the admin screens. See the linked issue above for more  details.

This PR overrides the logic so that for site frontend screens, the admin bar also uses the same user language, not site language.

**Before** (site language set to Japanese)

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/82a9ffd5-336e-4545-a94a-c919fc88d9a8">

**After**

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/9363a469-2b0a-4217-bf59-6782196694f4">

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test on both Simple and Atomic sites:

1. Set your user language at /me/account.
2. Set a different site language at Settings -> General.
3. Go to the site frontend.
4. Verify that the admin bar now uses the user language, not the site language.

