### PR TITLE
Stats: Avoid showing the admin bar widget to logged out visitors

### DIFF
--- a/projects/plugins/jetpack/changelog/update-do-not-show-stats-admin-bar-widget-to-visitors
+++ b/projects/plugins/jetpack/changelog/update-do-not-show-stats-admin-bar-widget-to-visitors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Do not check for capabilities if the user is not signed in when deciding whether to show the admin bar widget

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1032,6 +1032,11 @@ function stats_hide_smile_css() {
  * @return void
  */
 function stats_admin_bar_head() {
+	// Let's not show the stats admin bar to users who are not logged in.
+	if ( ! is_user_logged_in() ) {
+		return;
+	}
+
 	if ( ! Stats_Options::get_option( 'admin_bar' ) ) {
 		return;
 	}


### PR DESCRIPTION
We currently [check for the view_stats capability](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/modules/stats.php#L1039), which involves reading an option (`get_option('stats-options')`).

But for logged-out users, this check is unnecessary since they shouldn't see the admin bar at all. This PR optimizes the process by skipping the get_option('stats-options') call for logged-out users, avoiding an unnecessary database read.

This logic is 12 years old.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a check to see if the user is logged in, before checking capabilities of a user to decide whether to show the admin bar widget.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

pdWQjU-Ub-p2

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [Launch a site with query monitor and this branch](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=update/do-not-show-stats-admin-bar-widget-to-visitors&wp-debug-log&cache-drop-in=false&query-monitor)
* Visit the front while logged out.
* Check that there in't a request to the `stats-options` option

