### PR TITLE
Incompatible Plugins update: Remove wpcom-migration, add duplicator-pro

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-update-wpcomsh-incompatible-plugins
+++ b/projects/plugins/wpcomsh/changelog/add-update-wpcomsh-incompatible-plugins
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Minor patch
+
+

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -28,6 +28,7 @@ class Jetpack_Plugin_Compatibility {
 		'cf7-pipedrive-integration/class-cf7-pipedrive.php' => '"cf7-pipedrive-integration" has been deactivated, it interferes with site operation and is not supported on WordPress.com.',
 		'database-browser/database-browser.php'            => '"database-browser" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'duplicator/duplicator.php'                        => '"duplicator" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
+		'duplicator-pro/duplicator-pro.php'                => '"duplicator-pro" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'extended-wp-reset/extended-wp-reset.php'          => '"extended-wp-reset" has been deactivated, it interferes with site operation and is not supported on WordPress.com.',
 		'file-manager-advanced/file_manager_advanced.php'  => '"file-manager-advanced" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'file-manager/file-manager.php'                    => '"file-manager" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
@@ -169,7 +170,6 @@ class Jetpack_Plugin_Compatibility {
 		'wp-monero-miner-pro/monero-miner-pro.php'         => '"wp-monero-miner-pro" is not supported on WordPress.com.',
 		'wp-monero-miner-using-coin-hive/wp-coin-hive.php' => '"wp-monero-miner-using-coin-hive" is not supported on WordPress.com.',
 		'wp-optimize-by-xtraffic/wp-optimize-by-xtraffic.php' => '"wp-optimize-by-xtraffic" is not supported on WordPress.com.',
-		'wpcom-migration/wpcom-migration.php'              => '"wpcom-migration" is not supported on WordPress.com.',
 		'wpematico/wpematico.php'                          => '"wpematico" is not supported on WordPress.com.',
 		'wpstagecoach/wpstagecoach.php'                    => '"wpstagecoach" is not supported on WordPress.com.', // p9F6qB-66o-p2
 		'yuzo-related-post/yuzo_related_post.php'          => '"yuzo-related-post" is not supported on WordPress.com.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
Fixes: [#1141](https://github.com/Automattic/dotcom-migrations/issues/1141#issuecomment-2359092260) & [#1105](https://github.com/Automattic/dotcom-migrations/pull/1105#issuecomment-2351070364)


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
 Updates the incompatible plugins array to:
* add `duplicator-pro`, which causes fatals on dotcom
* remove `wpcom-migration` which is no longer incompatible and will be required for incoming migrations

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the steps to test this branch (should be a comment posted by the bot below)
* On your WoA dev site, Install `wpcom-migration` by running the wp-cli command `wp plugin install wpcom-migration`
* Navigate to /wp-admin/plugins.php and confirm that the plugin is able to be activated (should not be disabled)
* Create a dummy plugin in `~/htdocs/wp-content/plugins/duplicator-pro/duplicator-pro.php` with the following:

```
<?php
/**
 * Plugin Name: Duplicator Pro
 * Plugin URI:  http://na.com                     
 * Description: Duplicator Pro dummy plugin
 * Version:     1.0
 * Author:      villanovachile
 * Author URI:  http://na.com     
 */
```

* Navigate to /wp-admin/plugins.php and confirm that the plugin is disabled and cannot be activated
