### PR TITLE
Status Do not use _deprecated_function when deprecating is_onboarding

### DIFF
--- a/projects/packages/status/changelog/update-remove_call_to__deprecated_function-in-Status-is_onboarding
+++ b/projects/packages/status/changelog/update-remove_call_to__deprecated_function-in-Status-is_onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Removed usage of _deprecated_function when deprecating Status::is_onboarding

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -334,7 +334,6 @@ class Status {
 	 * @return bool True if the site is currently onboarding, false otherwise
 	 */
 	public function is_onboarding() {
-		_deprecated_function( __FUNCTION__, '4.0.0' );
 		return \Jetpack_Options::get_option( 'onboarding' ) !== false;
 	}
 


### PR DESCRIPTION
Deprecation of this method got noisy when two different Jetpack plugins are present, and one of them was released this week after https://github.com/Automattic/jetpack/pull/39229/commits/4f919bd228b580aa80f112df990d74bb0ca39cf3 got merged and some plugins were released.

Follow-up to #39229 

See https://wordpress.org/support/topic/jetpack-protect-crushed-my-website/#post-17999102


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes call to _deprecated_function

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

[None](https://wordpress.org/support/topic/jetpack-protect-crushed-my-website/#post-17999102)

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

