### PR TITLE
Logged-in Performance Profiler: Add rest fields to access the performance report associated url.

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-performance-profiler-urls
+++ b/projects/plugins/wpcomsh/changelog/add-performance-profiler-urls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Performance Profiler: Ensure the associated url created when the performance report is generated is accessible for each page or as part of site settings for the home/main url. 

--- a/projects/plugins/wpcomsh/performance-profiler/performance-profiler.php
+++ b/projects/plugins/wpcomsh/performance-profiler/performance-profiler.php
@@ -25,6 +25,34 @@ function wpcom_performance_url_rest_field() {
 }
 
 /**
+ * Filter the performance report URL field.
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_Post          $post     The post object.
+ * @param WP_REST_Request  $request  The request object.
+ * @return WP_REST_Response
+ */
+function filter_wpcom_performance_report_url( $response, $post, $request ) {
+	$fields = $request->get_param( '_fields' );
+
+	if ( is_string( $fields ) ) {
+		$fields = explode( ',', $fields );
+	}
+
+	if ( ! is_array( $fields ) ) {
+		$fields = array();
+	}
+
+	if ( empty( $fields ) || ! in_array( 'wpcom_performance_report_url', $fields, true ) ) {
+		unset( $response->data['wpcom_performance_report_url'] );
+	}
+
+	return $response;
+}
+
+add_filter( 'rest_prepare_page', 'filter_wpcom_performance_report_url', 10, 3 );
+
+/**
  * Get the performance report URL callback.
  *
  * @param array $object The object being requested.
@@ -97,4 +125,4 @@ function wpcom_performance_url_update_options_v1_api( $input, $unfiltered_input 
 	return $input;
 }
 
-add_filter( 'rest_api_update_site_settings', 'wpcom_performance_url_update_options', 10, 2 );
+add_filter( 'rest_api_update_site_settings', 'wpcom_performance_url_update_options_v1_api', 10, 2 );

--- a/projects/plugins/wpcomsh/performance-profiler/performance-profiler.php
+++ b/projects/plugins/wpcomsh/performance-profiler/performance-profiler.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Adds the generated performance report url for each page and also in v1 site settings payload for homepage.
+ *
+ * @package performance-profiler
+ */
+
+/**
+ * Adds the generated performance report url for each page.
+ */
+function wpcom_performance_url_rest_field() {
+	register_rest_field(
+		'page',
+		'wpcom_performance_report_url',
+		array(
+			'get_callback'    => 'wpcom_performance_report_url_get_value',
+			'update_callback' => 'wpcom_performance_report_url_update_value',
+			'schema'          => array(
+				'type'        => 'string',
+				'description' => __( 'The performance report URL for this page.', 'wpcomsh' ),
+				'default'     => '',
+			),
+		)
+	);
+}
+
+/**
+ * Get the performance report URL callback.
+ *
+ * @param array $object The object being requested.
+ * @return string|null The performance report URL.
+ */
+function wpcom_performance_report_url_get_value( $object ) {
+	return get_post_meta( $object['id'], '_wpcom_performance_report_url', true );
+}
+
+/**
+ * Update callback for the performance report URL.
+ *
+ * @param  mixed  $value The new value of the field.
+ * @param  object $object The object being updated.
+ * @return bool|int|null
+ */
+function wpcom_performance_report_url_update_value( $value, $object ) {
+	if ( ! $value || ! is_string( $value ) ) {
+		return;
+	}
+	return update_post_meta( $object->ID, '_wpcom_performance_report_url', sanitize_text_field( $value ) );
+}
+
+add_action( 'rest_api_init', 'wpcom_performance_url_rest_field' );
+
+/**
+ * Registers the performance report URL settings field.
+ */
+function wpcom_performance_report_url_settings_field() {
+	register_setting(
+		'wpcom_performance_profiler',
+		'wpcom_performance_report_url',
+		array(
+			'type'        => 'string',
+			'description' => __( 'The performance report URL for this site.', 'wpcomsh' ),
+			'default'     => '',
+		)
+	);
+}
+
+add_action( 'rest_api_init', 'wpcom_performance_report_url_settings_field' );
+
+/**
+ * Adds settings to the v1 API site settings endpoint.
+ *
+ * @param array $settings A single site's settings.
+ * @return array
+ */
+function wpcom_performance_url_get_options_v1_api( $settings ) {
+	$settings['wpcom_performance_report_url'] = get_option( 'wpcom_performance_report_url', '' );
+	return $settings;
+}
+
+add_filter( 'site_settings_endpoint_get', 'wpcom_performance_url_get_options_v1_api' );
+
+/**
+ * Updates settings via public-api.wordpress.com.
+ *
+ * @param array $input             Associative array of site settings to be updated.
+ *                                 Cast and filtered based on documentation.
+ * @param array $unfiltered_input  Associative array of site settings to be updated.
+ *                                 Neither cast nor filtered. Contains raw input.
+ * @return array
+ */
+function wpcom_performance_url_update_options_v1_api( $input, $unfiltered_input ) {
+	if ( isset( $unfiltered_input['wpcom_performance_report_url'] ) ) {
+		$input['wpcom_performance_report_url'] = sanitize_text_field( $unfiltered_input['wpcom_performance_report_url'] );
+	}
+
+	return $input;
+}
+
+add_filter( 'rest_api_update_site_settings', 'wpcom_performance_url_update_options', 10, 2 );

