### PR TITLE
Increases the timeout for the Blaze payment checkout endpoint

### DIFF
--- a/projects/packages/blaze/changelog/fix-blaze-payment-checkout-timeout-error
+++ b/projects/packages/blaze/changelog/fix-blaze-payment-checkout-timeout-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Increases the timeout for the Blaze payment checkout endpoint

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -665,7 +665,7 @@ class Dashboard_REST_Controller {
 	 * @return array|WP_Error
 	 */
 	public function edit_wpcom_checkout( $req ) {
-		return $this->edit_dsp_generic( 'v1/wpcom/checkout', $req, array( 'timeout' => 40 ) );
+		return $this->edit_dsp_generic( 'v1/wpcom/checkout', $req, array( 'timeout' => 60 ) );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -665,7 +665,7 @@ class Dashboard_REST_Controller {
 	 * @return array|WP_Error
 	 */
 	public function edit_wpcom_checkout( $req ) {
-		return $this->edit_dsp_generic( 'v1/wpcom/checkout', $req, array( 'timeout' => 20 ) );
+		return $this->edit_dsp_generic( 'v1/wpcom/checkout', $req, array( 'timeout' => 40 ) );
 	}
 
 	/**
@@ -676,7 +676,7 @@ class Dashboard_REST_Controller {
 	 */
 	public function edit_dsp_campaigns( $req ) {
 		$version = $req->get_param( 'api_version' ) ?? 'v1';
-		return $this->edit_dsp_generic( "{$version}/campaigns", $req, array( 'timeout' => 20 ) );
+		return $this->edit_dsp_generic( "{$version}/campaigns", $req, array( 'timeout' => 30 ) );
 	}
 
 	/**

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -676,7 +676,7 @@ class Dashboard_REST_Controller {
 	 */
 	public function edit_dsp_campaigns( $req ) {
 		$version = $req->get_param( 'api_version' ) ?? 'v1';
-		return $this->edit_dsp_generic( "{$version}/campaigns", $req, array( 'timeout' => 30 ) );
+		return $this->edit_dsp_generic( "{$version}/campaigns", $req, array( 'timeout' => 60 ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a timeout error we are getting from some users when they try to create a Blsaze campaign using a new credit card.

## Proposed changes:
* Increase the timeout of the endpoints `v1/wpcom/checkout` and `v1/campaigns`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1726571012779389-slack-C0351BKR0M6

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Tools->Advertising
* In the Jetpack Blaze Dashboard, click the promote button for any of your posts
* In the Create campaign widget, click the Make changes button (if you landed on the express flow)
* Complete all the necessary information, and on the Payment section, click the "Add new card" link
![Screenshot 2024-09-17 at 3 28 49 PM](https://github.com/user-attachments/assets/aa3bab0b-e0f8-4f9b-8a88-372230bf66f9)
* Complete the payment information with any valid credit card (you can choose to not store that card)
* Submit the campaign and verify that it ended correctly
* You can cancel the campaign if you don't want it to run