### PR TITLE
Social: Fix issues with share status retry UI and logic

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-share-status-retry
+++ b/projects/js-packages/publicize-components/changelog/fix-social-share-status-retry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed multiple issues in share status retry UI and logic

--- a/projects/js-packages/publicize-components/src/components/share-status/retry.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/retry.tsx
@@ -1,0 +1,76 @@
+import { IconTooltip } from '@automattic/jetpack-components';
+import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { __, _x } from '@wordpress/i18n';
+import { useCallback } from 'react';
+import useSharePost from '../../hooks/use-share-post';
+import { store as socialStore } from '../../social-store';
+import { ShareStatusItem } from '../../social-store/types';
+import { connectionMatchesShareItem } from '../../utils/share-status';
+import styles from './styles.module.scss';
+
+export type RetryProps = {
+	shareItem: ShareStatusItem;
+};
+
+/**
+ * Retry component.
+ *
+ * @param {RetryProps} props - component props
+ *
+ * @return {import('react').ReactNode} - React element
+ */
+export function Retry( { shareItem }: RetryProps ) {
+	// @ts-expect-error -- `@wordpress/editor` is badly typed, causes issue in CI
+	const postId = useSelect( select => select( editorStore ).getCurrentPostId(), [] );
+	const connections = useSelect( select => select( socialStore ).getConnections(), [] );
+
+	const connectionStillExists = connections.some( connectionMatchesShareItem( shareItem ) );
+
+	const { doPublicize } = useSharePost( postId );
+
+	const onRetry = useCallback( async () => {
+		const connectionMatches = connectionMatchesShareItem( shareItem );
+
+		const skippedConnections = connections
+			.filter( connection => ! connectionMatches( connection ) )
+			.map( ( { connection_id } ) => connection_id );
+
+		if ( skippedConnections.length === connections.length ) {
+			// We should ideally never reach this point,
+			// because we disable the retry button if the connection doesn't still exist,
+			// but just in case, if we do, we should return early
+			return;
+		}
+
+		await doPublicize( skippedConnections );
+	}, [ shareItem, connections, doPublicize ] );
+
+	return (
+		<div className={ styles[ 'retry-wrapper' ] }>
+			<Button
+				variant={ connectionStillExists ? 'link' : 'tertiary' }
+				onClick={ connectionStillExists ? onRetry : undefined }
+				disabled={ ! connectionStillExists }
+			>
+				{ __( 'Retry', 'jetpack' ) }
+			</Button>
+			{ ! connectionStillExists ? (
+				<IconTooltip shift placement="bottom-end">
+					{
+						// If we don't have external_id - in case of old share data,
+						// we can't be sure if the connection has been removed or reconnected
+						shareItem.external_id
+							? _x( 'This connection has been removed.', 'Social media connection', 'jetpack' )
+							: _x(
+									'This connection has been reconnected or removed.',
+									'Social media connection',
+									'jetpack'
+							  )
+					}
+				</IconTooltip>
+			) : null }
+		</div>
+	);
+}

--- a/projects/js-packages/publicize-components/src/components/share-status/shares-dataview.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/shares-dataview.tsx
@@ -67,11 +67,7 @@ export function SharesDataView( { postShareStatus }: SharesDataViewProps ) {
 								</td>
 								<td>
 									<div className="dataviews-view-table__cell-content-wrapper">
-										<ShareStatusAction
-											connectionId={ item.connection_id }
-											status={ item.status }
-											shareLink={ 'success' === item.status ? item.message : '' }
-										/>
+										<ShareStatusAction shareItem={ item } />
 									</div>
 								</td>
 							</tr>

--- a/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
@@ -19,22 +19,6 @@
 	min-height: 20rem;
 }
 
