### PR TITLE
Jetpack AI: fix checkout URL

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-simple-sites-checkout
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-simple-sites-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: fix checkout URL redirect to the right yearly product

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
@@ -41,8 +41,10 @@ export default function useAICheckout(): {
 				path: `jetpack_ai_yearly:-q-${ nextTier?.limit }`,
 				query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
 		  } )
-		: getRedirectUrl( 'jetpack-ai-monthly-plan-ai-assistant-block-banner', {
+		: getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
 				site: getSiteFragment() as string,
+				path: 'jetpack_ai_yearly',
+				query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
 		  } );
 
 	const checkoutUrl =


### PR DESCRIPTION
Checkout URL was being set for monthly purchase

## Proposed changes:
This PR changes the checkout URL to point to the yearly product for simple and AT sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1725912958411219-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Apply the patch on your sandbox and use a sandboxed simple site. Use any of the upgrade buttons on the editor (block nudge, sidebar). You should be redirected to checkout the product with the yearly discount.
