### PR TITLE
Block Editor Welcome Tour: Reduce steps

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-reduce-tour-steps
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-reduce-tour-steps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Removing some steps from the Block Editor Welcome Tour, since it currently has too many

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -42,6 +42,8 @@ try {
  * The WelcomeTour component
  */
 function WelcomeTour() {
+	// eslint-disable-next-line no-console
+	console.debug( '*** WelcomeTour' );
 	const [ showDraftPostModal ] = useState(
 		getQueryArg( window.location.href, 'showDraftPostModal' )
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -42,8 +42,6 @@ try {
  * The WelcomeTour component
  */
 function WelcomeTour() {
-	// eslint-disable-next-line no-console
-	console.debug( '*** WelcomeTour' );
 	const [ showDraftPostModal ] = useState(
 		getQueryArg( window.location.href, 'showDraftPostModal' )
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
@@ -251,23 +251,6 @@ function useTourSteps(
 			  ]
 			: [] ),
 		{
-			slug: 'drag-drop',
-			meta: {
-				heading: __( 'Drag & drop', 'jetpack-mu-wpcom' ),
-				descriptions: {
-					desktop: __( 'To move blocks around, click and drag the handle.', 'jetpack-mu-wpcom' ),
-					mobile: __( 'To move blocks around, tap the up and down arrows.', 'jetpack-mu-wpcom' ),
-				},
-				imgSrc: getTourAssets( 'moveBlock' ),
-			},
-			options: {
-				classNames: {
-					desktop: 'wpcom-editor-welcome-tour__step',
-					mobile: [ 'is-with-extra-padding', 'wpcom-editor-welcome-tour__step' ],
-				},
-			},
-		},
-		{
 			slug: 'payment-block',
 			meta: {
 				heading: __( 'The Payments block', 'jetpack-mu-wpcom' ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
@@ -276,36 +276,6 @@ function useTourSteps(
 					},
 			  ]
 			: [] ),
-		...( ! isMobile
-			? [
-					{
-						slug: 'undo',
-						...( referencePositioning && {
-							referenceElements: {
-								desktop:
-									'.edit-post-header .edit-post-header__toolbar .components-button.editor-history__undo',
-							},
-						} ),
-						meta: {
-							heading: __( 'Undo any mistake', 'jetpack-mu-wpcom' ),
-							descriptions: {
-								desktop: __(
-									"Click the Undo button if you've made a mistake.",
-									'jetpack-mu-wpcom'
-								),
-								mobile: null,
-							},
-							imgSrc: getTourAssets( 'undo' ),
-						},
-						options: {
-							classNames: {
-								desktop: 'wpcom-editor-welcome-tour__step',
-								mobile: 'wpcom-editor-welcome-tour__step',
-							},
-						},
-					},
-			  ]
-			: [] ),
 		{
 			slug: 'drag-drop',
 			meta: {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
@@ -1,4 +1,5 @@
 import { localizeUrl } from '@automattic/i18n-utils';
+import { isComingSoon } from '@automattic/jetpack-shared-extension-utils';
 import { ExternalLink } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { createInterpolateElement } from '@wordpress/element';
@@ -83,6 +84,8 @@ function useTourSteps(
 ): WpcomStep[] {
 	// eslint-disable-next-line no-console
 	console.debug( '*** useTourSteps' );
+	// eslint-disable-next-line no-console
+	console.debug( '*** isComingSoon', isComingSoon() );
 	const isVideoMaker = 'videomaker' === ( themeName ?? '' );
 	const isPatternAssembler = !! getQueryArg( window.location.href, 'assembler' );
 	const isMobile = useViewportMatch( 'mobile', '<' );
@@ -331,32 +334,50 @@ function useTourSteps(
 			meta: {
 				heading: __( 'Congratulations!', 'jetpack-mu-wpcom' ),
 				descriptions: {
-					desktop: createInterpolateElement(
-						__(
-							"You've learned the basics. Remember, your site is private until you <link_to_launch_site_docs>decide to launch</link_to_launch_site_docs>. View the <link_to_editor_docs>block editing docs</link_to_editor_docs> to learn more.",
-							'jetpack-mu-wpcom'
-						),
-						{
-							link_to_launch_site_docs: (
-								<ExternalLink
-									href={ localizeUrl(
-										'https://wordpress.com/support/settings/privacy-settings/#launch-your-site',
-										localeSlug
-									) }
-									children={ null }
-								/>
-							),
-							link_to_editor_docs: (
-								<ExternalLink
-									href={ localizeUrl(
-										'https://wordpress.com/support/wordpress-editor/',
-										localeSlug
-									) }
-									children={ null }
-								/>
-							),
-						}
-					),
+					desktop: isComingSoon()
+						? createInterpolateElement(
+								__(
+									"You've learned the basics. Remember, your site is private until you <link_to_launch_site_docs>decide to launch</link_to_launch_site_docs>. View the <link_to_editor_docs>block editing docs</link_to_editor_docs> to learn more.",
+									'jetpack-mu-wpcom'
+								),
+								{
+									link_to_launch_site_docs: (
+										<ExternalLink
+											href={ localizeUrl(
+												'https://wordpress.com/support/settings/privacy-settings/#launch-your-site',
+												localeSlug
+											) }
+											children={ null }
+										/>
+									),
+									link_to_editor_docs: (
+										<ExternalLink
+											href={ localizeUrl(
+												'https://wordpress.com/support/wordpress-editor/',
+												localeSlug
+											) }
+											children={ null }
+										/>
+									),
+								}
+						  )
+						: createInterpolateElement(
+								__(
+									"You've learned the basics. View the <link_to_editor_docs>block editing docs</link_to_editor_docs> to learn more.",
+									'jetpack-mu-wpcom'
+								),
+								{
+									link_to_editor_docs: (
+										<ExternalLink
+											href={ localizeUrl(
+												'https://wordpress.com/support/wordpress-editor/',
+												localeSlug
+											) }
+											children={ null }
+										/>
+									),
+								}
+						  ),
 					mobile: null,
 				},
 				imgSrc: getTourAssets( 'finish' ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
@@ -82,10 +82,6 @@ function useTourSteps(
 	themeName: string | null = null,
 	siteIntent: string | undefined = undefined
 ): WpcomStep[] {
-	// eslint-disable-next-line no-console
-	console.debug( '*** useTourSteps' );
-	// eslint-disable-next-line no-console
-	console.debug( '*** isComingSoon', isComingSoon() );
 	const isVideoMaker = 'videomaker' === ( themeName ?? '' );
 	const isPatternAssembler = !! getQueryArg( window.location.href, 'assembler' );
 	const isMobile = useViewportMatch( 'mobile', '<' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
@@ -81,6 +81,8 @@ function useTourSteps(
 	themeName: string | null = null,
 	siteIntent: string | undefined = undefined
 ): WpcomStep[] {
+	// eslint-disable-next-line no-console
+	console.debug( '*** useTourSteps' );
 	const isVideoMaker = 'videomaker' === ( themeName ?? '' );
 	const isPatternAssembler = !! getQueryArg( window.location.href, 'assembler' );
 	const isMobile = useViewportMatch( 'mobile', '<' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/welcome-tour/use-tour-steps.tsx
@@ -202,32 +202,6 @@ function useTourSteps(
 			},
 		},
 		{
-			slug: 'edit-block',
-			meta: {
-				heading: __( 'Click a block to change it', 'jetpack-mu-wpcom' ),
-				descriptions: {
-					desktop: isVideoMaker
-						? __(
-								'Use the toolbar to change the appearance of a selected block. Try replacing a video!',
-								'jetpack-mu-wpcom'
-						  )
-						: _x(
-								'Use the toolbar to change the appearance of a selected block. Try making it bold.',
-								'jetpack-mu-wpcom',
-								'jetpack-mu-wpcom'
-						  ),
-					mobile: null,
-				},
-				imgSrc: getTourAssets( isVideoMaker ? 'videomakerEdit' : 'makeBold' ),
-			},
-			options: {
-				classNames: {
-					desktop: 'wpcom-editor-welcome-tour__step',
-					mobile: 'wpcom-editor-welcome-tour__step',
-				},
-			},
-		},
-		{
 			slug: 'settings',
 			...( referencePositioning && {
 				referenceElements: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/dotcom-forge/issues/8765

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
1. Remove the ‘Undo any mistake,’ ‘Click a block to change it,’ and ‘Drag & drop’ steps.
2. Hide "Remember, your site is private until you decide to launch" in the last card if the site is already public.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch on your sandbox
* Create a new account, and with it, create a new site without getting to launch it
* Sandbox the new site
* Go to `/post/{siteSlug}.wordpress.com`
* Check that the welcome tour shown on the bottom left corner only has 6 steps, compared to the 9 that we had before:

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/2f2ddcc0-ddc2-479a-9937-70a47365e1c2)|![image](https://github.com/user-attachments/assets/2d6b433e-7f15-43f4-b493-678b61f30006)|

* Go to the last step, and check that it says `Remember, your site is private until you decide to launch↗.`
* Now launch the site and go back to the editor, check that on the last step the `Remember, your site is private until you decide to launch↗.` phrase is not shown