-.share-log-list {
-	outline: 1px solid var(--jp-gray-5);
-	border-radius: 4px;
-	margin: 0;
-	width: 100%;
-
-	.share-log-list-item {
-		margin-bottom: 0px;
-		padding: 0.8rem 1rem;
-
-		&:not(:last-child) {
-			border-bottom: 1px solid var(--jp-gray-5);
-		}
-	}
-}
-
 .share-item-name-wrapper {
 	display: flex;
 	flex-direction: column;
@@ -80,15 +64,16 @@
 	fill: var(--jp-green-50);
 }
 
-.disconnected-icon {
-	display: block;
-}
-
 .dataview-wrapper {
 
 	// Hide the table actions
 	:global(.dataviews__view-actions) {
 		display: none;
+	}
+
+	table {
+		// Avoid table shifting when there is tooltip in actions column
+		overflow: hidden;
 	}
 
 	// Make the table header buttons unclickable
@@ -97,12 +82,12 @@
 	}
 
 	// Make the actions column right-aligned
-	:global(.dataviews-view-table__row th:last-child),
-	:global(.dataviews-view-table__row td:last-child) {
-		text-align: end;
-	}
 	:global(.dataviews-view-table__row td:last-child) {
 		width: 1%;
+		// Making its content center-aligned
+		:global(.dataviews-view-table__cell-content-wrapper) {
+			justify-content: center;
+		}
 	}
 
 	.connection-name {
@@ -114,5 +99,24 @@
 	:global(.components-external-link) {
 		color: #2271b1; // $blue-50 from WP common CSS.
 		font-weight: normal;
+	}
+}
+
+.retry-wrapper {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+
+	button {
+		padding: 0;
+	}
+
+	// Fix tooltip icon alignment to center align it
+	:global(.icon-tooltip-wrapper) {
+		display: flex;
+
+		button span {
+			display: flex;
+		}
 	}
 }

