### PR TITLE
Portfolio CPTs: Ensure WPcom sites immediately hook into the function register the CPT, preventing display issues

### DIFF
--- a/projects/packages/classic-theme-helper/changelog/fix-portfolio-custom-post-type-toggle-issue
+++ b/projects/packages/classic-theme-helper/changelog/fix-portfolio-custom-post-type-toggle-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Portfolios: Ensure these are enabled and working properly on themes that support portfolios

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Classic_Theme_Helper;
 
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Status\Host;
 use Jetpack_Options;
 use WP_Customize_Image_Control;
 use WP_Customize_Manager;
@@ -60,8 +61,8 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Portfolio' ) ) {
 			// If called via REST API, we need to register later in lifecycle.
 			add_action( 'restapi_theme_init', array( $this, 'maybe_register_cpt' ) );
 
-			// If portfolio cpt is enabled, hook into init to register the CPT, otherwise run maybe_register_cpt immediately to deregister.
-			if ( get_option( self::OPTION_NAME, '0' ) ) {
+			// If portfolio cpt is enabled (on all but Simple sites), hook into init to register the CPT, otherwise run maybe_register_cpt immediately to deregister.
+			if ( get_option( self::OPTION_NAME, '0' ) || ( new Host() )->is_wpcom_simple() ) {
 				$this->maybe_register_cpt();
 			} else {
 				add_action( 'init', array( $this, 'maybe_register_cpt' ) );

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
@@ -62,7 +62,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Portfolio' ) ) {
 			add_action( 'restapi_theme_init', array( $this, 'maybe_register_cpt' ) );
 
 			// If portfolio cpt is enabled (on all but Simple sites), hook into init to register the CPT, otherwise run maybe_register_cpt immediately to deregister.
-			if ( get_option( self::OPTION_NAME, '0' ) || ( new Host() )->is_wpcom_simple() ) {
+			if ( get_option( self::OPTION_NAME, '0' ) || ( new Host() )->is_wpcom_platform() ) {
 				$this->maybe_register_cpt();
 			} else {
 				add_action( 'init', array( $this, 'maybe_register_cpt' ) );

--- a/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
+++ b/projects/packages/classic-theme-helper/src/custom-post-types/class-jetpack-portfolio.php
@@ -61,7 +61,7 @@ if ( ! class_exists( __NAMESPACE__ . '\Jetpack_Portfolio' ) ) {
 			// If called via REST API, we need to register later in lifecycle.
 			add_action( 'restapi_theme_init', array( $this, 'maybe_register_cpt' ) );
 
-			// If portfolio cpt is enabled (on all but Simple sites), hook into init to register the CPT, otherwise run maybe_register_cpt immediately to deregister.
+			// If portfolio cpt is enabled (on self hosted sites), hook into init to register the CPT, otherwise run maybe_register_cpt immediately to deregister.
 			if ( get_option( self::OPTION_NAME, '0' ) || ( new Host() )->is_wpcom_platform() ) {
 				$this->maybe_register_cpt();
 			} else {

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-portfolio-custom-post-type-toggle-issue
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-portfolio-custom-post-type-toggle-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Portfolios: Ensure these are enabled and working properly on themes that support portfolios

--- a/projects/plugins/jetpack/changelog/fix-portfolio-custom-post-type-toggle-issue
+++ b/projects/plugins/jetpack/changelog/fix-portfolio-custom-post-type-toggle-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Portfolios: Ensure these are enabled and working properly on themes that support portfolios

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-portfolio-custom-post-type-toggle-issue
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-portfolio-custom-post-type-toggle-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Portfolios: Ensure these are enabled and working properly on themes that support portfolios

--- a/projects/plugins/wpcomsh/changelog/fix-portfolio-custom-post-type-toggle-issue
+++ b/projects/plugins/wpcomsh/changelog/fix-portfolio-custom-post-type-toggle-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Portfolios: Ensure these are enabled and working properly on themes that support portfolios


### PR DESCRIPTION
## Proposed changes:

* This PR adds an additional check to see if a host is WordPres.com before registering the CPT for portfolios. This aims to prevent an issue where portfolios appeared enabled on sites that support Jetpack Portfolios, but portfolios could not be properly edited unless the featured was toggled off and on.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1726526824458159-slack-C02FMH4G8

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Follow the testing instructions here: https://github.com/Automattic/jetpack/pull/39268

On WoA what I'm seeing now when testing with a PR applied that was updated earlier than the above PR (on both plugins) is that portfolios does not auto activate when activating a theme that supports portfolios. Afterwards, the current expectation now is that with a theme that supports Jetpack Portfolio this should always be active.

Additionally, on Simple:

* Ensure that when activating a theme that supports Jetpack Portfolio (Sketch, Blask) that the feature works regardless of the initial toggle display on `https://wordpress.com/settings/writing/yoursite.com` and `/wp-admin/options-writing.php`.