### PR TITLE
Fix underlined links inside boxes

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/section-nav/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/section-nav/style.scss
@@ -239,7 +239,9 @@
 	margin-bottom: 0;
 
 	a.dops-section-nav-tab__link {
-		text-decoration: none;
+		span.components-external-link__contents {
+			text-decoration: none;
+		}
 	}
 
 	@include breakpoint( ">660px" ) {

--- a/projects/plugins/jetpack/_inc/client/my-plan/style.scss
+++ b/projects/plugins/jetpack/_inc/client/my-plan/style.scss
@@ -164,10 +164,6 @@
 		width: 49.5%;
 	}
 
-	@include breakpoint( ">660px" ) {
-		margin-bottom: 24px;
-	}
-
 	@include breakpoint( "<660px" ) {
 		max-width: 100%;
 		margin-bottom: rem( 8px );
@@ -231,6 +227,7 @@
 	flex-direction: row;
 	align-items: stretch;
 	justify-content: space-between;
+	gap: 24px;
 	margin-bottom: rem( 32px );
 	margin-left: rem( -8px );
 	margin-right: rem( -8px );
@@ -241,8 +238,6 @@
 }
 
 .jp-landing__plan-features-card:nth-child(odd) {
-	margin-right: 24px;
-
 	@include breakpoint( "<660px" ) {
 		margin-right: 8px;
 	}

--- a/projects/plugins/jetpack/_inc/client/my-plan/style.scss
+++ b/projects/plugins/jetpack/_inc/client/my-plan/style.scss
@@ -213,6 +213,10 @@
 	button {
 		font-weight: 500;
 		font-size: var(--font-body-extra-small);
+	
+		.components-external-link__contents {
+			text-decoration: none;
+		}
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/style.scss
@@ -67,6 +67,10 @@
 	a {
 		white-space: nowrap;
 	}
+
+	.components-external-link__contents {
+		text-decoration: none;
+	}
 }
 
 .jp-recommendations-question__description-list {
@@ -190,6 +194,10 @@
 			@include breakpoint( '<480px' ) {
 				width: 100%;
 			}
+		}
+
+		.components-external-link__contents {
+			text-decoration: none;
 		}
 	}
 

--- a/projects/plugins/jetpack/_inc/client/recommendations/sidebar/discount-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/recommendations/sidebar/discount-card/style.scss
@@ -98,6 +98,10 @@
 		.components-external-link__icon {
 			margin-left: 4px;
 		}
+
+		.components-external-link__contents {
+			text-decoration: none;
+		}
 	}
 
 	&__timer {

--- a/projects/plugins/jetpack/changelog/fix-underlined-links-inside-boxes
+++ b/projects/plugins/jetpack/changelog/fix-underlined-links-inside-boxes
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Subject: update styling for external links
+Styles: update styling for external links

--- a/projects/plugins/jetpack/changelog/fix-underlined-links-inside-boxes
+++ b/projects/plugins/jetpack/changelog/fix-underlined-links-inside-boxes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subject: update styling for external links


### PR DESCRIPTION
## Proposed changes:

* Many of the external links on the Jetpack Dashboard are styled inside of boxes but had an underline present. This PR removes the underline
* The plan features table has a minor styling issue when one of the cards is full width. This PR also fixes that

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to `/wp-admin/admin.php?page=jetpack#/my-plan` and make sure you don't see any external links with underlines that shouldn't have them
![image](https://github.com/user-attachments/assets/be7b709b-9b0e-4c2e-9ea5-3b7c353a82f7)
3. Go to `/wp-admin/admin.php?page=jetpack#/recommendations/summary` and make sure you don't see any external links with underlines that shouldn't have them
![image](https://github.com/user-attachments/assets/d6d5acdc-166b-4231-81a6-b7e764dce0c1)
![image](https://github.com/user-attachments/assets/40cda8ae-71bf-48c6-99ec-d05a5b39e5a6)
![image](https://github.com/user-attachments/assets/f200e016-fe9e-4942-b2e8-db7664dedd71)
4. Make sure the `Plans` tab at the top of the dashboard is not underlined
![image](https://github.com/user-attachments/assets/7e8efc7c-6b5d-4c21-a7b4-731ef2a9a4be)
5. Whether it be through Store Admin or purchasing products, add AI, Boost, and Search to your site. Go back to `/wp-admin/admin.php?page=jetpack#/my-plan` and make sure the plan features table looks good on all screen widths
![image](https://github.com/user-attachments/assets/b6bec69c-c183-4520-9fc1-bb0999fa9e4c)

