### PR TITLE
License activation: Add helpful error messages & display help steps on error response.

### DIFF
--- a/projects/js-packages/licensing/changelog/update-license-activate-error-messages
+++ b/projects/js-packages/licensing/changelog/update-license-activate-error-messages
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add more helpful error messages and help steps on license key activation error.

--- a/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
@@ -6,6 +6,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import ActivationScreenError from '../activation-screen-error';
+import { LICENSE_ERRORS } from '../activation-screen-error/constants';
 import './style.scss';
 
 /**
@@ -150,12 +151,20 @@ const ActivationScreenControls = props => {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_license_key_activation_view' );
 	}, [] );
 
-	const className = hasLicenseError
-		? 'jp-license-activation-screen-controls--license-field-with-error'
-		: 'jp-license-activation-screen-controls--license-field';
-
 	const errorTypeMatch = licenseError?.match( /\[[a-z_]+\]/ );
 	const errorType = errorTypeMatch && errorTypeMatch[ 0 ];
+
+	const { ACTIVE_ON_SAME_SITE } = LICENSE_ERRORS;
+	const isLicenseAlreadyAttached = ACTIVE_ON_SAME_SITE === errorType;
+	const className = useMemo( () => {
+		if ( hasLicenseError ) {
+			if ( isLicenseAlreadyAttached ) {
+				return 'jp-license-activation-screen-controls--license-field-with-success';
+			}
+			return 'jp-license-activation-screen-controls--license-field-with-error';
+		}
+		return 'jp-license-activation-screen-controls--license-field';
+	}, [ hasLicenseError, isLicenseAlreadyAttached ] );
 
 	const hasAvailableLicenseKey = availableLicenses && availableLicenses.length;
 

--- a/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
@@ -145,7 +145,6 @@ const ActivationScreenControls = props => {
 		licenseError,
 		onLicenseChange,
 	} = props;
-	const hasLicenseError = licenseError !== null && licenseError !== undefined;
 
 	useEffect( () => {
 		jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_license_key_activation_view' );
@@ -157,14 +156,15 @@ const ActivationScreenControls = props => {
 	const { ACTIVE_ON_SAME_SITE } = LICENSE_ERRORS;
 	const isLicenseAlreadyAttached = ACTIVE_ON_SAME_SITE === errorType;
 	const className = useMemo( () => {
-		if ( hasLicenseError ) {
-			if ( isLicenseAlreadyAttached ) {
-				return 'jp-license-activation-screen-controls--license-field-with-success';
-			}
-			return 'jp-license-activation-screen-controls--license-field-with-error';
+		if ( ! licenseError ) {
+			return 'jp-license-activation-screen-controls--license-field';
 		}
-		return 'jp-license-activation-screen-controls--license-field';
-	}, [ hasLicenseError, isLicenseAlreadyAttached ] );
+		if ( isLicenseAlreadyAttached ) {
+			return 'jp-license-activation-screen-controls--license-field-with-success';
+		}
+
+		return 'jp-license-activation-screen-controls--license-field-with-error';
+	}, [ licenseError, isLicenseAlreadyAttached ] );
 
 	const hasAvailableLicenseKey = availableLicenses && availableLicenses.length;
 
@@ -200,7 +200,7 @@ const ActivationScreenControls = props => {
 						value={ license }
 					/>
 				) }
-				{ hasLicenseError && (
+				{ licenseError && (
 					<ActivationScreenError licenseError={ licenseError } errorType={ errorType } />
 				) }
 			</div>

--- a/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-controls/index.jsx
@@ -3,10 +3,9 @@ import { JetpackLogo, Spinner } from '@automattic/jetpack-components';
 import { Button, TextControl, SelectControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
-import { Icon, warning } from '@wordpress/icons';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-
+import ActivationScreenError from '../activation-screen-error';
 import './style.scss';
 
 /**
@@ -155,6 +154,9 @@ const ActivationScreenControls = props => {
 		? 'jp-license-activation-screen-controls--license-field-with-error'
 		: 'jp-license-activation-screen-controls--license-field';
 
+	const errorTypeMatch = licenseError?.match( /\[[a-z_]+\]/ );
+	const errorType = errorTypeMatch && errorTypeMatch[ 0 ];
+
 	const hasAvailableLicenseKey = availableLicenses && availableLicenses.length;
 
 	return (
@@ -190,10 +192,7 @@ const ActivationScreenControls = props => {
 					/>
 				) }
 				{ hasLicenseError && (
-					<div className="jp-license-activation-screen-controls--license-field-error">
-						<Icon icon={ warning } />
-						<span>{ licenseError }</span>
-					</div>
+					<ActivationScreenError licenseError={ licenseError } errorType={ errorType } />
 				) }
 			</div>
 			<div>

--- a/projects/js-packages/licensing/components/activation-screen-controls/style.scss
+++ b/projects/js-packages/licensing/components/activation-screen-controls/style.scss
@@ -37,7 +37,8 @@
 
 
 	.jp-license-activation-screen-controls--license-field,
-	.jp-license-activation-screen-controls--license-field-with-error {
+	.jp-license-activation-screen-controls--license-field-with-error,
+	.jp-license-activation-screen-controls--license-field-with-success {
 		max-width: 500px;
 		.components-input-control__label.components-input-control__label.components-input-control__label {
 			font-weight: 600;
@@ -64,6 +65,13 @@
 		input.components-text-control__input,
 		select.components-select-control__input {
 			border: 1px solid var(--jp-red);
+		}
+	}
+
+	.jp-license-activation-screen-controls--license-field-with-success {
+		input.components-text-control__input,
+		select.components-select-control__input {
+			border: 1px solid var(--jp-green);
 		}
 	}
 

--- a/projects/js-packages/licensing/components/activation-screen-controls/style.scss
+++ b/projects/js-packages/licensing/components/activation-screen-controls/style.scss
@@ -67,24 +67,6 @@
 		}
 	}
 
-	.jp-license-activation-screen-controls--license-field-error {
-		display: flex;
-		flex-direction: row;
-		align-items: flex-start;
-		color: var(--jp-red);
-		max-width: 500px;
-
-		svg {
-			margin-right: 4px;
-			fill: var(--jp-red);
-			min-width: 24px;
-		}
-
-		span {
-			font-size: var(--font-body);
-		}
-	}
-
 	.jp-license-activation-screen-controls--button,
 	.jp-license-activation-screen-controls--button:active {
 		background-color: var( --jp-black );

--- a/projects/js-packages/licensing/components/activation-screen-controls/test/component.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-controls/test/component.jsx
@@ -47,7 +47,7 @@ describe( 'ActivationScreenControls', () => {
 			expect( node ).toBeInTheDocument();
 			expect(
 				// eslint-disable-next-line testing-library/no-node-access
-				node.closest( '.jp-license-activation-screen-controls--license-field-error' )
+				node.closest( '.activation-screen-error__message' )
 			).toBeInTheDocument();
 		} );
 	} );

--- a/projects/js-packages/licensing/components/activation-screen-error/constants.ts
+++ b/projects/js-packages/licensing/components/activation-screen-error/constants.ts
@@ -1,0 +1,9 @@
+export const LICENSE_ERRORS = {
+	NOT_SAME_OWNER: '[not_same_owner]',
+	ACTIVE_ON_SAME_SITE: '[active_on_same_site]',
+	ATTACHED_LICENSE: '[attached_license]',
+	PRODUCT_INCOMPATIBILITY: '[product_incompatibility]',
+	REVOKED_LICENSE: '[revoked_license]',
+	INVALID_INPUT: '[invalid_input]',
+	MULTISITE_INCOMPATIBILITY: '[multisite_incompatibility]',
+} as const;

--- a/projects/js-packages/licensing/components/activation-screen-error/index.tsx
+++ b/projects/js-packages/licensing/components/activation-screen-error/index.tsx
@@ -1,37 +1,36 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { Icon, warning, check } from '@wordpress/icons';
-import React, { FC, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { LICENSE_ERRORS } from './constants';
-import { UseGetErrorContent } from './use-get-error-content';
+import { useGetErrorContent } from './use-get-error-content';
+import type { FC } from 'react';
 
 import './style.scss';
 
 type LicenseErrorKeysType = keyof typeof LICENSE_ERRORS;
 type LicenseErrorValuesType = ( typeof LICENSE_ERRORS )[ LicenseErrorKeysType ];
 
-type Props = {
+interface Props {
 	licenseError: string;
 	errorType: LicenseErrorValuesType;
-};
+}
 
 const ActivationScreenError: FC< Props > = ( { licenseError, errorType } ) => {
-	const hasLicenseError = licenseError !== null && licenseError !== undefined;
-
 	useEffect( () => {
-		if ( hasLicenseError ) {
+		if ( licenseError ) {
 			jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_license_activation_error_view', {
 				error: licenseError,
 				error_type: errorType,
 			} );
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ licenseError, errorType ] );
 
-	if ( ! hasLicenseError ) {
+	const { errorMessage, errorInfo } = useGetErrorContent( licenseError, errorType );
+
+	if ( ! licenseError ) {
 		return null;
 	}
 
-	const { errorMessage, errorInfo } = UseGetErrorContent( licenseError, errorType );
 	const { ACTIVE_ON_SAME_SITE } = LICENSE_ERRORS;
 	const isLicenseAlreadyAttached = ACTIVE_ON_SAME_SITE === errorType;
 

--- a/projects/js-packages/licensing/components/activation-screen-error/index.tsx
+++ b/projects/js-packages/licensing/components/activation-screen-error/index.tsx
@@ -1,0 +1,53 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { Icon, warning, check } from '@wordpress/icons';
+import React, { FC, useEffect } from 'react';
+import { LICENSE_ERRORS } from './constants';
+import { UseGetErrorContent } from './use-get-error-content';
+
+import './style.scss';
+
+type LicenseErrorKeysType = keyof typeof LICENSE_ERRORS;
+type LicenseErrorValuesType = ( typeof LICENSE_ERRORS )[ LicenseErrorKeysType ];
+
+type Props = {
+	licenseError: string;
+	errorType: LicenseErrorValuesType;
+};
+
+const ActivationScreenError: FC< Props > = ( { licenseError, errorType } ) => {
+	const hasLicenseError = licenseError !== null && licenseError !== undefined;
+
+	useEffect( () => {
+		if ( hasLicenseError ) {
+			jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_license_activation_error_view', {
+				error: licenseError,
+				error_type: errorType,
+			} );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	if ( ! hasLicenseError ) {
+		return null;
+	}
+
+	const { errorMessage, errorInfo } = UseGetErrorContent( licenseError, errorType );
+	const { ACTIVE_ON_SAME_SITE } = LICENSE_ERRORS;
+	const isLicenseAlreadyAttached = ACTIVE_ON_SAME_SITE === errorType;
+
+	const errorMessageClass = isLicenseAlreadyAttached
+		? 'activation-screen-error__message--success'
+		: 'activation-screen-error__message--error';
+
+	return (
+		<>
+			<div className={ `activation-screen-error__message ${ errorMessageClass }` }>
+				<Icon icon={ isLicenseAlreadyAttached ? check : warning } size={ 20 } />
+				<span>{ errorMessage }</span>
+			</div>
+			{ errorInfo && <div className="activation-screen-error__info">{ errorInfo }</div> }
+		</>
+	);
+};
+
+export default ActivationScreenError;

--- a/projects/js-packages/licensing/components/activation-screen-error/style.scss
+++ b/projects/js-packages/licensing/components/activation-screen-error/style.scss
@@ -3,7 +3,7 @@
     flex-direction: row;
     align-items: flex-start;
     max-width: 500px;
-    margin-top: calc(var(--jp-spacing-base)*.5);
+    margin-top: calc(var(--spacing-base)*.5);
 
     svg {
         margin-left: -3px;

--- a/projects/js-packages/licensing/components/activation-screen-error/style.scss
+++ b/projects/js-packages/licensing/components/activation-screen-error/style.scss
@@ -3,6 +3,7 @@
     flex-direction: row;
     align-items: flex-start;
     max-width: 500px;
+    margin-top: calc(var(--jp-spacing-base)*.5);
 
     svg {
         margin-left: -3px;

--- a/projects/js-packages/licensing/components/activation-screen-error/style.scss
+++ b/projects/js-packages/licensing/components/activation-screen-error/style.scss
@@ -1,0 +1,62 @@
+.activation-screen-error__message {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    max-width: 500px;
+
+    svg {
+        margin-left: -3px;
+    }
+
+    span {
+        font-size: 13px;
+        line-height: 20px;
+        font-weight: 500;
+        letter-spacing: -0.044em;
+    }
+}
+
+.activation-screen-error__message--error {
+    color: var(--jp-red);
+    svg {
+        fill: var(--jp-red);
+    }
+}
+
+.activation-screen-error__message--success {
+    color: var(--jp-green);
+    svg {
+        fill: var(--jp-green);
+    }
+}
+
+.activation-screen-error__info {
+    background-color: var(--jp-gray-0);
+    color: var(--jp-gray-80);
+    font-size: var(--font-body-small);
+    line-height: calc(var(--font-title-small) - 2px);
+    border: 1px solid #F0F0F0;
+    border-radius: var(--jp-border-radius);
+    padding: var(--jp-modal-padding-small);
+    margin: 32px 0 8px;
+
+    > p {
+        margin: 0 0 1em !important;
+        font-size: var(--font-body-small) !important;
+    }
+    > p:last-child {
+        margin-bottom: 0 !important;
+    }
+
+    ol > li::marker {
+        font-weight: bold;
+    }
+
+    a {
+        color: var(--jp-green-50);
+    }
+    a:hover,
+    a:active {
+        color: var(--jp-green-70);
+    }
+}

--- a/projects/js-packages/licensing/components/activation-screen-error/style.scss
+++ b/projects/js-packages/licensing/components/activation-screen-error/style.scss
@@ -36,17 +36,17 @@
     color: var(--jp-gray-80);
     font-size: var(--font-body-small);
     line-height: calc(var(--font-title-small) - 2px);
-    border: 1px solid #F0F0F0;
+    border: 1px solid var(--jp-green-0);
     border-radius: var(--jp-border-radius);
     padding: var(--jp-modal-padding-small);
     margin: 32px 0 8px;
 
     > p {
-        margin: 0 0 1em !important;
-        font-size: var(--font-body-small) !important;
+        margin: 0 0 1em;
+        font-size: var(--font-body-small);
     }
     > p:last-child {
-        margin-bottom: 0 !important;
+        margin-bottom: 0;
     }
 
     ol > li::marker {
@@ -59,5 +59,17 @@
     a:hover,
     a:active {
         color: var(--jp-green-70);
+    }
+}
+
+.jp-license-activation-screen-controls {
+    .activation-screen-error__info {
+        > p {
+            margin: 0 0 1em;
+            font-size: var(--font-body-small);
+        }
+        > p:last-child {
+            margin-bottom: 0;
+        }
     }
 }

--- a/projects/js-packages/licensing/components/activation-screen-error/use-get-error-content.tsx
+++ b/projects/js-packages/licensing/components/activation-screen-error/use-get-error-content.tsx
@@ -1,0 +1,185 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import React from 'react';
+import { LICENSE_ERRORS } from './constants';
+
+type LicenseErrorKeysType = keyof typeof LICENSE_ERRORS;
+type LicenseErrorValuesType = ( typeof LICENSE_ERRORS )[ LicenseErrorKeysType ];
+
+export const UseGetErrorContent = ( licenseError: string, errorType: LicenseErrorValuesType ) => {
+	const hasLicenseError = licenseError !== null && licenseError !== undefined;
+
+	if ( ! hasLicenseError ) {
+		return {
+			errorMessage: null,
+			errorInfo: null,
+		};
+	}
+
+	const needHelpGetInTouchLink = createInterpolateElement(
+		__( 'Need help? <a>Get in touch</a>.', 'jetpack' ),
+		{
+			a: (
+				<ExternalLink
+					href={ getRedirectUrl( 'jetpack-contact-support' ) }
+					rel="noopener noreferrer"
+				></ExternalLink>
+			),
+		}
+	);
+
+	switch ( errorType ) {
+		case LICENSE_ERRORS.NOT_SAME_OWNER:
+			return {
+				errorMessage: __(
+					'The account that purchased the plan and the account managing this site are different.',
+					'jetpack'
+				),
+				errorInfo: (
+					<>
+						<p>
+							{ createInterpolateElement(
+								__( 'Follow these <a>steps</a> to resolve it.', 'jetpack' ),
+								{
+									a: (
+										<ExternalLink
+											rel="noopener noreferrer"
+											href={ getRedirectUrl( 'jetpack-support-activate-license' ) }
+										></ExternalLink>
+									),
+								}
+							) }
+						</p>
+						<ol>
+							<li>{ __( 'Disconnect Jetpack from your site.', 'jetpack' ) }</li>
+							<li>
+								{ __( 'Log in to the WordPress.com account that purchased the plan.', 'jetpack' ) }
+							</li>
+							<li>{ __( 'Reconnect Jetpack.', 'jetpack' ) }</li>
+						</ol>
+						<p>{ needHelpGetInTouchLink }</p>
+					</>
+				),
+			};
+		case LICENSE_ERRORS.ACTIVE_ON_SAME_SITE:
+			return {
+				errorMessage: __( 'This license is already active on your site.', 'jetpack' ),
+				errorInfo: null,
+			};
+		case LICENSE_ERRORS.ATTACHED_LICENSE:
+			return {
+				errorMessage: __( 'This license is already active on another website', 'jetpack' ),
+				errorInfo: (
+					<ul>
+						<li>
+							{ createInterpolateElement(
+								__( 'If you would like to transfer it, please <a>get in touch</a>.', 'jetpack' ),
+								{
+									a: (
+										<ExternalLink
+											rel="noopener noreferrer"
+											href={ getRedirectUrl( 'jetpack-contact-support' ) }
+										></ExternalLink>
+									),
+								}
+							) }
+						</li>
+						<li>
+							{ createInterpolateElement(
+								__( 'To use Jetpack on both sites, please <a>buy another license</a>.', 'jetpack' ),
+								{
+									a: (
+										<ExternalLink
+											rel="noopener noreferrer"
+											href={ getRedirectUrl( 'my-jetpack-my-plans-purchase-no-site' ) }
+										></ExternalLink>
+									),
+								}
+							) }
+						</li>
+					</ul>
+				),
+			};
+		case LICENSE_ERRORS.PRODUCT_INCOMPATIBILITY:
+			return {
+				errorMessage: __(
+					'Your site already has an active Jetpack plan of equal or higher value.',
+					'jetpack'
+				),
+				errorInfo: (
+					<>
+						<p>
+							{ __(
+								'It looks like your website already has a Jetpack plan that’s equal to or better than the one you’re trying to activate.',
+								'jetpack'
+							) }
+						</p>
+
+						<p>
+							{ __(
+								'You can either use this license on a different site or cancel your current plan for a refund.',
+								'jetpack'
+							) }
+						</p>
+						<p>{ needHelpGetInTouchLink }</p>
+					</>
+				),
+			};
+		case LICENSE_ERRORS.REVOKED_LICENSE:
+			return {
+				errorMessage: __(
+					'The subscription is no longer active or has expired. Please purchase a new license.',
+					'jetpack'
+				),
+				errorInfo: <p>{ needHelpGetInTouchLink }</p>,
+			};
+		case LICENSE_ERRORS.INVALID_INPUT:
+			return {
+				errorMessage: __( 'Unable to validate this license key.', 'jetpack' ),
+				errorInfo: (
+					<>
+						<p>
+							{ __(
+								'Please take a moment to check the license key from your purchase confirmation email—it might have a small typo.',
+								'jetpack'
+							) }
+						</p>
+
+						<p>{ needHelpGetInTouchLink }</p>
+					</>
+				),
+			};
+		case LICENSE_ERRORS.MULTISITE_INCOMPATIBILITY: {
+			const planNameMatch = licenseError.match( /We.re sorry, (.*) is not compatible/ );
+			const planName = planNameMatch && planNameMatch[ 1 ];
+			return {
+				errorMessage: sprintf(
+					/* translators: %s is the Jetpack product name, i.e.- Jetpack Backup, Jetpack Boost, etc., which the product name should not be translated. */
+					__(
+						'We’re sorry, %s is not compatible with multisite WordPress installations at this time.',
+						'jetpack'
+					),
+					planName
+				),
+				errorInfo: (
+					<>
+						<p>
+							{ __(
+								'This Jetpack plan doesn’t work with Multisite WordPress setups. Please use it on a single-site installation or consider canceling for a refund.',
+								'jetpack'
+							) }
+						</p>
+						<p>{ needHelpGetInTouchLink }</p>
+					</>
+				),
+			};
+		}
+		default:
+			return {
+				errorMessage: licenseError,
+				errorInfo: <p>{ needHelpGetInTouchLink }</p>,
+			};
+	}
+};

