### PR TITLE
Admin Page: display Stats yearly plan on "My Plan"

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/plans/plan-icon/index.jsx
@@ -97,6 +97,7 @@ import {
 	PLAN_JETPACK_STATS_BI_YEARLY,
 	PLAN_JETPACK_STATS,
 	PLAN_JETPACK_STATS_MONTHLY,
+	PLAN_JETPACK_STATS_YEARLY,
 	PLAN_JETPACK_STATS_PWYW_YEARLY,
 	PLAN_JETPACK_STATS_FREE,
 	PLAN_JETPACK_CREATOR_BI_YEARLY,
@@ -209,6 +210,7 @@ const PRODUCT_ICON_MAP = {
 	[ PLAN_JETPACK_STATS_BI_YEARLY ]: 'products/product-jetpack-stats.svg',
 	[ PLAN_JETPACK_STATS ]: 'products/product-jetpack-stats.svg',
 	[ PLAN_JETPACK_STATS_MONTHLY ]: 'products/product-jetpack-stats.svg',
+	[ PLAN_JETPACK_STATS_YEARLY ]: 'products/product-jetpack-stats.svg',
 	[ PLAN_JETPACK_STATS_PWYW_YEARLY ]: 'products/product-jetpack-stats.svg',
 	[ PLAN_JETPACK_STATS_FREE ]: 'products/product-jetpack-stats.svg',
 };
@@ -322,6 +324,7 @@ PlanIcon.propTypes = {
 		PLAN_JETPACK_STATS_BI_YEARLY,
 		PLAN_JETPACK_STATS,
 		PLAN_JETPACK_STATS_MONTHLY,
+		PLAN_JETPACK_STATS_YEARLY,
 		PLAN_JETPACK_STATS_PWYW_YEARLY,
 		PLAN_JETPACK_STATS_FREE,
 	] ).isRequired,

--- a/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
+++ b/projects/plugins/jetpack/_inc/client/lib/plans/constants.js
@@ -103,6 +103,7 @@ export const PLAN_JETPACK_SECURITY_REALTIME_MONTHLY = 'jetpack_security_realtime
 export const PLAN_JETPACK_STATS_BI_YEARLY = 'jetpack_stats_bi_yearly';
 export const PLAN_JETPACK_STATS = 'jetpack_stats';
 export const PLAN_JETPACK_STATS_MONTHLY = 'jetpack_stats_monthly';
+export const PLAN_JETPACK_STATS_YEARLY = 'jetpack_stats_yearly';
 export const PLAN_JETPACK_STATS_PWYW_YEARLY = 'jetpack_stats_pwyw_yearly';
 export const PLAN_JETPACK_STATS_FREE = 'jetpack_stats_free_yearly';
 
@@ -323,6 +324,7 @@ export const JETPACK_STATS_PRODUCTS = [
 	PLAN_JETPACK_STATS_BI_YEARLY,
 	PLAN_JETPACK_STATS,
 	PLAN_JETPACK_STATS_MONTHLY,
+	PLAN_JETPACK_STATS_YEARLY,
 	PLAN_JETPACK_STATS_PWYW_YEARLY,
 	PLAN_JETPACK_STATS_FREE,
 ];
@@ -775,6 +777,7 @@ export function getPlanClass( plan ) {
 		case PLAN_JETPACK_STATS_BI_YEARLY:
 		case PLAN_JETPACK_STATS:
 		case PLAN_JETPACK_STATS_MONTHLY:
+		case PLAN_JETPACK_STATS_YEARLY:
 		case PLAN_JETPACK_STATS_PWYW_YEARLY:
 			return 'is-jetpack-stats-plan';
 		case PLAN_JETPACK_STATS_FREE:

--- a/projects/plugins/jetpack/changelog/fix-stats-plan-yearly-myplan
+++ b/projects/plugins/jetpack/changelog/fix-stats-plan-yearly-myplan
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Dashboard: display the yearly Stats plan in the Jetpack dashboard immediately after you've purchased the plan.


### PR DESCRIPTION
## Proposed changes:

We had added support for multiple stats plans in #31732, but we didn't add support for yearly plans.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* p1725971038238289-slack-C06PK2W8F42

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site that's connected to WordPress.com.
* Go to Jetpack > Dashboard > Plans
* Purchase a Stats plan. Pick the yearly option.
* Go back to wp-admin > Jetpack > Dashboard > My Plan
* You should see the Stats plan in there.
