### PR TITLE
Admin menu: Replace Jetpack Cloud links with WordPress.com links

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-wpcom-jetpack-cloud-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-wpcom-jetpack-cloud-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin menu: Replace Jetpack cloud links with WordPress.com links

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -583,11 +583,6 @@ class Launchpad_Task_Lists {
 			return true;
 		}
 
-		// Allow Jetpack Cloud URLs.
-		if ( strpos( $input, 'https://cloud.jetpack.com' ) === 0 ) {
-			return true;
-		}
-
 		// Checks if the string is URL starting with the admin URL.
 		if ( strpos( $input, admin_url() ) === 0 ) {
 			return true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -21,16 +21,6 @@ function wpcom_launchpad_should_use_wp_admin_link() {
 }
 
 /**
- * Returns whether the task link should point to Jetpack Cloud page
- * instead of Calypso page.
- *
- * @return bool
- */
-function wpcom_launchpad_should_use_jetpack_cloud_link() {
-	return get_option( 'wpcom_admin_interface' ) === 'wp-admin';
-}
-
-/**
  * Get the task definitions for the Launchpad.
  *
  * @return Task[]
@@ -258,9 +248,6 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
-					return 'https://cloud.jetpack.com/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
-				}
 				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
 			},
 		),
@@ -526,9 +513,6 @@ function wpcom_launchpad_get_task_definitions() {
 			'target_repetitions'        => 10,
 			'repetition_count_callback' => 'wpcom_launchpad_get_newsletter_subscriber_count',
 			'get_calypso_path'          => function ( $task, $default, $data ) {
-				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
-					return 'https://cloud.jetpack.com/subscribers/' . $data['site_slug_encoded'];
-				}
 				return '/subscribers/' . $data['site_slug_encoded'];
 			},
 		),
@@ -552,9 +536,6 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => 'wpcom_launchpad_has_goal_import_subscribers',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
-					return 'https://cloud.jetpack.com/subscribers/' . $data['site_slug_encoded'];
-				}
 				return '/subscribers/' . $data['site_slug_encoded'];
 			},
 		),
@@ -606,9 +587,6 @@ function wpcom_launchpad_get_task_definitions() {
 						'earn-launchpad'
 					);
 				}
-				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
-					return 'https://cloud.jetpack.com/monetize/payments/' . $data['site_slug_encoded'];
-				}
 				return '/earn/payments/' . $data['site_slug_encoded'];
 			},
 		),
@@ -619,9 +597,6 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_has_paid_membership_plans',
 			'is_visible_callback'  => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
-					return 'https://cloud.jetpack.com/monetize/payments/' . $data['site_slug_encoded'] . '#add-new-payment-plan';
-				}
 				return '/earn/payments/' . $data['site_slug_encoded'] . '#add-new-payment-plan';
 			},
 		),
@@ -677,9 +652,6 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
-				if ( wpcom_launchpad_should_use_jetpack_cloud_link() ) {
-					return 'https://cloud.jetpack.com/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
-				}
 				return '/subscribers/' . $data['site_slug_encoded'] . '#add-subscribers';
 			},
 		),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -150,7 +150,6 @@ function wpcom_add_jetpack_submenu() {
 	$is_simple_site          = defined( 'IS_WPCOM' ) && IS_WPCOM;
 	$is_atomic_site          = ! $is_simple_site;
 	$uses_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
-	$domain                  = wp_parse_url( home_url(), PHP_URL_HOST );
 
 	if ( ! $uses_wp_admin_interface ) {
 		return;
@@ -171,6 +170,7 @@ function wpcom_add_jetpack_submenu() {
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
 	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'jetpack-menu-jetpack-manage-subscribers', array( 'site' => $blog_id ) ) ) );
 
+	$domain           = wp_parse_url( home_url(), PHP_URL_HOST );
 	$activity_log_url = 'https://wordpress.com/activity-log/' . $domain;
 	$vaultpress_url   = 'https://wordpress.com/backup/' . $domain;
 	$monetize_url     = 'https://wordpress.com/earn/' . $domain;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -185,7 +185,7 @@ function wpcom_add_jetpack_submenu() {
 		__( 'Activity Log', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		$activity_log_url,
-		null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
 
 	add_submenu_page(
@@ -194,7 +194,7 @@ function wpcom_add_jetpack_submenu() {
 		__( 'VaultPress', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		$vaultpress_url,
-		null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
 
 	add_submenu_page(
@@ -203,7 +203,7 @@ function wpcom_add_jetpack_submenu() {
 		__( 'Monetize', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		$monetize_url,
-		null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
 
 	if ( $is_atomic_site ) {
@@ -213,7 +213,7 @@ function wpcom_add_jetpack_submenu() {
 			__( 'Scan', 'jetpack-mu-wpcom' ),
 			'manage_options',
 			$scan_url,
-			null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		);
 	}
 
@@ -223,7 +223,7 @@ function wpcom_add_jetpack_submenu() {
 		__( 'Subscribers', 'jetpack-mu-wpcom' ),
 		'manage_options',
 		$subscribers_url,
-		null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
 
 	if ( $is_simple_site ) {
@@ -233,7 +233,7 @@ function wpcom_add_jetpack_submenu() {
 			__( 'Newsletter', 'jetpack-mu-wpcom' ),
 			'manage_options',
 			$newsletter_url,
-			null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+			null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -159,7 +159,7 @@ function wpcom_add_jetpack_submenu() {
 		return;
 	}
 
-	$blog_id = Connection_Manager::get_site_id( true );
+	$blog_id = Connection_Manager::get_site_id();
 	if ( is_wp_error( $blog_id ) ) {
 		return;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -10,7 +10,6 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 
 /**
  * Checks if the current user has a WordPress.com account connected.
@@ -148,31 +147,142 @@ add_action( 'admin_menu', 'wpcom_add_hosting_menu' );
  * Adds WordPress.com submenu items related to Jetpack under the Jetpack admin menu.
  */
 function wpcom_add_jetpack_submenu() {
-	/*
-	 * Do not display any menu on WoA and WordPress.com Simple sites (unless Classic wp-admin is enabled).
-	 * They already get a menu item under Users via nav-unification.
-	 */
-	if ( ( new Host() )->is_wpcom_platform() && get_option( 'wpcom_admin_interface' ) !== 'wp-admin' ) {
+	$is_simple_site          = defined( 'IS_WPCOM' ) && IS_WPCOM;
+	$is_atomic_site          = ! $is_simple_site;
+	$uses_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+	$domain                  = wp_parse_url( home_url(), PHP_URL_HOST );
+
+	if ( ! $uses_wp_admin_interface ) {
 		return;
 	}
 
-	/*
-	 * Do not display if we're in Offline mode, or if the user is not connected.
-	 */
-	if ( ( new Status() )->is_offline_mode() || ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) {
+	if ( $is_atomic_site && ( ( new Status() )->is_offline_mode() || ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) ) {
 		return;
 	}
+
+	$blog_id = Connection_Manager::get_site_id( true );
+	if ( is_wp_error( $blog_id ) ) {
+		return;
+	}
+
+	// Hide submenu items that link to Jetpack Cloud.
+	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'cloud-activity-log-wp-menu', array( 'site' => $blog_id ) ) ) );
+	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'cloud-scan-history-wp-menu' ) ) );
+	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'calypso-backups' ) ) );
+	wpcom_hide_submenu_page( 'jetpack', esc_url( Redirect::get_url( 'jetpack-menu-jetpack-manage-subscribers', array( 'site' => $blog_id ) ) ) );
+
+	$activity_log_url = 'https://wordpress.com/activity-log/' . $domain;
+	$vaultpress_url   = 'https://wordpress.com/backup/' . $domain;
+	$monetize_url     = 'https://wordpress.com/earn/' . $domain;
+	$subscribers_url  = 'https://wordpress.com/subscribers/' . $domain;
+	$newsletter_url   = 'https://wordpress.com/settings/newsletter/' . $domain;
+	$scan_url         = 'https://wordpress.com/scan/history/' . $domain;
+
+	// Add submenu items that link to WordPress.com.
+	add_submenu_page(
+		'jetpack',
+		__( 'Activity Log', 'jetpack-mu-wpcom' ),
+		__( 'Activity Log', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		$activity_log_url,
+		null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+	);
+
+	add_submenu_page(
+		'jetpack',
+		__( 'VaultPress', 'jetpack-mu-wpcom' ),
+		__( 'VaultPress', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		$vaultpress_url,
+		null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+	);
 
 	add_submenu_page(
 		'jetpack',
 		__( 'Monetize', 'jetpack-mu-wpcom' ),
-		__( 'Monetize', 'jetpack-mu-wpcom' ) . ' <span class="dashicons dashicons-external"></span>',
+		__( 'Monetize', 'jetpack-mu-wpcom' ),
 		'manage_options',
-		esc_url( Redirect::get_url( 'calypso-monetize' ) ),
-		null // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+		$monetize_url,
+		null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 	);
+
+	if ( $is_atomic_site ) {
+		add_submenu_page(
+			'jetpack',
+			__( 'Scan', 'jetpack-mu-wpcom' ),
+			__( 'Scan', 'jetpack-mu-wpcom' ),
+			'manage_options',
+			$scan_url,
+			null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		);
+	}
+
+	add_submenu_page(
+		'jetpack',
+		__( 'Subscribers', 'jetpack-mu-wpcom' ),
+		__( 'Subscribers', 'jetpack-mu-wpcom' ),
+		'manage_options',
+		$subscribers_url,
+		null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+	);
+
+	if ( $is_simple_site ) {
+		add_submenu_page(
+			'jetpack',
+			__( 'Newsletter', 'jetpack-mu-wpcom' ),
+			__( 'Newsletter', 'jetpack-mu-wpcom' ),
+			'manage_options',
+			$newsletter_url,
+			null // @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
+		);
+	}
+
+	// Re-order menu.
+	global $submenu;
+	if ( ! isset( $submenu['jetpack'] ) ) {
+		return;
+	}
+
+	$desired_order   = array(
+		'my-jetpack',
+		'stats',
+		$activity_log_url,
+		$vaultpress_url,
+		'akismet-key-config',
+		'jetpack-search',
+		$scan_url,
+		$monetize_url,
+		$subscribers_url,
+	);
+	$ordered_submenu = array();
+
+	// Re-add submenu items in the desired order.
+	foreach ( $desired_order as $slug ) {
+		foreach ( $submenu['jetpack'] as $item ) {
+			if ( $item[2] === $slug ) {
+				$ordered_submenu[] = $item;
+			}
+		}
+	}
+
+	// Add any remaining submenu items.
+	foreach ( $submenu['jetpack'] as $item ) {
+		if ( ! in_array( $item[2], $desired_order, true ) ) {
+			$ordered_submenu[] = $item;
+		}
+	}
+
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride
+	$submenu['jetpack'] = $ordered_submenu;
 }
-add_action( 'jetpack_admin_menu', 'wpcom_add_jetpack_submenu' );
+add_action( 'admin_menu', 'wpcom_add_jetpack_submenu', 999999 );
+
+/*
+ * Prevents the Jetpack menu from being overridden on Simple sites.
+ *
+ * TODO: After deploying TBD, we can remove the `add_jetpack_submenu` function and this `remove_action` call.
+ */
+remove_action( 'admin_menu', 'add_jetpack_submenu', 999999 );
 
 /**
  * Ensures customizer menu and admin bar items are not visible on a block theme.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -280,7 +280,7 @@ add_action( 'admin_menu', 'wpcom_add_jetpack_submenu', 999999 );
 /*
  * Prevents the Jetpack menu from being overridden on Simple sites.
  *
- * TODO: After deploying TBD, we can remove the `add_jetpack_submenu` function and this `remove_action` call.
+ * TODO: After deploying https://github.com/Automattic/jetpack/pull/39393, we can remove the `add_jetpack_submenu` function and this `remove_action` call.
  */
 remove_action( 'admin_menu', 'add_jetpack_submenu', 999999 );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/7342

## Proposed changes:

Replaces all the Jetpack submenu items that are linking to `cloud.jetpack.com` with a link to `wordpress.com`, so WordPress.com users don't need to learn another UI to manage their site.

It also updates the launchpad tasks that were redirecting to `cloud.jetpack.com` so they redirect to `wordpress.com`

**Simple sites**

Before | After
--- | ---
<img width="336" alt="Screenshot 2024-09-13 at 15 16 38" src="https://github.com/user-attachments/assets/e97c7e55-aa09-4f1d-b0b7-a7dfb9ad8423"> | <img width="336" alt="Screenshot 2024-09-13 at 15 17 17" src="https://github.com/user-attachments/assets/83988f0d-77d7-4d9e-9fd8-9df974e4e995">

- Items have been re-ordered to have better parity with Atomic sites
- Activity log, VaultPress, Monetize, and Subscribers now link to WordPress.com (aka Calypso blue) instead of Jetpack Cloud (aka Calypso Green)

**Atomic sites**

Before | After
--- | ---
<img width="336" alt="Screenshot 2024-09-13 at 15 18 33" src="https://github.com/user-attachments/assets/d6621bab-32b2-4126-bb68-ddddda11d992"> | <img width="334" alt="Screenshot 2024-09-13 at 15 19 34" src="https://github.com/user-attachments/assets/e3faab1c-6386-413d-ace7-3783213281ec">


- Items have been re-ordered to have better parity with Simple sites
- Activity log, VaultPress, Monetize, Scan, and Subscribers now link to WordPress.com (aka Calypso blue) instead of Jetpack Cloud (aka Calypso Green)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pekYwv-4AB-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Apply these changes to a WP.com simple site and to a WP.com atomic site following the instructions below.
- Activate the classic admin interface
- Observe the Jetpack menu
- Make sure there are items that link to `cloud.jetpack.com`
- Check testing instructions from https://github.com/Automattic/jetpack/pull/36573
- Make sure the launchpad tasks link to `wordpress.com` now regardless of the selected admin interface