### PR TITLE
Stats: Add Stats user feedback endpoint proxy

### DIFF
--- a/projects/packages/stats-admin/changelog/update-add_stats_user_feedback_endpoint_proxy
+++ b/projects/packages/stats-admin/changelog/update-add_stats_user_feedback_endpoint_proxy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Create the user feedback endpoint proxy with a user login status check.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -714,11 +714,7 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function post_user_feedback( $req ) {
-		$current_user = wp_get_current_user();
-		if ( ! $current_user ) {
-			return $this->get_forbidden_error();
-		}
-
+		$current_user  = wp_get_current_user();
 		$body_from_req = json_decode( $req->get_body(), true );
 		$body_data     = is_array( $body_from_req ) ? $body_from_req : array();
 		$user_email    = $current_user->user_email;

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -724,7 +724,9 @@ class REST_Controller {
 			$sent_by_text = '<br />' . esc_html__( 'Sent by an unverified visitor to your site.', 'jetpack-stats-admin' ) . '<br />';
 		}
 
-		$body_data = json_decode( $req->get_body(), true );
+		$body_from_req  = json_decode( $req->get_body(), true );
+		$body_data      = is_array( $body_from_req ) ? $body_from_req : array();
+		$passed_content = isset( $body_data['feedback'] ) ? $body_data['feedback'] : '';
 
 		return WPCOM_Client::request_as_blog_cached(
 			sprintf(
@@ -744,7 +746,7 @@ class REST_Controller {
 				array_merge(
 					$body_data,
 					array(
-						'feedback' => $body_data['feedback'] . $sent_by_text,
+						'feedback' => $passed_content . $sent_by_text,
 					)
 				)
 			),

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -714,19 +714,14 @@ class REST_Controller {
 	 * @return array
 	 */
 	public function post_user_feedback( $req ) {
-		if ( is_user_logged_in() ) {
-			$sent_by_text = sprintf(
-				// translators: the name of the site.
-				'<br />' . esc_html__( 'Sent by a verified %s user.', 'jetpack-stats-admin' ) . '<br />',
-				isset( $GLOBALS['current_site']->site_name ) && $GLOBALS['current_site']->site_name ? $GLOBALS['current_site']->site_name : '"' . get_option( 'blogname' ) . '"'
-			);
-		} else {
-			$sent_by_text = '<br />' . esc_html__( 'Sent by an unverified visitor to your site.', 'jetpack-stats-admin' ) . '<br />';
+		$current_user = wp_get_current_user();
+		if ( ! $current_user ) {
+			return $this->get_forbidden_error();
 		}
 
-		$body_from_req  = json_decode( $req->get_body(), true );
-		$body_data      = is_array( $body_from_req ) ? $body_from_req : array();
-		$passed_content = isset( $body_data['feedback'] ) ? $body_data['feedback'] : '';
+		$body_from_req = json_decode( $req->get_body(), true );
+		$body_data     = is_array( $body_from_req ) ? $body_from_req : array();
+		$user_email    = $current_user->user_email;
 
 		return WPCOM_Client::request_as_blog_cached(
 			sprintf(
@@ -746,7 +741,7 @@ class REST_Controller {
 				array_merge(
 					$body_data,
 					array(
-						'feedback' => $passed_content . $sent_by_text,
+						'user_email' => $user_email,
 					)
 				)
 			),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/red-team/issues/157.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Proxy the feedback API endpoint `/sites/%d/jetpack-stats/user-feedback` on Jetpack for Odyssey Stats.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

A part of pejTkB-1Ce-p2.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the Diff D160798-code and sandbox the API endpoint by defining the const in `wp-config.php`:
```
define( 'JETPACK__SANDBOX_DOMAIN', 'xxx' );
``` 
* Spin the latest trunk of Calypso Stats on Odyssey Stats: `cd /some-path-to/calypso/apps/odyssey-stats && STATS_PACKAGE_PATH=/some-path-to/jetpack/projects/packages/stats-admin yarn dev`.
* Navigate to Stats > Traffic page with the feature flag: `&flags=stats/user-feedback`.
* Ensure the user feedback floating panel shows.
* Ensure feedback form submission responds successfully for a `testing` status.