### PR TITLE
Social: Update social previews button styles to fit the translated string

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-social-preview-trigger-button
+++ b/projects/js-packages/publicize-components/changelog/fix-social-social-preview-trigger-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Update social previews button styles to fit the translated string

--- a/projects/js-packages/publicize-components/changelog/fix-social-social-preview-trigger-button
+++ b/projects/js-packages/publicize-components/changelog/fix-social-social-preview-trigger-button
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Social: Update social previews button styles to fit the translated string
+Social: Updated social previews button styles to fit the translated string

--- a/projects/js-packages/publicize-components/src/components/social-post-modal/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/social-post-modal/styles.module.scss
@@ -2,6 +2,10 @@
 
 .panel {
     margin: 1rem 0 1.5rem;
+
+    :global(button.is-secondary) {
+        white-space: break-spaces;
+    }
 }
 
 .modal {

--- a/projects/plugins/jetpack/changelog/fix-social-social-preview-trigger-button
+++ b/projects/plugins/jetpack/changelog/fix-social-social-preview-trigger-button
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Social: Update social previews button styles to fit the translated string
+Social: Updated social previews button styles to fit the translated string

--- a/projects/plugins/jetpack/changelog/fix-social-social-preview-trigger-button
+++ b/projects/plugins/jetpack/changelog/fix-social-social-preview-trigger-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Update social previews button styles to fit the translated string

--- a/projects/plugins/social/changelog/fix-social-social-preview-trigger-button
+++ b/projects/plugins/social/changelog/fix-social-social-preview-trigger-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Update social previews button styles to fit the translated string

--- a/projects/plugins/social/changelog/fix-social-social-preview-trigger-button
+++ b/projects/plugins/social/changelog/fix-social-social-preview-trigger-button
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Social: Update social previews button styles to fit the translated string
+Social: Updated social previews button styles to fit the translated string


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39389

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update social previews button styles to fit the translated string

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the steps in #39389 
* Confirm that the issue is fixed.

| BEFORE | AFTER |
|--------|--------|
| <img width="280" alt="Screenshot 2024-09-18 at 2 02 54 PM" src="https://github.com/user-attachments/assets/744a75c0-0958-4861-844f-753fc2b116e5"> | <img width="273" alt="Screenshot 2024-09-18 at 2 02 43 PM" src="https://github.com/user-attachments/assets/16aba6d4-3cfa-414a-abd3-9c4335b703a9"> | 

