### PR TITLE
Revert "Blocks: determine block names from filename convention instead of disk access (#39307)

### DIFF
--- a/projects/packages/blocks/changelog/add-get_block_name_from_path_convention
+++ b/projects/packages/blocks/changelog/add-get_block_name_from_path_convention
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Blocks: Determine block names from filename convention instead of disk access

--- a/projects/packages/blocks/src/class-blocks.php
+++ b/projects/packages/blocks/src/class-blocks.php
@@ -53,7 +53,8 @@ class Blocks {
 		// If a path is passed, make sure to get the block.json file from the build directory and get
 		// the block name from that file.
 		if ( path_is_absolute( $slug ) ) {
-			$slug = self::get_block_name_from_path_convention( $slug );
+			$block_type = self::get_path_to_block_metadata( $slug );
+			$slug       = self::get_block_name( $block_type );
 		}
 
 		if (
@@ -171,42 +172,6 @@ class Blocks {
 		$metadata = self::get_block_metadata( $arg );
 
 		return self::get_block_name_from_metadata( $metadata );
-	}
-
-	/**
-	 * Get the block name from the path convention.
-	 * For example, path "./extensions/blocks/pinterest" is assumed to define
-	 * a block named "jetpack/pinterest" without checking any files.
-	 *
-	 * Any exceptions should be added to the $breaks_convention array.
-	 * For example, blocks/premium-content defines "premium-content\/container", not "jetpack/premium-content".
-	 * These paths will use the code that checks the disk for the block name.
-	 *
-	 * The unit test test_get_block_name_from_path_convention_matches_get_block_name() verifies that
-	 * all names are correctly guessed.
-	 *
-	 * Run with `./vendor/bin/phpunit --filter WP_Test_Jetpack_Gutenberg`.
-	 *
-	 * @param string $path The path to extract the block name from.
-	 *
-	 * @return string The block name with 'jetpack/' prefix.
-	 */
-	public static function get_block_name_from_path_convention( $path ) {
-		$path_parts = explode( '/', $path );
-		if ( count( $path_parts ) <= 0 ) {
-			$block_type = self::get_path_to_block_metadata( $path );
-			return self::get_block_name( $block_type );
-		}
-
-		$last_part         = $path_parts[ count( $path_parts ) - 1 ];
-		$breaks_convention = array( 'premium-content' );
-
-		if ( in_array( $last_part, $breaks_convention, true ) ) {
-			$block_type = self::get_path_to_block_metadata( $path );
-			return self::get_block_name( $block_type );
-		}
-
-		return 'jetpack/' . $last_part;
 	}
 
 	/**

--- a/projects/packages/blocks/tests/php/test-blocks.php
+++ b/projects/packages/blocks/tests/php/test-blocks.php
@@ -513,30 +513,4 @@ class Test_Blocks extends TestCase {
 		$result = Blocks::get_block_feature( __DIR__ . '/fixtures/test-block/block.json' );
 		$this->assertEquals( 'test-block', $result );
 	}
-
-	/**
-	 * Test getting the block name from path convention.
-	 *
-	 * @since 1.x.x
-	 *
-	 * @covers Automattic\Jetpack\Blocks::get_block_name_from_path_convention
-	 */
-	public function test_get_block_name_from_path_convention() {
-		/**
-		 * Basic string based tests only.
-		 *
-		 * For a more comprehensive test, see the test_get_block_name_from_path_convention_matches_get_block_name test.
-		 * in test-class.jetpack-gutenberg.php.
-		 */
-		$test_cases = array(
-			'/path/to/extensions/blocks/apple' => 'jetpack/apple',
-			'/var/www/html/wp-content/plugins/jetpack/extensions/blocks/banana' => 'jetpack/banana',
-			'/home/user/wordpress/wp-content/plugins/jetpack/extensions/blocks/cherry' => 'jetpack/cherry',
-		);
-
-		foreach ( $test_cases as $path => $expected ) {
-			$result = Blocks::get_block_name_from_path_convention( $path );
-			$this->assertEquals( $expected, $result, "Failed for path: $path" );
-		}
-	}
 }

--- a/projects/plugins/jetpack/changelog/add-get_block_name_from_path_convention
+++ b/projects/plugins/jetpack/changelog/add-get_block_name_from_path_convention
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Adds a unit test for a change in the blocks repo
-
-

--- a/projects/plugins/jetpack/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/tests/php/general/test-class.jetpack-gutenberg.php
@@ -306,37 +306,4 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 		$this->assertFalse( $validated_url );
 	}
-
-	/**
-	 * Test that get_block_name_from_path_convention() provides the same results as get_block_name()
-	 * for all blocks registered by load_independent_blocks().
-	 *
-	 * @covers Automattic\Jetpack\Blocks::get_block_name_from_path_convention
-	 * @covers Automattic\Jetpack\Blocks::get_block_name
-	 */
-	public function test_get_block_name_from_path_convention_matches_get_block_name() {
-		$extensions = Jetpack_Gutenberg::get_available_extensions();
-
-		foreach ( $extensions as $extension ) {
-			$dirname         = 'blocks';
-			$path            = __DIR__ . "/../../../extensions/{$dirname}/{$extension}";
-			$block_json_file = "{$path}/block.json";
-
-			if ( file_exists( $path ) && file_exists( $block_json_file ) ) {
-				// Get the block name using the path name convention method
-				$conventional_name = Blocks::get_block_name_from_path_convention( $path );
-
-				// Get the block name using the existing method
-				$block_type    = Blocks::get_path_to_block_metadata( $path );
-				$existing_name = Blocks::get_block_name( $block_type );
-
-				// Assert that both methods return the same result
-				$this->assertEquals(
-					$existing_name,
-					$conventional_name,
-					"Block name mismatch for {$extension} in {$dirname} directory"
-				);
-			}
-		}
-	}
 }


### PR DESCRIPTION
When trying to deploy this, I see e2e failures.

## Proposed changes:

* revert

## Testing instructions:

* Go to '..'
*

## Does this pull request change what data or activity we track or use?

My PR adds *x* and *y*.