### PR TITLE
Device_Detection: get_info(): memoize

### DIFF
--- a/projects/packages/device-detection/changelog/update-device-detection
+++ b/projects/packages/device-detection/changelog/update-device-detection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Device_Detection::get_info() will now memoize its result

--- a/projects/packages/device-detection/src/class-device-detection.php
+++ b/projects/packages/device-detection/src/class-device-detection.php
@@ -24,6 +24,20 @@ use function Automattic\Jetpack\Device_Detection\wp_unslash;
 class Device_Detection {
 
 	/**
+	 * Memoization cache for get_info() results.
+	 *
+	 * @var array
+	 */
+	private static $get_info_memo = array();
+
+	/**
+	 * Maximum size of the memoization cache.
+	 *
+	 * @var int
+	 */
+	private static $max_memo_size = 100;
+
+	/**
 	 * Returns information about the current device accessing the page.
 	 *
 	 * @param string $ua (Optional) User-Agent string.
@@ -41,6 +55,14 @@ class Device_Detection {
 	 * );
 	 */
 	public static function get_info( $ua = '' ) {
+		// Return memoized result if available.
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput
+		$memo_key = ! empty( $ua ) ? $ua : ( $_SERVER['HTTP_USER_AGENT'] ?? '' );
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput
+		if ( isset( self::$get_info_memo[ $memo_key ] ) ) {
+			return self::$get_info_memo[ $memo_key ];
+		}
+
 		$ua_info = new User_Agent_Info( $ua );
 
 		$info = array(
@@ -68,6 +90,13 @@ class Device_Detection {
 			 */
 			$info = apply_filters( 'jetpack_device_detection_get_info', $info, $ua, $ua_info );
 		}
+
+		// Memoize the result.
+		self::$get_info_memo[ $memo_key ] = $info;
+		if ( count( self::$get_info_memo ) > self::$max_memo_size ) {
+			array_shift( self::$get_info_memo );
+		}
+
 		return $info;
 	}
 

--- a/projects/packages/device-detection/src/class-device-detection.php
+++ b/projects/packages/device-detection/src/class-device-detection.php
@@ -58,6 +58,8 @@ class Device_Detection {
 		// Return memoized result if available.
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput
 		$memo_key = ! empty( $ua ) ? $ua : ( $_SERVER['HTTP_USER_AGENT'] ?? '' );
+		// Note: UA string used raw for compatibility reasons.
+		// No sanitization is needed as the value is never output or persisted, and is only used for memoization.
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput
 		if ( isset( self::$get_info_memo[ $memo_key ] ) ) {
 			return self::$get_info_memo[ $memo_key ];


### PR DESCRIPTION
## Proposed changes:

* Device_Detection: get_info() will now memoize its result and immediately return the same value when requested for the same UA.

Somewhat minor, but every bit helps. I see some P2s running this 60-80 times per request! And a regular 2024 site running it 7 times. Noting that multiple calls to `self::is_mobile()` do wasted work - they used to have a $first_run optimization that no longer works - but this is the bigger bang for the buck fix for now.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* go to `projects/packages/device-detection`
* run `vendor/bin/phpunit --filter Test_Device_Detection`

