### PR TITLE
Write Brief: Fix highlight position on spelling mistake following ignored special word

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-spelling-mistake-position
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-spelling-mistake-position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Write Brief: Fix highlight position on spelling mistake following ignored special word

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -184,28 +184,31 @@ export default function spellingMistakes( text: string ): Array< HighlightedText
 	// \p{L} is a Unicode property that matches any letter in any language
 	// \p{M} is a Unicode property that matches any character intended to be combined with another character
 	const wordRegex = new RegExp( /[@#+$]{0,1}[\p{L}\p{M}'-]+/gu );
-	const words = ( text.match( wordRegex ) || [] )
-		// Filter out words that start with special characters
-		.filter( word => [ '@', '#', '+', '$', '/' ].indexOf( word[ 0 ] ) === -1 )
-		// Split hyphenated words into separate words as nspell doesn't work well with them
-		.map( word => word.split( '-' ) )
-		.flat();
+	const matches = Array.from( text.matchAll( wordRegex ) );
 
-	// To avoid highlighting the same word occurrence multiple times
-	let searchStartIndex = 0;
+	matches.forEach( match => {
+		const word = match[ 0 ];
+		const startIndex = match.index as number;
 
-	words.forEach( ( word: string ) => {
-		const wordIndex = text.indexOf( word, searchStartIndex );
-
-		if ( ! spellChecker.correct( word ) ) {
-			highlightedTexts.push( {
-				text: word,
-				startIndex: wordIndex,
-				endIndex: wordIndex + word.length,
-			} );
+		// Skip words that start with special characters
+		if ( [ '@', '#', '+', '$', '/' ].indexOf( word[ 0 ] ) !== -1 ) {
+			return;
 		}
 
-		searchStartIndex = wordIndex + word.length;
+		// Split hyphenated words into separate words as nspell doesn't work well with them
+		const subWords = word.split( '-' );
+
+		subWords.forEach( ( subWord, index ) => {
+			if ( ! spellChecker.correct( subWord ) ) {
+				const subWordStartIndex = startIndex + ( index > 0 ? word.indexOf( subWord ) : 0 );
+
+				highlightedTexts.push( {
+					text: subWord,
+					startIndex: subWordStartIndex,
+					endIndex: subWordStartIndex + subWord.length,
+				} );
+			}
+		} );
 	} );
 
 	return highlightedTexts;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -183,10 +183,10 @@ export default function spellingMistakes( text: string ): Array< HighlightedText
 	// Regex to match words, including contractions and hyphenated words, possibly prefixed with special characters
 	// \p{L} is a Unicode property that matches any letter in any language
 	// \p{M} is a Unicode property that matches any character intended to be combined with another character
-	const wordRegex = new RegExp( /[@#+$]{0,1}[\p{L}\p{M}'-]+/, 'gu' );
+	const wordRegex = new RegExp( /[@#+$]{0,1}[\p{L}\p{M}'-]+/gu );
 	const words = ( text.match( wordRegex ) || [] )
 		// Filter out words that start with special characters
-		.filter( word => [ '@', '#', '+', '$' ].indexOf( word[ 0 ] ) === -1 )
+		.filter( word => [ '@', '#', '+', '$', '/' ].indexOf( word[ 0 ] ) === -1 )
 		// Split hyphenated words into separate words as nspell doesn't work well with them
 		.map( word => word.split( '-' ) )
 		.flat();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39211 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `/` to the special symbols for spelling mistakes, so adding a block with `/` does not trigger a spelling mistake highlight
* Fixes the start and end index of a highlighted word to count words starting with a special character

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor and add word that triggers the spelling mistake highlight
* Copy the same word twice and add a special character to the start of the middle one (@, #, +. $ or /), like in the screenshots below (using a word that has a fix, like "lik")
* Check that the words without the special characters are highlighted, and the one without it is not
* Check that accepting a suggestion fixes the right occurrence of the word

| Before | After
| - | -
| ![2024-09-06_19-50-37](https://github.com/user-attachments/assets/a8e5e3dc-6640-41cd-9461-8110a435352b) | ![2024-09-06_19-50-09](https://github.com/user-attachments/assets/e4d46ee9-deac-4d04-bef3-f1366c2be243)
