### PR TITLE
Follow Blog Widget: Strip Slashes on Subscribe Text

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-slashes
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-slashes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: fix added slashes to the Follow Blog widget.

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -499,7 +499,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 				<?php
 				if ( $subscribe_text && ( ! isset( $_GET['subscribe'] ) || 'success' !== $_GET['subscribe'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Non-sensitive informational output.
 					?>
-					<div id="subscribe-text"><?php echo wp_kses( wpautop( str_replace( '[total-subscribers]', number_format_i18n( $subscribers_total ), $subscribe_text ) ), 'post' ); ?></div>
+					<div id="subscribe-text"><?php echo wp_kses( wp_unslash( wpautop( str_replace( '[total-subscribers]', number_format_i18n( $subscribers_total ), $subscribe_text ) ) ), 'post' ); ?></div>
 					<?php
 				}
 

--- a/projects/plugins/jetpack/modules/subscriptions/views.php
+++ b/projects/plugins/jetpack/modules/subscriptions/views.php
@@ -358,7 +358,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		$show_subscribers_total       = (bool) $instance['show_subscribers_total'];
 		$subscribers_total            = self::fetch_subscriber_count();
 		$subscribe_text               = empty( $instance['show_only_email_and_button'] ) ?
-			wp_kses_post( $instance['subscribe_text'] ) :
+			wp_kses_post( stripslashes( $instance['subscribe_text'] ) ) :
 			false;
 		$referer                      = esc_url_raw( ( is_ssl() ? 'https' : 'http' ) . '://' . ( isset( $_SERVER['HTTP_HOST'] ) ? wp_unslash( $_SERVER['HTTP_HOST'] ) : '' ) . ( isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '' ) );
 		$source                       = 'widget';
@@ -499,7 +499,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 				<?php
 				if ( $subscribe_text && ( ! isset( $_GET['subscribe'] ) || 'success' !== $_GET['subscribe'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Non-sensitive informational output.
 					?>
-					<div id="subscribe-text"><?php echo wp_kses( wp_unslash( wpautop( str_replace( '[total-subscribers]', number_format_i18n( $subscribers_total ), $subscribe_text ) ) ), 'post' ); ?></div>
+					<div id="subscribe-text"><?php echo wp_kses( wpautop( str_replace( '[total-subscribers]', number_format_i18n( $subscribers_total ), $subscribe_text ) ), 'post' ); ?></div>
 					<?php
 				}
 


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes slashes from the Subscribe text output on the Follow Blog widget. It looks like the Subscribe block already does this, which is why the issue doesn't happen there. It's just been annoying me a bit lately that the Follow Blog widget doesn't do the same too. 

## Jetpack product discussion
N/A.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Activate the Classics Widgets plugin
* Insert the Follow Blog (Subscriptions) widget under Appearance > Widgets
* For the subscribe text, enter something that gets escaped - eg. `We're`
* Confirm that this still appears as `We're` now instead of `We\'re`

<img width="307" alt="Screenshot 2024-09-18 at 10 48 53" src="https://github.com/user-attachments/assets/c186a043-30fa-41cb-a7ad-d76c25fa9378">
