### PR TITLE
Boost: Make sure Critical CSS always works with absolute URLs

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
@@ -142,6 +142,8 @@ class Source_Providers {
 					continue;
 				}
 
+				$urls = $this->make_absolute_urls( $urls );
+
 				$key = $provider_name . '_' . $group;
 
 				// For each URL
@@ -163,5 +165,30 @@ class Source_Providers {
 		}
 
 		return $sources;
+	}
+
+	/**
+	 * Make URLs absolute.
+	 *
+	 * @param array $urls The list of URLs to make absolute.
+	 *
+	 * @return array
+	 */
+	private function make_absolute_urls( $urls ) {
+		$absolute_urls = array();
+		foreach ( $urls as $url ) {
+			if ( class_exists( '\WP_Http' ) && method_exists( '\WP_Http', 'make_absolute_url' ) ) {
+				$absolute_urls[] = \WP_Http::make_absolute_url( $url, home_url() );
+				continue;
+			}
+
+			if ( stripos( $url, home_url() ) === 0 ) {
+				$absolute_urls[] = $url;
+			} else {
+				$absolute_urls[] = home_url( $url );
+			}
+		}
+
+		return $absolute_urls;
 	}
 }

--- a/projects/plugins/boost/changelog/prevent-relative-urls-in-css-source-providers
+++ b/projects/plugins/boost/changelog/prevent-relative-urls-in-css-source-providers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Critical CSS: Make sure all URLs that are being processed are absolute instead of relative.


### PR DESCRIPTION
Partially addresses https://github.com/Automattic/jetpack/issues/39455.

## Proposed changes:

* Prevent source providers from returning relative URLs. Bad for Critical/Cloud CSS.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1726628647463949-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

**To see the critical css source-providers endpoint (`wp-json/jetpack-boost/v1/list-source-providers)`, you'll need to have the Boost Developer plugin running.**

### Test that it shows relative URLs

* Setup Boost free from `trunk`;
* Add this snippet to your site - this will make posts have relative URLs (make sure you have at least one post on your site):

```php
add_filter('post_link', 'make_post_url_relative', 10, 2);
function make_post_url_relative($url, $post_id) {
    if (get_post_type($post_id) === 'post') {
        return wp_make_link_relative($url);
    }
    return $url;
}
```

* Visit the endpoint URL - http://jetpack-boost.test/wp-json/jetpack-boost/v1/list-source-providers
* There should be relative URLs on the page;
* Try to generate Critical CSS - it should fail with a fatal error similar to the one below:

![CleanShot 2024-09-19 at 13 43 20](https://github.com/user-attachments/assets/5872875f-4368-45b9-a237-e2f4b830c70d)


### Test that it doesn't show relative URLs

* Switch to this PR's branch;
* Visit the endpoint URL again;
* There should be no relative URLs;
* Try to generate Critical CSS - it should work.