### PR TITLE
My Jetpack: Introduce action 'myjetpack_enqueue_scripts'

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-enqueue-scripts
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-enqueue-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add new action myjetpack_enqueue_scripts

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -207,6 +207,13 @@ class Initializer {
 	 * @return void
 	 */
 	public static function enqueue_scripts() {
+		/**
+		 * Fires after the My Jetpack page is initialized.
+		 * Allows for enqueuing additional scripts only on the My Jetpack page.
+		 *
+		 * @since $$next-version$$
+		 */
+		do_action( 'myjetpack_enqueue_scripts' );
 		Assets::register_script(
 			'my_jetpack_main_app',
 			'../build/index.js',

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -611,7 +611,7 @@ class Jetpack_Ai extends Product {
 	 * @return void
 	 */
 	public static function extend_plugin_action_links() {
-		add_action( 'admin_enqueue_scripts', array( static::class, 'admin_enqueue_scripts' ) );
+		add_action( 'myjetpack_enqueue_scripts', array( static::class, 'admin_enqueue_scripts' ) );
 		add_filter( 'default_content', array( static::class, 'add_ai_block' ), 10, 2 );
 	}
 


### PR DESCRIPTION
Allows for including scripts specific to My Jetpack without having to resort to the more general `admin_enqueue_scripts`
Fixes #

Saves a request to dotcom from the editor.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduces action `myjetpack_enqueue_scripts` called from just the My Jetpack Page
* Updates the product class `Jetpack_ai` to enqueue scripts using the new filter

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
TBD

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to My Jetpack. Open the console. confirm that `window.jetpackAi.nonce` exists
* Go to the editor. Open the console. confirm that `window.jetpackAi.nonce` doesn't exist

