### PR TITLE
Protect: Add annual global blocked requests stats

### DIFF
--- a/projects/plugins/protect/changelog/add-protect-global-blocked-requests-stats
+++ b/projects/plugins/protect/changelog/add-protect-global-blocked-requests-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Adds annual global blocked requests stats

--- a/projects/plugins/protect/src/js/components/scan-footer/index.jsx
+++ b/projects/plugins/protect/src/js/components/scan-footer/index.jsx
@@ -70,10 +70,13 @@ const ProductPromotion = () => {
 const FooterInfo = () => {
 	const { hasPlan } = usePlan();
 	const { globalStats } = useWafData();
-	const totalVulnerabilities = parseInt( globalStats?.totalVulnerabilities );
-	const totalVulnerabilitiesFormatted = isNaN( totalVulnerabilities )
-		? '50,000'
-		: totalVulnerabilities.toLocaleString();
+	const { totalVulnerabilities, annualBlockedRequests } = globalStats;
+	const totalVulnerabilitiesFormatted = totalVulnerabilities
+		? totalVulnerabilities.toLocaleString()
+		: '50,000';
+	const annualBlockedRequestsFormatted = annualBlockedRequests
+		? annualBlockedRequests.toLocaleString()
+		: '50,000,000';
 
 	if ( hasPlan ) {
 		const learnMoreScanUrl = getRedirectUrl( 'protect-footer-learn-more-scan' );

--- a/projects/plugins/protect/src/js/routes/scan/index.jsx
+++ b/projects/plugins/protect/src/js/routes/scan/index.jsx
@@ -72,10 +72,13 @@ const ErrorSection = ( { errorMessage, errorCode } ) => {
 const ScanningSection = ( { currentProgress } ) => {
 	const { hasPlan } = usePlan();
 	const { globalStats } = useWafData();
-	const totalVulnerabilities = parseInt( globalStats?.totalVulnerabilities );
-	const totalVulnerabilitiesFormatted = isNaN( totalVulnerabilities )
-		? '50,000'
-		: totalVulnerabilities.toLocaleString();
+	const { totalVulnerabilities, annualBlockedRequests } = globalStats;
+	const totalVulnerabilitiesFormatted = totalVulnerabilities
+		? totalVulnerabilities.toLocaleString()
+		: '50,000';
+	const annualBlockedRequestsFormatted = annualBlockedRequests
+		? annualBlockedRequests.toLocaleString()
+		: '50,000,000';
 
 	return (
 		<>

--- a/projects/plugins/protect/src/js/types/waf.ts
+++ b/projects/plugins/protect/src/js/types/waf.ts
@@ -10,7 +10,8 @@ export type WafStatus = {
 
 	/** Global statistics. */
 	globalStats: {
-		totalVulnerabilities: string;
+		totalVulnerabilities: number;
+		annualBlockedRequests: number;
 	};
 
 	/** Whether the "waf" module is enabled. */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Description
Makes use of the new annual global blocked requests stats available within `globalStats` initial state property as of D161079

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1407

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch using Jurassic Tube
* Activate Protect
* Log out jetpackProtectInitialState from the browser dev console
* Validate that the `waf.globalStats` object now includes an `annualBlockedRequest` property with a relevant value
* TBD - verify that the stats display in the UI where applicable
