### PR TITLE
Blocks: determine block names from filename convention instead of disk access

### DIFF
--- a/projects/packages/blocks/changelog/add-get_block_name_from_path_convention
+++ b/projects/packages/blocks/changelog/add-get_block_name_from_path_convention
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blocks: Determine block names from filename convention instead of disk access

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -53,8 +53,7 @@ class Blocks {
 		// If a path is passed, make sure to get the block.json file from the build directory and get
 		// the block name from that file.
 		if ( path_is_absolute( $slug ) ) {
-			$block_type = self::get_path_to_block_metadata( $slug );
-			$slug       = self::get_block_name( $block_type );
+			$slug = self::get_block_name_from_path_convention( $slug );
 		}
 
 		if (
@@ -172,6 +171,42 @@ class Blocks {
 		$metadata = self::get_block_metadata( $arg );
 
 		return self::get_block_name_from_metadata( $metadata );
+	}
+
+	/**
+	 * Get the block name from the path convention.
+	 * For example, path "./extensions/blocks/pinterest" is assumed to define
+	 * a block named "jetpack/pinterest" without checking any files.
+	 *
+	 * Any exceptions should be added to the $breaks_convention array.
+	 * For example, blocks/premium-content defines "premium-content\/container", not "jetpack/premium-content".
+	 * These paths will use the code that checks the disk for the block name.
+	 *
+	 * The unit test test_get_block_name_from_path_convention_matches_get_block_name() verifies that
+	 * all names are correctly guessed.
+	 *
+	 * Run with `./vendor/bin/phpunit --filter WP_Test_Jetpack_Gutenberg`.
+	 *
+	 * @param string $path The path to extract the block name from.
+	 *
+	 * @return string The block name with 'jetpack/' prefix.
+	 */
+	public static function get_block_name_from_path_convention( $path ) {
+		$path_parts = explode( '/', $path );
+		if ( count( $path_parts ) <= 0 ) {
+			$block_type = self::get_path_to_block_metadata( $path );
+			return self::get_block_name( $block_type );
+		}
+
+		$last_part         = $path_parts[ count( $path_parts ) - 1 ];
+		$breaks_convention = array( 'premium-content' );
+
+		if ( in_array( $last_part, $breaks_convention, true ) ) {
+			$block_type = self::get_path_to_block_metadata( $path );
+			return self::get_block_name( $block_type );
+		}
+
+		return 'jetpack/' . $last_part;
 	}
 
 	/**

--- a/projects/packages/blocks/tests/php/test-blocks.php
+++ b/projects/packages/blocks/tests/php/test-blocks.php
@@ -513,4 +513,30 @@ class Test_Blocks extends TestCase {
 		$result = Blocks::get_block_feature( __DIR__ . '/fixtures/test-block/block.json' );
 		$this->assertEquals( 'test-block', $result );
 	}
+
+	/**
+	 * Test getting the block name from path convention.
+	 *
+	 * @since 1.x.x
+	 *
+	 * @covers Automattic\Jetpack\Blocks::get_block_name_from_path_convention
+	 */
+	public function test_get_block_name_from_path_convention() {
+		/**
+		 * Basic string based tests only.
+		 *
+		 * For a more comprehensive test, see the test_get_block_name_from_path_convention_matches_get_block_name test.
+		 * in test-class.jetpack-gutenberg.php.
+		 */
+		$test_cases = array(
+			'/path/to/extensions/blocks/apple' => 'jetpack/apple',
+			'/var/www/html/wp-content/plugins/jetpack/extensions/blocks/banana' => 'jetpack/banana',
+			'/home/user/wordpress/wp-content/plugins/jetpack/extensions/blocks/cherry' => 'jetpack/cherry',
+		);
+
+		foreach ( $test_cases as $path => $expected ) {
+			$result = Blocks::get_block_name_from_path_convention( $path );
+			$this->assertEquals( $expected, $result, "Failed for path: $path" );
+		}
+	}
 }

--- a/projects/plugins/jetpack/changelog/add-get_block_name_from_path_convention
+++ b/projects/plugins/jetpack/changelog/add-get_block_name_from_path_convention
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Adds a unit test for a change in the blocks repo
+
+

--- a/projects/plugins/jetpack/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/tests/php/general/test-class.jetpack-gutenberg.php
@@ -306,4 +306,37 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 		$this->assertFalse( $validated_url );
 	}
