### PR TITLE
Contact Form: remove www prefix from sender email address

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-from-email-no-www
+++ b/projects/packages/forms/changelog/fix-contact-form-from-email-no-www
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Email submissions: on sites using www., ensure that the sending email address does not use the www. prefix.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1247,8 +1247,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$to[ $to_key ] = self::add_name_to_address( $to_value );
 		}
 
-		$blog_url        = wp_parse_url( site_url() );
-		$from_email_addr = 'wordpress@' . $blog_url['host'];
+		// Get the site domain and get rid of www.
+		$sitename        = wp_parse_url( site_url(), PHP_URL_HOST );
+		$from_email_addr = 'wordpress@';
+
+		if ( null !== $sitename ) {
+			if ( str_starts_with( $sitename, 'www.' ) ) {
+				$sitename = substr( $sitename, 4 );
+			}
+
+			$from_email_addr .= $sitename;
+		}
 
 		if ( ! empty( $comment_author_email ) ) {
 			$reply_to_addr = $comment_author_email;


### PR DESCRIPTION
## Proposed changes:

On sites that use the www. prefix, there is no need to include that prefix in the default sender email address we generate before sending the emails.

Related discussion: https://wordpress.org/support/topic/wrong-domain-in-emails-sent-by-jetpack-2/


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site using `www` in its site address (check under Settings > General)
* Go to Pages > Add New, and add a new form block to your page.
* Publish your page
* Submit a form 
* Check your admin email address for the email you received about your submission
    * It should come from `wordpress@yoursite.com`, and not `wordpress@www.yoursite.com`
