### PR TITLE
Redirect from WP Admin settings to Calypso by filtering wp_redirect

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-cors-error-after-setting-admin-style
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-cors-error-after-setting-admin-style
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Admin interface API no longer redirects after updating setting
+Changinging wpcom_admin_interface via API no longer redirects

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-cors-error-after-setting-admin-style
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-cors-error-after-setting-admin-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin interface API no longer redirects after updating setting


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:

- https://github.com/Automattic/wp-calypso/issues/94558
- https://github.com/Automattic/dotcom-forge/issues/8866

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
After setting the admin interface option to calypso in WP Admin, it redirects to the Calypso options page. This was done in https://github.com/Automattic/jetpack/pull/38107 by adding a redirect in the `update_option_wpcom_admin_interface` filter. This means the redirect was running pretty widely. This was causing a CORS error when changing the interface option in Calypso (https://github.com/Automattic/wp-calypso/issues/94558) because the API call to change the interface would return `302` and cause a cascade of problems.

This PR changes the way the redirect is handled so that updating the `wpcom_admin_interface` option won't always cause a redirect, but if
- The user just switched the interface option to calypso
- They did so using the WP Admin interface page
- A redirect is about to happen anyway
- The redirect was going to land back on the WP Admin settings page
Then we redirect to Calypso's general settings page.

I've also changed the logic to ensure the redirect happens even on a WoA site. I don't see why we wouldn't redirect a WoA user who has just asked to use calypso by default.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Sandbox `public-api` and a _Simple_ test site
Apply change to sandbox with `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/cors-error-after-setting-admin-style`

**Test changing calypso -> wp-admin** (this wasn't broken before, testing for regression)
- Set admin interface to Calypso (use any interface to do so)
- Using the `wordpress.com/settings/general/your-site` screen, change the interface from Default to Classic
- Expect setting to persist
- Expect interface to automatically switch to wp-admin

**Test changing wp-admin -> calypso** (this wasn't broken before, testing for regression)
- Set admin interface to WP Admin (use any interface to do so)
- Using the `/wp-admin/options-general.php` screen, change the interface from Classic to Default
- Expect setting to persist
- Expect interface to automatically switch to wp-admin

**Test changing calypso -> wp-admin from wp-admin**
- Set admin interface to Calypso (use any interface to do so)
- Using the `/wp-admin/options-general.php` screen, change the interface from Default to Classic
- Expect setting to persist
- Expect to stay on wp-admin interface

**Test changing wp-admin -> calypso from Calypso**
- Set admin interface to WP Admin (use any interface to do so)
- Using the `wordpress.com/settings/general/your-site` screen, change the interface from Classic to Default
- Expect setting to persist
- Expect to stay on Calypso interface
- Expect no CORS errors

Now test it all again for an atomic site:
Use a WoA dev blog
Apply the `fix/cors-error-after-setting-admin-style` branch using the Jetpack Beta Tester plugin
See PCYsg-Osp-p2#woa-testing-for-a-pr