### PR TITLE
Admin bar: don't enqueue obsolete Core CSS overrides for Default scheme

### DIFF
--- a/projects/packages/masterbar/changelog/fix-fresh-masterbar
+++ b/projects/packages/masterbar/changelog/fix-fresh-masterbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: don't enqueue obsolete Core CSS overrides for Default scheme

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/fresh/colors.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/fresh/colors.scss
@@ -1,9 +1,3 @@
-@import "variables";
-@import "../_core-overrides";
-@import "../_gutenberg";
-@import "../_inline-help";
-@import "sidebar-notice";
-
 #wpadminbar .ab-icon {
 	color: #a7aaad;
 }


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/wp-calypso/issues/94650

## Proposed changes:

This PR ensures that we're not enqueuing any obsolete CSS overrides for the Default scheme. After pfsHM7-1kz-p2, such overrides are not required anymore. However, https://github.com/Automattic/jetpack/pull/39371 accidentally re-added them because it re-registers the `fresh` scheme using our CSS file (which contains the override).

This PR fixes that by just removing the override inclusion from that CSS file.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare a NEW Woa site.
   - It is important so that you won't get the cached `colors.css`.
   - Don't forget to add `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );` in `wp-config.php`
2. Patch this to Jetpack Beta Tester (WP.com Features)
3. Go to Users -> Profile and change the color scheme to Default.
4. Verify that the admin bar background color is `#c3c4c7`.
5. Verify that no colors are broken.