### PR TITLE
My Jetpack: remove typed parameter on Jetpack AI create post link

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-ai-use-block-default-content-filter
+++ b/projects/packages/my-jetpack/changelog/fix-ai-use-block-default-content-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack AI: fix default_content filter so it doesn't enforce parameter type

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -648,9 +648,11 @@ class Jetpack_Ai extends Product {
 	 * @param WP_Post $post The post object.
 	 * @return string
 	 */
-	public static function add_ai_block( $content, WP_Post $post ) {
+	public static function add_ai_block( $content, $post ) {
 		if ( isset( $_GET['use_ai_block'] ) && isset( $_GET['_wpnonce'] )
 			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'ai-assistant-content-nonce' )
+			&& ! empty( $post )
+			&& ! is_wp_error( $post )
 			&& current_user_can( 'edit_post', $post->ID )
 			&& '' === $content
 		) {


### PR DESCRIPTION
## Proposed changes:
Remove type from second parameter on `default_content` filter handler. As seen p1725517940291129-slack-C054LN8RNVA it might cause fatals and we can double check on filter conditions before attempting a read on the object.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1725517940291129-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Before applying the PR:

- use `jetpack docker tail` to keep an eye on your logs
- tamper with post class (`wp-admin/includes/post.php`, line 808) so it calls the filter with `null` as a third argument
- go to Jetpack AI product page at `wp-admin/admin.php?page=my-jetpack#/jetpack-ai`, use the second entry link to "Create new post"
- [ ] see the fatal on the logs (or even on the screen, depending on your setup)

- apply the PR and reload the editor
- [ ] you should see the editor with an empty post

- re-instate the `$post` argument on post.php and reload the page once more
- [ ] see the editor loads and has an AI Assistant block in it