### PR TITLE
Update/purchase flow when user is not connected

### DIFF
--- a/projects/packages/my-jetpack/_inc/utils/get-purchase-plan-url.ts
+++ b/projects/packages/my-jetpack/_inc/utils/get-purchase-plan-url.ts
@@ -16,19 +16,28 @@ const getPurchasePlanUrl = () => {
 		blogID,
 		myJetpackCheckoutUri,
 		lifecycleStats,
+		siteSuffix,
+		adminUrl,
 	} = getMyJetpackWindowInitialState();
 
 	const { isSiteConnected, isUserConnected } = lifecycleStats;
 
+	const isConnected = isSiteConnected && isUserConnected;
+
 	// If site or user is not connected, we will send the user to the purchase page without a site in context.
-	const redirectID =
-		isSiteConnected && isUserConnected
-			? MY_JETPACK_MY_PLANS_PURCHASE_SOURCE
-			: MY_JETPACK_MY_PLANS_PURCHASE_NO_SITE_SOURCE;
+	const redirectID = isConnected
+		? MY_JETPACK_MY_PLANS_PURCHASE_SOURCE
+		: MY_JETPACK_MY_PLANS_PURCHASE_NO_SITE_SOURCE;
 
 	const getUrlArgs = () => {
-		const query = myJetpackCheckoutUri ? `redirect_to=${ myJetpackCheckoutUri }` : null;
-		if ( ! isSiteConnected || ! isUserConnected ) {
+		const redirectUri = `redirect_to=${ myJetpackCheckoutUri }`;
+		// If the user is not connected, this query will trigger a connection after checkout flow.
+		const connectQuery = ! isConnected
+			? `&connect_after_checkout=true&from_site_slug=${ siteSuffix }&admin_url${ adminUrl }`
+			: '';
+		const query = `${ redirectUri }${ connectQuery }`;
+
+		if ( ! isConnected ) {
 			return {
 				query,
 			};

--- a/projects/packages/my-jetpack/_inc/utils/get-purchase-plan-url.ts
+++ b/projects/packages/my-jetpack/_inc/utils/get-purchase-plan-url.ts
@@ -33,7 +33,7 @@ const getPurchasePlanUrl = () => {
 		const redirectUri = `redirect_to=${ myJetpackCheckoutUri }`;
 		// If the user is not connected, this query will trigger a connection after checkout flow.
 		const connectQuery = ! isConnected
-			? `&connect_after_checkout=true&from_site_slug=${ siteSuffix }&admin_url${ adminUrl }`
+			? `&connect_after_checkout=true&from_site_slug=${ siteSuffix }&admin_url=${ adminUrl }`
 			: '';
 		const query = `${ redirectUri }${ connectQuery }`;
 

--- a/projects/packages/my-jetpack/_inc/utils/get-purchase-plan-url.ts
+++ b/projects/packages/my-jetpack/_inc/utils/get-purchase-plan-url.ts
@@ -33,7 +33,7 @@ const getPurchasePlanUrl = () => {
 		const redirectUri = `redirect_to=${ myJetpackCheckoutUri }`;
 		// If the user is not connected, this query will trigger a connection after checkout flow.
 		const connectQuery = ! isConnected
-			? `&connect_after_checkout=true&from_site_slug=${ siteSuffix }&admin_url=${ adminUrl }`
+			? `&connect_after_checkout=true&from_site_slug=${ siteSuffix }&admin_url=${ adminUrl }&unlinked=1`
 			: '';
 		const query = `${ redirectUri }${ connectQuery }`;
 

--- a/projects/packages/my-jetpack/changelog/update-purchase-flow-when-user-is-not-connected
+++ b/projects/packages/my-jetpack/changelog/update-purchase-flow-when-user-is-not-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Send non-connected users to a "connect after checkout" flow

--- a/projects/plugins/jetpack/changelog/update-purchase-flow-when-user-is-not-connected
+++ b/projects/plugins/jetpack/changelog/update-purchase-flow-when-user-is-not-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Send non-connected users to a "connect after checkout" flow


### PR DESCRIPTION
Right now, the `Purchase a plan` link in My Jetpack and the `Plans` link on the Dashboard have bad/broken user experiences when the site is not user-connected. See the link in Jetpack product discussion for more details

## Proposed changes:

* Update both links to send the query parameters needed for a "connect after checkout" flow when the user is not connected before clicking those CTAs

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1726225601073489-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Go to My Jetpack and connect your site (but not user)
3. Click on "Purchase a plan"
![image](https://github.com/user-attachments/assets/a8999e4c-737f-4f3a-8e85-ad6dcaccf50d)
4. Select any product (except CRM) on the pricing page and proceed to checkout
5. Purchase the product with credits (if you do it with the testing card, the receipt will return an error and will not be assigned to the site) and ensure you are prompted to connect your user account
![image](https://github.com/user-attachments/assets/6e9c4ca7-8f54-4579-98d0-62cdbf108d4a)
6. Connect your user
7. Ensure the site is autofilled
![image](https://github.com/user-attachments/assets/9fe9cdd2-155a-4463-9deb-f1372b3d4c9d)
8. Ensure the license is automatically assigned to the site
![image](https://github.com/user-attachments/assets/9c9120e5-0099-4548-8524-74cdd0782669)
9. Now go back to WP Admin and disconnect your user account (if needed, reconnect your site)
10. Go to `/wp-admin/admin.php?page=jetpack#/dashboard` and select the `Plans` tab at the top
11. Repeat steps 4-8 and ensure the behavior is exactly the same
12. Go back to WP Admin of your site
13. With your user still connected, go to My Jetpack and select "Purchase a plan" again
14. Go through the purchase process and ensure the license is attached to the correct site automatically and you are redirected back to WP Admin
15. Go back to `/wp-admin/admin.php?page=jetpack#/dashboard` and repeat test the purchase flow on the `Plans` CTA again to ensure the plan is assigned to the site automatically and that you are redirected back to WP Admin
