### PR TITLE
woocommerce-analytics: Check `WC_Install::STORE_ID_OPTION` before using it

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-undefined-WC_Install-STORE_ID_OPTION
+++ b/projects/packages/woocommerce-analytics/changelog/fix-undefined-WC_Install-STORE_ID_OPTION
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Check whether `\WC_Install::STORE_ID_OPTION` is defined before attempting to use it, for compatibility with WooCommerce <8.4.0.

--- a/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
+++ b/projects/packages/woocommerce-analytics/src/class-woo-analytics-trait.php
@@ -252,7 +252,7 @@ trait Woo_Analytics_Trait {
 	public function get_common_properties() {
 		$site_info          = array(
 			'blog_id'                            => Jetpack_Connection::get_site_id(),
-			'store_id'                           => get_option( \WC_Install::STORE_ID_OPTION ),
+			'store_id'                           => defined( '\\WC_Install::STORE_ID_OPTION' ) ? get_option( \WC_Install::STORE_ID_OPTION ) : false,
 			'ui'                                 => $this->get_user_id(),
 			'url'                                => home_url(),
 			'woo_version'                        => WC()->version,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
For compatibility with WooCommerce <8.4.0.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1725911686791599/1725909750.542229-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a site with Jetpack trunk and WooCommerce 8.3.2. Make sure woocommerce-analytics is enabled.
* Add a production to the store, then visit the store and attempt to add it to your cart. See error.
* Install Jetpack from this branch. Now it should work.