### PR TITLE
Sites API: Add is_a4a_dev_site to jetpack response field additions.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-a4a-site-props-jetpack-response-field-additions
+++ b/projects/plugins/jetpack/changelog/add-a4a-site-props-jetpack-response-field-additions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add `is_a4a_client` & `is_a4a_dev_site` to `jetpack_response_field_additions`.

--- a/projects/plugins/jetpack/changelog/add-a4a-site-props-jetpack-response-field-additions
+++ b/projects/plugins/jetpack/changelog/add-a4a-site-props-jetpack-response-field-additions
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Add `is_a4a_client` & `is_a4a_dev_site` to `jetpack_response_field_additions`.
+Add `is_a4a_dev_site` to `jetpack_response_field_additions`.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -234,7 +234,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'was_migration_trial',
 		'was_hosting_trial',
 		'was_upgraded_from_trial',
-		'is_a4a_client',
 		'is_a4a_dev_site',
 	);
 
@@ -612,6 +611,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'is_deleted':
 				$response[ $key ] = $this->site->is_deleted();
+				break;
+			case 'is_a4a_client':
+				$response[ $key ] = $this->site->is_a4a_client();
 				break;
 			case 'is_a4a_dev_site':
 				$response[ $key ] = $this->site->is_a4a_dev_site();

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -613,9 +613,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'is_deleted':
 				$response[ $key ] = $this->site->is_deleted();
 				break;
-			case 'is_a4a_client':
-				$response[ $key ] = $this->site->is_a4a_client();
-				break;
 			case 'is_a4a_dev_site':
 				$response[ $key ] = $this->site->is_a4a_dev_site();
 				break;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -234,6 +234,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'was_migration_trial',
 		'was_hosting_trial',
 		'was_upgraded_from_trial',
+		'is_a4a_client',
+		'is_a4a_dev_site',
 	);
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/9006

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The `is_a4a_dev_site` is returning false when calling the `/sites/<blog-id>` API endpoint. 

When making `/sites/<blog-id>` API request to an Atomic site, it calls the API on the Atomic server and then redecorates the API response with WPCOM-related values via `decorate_jetpack_response()`. This function calls `$this->render_response_keys( self::$jetpack_response_field_additions );` in which `is_a4a_dev_site` property is not part of the `$jetpack_response_field_additions` list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Related to A4A Dev Sites.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this PR using jetpack downloader script to your sandbox.
* Ensure `public-api-wordpress.com` is sandboxed.
* Test the `v1.2/sites/<blog-id>` endpoint using `WP.COM API`, `v1.2`, `GET`, `/sites/<your-a4a-dev-site-blog-id>` on https://developer.wordpress.com/docs/api/console/.
* The `is_a4a_dev_site` should return `true`.

Also, do the test instructions written in this comment. https://github.com/Automattic/dotcom-forge/issues/9006#issuecomment-2346075823