### PR TITLE
wpcomsh: Remove outdated sd-social-icon hotfix

### DIFF
--- a/projects/plugins/wpcomsh/changelog/remove-sd-hotfix
+++ b/projects/plugins/wpcomsh/changelog/remove-sd-hotfix
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Removed outdated hotfix for sd-social icon
+
+

--- a/projects/plugins/wpcomsh/plugin-hotfixes.php
+++ b/projects/plugins/wpcomsh/plugin-hotfixes.php
@@ -86,23 +86,6 @@ function wpcomsh_patch_auto_update_spinner_style() {
 add_action( 'admin_enqueue_scripts', 'wpcomsh_patch_auto_update_spinner_style', 999 );
 
 /**
- * Temporary hotfix.
- * Sharing buttons / Icon-only
- * See https://github.com/Automattic/jetpack/issues/29083.
- * To-do: remove once Jetpack 11.9-a.7 is released on WoA.
- */
-add_action(
-	'wp_footer',
-	function () {
-		echo '<style>
-			.sd-social-icon .sd-content ul li a.sd-button>span {
-				margin-left: 0;
-			}
-		</style>';
-	}
-);
-
-/**
  * Polyfill the create_function function for PHP versions >= 8.0
  * Code taken from https://github.com/php5friends/polyfill-create_function/blob/master/create_function.php
  *


### PR DESCRIPTION
## Proposed changes:

* Remove an 18 month year old css hotfix that is no longer needed. The CSS is included [here](https://github.com/Automattic/jetpack/blob/ff7cb448cb00b781ca3fe7eb44ecd92c2a74ef02/projects/plugins/jetpack/modules/sharedaddy/sharing.css#L131-L134).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify https://github.com/Automattic/jetpack/blob/ff7cb448cb00b781ca3fe7eb44ecd92c2a74ef02/projects/plugins/jetpack/modules/sharedaddy/sharing.css#L131-L134 matches the removed CSS.
* I couldn't actually figure out how to turn on the SD-style sharing icons. Is that still supported?