--- a/projects/plugins/wpcomsh/performance-profiler/performance-profiler.php
+++ b/projects/plugins/wpcomsh/performance-profiler/performance-profiler.php
@@ -73,7 +73,7 @@ function wpcom_performance_report_url_update_value( $value, $object ) {
 	if ( ! $value || ! is_string( $value ) ) {
 		return;
 	}
-	return update_post_meta( $object->ID, '_wpcom_performance_report_url', sanitize_text_field( $value ) );
+	return update_post_meta( $object->ID, '_wpcom_performance_report_url', sanitize_url( $value ) );
 }
 
 add_action( 'rest_api_init', 'wpcom_performance_url_rest_field' );

--- a/projects/plugins/wpcomsh/performance-profiler/performance-profiler.php
+++ b/projects/plugins/wpcomsh/performance-profiler/performance-profiler.php
@@ -119,7 +119,7 @@ add_filter( 'site_settings_endpoint_get', 'wpcom_performance_url_get_options_v1_
  */
 function wpcom_performance_url_update_options_v1_api( $input, $unfiltered_input ) {
 	if ( isset( $unfiltered_input['wpcom_performance_report_url'] ) ) {
-		$input['wpcom_performance_report_url'] = sanitize_text_field( $unfiltered_input['wpcom_performance_report_url'] );
+		$input['wpcom_performance_report_url'] = sanitize_url( $unfiltered_input['wpcom_performance_report_url'] );
 	}
 
 	return $input;

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -133,6 +133,9 @@ require_once __DIR__ . '/notices/media-library-private-site-cdn-notice.php';
 require_once __DIR__ . '/notices/anyone-can-register-notice.php';
 require_once __DIR__ . '/notices/feature-moved-to-jetpack-notices.php';
 
+// Performance Profiler
+require_once __DIR__ . '/performance-profiler/performance-profiler.php';
+
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once __DIR__ . '/class-wpcomsh-cli-commands.php';
 	require_once __DIR__ . '/woa.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes https://github.com/Automattic/dotcom-forge/issues/9057

## Proposed changes:
**Background**
The Performance Profiler apis uses the provided site url to run performance test. After the test is completed a report is generated and a unique hash is returned which is used to fetch associated report for that url. The format passed to the apis is `https://example.com/&hash=eYhha`, this has is returned by the api and is used to construct the url necessary to fetch the report. This PR stores that url on each page that the report was generated for allowing us to easily fetch reports per page.

Since our site index is not stored as a page this PR also adds the generated url to the site setting, similar to the existing site url. This way when the report is executed on  `/` path we can easily fetch the generated report for the site from it's settings.

Here's an example report with the generated url: pdt2If-1yN-p2#comment-1143
  
<!--- Explain what functional changes your PR includes -->
* Register rest field `wpcom_performance_report_url` to pages endpoint so we can easily fetch Performance report executed on the page
* Register setting `wpcom_performance_report_url` on sites v1 endpoint so we can easily fetch Performance report executed on the sites home page or `/` index path.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout branch to local machine
* Run `jetpack rsync plugins/wpcomsh` and rsync to your WoA dev site. See pf4qpu-sv-p2
* From [developer console](https://developer.wordpress.com/docs/api/console/) run `/rest/v1/sites/atomic_site/settings`
* Verify field `wpcom_performance_report_url` is returned under the `settings` json property
* Run `/wp/v2/sites/atomic_site/pages?_fields=wpcom_performance_report_url` and verify field `wpcom_performance_report_url` is returned as part of the page results