### PR TITLE
Social: Add resharing share status

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-social-resharing-share-status
+++ b/projects/js-packages/publicize-components/changelog/add-social-resharing-share-status
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added share status feedback to resharing

--- a/projects/js-packages/publicize-components/src/components/panel/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.jsx
@@ -14,8 +14,8 @@ import { usePostJustPublished } from '../../hooks/use-saving-post';
 import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
 import PublicizeForm from '../form';
 import { ManualSharing } from '../manual-sharing';
+import { ReSharingPanel } from '../resharing-panel';
 import { SharePostRow } from '../share-post';
-import { ShareStatusModalTrigger } from '../share-status';
 import styles from './styles.module.scss';
 import './global.scss';
 
@@ -74,7 +74,7 @@ const PublicizePanel = ( { prePublish, children } ) => {
 			) }
 			{ isPostPublished && (
 				<>
-					<ShareStatusModalTrigger withWrapper analyticsData={ { location: 'editor' } } />
+					<ReSharingPanel />
 					<ManualSharing />
 				</>
 			) }

--- a/projects/js-packages/publicize-components/src/components/panel/index.jsx
+++ b/projects/js-packages/publicize-components/src/components/panel/index.jsx
@@ -12,6 +12,7 @@ import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useRefreshConnections from '../../hooks/use-refresh-connections';
 import { usePostJustPublished } from '../../hooks/use-saving-post';
 import useSelectSocialMediaConnections from '../../hooks/use-social-media-connections';
+import { store as socialStore } from '../../social-store';
 import PublicizeForm from '../form';
 import { ManualSharing } from '../manual-sharing';
 import { ReSharingPanel } from '../resharing-panel';
