### PR TITLE
VideoPress: add unique ID attributes to videopress elements

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-id-in-html
+++ b/projects/packages/videopress/changelog/update-videopress-id-in-html
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+VideoPress: add video guid as ID in HTML

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -121,15 +121,15 @@ class Block_Editor_Content {
 
 		$block_template =
 		'<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player">' .
-			'<div class="jetpack-videopress-player__wrapper" id="%s">' .
+			'<div class="jetpack-videopress-player__wrapper" id="%1$s">' .
 				'<iframe ' .
 					'title="' . __( 'VideoPress Video Player', 'jetpack-videopress-pkg' ) . '" ' .
 					'aria-label="' . __( 'VideoPress Video Player', 'jetpack-videopress-pkg' ) . '" ' .
-					'src="%s" ' .
-					'width="%s"' .
-					'height="%s" ' .
+					'src="%2$s" ' .
+					'width="%3$s"' .
+					'height="%4$s" ' .
 					'frameborder="0" ' .
-					'allowfullscreen%s allow="clipboard-write">' .
+					'allowfullscreen%5$s allow="clipboard-write">' .
 				'</iframe>' .
 			'</div>' .
 		'</figure>';

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -121,7 +121,7 @@ class Block_Editor_Content {
 
 		$block_template =
 		'<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player">' .
-			'<div class="jetpack-videopress-player__wrapper">' .
+			'<div class="jetpack-videopress-player__wrapper" id="jetpack-videopress-%s">' .
 				'<iframe ' .
 					'title="' . __( 'VideoPress Video Player', 'jetpack-videopress-pkg' ) . '" ' .
 					'aria-label="' . __( 'VideoPress Video Player', 'jetpack-videopress-pkg' ) . '" ' .
@@ -138,7 +138,7 @@ class Block_Editor_Content {
 		Jwt_Token_Bridge::enqueue_jwt_token_bridge();
 		wp_enqueue_script( 'videopress-iframe', 'https://videopress.com/videopress-iframe.js', array(), $version, true );
 
-		return sprintf( $block_template, $src, $width, $height, $cover );
+		return sprintf( $block_template, esc_attr( $guid ), $src, $width, $height, $cover );
 	}
 
 	/**
@@ -169,7 +169,7 @@ class Block_Editor_Content {
 				// ref /client/lib/url/index.ts
 				$content = '<!-- wp:videopress/video {"guid":"' . $guid . '"} -->
 				<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player">
-					<div class="jetpack-videopress-player__wrapper">' . $url . '</div>
+					<div class="jetpack-videopress-player__wrapper" id="jetpack-videopress-' . esc_attr( $guid ) . '">' . $url . '</div>
 				</figure>
 				<!-- /wp:videopress/video -->';
 			}

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -121,7 +121,7 @@ class Block_Editor_Content {
 
 		$block_template =
 		'<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player">' .
-			'<div class="jetpack-videopress-player__wrapper" id="jetpack-videopress-%s">' .
+			'<div class="jetpack-videopress-player__wrapper" id="%s">' .
 				'<iframe ' .
 					'title="' . __( 'VideoPress Video Player', 'jetpack-videopress-pkg' ) . '" ' .
 					'aria-label="' . __( 'VideoPress Video Player', 'jetpack-videopress-pkg' ) . '" ' .
@@ -138,7 +138,7 @@ class Block_Editor_Content {
 		Jwt_Token_Bridge::enqueue_jwt_token_bridge();
 		wp_enqueue_script( 'videopress-iframe', 'https://videopress.com/videopress-iframe.js', array(), $version, true );
 
-		return sprintf( $block_template, esc_attr( $guid ), $src, $width, $height, $cover );
+		return sprintf( $block_template, esc_attr( get_videopress_html_id( $guid )[0] ), $src, $width, $height, $cover );
 	}
 
 	/**
@@ -169,7 +169,7 @@ class Block_Editor_Content {
 				// ref /client/lib/url/index.ts
 				$content = '<!-- wp:videopress/video {"guid":"' . $guid . '"} -->
 				<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player">
-					<div class="jetpack-videopress-player__wrapper" id="jetpack-videopress-' . esc_attr( $guid ) . '">' . $url . '</div>
+					<div class="jetpack-videopress-player__wrapper" id="' . esc_attr( get_videopress_html_id( $guid )[0] ) . '">' . $url . '</div>
 				</figure>
 				<!-- /wp:videopress/video -->';
 			}

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -302,9 +302,9 @@ class Initializer {
 			$videopress_url = wp_kses_post( $videopress_url );
 			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper  = sprintf(
-				'<div class="%s" id="jetpack-videopress-%s">%s %s</div>',
+				'<div class="%s" id="%s">%s %s</div>',
 				$video_wrapper_classes,
-				esc_attr( $guid ),
+				esc_attr( get_videopress_html_id( $guid )[0] ),
 				$preview_on_hover,
 				$oembed_html
 			);

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -302,8 +302,9 @@ class Initializer {
 			$videopress_url = wp_kses_post( $videopress_url );
 			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper  = sprintf(
-				'<div class="%s">%s %s</div>',
+				'<div class="%s" id="jetpack-videopress-%s">%s %s</div>',
 				$video_wrapper_classes,
+				esc_attr( $guid ),
 				$preview_on_hover,
 				$oembed_html
 			);

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -302,7 +302,7 @@ class Initializer {
 			$videopress_url = wp_kses_post( $videopress_url );
 			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper  = sprintf(
-				'<div class="%1$s" id="%2$s">%3$s %5$s</div>',
+				'<div class="%1$s" id="%2$s">%3$s %4$s</div>',
 				$video_wrapper_classes,
 				esc_attr( get_videopress_html_id( $guid )[0] ),
 				$preview_on_hover,

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -302,7 +302,7 @@ class Initializer {
 			$videopress_url = wp_kses_post( $videopress_url );
 			$oembed_html    = apply_filters( 'video_embed_html', $wp_embed->shortcode( array(), $videopress_url ) );
 			$video_wrapper  = sprintf(
-				'<div class="%s" id="%s">%s %s</div>',
+				'<div class="%1$s" id="%2$s">%3$s %5$s</div>',
 				$video_wrapper_classes,
 				esc_attr( get_videopress_html_id( $guid )[0] ),
 				$preview_on_hover,

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -38,7 +38,7 @@ function videopress_is_valid_guid( $guid ) {
  * @return array [ html_id, count ]
  */
 function get_videopress_html_id( $guid ) {
-	static $videopress_shown_video;
+	static $videopress_shown_video = array();
 
 	if ( ! isset( $videopress_shown_video[ $guid ] ) ) {
 		$videopress_shown_video[ $guid ] = 1;

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -29,6 +29,25 @@ function videopress_is_valid_guid( $guid ) {
 	}
 	return false;
 }
+/**
+ * Get the HTML ID for a videopress videos.
+ * So that we can link to it as a permalink on the page.
+ *
+ * @param string $guid video identifier.
+ *
+ * @return array [ html_id, count ]
+ */
+function get_videopress_html_id( $guid ) {
+	static $videopress_shown_video;
+
+	if ( ! isset( $videopress_shown_video[ $guid ] ) ) {
+		$videopress_shown_video[ $guid ] = 1;
+	} else {
+		++$videopress_shown_video[ $guid ];
+	}
+
+	return array( "v-{$guid}-{$videopress_shown_video[ $guid ]}", $videopress_shown_video[ $guid ] );
+}
 
 /**
  * Validates user-supplied video preload setting.

--- a/projects/plugins/jetpack/changelog/update-videopress-id-in-html
+++ b/projects/plugins/jetpack/changelog/update-videopress-id-in-html
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Add video ids to the html

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -56,13 +56,10 @@ class VideoPress_Player {
 	 * @param array  $options Player customizations.
 	 */
 	public function __construct( $guid, $maxwidth = 0, $options = array() ) {
-		if ( empty( self::$shown[ $guid ] ) ) {
-			self::$shown[ $guid ] = 0;
-		}
+		list( $html_id, $id_count ) = get_videopress_html_id( $guid );
+		self::$shown[ $guid ]       = $id_count;
 
-		++self::$shown[ $guid ];
-
-		$this->video_container_id = 'v-' . $guid . '-' . self::$shown[ $guid ];
+		$this->video_container_id = $html_id;
 		$this->video_id           = $this->video_container_id . '-video';
 
 		if ( is_array( $options ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->



## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds unique ID attributes to VideoPress attributes, thus allowing us to link directly to the point on the page where the video is, for example, from emails.

<img width="1830" alt="Screenshot 2024-09-19 at 16 51 25" src="https://github.com/user-attachments/assets/3ed1bc79-ce27-4c10-8d02-cbebac56709b">


Goes together with D161878-code, which adds the hash to URLs at emails:

<img width="613" alt="Screenshot 2024-09-19 at 16 33 17" src="https://github.com/user-attachments/assets/bd614482-4a7d-4f92-b2c6-1374ef3e8f72">



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### Block
* Add VideoPress block
* Look at the page's HTML on frontend of the site, and note `id="jetpack-videopress-UNIQUE_ID"` is in HTML.
* Try adding block an ID from Block's settings panel, and note how that gets added to parent `<figure>` element just fine.

    <img width="804" alt="Screenshot 2024-09-19 at 16 52 50" src="https://github.com/user-attachments/assets/733d4c19-17e5-4804-b2ba-52f0238fad8d">

### Shortcode
- Go to the WP media library, find the video, and copy the shortcode from its details page.
- Add shortcode block, and use the videopress shortcode.

    <img width="475" alt="image" src="https://github.com/user-attachments/assets/84881664-a199-46e9-b0cc-4ddad1b273f6">

- The HTML output should contain the ID.
