### PR TITLE
Title Optimization: release "target keywords" feature to production

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-keywords-support-production
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-keywords-support-production
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: add keywords support to AI Assistant SEO title feature

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -70,7 +70,8 @@
 		"ai-assistant-experimental-image-generation-support",
 		"ai-general-purpose-image-generator",
 		"ai-proofread-breve",
-		"ai-assistant-site-logo-support"
+		"ai-assistant-site-logo-support",
+		"ai-title-optimization-keywords-support"
 	],
 	"beta": [
 		"google-docs-embed",
@@ -78,8 +79,7 @@
 		"recipe",
 		"v6-video-frame-poster",
 		"videopress/video-chapters",
-		"ai-assistant-backend-prompts",
-		"ai-title-optimization-keywords-support"
+		"ai-assistant-backend-prompts"
 	],
 	"experimental": [],
 	"no-post-editor": [


### PR DESCRIPTION
## Proposed changes:
Move SEO title AI feature to production

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1726078224930519/1726072107.417869-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

Make sure you're working with blocks variation `production` (default JN setup).

Go to the editor and add some content to the post (tip: use the AI Assistant to write 2 paragraphs about some theme, like "sailing on the Adriatic Sea").

Look for the "Improve title for SEO" option on the sidebar. It should replace the old "Improve title" button.

Click the "Improve title for SEO" button. The modal will show and display 3 suggested titles.

Confirm there is a textarea at the top asking for target keywords. Use the input to add specific keywords and generate again.

Confirm that AI tries to accommodate the keywords in the suggested titles.