### PR TITLE
Build: do not ship TypeScript files in production build

### DIFF
--- a/projects/plugins/jetpack/.gitattributes
+++ b/projects/plugins/jetpack/.gitattributes
@@ -41,6 +41,8 @@
 /css/*.css.min.map                                       production-exclude
 /extensions/**/*.jpg                                     production-exclude
 /extensions/**/*.js                                      production-exclude
+/extensions/**/*.ts                                      production-exclude
+/extensions/**/*.tsx                                     production-exclude
 /extensions/**/*.json                                    production-exclude
 /extensions/**/*.jsx                                     production-exclude
 /extensions/**/*.md                                      production-exclude

--- a/projects/plugins/jetpack/changelog/fix-ship-ts-files-prod
+++ b/projects/plugins/jetpack/changelog/fix-ship-ts-files-prod
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Build: do not ship TypeScript files in the production version of Jetpack.


### PR DESCRIPTION
## Proposed changes:

We do not need to ship `.ts` and `.tsx` files in the Production version of the plugin.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* https://wordpress.org/support/topic/public-visibility-issue-with-jetpack-directory-in-google-search-console/


## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

You can check the production build generated on this PR, and ensure there are no such TypeScript files included in the `extensions` directory.

