### PR TITLE
Social: adds hook for social shares URLs upon save

### DIFF
--- a/projects/packages/publicize/changelog/add-share-save-hook
+++ b/projects/packages/publicize/changelog/add-share-save-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social: adds hook for plugin developers to be able to pull social share URLs on save.

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -659,7 +659,7 @@ class REST_Controller {
 			foreach ( $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] as $share ) {
 				if ( isset( $share['status'] ) && 'success' === $share['status'] ) {
 					$urls[] = array(
-						'url'     => $share['url'],
+						'url'     => $share['message'],
 						'service' => $share['service'],
 					);
 				}

--- a/projects/packages/publicize/src/class-rest-controller.php
+++ b/projects/packages/publicize/src/class-rest-controller.php
@@ -655,6 +655,25 @@ class REST_Controller {
 
 		if ( $post && 'publish' === $post->post_status && isset( $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] ) ) {
 			update_post_meta( $post_id, self::SOCIAL_SHARES_POST_META_KEY, $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] );
+			$urls = array();
+			foreach ( $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] as $share ) {
+				if ( isset( $share['status'] ) && 'success' === $share['status'] ) {
+					$urls[] = array(
+						'url'     => $share['url'],
+						'service' => $share['service'],
+					);
+				}
+			}
+			/**
+			 * Fires after Publicize Shares post meta has been saved.
+			 *
+			 * @param array $urls {
+			 *     An array of social media shares.
+			 *     @type array $url URL to the social media post.
+			 *     @type string $service Social media service shared to.
+			 * }
+			 */
+			do_action( 'jetpack_publicize_share_urls_saved', $urls );
 			return rest_ensure_response( new WP_REST_Response() );
 		}
 

--- a/projects/plugins/social/changelog/add-share-save-hook
+++ b/projects/plugins/social/changelog/add-share-save-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social: adds hook for plugin developers to be able to pull social share URLs on save.

--- a/projects/plugins/social/src/class-rest-social-note-controller.php
+++ b/projects/plugins/social/src/class-rest-social-note-controller.php
@@ -70,7 +70,7 @@ class REST_Social_Note_Controller extends WP_REST_Controller {
 			foreach ( $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] as $share ) {
 				if ( isset( $share['status'] ) && 'success' === $share['status'] ) {
 					$urls[] = array(
-						'url'     => $share['url'],
+						'url'     => $share['message'],
 						'service' => $share['service'],
 					);
 				}

--- a/projects/plugins/social/src/class-rest-social-note-controller.php
+++ b/projects/plugins/social/src/class-rest-social-note-controller.php
@@ -66,6 +66,17 @@ class REST_Social_Note_Controller extends WP_REST_Controller {
 
 		if ( $post && $post->post_type === Note::JETPACK_SOCIAL_NOTE_CPT && $post->post_status === 'publish' && isset( $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] ) ) {
 			update_post_meta( $post_id, self::SOCIAL_SHARES_POST_META_KEY, $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] );
+			$urls = array();
+			foreach ( $post_meta[ self::SOCIAL_SHARES_POST_META_KEY ] as $share ) {
+				if ( isset( $share['status'] ) && 'success' === $share['status'] ) {
+					$urls[] = array(
+						'url'     => $share['url'],
+						'service' => $share['service'],
+					);
+				}
+			}
+			/** This action is documented in src/class-rest-controller.php */
+			do_action( 'jetpack_publicize_share_urls_saved', $urls );
 			return rest_ensure_response( new WP_REST_Response() );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #7359 and supports https://github.com/dshanske/syndication-links/issues/46

While social share URLs are now saved to the database, it requires a post meta read and data processing to get the URLs. To help plugin authors be able to access this information and save it in their own fields, this adds a hook to provide the urls and service names when that information is saved.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a hook for plugin authors to be able to grab social share URLs upon save.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Site with Jetpack with this branch, site and user connected, Publicize enabled, and a connection established to a social network.
* Add this or similar code in a snippets plugin, etc:
```
add_action( 'jetpack_publicize_share_urls_saved', 'bk_test_save', 10, 2);

function bk_test_save( $urls ) {
	if ( $urls ) {
		update_option( 'bk_test_urls', $urls );
	} else {
		update_option( 'bk_test_urls', 'nothing present');
	}
}
```
* Write a new post, publish with sharing to the social media connection.
* `wp option get bk_test_urls` via CLI

Should get something akin to:
```
$ wp option get bk_test_urls
array (
  0 =>
  array (
    'url' => 'https://mastodon.social/@KraftTesting/113131834695319922',
    'service' => 'mastodon',
  ),
)
```
* Activate Social paid plan.
* Go back to the post and try sharing the post again to social media.
* You should have both entries in the option.
Should be something akin to:
```
$ wp option get bk_test_urls
array (
  0 =>
  array (
    'url' => 'https://mastodon.social/@KraftTesting/113131834695319922',
    'service' => 'mastodon',
  ),
  1 =>
  array (
    'url' => 'https://mastodon.social/@KraftTesting/113131853992527539',
    'service' => 'mastodon',
  ),
  2 =>
  array (
    'url' => 'https://mastodon.social/@KraftTesting/113131884688679461',
    'service' => 'mastodon',
  ),
)
```
