### PR TITLE
Fix/recommendations showing before dismissing welcome banner

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -165,7 +165,7 @@ export default function MyJetpackScreen() {
 					</Container>
 				)
 			) }
-			{ isSectionVisible && <EvaluationRecommendations /> }
+			{ ! isWelcomeBannerVisible && isSectionVisible && <EvaluationRecommendations /> }
 
 			<ProductCardsSection />
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -165,7 +165,7 @@ export default function MyJetpackScreen() {
 					</Container>
 				)
 			) }
-			{ ! isWelcomeBannerVisible && isSectionVisible && <EvaluationRecommendations /> }
+			{ isSectionVisible && <EvaluationRecommendations /> }
 
 			<ProductCardsSection />
 

--- a/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
+++ b/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
@@ -41,7 +41,7 @@ const useEvaluationRecommendations = () => {
 
 	const [ isSectionVisible, setIsSectionVisible ] = useValueStore(
 		'recommendedModulesVisible',
-		isEligibleForRecommendations && !! unownedRecommendedModules?.length
+		! isWelcomeBannerVisible && isEligibleForRecommendations && !! unownedRecommendedModules?.length
 	);
 
 	const { mutate: handleSubmitRecommendations } = useSimpleMutation< SubmitRecommendationsResult >(

--- a/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
+++ b/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useValueStore } from '../../context/value-store/valueStoreContext';
 import useAnalytics from '../../hooks/use-analytics';
 import {
@@ -121,6 +121,19 @@ const useEvaluationRecommendations = () => {
 		showWelcomeBanner();
 		recordEvent( 'jetpack_myjetpack_evaluation_recommendations_redo_click' );
 	}, [ recordEvent, setIsSectionVisible, showWelcomeBanner ] );
+
+	useEffect( () => {
+		setIsSectionVisible(
+			! isWelcomeBannerVisible &&
+				isEligibleForRecommendations &&
+				!! unownedRecommendedModules?.length
+		);
+	}, [
+		isWelcomeBannerVisible,
+		isEligibleForRecommendations,
+		unownedRecommendedModules,
+		setIsSectionVisible,
+	] );
 
 	return {
 		submitEvaluation,

--- a/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
+++ b/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useValueStore } from '../../context/value-store/valueStoreContext';
 import useAnalytics from '../../hooks/use-analytics';
 import {
@@ -41,7 +41,7 @@ const useEvaluationRecommendations = () => {
 
 	const [ isSectionVisible, setIsSectionVisible ] = useValueStore(
 		'recommendedModulesVisible',
-		! isWelcomeBannerVisible && isEligibleForRecommendations && !! unownedRecommendedModules?.length
+		isEligibleForRecommendations && !! unownedRecommendedModules?.length
 	);
 
 	const { mutate: handleSubmitRecommendations } = useSimpleMutation< SubmitRecommendationsResult >(
@@ -121,19 +121,6 @@ const useEvaluationRecommendations = () => {
 		showWelcomeBanner();
 		recordEvent( 'jetpack_myjetpack_evaluation_recommendations_redo_click' );
 	}, [ recordEvent, setIsSectionVisible, showWelcomeBanner ] );
-
-	useEffect( () => {
-		setIsSectionVisible(
-			! isWelcomeBannerVisible &&
-				isEligibleForRecommendations &&
-				!! unownedRecommendedModules?.length
-		);
-	}, [
-		isWelcomeBannerVisible,
-		isEligibleForRecommendations,
-		unownedRecommendedModules,
-		setIsSectionVisible,
-	] );
 
 	return {
 		submitEvaluation,

--- a/projects/packages/my-jetpack/changelog/fix-recommendations-showing-before-dismissing-welcome-banner
+++ b/projects/packages/my-jetpack/changelog/fix-recommendations-showing-before-dismissing-welcome-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix issue where recommendations are showing slightly before the welcome banner dismisses

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -42,7 +42,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.35.5';
+	const PACKAGE_VERSION = '4.35.6';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -42,7 +42,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '4.35.6';
+	const PACKAGE_VERSION = '4.35.5';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.
@@ -211,7 +211,7 @@ class Initializer {
 		 * Fires after the My Jetpack page is initialized.
 		 * Allows for enqueuing additional scripts only on the My Jetpack page.
 		 *
-		 * @since 4.35.6
+		 * @since $$next-version$$
 		 */
 		do_action( 'myjetpack_enqueue_scripts' );
 		Assets::register_script(


### PR DESCRIPTION
## Proposed changes:

* Stops recommendations from showing until welcome banner is not showing anymore

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment (if you use your local environment, you'll probably need to edit some code to fake being a new user)
2. Go to `/wp-admin/admin.php?page=my-jetpack`
3. Connect your site from the welcome banner
4. Fill out the survey and select **See Solutions**
5. Make sure the recommendations do not show up until the welcome banner is gone

https://github.com/user-attachments/assets/85ff1206-274a-4173-8ffe-28227f50cfd3
