### PR TITLE
Shortcode: Fix the youtube url cannot be embedded due to the trailing question mark of the youtube id

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-youtube-embed-trailing-question-mark
+++ b/projects/plugins/jetpack/changelog/fix-youtube-embed-trailing-question-mark
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Shortcode: Fix the youtube url cannot be embeded due to the trailing question mark of the youtube id

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -549,7 +549,7 @@ function wpcom_youtube_embed_crazy_url_init() {
 }
 
 /**
- * Remove  Add auth token required by Instagram's oEmbed REST API, or proxy through WP.com.
+ * Remove the ending question mark from the video id of the YouTube URL.
  *
  * Example: https://www.youtube.com/watch?v=AVAWwXeOyyQ?
  *

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -548,6 +548,42 @@ function wpcom_youtube_embed_crazy_url_init() {
 	wp_embed_register_handler( 'wpcom_youtube_embed_crazy_url', '#https?://(?:www\.)?(?:youtube.com/(?:v/|playlist|watch[/\#?])|youtu\.be/).*#i', 'wpcom_youtube_embed_crazy_url' );
 }
 
+/**
+ * Remove  Add auth token required by Instagram's oEmbed REST API, or proxy through WP.com.
+ *
+ * Example: https://www.youtube.com/watch?v=AVAWwXeOyyQ?
+ *
+ * @since $$next-version$$
+ *
+ * @param string $provider URL of the oEmbed provider.
+ * @param string $url      URL of the content to be embedded.
+ *
+ * @return string
+ */
+function wpcom_youtube_oembed_fetch_url( $provider, $url ) {
+	if ( ! wp_startswith( $provider, 'https://www.youtube.com/oembed' ) ) {
+		return $provider;
+	}
+
+	$parsed = wp_parse_url( $url );
+	if ( ! isset( $parsed['query'] ) ) {
+		return $provider;
+	}
+
+	$query_vars = array();
+	wp_parse_str( $parsed['query'], $query_vars );
+	if ( isset( $query_vars['v'] ) && wp_endswith( $query_vars['v'], '?' ) ) {
+		$url = remove_query_arg( array( 'v' ), $url );
+		$url = add_query_arg( 'v', preg_replace( '/\?$/', '', $query_vars['v'] ), $url );
+	}
+
+	$provider = remove_query_arg( array( 'url' ), $provider );
+	$provider = add_query_arg( 'url', rawurlencode( $url ), $provider );
+
+	return $provider;
+}
+add_filter( 'oembed_fetch_url', 'wpcom_youtube_oembed_fetch_url', 10, 2 );
+
 if (
 	! is_admin()
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.youtube.php
@@ -299,4 +299,47 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 		$GLOBALS['content_width'] = self::CONTENT_WIDTH;
 		$this->assertEquals( $expected, jetpack_shortcode_youtube_dimensions( $query_args ) );
 	}
+
+	/**
+	 * List of variation of Instagram embed URLs.
+	 */
+	public function get_youtube_urls() {
+		return array(
+			'valid_url'                          => array(
+				'https://www.youtube.com/watch?v=SVRiktFlWxI',
+				'https://www.youtube.com/watch?v=SVRiktFlWxI',
+			),
+			'short_youtube_url'                  => array(
+				'https://youtu.be/gS6_xOABTWo',
+				'https://youtu.be/gS6_xOABTWo',
+			),
+			'video_id_ending_with_question_mark' => array(
+				'https://www.youtube.com/watch?v=WVbQ-oro7FQ?',
+				'https://www.youtube.com/watch?v=WVbQ-oro7FQ',
+			),
+		);
+	}
+
+	/**
+	 * Test different oEmbed URLs and their output.
+	 *
+	 * @covers ::wpcom_youtube_oembed_fetch_url
+	 * @dataProvider get_youtube_urls
+	 *
+	 * @param string $original The original YouTube provider URL.
+	 * @param string $expected The final YouTube provider URL after wpcom_youtube_oembed_fetch_url.
+	 */
+	public function test_youtube_oembed_fetch_url( $original, $expected ) {
+		$provider_url = apply_filters(
+			'oembed_fetch_url',
+			'https://www.youtube.com/oembed?url=' . rawurlencode( $original ),
+			$original,
+			''
+		);
+
+		$this->assertEquals(
+			$provider_url,
+			'https://www.youtube.com/oembed?url=' . rawurlencode( $expected )
+		);
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/test-class.youtube.php
@@ -301,7 +301,7 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 	}
 
 	/**
-	 * List of variation of Instagram embed URLs.
+	 * List of variation of YouTube embed URLs.
 	 */
 	public function get_youtube_urls() {
 		return array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes 8674608-zd-a8c. See p1725860629793219/1725499365.595119-slack-CRWCHQGUB fo more details.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Remove the trailing question mark from the video id of the YouTube URL.
* I'm not sure whether there is any changes on the `https://www.youtube.com/oembed?format=json&url=<youtube_url>` endpoint but now the YouTube URL with the trailing question mark doesn't work and the endpoint returns 400 so that the URL cannot be embedded correctly. But it might also related to the following changes
  * The editor - The embed block converts to the paragraph block automatically instead of displaying the placeholder with the error message. As a result, the user understands that it cannot be embedded immediately
    ![image](https://github.com/user-attachments/assets/e9cc28ce-0357-4fd0-be06-64cfa8fc7787)
  * The frontend - https://github.com/Automattic/jetpack/pull/39096 removed the custom handler for the YouTube URL so the paragraph block with the YouTube URL cannot be replaced with the embedded YouTube video. As a result, it displays the paragraph block on the frontend as well

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site
* Create a new post 
* Insert the YouTube Embed block with the following URL
  * https://www.youtube.com/watch?v=ax1csKKQnns?
* Make sure it can be embedded correctly