### PR TITLE
Blog Privacy: Don't add custom rules to wpcom robots.txt if blog_public=0

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-blog-privacy-cluttering-wpcom-robots-txt
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-blog-privacy-cluttering-wpcom-robots-txt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Blog Privacy: Do not add custom rules to wpcom's robots.txt if blog_public=0

--- a/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/blog-privacy/blog-privacy.php
@@ -26,12 +26,12 @@ function robots_txt( string $output, $public ): string {
 	$public = (int) $public;
 
 	// If the site is completely private, don't bother with the additional restrictions.
-	if ( -1 === $public ) {
+	// For blog_public=0, WP.com Disallows all user agents and Core does not (relying on <meta name="robots">).
+	// Let wpcom do it's thing to not clutter the robots.txt file.
+	if ( -1 === $public || ( 0 === $public && defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 		return $output;
 	}
 
-	// For blog_public=0, WP.com Disallows all user agents and Core does not (relying on <meta name="robots">).
-	// Always add Disallow blocks for blog_public=0 even on WP.com where it may be redundant.
 	// An option oddly named because of history.
 	if ( 0 === $public || get_option( 'wpcom_data_sharing_opt_out' ) ) {
 		$ai_bots = array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

In #35803, these rules were added to robots.txt regardless of the environment. It cluttered up the robots.txt and was confusing on simple, for sites that are discouraging search engines already. 

This change implements custom behavior based on the environment
- wpcom: different
- core/woa: same as before

I think we can revert the wpcom test change too D161949-code

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
- Do not output extra robots.txt rules in wpcom simple environment when blog_public=0

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1726689440830569/1726685246.860939-slack-C02AVAR9B

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Full instructions in Field Guide here for both Atomic and WPCOM testing PCYsg-Osp-p2#simple-testing

In WPCOM simple: 
- jetpack build plugins/mu-wpcom-plugin
- jetpack rsync mu-wpcom-plugin {yoursandbox/to/mu-plugins/jetpack-mu-wpcom-plugin/production}
- Point a simple site to your sandbox
- Comment out the domo_arigato_mr_sandboxo hook (in wpcom sandbox)
- Visit the site's /robots.txt

Toggle these settings and test individually: 
- `Discourage search engines from indexing this site:` robots.txt should just have `User-agent: * Disallow: /`
- `Prevent third-party sharing for dsmartsandbox.wordpress.com`: Should show the list of AI user agents in robots.txt.

Test also on a WoA site using the Jetpack Beta plugin