### PR TITLE
Backup: do not consider discarded backups as successful backups

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-discarded-as-successful
+++ b/projects/packages/backup/changelog/fix-backup-discarded-as-successful
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop considering discarded backups as successful backups on the admin page

--- a/projects/packages/backup/src/js/hooks/test/useBackupsState.js
+++ b/projects/packages/backup/src/js/hooks/test/useBackupsState.js
@@ -17,6 +17,31 @@ const fixtures = {
 			is_scan: 0,
 		},
 	],
+	discarded: [
+		{
+			id: 381971090,
+			started: '2023-01-01 02:16:32',
+			last_updated: '2023-01-01 02:16:34',
+			status: 'finished',
+			period: 1672530000,
+			percent: 100,
+			is_backup: 1,
+			is_scan: 0,
+			has_warnings: false,
+			discarded: '1',
+			stats: {
+				prefix: 'wp_',
+				plugins: { count: 100 },
+				themes: { count: 100 },
+				uploads: { count: 100 },
+				tables: {
+					wp_posts: {
+						post_published: 100,
+					},
+				},
+			}, // full stats details are not required currently
+		},
+	],
 	complete: [
 		{
 			id: 381971090,
@@ -28,6 +53,7 @@ const fixtures = {
 			is_backup: 1,
 			is_scan: 0,
 			has_warnings: false,
+			discarded: '0',
 			stats: {
 				prefix: 'wp_',
 				plugins: { count: 100 },
@@ -51,6 +77,54 @@ const fixtures = {
 			percent: 0,
 			is_backup: 1,
 			is_scan: 0,
+		},
+	],
+	complete_and_discarded: [
+		{
+			id: 234567,
+			started: '2024-01-02 01:00:00',
+			last_updated: '2024-01-02 01:05:00',
+			status: 'finished',
+			period: 1704157200,
+			percent: 100,
+			is_backup: 1,
+			is_scan: 0,
+			has_warnings: false,
+			discarded: '1', // Discarded backup
+			stats: {
+				prefix: 'wp_',
+				plugins: { count: 100 },
+				themes: { count: 100 },
+				uploads: { count: 100 },
+				tables: {
+					wp_posts: {
+						post_published: 100,
+					},
+				},
+			},
+		},
+		{
+			id: 123456,
+			started: '2024-01-01 01:00:00',
+			last_updated: '2024-01-01 01:05:00',
+			status: 'finished',
+			period: 1704070800,
+			percent: 100,
+			is_backup: 1,
+			is_scan: 0,
+			has_warnings: false,
+			discarded: '0', // Complete backup
+			stats: {
+				prefix: 'wp_',
+				plugins: { count: 100 },
+				themes: { count: 100 },
+				uploads: { count: 100 },
+				tables: {
+					wp_posts: {
+						post_published: 100,
+					},
+				},
+			},
 		},
 	],
 };
@@ -149,6 +223,44 @@ describe( 'useBackupsState', () => {
 
 		await waitFor( () => {
 			expect( result.current.backupState ).toBe( BACKUP_STATE.NO_GOOD_BACKUPS );
+		} );
+	} );
+
+	it( 'backupState should be NO_GOOD_BACKUPS when last backup finished as discarded', async () => {
+		useSelect.mockImplementation( selector => {
+			if ( typeof selector === 'function' ) {
+				return selector( () => ( {
+					getBackups: () => fixtures.discarded,
+					isFetchingBackups: () => false,
+					hasLoadedBackups: () => true,
+				} ) );
+			}
+			return [];
+		} );
+
+		const { result } = renderHook( () => useBackupsState() );
+
+		await waitFor( () => {
+			expect( result.current.backupState ).toBe( BACKUP_STATE.NO_GOOD_BACKUPS );
+		} );
+	} );
+
+	it( 'backupState should be COMPLETE by selecting the latest non-discarded finished backup', async () => {
+		useSelect.mockImplementation( selector => {
+			if ( typeof selector === 'function' ) {
+				return selector( () => ( {
+					getBackups: () => fixtures.complete_and_discarded,
+					isFetchingBackups: () => false,
+					hasLoadedBackups: () => true,
+				} ) );
+			}
+			return [];
+		} );
+
+		const { result } = renderHook( () => useBackupsState() );
+
+		await waitFor( () => {
+			expect( result.current.backupState ).toBe( BACKUP_STATE.COMPLETE );
 		} );
 	} );
 } );

--- a/projects/packages/backup/src/js/hooks/useBackupsState.js
+++ b/projects/packages/backup/src/js/hooks/useBackupsState.js
@@ -59,7 +59,7 @@ const useBackupsState = ( shouldPoll = false ) => {
 						return;
 					}
 
-					if ( 'finished' === backup.status && backup.stats ) {
+					if ( 'finished' === backup.status && backup.stats && '0' === backup.discarded ) {
 						latestBackup = backup;
 						setBackupState( BACKUP_STATE.COMPLETE );
 					}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-backup-team/issues/572

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a condition to stop considering discarded backups as successful backups in the admin page

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/jetpack-backup-team/issues/572

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Unit testing
Unit tests run as part of the repo checks, but you can also run them locally using the following command:
* JS: `jetpack test packages/backup js`

### Acceptance testing
* Using [Jetpack Beta](https://jetpack.com/download-jetpack-beta/), install the Jetpack VaultPress Backup using this branch on a site with Jetpack VaultPress Backup with at least 2 successful backups.
* Navigate to the VaultPress Backup admin page.
* Verify that the latest successful backup date is shown.
* Mark the latest successful backup as discarded. You can find instructions for doing this in the backend [here](https://github.com/Automattic/jetpack-backup-team/issues/572#issuecomment-2347403641).
* Refresh the admin page. Now, the date of the previous successful backup (the one before the discarded one) should be displayed