### PR TITLE
Add wp-downgrade to incompatible plugins in wpcomsh

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-wp-downgrade-to-incompatible-plugins-in-wpcomsh
+++ b/projects/plugins/wpcomsh/changelog/add-wp-downgrade-to-incompatible-plugins-in-wpcomsh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Added wp-downgrade to the incompatible list

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -57,6 +57,7 @@ class Jetpack_Plugin_Compatibility {
 		'wpmu-database-reset/wpmu-database-reset.php'      => '"wpmu-database-reset" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'wps-hide-login/wps-hide-login.php'                => '"wps-hide-login" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'z-inventory-manager/z-inventory-manager.php'      => '"z-inventory-manager" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
+		'wp-downgrade/wp-downgrade.php' 	           => '"wp-downgrade" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 
 		// Backup.
 		'backup-wd/backup-wd.php'                          => '"backup-wd" has been deactivated, WordPress.com handles managing your site backups for you.',

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -57,7 +57,7 @@ class Jetpack_Plugin_Compatibility {
 		'wpmu-database-reset/wpmu-database-reset.php'      => '"wpmu-database-reset" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'wps-hide-login/wps-hide-login.php'                => '"wps-hide-login" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'z-inventory-manager/z-inventory-manager.php'      => '"z-inventory-manager" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
-		'wp-downgrade/wp-downgrade.php' 	           => '"wp-downgrade" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
+		'wp-downgrade/wp-downgrade.php'                    => '"wp-downgrade" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 
 		// Backup.
 		'backup-wd/backup-wd.php'                          => '"backup-wd" has been deactivated, WordPress.com handles managing your site backups for you.',


### PR DESCRIPTION
Adding WP Downgrade (wp-downgrade) to incompatible plugins list in wpcomsh.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wpcomsh/issues/1920

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add wp-downgrade (aka WP Downgrade) to the list of incompatible plugins since it's mentioned publicly https://wordpress.com/support/plugins/incompatible-plugins/#database-file-system-altering-plugins

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

I discovered this plugin was active on a p1725456316432119-slack-CEYCDRUL9.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the steps to test this branch (should be a comment posted by the bot below)
* On your WoA dev site, install `wp-downgrade` by running `wp plugin install wp-downgrade --activate`
* Navigate to the WoA dev site's `/wp-admin/plugins.php` page and confirm that the WP Downgrade is disabled.