### PR TITLE
Fix/interstitial button loading states

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/index.jsx
@@ -77,7 +77,7 @@ export default function ProductInterstitial( {
 } ) {
 	const { detail } = useProduct( slug );
 	const { detail: bundleDetail } = useProduct( bundle );
-	const { activate, isPending: isActivating } = useActivate( slug );
+	const { activate, isPending: isActivating, isSuccess } = useActivate( slug );
 
 	// Get the post activation URL for the product.
 	let redirectUri = detail?.postActivationUrl || null;
@@ -242,6 +242,7 @@ export default function ProductInterstitial( {
 							trackProductButtonClick={ trackProductOrBundleClick }
 							preferProductName={ preferProductName }
 							isFetching={ isActivating || siteIsRegistering }
+							isFetchingSuccess={ isSuccess }
 							feature={ feature }
 						/>
 					) : (
@@ -264,6 +265,7 @@ export default function ProductInterstitial( {
 									quantity={ quantity }
 									highlightLastFeature={ highlightLastFeature }
 									isFetching={ isActivating || siteIsRegistering }
+									isFetchingSuccess={ isSuccess }
 								/>
 							</Col>
 							<Col
@@ -282,6 +284,7 @@ export default function ProductInterstitial( {
 										quantity={ quantity }
 										highlightLastFeature={ highlightLastFeature }
 										isFetching={ isActivating }
+										isFetchingSuccess={ isSuccess }
 									/>
 								) : (
 									children

--- a/projects/packages/my-jetpack/_inc/data/products/use-activate.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-activate.ts
@@ -33,7 +33,11 @@ const useActivate = ( productId: string ) => {
 	const { detail, refetch } = useProduct( productId );
 	const { recordEvent } = useAnalytics();
 
-	const { mutate: activate, isPending } = useSimpleMutation( {
+	const {
+		mutate: activate,
+		isPending,
+		isSuccess,
+	} = useSimpleMutation( {
 		name: QUERY_ACTIVATE_PRODUCT_KEY,
 		query: {
 			path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }/${ productId }`,
@@ -64,6 +68,7 @@ const useActivate = ( productId: string ) => {
 	return {
 		activate,
 		isPending,
+		isSuccess,
 	};
 };
 

--- a/projects/packages/my-jetpack/changelog/fix-interstitial-button-loading-states
+++ b/projects/packages/my-jetpack/changelog/fix-interstitial-button-loading-states
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix issue on interstitials show both buttons loading when only one is pressed


### PR DESCRIPTION
## Proposed changes:

* Structure interstitial button loading state so the button pressed is the only one that shows as loading, and both buttons stay disabled if the activation is successful so users can't click on a different one during the redirect

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A - See issue this is attached to

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to `/wp-admin/admin.php?page=my-jetpack#/add-boost`
3. Click on either of the buttons. Make sure both buttons are disabled all the way up until the redirect, and that only the button clicked shows the loading state

https://github.com/user-attachments/assets/f10ee61d-9d14-44a4-8249-0307f353537c

4. Go to `/wp-admin/admin.php?page=my-jetpack#/add-search` and make sure the two buttons act the same as the ones on the boost table

https://github.com/user-attachments/assets/c4820023-4526-4f9a-96cb-52ea5644f0fd

