### PR TITLE
Social: Fix resharing in classic editor for simple sites

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-resharing-for-simple-sites
+++ b/projects/packages/publicize/changelog/fix-social-resharing-for-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed resharing not working in classic editor for wp.com sites

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Only user facing pieces of Publicize are found here.
@@ -172,6 +173,9 @@ class Publicize_UI {
 				'textdomain' => 'jetpack-publicize-pkg',
 			)
 		);
+
+		$is_simple_site = ( new Host() )->is_wpcom_simple();
+
 		wp_add_inline_script(
 			'jetpack-social-classic-editor-options',
 			'var jetpackSocialClassicEditorOptions = ' . wp_json_encode(
@@ -179,7 +183,7 @@ class Publicize_UI {
 					'ajaxUrl'                     => admin_url( 'admin-ajax.php' ),
 					'connectionsUrl'              => esc_url( $this->publicize_settings_url ),
 					'isEnhancedPublishingEnabled' => $this->publicize->has_enhanced_publishing_feature(),
-					'resharePath'                 => '/jetpack/v4/publicize/{postId}',
+					'resharePath'                 => $is_simple_site ? '/wpcom/v2/posts/{postId}/publicize' : '/jetpack/v4/publicize/{postId}',
 					'isReshareSupported'          => Current_Plan::supports( 'republicize' ),
 				)
 			),


### PR DESCRIPTION
Right now, resharing in classic editor only works in Jetpack and Atomic sites but not in simple sites because of the wrong enpoint being used.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix the endpoint used for resharing in simple sites

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable classic editor on a WPCOM site
* Edit a post using classic editor
* Click on "Edit" under Jetpack social options in publish section
* Select a social connection and click on "Share now"
* Confirm that the request is not 404 and is rather a success
* Confirm that the post gets shared to the selected connection

