### PR TITLE
Redirect to General Settings When Admin Interface is Set to Calypso

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-interface-redirect
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-interface-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Redirect to General Settings When Admin Interface is Set to Calypso

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-interface/wpcom-admin-interface.php
@@ -74,6 +74,10 @@ function wpcom_admin_interface_pre_update_option( $new_value, $old_value ) {
 		wpcom_admin_interface_track_changed_event( $new_value );
 	}
 
+	if ( ( new Automattic\Jetpack\Status\Host() )->is_wpcom_simple() ) {
+		return $new_value;
+	}
+
 	$blog_id = Jetpack_Options::get_option( 'id' );
 	Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
 		"/sites/$blog_id/hosting/admin-interface",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/8866

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR changes to redirect to WordPress.com's general settings page when the admin interface is switched to Default Style. 

---
In the initial approach, redirection logic was hooked into `update_option_wpcom_admin_interface`, which triggers after the option is updated. However, this approach seems to conflict with [Core's internal redirection process](https://github.com/WordPress/wordpress-develop/blob/5a30482419f1b0bcc713a7fdee3a14afd67a1bca/src/wp-admin/options.php#L374), which occurs after options are updated (`options-general.php` -> `options.php` -> `options-general.php`). (I'm not sure why the issue does not happen on Simple, though.)

Switching to the load-options-general.php hook triggers the redirection when the user revisits the settings page after the update. This ensures that the settings are fully processed and avoids conflicts with Core's redirection.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Prepare a site
- Patch this PR
- Test the following scenarios

| - | Change "Admin Interface Style" from Default to Classic | Change "Admin Interface Style" from Classic to Default |
|--------|--------|--|
| Atomic | redirect to `/wp-admin/?admin-interface-changed=true` | redirect to `https://wordpress.com/settings/general/<site>` |
| Simple | redirect to `/wp-admin/?admin-interface-changed=true` | redirect to `https://wordpress.com/settings/general/<site>`|
