### PR TITLE
Jetpack-mu-wpcom: Fix admin bar reader item padding

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-reader-padding-width
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-admin-bar-reader-padding-width
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Remove the extra padding around the admin bar Reader item to match Calypso.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -165,27 +165,38 @@
 
 			#wp-admin-bar-reader {
 				display: block;
-				width: auto !important;
-				min-width: 52px;
-				padding: 0px;
 
-				.ab-icon {
+				.ab-item {
+					display: flex;
 					justify-content: center;
-					padding: 0px 10px;
 
-					&:before {
-						width: 36px;
-						height: 36px;
-						margin: 0px;
-						mask-size: contain;
+					.ab-icon {
+						justify-content: center;
+						padding: 0px;
+	
+						&:before {
+							width: 36px;
+							height: 36px;
+							margin: 0px;
+							mask-size: contain;
+						}
 					}
 				}
 			}
 
 			#wp-admin-bar-help-center {
 				display: block !important;
-				width: 49px !important;
 				margin-right: 0 !important;
+				width: 52px !important;
+
+				.ab-item {
+					display: flex;
+					justify-content: center;
+
+					svg {
+						position: relative;
+					}
+				}
 			}
 
 			#wp-admin-bar-notes {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/93534
Corresponding Calypso PR: https://github.com/Automattic/wp-calypso/pull/94387

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes padding from the Reader admin bar item so that it's the same width as the other items.
* Corrects the Help Center admin bar item width to be the same as the other items.

Less than 781px wide, all icons are now 52px wide:

<img width="761" alt="Screen Shot 2024-09-11 at 1 39 13 PM" src="https://github.com/user-attachments/assets/881fcf63-194a-4276-9281-222f1f5bc230">

Less than 480px wide, all icons are now 46px wide:

<img width="380" alt="Screen Shot 2024-09-11 at 1 39 32 PM" src="https://github.com/user-attachments/assets/5e889393-3c3e-4766-a000-725ac673377c">

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1724359596888999/1724342199.104349-slack-C07GQ1Q0L6B

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No change.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to WP Admin.
* Change your screen size to < 781px.
* Verify that the Reader and Help Center menu items are both 52px wide.
* Change your screen size to < 480px.
* Verify that the Reader and Help Center menu items are both 46px wide.
* Test on both Simple and Atomic.