### PR TITLE
Add/shield memberships blocks for unconnected jetpack sites

### DIFF
--- a/projects/plugins/jetpack/changelog/add-shield-memberships-blocks-for-unconnected-jetpack-sites
+++ b/projects/plugins/jetpack/changelog/add-shield-memberships-blocks-for-unconnected-jetpack-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Do not register Memberships blocks when the site is not connected to Jetpack

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -19,12 +19,16 @@ use WP_Post;
  * registration if we need to.
  */
 function register_block() {
-	Blocks::jetpack_register_block(
-		__DIR__,
-		array(
-			'render_callback' => __NAMESPACE__ . '\render_block',
-		)
-	);
+
+	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
+	if ( \Jetpack_Memberships::is_enabled_jetpack_recurring_payments() ) {
+		Blocks::jetpack_register_block(
+			__DIR__,
+			array(
+				'render_callback' => __NAMESPACE__ . '\render_block',
+			)
+		);
+	}
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -21,7 +21,7 @@ use WP_Post;
 function register_block() {
 
 	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
-	if ( \Jetpack_Memberships::is_enabled_jetpack_recurring_payments() ) {
+	if ( \Jetpack_Memberships::should_enable_monetize_blocks_in_editor() ) {
 		Blocks::jetpack_register_block(
 			__DIR__,
 			array(

--- a/projects/plugins/jetpack/extensions/blocks/payment-buttons/payment-buttons.php
+++ b/projects/plugins/jetpack/extensions/blocks/payment-buttons/payment-buttons.php
@@ -22,7 +22,7 @@ function register_block() {
 	}
 
 	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
-	if ( \Jetpack_Memberships::is_enabled_jetpack_recurring_payments() ) {
+	if ( \Jetpack_Memberships::should_enable_monetize_blocks_in_editor() ) {
 		Blocks::jetpack_register_block(
 			__DIR__,
 			array(

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -25,21 +25,26 @@ require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/subscriptions/constants.ph
  * registration if we need to.
  */
 function register_block() {
-	// Determine required `context` key based on Gutenberg version.
-	$deprecated = function_exists( 'gutenberg_get_post_from_context' );
-	$provides   = $deprecated ? 'providesContext' : 'provides_context';
 
-	Blocks::jetpack_register_block(
-		__DIR__,
-		array(
-			'render_callback' => __NAMESPACE__ . '\render_block',
-			$provides         => array(
-				'premium-content/planId'  => 'selectedPlanId', // Deprecated.
-				'premium-content/planIds' => 'selectedPlanIds',
-				'isPremiumContentChild'   => 'isPremiumContentChild',
-			),
-		)
-	);
+	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
+	if ( \Jetpack_Memberships::is_enabled_jetpack_recurring_payments() ) {
+
+		// Determine required `context` key based on Gutenberg version.
+		$deprecated = function_exists( 'gutenberg_get_post_from_context' );
+		$provides   = $deprecated ? 'providesContext' : 'provides_context';
+
+		Blocks::jetpack_register_block(
+			__DIR__,
+			array(
+				'render_callback' => __NAMESPACE__ . '\render_block',
+				$provides         => array(
+					'premium-content/planId'  => 'selectedPlanId', // Deprecated.
+					'premium-content/planIds' => 'selectedPlanIds',
+					'isPremiumContentChild'   => 'isPremiumContentChild',
+				),
+			)
+		);
+	}
 
 	register_post_meta(
 		'post',

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/premium-content.php
@@ -27,7 +27,7 @@ require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/subscriptions/constants.ph
 function register_block() {
 
 	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
-	if ( \Jetpack_Memberships::is_enabled_jetpack_recurring_payments() ) {
+	if ( \Jetpack_Memberships::should_enable_monetize_blocks_in_editor() ) {
 
 		// Determine required `context` key based on Gutenberg version.
 		$deprecated = function_exists( 'gutenberg_get_post_from_context' );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -8,10 +8,8 @@
 namespace Automattic\Jetpack\Extensions\Subscriptions;
 
 use Automattic\Jetpack\Blocks;
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Jetpack_Token_Subscription_Service;
-use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use Jetpack;
 use Jetpack_Gutenberg;
@@ -45,10 +43,9 @@ function register_block() {
 		return;
 	}
 
-	if (
-		( defined( 'IS_WPCOM' ) && IS_WPCOM )
-		|| ( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() && ! ( new Status() )->is_offline_mode() )
-	) {
+	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
+	if ( \Jetpack_Memberships::is_enabled_jetpack_recurring_payments() ) {
+
 		Blocks::jetpack_register_block(
 			__DIR__,
 			array(

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -44,7 +44,7 @@ function register_block() {
 	}
 
 	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
-	if ( \Jetpack_Memberships::is_enabled_jetpack_recurring_payments() ) {
+	if ( \Jetpack_Memberships::should_enable_monetize_blocks_in_editor() ) {
 
 		Blocks::jetpack_register_block(
 			__DIR__,

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -755,8 +755,8 @@ class Jetpack_Memberships {
 	 * @return bool
 	 */
 	public static function should_enable_monetize_blocks_in_editor() {
-		$jetpack_ready_and_user_connected = Jetpack::is_connection_ready() &&
-			( new Connection_Manager( 'jetpack' ) )->is_user_connected() && current_user_can( 'edit_posts' );
+		$manager                          = new Connection_Manager( 'jetpack' );
+		$jetpack_ready_and_user_connected = $manager->is_connected() && $manager->is_user_connected();
 		$api_available                    = ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || $jetpack_ready_and_user_connected );
 		return $api_available;
 	}

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -175,7 +175,7 @@ class Jetpack_Memberships {
 			self::$instance->register_init_hook();
 			// Yes, `pro-plan` with a dash, `jetpack_personal` with an underscore. Check the v1.5 endpoint to verify.
 			$wpcom_plan_slug     = defined( 'ENABLE_PRO_PLAN' ) ? 'pro-plan' : 'personal-bundle';
-			self::$required_plan = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? $wpcom_plan_slug : 'jetpack_personal';
+			self::$required_plan = ( new Host() )->is_wpcom_simple() ? $wpcom_plan_slug : 'jetpack_personal';
 		}
 
 		return self::$instance;
@@ -744,7 +744,7 @@ class Jetpack_Memberships {
 	 * @return bool
 	 */
 	public static function is_enabled_jetpack_recurring_payments() {
-		$api_available = ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_connection_ready() );
+		$api_available = ( new Host() )->is_wpcom_simple() || Jetpack::is_connection_ready();
 		return $api_available;
 	}
 
@@ -757,7 +757,7 @@ class Jetpack_Memberships {
 	public static function should_enable_monetize_blocks_in_editor() {
 		$manager                          = new Connection_Manager( 'jetpack' );
 		$jetpack_ready_and_user_connected = $manager->is_connected() && $manager->is_user_connected();
-		$api_available                    = ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || $jetpack_ready_and_user_connected );
+		$api_available                    = ( new Host() )->is_wpcom_simple() || $jetpack_ready_and_user_connected;
 		return $api_available;
 	}
 

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -9,6 +9,7 @@
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
 use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_TIER_ID_SETTINGS;
@@ -757,7 +758,8 @@ class Jetpack_Memberships {
 	public static function should_enable_monetize_blocks_in_editor() {
 		$manager                          = new Connection_Manager( 'jetpack' );
 		$jetpack_ready_and_user_connected = $manager->is_connected() && $manager->is_user_connected();
-		$api_available                    = ( new Host() )->is_wpcom_simple() || $jetpack_ready_and_user_connected;
+		$is_offline_mode                  = ( new Status() )->is_offline_mode();
+		$api_available                    = ( new Host() )->is_wpcom_simple() || ( $jetpack_ready_and_user_connected && ! $is_offline_mode );
 		return $api_available;
 	}
 

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
 use Automattic\Jetpack\Status\Host;
 use const Automattic\Jetpack\Extensions\Subscriptions\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS;
@@ -744,6 +745,19 @@ class Jetpack_Memberships {
 	 */
 	public static function is_enabled_jetpack_recurring_payments() {
 		$api_available = ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_connection_ready() );
+		return $api_available;
+	}
+
+	/**
+	 * Whether to enable the blocks in the editor.
+	 * All Monetize blocks (except Simple Payments) need an active connecting and a user with at least `edit_posts` capability
+	 *
+	 * @return bool
+	 */
+	public static function should_enable_monetize_blocks_in_editor() {
+		$jetpack_ready_and_user_connected = Jetpack::is_connection_ready() &&
+			( new Connection_Manager( 'jetpack' ) )->is_user_connected() && current_user_can( 'edit_posts' );
+		$api_available                    = ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || $jetpack_ready_and_user_connected );
 		return $api_available;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack/issues/39308

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Do not register Memberships blocks that actively use Jetpack connection when the site is not connected to Jetpack
* Use of utility function `Jetpack_Memberships::is_enabled_jetpack_recurring_payments()`

Note: Simple payments blocks. (aka as Paypal button) is not shielded as it does not need a JP connection to be working

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See https://github.com/Automattic/jetpack/issues/39308#issuecomment-2340110903

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JP site that is not connected
* Make sure Donations, Payment Button and Premium content buttons are not available
* Connect the site
* Make sure Donations, Payment Button and Premium content buttons are now available

