### PR TITLE
Admin bar: fix paddings around wpcom and reader logos

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/admin-bar-consistency
+++ b/projects/packages/jetpack-mu-wpcom/changelog/admin-bar-consistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: fix paddings around wpcom and reader logos

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -40,10 +40,18 @@
 /**
  * WP logo menu
  */
-#wpadminbar #wp-admin-bar-wpcom-logo>.ab-item .ab-icon {
-	width: 15px;
+#wpadminbar #wp-admin-bar-wpcom-logo>.ab-item {
+	padding: 0 10px;
+
 	@media (max-width: 782px) {
-		width: revert;
+		padding: 0;
+	}
+}
+#wpadminbar #wp-admin-bar-wpcom-logo>.ab-item .ab-icon {
+	margin-right: 0 !important;
+
+	@media (max-width: 480px) {
+		width: 44px;
 	}
 }
 #wpadminbar #wp-admin-bar-wpcom-logo>.ab-item .ab-icon:before {
@@ -134,7 +142,7 @@
 			.ab-icon {
 				display: flex;
 				align-items: center;
-				padding: 0 10px;
+				padding: 0 8px;
 				margin: 0;
 				height: 100%;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/pull/93695/files#r1725178524

## Proposed changes:

This PR re-aligns wpcom and Reader logos after they became out-of-sync with Calypso screens after https://github.com/Automattic/wp-calypso/pull/93695.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Verify that ALL icons on the masterbar / admin bar are aligned with the Calypso ones on various resolutions:

- `> 782px
- < 782px
- < 480px

