### PR TITLE
Shortcode: Fix the YouTube URL for the private video

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-youtube-schedule-video
+++ b/projects/plugins/jetpack/changelog/fix-youtube-schedule-video
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Shortcode: Fix the YouTube URL for the private video

--- a/projects/plugins/jetpack/modules/shortcodes/youtube.php
+++ b/projects/plugins/jetpack/modules/shortcodes/youtube.php
@@ -527,26 +527,65 @@ function jetpack_shortcode_youtube_dimensions( $query_args ) {
  * For bare URLs on their own line of the form
  * http://www.youtube.com/v/9FhMMmqzbD8?fs=1&hl=en_US
  *
- * @deprecated since 13.8
- *
  * @param array  $matches Regex partial matches against the URL passed.
  * @param array  $attr    Attributes received in embed response.
  * @param string $url     Requested URL to be embedded.
  */
 function wpcom_youtube_embed_crazy_url( $matches, $attr, $url ) {
-	_deprecated_function( __FUNCTION__, 'jetpack-13.8' );
 	return youtube_id( $url );
 }
 
 /**
+ * Get the regex for Youtube URLs.
+ */
+function wpcom_youtube_get_regex() {
+	return '#https?://(?:www\.)?(?:youtube.com/(?:v/|playlist|watch[/\#?])|youtu\.be/).*#i';
+}
+
+/**
  * Add a new handler to automatically transform custom Youtube URLs (like playlists) into embeds.
- *
- * @deprecated since 13.8
  */
 function wpcom_youtube_embed_crazy_url_init() {
-	_deprecated_function( __FUNCTION__, 'jetpack-13.8' );
-	wp_embed_register_handler( 'wpcom_youtube_embed_crazy_url', '#https?://(?:www\.)?(?:youtube.com/(?:v/|playlist|watch[/\#?])|youtu\.be/).*#i', 'wpcom_youtube_embed_crazy_url' );
+	if ( ! defined( 'REST_API_REQUEST' ) ) {
+		return;
+	}
+
+	// Unregister the Core's one.
+	wp_embed_unregister_handler( 'youtube_embed_url' );
+	// Register the custom handler to provide the better support for the private video.
+	wp_embed_register_handler( 'wpcom_youtube_embed_crazy_url', wpcom_youtube_get_regex(), 'wpcom_youtube_embed_crazy_url' );
 }
+add_action( 'init', 'wpcom_youtube_embed_crazy_url_init' );
+
+/**
+ * Filters the oEmbed result before any HTTP requests are made for YouTube.
+ *
+ * @since $$next-version$$
+ *
+ * @param null|string $result The UNSANITIZED (and potentially unsafe) HTML that should be used to embed. Default null.
+ * @param string      $url    The URL that should be inspected for discovery `<link>` tags.
+ * @param array       $args   oEmbed remote get arguments.
+ * @return null|string The UNSANITIZED (and potentially unsafe) HTML that should be used to embed.
+ *                     Null if the URL does not belong to the current site.
+ */
+function wpcom_youtube_filter_pre_oembed_result( $result, $url, $args ) {
+	// Return early if it's not a YouTube URL.
+	if ( ! preg_match( wpcom_youtube_get_regex(), $url, $matches ) ) {
+		return $result;
+	}
+
+	// Try to get the oembed data by the Core's approach.
+	$wp_oembed = _wp_oembed_get_object();
+	$data      = $wp_oembed->get_data( $url, $args );
+	if ( $data ) {
+		/** This filter is documented in wp-includes/class-wp-oembed.php */
+		return apply_filters( 'oembed_result', $wp_oembed->data2html( $data, $url ), $url, $args );
+	}
+
+	// Fallback to the custom handler if the oembed result is not found, especially for the private video.
+	return youtube_id( $url );
+}
+add_filter( 'pre_oembed_result', 'wpcom_youtube_filter_pre_oembed_result', 10, 3 );
 
 /**
  * Remove the ending question mark from the video id of the YouTube URL.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p1725499365595119-slack-CRWCHQGUB

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* There is a regression caused by https://github.com/Automattic/jetpack/pull/39096 as we didn't notice that the custom embed handler would be called by the `/oembed/1.0/sites/:site_id/proxy` endpoint. Before that change, we could always get the result from the oembed proxy endpoint for every YouTube URL even if it was either private or invalid. As a result, the scheduled YouTube video (as a private video) could be embedded correctly.
* To make the scheduled YouTube video work as before, we reverted part of that PR and made a slight change to keep the title of the YouTube video available on the iframe. But it also means that every YouTube URL can be embedded correctly even if it's the wrong one.
* The changes might look weird as the custom embed hanlder (`$wp_embed->get_embed_handler_html`) works differently between the oembed proxy endpoint and how it renders on the frontend.
  * For the oembed proxy endpoint, the order is
    * Get the data from the cache
    * Get the data from the oembed endpoint according to the provider of the URL. For YouTube, it's `https://www.youtube.com/oembed?format=json&url=`
    * If we cannot get the result, fallback to the custom oembed handler, that is, `wpcom_youtube_embed_crazy_url`
    * See [here](https://github.com/WordPress/wordpress-develop/blob/bf09fe506620678fb82c3b872309edda0ed8ce61/src/wp-includes/class-wp-oembed-controller.php#L194-L244) for more details.
  * For how it renders on the frontend, the order is 
    * Get the HTML from the custom oembed handler first
    * If not, get the HTML from the cache
    * If not, get the HTML from the oembed endpoint according to the provider of the URL
    * See [here](https://github.com/WordPress/wordpress-develop/blob/bf09fe506620678fb82c3b872309edda0ed8ce61/src/wp-includes/class-wp-embed.php#L222-L308) for more details
* As mentioned above, the HTML from the custom handler is different. If we keep the previous way, the title of the YouTube video would be missing because the custom embed handler of YouTube couldn't get the title of the video. Hence, this PR registers the custom embed handler of YouTube for the oembed proxy endpoint and then hooks the HTML from the custom handler to the `pre_oembed_result` filter to deprioritize its order on the frontend
* Maybe we have to raise the PR to Core to make the order the same in the follow-up PR 🤔

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to wpcom
* Sandbox your site
* Go to create a new post
* Embed the following YouTube URLs
  * https://www.youtube.com/watch?v=63XUTCLOCnM (Public)
  * https://www.youtube.com/watch?v=63XUTCLOCnMxxx (Invalid)
  * https://www.youtube.com/watch?v=X47UjFQXxAY (Scheduled Private Video)
* Make sure all of the above videos can be embedded correctly
* Make sure there is the title attribute on the iframe of the public video (the first one)