### PR TITLE
Jetpack-mu-wpcom: prevent PHP warnings

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-csstidy-warnings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-csstidy-warnings
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent PHP warnings
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/custom-css/csstidy/class.csstidy-optimise.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/custom-css/csstidy/class.csstidy-optimise.php
@@ -298,18 +298,22 @@ class csstidy_optimise { // phpcs:ignore
 			for ( $i = 0, $l = count( $color_tmp ); $i < $l; $i++ ) {
 				$color_tmp[ $i ] = trim( $color_tmp[ $i ] );
 				if ( str_ends_with( $color_tmp[ $i ], '%' ) ) {
-					$color_tmp[ $i ] = round( ( 255 * $color_tmp[ $i ] ) / 100 );
+					$color_tmp[ $i ] = round( ( 255 * (int) substr( $color_tmp[ $i ], 0, -1 ) ) / 100 );
 				}
 				if ( $color_tmp[ $i ] > 255 ) {
 					$color_tmp[ $i ] = 255;
 				}
 			}
-			$color = '#';
-			for ( $i = 0; $i < 3; $i++ ) {
-				if ( $color_tmp[ $i ] < 16 ) {
-					$color .= '0' . dechex( $color_tmp[ $i ] );
-				} else {
-					$color .= dechex( $color_tmp[ $i ] );
+
+			if ( count( $color_tmp ) >= 3 ) {
+				$color = '#';
+
+				for ( $i = 0; $i < 3; $i++ ) {
+					if ( $color_tmp[ $i ] < 16 ) {
+						$color .= '0' . dechex( $color_tmp[ $i ] );
+					} else {
+						$color .= dechex( $color_tmp[ $i ] );
+					}
 				}
 			}
 		}
@@ -636,8 +640,11 @@ class csstidy_optimise { // phpcs:ignore
 		$shorthands = & $GLOBALS['csstidy']['shorthands'];
 
 		foreach ( $shorthands as $key => $value ) {
-			if ( $value !== 0 && isset( $array[ $value[0] ] ) && isset( $array[ $value[1] ] )
-							&& isset( $array[ $value[2] ] ) && isset( $array[ $value[3] ] ) ) {
+			if ( $value === 0 || ( is_array( $value ) && count( $value ) < 4 ) ) {
+				continue;
+			}
+
+			if ( isset( $array[ $value[0] ] ) && isset( $array[ $value[1] ] ) && isset( $array[ $value[2] ] ) && isset( $array[ $value[3] ] ) ) {
 				$return[ $key ] = '';
 
 				$important = '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the CSStidy lib to prevent some PHP warnings. It copies the changes that were initially made in this diff: D156874-code. We're porting the changes to the `jetpack-mu-wpcom` package since WPCom will reference it instead of the `custom-css` mu-plugin. See https://github.com/Automattic/vulcan/issues/480.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Since D154031-code was approved and did prevent the PHP warnings, ensuring that this PR makes the same changes should be enough.