### PR TITLE
Jetpack: fix the 'invalid date' error on new site stats

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -70,9 +70,11 @@ class DashStatsBottom extends Component {
 										numberFormat( s.bestDay.count )
 								  ) }
 						</h3>
-						<p className="jp-at-a-glance__stat-details">
-							{ '-' === s.bestDay.day ? '-' : dateI18n( this.props.dateFormat, s.bestDay.day ) }
-						</p>
+						{ s.bestDay.day && (
+							<p className="jp-at-a-glance__stat-details">
+								{ '-' === s.bestDay.day ? '-' : dateI18n( this.props.dateFormat, s.bestDay.day ) }
+							</p>
+						) }
 					</div>
 					<div className="jp-at-a-glance__stats-summary-alltime-views">
 						<p className="jp-at-a-glance__stat-details">

--- a/projects/plugins/jetpack/changelog/fix-stats-best-day-new-site
+++ b/projects/plugins/jetpack/changelog/fix-stats-best-day-new-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix the 'invalid date' error on new site stats.


### PR DESCRIPTION
New Jetpack sites don't have any stats, so Jetpack Dashboard displays zeroes for "Best overall days".
Jetpack tries to parse an empty string as a date and fails, showing the "invalid date" message.

## Proposed changes:
- Hide the "Best overall day" date until we have something to show instead of displaying "invalid date".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect new Jetpack site with no stats.
2. Go to Jetpack Dashboard, see the "Best overall day" block in the bottom of the "Jetpack Stats" module.
3. Confirm the date for that block doesn't show up wile the number of views is 0.
4. Visit the site a few times, wait a couple of minutes until the number of views increases. Confirm the date now shows up correctly. Or just try the PR on an older site that already has some data, confirm the date shows up.

### Before
<img width="224" alt="Screenshot 2024-09-06 at 20 01 48" src="https://github.com/user-attachments/assets/95087454-fa4b-45ef-932d-f96db3ad89b4">

### After
<img width="224" alt="Screenshot 2024-09-06 at 20 00 17" src="https://github.com/user-attachments/assets/eb056af7-5e67-4a2a-b5f4-38d26b7bbc2c">
<img width="209" alt="Screenshot 2024-09-06 at 19 59 56" src="https://github.com/user-attachments/assets/a4fa139b-93f9-4a03-bada-328fbae34152">
