### PR TITLE
Sync Checksums: Ensure is plugin active exists

### DIFF
--- a/projects/packages/sync/changelog/update-sync-ensure-is-plugin-active-exists
+++ b/projects/packages/sync/changelog/update-sync-ensure-is-plugin-active-exists
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Sync: Ensure is_plugin_active exists when loading Table Checksums

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -85,6 +85,11 @@ class WooCommerce_HPOS_Orders extends Module {
 	public static function get_order_types_to_sync( $prefixed = false ) {
 		$types = array( 'order', 'order_refund' );
 
+		// Ensure this is available.
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		if ( is_plugin_active( self::WOOCOMMERCE_SUBSCRIPTIONS_PATH ) ) {
 			$types[] = 'subscription';
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
After #39118 , there seem to be some blogs that are fataling with `Call to undefined function Automattic\Jetpack\Sync\Modules\is_plugin_active()`. This ensures the function exists.

Related logs 829c5c0c8d71089be4f19f21a2f93444-logstash
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure is plugin active exists when loading
Prior art with a similar check for `get_plugins` https://github.com/Automattic/jetpack/blob/update/sync-ensure-is-plugin-active-exists/projects/packages/sync/src/modules/class-plugins.php#L367
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I have not been able to reproduce in my local, code review should be sufficient.

