### PR TITLE
Revert "Disable terser conditional optimization"

### DIFF
--- a/projects/js-packages/i18n-check-webpack-plugin/README.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/README.md
@@ -102,6 +102,37 @@ Instead put it inside the property:
 />
 ```
 
+### Conditional function call compaction
+
+When a conditional calls the same function in each branch with only one argument different, Terser will transform it to a single call with the condition inside the argument. For example, either of these
+```js
+example = flag ? __( 'Flag is set', 'domain' ) : __( 'Flag is not set', 'domain' );
+```
+```js
+if ( flag ) {
+	example = __( 'Flag is set', 'domain' );
+} else {
+	example = __( 'Flag is not set', 'domain' );
+}
+```
+will become
+```js
+example = __( flag ? 'Flag is set' : 'Flag is not set', 'domain' );
+```
+which will result in neither string being detected for translation.
+
+You can fix this by making the calls less similar, for example by adding a dummy argument to one call
+```js
+example = flag ? __( 'Flag is set', 'domain' ) : __( 'Flag is not set', 'domain', /* dummy arg to avoid bad minification */ 0 );
+```
+or by specifying an unnecessary context in one call (or a different context in both)
+```js
+example = flag ? __( 'Flag is set', 'domain' ) : _x( 'Flag is not set', '', 'domain' );
+```
+```js
+example = flag ? _x( 'Flag is set', 'Something', 'domain' ) : _x( 'Flag is not set', 'Something different', 'domain' );
+```
+
 ### Pruned branches and common strings
 
 In some cases, such as when `process.env.NODE_ENV` is tested or when ES module tree-shaking is done, code paths can be known to be unreachable. For example, only one branch in the following will be kept:

--- a/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-etk-translation-issues
+++ b/projects/js-packages/i18n-check-webpack-plugin/changelog/fix-etk-translation-issues
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Updated tests now that Terser's conditionals' optimization is disabled

--- a/projects/js-packages/i18n-check-webpack-plugin/tests/__snapshots__/build.test.js.snap
+++ b/projects/js-packages/i18n-check-webpack-plugin/tests/__snapshots__/build.test.js.snap
@@ -103,12 +103,20 @@ exports[`Webpack \`known-problems\`: Webpack build stats 1`] = `
 {
   "errors": [
     {
+      "message": "main.js:3:148: msgid argument is not a string literal: __(o?"Foo is set":"Foo is not set","domain")",
+    },
+    {
       "message": "main.js: Translator comments have gone missing for "The comment will be lost when the assignment is merged into the above const" (context "context")
  - Translators: This comment will be lost",
     },
     {
       "message": "main.js: Translator comments have gone missing for "This is another workaround" (context "context")
  - Translators: This comment will be in the source but not detected for the right message.",
+    },
+    {
+      "message": "main.js: Optimization seems to have broken the following translation strings:
+ - "Foo is not set"
+ - "Foo is set"",
     },
   ],
   "warnings": [],
@@ -157,32 +165,245 @@ exports[`Webpack \`options-filter\`: Webpack build stats 1`] = `
 {
   "children": [
     {
-      "errors": [],
+      "errors": [
+        {
+          "message": "string/main.js:1:76: msgid argument is not a string literal: __(t?"arr is set":"arr is not set","domain")",
+        },
+        {
+          "message": "string/main.js:1:186: msgid argument is not a string literal: __(t?"func is set":"func is not set","domain")",
+        },
+        {
+          "message": "string/main.js:1:374: msgid argument is not a string literal: __(t?"regex is set":"regex is not set","domain")",
+        },
+        {
+          "message": "string/main.js:1:488: msgid argument is not a string literal: __(t?"string is set":"string is not set","domain")",
+        },
+        {
+          "message": "string/main.js: Optimization seems to have broken the following translation strings:
+ - "string is not set"
+ - "string is set"",
+        },
+      ],
       "name": "string",
       "warnings": [],
     },
     {
-      "errors": [],
+      "errors": [
+        {
+          "message": "regex/main.js:1:76: msgid argument is not a string literal: __(t?"arr is set":"arr is not set","domain")",
+        },
+        {
+          "message": "regex/main.js:1:186: msgid argument is not a string literal: __(t?"func is set":"func is not set","domain")",
+        },
+        {
+          "message": "regex/main.js:1:374: msgid argument is not a string literal: __(t?"regex is set":"regex is not set","domain")",
+        },
+        {
+          "message": "regex/main.js:1:488: msgid argument is not a string literal: __(t?"string is set":"string is not set","domain")",
+        },
+        {
+          "message": "regex/main.js: Optimization seems to have broken the following translation strings:
+ - "regex is not set"
+ - "regex is set"",
+        },
+      ],
       "name": "regex",
       "warnings": [],
     },
     {
-      "errors": [],
+      "errors": [
+        {
+          "message": "function/main.js:1:76: msgid argument is not a string literal: __(t?"arr is set":"arr is not set","domain")",
+        },
+        {
+          "message": "function/main.js:1:186: msgid argument is not a string literal: __(t?"func is set":"func is not set","domain")",
+        },
+        {
+          "message": "function/main.js:1:374: msgid argument is not a string literal: __(t?"regex is set":"regex is not set","domain")",
+        },
+        {
+          "message": "function/main.js:1:488: msgid argument is not a string literal: __(t?"string is set":"string is not set","domain")",
+        },
+        {
+          "message": "function/main.js: Optimization seems to have broken the following translation strings:
+ - "func is not set"
+ - "func is set"",
+        },
+      ],
       "name": "function",
       "warnings": [],
     },
     {
-      "errors": [],
+      "errors": [
+        {
+          "message": "array/main.js:1:76: msgid argument is not a string literal: __(t?"arr is set":"arr is not set","domain")",
+        },
+        {
+          "message": "array/main.js:1:186: msgid argument is not a string literal: __(t?"func is set":"func is not set","domain")",
+        },
+        {
+          "message": "array/main.js:1:374: msgid argument is not a string literal: __(t?"regex is set":"regex is not set","domain")",
+        },
+        {
+          "message": "array/main.js:1:488: msgid argument is not a string literal: __(t?"string is set":"string is not set","domain")",
+        },
+        {
+          "message": "array/main.js: Optimization seems to have broken the following translation strings:
+ - "arr is not set"
+ - "arr is set"",
+        },
+      ],
       "name": "array",
       "warnings": [],
     },
     {
-      "errors": [],
+      "errors": [
+        {
+          "message": "undefined/main.js:1:76: msgid argument is not a string literal: __(t?"arr is set":"arr is not set","domain")",
+        },
+        {
+          "message": "undefined/main.js:1:186: msgid argument is not a string literal: __(t?"func is set":"func is not set","domain")",
+        },
+        {
+          "message": "undefined/main.js:1:374: msgid argument is not a string literal: __(t?"regex is set":"regex is not set","domain")",
+        },
+        {
+          "message": "undefined/main.js:1:488: msgid argument is not a string literal: __(t?"string is set":"string is not set","domain")",
+        },
+        {
+          "message": "undefined/main.js: Optimization seems to have broken the following translation strings:
+ - "arr is not set"
+ - "arr is set"
+ - "func is not set"
+ - "func is set"
+ - "regex is not set"
+ - "regex is set"
+ - "string is not set"
+ - "string is set"",
+        },
+      ],
       "name": "undefined",
       "warnings": [],
     },
   ],
-  "errors": [],
+  "errors": [
+    {
+      "compilerPath": "string",
+      "message": "string/main.js:1:76: msgid argument is not a string literal: __(t?"arr is set":"arr is not set","domain")",
+    },
+    {
+      "compilerPath": "string",
+      "message": "string/main.js:1:186: msgid argument is not a string literal: __(t?"func is set":"func is not set","domain")",
+    },
+    {
+      "compilerPath": "string",
+      "message": "string/main.js:1:374: msgid argument is not a string literal: __(t?"regex is set":"regex is not set","domain")",
+    },
+    {
+      "compilerPath": "string",
+      "message": "string/main.js:1:488: msgid argument is not a string literal: __(t?"string is set":"string is not set","domain")",
+    },
+    {
+      "compilerPath": "string",
+      "message": "string/main.js: Optimization seems to have broken the following translation strings:
+ - "string is not set"
+ - "string is set"",
+    },
+    {
+      "compilerPath": "regex",
+      "message": "regex/main.js:1:76: msgid argument is not a string literal: __(t?"arr is set":"arr is not set","domain")",
+    },
+    {
+      "compilerPath": "regex",
+      "message": "regex/main.js:1:186: msgid argument is not a string literal: __(t?"func is set":"func is not set","domain")",
+    },
+    {
+      "compilerPath": "regex",
+      "message": "regex/main.js:1:374: msgid argument is not a string literal: __(t?"regex is set":"regex is not set","domain")",
+    },
+    {
+      "compilerPath": "regex",
+      "message": "regex/main.js:1:488: msgid argument is not a string literal: __(t?"string is set":"string is not set","domain")",
+    },
+    {
+      "compilerPath": "regex",
+      "message": "regex/main.js: Optimization seems to have broken the following translation strings:
+ - "regex is not set"
+ - "regex is set"",
+    },
+    {
+      "compilerPath": "function",
+      "message": "function/main.js:1:76: msgid argument is not a string literal: __(t?"arr is set":"arr is not set","domain")",
+    },
+    {
+      "compilerPath": "function",
+      "message": "function/main.js:1:186: msgid argument is not a string literal: __(t?"func is set":"func is not set","domain")",
+    },
+    {
+      "compilerPath": "function",
+      "message": "function/main.js:1:374: msgid argument is not a string literal: __(t?"regex is set":"regex is not set","domain")",
+    },
+    {
+      "compilerPath": "function",
+      "message": "function/main.js:1:488: msgid argument is not a string literal: __(t?"string is set":"string is not set","domain")",
+    },
+    {
+      "compilerPath": "function",
+      "message": "function/main.js: Optimization seems to have broken the following translation strings:
+ - "func is not set"
+ - "func is set"",
+    },
+    {
+      "compilerPath": "array",
+      "message": "array/main.js:1:76: msgid argument is not a string literal: __(t?"arr is set":"arr is not set","domain")",
+    },
+    {
+      "compilerPath": "array",
+      "message": "array/main.js:1:186: msgid argument is not a string literal: __(t?"func is set":"func is not set","domain")",
+    },
+    {
+      "compilerPath": "array",
+      "message": "array/main.js:1:374: msgid argument is not a string literal: __(t?"regex is set":"regex is not set","domain")",
+    },
+    {
+      "compilerPath": "array",
+      "message": "array/main.js:1:488: msgid argument is not a string literal: __(t?"string is set":"string is not set","domain")",
+    },
+    {
+      "compilerPath": "array",
+      "message": "array/main.js: Optimization seems to have broken the following translation strings:
+ - "arr is not set"
+ - "arr is set"",
+    },
+    {
+      "compilerPath": "undefined",
+      "message": "undefined/main.js:1:76: msgid argument is not a string literal: __(t?"arr is set":"arr is not set","domain")",
+    },
+    {
+      "compilerPath": "undefined",
+      "message": "undefined/main.js:1:186: msgid argument is not a string literal: __(t?"func is set":"func is not set","domain")",
+    },
+    {
+      "compilerPath": "undefined",
+      "message": "undefined/main.js:1:374: msgid argument is not a string literal: __(t?"regex is set":"regex is not set","domain")",
+    },
+    {
+      "compilerPath": "undefined",
+      "message": "undefined/main.js:1:488: msgid argument is not a string literal: __(t?"string is set":"string is not set","domain")",
+    },
+    {
+      "compilerPath": "undefined",
+      "message": "undefined/main.js: Optimization seems to have broken the following translation strings:
+ - "arr is not set"
+ - "arr is set"
+ - "func is not set"
+ - "func is set"
+ - "regex is not set"
+ - "regex is set"
+ - "string is not set"
+ - "string is set"",
+    },
+  ],
   "warnings": [],
 }
 `;
