### PR TITLE
Admin bar: update 'My Account' link to /me

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/my-account-url
+++ b/projects/packages/jetpack-mu-wpcom/changelog/my-account-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin bar: update 'My Account' link to /me

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -182,7 +182,7 @@ function wpcom_maybe_replace_edit_profile_menu_to_me( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'wpcom_maybe_replace_edit_profile_menu_to_me', 9999 );
 
 /**
- * Adds (Profile) -> My Account menu pointing to /me/account.
+ * Adds (Profile) -> My Account menu pointing to /me.
  *
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
@@ -198,7 +198,7 @@ function wpcom_add_my_account_item_to_profile_menu( $wp_admin_bar ) {
 			'id'     => 'wpcom-profile',
 			'parent' => 'user-actions',
 			'title'  => __( 'My Account', 'jetpack-mu-wpcom' ),
-			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/me/account' ),
+			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/me' ),
 		)
 	);
 


### PR DESCRIPTION
Related to pbxlJb-6it-p2

## Proposed changes:

This PR updates the following admin bar profile menu item "My Account" to point to `/me`.

<img width="704" alt="image" src="https://github.com/user-attachments/assets/bce564a7-25fe-452b-a181-1599be75af35">

Reasons:

1. After pbxlJb-63Y-p2, the "Edit Profile" menu item points to `profile.php` in most cases, making the original `/me` link hidden.
2. `/me` page is the entrypoint of all `/me/*` subpages, so it makes sense to point the link there.


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to any wp-admin page.
2. Verify that the `Howdy` -> `My Account` menu item point to `/me`.