### PR TITLE
creating WAF rules 99110051 & 99110052 for blocking requests containi…

### DIFF
--- a/rules/REQUEST-902.9910-JETPACK-CUSTOM-RULES.conf
+++ b/rules/REQUEST-902.9910-JETPACK-CUSTOM-RULES.conf
@@ -1,0 +1,894 @@
+# This is a merge between Atomic's Ruleset and Security Research team's rules
+# ModSecurity team reserved the range 99,100,000-99,199,999 to us https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-(v2.x)#id
+# Rules with numbers above 4200000 can be shared, the rest is internal https://coreruleset.org/docs/rules/ruleid/
+# 99100000 - 99100999 - Exception rules
+# 99101000 - 99199999 - Block rules
+
+# 99110008 Starting to see mass scans for https://wpvulndb.com/vulnerabilities/10080 - Adjusted by Fio
+SecRule REQUEST_FILENAME "/wp-admin/admin-post.php" \
+	"id:99110008,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'Poll, Survey, Form & Quiz Maker XSS Attempt Detected', \
+	logdata:'%{TX.0}',\
+	t:none,\
+	chain"
+        SecRule ARGS_GET:page "opinionstage-content-login-callback-page" "chain"
+                SecRule ARGS_GET "@rx (var\s*u\s*=|\"?>.+)" \
+			"capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110010 WooCommerce currency switcher - By Marc Montpas, adjusted by Fio https://backupandscan.wordpress.com/2021/09/16/writing-modsecurity-rules-a-work-in-progress/#:~:text=rule%20to%20block-,Woocommerce%2Dcurrency%2Dswitcher,-and%20let%E2%80%99s%20dissect
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99110010,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'WooCommerce Currency Switcher LFI Attempt Detected',\
+	logdata:'%{TX.0}',\
+	t:none,\
+	chain"
+	SecRule ARGS:action "@streq parse-media-shortcode" "chain"
+		SecRule ARGS_POST:shortcode "@rx (\[woocs\s.*(?<=\s)pagepath[^\]]+\])" \
+			"capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110011 Block WordPress Plugin 3DPrint Lite 1.9.1.4 - Arbitrary File Upload
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99110011,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'3DPrint Lite Arbitrary File Upload detected',\
+	logdata:'%{TX.0}',\
+	t:none,\
+	chain"
+        SecRule ARGS:/^\s*action$/ "@streq p3dlite_handle_upload" "chain"
+                SecRule FILES "@rx \.php" \
+			"capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110009 Block known scanning patterns triggering OWASP rule id: 942190. This is to 1) block scanners from using so many resources,
+# and 2) remove noise from the audit logs for that rule. This rule is not currently intended to block hand crafted artisenal attacks.
+#		?s=weekly meal plan -6863 union all select 1,1,1,1,1,CONCAT(0x3a6f79753a,0x4244764877697569706b,0x3a70687a3a)1,1#
+#		?s=-1 union select 0x6c6f67696e70776e7a,
+#		?s=1 UNION ALL SELECT NULL,NULL,NULL,NULL,NULL
+#		?s=bif1111111111111" UNION SELECT CHAR(45,120,49,45,81,45),CHAR(45,120,50,45,81,45)
+SecRule REQUEST_COOKIES|!REQUEST_COOKIES:/__utm/|REQUEST_COOKIES_NAMES|ARGS_NAMES|ARGS|XML:/* \
+	"@rx (?i:(union (?:all )?select (?:(?:1,)+concat\(0x|null|unhex|0x6c6f67696e70776e7a,|char\(45,120,49,45,81,45\))))" \
+	"id:99110009,\
+	phase:2,\
+	block,\
+	capture,\
+	rev:1,\
+	severity:'CRITICAL',\
+	msg:'Block MSSQL code execution and information gathering attempts',\
+	logdata:'%{TX.0}',\
+	t:none,\
+	t:urlDecode,\
+	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99101000 Block Ninja Forms RCE Vulnerability - https://sirtp2.wordpress.com/2022/06/10/ninja-forms-critical-security-vulnerability/
+# The vulnerability is exploited via Ninja Forms' "nf_ajax_submit" endpoint
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99101000,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'Potential Ninja Forms RCE',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*action$/ "nf_ajax_submit" "t:none,chain"
+		# Bail the moment we see any indications someone is trying to pass a static method call in the referer
+		SecRule REQUEST_HEADERS:Referer|ARGS:/^\s*.wp.http.referer$/ "@rx \?.*::" \
+			"t:none,\
+			t:urlDecode,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99101001 Auth Bypass in td-composer - https://wpscan.com/reports/submissions/7453
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99101001,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'Authentication bypass exploit attempt',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@rx ^td_ajax_fb_login_(user|get_credentials)$" \
+		"t:none,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99101002 Subscriber+ Privilege Escalation in "iubenda"  - https://wpscan.com/reports/submissions/7597
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99101002,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'Authentication bypass exploit attempt',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@rx ^ajax_save_options$" "t:none,chain"
+	# A quick grep of the plugin shows that the only legitimate section names all begin with "iubenda_".
+		SecRule ARGS_POST:/^\s*iubenda.section.name$/ "@rx ^(?!iubenda_)" \
+			"t:none,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99101003 Subscriber+ Arbitrary File Upload in user-registration - https://wpscan.com/reports/submissions/7595
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99101003,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'Backdoor Upload Exploit Attempt',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@rx ^user_registration_profile_pic_upload$" "t:none,chain"
+		SecRule FILES:/^\s*file$/ "@rx \.(ph(p|tml)[3-8]?|htaccess)$" \
+			"t:none,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99101004 Unauthenticated Arbitrary File Upload in JobBoardWP < 1.2.2 - https://wpscan.com/vulnerability/fec68e6e-f612-43c8-8301-80f7ae3be665
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99101004,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'Backdoor Upload Exploit Attempt',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:action "jb-upload-company-logo" "t:none,chain"
+		SecRule REQUEST_COOKIES "@rx \.(ph(p|tml)[3-8]?|htaccess)$" \
+			"t:none,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99101005 Subscriber+ Arbitrary Plugin Install in multiple plugins
+# https://wpscan.com/reports/submissions/7579
+# https://wpscan.com/reports/submissions/7578
+# https://wpscan.com/reports/submissions/7577
+# https://wpscan.com/reports/submissions/7575
+# https://wpscan.com/reports/submissions/7574
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99101005,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'Arbitrary Plugin Upload Attack Detected',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@rx ^(stopbadbots|wpmemory|wptools|antihacker|cardealer)_install_plugin$" "t:none,chain"
+		SecRule ARGS_POST:/^\s*slug$/ "!@rx ^(antihacker|stopbadbots|recaptcha-for-all|wp-memory|toolstruthsocial)$" \
+			"t:none,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99101300 Block directory traversal attacks for 3DPrint premium pligin with TinyFileManager
+# We don't case about the values of the post args (except `file`), so just check that the names are present.
+SecRule REQUEST_FILENAME "3dprint.*tinyfilemanager\.php$" \
+	"id:99101300,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'3DPrint-FileManager directory traversal attack',\
+	chain"
+	SecRule ARGS_POST_NAMES "@rx (?i)group" "chain"
+		SecRule ARGS_POST_NAMES "@rx (?i)(delete|zip|tar)" "chain"
+			SecRule ARGS_POST:file "@rx \.\.(\\|/)" \
+				"setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99101301 Block POST request with json payloads to the 3DPrint/TinyFileManager.
+# A bit crude, but since the WAF does not support parsing jason payloads yet, we go for safe
+SecRule REQUEST_FILENAME "3dprint.*tinyfilemanager\.php$" \
+	"id:99101301,\
+	phase:1,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'3DPrint-FileManager json payload blocked',\
+	chain"
+	SecRule REQUEST_METHOD "POST" "chain"
+		SecRule REQUEST_HEADERS:content-type "application/json" \
+			"setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110012 Block requests to the corestab file.
+# This rule will block any request directly made to the core-stab files, I found some different versions of index.php, that's why the .* in there
+SecRule REQUEST_FILENAME "\/wp-content\/plugins\/core-stab\/index.*\.php$" \
+	"id:99110012,\
+	phase:1,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'core-stab fake plugin direct access blocked',\
+	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110013
+# A common type of shell passes remote commands in cookies with numeric names.
+# This is a general rule to detect these typical cookie shells. It will detect any request
+# with five or more cookies with numeric names.
+SecRule &REQUEST_COOKIES_NAMES:/^\d+$/ "@ge 5" \
+	"id:99110013,\
+	phase:1,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'request for cookie based shell found and blocked',\
+	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110014
+# Block whenever we see the X-Wcpay-Platform-Checkout-User HTTP header.
+# Prevents https://sirtp2.wordpress.com/2023/03/22/remote-full-site-takeover-via-woocommerce-payments-plugin/
+SecRule REQUEST_FILENAME "/wp-json/wp/v2/users" \
+	"id:99110014,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'Block WooCommerce-Payments Priv. Escalation',\
+	t:none,\
+	t:normalizePath,\
+	t:lowercase,\
+	chain"
+	SecRule REQUEST_HEADERS:/^(?i)X-WCPAY-PLATFORM-CHECKOUT-USER$/ "^\d+$" "t:none,chain"
+		SecRule REQUEST_HEADERS:/^(?i)Content-Type$/ "application/json" "t:none,t:lowercase,chain"
+			SecRule REQUEST_BODY "@contains administrator" \
+				"t:none,\
+				t:lowercase,\
+				setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110015
+# Block usage of the `frm-admin/v1/install-addon` REST API call trying to install a plugin from WordPress.org
+# Prevents https://securityresearchp2.wordpress.com/2023/05/24/new-vulnerability-in-formidable-forms/
+SecRule ARGS:/^\s*rest.route$/|REQUEST_FILENAME "@rx (?i)(/wp-json/)?frm-admin/v1/install-addon" \
+	"id:99110015,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'Block Formidable-Forms Arbitrary Plugin Install.',\
+	t:normalizePath,\
+	logdata:'Matched Data: %{MATCHED_VAR}',\
+	chain"
+	SecRule ARGS:/^\s*file.url$/|REQUEST_COOKIES:/^\s*file.url$/ "@rx (?i)wordpress\.org" \
+		"t:none,\
+		chain"
+		SecRule ARGS:/^\s*file.url$/|REQUEST_COOKIES:/^\s*file.url$/ "!@rx ^(?i)https://downloads\.wordpress\.org/plugin/((formidable-(gravity-forms-importer|import-pirate-forms))|wp-mail-smtp)\.zip$" \
+			"t:none,\
+        	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99101302 Block rendering of unsupported shortcodes using parse-media-shortcode ajax action.
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99101302,\
+	phase:2,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'Unsupported shortcode rendering detected',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@streq parse-media-shortcode" "chain"
+		SecRule ARGS_POST:/^\s*shortcode$/ "@rx (\[(?!(audio|video|playlist)[\s\]])[^\s\]]*)" \
+			"capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110016 Block RCE against WP User Post Gallery <= 2.19
+#
+# This one is a bit coarse, and will break the plugin. However, given that it
+# takes function names and args from the query params that it will run without
+# any sanitization, we think it's worth it. The plugin is old, so we don't
+# expect many complaints.
+#
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99110016,\
+	phase:1,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'Remote Code Execution attempt against WP User Post Gallary detected',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@streq upg_datatable" "chain"
+		SecRule ARGS "field" \
+			"capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110017 Block Privilege Escalation against Ultimate Member <= 2.6.4
+# Meant to mitigate obvious attempts to exploit:
+# https://sirtp2.wordpress.com/2023/06/27/unauthenticated-privilege-escalation-ultimate/
+
+# If the ultimate-member's "honeypot" parameter is not present, this is not 
+# a request meant for the plugin to handle
+SecRule ARGS_POST_NAMES "@rx ^\s*um.request$" \
+	"id:99110017,\
+	phase:2,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'Privilege Escalation attack against Ultimate Member detected',\
+	t:none,\
+	chain"
+	# If there's no nonce, this was probably not meant for the plugin to handle either?
+	SecRule ARGS_POST_NAMES "@rx ^\s*.wpnonce$" "chain"
+		# Same for the form_id parameter
+		SecRule ARGS_POST_NAMES "@rx ^\s*form.id$" "chain"
+			# Block the obvious hack attempts. Like wp_capabilities[administrator]
+			# There's virtually no way to 100% protect 
+			# as the plugin relies on a leaky blocklist to prevent updating certain user metas,
+			# which effectively means _any_ other metas, including those of other plugins, can be created.
+			SecRule ARGS_POST_NAMES "@rx \[(?:administrator|editor|author|contributor)\]$" \
+			"capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110018 Block RCE against Media Library Assistant < 3.10
+# https://patrowl.io/blog-wordpress-media-library-rce-cve-2023-4634
+# Block requests to /wp-content/plugins/media-library-assistant/includes/mla-stream-image.php
+# with parameter mla_stream_file using any stream wrapper that isn't `file://`.
+SecRule REQUEST_FILENAME "/wp-content/plugins/media-library-assistant/includes/mla-stream-image.php" \
+	"id:99110018,\
+	phase:1,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'Local File Inclusion or Remote Code Execution attempt against Media Library Assistant',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*mla.stream.file$/ "@rx (^(https?|s?ftp|php|zlib|data|glob|phar|ssh2?|rar|ogg|expect)://)" \
+		"capture,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110019 Block XSS against tagDiv Composer in the CSS field.
+# https://wpscan.com/vulnerability/e6d8216d-ace4-48ba-afca-74da0dc5abb5
+SecRule ARGS:/^\s*rest.route$/|REQUEST_FILENAME "@rx (?i)(/wp-json/)?tdw/save_css" \
+	"id:99110019,\
+	phase:2,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'XSS attempt against tagDiv Composer',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*compiled.css$/ "@rx (<[^>]+>)" \
+		"capture,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110020 Block POST request with json payloads to tagDiv Composer's CSS field.
+# A bit crude, but since the WAF does not support parsing jason payloads yet, we go for safe
+SecRule ARGS:/^\s*rest.route$/|REQUEST_FILENAME "@rx (?i)(/wp-json/)?tdw/save_css" \
+	"id:99110020,\
+	phase:1,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'tagDiv Composer json paylod blocked',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule REQUEST_HEADERS:content-type "application/json" \
+		"setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110021 Block Arbitrary Option Deletion on 10Web Booster plugin.
+# https://wpscansubmissions.wordpress.com/submissions/11021
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99110021,\
+	phase:2,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'Malicious attempt to delete options',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@rx ^(two_init_flow_score|two_activate_score_check)$" "chain"
+		SecRule ARGS:/^\s*nonce$/ "@rx ^(?!two_).*$" \
+			"capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110022 Block RCE in buddypress-media plugin.
+# https://wpscansubmissions.wordpress.com/submissions/11426
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99110022,\
+	phase:2,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'Attempted RCE through file upload',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@streq rtmedia_api" "chain"
+		SecRule ARGS:/^\s*image.type$/ "@rx .*(?:php\d*|phtml)\.*$" \
+			"capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110023 Block Arbitrary File Upload on wp-mail-log.
+# https://wpscansubmissions.wordpress.com/submissions/11189
+SecRule ARGS:/^\s*rest.route$/|REQUEST_FILENAME "@rx (?i)(/wp-json/)?wml/v1/wml_logs/send_mail/?$" \
+	"id:99110023,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'Backdoor Upload Exploit Attempt',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule FILES "@rx (?i)\.(ph(p|tml)\d*|htaccess)$" \
+		"t:none,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110024 Block SQLi on wp-mail-log wml_logs endpoint.
+# https://wpscansubmissions.wordpress.com/submissions/11186
+SecRule ARGS:/^\s*rest.route$/|REQUEST_FILENAME "@rx (?i)(/wp-json/)?wml/v1/wml_logs/?$" \
+	"id:99110024,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'SQL injection in wp-mail-log',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule REQUEST_BODY "@rx (?i)(\"key\"\s*:\s*\"\w*[^\w\"]|\"operator\"\s*:\s*(?!\"\s*(=|!=|LIKE|NOT\s+LIKE)\s*\")|\"value\"\s*:\s*\"(?:[^'\"]|\\\")*'|\"filterRelation\"\s*:\s*(?!\"\s*(and|or)\s*\")|\"page(Size|Index)\"\s*:\s*[^\d])" \
+		"t:none,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110025 Prevent SQLi on wp-mail-log wml_logs endpoint by blocking non-JSON requests.
+SecRule ARGS:/^\s*rest.route$/|REQUEST_FILENAME "@rx (?i)(/wp-json/)?wml/v1/wml_logs/?$" \
+	"id:99110025,\
+	phase:1,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'SQL injection in wp-mail-log (non-JSON request)',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule REQUEST_HEADERS:content-type "!@rx (?i)application/json" \
+		"t:none,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110026 Block SQLi in send_mail on wp-mail-log.
+# https://wpscansubmissions.wordpress.com/submissions/11187
+SecRule ARGS:/^\s*rest.route$/|REQUEST_FILENAME "@rx (?i)(/wp-json/)?wml/v1/wml_logs/send_mail/?$" \
+	"id:99110026,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'SQL injection in wp-mail-log send_mail',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*id$/ "@rx [^\d]" \
+		"t:none,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110027 Block JSON requests to wp-mail-log send_mail endpoint.
+SecRule ARGS:/^\s*rest.route$/|REQUEST_FILENAME "@rx (?i)(/wp-json/)?wml/v1/wml_logs/send_mail/?$" \
+	"id:99110027,\
+	phase:1,\
+	block,\
+	severity:'CRITICAL',\
+	msg:'SQL injection in wp-mail-log send_mail (JSON request)',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule REQUEST_HEADERS:content-type "@rx (?i)application/json" \
+		"t:none,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110028 Block Unauthenticaed SQLi in WP Fastest Cache plugin.
+# https://wpscansubmissions.wordpress.com/submissions/11623
+SecRule REQUEST_COOKIES:/wordpress.logged.in/ "@rx ^[^|]*['\"]" \
+	"id:99110028,\
+	phase:1,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'SQL Injection in wordpress_logged_in cookie',\
+	t:none,\
+	capture,\
+	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110029 Block attempt to list temporary backups directory in Duplicator.
+# https://wpscansubmissions.wordpress.com/submissions/11657
+SecRule REQUEST_FILENAME "@rx /wp-content/backups-dup-.*/tmp/?$" \
+	"id:99110029,\
+	phase:1,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'Attempt to list Duplicator backups directory',\
+	t:none,\
+	t:normalizePath,\
+	capture,\
+	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110030 Block Stored XSS via Authentication Bypass in WP-Google-Map
+# https://wpscansubmissions.wordpress.com/submissions/11808
+SecRule REQUEST_FILENAME|ARGS:/^\s*rest.route$/ "@rx /wpgmza/v1/(markers|features|polygons|polylines|circles|rectangles|pointlabels)" \
+	"id:99110030,\
+	phase:2,\
+	block,\
+	t:none,\
+	t:urlDecode,\
+	t:lowercase,\
+	t:normalizePath,\
+	chain"
+	SecRule REQUEST_HEADERS:X-HTTP-Method-Override|ARGS:/^\s*.method$/ "@streq get" "t:lowercase, chain"
+		SecRule REQUEST_METHOD "!@streq get" "t:lowercase"
+
+# 99110031 Block LFI in Essential Blocks <= 4.3.8
+# https://wpscansubmissions.wordpress.com/submissions/11823
+SecRule REQUEST_FILENAME|ARGS:/^\s*rest.route$/ "@rx /essential-blocks/v1/queries" \
+	"id:99110031,\
+	phase:2,\
+	block,\
+	msg:'LFI in Essential Blocks',\
+	t:none,\
+	t:lowercase,\
+	chain"
+	SecRule REQUEST_BODY|ARGS:/^\s*attributes$/ "@rx \\?\x22__file\\?\x22" \
+	"t:none,\
+	t:jsDecode"
+
+# 99110032 Block (Most) Unauth. Stored XSS Attacks in Popup Builder
+# https://wpscansubmissions.wordpress.com/submissions/11310
+SecRule ARGS_POST:/^\s*sgpb-is-preview$/ "@streq 1" \
+	"id:99110032,\
+	phase:2,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'Popup Builder Stored XSS exploit attempt blocked',\
+	chain"
+	SecRule REQUEST_FILENAME "!@streq /wp-admin/post.php" \
+		"t:normalizePath,\
+		capture,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110033 Block Unauthenticated SQLi in `url` field of Burst Statistics.
+# https://wpscan.com/vulnerability/0c0ab92c-8fdd-4a58-814f-e974714a20c8/
+SecRule REQUEST_FILENAME "@contains burst-statistics-endpoint.php" \
+	"id:99110033,\
+	phase:2,\
+	block,\
+	t:none,\
+	t:urlDecode,\
+	t:lowercase,\
+	t:normalizePath,\
+	chain"
+	SecRule REQUEST_BODY "@rx (?i)(\\\"url\\\"\s*:\s*\\\"(([^'\"]|\\\\\")*')([^\"]|\\\\\")*[^\\\\]\\\")" "capture"
+
+# 99110034 Block Contributor+ RCE in Elementor.
+# https://wpscan.com/vulnerability/a6b3b14c-f06b-4506-9b88-854f155ebca9/
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99110034,\
+	phase:2,\
+	block,\
+	t:none,\
+	t:urlDecode,\
+	t:lowercase,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*action$/ "elementor_ajax" "t:none,t:urlDecode,t:lowercase,chain"
+		SecRule ARGS:/^\s*actions$/ "@rx (\"import_template\"\s*:\s*\{)" \
+			"t:none,\
+			t:urlDecode,\
+			t:lowercase,\
+			chain"
+			SecRule ARGS:/^\s*actions$/ "@rx (\"filename\"\s*:\s*\"((?!\\\\)[^\"]|\\\")*(\.ph(p\d*|tml)[ .]*\"|\.\.\/))" \
+				"t:none,\
+				t:urlDecode,\
+				t:lowercase,\
+				capture,\
+				setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110035 and 99110036 Prevent invalid authentication in POST SMTP.
+# https://wpscan.com/vulnerability/b66c4057-e3d5-4a92-a319-f3e36441270f/
+SecRule REQUEST_FILENAME|ARGS:/^\s*rest.route$/ "@rx (?i)(/wp-json/)?post-smtp/v1/connect-app" \
+	"id:99110035,\
+	phase:1,\
+	block,\
+	t:none,\
+	t:urlDecode,\
+	t:lowercase,\
+	t:normalizePath,\
+	chain"
+	SecRule REQUEST_HEADERS:/^(?i)auth.key$/ "@rx (?i)^0?$" \
+		"t:none,\
+		t:lowercase,\
+		capture,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+SecRule REQUEST_FILENAME|ARGS:/^\s*rest.route$/ "@rx (?i)(/wp-json/)?post-smtp/v1/connect-app" \
+	"id:99110036,\
+	phase:1,\
+	block,\
+	t:none,\
+	t:urlDecode,\
+	t:lowercase,\
+	t:normalizePath,\
+	chain"
+	SecRule &REQUEST_HEADERS:auth-key "@eq 0" \
+		"t:none,\
+		t:lowercase,\
+		capture,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110037 Prevent unauthenticated RCE and RFI in Backup Migration plugin.
+# https://wpscan.com/vulnerability/6a4d0af9-e1cd-4a69-a56c-3c009e207eca/
+# https://wpscan.com/vulnerability/9819c6d8-f805-426f-b20b-e6a38715a273/
+SecRule REQUEST_FILENAME "@rx (?i)/backup-heart\.php$" \
+	"id:99110037,\
+	phase:1,\
+	block,\
+	t:none,\
+	t:urlDecode,\
+	t:lowercase,\
+	t:normalizePath,\
+	chain"
+	SecRule REQUEST_HEADERS:content-dir "@rx (?i)^\w+://" \
+		"t:none,\
+		capture,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110038 Arbitrary Option Update in Cookie Information.
+# https://wpscan.com/vulnerability/0c207e0a-f52d-4a59-a7b1-94e4a19b45f6/
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99110038,\
+	phase:2,\
+	block,\
+	t:none,\
+	t:urlDecode,\
+	t:lowercase,\
+	t:normalizePath,\
+	logdata:'%{TX.0}',\
+	msg:'Cookie Information Arbitrary Option Update Exploit',\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@streq wpgdprc_update_integration" "t:none,chain" 
+		SecRule ARGS_POST:/^\s*data$/ "@rx (\"name\"\s*:\s*\"(?!wpgdprc_[^\"]+|integrations\[[^\"]+)[^\"]+\"|\"[^\"]*\\[^\"]*\":)" \
+			"t:none,\
+			capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99101303 Block attempts to upload malicious files using royal-elementor-addons
+# Not adding too much information there to not give out this 0day
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99101303,\
+	phase:2,\
+	block,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'Malicious file upload blocked',\
+	t:none,\
+	t:normalizePath,\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@streq wpr_addons_upload_file" "chain"
+		SecRule FILES "@rx \..*([^a-zA-Z0-9_.]+|\.$)" \
+			"capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# 99110039 Block XSS in events calendar plugin <= 6.3.7.
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99110039,\
+	phase:2,\
+	block,\
+	t:none,\
+	t:urlDecode,\
+ 	t:lowercase,\
+	t:normalizePath,\
+	logdata:'%{TX.0}',\
+	severity:'CRITICAL',\
+	msg:'Attempted XSS in events calendar plugin ',\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@streq tribe_events_views_v2_fallback" "t:none,chain"
+		SecRule ARGS:/^\s*view$/ "reflector" "t:none,t:urlDecode,t:lowercase,chain"
+			SecRule ARGS "@rx <" \
+			"capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
+#wp automatic < 3.92.1 - Unauthenticated SQL Injection
+#99110040 This rule will block any request directly made to the csv.php file,  attacker renamed this file in multiple sites, that's why the .*
+#https://wpscan.com/vulnerability/53a51e79-a216-4ca3-ac2d-57098fd2ebb5/
+SecRule REQUEST_FILENAME "/wp-content/plugins/wp-automatic/inc/csv.*\.php$" \
+        "id:99110040,\
+        phase:2,\
+        block,\
+	t:none,\
+	t:normalizePath,\
+        severity:'CRITICAL',\
+        msg:'Automatic < 3.92.1 - Unauthenticated SQL Injection',\
+        setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+#Yoast SEO < 22.6 - Reflected Cross Site Scripting
+#https://wpscan.com/vulnerability/6eb8e01b-0bc6-4ca9-b489-38f2a94c2909/
+SecRule REQUEST_FILENAME "!/wp-admin/"  \
+        "id:99110041,\
+        phase:2,\
+        block,\
+	t:none,\
+	t:urlDecode,\
+	t:normalizePath,\
+        severity:'CRITICAL',\
+        msg:'Yoast SEO < 22.6 - Reflected Cross Site Scripting',\
+	chain"	
+		SecRule ARGS_GET:page "@rx [\"]"
+        	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
+# SEOPress <= 7.7.2 - Auth. Bypass leading to Unauth. Object Injection and Stored XSS
+# https://wpscansubmissions.wordpress.com/submissions/16565
+# https://wpscansubmissions.wordpress.com/submissions/16553
+SecRule REQUEST_FILENAME|ARGS:/^\s*rest.route$/ "@rx (?i)(/wp-json/)?seopress/v1/posts/" \
+	"id:99110042,\
+	phase:2,\
+	block,\
+	t:none,\
+	t:urlDecode,\
+	t:lowercase,\
+	t:normalizePath,\
+	msg:'SEOPress Auth. Bypass',\
+	chain"
+	SecRule REQUEST_HEADERS_NAMES "@rx (?i)Authorization" \
+		"t:none,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+#XML Sitemap & Google News <= 5.4.8 - Local File Inclusion
+#https://wpscansubmissions.wordpress.com/submissions/16093
+#not adding sitemap in the regex because this can be changed in the pro version
+SecRule REQUEST_FILENAME "!/wp-admin/" \
+        "id:99110043,\
+        phase:2,\
+        block,\
+	t:none,\
+	t:urlDecode,\
+	t:normalizePath,\
+        severity:'CRITICAL',\
+        msg:'XML Sitemap & Google News <= 5.4.8 - Local File Inclusion',\
+	chain"
+		SecRule ARGS:feed "@rx sitemap[^/]*/" \
+		"capture,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+		
+
+# LearnPress <= 4.2.6.5  - Unauthenticated SQLi
+# https://wpscansubmissions.wordpress.com/submissions/16181
+SecRule REQUEST_FILENAME|ARGS:/^\s*rest.route$/ "@rx (?i)(/wp-json/)?lp/v1/courses/archive-course" \
+	"id:99110044,\
+	phase:2,\
+	block,\
+	t:none,\
+	t:urlDecode,\
+	t:lowercase,\
+	t:normalizePath,\
+	msg:'LearnPress <= 4.2.6.5 - Unauthenticated SQLi',\
+	chain"
+	SecRule ARGS:term_id "@rx \)" \
+		"t:none,\
+		chain"
+		SecRule REQUEST_HEADERS_NAMES "@rx (?i)X-WP-Nonce" \
+			"t:none,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# Email Subscribers by Icegram Express < 5.7.21 - Unauthenticated SQLi
+# https://wpscansubmissions.wordpress.com/submissions/16716
+# $REQUEST
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+	"id:99110045,\
+	phase:2,\
+	block,\
+	severity:'CRITICAL',\
+	t:none,\
+	t:urlDecode,\
+	t:lowercase,\
+	t:normalizePath,\
+	msg:'Email Subscribers by Icegram < 5.7.21 - Unauthenticated SQLi',\
+	chain"
+	SecRule ARGS:action "@streq es_add_subscriber" "t:none,chain"
+		SecRule ARGS:/^\s*hash$/ "@rx (?i)(\"list_ids\"\s*:\s*(\"[^\"]*(=|-|SELECT|FROM|\\u[0-9a-fA-F]{4})[^\"]*\"))" \
+			"t:base64DecodeExt, \
+			chain"
+ 			SecRule ARGS:/^\s*es$/ "@streq optin"
+			"t:none,setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+# 99110046 Block attempts to post serialized object data to GiveWP.
+# https://wpscansubmissions.wordpress.com/submissions/16124
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php" \
+    "id:99110046,\
+    phase:2,\
+    block,\
+    logdata:'%{TX.0}',\
+    severity:'CRITICAL',\
+    msg:'Malicious object injection blocked',\
+    t:none,\
+    t:normalizePath,\
+    chain"
+    SecRule ARGS:/^\s*action$/ "@streq give_donation_import" "t:none,chain" 
+        SecRule ARGS_POST:/^\s*mapto$/ "@rx [oOcC]:?\+?\d+:\".+?[\w\W]{2}\+?\d+..*}" \
+            "t:none,\
+            capture,\
+            setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+
+
+#Profile-builder <= 3.11.8 Privelege Escalation
+#https://wpscansubmissions.wordpress.com/submissions/17602
+SecRule REQUEST_FILENAME "!/wp-admin/"  \
+        "id:99110047,\
+        phase:2,\
+        block,\
+	t:none,\
+	t:urlDecode,\
+	t:normalizePath,\
+        severity:'CRITICAL',\
+        msg:'Profile Builder <= 3.11.8 - Privilege Escalation',\
+	chain"
+	SecRule ARGS_POST:/^\s*action$/ "@streq register" "t:none,chain" 
+		SecRule ARGS_POST:/^\s*email$/ "@rx [\s\n\r\t\v\x00]" \
+			"t:none,\
+			capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# GiveWP RCE via Object Injection <= 3.14.1
+# https://wpscansubmissions.wordpress.com/submissions/18310
+SecRule REQUEST_FILENAME "/wp-admin/admin-ajax.php"  \
+	"id:99110048,\
+	phase:2,\
+	block,\
+	t:none,\
+	t:urlDecode,\
+	t:normalizePath,\
+	severity:'CRITICAL',\
+	msg:'GiveWP <= 3.14.1 - Object Injection',\
+	chain"
+	SecRule ARGS:/^\s*action$/ "@streq give_process_donation" "t:none,chain" 
+		# Have to be careful since the whole thing is wp_unslash()'ed multiple times
+		SecRule ARGS_POST:/^\s*give.title$/|ARGS_POST:/^\s*give-form-title$/ "@rx [oOC]\\*:\\*\+?\\*\d+\\*:\\*\"" \
+			"t:none,\
+			capture,\
+			setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+# LiteSpeed Cache Privilege Escalation <= 6.3.0.1
+# https://wpscansubmissions.wordpress.com/submissions/18386
+SecRule &REQUEST_COOKIES_NAMES:/^\s*litespeed.role$/ "@gt 0"  \
+	"id:99110049,\
+	phase:2,\
+	block,\
+	t:none,\
+	severity:'CRITICAL',\
+	msg:'LiteSpeed Cache Privilege Escalation',\
+	capture,\
+	setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+#TI Woocommerce Wishlist <= 2.8.2 - Unauth SQLi
+#https://wpscan.com/vulnerability/e994753e-ce18-48cf-8087-897ec8db2eef/
+#Rule to block only the unauth sql - WPML has to be installed for the exloit to work
+SecRule ARGS_GET:/^\s*wc-ajax$/ "@rx (tinvwl)" \
+        "id:99110050,\
+        phase:2,\
+        block,\
+	t:none,\
+        severity:'CRITICAL',\
+        msg:'TI WooCommerce Wishlist <= 2.8.2 - Unauthenticated SQLi',\
+	chain"
+	SecRule ARGS_POST:/^\s*lang$/ "@rx (\\)" \
+		"capture,\
+		setvar:'tx.anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+
+#Blocking known malicious, unique UAs associated with malware crawling
+#https://securityresearchp2.wordpress.com/2024/08/19/identifying-malware-crawlers/
+SecRule REQUEST_HEADERS:User-Agent "@rx ^wp_is_mobile|Moblie Safari|SM-G892A Bulid|Mozlila|Team Anon Force" \
+    "id:99110051,\
+	phase:1,\
+	deny,\
+	status:403,\
+	log,\
+	msg:'Blocked request - contains malware crawler user-agent'"
+
+SecRule REQUEST_HEADERS:Referer "@rx ^(www.)?google\.com$|^(www.)?bing\.com$|^(www.)?binance\.com$|^(www.)?google\.comwww\.duckduckgo\.com$|^(www.)?yahoo\.com$" \
+    "id:99110052,\
+	phase:1,\
+	deny,\
+	status:403,\
+	log,\
+	msg:'Blocked request - contains malware crawler referer URL'"


