### PR TITLE
WPCOMSH change call to wpcom_get_site_purchases after faster checks

### DIFF
--- a/projects/plugins/wpcomsh/changelog/change-wpcom-purchases-check-order
+++ b/projects/plugins/wpcomsh/changelog/change-wpcom-purchases-check-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WPCOMSH: change call to so it doesn't trigger if not necessary

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -54,8 +54,6 @@ function wpcom_site_has_feature( $feature, $blog_id = 0 ) {
 		$blog_id = _wpcom_get_current_blog_id();
 	}
 
-	$purchases = wpcom_get_site_purchases( $blog_id );
-
 	$blog = null;
 	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 		$site_type = 'wpcom';
@@ -82,6 +80,8 @@ function wpcom_site_has_feature( $feature, $blog_id = 0 ) {
 	if ( $feature === WPCOM_Features::CLASSIC_SEARCH && ( function_exists( 'wpcom_is_wporg_jp_index' ) && wpcom_is_wporg_jp_index( $blog_id ) ) ) {
 		return true;
 	}
+
+	$purchases = wpcom_get_site_purchases( $blog_id );
 
 	if ( isset( $blog->registered ) ) {
 		WPCOM_Features::add_free_plan_purchase( $purchases, $site_type, $blog->registered );


### PR DESCRIPTION
It makes sense not to call an expensive process unless necessary. The process can return earlier without the need of the call to `wpcom_get_site_purchases` response.

## Proposed changes:
Move call to `wpcom_get_site_purchases` down the line, after faster checks

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
It just makes sense.

The process is called every time we request ai-assistant-feature. Test there are no regressions on free and paid plans by visiting My Jetpack -> AI card and using any of the AI features on the editor (AI Assistant block AI Excerpt, SEO, AI Image generation, Logo block...)