### PR TITLE
Title Optimization: small UI/UX fixes

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-alignment-on-title-optimization
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-fix-alignment-on-title-optimization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Title Optimization: handle enter/return key to trigger a generation when they are pressed.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/title-optimization-keywords.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/title-optimization-keywords.scss
@@ -6,6 +6,11 @@
 		display: flex;
 		justify-content: center;
 
+		// The element created by the KeyboardShortcuts component
+		div {
+			width: 100%;
+		}
+
 		textarea {
 			width: 100%;
 			outline: none;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/title-optimization-keywords.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/title-optimization-keywords.tsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, KeyboardShortcuts } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import './title-optimization-keywords.scss';
 
@@ -25,17 +25,28 @@ export default function TitleOptimizationKeywords( {
 	return (
 		<div className="jetpack-ai-title-optimization__keywords">
 			<div className="jetpack-ai-title-optimization__keywords__textarea">
-				<textarea
-					value={ currentKeywords }
-					disabled={ disabled }
-					maxLength={ 100 }
-					rows={ 1 }
-					onChange={ handleKeywordChange }
-					placeholder={ __(
-						"Add optional keywords you'd like to include and generate new suggestions.",
-						'jetpack'
-					) }
-				></textarea>
+				<KeyboardShortcuts
+					bindGlobal
+					shortcuts={ {
+						enter: () => {
+							if ( ! disabled ) {
+								onGenerate();
+							}
+						},
+					} }
+				>
+					<textarea
+						value={ currentKeywords }
+						disabled={ disabled }
+						maxLength={ 100 }
+						rows={ 1 }
+						onChange={ handleKeywordChange }
+						placeholder={ __(
+							"Add optional keywords you'd like to include and generate new suggestions.",
+							'jetpack'
+						) }
+					></textarea>
+				</KeyboardShortcuts>
 			</div>
 			<div className="jetpack-ai-title-optimization__keywords__button">
 				<Button onClick={ onGenerate } variant="secondary" disabled={ disabled }>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/title-optimization-options.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/title-optimization-options.scss
@@ -4,7 +4,7 @@
 
 .jetpack-ai-title-optimization__option {
 	display: flex;
-	justify-content: center;
+	justify-content: left;
 	align-items: start;
 	gap: 16px;
 	margin-bottom: 16px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Trigger a new generation when enter/return is pressed on the keywords textarea
* Fix alignment of options when items are shorter

| Before | After |
| --- | --- |
| <img width="500" alt="Screenshot 2024-09-13 at 15 50 11" src="https://github.com/user-attachments/assets/d04864f8-e86d-4941-b589-650325900995"> | <img width="500" alt="Screenshot 2024-09-13 at 15 49 57" src="https://github.com/user-attachments/assets/7ab3e9c8-770a-40d2-bc66-aed65fff4c0b"> |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure your testing site is running the beta blocks variation
* Go to the block editor and add some content
* Look for the "Improve title for SEO" button on the Jetpack sidebar and click it
* When the generation is done, type some keyword on the keyword textarea and hit enter/return
* Confirm the new generation will start when you hit enter/return
* To test the alignement issue, apply the D161478-code diff to your sandbox and sandbox the `public-api`domain
   * the issue would only happen when the suggestions and explanations are short
   * it is a hard thing to test on normal conditions, so I created the patch to force the suggestions to be short
   * the backend patch will be discarded after this PR
* With the patch applied, go to the block editor and click the "Improve title for SEO" button again (or generate a new suggestion if the modal was already open)
* Confirm that, even with short suggestions, the UI looks good:

| Before | After |
| --- | --- |
| <img width="500" alt="Screenshot 2024-09-13 at 15 50 11" src="https://github.com/user-attachments/assets/d04864f8-e86d-4941-b589-650325900995"> | <img width="500" alt="Screenshot 2024-09-13 at 15 49 57" src="https://github.com/user-attachments/assets/7ab3e9c8-770a-40d2-bc66-aed65fff4c0b"> |