### PR TITLE
wpcomsh: Remove Gutenberg site logo hotfix from 2021

### DIFF
--- a/projects/plugins/wpcomsh/.phan/baseline.php
+++ b/projects/plugins/wpcomsh/.phan/baseline.php
@@ -20,7 +20,6 @@ return [
     // PhanImpossibleCondition : 3 occurrences
     // PhanTypeArraySuspiciousNullable : 3 occurrences
     // PhanUndeclaredClassMethod : 3 occurrences
-    // PhanUndeclaredFunctionInCallable : 3 occurrences
     // PhanNoopNew : 2 occurrences
     // PhanTypeVoidArgument : 2 occurrences
     // PhanUndeclaredProperty : 2 occurrences
@@ -35,6 +34,7 @@ return [
     // PhanTypeObjectUnsetDeclaredProperty : 1 occurrence
     // PhanUndeclaredClassConstant : 1 occurrence
     // PhanUndeclaredClassStaticProperty : 1 occurrence
+    // PhanUndeclaredFunctionInCallable : 1 occurrence
     // PhanUndeclaredMethod : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
@@ -47,7 +47,6 @@ return [
         'endpoints/class-marketplace-webhook-response.php' => ['PhanPluginMixedKeyNoKey'],
         'feature-plugins/autosave-revision.php' => ['PhanPluginRedundantAssignment', 'PhanTypeMismatchArgumentNullable'],
         'feature-plugins/coblocks-mods.php' => ['PhanUndeclaredClassConstant', 'PhanUndeclaredClassMethod'],
-        'feature-plugins/gutenberg-mods.php' => ['PhanUndeclaredFunctionInCallable'],
         'feature-plugins/managed-plugins.php' => ['PhanRedundantCondition', 'PhanUndeclaredClassMethod', 'PhanUndeclaredFunctionInCallable'],
         'feature-plugins/sensei-pro-mods.php' => ['PhanUndeclaredClassMethod'],
         'footer-credit/theme-optimizations.php' => ['PhanUndeclaredConstant', 'PhanUndeclaredStaticMethod'],

--- a/projects/plugins/wpcomsh/changelog/remove-logo-bug
+++ b/projects/plugins/wpcomsh/changelog/remove-logo-bug
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Removed outdated Gutenberg hotfix from 2021 related to site logos
+
+

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -42,47 +42,6 @@ function wpcomsh_remove_gutenberg_experimental_menu() {
 }
 
 /**
- * Updates the site_logo option when the custom_logo theme-mod gets updated.
- *
- * Registered on the `pre_set_theme_mod_custom_logo` hook.
- *
- * @param  mixed $value Attachment ID of the custom logo or an empty value.
- * @return mixed
- */
-function wpcomsh_sync_custom_logo_to_site_logo( $value ) {
-	if ( empty( $value ) ) {
-		delete_option( 'site_logo' );
-	} else {
-		update_option( 'site_logo', $value );
-	}
-
-	return $value;
-}
-
-/**
- * Hotfix a Gutenberg bug that prevents updating a logo from the Customizer.
- *
- * These fixes are from https://github.com/WordPress/gutenberg/pull/33179, and can be
- * removed when that change is released in Gutenberg and all Atomic sites are updated.
- *
- * Ported from wpcom hotfix: D63662-code
- */
-function wpcomsh_hotfix_gutenberg_logo_bug() {
-	// Only add the filter if Gutenberg is active and the current version is missing the filter.
-	if (
-		( defined( 'GUTENBERG_VERSION' ) || defined( 'GUTENBERG_DEVELOPMENT_MODE' ) ) &&
-		false === has_action( 'pre_set_theme_mod_custom_logo', 'gutenberg__sync_custom_logo_to_site_logo' )
-	) {
-		add_filter( 'pre_set_theme_mod_custom_logo', 'wpcomsh_sync_custom_logo_to_site_logo' );
-	}
-
-	// Remove a function that can inadvertently delete your logo.
-	remove_action( 'update_option_site_logo', 'gutenberg__sync_site_logo_to_custom_logo', 10 );
-}
-// Wait until after Gutenberg has registered the Site Logo block on the `init` action, priority 10.
-add_action( 'init', 'wpcomsh_hotfix_gutenberg_logo_bug', 11 );
-
-/**
  * Hotfix a Gutenberg bug that inadvertently loads wp-reset-editor-syles stylesheet in the
  * iframed site editor.
  *


### PR DESCRIPTION
## Proposed changes:

* Remove the hotfix for a bug in Gutenberg preventing updating a logo in the Customizer.
  * The changes were merged to Gutenberg here: https://github.com/WordPress/gutenberg/pull/33179
  * We can verify the same code exists here: https://github.com/mreishus/gutenberg/blob/56bfef82bb93d2bba226e0631aed03eb16057cfd/packages/block-library/src/site-logo/index.php#L145-L155
  * I also removed this same one from simple sites with no problem here: D152692-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*