### PR TITLE
Ai Client: Add logo generator flux model style dropdown

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-logo-generator-flux-model-style-test
+++ b/projects/js-packages/ai-client/changelog/add-logo-generator-flux-model-style-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Client: add drafted dropdown to pick styles on logo generator

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -89,7 +89,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 
 			// Then generate the logo based on the prompt.
 			setLoadingState( 'generating' );
-			await generateLogo( { prompt } );
+			await generateLogo( { prompt, style: 'line-art' } );
 			setLoadingState( null );
 		} catch ( error ) {
 			debug( 'Error generating first logo', error );

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -188,7 +188,6 @@ export const LogoPresenter: React.FC< LogoPresenterProps > = ( {
 	logoAccepted = false,
 	siteId,
 } ) => {
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- @todo Start extending jetpack-js-tools/eslintrc/react in eslintrc, then we can remove this disable comment.
 	const { isRequestingImage } = useLogoGenerator();
 	const { saveToLibraryError, logoUpdateError } = useRequestErrors();
 

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -34,6 +34,7 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 	const { enhancePromptFetchError, logoFetchError } = useRequestErrors();
 	const { nextTierCheckoutURL: checkoutUrl, hasNextTier } = useCheckout();
 	const hasPrompt = prompt?.length >= MINIMUM_PROMPT_LENGTH;
+	const [ style, setStyle ] = useState( 'line-art' );
 
 	const {
 		generateLogo,
@@ -92,8 +93,8 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 
 	const onGenerate = useCallback( async () => {
 		recordTracksEvent( EVENT_GENERATE, { context, tool: 'image' } );
-		generateLogo( { prompt } );
-	}, [ context, generateLogo, prompt ] );
+		generateLogo( { prompt, style } );
+	}, [ context, generateLogo, prompt, style ] );
 
 	const onPromptInput = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		setPrompt( event.target.textContent || '' );
@@ -120,6 +121,10 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 
 	const onUpgradeClick = () => {
 		recordTracksEvent( EVENT_UPGRADE, { context, placement: EVENT_PLACEMENT_INPUT_FOOTER } );
+	};
+
+	const onStyleChange = ( event: React.ChangeEvent< HTMLSelectElement > ) => {
+		setStyle( event.target.value );
 	};
 
 	return (
@@ -162,6 +167,26 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 					{ __( 'Generate', 'jetpack-ai-client' ) }
 				</Button>
 			</div>
+			<select name="style" value={ style } onChange={ onStyleChange }>
+				<option value="enhance">Normal</option>
+				<option value="anime">Anime</option>
+				<option value="photographic">Photographic</option>
+				<option value="digital-art">Digital Art</option>
+				<option value="comicbook">Comicbook</option>
+				<option value="fantasy-art">Fantasy Art</option>
+				<option value="analog-film">Analog Film</option>
+				<option value="neonpunk">Neon Punk</option>
+				<option value="isometric">Isometric</option>
+				<option value="lowpoly">Low Poly</option>
+				<option value="origami">Origami</option>
+				<option value="line-art">Line Art</option>
+				<option value="craft-clay">Craft Clay</option>
+				<option value="cinematic">Cinematic</option>
+				<option value="3d-model">3D Model</option>
+				<option value="pixel-art">Pixel Art</option>
+				<option value="texture">Texture</option>
+				<option value="monty-python">Monty Python</option>
+			</select>
 			<div className="jetpack-ai-logo-generator__prompt-footer">
 				{ ! isUnlimited && ! requireUpgrade && (
 					<div className="jetpack-ai-logo-generator__prompt-requests">

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -35,6 +35,9 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 	const { nextTierCheckoutURL: checkoutUrl, hasNextTier } = useCheckout();
 	const hasPrompt = prompt?.length >= MINIMUM_PROMPT_LENGTH;
 	const [ style, setStyle ] = useState( 'line-art' );
+	const showStyleSelector =
+		window?.Jetpack_Editor_Initial_State?.available_blocks[ 'ai-logo-style-selector-support' ]
+			?.available;
 
 	const {
 		generateLogo,
@@ -167,26 +170,28 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 					{ __( 'Generate', 'jetpack-ai-client' ) }
 				</Button>
 			</div>
-			<select name="style" value={ style } onChange={ onStyleChange }>
-				<option value="enhance">Normal</option>
-				<option value="anime">Anime</option>
-				<option value="photographic">Photographic</option>
-				<option value="digital-art">Digital Art</option>
-				<option value="comicbook">Comicbook</option>
-				<option value="fantasy-art">Fantasy Art</option>
-				<option value="analog-film">Analog Film</option>
-				<option value="neonpunk">Neon Punk</option>
-				<option value="isometric">Isometric</option>
-				<option value="lowpoly">Low Poly</option>
-				<option value="origami">Origami</option>
-				<option value="line-art">Line Art</option>
-				<option value="craft-clay">Craft Clay</option>
-				<option value="cinematic">Cinematic</option>
-				<option value="3d-model">3D Model</option>
-				<option value="pixel-art">Pixel Art</option>
-				<option value="texture">Texture</option>
-				<option value="monty-python">Monty Python</option>
-			</select>
+			{ showStyleSelector && (
+				<select name="style" value={ style } onChange={ onStyleChange }>
+					<option value="enhance">Normal</option>
+					<option value="anime">Anime</option>
+					<option value="photographic">Photographic</option>
+					<option value="digital-art">Digital Art</option>
+					<option value="comicbook">Comicbook</option>
+					<option value="fantasy-art">Fantasy Art</option>
+					<option value="analog-film">Analog Film</option>
+					<option value="neonpunk">Neon Punk</option>
+					<option value="isometric">Isometric</option>
+					<option value="lowpoly">Low Poly</option>
+					<option value="origami">Origami</option>
+					<option value="line-art">Line Art</option>
+					<option value="craft-clay">Craft Clay</option>
+					<option value="cinematic">Cinematic</option>
+					<option value="3d-model">3D Model</option>
+					<option value="pixel-art">Pixel Art</option>
+					<option value="texture">Texture</option>
+					<option value="monty-python">Monty Python</option>
+				</select>
+			) }
 			<div className="jetpack-ai-logo-generator__prompt-footer">
 				{ ! isUnlimited && ! requireUpgrade && (
 					<div className="jetpack-ai-logo-generator__prompt-requests">

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -193,8 +193,10 @@ For example: user's prompt: A logo for an ice cream shop. Returned prompt: A log
 
 	const generateImage = useCallback( async function ( {
 		prompt,
+		style,
 	}: {
 		prompt: string;
+		style: string;
 	} ): Promise< { data: Array< { url: string } > } > {
 		setLogoFetchError( null );
 
@@ -207,20 +209,24 @@ For example: user's prompt: A logo for an ice cream shop. Returned prompt: A log
 
 			debug( 'Generating image with prompt', prompt );
 
-			const imageGenerationPrompt = `I NEED to test how the tool works with extremely simple prompts. DO NOT add any detail, just use it AS-IS:
-Create a single text-free iconic vector logo that symbolically represents the user request, using abstract or symbolic imagery.
-The design should be modern, with either a vivid color scheme full of gradients or a color scheme that's monochromatic. Use any of those styles based on the user request mood.
-Ensure the logo is set against a clean solid background.
-Ensure the logo works in small sizes.
-The imagery in the logo should subtly hint at the mood of the user request but DO NOT use any text, letters, or the name of the site on the imagery.
-The image should contain a single icon, without variations, color palettes or different versions.
+			const imageGenerationPrompt = `You are a top notch graphic artist, specialized in creating logos for websites.
+You have been asked to create a logo for a website.
+The logo should be a single iconic vector logo that symbolically represents the user request, using abstract or symbolic imagery.
+The logo, unless specified in the prompt, should not include text or letters.
+If the prompt specifies a mood, the logo should reflect that mood.
+If the prompt specifies a color scheme, the logo should use that color scheme.
+If the prompt specifies a brand or word or letters, include them but make sure they are written properly as provided.
+The logo should be set against a clean solid background and work in small sizes.
+Maximize the size of the logo in the image, so it's easy to see and doesn't hold so much padding around it.
+The imagery in the logo should subtly hint at the mood of the user request but should not use any text, letters, or the name of the site on the imagery.
 
-User request:${ prompt }`;
+User request: ${ prompt }`;
 
 			const body = {
 				prompt: imageGenerationPrompt,
 				feature: 'jetpack-ai-logo-generator',
 				response_format: 'b64_json',
+				style,
 			};
 
 			const data = await generateImageWithParameters( body );
@@ -309,7 +315,7 @@ User request:${ prompt }`;
 	);
 
 	const generateLogo = useCallback(
-		async function ( { prompt }: { prompt: string } ): Promise< void > {
+		async function ( { prompt, style }: { prompt: string; style: string } ): Promise< void > {
 			debug( 'Generating logo for site' );
 
 			setIsRequestingImage( true );
@@ -324,7 +330,7 @@ User request:${ prompt }`;
 				let image;
 
 				try {
-					image = await generateImage( { prompt } );
+					image = await generateImage( { prompt, style } );
 
 					if ( ! image || ! image.data.length ) {
 						throw new Error( 'No image returned' );

--- a/projects/plugins/jetpack/changelog/add-logo-generator-flux-model-style-test
+++ b/projects/plugins/jetpack/changelog/add-logo-generator-flux-model-style-test
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: add logo style selector as beta feature

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -197,3 +197,15 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Register the `ai-logo-style-selector-support` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		if ( apply_filters( 'jetpack_ai_enabled', true ) ) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-logo-style-selector-support' );
+		}
+	}
+);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -79,7 +79,9 @@
 		"recipe",
 		"v6-video-frame-poster",
 		"videopress/video-chapters",
-		"ai-assistant-backend-prompts"
+		"ai-assistant-backend-prompts",
+		"ai-title-optimization-keywords-support",
+		"ai-logo-style-selector-support"
 	],
 	"experimental": [],
 	"no-post-editor": [


### PR DESCRIPTION
WIP, do not merge!

## Proposed changes:
Add style dropdown for Logo Generator

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1726168714255029-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Sandbox public API and patch your sandbox with D161383-code
Set blocks variation to BETA

Add a logo block to a post and open the logo generator modal with the AI button on the toolbar:
<img width="421" alt="image" src="https://github.com/user-attachments/assets/9f6db7c7-84c1-449e-98b6-8a4eeeb42539">

There should be a very simplistic style dropdown below the prompt input:
<img width="728" alt="image" src="https://github.com/user-attachments/assets/3dbd716a-0299-416e-81b8-d8f550d6696d">

Use a prompt and test different styles to generate a logo.

Confirm the selector is not available with PRODUCTION variation and the logo generator works