@@ -199,7 +420,16 @@ exports[`Webpack \`options-warnOnly\`: Webpack build files 1`] = `
 exports[`Webpack \`options-warnOnly\`: Webpack build stats 1`] = `
 {
   "errors": [],
-  "warnings": [],
+  "warnings": [
+    {
+      "message": "main.js:1:77: msgid argument is not a string literal: __(t?"X is set":"X is not set","domain")",
+    },
+    {
+      "message": "main.js: Optimization seems to have broken the following translation strings:
+ - "X is not set"
+ - "X is set"",
+    },
+  ],
 }
 `;
 

--- a/projects/js-packages/webpack-config/changelog/fix-etk-translation-issues
+++ b/projects/js-packages/webpack-config/changelog/fix-etk-translation-issues
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Prevents an optimization of conditionals which breaks translatable strings

--- a/projects/js-packages/webpack-config/src/webpack/terser.js
+++ b/projects/js-packages/webpack-config/src/webpack/terser.js
@@ -59,9 +59,6 @@ const defaultOptions = {
 				`${ isTranslatorsComment }; return isTranslatorsComment( comment )`
 			),
 		},
-		compress: {
-			conditionals: false,
-		},
 	},
 	// Same.
 	extractComments: new Function(


### PR DESCRIPTION
This should not have been merged without review and discussion.

Even if we did decide to do this, we shouldn't have removed the documentation of the workaround from i18n-check-webpack-plugin; that's a publicly published package, not something a8c-internal.

Reverts Automattic/jetpack#39279