### PR TITLE
Help Center: Fix the icon color when previewing color scheme

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-icon-color
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-icon-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Help Center: Fix the icon color when previewing color scheme

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -99,7 +99,7 @@ CSS
 	wp_add_inline_style(
 		'wpcom-admin-bar',
 		<<<CSS
-			#wpadminbar .ab-icon {
+			:where(#wpadminbar .ab-icon) {
 				color: $admin_icon_color;
 			}
 CSS

--- a/projects/packages/masterbar/changelog/fix-help-center-icon-color
+++ b/projects/packages/masterbar/changelog/fix-help-center-icon-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Help Center: Fix the icon color when previewing color scheme

--- a/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
+++ b/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
@@ -148,6 +148,18 @@ class Admin_Color_Schemes {
 		);
 
 		wp_admin_css_color(
+			'fresh',
+			__( 'Default', 'jetpack-masterbar' ),
+			$this->get_admin_color_scheme_url( 'fresh' ),
+			array( '#1d2327', '#2c3338', '#2271b1', '#72aee6' ),
+			array(
+				'base'    => '#a7aaad',
+				'focus'   => '#72aee6',
+				'current' => '#fff',
+			)
+		);
+
+		wp_admin_css_color(
 			'nightfall',
 			__( 'Nightfall', 'jetpack-masterbar' ),
 			$this->get_admin_color_scheme_url( 'nightfall' ),

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/fresh/colors.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/fresh/colors.scss
@@ -4,10 +4,7 @@
 @import "../_inline-help";
 @import "sidebar-notice";
 
-#wpadminbar .ab-icon,
-#wpadminbar .ab-icon:before,
-#wpadminbar .ab-item:before,
-#wpadminbar .ab-item:after {
+#wpadminbar .ab-icon {
 	color: #a7aaad;
 }
 

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/fresh/colors.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/fresh/colors.scss
@@ -4,6 +4,13 @@
 @import "../_inline-help";
 @import "sidebar-notice";
 
+#wpadminbar .ab-icon,
+#wpadminbar .ab-icon:before,
+#wpadminbar .ab-item:before,
+#wpadminbar .ab-item:after {
+	color: #a7aaad;
+}
+
 // Fresh theme specifics
 #wpadminbar .ab-top-menu > #wp-admin-bar-blog.my-sites > .ab-item {
   background: #23282d;

--- a/projects/plugins/jetpack/changelog/fix-help-center-icon-color
+++ b/projects/plugins/jetpack/changelog/fix-help-center-icon-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Help Center: Fix the icon color when previewing color scheme

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/fresh/colors.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/fresh/colors.scss
@@ -4,10 +4,7 @@
 @import "../_inline-help";
 @import "sidebar-notice";
 
-#wpadminbar .ab-icon,
-#wpadminbar .ab-icon:before,
-#wpadminbar .ab-item:before,
-#wpadminbar .ab-item:after {
+#wpadminbar .ab-icon {
 	color: #a7aaad;
 }
 

--- a/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/fresh/colors.scss
+++ b/projects/plugins/jetpack/modules/masterbar/admin-color-schemes/colors/fresh/colors.scss
@@ -4,6 +4,13 @@
 @import "../_inline-help";
 @import "sidebar-notice";
 
+#wpadminbar .ab-icon,
+#wpadminbar .ab-icon:before,
+#wpadminbar .ab-item:before,
+#wpadminbar .ab-item:after {
+	color: #a7aaad;
+}
+
 // Fresh theme specifics
 #wpadminbar .ab-top-menu > #wp-admin-bar-blog.my-sites > .ab-item {
   background: #23282d;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/94461

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Deprioritize the default color of the icon on the masterbar so that it won't override the color when previewing different color scheme

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/b3283e3e-fda9-4527-8783-01aa120e9be4) | ![image](https://github.com/user-attachments/assets/a768c3ad-b7e8-4686-a904-c4c9604b07c8) |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your site
* Go to /wp-admin/profile.php
* Change the color scheme
* Make sure the color of the help center icon looks good