--- a/projects/js-packages/publicize-components/src/hooks/use-share-post/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-share-post/index.js
@@ -67,7 +67,7 @@ function getHumanReadableError( result ) {
  * A hook to get the necessary data and callbacks to reshare a post.
  *
  * @param {number} postId - The ID of the post to share.
- * @return { { doPublicize: Function, data: object } } The doPublicize callback to share the post.
+ * @return { { doPublicize: (connectionsToSkip: Array<string>) => Promise<void>, data: object } } The doPublicize callback to share the post.
  */
 export default function useSharePost( postId ) {
 	// Sharing data.

--- a/projects/js-packages/publicize-components/src/social-store/types.ts
+++ b/projects/js-packages/publicize-components/src/social-store/types.ts
@@ -32,10 +32,8 @@ export type JetpackSettings = {
 	showNudge?: boolean;
 };
 
-export type ShareStatusItem = Pick<
-	Connection,
-	'connection_id' | 'profile_link' | 'profile_picture'
-> & {
+export type ShareStatusItem = Pick< Connection, 'profile_link' | 'profile_picture' > & {
+	connection_id: number;
 	status: 'success' | 'failure';
 	message: string;
 	timestamp: number;

--- a/projects/js-packages/publicize-components/src/utils/share-status.ts
+++ b/projects/js-packages/publicize-components/src/utils/share-status.ts
@@ -1,4 +1,4 @@
-import { PostShareStatus } from '../social-store/types';
+import { Connection, PostShareStatus, ShareStatusItem } from '../social-store/types';
 
 /**
  * Normalizes the share status object.
@@ -13,4 +13,28 @@ export function normalizeShareStatus( shareStatus: PostShareStatus ) {
 	}
 
 	return shareStatus;
+}
+
+/**
+ * Check if a connection matches a share item.
+ *
+ * @param {ShareStatusItem} shareItem - The share item to match.
+ *
+ * @return {(connection: Connection) => boolean} - The function to check if a connection matches the share item.
+ */
+export function connectionMatchesShareItem( shareItem: ShareStatusItem ) {
+	return ( connection: Connection ) => {
+		// Let return early if the service name doesn't match
+		if ( connection.service_name !== shareItem.service ) {
+			return false;
+		}
+
+		// external_id may not be present in old data, so we need to check for it
+		if ( shareItem.external_id ) {
+			return connection.external_id === shareItem.external_id;
+		}
+
+		// Fallback to matching by connection_id
+		return connection.connection_id === shareItem.connection_id.toString();
+	};
 }


### PR DESCRIPTION
See this comment https://github.com/Automattic/jetpack/pull/39157#issuecomment-2335109162

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Prefer `external_id` (when available) over `connection_id` when finding the connection for a share status item.
* Disable retry when a connection is removed because we can't retry a removed connection
* Clarify with a tooltip why the retry button is disabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the share status feature - `define( 'JETPACK_SOCIAL_HAS_SHARE_STATUS', true );`
* Goto the post editor for a post which has some shares or reshare posts to create a few entries
* Click on "View share history" in the publicize panel
* Confirm that the share status is shown correctly for successful shares
* Now try a failed share by resharing a post to Instagram without image or SIG.
* Confirm that the failed share shows correctly and there is a retry link which is clickable
* Click on retry to confirm it works as expected
* Run this in the browser console to refetch share status 

   ```js
   wp.data.dispatch( 'jetpack-social-plugin').invalidateResolution( 'getPostShareStatus', [] );
   ```
* Now remove the connection that has a failed share and come back to the share status modal
* Confirm that the retry button for a removed connection is disabled with a tooltip saying `This connection has been removed.`
* Now add the same connection again - which will change the connection_id
* Now confirm that the retry button works again - because of having the same `external_id`
* Now, for old failed shares, try a post that was shared before 3rd September 2024 when D160160-code landed because it won't have `external_id`
* Remove the connection that has failed share.
* Open the share status modal.
* Confirm that retry button is disabled saying that `This connection has been reconnected or removed.`
* Now connect the same account again and open the share status modal
* Confirm that retry button is still disabled saying that `This connection has been reconnected or removed.`
* Confirm that the tracking works fine as per the instruction given in #39198


<table>
    <tbody>
        <tr>
            <th>BEFORE</th>
            <th>AFTER</th>
        </tr>
        <tr>
            <th colspan="2">When the same account is reconnected</th>
        </tr>
        <tr>
            <td>
<img width="946" alt="Screenshot 2024-09-07 at 11 34 19 PM" src="https://github.com/user-attachments/assets/ca8820d0-6c07-49a5-b5b2-498cd8bd70bf">

</td>
            <td>
<img width="891" alt="Screenshot 2024-09-07 at 11 31 39 PM" src="https://github.com/user-attachments/assets/fd78ac82-cb3a-4d14-b65f-d5cf16a05ffa">

</td>
        <tr>
            <th colspan="2">When the account is removed</th>
        </tr>
        <tr>
            <td>
<img width="946" alt="Screenshot 2024-09-07 at 11 34 19 PM" src="https://github.com/user-attachments/assets/e447fa8e-0933-44fb-8ca5-cb837e86fc14">

</td>
            <td>
<img width="928" alt="Screenshot 2024-09-07 at 11 32 24 PM" src="https://github.com/user-attachments/assets/57793876-b50e-4ea3-a00f-40d343a4f534">

</td>
        </tr>
        <tr>
            <th colspan="2">For old shares which don't have <code>external_id</code></th>
        </tr>
        <tr>
            <td>
<img width="915" alt="Screenshot 2024-09-07 at 11 34 04 PM" src="https://github.com/user-attachments/assets/3bd90d80-05be-41b2-9520-3926b7db3c95">

</td>
            <td>
<img width="917" alt="Screenshot 2024-09-07 at 11 31 53 PM" src="https://github.com/user-attachments/assets/5b95abd8-9f94-42ab-b9d6-a21d27375cba">

</td>
        </tr>
    </tbody>
</table>
