### PR TITLE
wpcomsh: Remove outdated temporary feature flags

### DIFF
--- a/projects/plugins/wpcomsh/changelog/remove-temp-feature-flags
+++ b/projects/plugins/wpcomsh/changelog/remove-temp-feature-flags
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal change, removing unused feature flags
+
+

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -673,13 +673,3 @@ if (
 	0 === strncmp( $_SERVER['REQUEST_URI'], '/wp-admin/widgets.php?', strlen( '/wp-admin/widgets.php?' ) ) ) { //phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 	add_action( 'plugins_loaded', 'wpcomsh_avoid_proxied_v2_banner' );
 }
-
-// Temporary feature flag for the new Reading Settings page.
-add_filter( 'calypso_use_modernized_reading_settings', '__return_true' );
-
-/**
- * Temporary feature flags for the new Newsletter and podcasting Settings pages,
- * its removal should be preceded by a removal of the filter's usage in Jetpack: https://github.com/Automattic/jetpack/pull/32146
- */
-add_filter( 'calypso_use_newsletter_settings', '__return_true' );
-add_filter( 'calypso_use_podcasting_settings', '__return_true' );


### PR DESCRIPTION
## Proposed changes:

* Remove filters added to these flags:
* `calypso_use_modernized_reading_settings`
  * Filter added in wpcomsh PR 1244
  * Filter call removed in #32450
* `calypso_use_newsletter_settings`
  * Filter added in wpcomsh PR 1468
  * Filter call removed in #33065
* `calypso_use_podcasting_settings`
  * Filter added in wpcomsh PR 1468
  * Filter call removed in #33065

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify there is no code anywhere running on these filters

