### PR TITLE
Search: Add option caching for Instant Search configurator

### DIFF
--- a/projects/packages/search/changelog/add-search-customberg-option-caching
+++ b/projects/packages/search/changelog/add-search-customberg-option-caching
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added option caching for Instant Search settings.

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -829,7 +829,7 @@ class Helper {
 			$posts_per_page = 20;
 		}
 
-		$excluded_post_types   = get_option( $prefix . 'excluded_post_types' ) ? explode( ',', get_option( $prefix . 'excluded_post_types', '' ) ) : array();
+		$excluded_post_types   = Options::get_cached_option( $prefix . 'excluded_post_types' ) ? explode( ',', Options::get_cached_option( $prefix . 'excluded_post_types', '' ) ) : array();
 		$post_types            = array_values(
 			get_post_types(
 				array(
@@ -850,15 +850,15 @@ class Helper {
 
 		$options = array(
 			'overlayOptions'              => array(
-				'colorTheme'                  => get_option( $prefix . 'color_theme', 'light' ),
-				'enableInfScroll'             => get_option( $prefix . 'inf_scroll', '1' ) === '1',
-				'enableFilteringOpensOverlay' => get_option( $prefix . 'filtering_opens_overlay', '1' ) === '1',
-				'enablePostDate'              => get_option( $prefix . 'show_post_date', '1' ) === '1',
-				'enableSort'                  => get_option( $prefix . 'enable_sort', '1' ) === '1',
-				'highlightColor'              => get_option( $prefix . 'highlight_color', '#FFC' ),
-				'overlayTrigger'              => get_option( $prefix . 'overlay_trigger', Options::DEFAULT_OVERLAY_TRIGGER ),
-				'resultFormat'                => get_option( $prefix . 'result_format', Options::RESULT_FORMAT_MINIMAL ),
-				'showPoweredBy'               => ( new Plan() )->is_free_plan() || ( get_option( $prefix . 'show_powered_by', '1' ) === '1' ),
+				'colorTheme'                  => Options::get_cached_option( $prefix . 'color_theme', 'light' ),
+				'enableInfScroll'             => Options::get_cached_option( $prefix . 'inf_scroll', '1' ) === '1',
+				'enableFilteringOpensOverlay' => Options::get_cached_option( $prefix . 'filtering_opens_overlay', '1' ) === '1',
+				'enablePostDate'              => Options::get_cached_option( $prefix . 'show_post_date', '1' ) === '1',
+				'enableSort'                  => Options::get_cached_option( $prefix . 'enable_sort', '1' ) === '1',
+				'highlightColor'              => Options::get_cached_option( $prefix . 'highlight_color', '#FFC' ),
+				'overlayTrigger'              => Options::get_cached_option( $prefix . 'overlay_trigger', Options::DEFAULT_OVERLAY_TRIGGER ),
+				'resultFormat'                => Options::get_cached_option( $prefix . 'result_format', Options::RESULT_FORMAT_MINIMAL ),
+				'showPoweredBy'               => Options::get_cached_option( $prefix . 'show_powered_by', '1' ) === '1',
 
 				// These options require kicking off a new search.
 				'defaultSort'                 => get_option( $prefix . 'default_sort', 'relevance' ),

--- a/projects/packages/search/src/class-options.php
+++ b/projects/packages/search/src/class-options.php
@@ -92,4 +92,40 @@ class Options {
 		 */
 		return apply_filters( 'jetpack_search_has_vip_index', $has_vip_index );
 	}
+
+	/**
+	 * Returns the cache key for an option if persisted with get_cached_option method below.
+	 *
+	 * @return bool
+	 */
+	public static function get_cached_option_key( $option_name ) {
+		return 'jetpack-search-' . Package::version . '-' . $option_name;
+	}
+
+	/**
+	 * Checks the cache for the option. If it doesn't exist, fetch from DB and persist in the cache.
+	 * Designed to be used for "pre_option_${option_name}" filters.
+	 *
+	 * @return bool
+	 */
+	public static function get_cached_option( $option_name, $default_value = false, $cache_timeout = 3600 ) {
+		$cache_key = self::get_cached_option_key( $option_name );
+		$value = wp_cache_get( $cache_key );
+		if ( false === $value ) {
+			$value = get_option( $option_name, $default );
+			wp_cache_set( $cache_key, $value, '', $cache_timeout );
+		}
+		return $value;
+	}
+
+	/**
+	 * Updates the cache for the option.
+	 * Designed to be used for "updated_option" actions.
+	 *
+	 * @return bool
+	 */
+	public static function update_cached_option( $option_name, $value ) {
+		$option_key = self::get_cached_option_key( $option_name );
+		wp_cache_set( $option_key, $value );
+	}
 }

--- a/projects/packages/search/src/class-options.php
+++ b/projects/packages/search/src/class-options.php
@@ -96,24 +96,30 @@ class Options {
 	/**
 	 * Returns the cache key for an option if persisted with get_cached_option method below.
 	 *
+	 * @param string $option_name - The name of the option to get the cache key for.
+	 *
 	 * @return bool
 	 */
 	public static function get_cached_option_key( $option_name ) {
-		return 'jetpack-search-' . Package::version . '-' . $option_name;
+		return Package::VERSION . '-' . $option_name;
 	}
 
 	/**
 	 * Checks the cache for the option. If it doesn't exist, fetch from DB and persist in the cache.
 	 * Designed to be used for "pre_option_${option_name}" filters.
 	 *
+	 * @param string $option_name - The name of the option to get.
+	 * @param mixed  $default_value - The fallback value if the option does not exist.
+	 * @param int    $cache_timeout - The number of seconds to cache the option for.
+	 *
 	 * @return bool
 	 */
 	public static function get_cached_option( $option_name, $default_value = false, $cache_timeout = 3600 ) {
 		$cache_key = self::get_cached_option_key( $option_name );
-		$value = wp_cache_get( $cache_key );
+		$value     = wp_cache_get( $cache_key, 'jetpack-search' );
 		if ( false === $value ) {
-			$value = get_option( $option_name, $default );
-			wp_cache_set( $cache_key, $value, '', $cache_timeout );
+			$value = get_option( $option_name, $default_value );
+			wp_cache_set( $cache_key, $value, 'jetpack-search', $cache_timeout );
 		}
 		return $value;
 	}
@@ -122,10 +128,15 @@ class Options {
 	 * Updates the cache for the option.
 	 * Designed to be used for "updated_option" actions.
 	 *
+	 * @param string $option_name - The name of the option to update.
+	 * @param mixed  $value - The value to update the option to.
+	 * @param int    $cache_timeout - The number of seconds to cache the option for.
+	 *
 	 * @return bool
 	 */
-	public static function update_cached_option( $option_name, $value ) {
+	public static function update_cached_option( $option_name, $value, $cache_timeout = 3600 ) {
 		$option_key = self::get_cached_option_key( $option_name );
-		wp_cache_set( $option_key, $value );
+		wp_cache_set( $option_key, $value, 'jetpack-search', $cache_timeout );
+		return true;
 	}
 }

--- a/projects/packages/search/src/class-options.php
+++ b/projects/packages/search/src/class-options.php
@@ -98,7 +98,7 @@ class Options {
 	 *
 	 * @param string $option_name - The name of the option to get the cache key for.
 	 *
-	 * @return bool
+	 * @return string
 	 */
 	public static function get_cached_option_key( $option_name ) {
 		return Package::VERSION . '-' . $option_name;
@@ -112,7 +112,7 @@ class Options {
 	 * @param mixed  $default_value - The fallback value if the option does not exist.
 	 * @param int    $cache_timeout - The number of seconds to cache the option for.
 	 *
-	 * @return bool
+	 * @return mixed
 	 */
 	public static function get_cached_option( $option_name, $default_value = false, $cache_timeout = 3600 ) {
 		$cache_key = self::get_cached_option_key( $option_name );

--- a/projects/packages/search/src/class-package.php
+++ b/projects/packages/search/src/class-package.php
@@ -26,7 +26,7 @@ class Package {
 	 *
 	 * @param array $package_versions The package version array.
 	 *
-	 * @return array The packge version array.
+	 * @return array The package version array.
 	 */
 	public static function send_version_to_tracker( $package_versions ) {
 		// Multiple versions could co-exist, we want to send the version which is in use.

--- a/projects/packages/search/src/customberg/class-customberg.php
+++ b/projects/packages/search/src/customberg/class-customberg.php
@@ -32,6 +32,21 @@ class Customberg {
 	 */
 	public $plan;
 
+	// Configurable options for the Instant Search experience.
+	const OPTIONS = array(
+		'jetpack_search_color_theme',
+		'jetpack_search_result_format',
+		'jetpack_search_default_sort',
+		'jetpack_search_overlay_trigger',
+		'jetpack_search_highlight_color',
+		'jetpack_search_enable_sort',
+		'jetpack_search_inf_scroll',
+		'jetpack_search_filtering_opens_overlay',
+		'jetpack_search_show_powered_by',
+		'jetpack_search_show_post_date',
+		'jetpack_search_excluded_post_types',
+	);
+
 	/**
 	 * Get the singleton instance of the class.
 	 *
@@ -51,8 +66,9 @@ class Customberg {
 	 */
 	public function init_hooks() {
 		add_action( 'admin_menu', array( $this, 'add_wp_admin_page' ), 999 );
-		add_filter( 'pre_option_jetpack_search_show_powered_by', array( $this, 'get_show_powered_by' ) );
 		$this->plan = new Plan();
+		add_action( 'updated_option', array( $this, 'update_cached_option' ), 10, 3 );
+		add_filter( 'pre_option_jetpack_search_show_powered_by', array( $this, 'get_show_powered_by' ) );
 	}
 
 	/**
@@ -75,6 +91,20 @@ class Customberg {
 
 		add_action( "admin_print_scripts-$hook", array( $this, 'load_assets' ) );
 		add_action( 'admin_footer', array( 'Automattic\Jetpack\Search\Helper', 'print_instant_search_sidebar' ) );
+	}
+
+	/**
+	 * Update the cached option value.
+	 *
+	 * @param string $option_name The option name.
+	 * @param mixed  $old_value   The old value, not used.
+	 * @param mixed  $value       The new value.
+	 */
+	public function update_cached_option( $option_name, $old_value, $value ) {
+		if ( in_array( $option_name, self::OPTIONS, true ) ) {
+			// Update option cache only if it's one of Customberg's options.
+			Options::update_cached_option( $option_name, $value );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
* Adds caching for options powering Instant Search configuration ("Customberg").
  * Note that this will only improve performance on sites with [persistent object caching enabled](https://developer.wordpress.org/reference/classes/wp_object_cache/#role-of-the-wordpress-object-cache).

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pdWQjU-Ub-p2#comment-959

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
- On a test site with a Jetpack Search subscription, enable the Instant Search experience.
- Navigate to the site root `/`.
- In Query Monitor, ensure Jetpack Search config option values are fetched using the new cache-augmented function.
- If on a host with caching, reload the page and ensure get_option is not invoked.
![image](https://github.com/user-attachments/assets/2c1bafb0-7e2e-4294-aab7-67f0178755aa)
