### PR TITLE
wpcomsh: Update wc-calypso-bridge to 2.6.0

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-wc-calypso-bridge-2.6.0
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-wc-calypso-bridge-2.6.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update wc-calypso-bridge dependency to 2.6.0

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.5.5",
+		"automattic/wc-calypso-bridge": "2.6.0",
 		"wordpress/classic-editor-plugin": "1.5",
 		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-post-list": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "db2d649fe88d2b70941a9a4b77d82753",
+    "content-hash": "abd021117ab176c49e44e4e54a122e75",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -1866,16 +1866,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.5.5",
+            "version": "v2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "f7dc90d348ac82031f26dff6076e4cf492b09138"
+                "reference": "cb8300f827fcf2dd1174822c08f0957f65f0e42e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/f7dc90d348ac82031f26dff6076e4cf492b09138",
-                "reference": "f7dc90d348ac82031f26dff6076e4cf492b09138",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/cb8300f827fcf2dd1174822c08f0957f65f0e42e",
+                "reference": "cb8300f827fcf2dd1174822c08f0957f65f0e42e",
                 "shasum": ""
             },
             "require": {
@@ -1916,7 +1916,7 @@
                     "phpcbf -p"
                 ]
             },
-            "time": "2024-07-23T22:02:25+00:00"
+            "time": "2024-09-10T04:10:28+00:00"
         },
         {
             "name": "composer/installers",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR bumps the version of `wc-calypso-bridge` to `2.6.0`, which includes the following change:

- https://github.com/Automattic/wc-calypso-bridge/pull/1500
- https://github.com/Automattic/wc-calypso-bridge/pull/1501
- https://github.com/Automattic/wc-calypso-bridge/pull/1502
- https://github.com/Automattic/wc-calypso-bridge/pull/1503
- https://github.com/Automattic/wc-calypso-bridge/pull/1506
- https://github.com/Automattic/wc-calypso-bridge/pull/1507
- https://github.com/Automattic/wc-calypso-bridge/pull/1509
- https://github.com/Automattic/wc-calypso-bridge/pull/1511

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

The changes related to the wc-calypso-bridge were already tested in the linked PRs. Testing instructions can be found on the linked PRs above.