--- a/projects/js-packages/licensing/components/activation-screen-error/use-get-error-content.tsx
+++ b/projects/js-packages/licensing/components/activation-screen-error/use-get-error-content.tsx
@@ -23,7 +23,7 @@ export const UseGetErrorContent = ( licenseError: string, errorType: LicenseErro
 		{
 			a: (
 				<ExternalLink
-					href={ getRedirectUrl( 'jetpack-contact-support' ) }
+					href={ getRedirectUrl( 'jetpack-support-license-activation' ) }
 					rel="noopener noreferrer"
 				></ExternalLink>
 			),
@@ -80,7 +80,7 @@ export const UseGetErrorContent = ( licenseError: string, errorType: LicenseErro
 									a: (
 										<ExternalLink
 											rel="noopener noreferrer"
-											href={ getRedirectUrl( 'jetpack-contact-support' ) }
+											href={ getRedirectUrl( 'jetpack-support-license-activation' ) }
 										></ExternalLink>
 									),
 								}

--- a/projects/js-packages/licensing/components/activation-screen-error/use-get-error-content.tsx
+++ b/projects/js-packages/licensing/components/activation-screen-error/use-get-error-content.tsx
@@ -8,10 +8,8 @@ import { LICENSE_ERRORS } from './constants';
 type LicenseErrorKeysType = keyof typeof LICENSE_ERRORS;
 type LicenseErrorValuesType = ( typeof LICENSE_ERRORS )[ LicenseErrorKeysType ];
 
-export const UseGetErrorContent = ( licenseError: string, errorType: LicenseErrorValuesType ) => {
-	const hasLicenseError = licenseError !== null && licenseError !== undefined;
-
-	if ( ! hasLicenseError ) {
+export const useGetErrorContent = ( licenseError: string, errorType: LicenseErrorValuesType ) => {
+	if ( ! licenseError ) {
 		return {
 			errorMessage: null,
 			errorInfo: null,
@@ -46,7 +44,9 @@ export const UseGetErrorContent = ( licenseError: string, errorType: LicenseErro
 									a: (
 										<ExternalLink
 											rel="noopener noreferrer"
-											href={ getRedirectUrl( 'jetpack-support-activate-license' ) }
+											href={ getRedirectUrl( 'jetpack-support-activate-license', {
+												anchor: 'different-user',
+											} ) }
 										></ExternalLink>
 									),
 								}


### PR DESCRIPTION
This PR updates the various error messages and displays error help steps upon license key activation error.

You can view the Figma designs here: B09ms2D7kgqRmn10LL9lsL-fi-4387_6302
Fixes: https://github.com/Automattic/jetpack-marketing/issues/967

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reword (and translate) the various error response messages that come from the server.
* Display some specific error help steps below the error message.
* See Figma design link above.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-marketing/issues/967

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Adds a new tracking event, tracks when error message is viewed and tracks the type of error thrown.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a JN site with Jetpack Beta. In the Beta plugin, activate this branch on the Jetpack plugin.
* Connect Jetpack to a different WordPress account (Not your A11N wordpress.com account)
    - I suggest you log-in to the JN site wp-admin dashboard from a **new incognito window**, then log into your non-A11N wordpress.com account in another tab (in that same incognito window), and then connect Jetpack to that (non A11N) user account.
    That way you can stay logged in to your A11N WordPress.com account in your other, non-incognito browser window.
* On the JN site, open My Jetpack, and click "Activate a license"
* Paste in a Jetpack Security or Complete license key that was purchased with your A11N account (with credits). (If you don't have one, you'll need to go ahead and purchase one (with your A11N account).
* Click "Activate" button.
* Verify the error message and the additional help info are displayed and that it matches the Figma design (link above).  See screenshot:
![Screen Shot 2024-09-10 at 17 56 38](https://github.com/user-attachments/assets/532d9c8d-4e84-4ac7-9181-b887c967d41b)
* Verify the copy looks good and the links work correctly.
* Disconnect the site/user from Jetpack.
* Now connect Jetpack to your A11N WordPress.com account.
* Go to the "Activate a license" page again and go ahead and activate the Security or Complete license that was purchased with the A11N account. It should activate the product with no errors.
* Now go to the "Activate a license" page again, and paste and activate the same license you just activated in the previous steps.
* Verify a "This license is already active on your site." message displays (in green with check-mark), and it matches the Figma design. See screenshot:
![Screen Shot 2024-09-10 at 17 55 00](https://github.com/user-attachments/assets/0381f6fe-36bb-4aa6-a792-64747ef7f61a)
* Now purchase a Jetpack Backup license.
* Go to the "Activate a license" page, paste in the Jetpack Backup license, and click "Activate"
* Verify you see error, "Your site already has an active Jetpack plan of equal or higher value.", and the additional help info is displayed and that it matches the Figma design. Also see screenshot:
![Screen Shot 2024-09-10 at 19 21 30](https://github.com/user-attachments/assets/e9059d9e-585e-48ee-b95a-b21a832ffbec)
* Verify the copy looks good and the links work correctly.
* In Store Admin (SA), find the Jetpack Backup license subscription (still attached to a Jetpack Simple Checkout Temporary Site).  Copy the license key, but then Remove the subscription.
* Go to the "Activate a license" page, paste in the Jetpack Backup license key you copied, and click "Activate".
* Verify you see error, "The subscription is no longer active or has expired. Please purchase a new license." and the additional help info is displayed and that it matches the Figma design. Also see screenshot:
![Screen Shot 2024-09-10 at 19 40 23](https://github.com/user-attachments/assets/99c29884-5bf8-4014-80a3-e8ab5aecdd52)
* Verify the copy looks good and the link works correctly.
* Again go to the "Activate a license" page: type in some rubbish (an invalid license key), and click "Activate"
* Verify you see error, "Unable to validate this license key." and the additional help info is displayed and that it matches the Figma design. Also see screenshot:
![Screen Shot 2024-09-10 at 19 49 34](https://github.com/user-attachments/assets/233b11d9-d796-40d5-8aec-cb1bfbd4a5a5)

**Additional notes:**  
- The `[multisite_incompatibility]` error cannot be thrown (and tested) at this time, because My Jetpack was removed from multisite sites and therefore cannot activate licenses on multisite sites.  There may be some issues concerning this, but it is not in scope of this PR.
- The `[attached_license]` error ("This license is already active on another website.") also is not thrown anymore. The `[not_same_owner]` error is thrown instead.  Still, I'm leaving the front-end code for this error in place because in the near future when we implement the "Error flow for Owned by different user": pbNhbs-aGG-p2, we will need this error message.