### PR TITLE
API: create REST endpoint for 'features/available'

### DIFF
--- a/projects/packages/connection/changelog/add-restful-features-available
+++ b/projects/packages/connection/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -826,24 +826,6 @@ class Jetpack_XMLRPC_Server {
 	/**
 	 * Deprecated: This method is no longer part of the Connection package and now lives on the Jetpack plugin.
 	 *
-	 * Returns what features are available. Uses the slug of the module files.
-	 *
-	 * @deprecated since 1.25.0
-	 * @see Jetpack_XMLRPC_Methods::features_available() in the Jetpack plugin
-	 *
-	 * @return array
-	 */
-	public function features_available() {
-		_deprecated_function( __METHOD__, '1.25.0', 'Jetpack_XMLRPC_Methods::features_available()' );
-		if ( class_exists( 'Jetpack_XMLRPC_Methods' ) ) {
-			return Jetpack_XMLRPC_Methods::features_available();
-		}
-		return array();
-	}
-
-	/**
-	 * Deprecated: This method is no longer part of the Connection package and now lives on the Jetpack plugin.
-	 *
 	 * Returns what features are enabled. Uses the slug of the modules files.
 	 *
 	 * @deprecated since 1.25.0

--- a/projects/plugins/automattic-for-agencies-client/changelog/add-restful-features-available
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/automattic-for-agencies-client/changelog/add-restful-features-available
+++ b/projects/plugins/automattic-for-agencies-client/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available

--- a/projects/plugins/backup/changelog/add-restful-features-available
+++ b/projects/plugins/backup/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/backup/changelog/add-restful-features-available
+++ b/projects/plugins/backup/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available

--- a/projects/plugins/boost/changelog/add-restful-features-available
+++ b/projects/plugins/boost/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/boost/changelog/add-restful-features-available
+++ b/projects/plugins/boost/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available

--- a/projects/plugins/inspect/changelog/add-restful-features-available
+++ b/projects/plugins/inspect/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/inspect/changelog/add-restful-features-available
+++ b/projects/plugins/inspect/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -4511,7 +4511,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'You do not have the correct user permissions to perform this action. Please contact your site admin if you think this is a mistake.',
 				'jetpack'
 			);
-			return new WP_Error( 'invalid_permission_update_user_token', $message, array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'invalid_permission_fetch_features', $message, array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -787,6 +787,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 				),
 			)
 		);
+
+		/**
+		 * Get the list of available Jetpack features.
+		 *
+		 * @since $$next-version$$
+		 */
+		register_rest_route(
+			'jetpack/v4',
+			'/features/available',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( static::class, 'get_features_available' ),
+				'permission_callback' => array( static::class, 'get_features_permission_check' ),
+			)
+		);
 	}
 
 	/**
@@ -4466,5 +4481,39 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'data' => $data,
 			)
 		);
+	}
+
+	/**
+	 * Return the list of available features.
+	 *
+	 * @return array
+	 */
+	public static function get_features_available() {
+		$raw_modules = Jetpack::get_available_modules();
+		$modules     = array();
+		foreach ( $raw_modules as $module ) {
+			$modules[] = Jetpack::get_module_slug( $module );
+		}
+
+		return $modules;
+	}
+
+	/**
+	 * Verify that the API client is allowed to replace user token.
+	 *
+	 * @since 1.29.0
+	 *
+	 * @return bool|WP_Error
+	 */
+	public static function get_features_permission_check() {
+		if ( ! Rest_Authentication::is_signed_with_blog_token() ) {
+			$message = esc_html__(
+				'You do not have the correct user permissions to perform this action. Please contact your site admin if you think this is a mistake.',
+				'jetpack'
+			);
+			return new WP_Error( 'invalid_permission_update_user_token', $message, array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
 	}
 } // class end

--- a/projects/plugins/jetpack/changelog/add-restful-features-available
+++ b/projects/plugins/jetpack/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Create the 'features/available' REST endpoint.

--- a/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
+++ b/projects/plugins/jetpack/class-jetpack-xmlrpc-methods.php
@@ -44,6 +44,8 @@ class Jetpack_XMLRPC_Methods {
 	/**
 	 * Returns what features are available. Uses the slug of the module files.
 	 *
+	 * @deprecated $$next-version$$
+	 * @see Jetpack_Core_Json_Api_Endpoints::get_features_available()
 	 * @return array
 	 */
 	public static function features_available() {

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-authentication.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-authentication.php
@@ -465,6 +465,50 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 		$this->assertEquals( self::$admin_id, get_current_user_id() );
 	}
 
+	/**
+	 * @author darssen
+	 *
+	 * Test the 'features/available' endpoint authentication.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_features_available_authentication_success() {
+		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
+		$token     = 'pretend_this_is_valid_blog_token:1:0';
+		$timestamp = (string) time();
+		$nonce     = 'testing123';
+		$body_hash = '';
+
+		$_GET['token']     = $token;
+		$_GET['timestamp'] = $timestamp;
+		$_GET['nonce']     = $nonce;
+		$_GET['body-hash'] = $body_hash;
+		$_GET['signature'] = base64_encode(
+			hash_hmac(
+				'sha1',
+				implode(
+					"\n",
+					array(
+						$token,
+						$timestamp,
+						$nonce,
+						$body_hash,
+						'GET',
+						'example.org',
+						'80',
+						'/jetpack/v4/features/available',
+						'qstest=yep',
+					)
+				) . "\n",
+				'secret_blog',
+				true
+			)
+		);
+		$this->request     = new WP_REST_Request( 'GET', '/jetpack/v4/features/available' );
+		$response          = $this->server->dispatch( $this->request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
 	public function mock_jetpack_private_options( $value, $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$user_tokens                    = array();
 		$user_tokens[ self::$admin_id ] = 'pretend_this_is_valid.secret.' . self::$admin_id;

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -1237,17 +1237,4 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertResponseStatus( 401, $response );
 		$this->assertResponseData( array( 'code' => 'invalid_permission_update_user_token' ), $response );
 	}
-
-	/**
-	 * Test the 'features/available' endpoint, properly authorized.
-	 *
-	 * @since $$next-version$$
-	 */
-	public function test_features_available_authorized() {
-		// Create REST request in JSON format and dispatch
-		$response = $this->create_and_get_request( 'features/available' );
-
-		$this->assertResponseStatus( 401, $response );
-		$this->assertResponseData( array( 'code' => 'invalid_permission_update_user_token' ), $response );
-	}
 } // class end

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -1235,6 +1235,6 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$response = $this->create_and_get_request( 'features/available' );
 
 		$this->assertResponseStatus( 401, $response );
-		$this->assertResponseData( array( 'code' => 'invalid_permission_update_user_token' ), $response );
+		$this->assertResponseData( array( 'code' => 'invalid_permission_fetch_features' ), $response );
 	}
 } // class end

