### PR TITLE
repo-gardening: Update release timing information

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-gardening-release-timing
+++ b/projects/github-actions/repo-gardening/changelog/update-gardening-release-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Check description task: Update timing for Jetpack, wpcomsh, and mu-wpcom-plugin releases.

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.js
@@ -79,9 +79,9 @@ async function getMilestoneDates( plugin, nextMilestone ) {
 			codeFreezeDate = moment( freezeDateDescription[ 1 ] ).format( 'LL' );
 		}
 	} else if ( plugin === 'wpcomsh' ) {
-		releaseDate = 'on demand (usually Mondays if not sooner)';
+		releaseDate = 'Atomic deploys happen twice daily on weekdays (p9o2xV-2EN-p2)';
 	} else if ( plugin === 'mu-wpcom' ) {
-		releaseDate = 'WordPress.com Simple releases happen daily';
+		releaseDate = 'WordPress.com Simple releases happen semi-continuously (PCYsg-Jjm-p2)';
 	}
 
 	const capitalizedName = plugin
@@ -100,7 +100,7 @@ ${
 	'Jetpack' === capitalizedName
 		? `The Jetpack plugin has different release cadences depending on the platform:
 
-- WordPress.com Simple releases happen daily.
+- WordPress.com Simple releases happen semi-continuously (PCYsg-Jjm-p2).
 - WoA releases happen weekly.
 - Releases to self-hosted sites happen monthly. The next release is scheduled for _${ releaseDate }_ (scheduled code freeze on _${ codeFreezeDate }_).`
 		: `


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Now that we have rolling releases, wpcomsh happens twice daily on weekdays.
* Jetpack and mu-wpcom-plugin releases happen semi-continuously now, more frequently than daily.

In both cases, include a shortlink with details.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make a PR based on this one that affects those plugins, see what happens.