### PR TITLE
Fix email preview not allowing scrolling

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-email-preview-pointer-events
+++ b/projects/plugins/jetpack/changelog/fix-email-preview-pointer-events
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Email preview: fix disabling pointer events preventing scroll in Firefox

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -328,7 +328,6 @@ export function NewsletterPreviewModal( { isOpen, onClose, postId } ) {
 								height: '100%',
 								border: 'none',
 								transition: 'width 0.3s ease-in-out',
-								pointerEvents: 'none',
 							} }
 							title={ __( 'Email Preview', 'jetpack' ) }
 						/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue where it wasn't possible to scroll the email preview (tested Firefox).

Intended effect was that it's not possible to click links inside the preview, leading you to navigate stuff inside the preview modal.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes `pointer-events:none` from the iframe, allowing scrolling the iframe itself again. 

Goes together with D161864-code which moves the pointer-events CSS _inside_ the iframe, but one PR doesn't block the other.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply both PRs to sandbox, or just this PR locally.
* Open preview from sidebar
    <img width="301" alt="image" src="https://github.com/user-attachments/assets/eb5286cf-5cb8-4246-988f-f31a6040d618">
* You can now scroll long emails in the iframe (tested Firefox was broken previously)
* If you apply patch at sandbox, you can't click links

