### PR TITLE
Jetpack Sync: Stop syncing 'automatic_updates_complete' actions

### DIFF
--- a/projects/packages/sync/changelog/update-sync-remove-automatic_updates_complete-action
+++ b/projects/packages/sync/changelog/update-sync-remove-automatic_updates_complete-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Jetpack Sync: Stop syncing 'automatic_updates_complete' actions

--- a/projects/packages/sync/src/modules/class-updates.php
+++ b/projects/packages/sync/src/modules/class-updates.php
@@ -103,8 +103,6 @@ class Updates extends Module {
 			2
 		);
 
-		add_action( 'automatic_updates_complete', $callable );
-
 		if ( is_multisite() ) {
 			add_filter( 'pre_update_site_option_wpmu_upgrade_site', array( $this, 'update_core_network_event' ), 10, 2 );
 			add_action( 'jetpack_sync_core_update_network', $callable, 10, 3 );

--- a/projects/plugins/jetpack/changelog/update-sync-remove-automatic_updates_complete-action
+++ b/projects/plugins/jetpack/changelog/update-sync-remove-automatic_updates_complete-action
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Jetpack plugin: Update unit tests
+
+

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-updates.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-updates.php
@@ -202,25 +202,6 @@ class WP_Test_Jetpack_Sync_Updates extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 'bar', $this->server_replica_storage->get_callable( 'wp_version' ) );
 	}
 
-	public function test_automatic_updates_complete_sync_action() {
-		// Commenting this out for now. wp_maybe_auto_update();
-		do_action(
-			'automatic_updates_complete',
-			array(
-				'core' => array(
-					'item'     => array( 'somedata' ),
-					'result'   => 'some more data',
-					'name'     => 'WordPress 4.7',
-					'messages' => array( 'it worked.' ),
-				),
-			)
-		);
-		$this->sender->do_sync();
-
-		$event = $this->server_event_storage->get_most_recent_event( 'automatic_updates_complete' );
-		$this->assertTrue( (bool) $event );
-	}
-
 	public function test_network_core_update_sync_action() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Not compatible with single site mode' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Stop syncing 'automatic_updates_complete' actions to WPCOM. Part of Sync cleanup and ensuring we sync only actions we actually use on WPCOM and minimize Sync's footprint on Jetpack sites.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\Updates`: Remove Sync listener for `automatic_updates_complete` actions.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf5801-17n-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Trigger an update for a plugin with auto-updates enabled (eg using the WP rollback plugin)
* Ensure no `automatic_updates_complete` actions were synced to WPCOM