### PR TITLE
Options: Do not throw warning if a Jetpack Option is not available

### DIFF
--- a/projects/packages/connection/changelog/update-do-not-show-warning-if-jetpack-option-is-not-available
+++ b/projects/packages/connection/changelog/update-do-not-show-warning-if-jetpack-option-is-not-available
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed throwing of warning if a given Jetpack options does not exist

--- a/projects/packages/connection/legacy/class-jetpack-options.php
+++ b/projects/packages/connection/legacy/class-jetpack-options.php
@@ -228,8 +228,6 @@ class Jetpack_Options {
 			}
 		}
 
-		trigger_error( sprintf( 'Invalid Jetpack option name: %s', esc_html( $name ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Don't wish to change legacy behavior.
-
 		return $default;
 	}
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://wordpress.org/support/topic/jetpack-protect-crushed-my-website/

Follow-up to #39229 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

But see https://wordpress.org/support/topic/jetpack-protect-crushed-my-website/

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

