### PR TITLE
Revert "Sharing Service: Make sure we only check for legacy sharing buttons implementation on non-block themes"

### DIFF
--- a/projects/plugins/jetpack/changelog/update-sharing-services-assets-only-on-old-themes
+++ b/projects/plugins/jetpack/changelog/update-sharing-services-assets-only-on-old-themes
@@ -1,4 +1,0 @@
-Significance: major
-Type: compat
-
-Improved compatibiliy with modern block themes by not checking whether we should use legacy sharing buttons mechanism

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-service.php
@@ -898,10 +898,6 @@ function sharing_add_footer() {
  * @return void
  */
 function sharing_add_header() {
-	if ( ! sharing_should_load_legacy_sharing_buttons() ) {
-		return;
-	}
-
 	$sharer  = new Sharing_Service();
 	$enabled = $sharer->get_blog_services();
 
@@ -915,20 +911,6 @@ function sharing_add_header() {
 	}
 }
 add_action( 'wp_head', 'sharing_add_header', 1 );
-
-/**
- * Determine if legacy sharing buttons should be loaded.
- * Do this by checking if the current theme is a block theme
- * If it is, we shouldn't enqueue the sharing assets
- * as the recommended way of adding sharing buttons is via the editor.
- *
- * @since $$next-version$$
- *
- * @return bool True if legacy sharing buttons should be loaded, false otherwise.
- */
-function sharing_should_load_legacy_sharing_buttons() {
-	return ! wp_is_block_theme();
-}
 
 /**
  * Launch sharing requests on page load when a specific query string is used.


### PR DESCRIPTION
Reverts Automattic/jetpack#39349

Amother approach is needed as this one can be disruptive

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Saves a call to `get_option( 'sharing-services' )` for modern themes in the frontend.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a function `sharing_should_load_legacy_sharing_buttons()` that checks if the theme is a modern theme
* Updates `sharing_add_header()` to check with `sharing_should_load_legacy_sharing_buttons()` before checking if it should load the sharing assets in the frontend

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-Ub-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*