### PR TITLE
Protect: Remove database category from threats navigation

### DIFF
--- a/projects/plugins/protect/changelog/remove-protect-database-results
+++ b/projects/plugins/protect/changelog/remove-protect-database-results
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Security Scanning: disabled database threat category

--- a/projects/plugins/protect/src/js/components/threats-list/navigation.jsx
+++ b/projects/plugins/protect/src/js/components/threats-list/navigation.jsx
@@ -6,7 +6,6 @@ import {
 	warning as warningIcon,
 	color as themesIcon,
 	code as filesIcon,
-	grid as databaseIcon,
 } from '@wordpress/icons';
 import { useCallback, useMemo } from 'react';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
@@ -19,12 +18,7 @@ const ThreatsNavigation = ( { selected, onSelect, sourceType = 'scan', statusFil
 	const {
 		results: { plugins, themes },
 		counts: {
-			current: {
-				threats: numThreats,
-				core: numCoreThreats,
-				files: numFilesThreats,
-				database: numDatabaseThreats,
-			},
+			current: { threats: numThreats, core: numCoreThreats, files: numFilesThreats },
 		},
 	} = useProtectData( { sourceType, filter: { status: statusFilter } } );
 
@@ -49,10 +43,6 @@ const ThreatsNavigation = ( { selected, onSelect, sourceType = 'scan', statusFil
 
 	const trackNavigationClickFiles = useCallback( () => {
 		recordEvent( 'jetpack_protect_navigation_file_click' );
-	}, [ recordEvent ] );
-
-	const trackNavigationClickDatabase = useCallback( () => {
-		recordEvent( 'jetpack_protect_navigation_database_click' );
 	}, [ recordEvent ] );
 
 	const allLabel = useMemo( () => {
@@ -129,15 +119,6 @@ const ThreatsNavigation = ( { selected, onSelect, sourceType = 'scan', statusFil
 						badge={ numFilesThreats }
 						disabled={ numFilesThreats <= 0 }
 						onClick={ trackNavigationClickFiles }
-						checked={ true }
-					/>
-					<NavigationItem
-						id="database"
-						label={ __( 'Database', 'jetpack-protect' ) }
-						icon={ databaseIcon }
-						badge={ numDatabaseThreats }
-						disabled={ numDatabaseThreats <= 0 }
-						onClick={ trackNavigationClickDatabase }
 						checked={ true }
 					/>
 				</>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the "database" threat category from the navigation on the scan results screen, as the database scanner has been disabled.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1726744868764319-slack-C029WFNV69M

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review the threats UI, confirm that the database link is removed.

<img width="1140" alt="Screenshot 2024-09-19 at 12 03 21 PM" src="https://github.com/user-attachments/assets/b84ed594-38ed-4af4-8376-13560c29a971">
