### PR TITLE
Social: Add resharing tracking

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2617,6 +2617,9 @@ importers:
 
   projects/packages/publicize:
     dependencies:
+      '@automattic/jetpack-analytics':
+        specifier: workspace:*
+        version: link:../../js-packages/analytics
       '@wordpress/i18n':
         specifier: 5.7.0
         version: 5.7.0

--- a/projects/js-packages/publicize-components/changelog/add-social-resharing-tracking
+++ b/projects/js-packages/publicize-components/changelog/add-social-resharing-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added tracking for the resharing action

--- a/projects/packages/publicize/changelog/add-social-resharing-tracking
+++ b/projects/packages/publicize/changelog/add-social-resharing-tracking
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added tracking for the resharing action

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -34,6 +34,7 @@
 		"webpack-cli": "4.9.1"
 	},
 	"dependencies": {
+		"@automattic/jetpack-analytics": "workspace:*",
 		"@wordpress/i18n": "5.7.0"
 	}
 }

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Only user facing pieces of Publicize are found here.
@@ -162,6 +163,10 @@ class Publicize_UI {
 			return;
 		}
 
+		$is_atomic_site = ( new Host() )->is_woa_site();
+		$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$site_type      = $is_atomic_site ? 'atomic' : ( $is_simple_site ? 'simple' : 'jetpack' );
+
 		Assets::register_script(
 			'jetpack-social-classic-editor-options',
 			'../build/classic-editor-connections.js',
@@ -181,6 +186,7 @@ class Publicize_UI {
 					'isEnhancedPublishingEnabled' => $this->publicize->has_enhanced_publishing_feature(),
 					'resharePath'                 => '/jetpack/v4/publicize/{postId}',
 					'isReshareSupported'          => Current_Plan::supports( 'republicize' ),
+					'siteType'                    => $site_type,
 				)
 			),
 			'before'

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -164,7 +164,7 @@ class Publicize_UI {
 		}
 
 		$is_atomic_site = ( new Host() )->is_woa_site();
-		$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$is_simple_site = ( new Host() )->is_wpcom_simple();
 		$site_type      = $is_atomic_site ? 'atomic' : ( $is_simple_site ? 'simple' : 'jetpack' );
 
 		Assets::register_script(

--- a/projects/packages/publicize/src/js/classic-editor-connections.js
+++ b/projects/packages/publicize/src/js/classic-editor-connections.js
@@ -1,10 +1,20 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import apiFetch from '@wordpress/api-fetch';
 import { _n, __ } from '@wordpress/i18n';
 import jQuery from 'jquery';
 
-const { ajaxUrl, connectionsUrl, isEnhancedPublishingEnabled, resharePath, isReshareSupported } =
-	window.jetpackSocialClassicEditorOptions;
+const {
+	ajaxUrl,
+	connectionsUrl,
+	isEnhancedPublishingEnabled,
+	resharePath,
+	isReshareSupported,
+	siteType,
+} = window.jetpackSocialClassicEditorOptions;
 const CONNECTIONS_NEED_MEDIA = [ 'instagram-business' ];
+
+const { tracks } = jetpackAnalytics;
+const { recordEvent } = tracks;
 
 const validateFeaturedMedia = ( $, connectionsNeedValidation ) => {
 	const featuredImage = window.wp.media.featuredImage.get();
@@ -218,6 +228,11 @@ jQuery( function ( $ ) {
 		const message = $( 'textarea[name="wpas_title"]' ).val();
 
 		shareNowButton.prop( 'disabled', true ).text( __( 'Sharing…', 'jetpack-publicize-pkg' ) );
+
+		recordEvent( 'jetpack_social_reshare_clicked', {
+			location: 'classic-editor',
+			environment: siteType,
+		} );
 
 		apiFetch( {
 			path,

--- a/projects/packages/publicize/src/js/classic-editor-connections.js
+++ b/projects/packages/publicize/src/js/classic-editor-connections.js
@@ -13,8 +13,7 @@ const {
 } = window.jetpackSocialClassicEditorOptions;
 const CONNECTIONS_NEED_MEDIA = [ 'instagram-business' ];
 
-const { tracks } = jetpackAnalytics;
-const { recordEvent } = tracks;
+const { recordEvent } = jetpackAnalytics.tracks;
 
 const validateFeaturedMedia = ( $, connectionsNeedValidation ) => {
 	const featuredImage = window.wp.media.featuredImage.get();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/580

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds tracking to Gutenberg and the Classic editor for resharing

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `jetpack install packages/publicize` and then `jetpack build packages/publicize`. There is no watcher for this package.
* Open browser console and run `localStorage.setItem('debug', 'dops:analytics');`
* Test these scenarios, and check the corresponding props. It should be logged into the browser console, but after 10 minutes you can also check it in the Tracks live view

| | | | |
|--------|--------|--------|--------|
|  | **Atomic site** | **Simple site** | **Jetpack site** |
| **Gutenberg** | ```location: 'editor', environment: atomic``` | ```location: 'editor', environment: simple``` | ```location: 'editor', environment: jetpack``` |
| **Classic editor** | ```location: 'classic-editor', environment: atomic``` | ```location: 'classic-editor', environment: simple``` | ```location: 'classic-editor', environment: jetpack``` | 