### PR TITLE
Connection: Keep onboarding and edit_links_calypso_redirect around for some time to prevent warnings

### DIFF
--- a/projects/packages/connection/changelog/update-keep-deprecated-options-to-avoid-warnings
+++ b/projects/packages/connection/changelog/update-keep-deprecated-options-to-avoid-warnings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reintroduced onboarding and edit_links_calypso_redirect options to avoid warnings with plugins using the old version of the connection package'

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -71,6 +71,7 @@ class Jetpack_Options {
 					'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
 					'xmlrpc_errors',               // (array) Keys are XML-RPC signature error codes. Values are truthy.
 					'dismissed_wizard_banner',     // (int) (DEPRECATED) True if the Wizard banner has been dismissed.
+					'edit_links_calypso_redirect', // (bool) (DEPRECATED) Whether post/page edit links on front end should point to Calypso.
 				);
 
 			case 'private':
@@ -85,6 +86,7 @@ class Jetpack_Options {
 			case 'network':
 				return array(
 					'file_data',                     // (array) List of absolute paths to all Jetpack modules
+					'onboarding',                    // (string) (DEPRECATED) Auth token to be used in the onboarding connection flow
 				);
 		}
 
@@ -128,6 +130,7 @@ class Jetpack_Options {
 			'recommendations_evaluation',          // (object) Catalog of recommended modules with corresponding score following successful site evaluation in Welcome Banner.
 			'dismissed_recommendations',           // (bool) Determines if the recommendations have been dismissed or not.
 			'historically_active_modules',         // (array) List of installed plugins/enabled modules that have at one point in time been active and working
+			'onboarding',                          // (string) (DEPRECATED) Auth token to be used in the onboarding connection flow
 		);
 	}
 


### PR DESCRIPTION
In installations with a recent full release of a standalone and an old Jetpack version, jetpack still tries to access the options, while the newest version of the connection package loaded from the standalone has already deprecated the options

See https://wordpress.org/support/topic/jetpack-protect-crushed-my-website/

Caused by https://github.com/Automattic/jetpack/pull/39171, https://github.com/Automattic/jetpack/pull/39229/commits/4f919bd228b580aa80f112df990d74bb0ca39cf3,  and https://github.com/Automattic/jetpack/pull/39229/commits/7258afbb40088e2aa9958a7e33faba69e930c0f1

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

**NOTE::** This won't help with sites logging the warnings to the frontend and getting a deprecation notice for a function that was properly deprecated

> PHP Deprecated: Function is_onboarding is deprecated since version 4.0.0 with no alternative available

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://wordpress.org/support/topic/jetpack-protect-crushed-my-website

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

