### PR TITLE
Connection: remove deprecated code from connected plugins component

### DIFF
--- a/projects/packages/connection/changelog/remove-deprecated-disable-plugin-connection
+++ b/projects/packages/connection/changelog/remove-deprecated-disable-plugin-connection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove deprecated code from connected plugins component.

--- a/projects/packages/connection/src/class-plugin-storage.php
+++ b/projects/packages/connection/src/class-plugin-storage.php
@@ -18,14 +18,6 @@ class Plugin_Storage {
 	const ACTIVE_PLUGINS_OPTION_NAME = 'jetpack_connection_active_plugins';
 
 	/**
-	 * Options where disabled plugins were stored
-	 *
-	 * @deprecated since 1.39.0.
-	 * @var string
-	 */
-	const PLUGINS_DISABLED_OPTION_NAME = 'jetpack_connection_disabled_plugins';
-
-	/**
 	 * Transient name used as flag to indicate that the active connected plugins list needs refreshing.
 	 */
 	const ACTIVE_PLUGINS_REFRESH_FLAG = 'jetpack_connection_active_plugins_refresh';
@@ -93,13 +85,9 @@ class Plugin_Storage {
 	 * Even if you don't use Jetpack Config, it may be introduced later by other plugins,
 	 * so please make sure not to run the method too early in the code.
 	 *
-	 * @since 1.39.0 deprecated the $connected_only argument.
-	 *
-	 * @param null $deprecated null plugins that were explicitly disconnected. Deprecated, there's no such a thing as disconnecting only specific plugins anymore.
-	 *
 	 * @return array|WP_Error
 	 */
-	public static function get_all( $deprecated = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public static function get_all() {
 		$maybe_error = self::ensure_configured();
 
 		if ( $maybe_error instanceof WP_Error ) {
@@ -235,43 +223,6 @@ class Plugin_Storage {
 				Jetpack_Options::update_raw_option( 'jetpack_callables_sync_checksum', $jetpack_callables_sync_checksum );
 			}
 		}
-	}
-
-	/**
-	 * Add the plugin to the set of disconnected ones.
-	 *
-	 * @deprecated since 1.39.0.
-	 *
-	 * @param string $slug Plugin slug.
-	 *
-	 * @return bool
-	 */
-	public static function disable_plugin( $slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		return true;
-	}
-
-	/**
-	 * Remove the plugin from the set of disconnected ones.
-	 *
-	 * @deprecated since 1.39.0.
-	 *
-	 * @param string $slug Plugin slug.
-	 *
-	 * @return bool
-	 */
-	public static function enable_plugin( $slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		return true;
-	}
-
-	/**
-	 * Get all plugins that were disconnected by user.
-	 *
-	 * @deprecated since 1.39.0.
-	 *
-	 * @return array
-	 */
-	public static function get_all_disabled_plugins() { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		return array();
 	}
 
 	/**

--- a/projects/packages/connection/src/class-plugin.php
+++ b/projects/packages/connection/src/class-plugin.php
@@ -87,36 +87,4 @@ class Plugin {
 
 		return ! $plugins || ( array_key_exists( $this->slug, $plugins ) && 1 === count( $plugins ) );
 	}
-
-	/**
-	 * Add the plugin to the set of disconnected ones.
-	 *
-	 * @deprecated since 1.39.0.
-	 *
-	 * @return bool
-	 */
-	public function disable() {
-		return true;
-	}
-
-	/**
-	 * Remove the plugin from the set of disconnected ones.
-	 *
-	 * @deprecated since 1.39.0.
-	 *
-	 * @return bool
-	 */
-	public function enable() {
-		return true;
-	}
-
-	/**
-	 * Whether this plugin is allowed to use the connection.
-	 *
-	 * @deprecated since 11.0
-	 * @return bool
-	 */
-	public function is_enabled() {
-		return true;
-	}
 }


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove the long deprecated remains of the "soft disconnect" functionality which hasn't been in use since 2022.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p9dueE-4n9-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack. Check Jetpack Debugger, confirm Jetpack shows up in the list of active Jetpack plugins.
2. Install a standalone Jetpack plugin. Check the Debugger, confirm it shows up as well.
3. Deactivate that another Jetpack plugin. Confirm it disappears from the list in Debugger, and Jetpack is still connected.
4. Deactivate Jetpack, activate it again. Confirm it's been disconnected and needs to be reconnected.