### PR TITLE
Connection\Manager: is_connected: Memoize

### DIFF
--- a/projects/packages/connection/changelog/update-is-connected
+++ b/projects/packages/connection/changelog/update-is-connected
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal performance change for is_connected()
+
+

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -81,6 +81,13 @@ class Manager {
 	private static $disconnected_users = array();
 
 	/**
+	 * Cached connection status.
+	 *
+	 * @var bool|null True if the site is connected, false if not, null if not determined yet.
+	 */
+	private static $is_connected = null;
+
+	/**
 	 * Initialize the object.
 	 * Make sure to call the "Configure" first.
 	 *
@@ -596,9 +603,17 @@ class Manager {
 	 * @return bool
 	 */
 	public function is_connected() {
-		$has_blog_id    = (bool) \Jetpack_Options::get_option( 'id' );
-		$has_blog_token = (bool) $this->get_tokens()->get_access_token();
-		return $has_blog_id && $has_blog_token;
+		if ( self::$is_connected === null ) {
+			$has_blog_id = (bool) \Jetpack_Options::get_option( 'id' );
+			if ( $has_blog_id ) {
+				$has_blog_token     = (bool) $this->get_tokens()->get_access_token();
+				self::$is_connected = ( $has_blog_id && $has_blog_token );
+			} else {
+				// Short-circuit, no need to check for tokens if there's no blog ID.
+				self::$is_connected = false;
+			}
+		}
+		return self::$is_connected;
 	}
 
 	/**

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -152,11 +152,10 @@ class Manager {
 		add_action( 'jetpack_site_disconnected', array( $manager, 'reset_connection_status' ) );
 		add_action( 'jetpack_sync_register_user', array( $manager, 'reset_connection_status' ) );
 		add_action( 'pre_update_jetpack_option_id', array( $manager, 'reset_connection_status' ) );
+		add_action( 'pre_update_jetpack_option_blog_token', array( $manager, 'reset_connection_status' ) );
+		add_action( 'pre_update_jetpack_option_user_token', array( $manager, 'reset_connection_status' ) );
+		add_action( 'pre_update_jetpack_option_user_tokens', array( $manager, 'reset_connection_status' ) );
 		add_action( 'switch_blog', array( $manager, 'reset_connection_status' ) );
-		// blog_token, user_token, user_tokens - handled by the next three that look for jetpack_private_options.
-		add_action( 'update_option', array( $manager, 'maybe_reset_connection_status' ), 10, 1 );
-		add_action( 'add_option', array( $manager, 'maybe_reset_connection_status' ), 10, 1 );
-		add_action( 'delete_option', array( $manager, 'maybe_reset_connection_status' ), 10, 1 );
 
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
@@ -635,22 +634,6 @@ class Manager {
 	 */
 	public function reset_connection_status() {
 		self::$is_connected = null;
-	}
-
-	/**
-	 * Resets the memoized connection status if jetpack_private_options is updated.
-	 *
-	 * Ideally, we would only do this on certain "sub" options stored inside
-	 * jetpack_private_options, but delete_option() -> delete_grouped_option()
-	 * provides us no hook to detect which options are being deleted.
-	 *
-	 * @param string $option The option name.
-	 */
-	public function maybe_reset_connection_status( $option ) {
-		$reset_options = array( 'jetpack_private_options' );
-		if ( in_array( $option, $reset_options, true ) ) {
-			self::$is_connected = null;
-		}
 	}
 
 	/**

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -152,9 +152,7 @@ class Manager {
 		add_action( 'jetpack_site_disconnected', array( $manager, 'reset_connection_status' ) );
 		add_action( 'jetpack_sync_register_user', array( $manager, 'reset_connection_status' ) );
 		add_action( 'pre_update_jetpack_option_id', array( $manager, 'reset_connection_status' ) );
-		add_action( 'pre_update_jetpack_blog_token', array( $manager, 'reset_connection_status' ) );
-		add_action( 'pre_update_jetpack_user_token', array( $manager, 'reset_connection_status' ) );
-		add_action( 'pre_update_jetpack_user_tokens', array( $manager, 'reset_connection_status' ) );
+		// blog_token, user_token, user_tokens - handled by the next three that look for jetpack_private_options.
 		add_action( 'update_option', array( $manager, 'maybe_reset_connection_status' ), 10, 1 );
 		add_action( 'add_option', array( $manager, 'maybe_reset_connection_status' ), 10, 1 );
 		add_action( 'delete_option', array( $manager, 'maybe_reset_connection_status' ), 10, 1 );

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -147,6 +147,9 @@ class Manager {
 		add_action( 'deleted_user', array( $manager, 'disconnect_user_force' ), 9, 1 );
 		add_action( 'remove_user_from_blog', array( $manager, 'disconnect_user_force' ), 9, 1 );
 
+		add_action( 'jetpack_site_registered', array( $manager, 'reset_connection_status' ) );
+		add_action( 'jetpack_site_disconnected', array( $manager, 'reset_connection_status' ) );
+
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
 
@@ -614,6 +617,16 @@ class Manager {
 			}
 		}
 		return self::$is_connected;
+	}
+
+	/**
+	 * Resets the memoized connection status.
+	 * This will force the connection status to be recomputed on the next check.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function reset_connection_status() {
+		self::$is_connected = null;
 	}
 
 	/**

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -152,6 +152,7 @@ class Manager {
 		add_action( 'jetpack_site_disconnected', array( $manager, 'reset_connection_status' ) );
 		add_action( 'jetpack_sync_register_user', array( $manager, 'reset_connection_status' ) );
 		add_action( 'pre_update_jetpack_option_id', array( $manager, 'reset_connection_status' ) );
+		add_action( 'switch_blog', array( $manager, 'reset_connection_status' ) );
 		// blog_token, user_token, user_tokens - handled by the next three that look for jetpack_private_options.
 		add_action( 'update_option', array( $manager, 'maybe_reset_connection_status' ), 10, 1 );
 		add_action( 'add_option', array( $manager, 'maybe_reset_connection_status' ), 10, 1 );

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -147,15 +147,7 @@ class Manager {
 		add_action( 'deleted_user', array( $manager, 'disconnect_user_force' ), 9, 1 );
 		add_action( 'remove_user_from_blog', array( $manager, 'disconnect_user_force' ), 9, 1 );
 
-		// Force is_connected() to recompute after important actions.
-		add_action( 'jetpack_site_registered', array( $manager, 'reset_connection_status' ) );
-		add_action( 'jetpack_site_disconnected', array( $manager, 'reset_connection_status' ) );
-		add_action( 'jetpack_sync_register_user', array( $manager, 'reset_connection_status' ) );
-		add_action( 'pre_update_jetpack_option_id', array( $manager, 'reset_connection_status' ) );
-		add_action( 'pre_update_jetpack_option_blog_token', array( $manager, 'reset_connection_status' ) );
-		add_action( 'pre_update_jetpack_option_user_token', array( $manager, 'reset_connection_status' ) );
-		add_action( 'pre_update_jetpack_option_user_tokens', array( $manager, 'reset_connection_status' ) );
-		add_action( 'switch_blog', array( $manager, 'reset_connection_status' ) );
+		$manager->add_connection_status_invalidation_hooks();
 
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
@@ -172,6 +164,21 @@ class Manager {
 
 		// Initial Partner management.
 		Partner::init();
+	}
+
+	/**
+	 * Adds hooks to invalidate the memoized connection status.
+	 */
+	private function add_connection_status_invalidation_hooks() {
+		// Force is_connected() to recompute after important actions.
+		add_action( 'jetpack_site_registered', array( $this, 'reset_connection_status' ) );
+		add_action( 'jetpack_site_disconnected', array( $this, 'reset_connection_status' ) );
+		add_action( 'jetpack_sync_register_user', array( $this, 'reset_connection_status' ) );
+		add_action( 'pre_update_jetpack_option_id', array( $this, 'reset_connection_status' ) );
+		add_action( 'pre_update_jetpack_option_blog_token', array( $this, 'reset_connection_status' ) );
+		add_action( 'pre_update_jetpack_option_user_token', array( $this, 'reset_connection_status' ) );
+		add_action( 'pre_update_jetpack_option_user_tokens', array( $this, 'reset_connection_status' ) );
+		add_action( 'switch_blog', array( $this, 'reset_connection_status' ) );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/identity-crisis/test-identity-crisis.php
+++ b/projects/packages/connection/tests/php/identity-crisis/test-identity-crisis.php
@@ -26,6 +26,7 @@ class Test_Identity_Crisis extends BaseTestCase {
 	public function set_up() {
 		Constants::set_constant( 'JETPACK_DISABLE_RAW_OPTIONS', true );
 		StatusCache::clear();
+		$this->reset_connection_status();
 	}
 
 	/**
@@ -43,6 +44,20 @@ class Test_Identity_Crisis extends BaseTestCase {
 		$instance->setAccessible( true );
 		$instance->setValue( null, null );
 		$instance->setAccessible( false );
+		$this->reset_connection_status();
+	}
+
+	/**
+	 * Reset the connection status.
+	 * Needed because the connection status is memoized and not reset between tests.
+	 * WorDBless does not fire the options update hooks that would reset the connection status.
+	 */
+	public function reset_connection_status() {
+		static $manager = null;
+		if ( ! $manager ) {
+			$manager = new \Automattic\Jetpack\Connection\Manager();
+		}
+		$manager->reset_connection_status();
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/identity-crisis/test-rest-endpoints.php
+++ b/projects/packages/connection/tests/php/identity-crisis/test-rest-endpoints.php
@@ -35,6 +35,19 @@ class Test_REST_Endpoints extends TestCase {
 	private $api_host_original;
 
 	/**
+	 * Reset the connection status.
+	 * Needed because the connection status is memoized and not reset between tests.
+	 * WorDBless does not fire the options update hooks that would reset the connection status.
+	 */
+	public function reset_connection_status() {
+		static $manager = null;
+		if ( ! $manager ) {
+			$manager = new \Automattic\Jetpack\Connection\Manager();
+		}
+		$manager->reset_connection_status();
+	}
+
+	/**
 	 * Setting up the test.
 	 *
 	 * @suppress PhanNoopNew
@@ -57,6 +70,7 @@ class Test_REST_Endpoints extends TestCase {
 		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
 
 		set_transient( 'jetpack_assumed_site_creation_date', '2020-02-28 01:13:27' );
+		$this->reset_connection_status();
 	}
 
 	/**
@@ -74,6 +88,7 @@ class Test_REST_Endpoints extends TestCase {
 		$_GET = array();
 
 		Connection_Rest_Authentication::init()->reset_saved_auth_state();
+		$this->reset_connection_status();
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test-rest-endpoints.php
+++ b/projects/packages/connection/tests/php/test-rest-endpoints.php
@@ -110,6 +110,7 @@ class Test_REST_Endpoints extends TestCase {
 		Constants::$set_constants['JETPACK__API_BASE'] = 'https://jetpack.wordpress.com/jetpack.';
 
 		set_transient( 'jetpack_assumed_site_creation_date', '2020-02-28 01:13:27' );
+		$this->reset_connection_status();
 	}
 
 	/**
@@ -137,6 +138,20 @@ class Test_REST_Endpoints extends TestCase {
 		$_GET = array();
 
 		Connection_Rest_Authentication::init()->reset_saved_auth_state();
+		$this->reset_connection_status();
+	}
+
+	/**
+	 * Reset the connection status.
+	 * Needed because the connection status is memoized and not reset between tests.
+	 * WorDBless does not fire the options update hooks that would reset the connection status.
+	 */
+	public function reset_connection_status() {
+		static $manager = null;
+		if ( ! $manager ) {
+			$manager = new \Automattic\Jetpack\Connection\Manager();
+		}
+		$manager->reset_connection_status();
 	}
 
 	/**
@@ -1764,6 +1779,7 @@ class Test_REST_Endpoints extends TestCase {
 		}
 
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_options' ), 10, 2 );
+		$this->reset_connection_status();
 	}
 
 	/**
@@ -1816,5 +1832,6 @@ class Test_REST_Endpoints extends TestCase {
 		}
 
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_options' ), 10 );
+		$this->reset_connection_status();
 	}
 }

--- a/projects/packages/connection/tests/php/test_Manager_integration.php
+++ b/projects/packages/connection/tests/php/test_Manager_integration.php
@@ -27,6 +27,7 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	public function set_up() {
 		$this->manager = new Manager();
 		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
+		$this->reset_connection_status();
 	}
 
 	/**
@@ -36,6 +37,20 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	 */
 	public function tear_down() {
 		Constants::clear_constants();
+		$this->reset_connection_status();
+	}
+
+	/**
+	 * Reset the connection status.
+	 * Needed because the connection status is memoized and not reset between tests.
+	 * WorDBless does not fire the options update hooks that would reset the connection status.
+	 */
+	public function reset_connection_status() {
+		static $manager = null;
+		if ( ! $manager ) {
+			$manager = new \Automattic\Jetpack\Connection\Manager();
+		}
+		$manager->reset_connection_status();
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test_package_version_tracker.php
+++ b/projects/packages/connection/tests/php/test_package_version_tracker.php
@@ -48,6 +48,7 @@ class Test_Package_Version_Tracker extends TestCase {
 	public function set_up() {
 		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
 		Sync_Settings::update_settings( array( 'disable' => true ) );
+		$this->reset_connection_status();
 	}
 
 	/**
@@ -66,6 +67,20 @@ class Test_Package_Version_Tracker extends TestCase {
 
 		delete_transient( Package_Version_Tracker::CACHED_FAILED_REQUEST_KEY );
 		delete_transient( Package_Version_Tracker::RATE_LIMITER_KEY );
+		$this->reset_connection_status();
+	}
+
+	/**
+	 * Reset the connection status.
+	 * Needed because the connection status is memoized and not reset between tests.
+	 * WorDBless does not fire the options update hooks that would reset the connection status.
+	 */
+	public function reset_connection_status() {
+		static $manager = null;
+		if ( ! $manager ) {
+			$manager = new \Automattic\Jetpack\Connection\Manager();
+		}
+		$manager->reset_connection_status();
 	}
 
 	/**
@@ -305,6 +320,7 @@ class Test_Package_Version_Tracker extends TestCase {
 	public function test_maybe_update_package_versions_with_sync_disabled_remote_request_success() {
 		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
 		\Jetpack_Options::update_option( 'id', 1234 );
+		$this->reset_connection_status();
 
 		add_filter( 'pre_http_request', array( $this, 'intercept_http_request_success' ) );
 
@@ -360,6 +376,7 @@ class Test_Package_Version_Tracker extends TestCase {
 	public function test_maybe_update_package_versions_with_sync_disabled_remote_request_failure() {
 		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
 		\Jetpack_Options::update_option( 'id', 1234 );
+		$this->reset_connection_status();
 
 		add_filter( 'pre_http_request', array( $this, 'intercept_http_request_failure' ) );
 
@@ -393,6 +410,7 @@ class Test_Package_Version_Tracker extends TestCase {
 
 		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
 		\Jetpack_Options::update_option( 'id', 1234 );
+		$this->reset_connection_status();
 
 		add_filter( 'pre_http_request', array( $this, 'intercept_http_request_failure' ) );
 

--- a/projects/packages/connection/tests/php/test_plugin_storage.php
+++ b/projects/packages/connection/tests/php/test_plugin_storage.php
@@ -35,6 +35,7 @@ class Test_Plugin_Storage extends TestCase {
 	public function set_up() {
 		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
 		Sync_Settings::update_settings( array( 'disable' => true ) );
+		$this->reset_connection_status();
 	}
 
 	/**
@@ -61,6 +62,20 @@ class Test_Plugin_Storage extends TestCase {
 			$plugins->setAccessible( true );
 			$plugins->setValue( array() );
 		}
+		$this->reset_connection_status();
+	}
+
+	/**
+	 * Reset the connection status.
+	 * Needed because the connection status is memoized and not reset between tests.
+	 * WorDBless does not fire the options update hooks that would reset the connection status.
+	 */
+	public function reset_connection_status() {
+		static $manager = null;
+		if ( ! $manager ) {
+			$manager = new \Automattic\Jetpack\Connection\Manager();
+		}
+		$manager->reset_connection_status();
 	}
 
 	/**
@@ -71,6 +86,7 @@ class Test_Plugin_Storage extends TestCase {
 	public function test_update_active_plugins_option_without_sync_will_trigger_fallback() {
 		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
 		\Jetpack_Options::update_option( 'id', 1234 );
+		$this->reset_connection_status();
 
 		add_filter( 'pre_http_request', array( $this, 'intercept_remote_request' ), 10, 3 );
 		Plugin_Storage::update_active_plugins_option();
@@ -109,6 +125,7 @@ class Test_Plugin_Storage extends TestCase {
 	public function test_maybe_update_active_connected_plugins_not_configured() {
 		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
 		\Jetpack_Options::update_option( 'id', 1234 );
+		$this->reset_connection_status();
 
 		Plugin_Storage::upsert( 'dummy-slug' );
 		set_transient( Plugin_Storage::ACTIVE_PLUGINS_REFRESH_FLAG, microtime() );
@@ -130,6 +147,7 @@ class Test_Plugin_Storage extends TestCase {
 	public function test_maybe_update_active_connected_plugins_flag_not_set() {
 		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
 		\Jetpack_Options::update_option( 'id', 1234 );
+		$this->reset_connection_status();
 
 		Plugin_Storage::upsert( 'dummy-slug' );
 		Plugin_Storage::configure();
@@ -151,6 +169,7 @@ class Test_Plugin_Storage extends TestCase {
 	public function test_maybe_update_active_connected_plugins_non_post_request() {
 		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
 		\Jetpack_Options::update_option( 'id', 1234 );
+		$this->reset_connection_status();
 
 		Plugin_Storage::upsert( 'dummy-slug' );
 		Plugin_Storage::configure();
@@ -172,6 +191,7 @@ class Test_Plugin_Storage extends TestCase {
 	public function test_maybe_update_active_connected_plugins_success() {
 		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
 		\Jetpack_Options::update_option( 'id', 1234 );
+		$this->reset_connection_status();
 
 		Plugin_Storage::upsert( 'dummy-slug' );
 		Plugin_Storage::configure();
@@ -195,6 +215,7 @@ class Test_Plugin_Storage extends TestCase {
 	public function test_maybe_update_active_connected_plugins_success_same_plugins() {
 		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
 		\Jetpack_Options::update_option( 'id', 1234 );
+		$this->reset_connection_status();
 		$stored_value = array( 'dummy-slug' => array() );
 		update_option( Plugin_Storage::ACTIVE_PLUGINS_OPTION_NAME, $stored_value );
 
@@ -220,6 +241,7 @@ class Test_Plugin_Storage extends TestCase {
 	public function test_maybe_update_active_connected_plugins_success_same_count_different_plugins() {
 		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
 		\Jetpack_Options::update_option( 'id', 1234 );
+		$this->reset_connection_status();
 		update_option( Plugin_Storage::ACTIVE_PLUGINS_OPTION_NAME, array( 'dummy-slug2' => array() ) );
 
 		Plugin_Storage::upsert( 'dummy-slug' );

--- a/projects/packages/protect-status/changelog/update-is-connected
+++ b/projects/packages/protect-status/changelog/update-is-connected
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal unit test changes
+
+

--- a/projects/packages/protect-status/tests/php/test-scan-status.php
+++ b/projects/packages/protect-status/tests/php/test-scan-status.php
@@ -303,6 +303,10 @@ class Test_Scan_Status extends BaseTestCase {
 		( new Tokens() )->update_blog_token( 'test.test' );
 		Jetpack_Options::update_option( 'id', 123 );
 		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		// Since this uses WorDBless, our typical invalidation on option update does not work, so invalidate manually
+		$manager = new \Automattic\Jetpack\Connection\Manager();
+		$manager->reset_connection_status();
 	}
 
 	/**

--- a/projects/packages/stats/changelog/update-is-connected
+++ b/projects/packages/stats/changelog/update-is-connected
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal unit test changes
+
+

--- a/projects/packages/stats/tests/php/test-base.php
+++ b/projects/packages/stats/tests/php/test-base.php
@@ -25,6 +25,10 @@ abstract class StatsBaseTestCase extends BaseTestCase {
 		// Mock Jetpack Connection.
 		Jetpack_Options::update_option( 'id', 1234 );
 		Jetpack_Options::update_option( 'blog_token', 'blog_token.secret' );
+
+		// Since this uses WorDBless, our typical invalidation on option update does not work, so invalidate manually
+		$manager = new \Automattic\Jetpack\Connection\Manager();
+		$manager->reset_connection_status();
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:

* Memoize the `is_connected()` function, so it's only figured out once per request
  * Also a short boolean optimization, for `a && b`, if `a` is false, we don't need to figure out `b`.

### Reasoning

I noticed it popping up a lot while I reviewed timelines for my local site running JP. I used `ac_start()` and `ac_stop()` to measure its timing ([link](https://github.com/mreishus/wp-misc/blob/master/debug-helpers.php#L90-L125)) before and after adding memoization.

**Before**
```
[             ] https://myJTsite.example.com/wp-cron.php?doing_wp_cron=1726077077.1958370208740234375000
[             a19432] AC Debug: 'is_connected1' ran 38 times, total time: 5.82 ms, avg time: 0.15 ms
[             ] https://myJTsite.example.com/
[             c43038] AC Debug: 'is_connected1' ran 32 times, total time: 4.33 ms, avg time: 0.14 ms
[             ] https://myJTsite.example.com/wp-admin/admin.php?page=stats&noheader&proxy&chart=admin-bar-hours-scale
[             adcb58] AC Debug: 'is_connected1' ran 45 times, total time: 3.83 ms, avg time: 0.09 ms
[             ] https://myJTsite.example.com/
[             d41c05] AC Debug: 'is_connected1' ran 31 times, total time: 3.8 ms, avg time: 0.12 ms
[             ] https://myJTsite.example.com/wp-admin/admin.php?page=stats&noheader&proxy&chart=admin-bar-hours-scale
[             1b0db2] AC Debug: 'is_connected1' ran 45 times, total time: 5.83 ms, avg time: 0.13 ms
[             ] https://myJTsite.example.com/
```

**after**
```
[             f07557] AC Debug: 'is_connected2' ran 31 times, total time: 0.17 ms, avg time: 0.01 ms
[             ] https://myJTsite.example.com/wp-admin/admin.php?page=stats&noheader&proxy&chart=admin-bar-hours-scale
[             baec98] AC Debug: 'is_connected2' ran 45 times, total time: 0.19 ms, avg time: 0 ms
[             ] https://myJTsite.example.com/
[             cdd611] AC Debug: 'is_connected2' ran 31 times, total time: 0.15 ms, avg time: 0 ms
[             ] https://myJTsite.example.com/wp-admin/admin.php?page=stats&noheader&proxy&chart=admin-bar-hours-scale
[             6dcbd5] AC Debug: 'is_connected2' ran 45 times, total time: 0.14 ms, avg time: 0 ms
[             ] https://myJTsite.example.com/
[             38bb3d] AC Debug: 'is_connected2' ran 31 times, total time: 0.11 ms, avg time: 0 ms
[             ] https://myJTsite.example.com/wp-admin/admin.php?page=stats&noheader&proxy&chart=admin-bar-hours-scale
[             299baf] AC Debug: 'is_connected2' ran 45 times, total time: 0.13 ms, avg time: 0 ms
[             ] https://myJTsite.example.com/wp-cron.php?doing_wp_cron=1726077292.4192719459533691406250
[             1f2e26] AC Debug: 'is_connected2' ran 36 times, total time: 0.16 ms, avg time: 0 ms
[             ] https://myJTsite.example.com/
[             50359e] AC Debug: 'is_connected2' ran 32 times, total time: 0.21 ms, avg time: 0.01 ms
[             ] https://myJTsite.example.com/wp-admin/admin.php?page=stats&noheader&proxy&chart=admin-bar-hours-scale
[             863e0f] AC Debug: 'is_connected2' ran 45 times, total time: 0.18 ms, avg time: 0 ms
```
### Concerns

- Would there be any need to invalidate this? For example, a request that starts out connected and then is later not connected? Or vice versa? I don't know the JP codebase well enough to know if this is something that would be accounted for. If so, it's not a big deal, I just don't know where that would be or how to test it.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Unknown :( General connection working? Connect / Disconnect?

