### PR TITLE
Social: Disable resharing on Simple sites in classic editor

### DIFF
--- a/projects/packages/publicize/changelog/update-social-disable-resharing-on-simple-sites-in-classic-editor
+++ b/projects/packages/publicize/changelog/update-social-disable-resharing-on-simple-sites-in-classic-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social: Disabled resharing on Simple sites in classic editor

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Only user facing pieces of Publicize are found here.
@@ -172,6 +173,8 @@ class Publicize_UI {
 				'textdomain' => 'jetpack-publicize-pkg',
 			)
 		);
+		$is_simple_site = ( new Host() )->is_wpcom_simple();
+
 		wp_add_inline_script(
 			'jetpack-social-classic-editor-options',
 			'var jetpackSocialClassicEditorOptions = ' . wp_json_encode(
@@ -180,7 +183,7 @@ class Publicize_UI {
 					'connectionsUrl'              => esc_url( $this->publicize_settings_url ),
 					'isEnhancedPublishingEnabled' => $this->publicize->has_enhanced_publishing_feature(),
 					'resharePath'                 => '/jetpack/v4/publicize/{postId}',
-					'isReshareSupported'          => Current_Plan::supports( 'republicize' ),
+					'isReshareSupported'          => ! $is_simple_site && Current_Plan::supports( 'republicize' ),
 				)
 			),
 			'before'
@@ -634,6 +637,8 @@ jQuery( function($) {
 
 		$all_done = $all_done || $all_connections_done;
 
+		$is_simple_site = ( new Host() )->is_wpcom_simple();
+
 		?>
 
 			</ul>
@@ -645,7 +650,7 @@ jQuery( function($) {
 				<a href="#" class="hide-if-no-js button" id="publicize-form-hide"><?php esc_html_e( 'OK', 'jetpack-publicize-pkg' ); ?></a>
 				<input type="hidden" name="wpas[0]" value="1" />
 			<?php endif; ?>
-			<?php if ( $is_post_published && Current_Plan::supports( 'republicize' ) ) : ?>
+			<?php if ( $is_post_published && ! $is_simple_site && Current_Plan::supports( 'republicize' ) ) : ?>
 				<button type="button" class="hide-if-no-js button" id="publicize-share-now">
 					<?php esc_html_e( 'Share now', 'jetpack-publicize-pkg' ); ?>
 				</button>


### PR DESCRIPTION
After some failed attempts like #39388 and more, we decided to disable resharing on Simple sites in classic editor.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Disable resharing on Simple sites in classic editor

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a Simple site, goto post editor using classic editor
* Click on "Edit" beside "Jetpack Social"
* Confirm that you don't see the "Share now" button.
* Now do the same for Jetpack and Atomic sites
* Confirm that you see the "Share now" button

| BEFORE | AFTER |
|--------|--------|
| <img width="295" alt="Screenshot 2024-09-17 at 4 43 33 PM" src="https://github.com/user-attachments/assets/44ad6e3c-567d-4aed-8ebd-c7c7085fc468"> | <img width="289" alt="Screenshot 2024-09-17 at 4 48 24 PM" src="https://github.com/user-attachments/assets/a3d99335-6fe3-465e-ac12-1ec12057b429"> |

