### PR TITLE
Subscribe Block: Remove call to dotcom from the frontend when rendering subscribe block in modal if we don't need it

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-fetch-subscribers-count
+++ b/projects/plugins/jetpack/changelog/fix-fetch-subscribers-count
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Reduces number of calls to wpcom for fetching subscribers counts
+
+

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -691,7 +691,7 @@ function render_block( $attributes ) {
 			esc_html__( "Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm' to start subscribing.", 'jetpack' )
 		),
 		'show_subscribers_total'        => (bool) get_attribute( $attributes, 'showSubscribersTotal' ),
-		'subscribers_total'             => get_subscriber_count( $include_social_followers ),
+		'subscribers_total'             => get_attribute( $attributes, 'showSubscribersTotal' ) ? get_subscriber_count( $include_social_followers ) : 0,
 		'referer'                       => esc_url_raw(
 			( is_ssl() ? 'https' : 'http' ) . '://' . ( isset( $_SERVER['HTTP_HOST'] ) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : '' ) .
 			( isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '' )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39360

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove call to dotcom from the frontend when rendering subscribe block in modal if we don't need it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a Jetpack site with subscribers
* Add two subscribe blocks, one with and one without "Show subscriber count"
* When on confirm subscriber count still shows the right number
* When off confirm that no request is made to wpcom (there's [an hour cache here](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php#L694) that you need to turn off)

