### PR TITLE
Contact Form: add filter to exclude IP address from db/email

### DIFF
--- a/projects/packages/forms/changelog/add-no-save-ip-contact-form
+++ b/projects/packages/forms/changelog/add-no-save-ip-contact-form
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+New filter to allow for excluding the contact form submission IP from being saved or e-mailed.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1160,9 +1160,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		$contact_form_subject = trim( $contact_form_subject );
 
-		$comment_author_IP = Contact_Form_Plugin::get_ip_address(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		$comment_author_ip = Contact_Form_Plugin::get_ip_address();
 
-		$vars = array( 'comment_author', 'comment_author_email', 'comment_author_url', 'contact_form_subject', 'comment_author_IP' );
+		$vars = array( 'comment_author', 'comment_author_email', 'comment_author_url', 'contact_form_subject', 'comment_author_ip' );
 		foreach ( $vars as $var ) {
 			$$var = str_replace( array( "\n", "\r" ), '', (string) $$var );
 		}
@@ -1363,6 +1363,25 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 */
 		add_filter( 'wp_insert_post_data', array( $plugin, 'insert_feedback_filter' ), 10, 2 );
 
+		/**
+		 * Allows site owners to not include IP addresses in the saved form response.
+		 *
+		 * The IP address is still used as part of spam filtering, if enabled, but it is removed when this filter
+		 * is set to true before saving to the database and e-mailing the form recipients.
+
+		 * @module contact-form
+		 *
+		 * @param bool $remove_ip_address Should the IP address be removed. Default false.
+		 * @param string $ip_address IP address of the form submission.
+		 *
+		 * @since $$next-version$$
+		 */
+		if ( apply_filters( 'jetpack_contact_form_forget_ip_address', true, $comment_author_ip ) ) {
+			$comment_author_ip = null;
+		}
+
+		$comment_ip_text = $comment_author_ip ? "IP: {$comment_author_ip}\n" : null;
+
 		$post_id = wp_insert_post(
 			array(
 				'post_date'    => addslashes( $feedback_time ),
@@ -1371,7 +1390,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'post_parent'  => $post ? (int) $post->ID : 0,
 				'post_title'   => addslashes( wp_kses( $feedback_title, array() ) ),
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase, WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DevelopmentFunctions.error_log_print_r
-				'post_content' => addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\nIP: {$comment_author_IP}\nJSON_DATA\n" . @wp_json_encode( $all_values, true ), array() ) ), // so that search will pick up this data
+				'post_content' => addslashes( wp_kses( "$comment_content\n<!--more-->\nAUTHOR: {$comment_author}\nAUTHOR EMAIL: {$comment_author_email}\nAUTHOR URL: {$comment_author_url}\nSUBJECT: {$subject}\n{$comment_ip_text}JSON_DATA\n" . @wp_json_encode( $all_values, true ), array() ) ), // so that search will pick up this data
 				'post_name'    => $feedback_id,
 			)
 		);
@@ -1432,11 +1451,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 			esc_html__( 'Time: %1$s', 'jetpack-forms' ),
 			$time
 		);
-		$footer_ip = sprintf(
+		$footer_ip = null;
+		if ( $comment_author_ip ) {
+			$footer_ip = sprintf(
 			/* translators: Placeholder is the IP address of the person who submitted a form. */
-			esc_html__( 'IP Address: %1$s', 'jetpack-forms' ),
-			$comment_author_IP // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		);
+				esc_html__( 'IP Address: %1$s', 'jetpack-forms' ),
+				$comment_author_ip
+			) . '<br />';
+		}
+
 		$footer_url = sprintf(
 			/* translators: Placeholder is the URL of the page where a form was submitted. */
 			__( 'Source URL: %1$s', 'jetpack-forms' ),
@@ -1461,7 +1484,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 					'<hr />',
 					'<span style="font-size: 12px">',
 					$footer_time . '<br />',
-					$footer_ip . '<br />',
+					$footer_ip ? $footer_ip . '<br />' : null,
 					$footer_url . '<br />',
 					$sent_by_text,
 					'</span>',

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1376,7 +1376,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 *
 		 * @since $$next-version$$
 		 */
-		if ( apply_filters( 'jetpack_contact_form_forget_ip_address', true, $comment_author_ip ) ) {
+		if ( apply_filters( 'jetpack_contact_form_forget_ip_address', false, $comment_author_ip ) ) {
 			$comment_author_ip = null;
 		}
 

--- a/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
+++ b/projects/packages/forms/tests/php/contact-form/test-class.contact-form.php
@@ -136,6 +136,29 @@ class WP_Test_Contact_Form extends BaseTestCase {
 
 	/**
 	 * Tests that the submission as a whole will produce something in the
+	 * database when required information is provided.
+	 *
+	 * @author tonykova
+	 */
+	public function test_process_submission_will_not_store_ip() {
+		add_filter( 'jetpack_contact_form_forget_ip_address', '__return_true' );
+		$form   = new Contact_Form( array() );
+		$result = $form->process_submission();
+
+		// Processing should be successful and produce the success message.
+		$this->assertTrue( is_string( $result ) );
+
+		$feedback_id = end( Posts::init()->posts )->ID;
+		$submission  = get_post( $feedback_id );
+
+		// Default metadata should be saved.
+		$email = get_post_meta( $submission->ID, '_feedback_email', true );
+		$this->assertStringNotContainsString( 'IP Address', $email['message'] );
+		remove_all_filters( 'jetpack_contact_form_forget_ip_address' );
+	}
+
+	/**
+	 * Tests that the submission as a whole will produce something in the
 	 * database when some labels are provided.
 	 *
 	 * @author tonykova


### PR DESCRIPTION
When a site owner wishes to intentionally not retain submission IP address, this filter allows site owners to set a new `add_filter( 'jetpack_contact_form_forget_ip_address', '__return_true` ); to not retain the IP address in the database or included in the notification e-mails.

The IP address is still used with Akismet or other spam filtering, if so enabled, but is discarded after it has been used for that and IP disallow list checking.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `jetpack_contact_form_forget_ip_address` filter.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1726177662638909-slack-CDD9LQRSN 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. Allows for a reduction of data saved.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Without the filter, setup Jetpack and add a Contact Form. Submit the form. Notice the IP in the Feedbacks entry and e-mail.
* Add filter as described above, repeat. The submission will be in the db and the e-mail will be sent, without the IP info.