### PR TITLE
OpenTable: show error if search request fails

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-open-table-error-notice
+++ b/projects/plugins/jetpack/changelog/fix-open-table-error-notice
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: OpenTable: show error if search request fails
+
+

--- a/projects/plugins/jetpack/extensions/blocks/opentable/restaurant-picker.js
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/restaurant-picker.js
@@ -1,4 +1,4 @@
-import { Button, FormTokenField } from '@wordpress/components';
+import { Button, FormTokenField, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, _n } from '@wordpress/i18n';
 import { isEmpty } from 'lodash';
@@ -8,7 +8,7 @@ const MAX_SUGGESTIONS = 20;
 
 export default function RestaurantPicker( props ) {
 	const [ input, setInput ] = useState( '' );
-	const restaurants = useRestaurantSearch( input, MAX_SUGGESTIONS );
+	const { restaurants, hasRequestFailed } = useRestaurantSearch( input, MAX_SUGGESTIONS );
 	const [ selectedRestaurants, setSelectedRestaurants ] = useState( props.rids || [] );
 
 	const idRegex = /^(\d+)$|\(\#(\d+)\)$/;
@@ -57,6 +57,14 @@ export default function RestaurantPicker( props ) {
 				</form>
 			) : (
 				formInput
+			) }
+			{ hasRequestFailed && (
+				<Notice status="error" isDismissible={ false }>
+					{ __(
+						"OpenTable can't find this restaurant right now. Please try again later.",
+						'jetpack'
+					) }
+				</Notice>
 			) }
 		</div>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/opentable/use-restaurant-search.js
+++ b/projects/plugins/jetpack/extensions/blocks/opentable/use-restaurant-search.js
@@ -5,8 +5,11 @@ export const possibleEmbed = /^\s*(http[s]?:\/\/|\<script)/;
 
 export default function useRestaurantSearch( searchTerm, maxResults ) {
 	const [ restaurants, setRestaurants ] = useState( [] );
+	const [ hasRequestFailed, setHasRequestFailed ] = useState( false );
 
 	const searchRestaurants = ( input = '' ) => {
+		setHasRequestFailed( false );
+
 		fetch(
 			'https://www.opentable.com/widget/reservation/restaurant-search?pageSize=' +
 				maxResults +
@@ -14,9 +17,11 @@ export default function useRestaurantSearch( searchTerm, maxResults ) {
 				encodeURIComponent( input )
 		)
 			.then( result => result.json() )
-			.then( restaurantResponse =>
-				setRestaurants( unionBy( restaurants, restaurantResponse.items, 'rid' ) )
-			);
+			.then( restaurantResponse => {
+				setHasRequestFailed( false );
+				setRestaurants( unionBy( restaurants, restaurantResponse.items, 'rid' ) );
+			} )
+			.catch( () => setHasRequestFailed( true ) );
 	};
 
 	const throttledSearchRestaurants = useCallback( throttle( searchRestaurants, 500 ), [
@@ -29,5 +34,5 @@ export default function useRestaurantSearch( searchTerm, maxResults ) {
 		}
 	}, [ searchTerm ] );
 
-	return restaurants;
+	return { restaurants, hasRequestFailed };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR displays an error notice in the _OpenTable Reservation_ block when the request to search for restaurants fails.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Issue: https://github.com/Automattic/jetpack/issues/39410

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a Jetpack test site
- Open the network panel
- Create a new post
- Add the `OpenTable Reservation` block
- Search for a restaurant, i.e., `Miku Restaurant - Vancouver`
- In the network panel, you should see the `restaurant-search` endpoint fail (retry if you haven't)
- You should also see an error notice in the UI
<img width="639" alt="Screenshot 2024-09-19 at 11 28 23 AM" src="https://github.com/user-attachments/assets/bce6585c-837b-496d-9f44-05acbfd31d0f">


