### PR TITLE
Social: Call Publicize_UI::init on admin_init instead of on init

### DIFF
--- a/projects/packages/publicize/changelog/update-publicize-ui-init-on-admin-only
+++ b/projects/packages/publicize/changelog/update-publicize-ui-init-on-admin-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Moved initialization of Publicize UI from init action to admin_init action

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -38,7 +38,7 @@ class Publicize_UI {
 		}
 		$this->publicize = $publicize;
 
-		add_action( 'init', array( $this, 'init' ) );
+		add_action( 'admin_init', array( $this, 'init' ) );
 	}
 
 	/**


### PR DESCRIPTION
Everything done in `Publicize_UI::init` belongs in the admin-side.

<img width="773" alt="image" src="https://github.com/user-attachments/assets/518084b0-5fbc-475e-b165-80e17749faa0">


Right now we're initializing this code even with each front side load

For example, we try to get an option with each page load

<img width="1255" alt="image" src="https://github.com/user-attachments/assets/c08c4a6e-bab4-4747-9b40-0ff7bdc2fb65">



Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates initialization of Publicize's UI to load on `admin_init` instead of on `init`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
TBD

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Boot up this branch on JN and be able to add a Jetpack Social connection on both Jetpack and Jetpack Social connections
* Be able to publicize the post to your jetpack social connections.
* Be able to republicize the post to your jetpack social connections.
* Repeat the above two steps after enabling the classic editor. 