+
+	/**
+	 * Test that get_block_name_from_path_convention() provides the same results as get_block_name()
+	 * for all blocks registered by load_independent_blocks().
+	 *
+	 * @covers Automattic\Jetpack\Blocks::get_block_name_from_path_convention
+	 * @covers Automattic\Jetpack\Blocks::get_block_name
+	 */
+	public function test_get_block_name_from_path_convention_matches_get_block_name() {
+		$extensions = Jetpack_Gutenberg::get_available_extensions();
+
+		foreach ( $extensions as $extension ) {
+			$dirname         = 'blocks';
+			$path            = __DIR__ . "/../../../extensions/{$dirname}/{$extension}";
+			$block_json_file = "{$path}/block.json";
+
+			if ( file_exists( $path ) && file_exists( $block_json_file ) ) {
+				// Get the block name using the path name convention method
+				$conventional_name = Blocks::get_block_name_from_path_convention( $path );
+
+				// Get the block name using the existing method
+				$block_type    = Blocks::get_path_to_block_metadata( $path );
+				$existing_name = Blocks::get_block_name( $block_type );
+
+				// Assert that both methods return the same result
+				$this->assertEquals(
+					$existing_name,
+					$conventional_name,
+					"Block name mismatch for {$extension} in {$dirname} directory"
+				);
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Proposed changes:

* When registering blocks, use the composition of the path instead of reading the block.json file to determine the filename.

For example, when we see the path `extensions/blocks/ai-assistant`, we know the block name will be `jetpack/ai-assistant`. This holds true 99% of the time.

See also: pdWQjU-RU-p2#comment-932

### Why - Performance

This is a performance based change, saving us from having to `json_decode( file_get_contents( 'block.json' ) )` to get the block name. On wpcom, here are some example trials when wrapping `wp_json_file_decode()` in `ac_start()` and `ac_stop()` ([defined here](https://github.com/mreishus/wp-misc/blob/master/debug-helpers.php#L90-L125)).

**Before**:
```
[1            b3bf7] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=hpkmx1yd
[1            b3bf7] AC Debug: 'decode' ran 191 times, total time: 8.51 ms, avg time: 0.04 ms
[1            49f43] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=6gbhpgny
[1            49f43] AC Debug: 'decode' ran 191 times, total time: 8.68 ms, avg time: 0.05 ms
[1            32755] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=4e4ol5d3
[1            32755] AC Debug: 'decode' ran 191 times, total time: 7.44 ms, avg time: 0.04 ms
[1            73db4] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=b48rjlzy
[1            73db4] AC Debug: 'decode' ran 191 times, total time: 8.7 ms, avg time: 0.05 ms
[1            161e4] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=sq357how
[1            161e4] AC Debug: 'decode' ran 191 times, total time: 10.1 ms, avg time: 0.05 ms
[1            837d5] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=mooppp68
[1            837d5] AC Debug: 'decode' ran 191 times, total time: 7 ms, avg time: 0.04 ms
[1            774a1] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=uz4s5jjo
[1            774a1] AC Debug: 'decode' ran 191 times, total time: 7.55 ms, avg time: 0.04 ms
[1            886d6] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=p73evouz
[1            886d6] AC Debug: 'decode' ran 191 times, total time: 7.04 ms, avg time: 0.04 ms
[1            83988] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=c4lm2jmq
[1            83988] AC Debug: 'decode' ran 191 times, total time: 7.2 ms, avg time: 0.04 ms
[1            47300] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=wej26sn6
[1            47300] AC Debug: 'decode' ran 191 times, total time: 10.83 ms, avg time: 0.06 ms
```

**After**:
```
[1            a99ca] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=7ab0dpyx
[1            a99ca] AC Debug: 'decode' ran 108 times, total time: 5.34 ms, avg time: 0.05 ms
[1            f3127] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=1armlnw7
[1            f3127] AC Debug: 'decode' ran 108 times, total time: 4.83 ms, avg time: 0.04 ms
[1            f25d3] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=k8xd0e8k
[1            f25d3] AC Debug: 'decode' ran 108 times, total time: 5.4 ms, avg time: 0.05 ms
[1            4abbd] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=zwue94yv
[1            4abbd] AC Debug: 'decode' ran 108 times, total time: 4.09 ms, avg time: 0.04 ms
[1            bf358] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=38dpegr3
[1            bf358] AC Debug: 'decode' ran 108 times, total time: 4.06 ms, avg time: 0.04 ms
[1            75e77] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=17qwe8om
[1            75e77] AC Debug: 'decode' ran 108 times, total time: 3.98 ms, avg time: 0.04 ms
[1            afe3a] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=3smekv6c
[1            afe3a] AC Debug: 'decode' ran 108 times, total time: 4.03 ms, avg time: 0.04 ms
[1            2dc15] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=9tobu3yl
[1            2dc15] AC Debug: 'decode' ran 108 times, total time: 4.26 ms, avg time: 0.04 ms
[1            4bc37] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=ogsz24u0
[1            4bc37] AC Debug: 'decode' ran 108 times, total time: 6.31 ms, avg time: 0.06 ms
[1            18d97] https://public-api.wordpress.com/rest/v1.1/test/1?defeatcache=0hzbcwad
[1            18d97] AC Debug: 'decode' ran 108 times, total time: 5.01 ms, avg time: 0.05 ms
```

### Exceptions

* The path blocks/premium-content defines `premium-content\/container`, not `jetpack/premium-content`.

This is added to a `$breaks_convention` array, which means we fall through to the old method instead of looking at the path.

### Exceptions - Catching future ones

The unit test `test_get_block_name_from_path_convention_matches_get_block_name()` does the path-based method and the block.json method for all blocks, and makes sure they're the same. Therefore, if a new block which is added which breaks convention, the unit tests will fail in order to alert us.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In `projects/packages/blocks`, run `./vendor/bin/phpunit --filter Test_Blocks`
* In `projects/plugins/jetpack`, run `./vendor/bin/phpunit --filter WP_Test_Jetpack_Gutenberg`
* General block usage; can log out the names that are being registered
* Can check # of calls to `wp_json_file_decode()` in `wp-includes/functions.php` to verify reduced disk access