@@ -22,6 +23,8 @@ import './global.scss';
 const PublicizePanel = ( { prePublish, children } ) => {
 	const { refresh, hasConnections, hasEnabledConnections } = useSelectSocialMediaConnections();
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
+	const featureFlags = useSelect( select => select( socialStore ).featureFlags(), [] );
+
 	const refreshConnections = useRefreshConnections();
 
 	const { isPublicizeEnabled, hidePublicizeFeature, togglePublicizeFeature } = usePublicizeConfig();
@@ -74,7 +77,7 @@ const PublicizePanel = ( { prePublish, children } ) => {
 			) }
 			{ isPostPublished && (
 				<>
-					<ReSharingPanel />
+					{ featureFlags.useShareStatus ? <ReSharingPanel /> : null }
 					<ManualSharing />
 				</>
 			) }

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
@@ -20,7 +20,7 @@ export function ShareStatus( { reShareTimestamp = null }: ShareStatusProps ) {
 	const shareStatus = useSelect( select => select( socialStore ).getPostShareStatus(), [] );
 
 	const currentShares = reShareTimestamp
-		? shareStatus.shares.filter( share => share.timestamp * 1000 > reShareTimestamp )
+		? shareStatus.shares.filter( share => share.timestamp > reShareTimestamp )
 		: shareStatus.shares;
 
 	if ( shareStatus.polling ) {

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
@@ -6,14 +6,22 @@ import Notice from '../notice';
 import { ShareStatusModalTrigger } from '../share-status';
 import styles from './styles.module.scss';
 
+type ShareStatusProps = {
+	reShareTimestamp?: number | null;
+};
+
 /**
  * Share status component.
  *
- *
- * @return {import('react').ReactNode} - Share status UI.
+ * @param {ShareStatusProps} props - component props
+ * @return {import('react').ReactNode} - React element
  */
-export function ShareStatus() {
+export function ShareStatus( { reShareTimestamp = null }: ShareStatusProps ) {
 	const shareStatus = useSelect( select => select( socialStore ).getPostShareStatus(), [] );
+
+	const currentShares = reShareTimestamp
+		? shareStatus.shares.filter( share => share.timestamp * 1000 > reShareTimestamp )
+		: shareStatus.shares;
 
 	if ( shareStatus.polling ) {
 		return (
@@ -26,9 +34,7 @@ export function ShareStatus() {
 		);
 	}
 
-	const numberOfFailedShares = shareStatus.shares.filter(
-		share => share.status === 'failure'
-	).length;
+	const numberOfFailedShares = currentShares.filter( share => share.status === 'failure' ).length;
 
 	if ( numberOfFailedShares > 0 ) {
 		return (
@@ -67,7 +73,7 @@ export function ShareStatus() {
 		);
 	}
 
-	if ( ! shareStatus.shares.length ) {
+	if ( ! currentShares.length ) {
 		// We should ideally never reach here but just in case.
 		return <span>{ __( 'Your post was not shared.', 'jetpack' ) }</span>;
 	}
@@ -81,13 +87,17 @@ export function ShareStatus() {
 					_n(
 						'You post was successfuly shared to %d connection.',
 						'You post was successfuly shared to %d connections.',
-						shareStatus.shares.length,
+						currentShares.length,
 						'jetpack'
 					),
-					shareStatus.shares.length
+					currentShares.length
 				) }
 			</p>
-			<ShareStatusModalTrigger analyticsData={ { location: 'post-publish-panel' } } />
+			<ShareStatusModalTrigger
+				analyticsData={ {
+					location: reShareTimestamp ? 'resharing-section' : 'post-publish-panel',
+				} }
+			/>
 		</>
 	);
 }

--- a/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
+++ b/projects/js-packages/publicize-components/src/components/post-publish-share-status/share-status.tsx
@@ -7,7 +7,7 @@ import { ShareStatusModalTrigger } from '../share-status';
 import styles from './styles.module.scss';
 
 type ShareStatusProps = {
-	reShareTimestamp?: number | null;
+	reShareTimestamp?: number;
 };
 
 /**
@@ -16,7 +16,7 @@ type ShareStatusProps = {
  * @param {ShareStatusProps} props - component props
  * @return {import('react').ReactNode} - React element
  */
-export function ShareStatus( { reShareTimestamp = null }: ShareStatusProps ) {
+export function ShareStatus( { reShareTimestamp }: ShareStatusProps ) {
 	const shareStatus = useSelect( select => select( socialStore ).getPostShareStatus(), [] );
 
 	const currentShares = reShareTimestamp

--- a/projects/js-packages/publicize-components/src/components/resharing-panel/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/resharing-panel/index.tsx
@@ -14,7 +14,7 @@ export const ReSharingPanel = () => {
 	useEffect( () => {
 		if ( shareStatus.polling ) {
 			// Update the timestamp whenever polling becomes true
-			setReShareTimestamp( Date.now() );
+			setReShareTimestamp( Date.now() / 1000 );
 		}
 	}, [ shareStatus.polling ] );
 
@@ -22,15 +22,11 @@ export const ReSharingPanel = () => {
 		return null;
 	}
 
-	return (
-		<>
-			{ reShareTimestamp ? (
-				<div className={ styles.wrapper }>
-					<ShareStatus reShareTimestamp={ reShareTimestamp } />
-				</div>
-			) : (
-				<ShareStatusModalTrigger withWrapper analyticsData={ { location: 'editor' } } />
-			) }
-		</>
+	return reShareTimestamp ? (
+		<div className={ styles.wrapper }>
+			<ShareStatus reShareTimestamp={ reShareTimestamp } />
+		</div>
+	) : (
+		<ShareStatusModalTrigger withWrapper analyticsData={ { location: 'editor' } } />
 	);
 };

--- a/projects/js-packages/publicize-components/src/components/resharing-panel/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/resharing-panel/index.tsx
@@ -6,7 +6,6 @@ import { ShareStatusModalTrigger } from '../share-status';
 import styles from './styles.module.scss';
 
 export const ReSharingPanel = () => {
-	const featureFlags = useSelect( select => select( socialStore ).featureFlags(), [] );
 	const shareStatus = useSelect( select => select( socialStore ).getPostShareStatus(), [] );
 
 	const [ reShareTimestamp, setReShareTimestamp ] = useState( null );
@@ -17,10 +16,6 @@ export const ReSharingPanel = () => {
 			setReShareTimestamp( Date.now() / 1000 );
 		}
 	}, [ shareStatus.polling ] );
-
-	if ( ! featureFlags.useShareStatus ) {
-		return null;
-	}
 
 	return reShareTimestamp ? (
 		<div className={ styles.wrapper }>

--- a/projects/js-packages/publicize-components/src/components/resharing-panel/index.tsx
+++ b/projects/js-packages/publicize-components/src/components/resharing-panel/index.tsx
@@ -1,0 +1,36 @@
+import { useSelect } from '@wordpress/data';
+import { useEffect, useState } from 'react';
+import { store as socialStore } from '../../social-store';
+import { ShareStatus } from '../post-publish-share-status/share-status';
+import { ShareStatusModalTrigger } from '../share-status';
+import styles from './styles.module.scss';
+
+export const ReSharingPanel = () => {
+	const featureFlags = useSelect( select => select( socialStore ).featureFlags(), [] );
+	const shareStatus = useSelect( select => select( socialStore ).getPostShareStatus(), [] );
+
+	const [ reShareTimestamp, setReShareTimestamp ] = useState( null );
+
+	useEffect( () => {
+		if ( shareStatus.polling ) {
+			// Update the timestamp whenever polling becomes true
+			setReShareTimestamp( Date.now() );
+		}
+	}, [ shareStatus.polling ] );
+
+	if ( ! featureFlags.useShareStatus ) {
+		return null;
+	}
+
+	return (
+		<>
+			{ reShareTimestamp ? (
+				<div className={ styles.wrapper }>
+					<ShareStatus reShareTimestamp={ reShareTimestamp } />
+				</div>
+			) : (
+				<ShareStatusModalTrigger withWrapper analyticsData={ { location: 'editor' } } />
+			) }
+		</>
+	);
+};

--- a/projects/js-packages/publicize-components/src/components/resharing-panel/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/resharing-panel/styles.module.scss
@@ -1,0 +1,4 @@
+.wrapper {
+	margin-top: 1rem;
+	padding-block: 1rem;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/576

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Used the `ShareStatus` component if the feature flag is on, and resharing is ongoing
* Updated that component to only show the latest shares if resharing

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-reach/issues/576
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor and reshare without the share status feature flag. It should simply show the toast and nothing else
* Now have the feature flag.
* Try resharing to 2 networks. When the API call starts flying, the view sharing history button should change to a Spinner. After the polling is finished you should see the congrats message mentioning 2 connections, even if the post was shared to multiple ones before
* Try to sharing with failure, you should see the fail message
* Switching tabs, or reloading should put the component back to the normal state with the View sharing history button.

https://github.com/user-attachments/assets/05f410b5-bf53-4890-9ccc-43fa143b9aa2




