### PR TITLE
My Jetpack: Always show the purchase link regardless of the number of plans owned.

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.jsx
@@ -91,22 +91,22 @@ function PlanSectionFooter( { numberOfPurchases } ) {
 	const { recordEvent } = useAnalytics();
 	const { isUserConnected } = useMyJetpackConnection();
 
-	let planLinkDescription = __( 'Purchase a plan', 'jetpack-my-jetpack' );
-	if ( numberOfPurchases >= 1 ) {
-		planLinkDescription = _n(
-			'Manage your plan',
-			'Manage your plans',
-			numberOfPurchases,
-			'jetpack-my-jetpack'
-		);
-	}
+	const planManageDescription = _n(
+		'Manage your plan',
+		'Manage your plans',
+		numberOfPurchases,
+		'jetpack-my-jetpack'
+	);
 
-	const purchaseClickHandler = useCallback( () => {
-		const event = numberOfPurchases
-			? 'jetpack_myjetpack_plans_manage_click'
-			: 'jetpack_myjetpack_plans_purchase_click';
-		recordEvent( event );
-	}, [ numberOfPurchases, recordEvent ] );
+	const planPurchaseDescription = __( 'Purchase a plan', 'jetpack-my-jetpack' );
+
+	const planManageClickHandler = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_plans_manage_click' );
+	}, [ recordEvent ] );
+
+	const planPurchaseClickHandler = useCallback( () => {
+		recordEvent( 'jetpack_myjetpack_plans_purchase_click' );
+	}, [ recordEvent ] );
 
 	const navigateToConnectionPage = useMyJetpackNavigate( MyJetpackRoutes.Connection );
 	const activateLicenseClickHandler = useCallback( () => {
@@ -128,15 +128,28 @@ function PlanSectionFooter( { numberOfPurchases } ) {
 
 	return (
 		<ul>
+			{ numberOfPurchases > 0 && (
+				<li className={ styles[ 'actions-list-item' ] }>
+					<Button
+						onClick={ planManageClickHandler }
+						href={ getManageYourPlanUrl() }
+						weight="regular"
+						variant="link"
+						isExternalLink={ true }
+					>
+						{ planManageDescription }
+					</Button>
+				</li>
+			) }
 			<li className={ styles[ 'actions-list-item' ] }>
 				<Button
-					onClick={ purchaseClickHandler }
-					href={ numberOfPurchases ? getManageYourPlanUrl() : getPurchasePlanUrl() }
+					onClick={ planPurchaseClickHandler }
+					href={ getPurchasePlanUrl() }
 					weight="regular"
 					variant="link"
 					isExternalLink={ true }
 				>
-					{ planLinkDescription }
+					{ planPurchaseDescription }
 				</Button>
 			</li>
 			{ loadAddLicenseScreen && (

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-plans-permanent-purchase-link
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-plans-permanent-purchase-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Always show the purchase link regardless of the number of plans owned.


### PR DESCRIPTION
Reported in p1725863792891889-slack-C06PK2W8F42

## Proposed changes:

* Always show the purchase link regardless of the number of plans owned in “Your plan(s)” section in My Jetpack.

## Screenshots

Before | After, 1 Plan | After, 1+ Plans
--|--|--
<img width="485" alt="image" src="https://github.com/user-attachments/assets/94b402ab-a05a-42f1-9b74-6e9317adc885">|<img width="524" alt="image" src="https://github.com/user-attachments/assets/1855a7ca-4ce8-4cb9-bf2b-ae0c7a760465">|<img width="580" alt="image" src="https://github.com/user-attachments/assets/8ee4435a-489d-43de-9032-db2a367ae918">




## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Start with a site with no plans.
* Go to My Jetpack and ensure you see an upgrade link in the plans section.
* Purchase a plan.
* Go back to My Jetpack and ensure you still see the upgrade link, in addition to the new “Manage plan(s)” link.