### PR TITLE
Social: Hide share statuses that are not from the connections belonging to the current user

### DIFF
--- a/projects/packages/publicize/changelog/update-social-share-status
+++ b/projects/packages/publicize/changelog/update-social-share-status
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Hide share logs not belonging to current admin.

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -680,6 +680,28 @@ class REST_Controller {
 		// If the data is not an array, it means that sharing is not done yet.
 		$done = is_array( $shares );
 
+		if ( $done ) {
+			// The site could have multiple admins, editors and authors connected. Load shares information that only the current user has access to.
+			global $publicize;
+			$connection_ids = array_map(
+				function ( $connection ) {
+					if ( isset( $connection['connection_id'] ) ) {
+						return (int) $connection['connection_id'];
+					}
+					return 0;
+				},
+				$publicize->get_all_connections_for_user()
+			);
+			$shares         = array_values(
+				array_filter(
+					$shares,
+					function ( $share ) use ( $connection_ids ) {
+						return in_array( (int) $share['connection_id'], $connection_ids, true );
+					}
+				)
+			);
+		}
+
 		return rest_ensure_response(
 			array(
 				'shares' => $done ? $shares : array(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Users shouldn't see the connections logs of connections they don't have access to. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1725873986116619-slack-C02JJ910CNL

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On trunk setup a site with two admins, enable share status reporting and add jetpack social connections on accounts belonging to both admins. Both admins need their own WPCOM accounts to establish a Jetpack connection
* Publish a post and wait for the share status to show up. 
* Now, as the other admin go to the edit post view of the post published in the step above.
* In the share logs you will see the other admin's connections
* Enable this branch and repeat the above step. The view shars history button will have disappeared. 
* As the first admin, globalize the connections.
* As the second admin, go to the same post and ensure that you can see the view shares history button which will show the log from the global connection
* A caveat: Don't attempt to reshare a post the admin isn't the author of. That flow is broken and need to be fixed. I have a separate fix for it here: D161311-code. 
