### PR TITLE
White-labeled plugin: Add wpcom-migration key endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/baseline.php
@@ -79,6 +79,7 @@ return [
         'src/features/verbum-comments/class-verbum-comments.php' => ['PhanImpossibleTypeComparison', 'PhanNoopNew', 'PhanParamTooMany', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredFunction'],
         'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-launchpad.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-migrate-guru-key.php' => ['PhanUndeclaredClassMethod'],
+        'src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-wpcom-migration-key.php' => ['PhanUndeclaredClassMethod'],
         'tests/lib/functions-wordpress.php' => ['PhanRedefineFunction'],
         'tests/php/features/block-patterns/class-wpcom-block-patterns-from-api-test.php' => ['PhanDeprecatedFunction'],
         'tests/php/features/coming-soon/class-coming-soon-test.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-key-endpoint
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-key-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new wpcom-migration-key endpoint.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-wpcom-migration-key.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-wpcom-migration-key.php
@@ -95,7 +95,7 @@ class WPCOM_REST_API_V2_Endpoint_Site_Migration_WPCOM_Migration_Key extends WP_R
 	}
 
 	/**
-	 * Returns Launchpad-related options.
+	 * Returns migration key.
 	 *
 	 * @return array Associative array with `migration_key`.
 	 */

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-wpcom-migration-key.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-wpcom-migration-key.php
@@ -69,7 +69,7 @@ class WPCOM_REST_API_V2_Endpoint_Site_Migration_WPCOM_Migration_Key extends WP_R
 			return false;
 		}
 
-		if ( ! class_exists( 'WPCOMWPSettings' ) || ! class_exists( 'WPCOMWPInfo' ) ) {
+		if ( ! class_exists( 'WPCOMWPSettings' ) || ! class_exists( 'WPCOMInfo' ) ) {
 			return false;
 		}
 
@@ -87,7 +87,7 @@ class WPCOM_REST_API_V2_Endpoint_Site_Migration_WPCOM_Migration_Key extends WP_R
 	 */
 	private function get_migration_key() {
 		$wpcom_migration_settings = new WPCOMWPSettings();
-		$wpcom_migration_info     = new WPCOMWPInfo( $wpcom_migration_settings );
+		$wpcom_migration_info     = new WPCOMInfo( $wpcom_migration_settings );
 
 		update_option( $this->key_is_read_option_name, 'read' );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-wpcom-migration-key.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-site-migration-wpcom-migration-key.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Allow us to access the Migrate Guru site migration key via API.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * WARNING: This file is distributed verbatim in Jetpack.
+ * There should be nothing WordPress.com specific in this file.
+ *
+ * @hide-in-jetpack
+ */
+class WPCOM_REST_API_V2_Endpoint_Site_Migration_WPCOM_Migration_Key extends WP_REST_Controller {
+	/**
+	 * Option name that tracks wether the key has been read or not.
+	 * The only possible value for the option is 'read'.
+	 *
+	 * @var string
+	 */
+	protected $key_is_read_option_name = 'wpcom_site_migration_wpcom_migration_key_read';
+
+	/**
+	 * Class constructor
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'atomic-migration-status/wpcom-migration-key';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register our routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_data' ),
+					'permission_callback' => array( $this, 'can_access' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission callback for the REST route.
+	 *
+	 * @return boolean
+	 */
+	public function can_access() {
+		if ( ! class_exists( 'Automattic\Jetpack\Status\Host' ) ) {
+			return false;
+		}
+
+		if ( ! ( new Automattic\Jetpack\Status\Host() )->is_woa_site() ) {
+			return false;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
+		if ( ! is_plugin_active( 'wpcom-migration/wpcom_migration.php' ) ) {
+			return false;
+		}
+
+		if ( ! class_exists( 'WPCOMWPSettings' ) || ! class_exists( 'WPCOMWPInfo' ) ) {
+			return false;
+		}
+
+		if ( 'read' === get_option( $this->key_is_read_option_name, false ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the migration key.
+	 *
+	 * @return string
+	 */
+	private function get_migration_key() {
+		$wpcom_migration_settings = new WPCOMWPSettings();
+		$wpcom_migration_info     = new WPCOMWPInfo( $wpcom_migration_settings );
+
+		update_option( $this->key_is_read_option_name, 'read' );
+
+		return $wpcom_migration_info->getConnectionKey();
+	}
+
+	/**
+	 * Returns Launchpad-related options.
+	 *
+	 * @return array Associative array with `migration_key`.
+	 */
+	public function get_data() {
+		return array(
+			'migration_key' => $this->get_migration_key(),
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Site_Migration_WPCOM_Migration_Key' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a new endpoint to fetch a site's wpcom migration key from the `wpcom-migration` plugin. This is modeled after the migrate guru plugin endpoint but uses different classes and a more accurate endpoint name.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this branch to your AT using Jetpack Beta plugin following instructions in https://github.com/Automattic/jetpack/pull/39377#issuecomment-2346557311
* Apply D161332-code to your sandbox and sandbox `public-api.wordpress.com`. 
* Apply this branch also on your sandbox by running `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/wpcom-key-endpoint` (make sure this PR and D161332-code are running on your sandbox at the same time)
* Visit the developer console and fetch from `/wpcom/v2/sites/%your-AT-site%/atomic-migration-status/wpcom-migration-key`
* You should see a 403 error
* On the AT site, install and activate the Migrate to WordPress.com plugin (link found in Slack).
* Fetch the endpoint from the developer console; the migration key field should be populated with the same migration key you'll find at `/wp-admin/admin.php?page=wpcom-migration`
* Try to fetch it again and verify that a 403 error is returned
