### PR TITLE
Social: Fix share status tool tip. 

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-share-status-tooltip
+++ b/projects/js-packages/publicize-components/changelog/fix-social-share-status-tooltip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fixed the display where the error wasn't visible to the user.

--- a/projects/js-packages/publicize-components/src/components/share-status/share-status-label.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/share-status-label.tsx
@@ -21,6 +21,8 @@ export function ShareStatusLabel( { status, message } ) {
 		<Icon className={ styles[ 'share-status-icon' ] } icon={ check } />
 	) : (
 		<IconTooltip
+			shift={ true }
+			inline={ false }
 			title={ __( 'Sharing failed with the following message:', 'jetpack' ) }
 			className={ styles[ 'share-status-icon-tooltip' ] }
 		>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fixes the css for the icon tool tip. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1725872384827009-slack-C02JJ910CNL

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
NO

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post with lots of share failures and ensure that the errors are displayed correctly. I have one such site if you want to just test different branches on it, you can DM me.

**Before**:

The error  message is not visible in the tooltip

<img width="1000" alt="Screenshot 2024-09-12 at 3 35 11 PM" src="https://github.com/user-attachments/assets/0c92a36e-3892-4b79-ad14-d99ac2372d1a">



**After**:

I even hardcoded a custom long error message 

<img width="1021" alt="Screenshot 2024-09-12 at 3 39 17 PM" src="https://github.com/user-attachments/assets/56bafde4-e7ed-45b8-849b-688459a8d3dd">

<img width="1015" alt="Screenshot 2024-09-12 at 3 39 11 PM" src="https://github.com/user-attachments/assets/7b182367-2ea7-4c2b-a449-c41f2b2aee71">