### PR TITLE
Connection: fix the connected plugins option on multisites

### DIFF
--- a/projects/packages/connection/changelog/fix-connected-plugins-on-multisites
+++ b/projects/packages/connection/changelog/fix-connected-plugins-on-multisites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the connected plugins option on multisites.

--- a/projects/packages/connection/src/class-plugin-storage.php
+++ b/projects/packages/connection/src/class-plugin-storage.php
@@ -144,7 +144,10 @@ class Plugin_Storage {
 		}
 
 		if ( is_multisite() && get_current_blog_id() !== self::$current_blog_id ) {
-			self::$plugins         = (array) get_option( self::ACTIVE_PLUGINS_OPTION_NAME, array() );
+			if ( self::$current_blog_id ) {
+				// If blog ID got changed, pull the list of active plugins for that blog from the database.
+				self::$plugins = (array) get_option( self::ACTIVE_PLUGINS_OPTION_NAME, array() );
+			}
 			self::$current_blog_id = get_current_blog_id();
 		}
 


### PR DESCRIPTION
## Proposed changes:
Recent optimizations of the connected plugin options update/sync exposed an issue in the original implementation made in #17908, making the "active connected plugins" option always empty on multisites.
Here we fix that problem.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1725991000681419-slack-CDLH4C1UZ
https://github.com/Automattic/jetpack-marketing/issues/976

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Create a new multisite, create a couple of subsites.
2. Switch Jetpack Beta to the branch, activate Jetpack, connect it. Confirm Jetpack Debug shows Jetpack in "Jetpack Plugins" card.
3. Try the same on another subsite with another set of Jetpack plugins, confirm the plugins show up the same way.