--- a/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -1224,4 +1224,30 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertResponseStatus( 200, $response );
 		$this->assertResponseData( array( 'success' => true ), $response );
 	}
+
+	/**
+	 * Test the 'features/available' endpoint, unauthorized.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_features_available_unauthorized() {
+		// Create REST request in JSON format and dispatch
+		$response = $this->create_and_get_request( 'features/available' );
+
+		$this->assertResponseStatus( 401, $response );
+		$this->assertResponseData( array( 'code' => 'invalid_permission_update_user_token' ), $response );
+	}
+
+	/**
+	 * Test the 'features/available' endpoint, properly authorized.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function test_features_available_authorized() {
+		// Create REST request in JSON format and dispatch
+		$response = $this->create_and_get_request( 'features/available' );
+
+		$this->assertResponseStatus( 401, $response );
+		$this->assertResponseData( array( 'code' => 'invalid_permission_update_user_token' ), $response );
+	}
 } // class end

--- a/projects/plugins/migration/changelog/add-restful-features-available
+++ b/projects/plugins/migration/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/migration/changelog/add-restful-features-available
+++ b/projects/plugins/migration/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-restful-features-available
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-restful-features-available
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available

--- a/projects/plugins/protect/changelog/add-restful-features-available
+++ b/projects/plugins/protect/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/protect/changelog/add-restful-features-available
+++ b/projects/plugins/protect/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available

--- a/projects/plugins/search/changelog/add-restful-features-available
+++ b/projects/plugins/search/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/search/changelog/add-restful-features-available
+++ b/projects/plugins/search/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available

--- a/projects/plugins/social/changelog/add-restful-features-available
+++ b/projects/plugins/social/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/social/changelog/add-restful-features-available
+++ b/projects/plugins/social/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available

--- a/projects/plugins/starter-plugin/changelog/add-restful-features-available
+++ b/projects/plugins/starter-plugin/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/starter-plugin/changelog/add-restful-features-available
+++ b/projects/plugins/starter-plugin/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available

--- a/projects/plugins/videopress/changelog/add-restful-features-available
+++ b/projects/plugins/videopress/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/videopress/changelog/add-restful-features-available
+++ b/projects/plugins/videopress/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available

--- a/projects/plugins/wpcomsh/changelog/add-restful-features-available
+++ b/projects/plugins/wpcomsh/changelog/add-restful-features-available
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Connection: Removed deprecated method features_available

--- a/projects/plugins/wpcomsh/changelog/add-restful-features-available
+++ b/projects/plugins/wpcomsh/changelog/add-restful-features-available
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: removed
 
 Connection: Removed deprecated method features_available


### PR DESCRIPTION
## Proposed changes:
* Create REST endpoint for 'features/available'.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pf5801-18d-p2#comment-552

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

- Check tests in the CI
- Run tests with `jetpack docker phpunit -- --filter=WP_Test_Jetpack_REST_API_endpoints` and make sure all of them pass.
- Run tests with `jetpack docker phpunit -- --filter=WP_Test_Jetpack_REST_API_Authentication` and make sure all of them pass.
- Use 35b21-pb to test these endpoints with both a blog and user token. Only `blog_token` should work
