### PR TITLE
Color Scheme: Avoid wpcom user data overriding the admin color after flushing cache

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-color-scheme-on-default-interface
+++ b/projects/plugins/wpcomsh/changelog/fix-color-scheme-on-default-interface
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Color Scheme: Avoid wpcom user data overriding the admin color after flushing cache

--- a/projects/plugins/wpcomsh/feature-plugins/masterbar.php
+++ b/projects/plugins/wpcomsh/feature-plugins/masterbar.php
@@ -119,10 +119,6 @@ function wpcomsh_set_connected_user_data_as_user_options( $transient, $value ) {
 		return;
 	}
 
-	if ( isset( $value['color_scheme'] ) && get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
-		update_user_option( get_current_user_id(), 'admin_color', $value['color_scheme'] );
-	}
-
 	if ( isset( $value['site_count'] ) ) {
 		update_user_option( get_current_user_id(), 'wpcom_site_count', $value['site_count'] );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/94308

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The `color_scheme` was overridden by the wpcom user data after the cache was flushed so it changed back to the color scheme of your WordPress.com user.
* As a result, this PR removes this mechanism as the color scheme now is a user-level setting and we don't need to sync wpcom user data to it

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your atomic site
* Go to Settings > General
* Configure the Admin Interface Style to `Default Style`
* Go to Users > Profile
* Update the Color Scheme
* Open a new tab and go to /_cli
* Flush the cache with cache flush
* Go back to original tab and refresh
* Make sure the color scheme still takes effect.

