### PR TITLE
Protect WAF: Ensure request body is parsed correctly

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-request-post-data
+++ b/projects/packages/waf/changelog/fix-waf-request-post-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Waf: Ensure that request body is parsed correctly

--- a/projects/packages/waf/src/class-waf-request.php
+++ b/projects/packages/waf/src/class-waf-request.php
@@ -342,7 +342,7 @@ class Waf_Request {
 			// Attempt to decode JSON requests.
 			$decoded_json = json_decode( $this->get_body(), true ) ?? array();
 			return flatten_array( $decoded_json, 'json', true );
-		} elseif ( 'application/x-www-form-urlencoded' === $content_type ) {
+		} elseif ( strpos( $content_type, 'application/x-www-form-urlencoded' ) !== false ) {
 			// Attempt to decode url-encoded data
 			parse_str( $this->get_body(), $params );
 			return flatten_array( $params );

--- a/projects/packages/waf/src/class-waf-request.php
+++ b/projects/packages/waf/src/class-waf-request.php
@@ -334,17 +334,21 @@ class Waf_Request {
 	 * @return array{string, scalar}[]
 	 */
 	public function get_post_vars() {
+		$content_type = $this->get_header( 'content-type' );
 		if ( ! empty( $_POST ) ) {
+			// If $_POST is populated, use it.
 			return flatten_array( $_POST );
-		} elseif ( strpos( $this->get_header( 'content-type' ), 'application/json' ) !== false ) {
+		} elseif ( strpos( $content_type, 'application/json' ) !== false ) {
 			// Attempt to decode JSON requests.
 			$decoded_json = json_decode( $this->get_body(), true ) ?? array();
 			return flatten_array( $decoded_json, 'json', true );
-		} else {
-			// Attempt to retrieve all parameters when method used isn't POST
-			$body = $this->get_body();
-			parse_str( $body, $params );
+		} elseif ( 'application/x-www-form-urlencoded' === $content_type || '' === $content_type ) {
+			// Attempt to decode url-encoded data
+			parse_str( $this->get_body(), $params );
 			return flatten_array( $params );
+		} else {
+			// Don't try to parse any other content types
+			return array();
 		}
 	}
 

--- a/projects/packages/waf/src/class-waf-request.php
+++ b/projects/packages/waf/src/class-waf-request.php
@@ -342,7 +342,7 @@ class Waf_Request {
 			// Attempt to decode JSON requests.
 			$decoded_json = json_decode( $this->get_body(), true ) ?? array();
 			return flatten_array( $decoded_json, 'json', true );
-		} elseif ( 'application/x-www-form-urlencoded' === $content_type || '' === $content_type ) {
+		} elseif ( 'application/x-www-form-urlencoded' === $content_type ) {
 			// Attempt to decode url-encoded data
 			parse_str( $this->get_body(), $params );
 			return flatten_array( $params );

--- a/projects/packages/waf/tests/php/unit/test-waf-request.php
+++ b/projects/packages/waf/tests/php/unit/test-waf-request.php
@@ -302,7 +302,7 @@ class WafRequestTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	 * Test that the Waf_Request class returns $_POST data correctly decoded from JSON via Waf_Request::get_post_vars().
+	 * Test that the Waf_Request class returns POST-ed data correctly decoded from JSON via Waf_Request::get_post_vars().
 	 */
 	public function testGetVarsPostWithJson() {
 		$_SERVER['CONTENT_TYPE'] = 'application/json';
@@ -330,9 +330,22 @@ class WafRequestTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * Test that the Waf_Request class returns POST data correctly when the content is XML
+	 */
+	public function testGetVarsPostWithXml() {
+		$_SERVER['CONTENT_TYPE'] = 'text/xml';
+		$request                 = $this->mock_request(
+			array(
+				'body' => '<?xml version="1.0"?><methodCall><methodName>methodName</methodName><params><param><value><string>AB</string></value></param></params></methodCall>',
+			)
+		);
+		$this->assertEmpty( $request->get_post_vars() );
+	}
+
+	/**
 	 * Test that the Waf_Request class returns any parameters when HTTP method isn't POST.
 	 */
-	public function testGetVarsPostHttpMethodNotPost() {
+	public function testGetVarsPostWithUrlEncoded() {
 		$_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
 		$request                 = $this->mock_request(
 			array(


### PR DESCRIPTION
## Proposed changes:
* Improve how the WAF parses the request body for rules

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pdMJwJ-2wb-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Verify that WAF no longer incorrectly blocks requests such as XMLRPC
* Verify that WAF still block "malicious" requests as expected
