### PR TITLE
Jetpack AI: Add fair usage link to interstitial on My Jetpack

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import { useCallback } from 'react';
@@ -24,6 +25,8 @@ export default function JetpackAiInterstitial() {
 	const { detail } = useProduct( slug );
 	debug( detail );
 
+	const tierPlansEnabled = detail?.aiAssistantFeature?.tierPlansEnabled || false;
+
 	const { userConnectionData } = useMyJetpackConnection();
 	const { currentUser } = userConnectionData;
 	const { wpcomUser } = currentUser;
@@ -39,6 +42,22 @@ export default function JetpackAiInterstitial() {
 		[ userOptKey ]
 	);
 
+	const fairUsageSupportingInfo = createInterpolateElement(
+		__(
+			'* Limits apply for high request capacity. <link>Learn more about it here</link>.',
+			'jetpack-my-jetpack'
+		),
+		{
+			link: (
+				<a
+					href="https://jetpack.com/redirect/?source=ai-assistant-fair-usage-policy"
+					target="_blank"
+					rel="noreferrer"
+				/>
+			),
+		}
+	);
+
 	return (
 		<ProductInterstitial
 			slug="jetpack-ai"
@@ -48,6 +67,7 @@ export default function JetpackAiInterstitial() {
 			directCheckout={ false }
 			ctaCallback={ ctaClickHandler }
 			ctaButtonLabel={ __( 'Upgrade', 'jetpack-my-jetpack' ) }
+			supportingInfo={ ! tierPlansEnabled ? fairUsageSupportingInfo : null }
 		>
 			<img src={ jetpackAiImage } alt="Jetpack AI" />
 		</ProductInterstitial>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/index.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Button } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
@@ -49,10 +50,12 @@ export default function JetpackAiInterstitial() {
 		),
 		{
 			link: (
-				<a
+				<Button
 					href="https://jetpack.com/redirect/?source=ai-assistant-fair-usage-policy"
+					variant="link"
+					weight="regular"
+					size="small"
 					target="_blank"
-					rel="noreferrer"
 				/>
 			),
 		}

--- a/projects/packages/my-jetpack/changelog/update-jetpack-ai-add-fair-usage-link-to-interstitial
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-ai-add-fair-usage-link-to-interstitial
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Jetpack AI: add fair usage policy link to the Jetpack AI product interstitial.

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -272,6 +272,7 @@ class Jetpack_Ai extends Product {
 		}
 
 		$features = array(
+			__( 'High request capacity *', 'jetpack-my-jetpack' ),
 			__( 'Generate text, tables, lists, and forms', 'jetpack-my-jetpack' ),
 			__( 'Easily refine content to your liking', 'jetpack-my-jetpack' ),
 			__( 'Make your content easier to read', 'jetpack-my-jetpack' ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Include the fair usage policy link to the Jetpack AI product interstitial page
* The wording was copied from https://jetpack.com/ai/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run this branch on a site with a free Jetpack AI plan (a fresh JN will do)
* Go to My Jetpack, look for the AI card and click the upgrade button on it
* On the product interstitial page that will open:
   * confirm `High request capacity *` is listed as a feature of the product
   * confirm a disclaimer is showed below the Upgrade button, saying that limits may apply and linking to the fair usage policy page
   * confirm the link uses the `ai-assistant-fair-usage-policy` Jetpack redirect
   * confirm you will land on the `https://jetpack.com/support/create-better-content-with-jetpack-ai/#jetpack-ai-usage-limit` page when clicking it

<img width="600" alt="Screenshot 2024-09-06 at 17 54 10" src="https://github.com/user-attachments/assets/734015f7-0ad5-4da6-85a6-a3e23848b2a0">