### PR DESCRIPTION
## Proposed changes:

Adding two new mod_security rules, 99110051 and 99110052, for the purpose of blocking requests that contain unique identifier strings (user-agents and referer URLs) that differentiate them from normal traffic.

### Other information:

Should block ~2 million requests per day that are sent to our web hosting servers and contain these specific, unique user-agents or referer URLs.

## P2 post

pdMJwJ-2tX-p2

## Testing instructions:

Test in WAF testing environment

```
➜  jetpack-waf-rules git:(mrlukeleal) ✗ curl -sD - -L -e "https://www.google.com" -A "wp_is_mobile" "localhost:1234"
HTTP/1.1 403 Forbidden
Server: nginx
Date: Mon, 16 Sep 2024 13:50:40 GMT
Content-Type: text/html
Content-Length: 146
Connection: keep-alive

<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
<hr><center>nginx</center>
</body>
</html>

➜  jetpack-waf-rules git:(mrlukeleal) ✗ curl -sD - -L -e "yahoo.com" -A "Googlebot" "localhost:1234"
HTTP/1.1 403 Forbidden
Server: nginx
Date: Mon, 16 Sep 2024 13:50:53 GMT
Content-Type: text/html
Content-Length: 146
Connection: keep-alive

<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
<hr><center>nginx</center>
</body>
</html>

etc
```