### PR TITLE
Search: Verify plan allows for instant search before checking the option

### DIFF
--- a/projects/packages/search/.phan/baseline.php
+++ b/projects/packages/search/.phan/baseline.php
@@ -16,11 +16,11 @@ return [
     // PhanTypeMismatchArgument : 6 occurrences
     // PhanUndeclaredProperty : 6 occurrences
     // PhanTypeMismatchReturn : 5 occurrences
-    // PhanDeprecatedFunction : 4 occurrences
     // PhanImpossibleCondition : 4 occurrences
     // PhanTypeMismatchProperty : 4 occurrences
     // PhanPluginMixedKeyNoKey : 3 occurrences
     // PhanTypeSuspiciousEcho : 3 occurrences
+    // PhanDeprecatedFunction : 2 occurrences
     // PhanNoopNew : 2 occurrences
     // PhanDeprecatedPartiallySupportedCallable : 1 occurrence
     // PhanPluginRedundantAssignment : 1 occurrence
@@ -38,7 +38,6 @@ return [
         'src/class-cli.php' => ['PhanTypeMismatchArgument'],
         'src/class-helper.php' => ['PhanDeprecatedPartiallySupportedCallable', 'PhanImpossibleCondition', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanUndeclaredClassMethod'],
         'src/class-options.php' => ['PhanPluginSimplifyExpressionBool'],
-        'src/class-plan.php' => ['PhanDeprecatedFunction'],
         'src/class-rest-controller.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/class-template-tags.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/classic-search/class-classic-search.php' => ['PhanImpossibleCondition', 'PhanPluginRedundantAssignment', 'PhanRedundantCondition', 'PhanTypeInvalidDimOffset', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypeMismatchProperty', 'PhanTypeMismatchReturn', 'PhanTypePossiblyInvalidDimOffset'],

--- a/projects/packages/search/changelog/optimize-search-loading
+++ b/projects/packages/search/changelog/optimize-search-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search: reduce database calls by ensuring plan support before checking options

--- a/projects/packages/search/src/class-module-control.php
+++ b/projects/packages/search/src/class-module-control.php
@@ -13,7 +13,7 @@ use Automattic\Jetpack\Status;
 use WP_Error;
 
 /**
- * To get and set Searh module settings
+ * To get and set Search module settings
  */
 class Module_Control {
 	/**
@@ -73,7 +73,7 @@ class Module_Control {
 	 * @return bool
 	 */
 	public function is_instant_search_enabled() {
-		return (bool) get_option( self::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY );
+		return (bool) $this->plan->supports_instant_search() && get_option( self::SEARCH_MODULE_INSTANT_SEARCH_OPTION_KEY );
 	}
 
 	/**

--- a/projects/packages/search/src/class-plan.php
+++ b/projects/packages/search/src/class-plan.php
@@ -91,7 +91,7 @@ class Plan {
 	 */
 	public function supports_instant_search() {
 		$plan_info = $this->get_plan_info();
-		return ( isset( $plan_info['supports_instant_search'] ) && $plan_info['supports_instant_search'] ) || $this->has_jetpack_search_product();
+		return ( isset( $plan_info['supports_instant_search'] ) && $plan_info['supports_instant_search'] );
 	}
 
 	/**
@@ -99,7 +99,7 @@ class Plan {
 	 */
 	public function supports_search() {
 		$plan_info = $this->get_plan_info();
-		return ( isset( $plan_info['supports_search'] ) && $plan_info['supports_search'] ) || $this->has_jetpack_search_product();
+		return ( isset( $plan_info['supports_search'] ) && $plan_info['supports_search'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39352

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Reduce calls to the database through more selective function calling. This removes two option calls from the frontend of a Jetpack site.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-Ub-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* With the patch, activate a Jetpack site (without search) with query monitor 
* Go to front-end and see if `instant_search_enabled` or `has_jetpack_search_product` option calls are hitting the db.
* Activate free search — confirm it works on the front end.
* Activate paid search — confirm it works on the front end.