### PR TITLE
Jetpack AI: point upgrade buttons to checkout instead of product interstitial

### DIFF
--- a/projects/js-packages/ai-client/changelog/update-jetpack-ai-change-upgrade-url
+++ b/projects/js-packages/ai-client/changelog/update-jetpack-ai-change-upgrade-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack AI: point upgrade links and buttons to checkout instead of product interstitial.

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-checkout.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-checkout.ts
@@ -29,24 +29,26 @@ export const useCheckout = () => {
 	}, [] );
 
 	/**
+	 * Determine the post-checkout URL
+	 */
+	const siteFragment = getSiteFragment() as string;
+	const redirectToURL =
+		isAtomicSite() || isSimpleSite()
+			? `https://wordpress.com/home/${ siteFragment }`
+			: `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/jetpack-ai`;
+
+	/**
 	 * Use the Jetpack redirect URL to open the checkout page
 	 */
-	const wpcomCheckoutUrl = new URL( `https://jetpack.com/redirect/` );
-	wpcomCheckoutUrl.searchParams.set( 'source', 'jetpack-ai-yearly-tier-upgrade-nudge' );
-	wpcomCheckoutUrl.searchParams.set( 'site', getSiteFragment() as string );
-
-	wpcomCheckoutUrl.searchParams.set(
+	const checkoutUrl = new URL( `https://jetpack.com/redirect/` );
+	checkoutUrl.searchParams.set( 'source', 'jetpack-ai-yearly-tier-upgrade-nudge' );
+	checkoutUrl.searchParams.set( 'site', siteFragment );
+	checkoutUrl.searchParams.set(
 		'path',
 		tierPlansEnabled ? `jetpack_ai_yearly:-q-${ nextTier?.limit }` : 'jetpack_ai_yearly'
 	);
-
-	/**
-	 * Open the product interstitial page
-	 */
-	const jetpackCheckoutUrl = `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?redirect_to_referrer=1&page=my-jetpack#/add-jetpack-ai`;
-
-	const nextTierCheckoutURL =
-		isAtomicSite() || isSimpleSite() ? wpcomCheckoutUrl.toString() : jetpackCheckoutUrl;
+	checkoutUrl.searchParams.set( 'query', `redirect_to=${ encodeURIComponent( redirectToURL ) }` );
+	const nextTierCheckoutURL = checkoutUrl.toString();
 
 	debug( 'Next tier checkout URL: ', nextTierCheckoutURL );
 

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-checkout.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-checkout.ts
@@ -35,7 +35,7 @@ export const useCheckout = () => {
 	const redirectToURL =
 		isAtomicSite() || isSimpleSite()
 			? `https://wordpress.com/home/${ siteFragment }`
-			: `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/jetpack-ai`;
+			: `admin.php?page=my-jetpack#/jetpack-ai`;
 
 	/**
 	 * Use the Jetpack redirect URL to open the checkout page

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-change-upgrade-url
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-change-upgrade-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: point upgrade links and buttons to checkout instead of product interstitial.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
@@ -35,17 +35,11 @@ export default function useAICheckout(): {
 
 	const wpcomRedirectToURL = getWPComRedirectToURL();
 
-	const wpcomCheckoutUrl = tierPlansEnabled
-		? getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
-				site: getSiteFragment() as string,
-				path: `jetpack_ai_yearly:-q-${ nextTier?.limit }`,
-				query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
-		  } )
-		: getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
-				site: getSiteFragment() as string,
-				path: 'jetpack_ai_yearly',
-				query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
-		  } );
+	const wpcomCheckoutUrl = getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
+		site: getSiteFragment() as string,
+		path: tierPlansEnabled ? `jetpack_ai_yearly:-q-${ nextTier?.limit }` : 'jetpack_ai_yearly',
+		query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
+	} );
 
 	const jetpackCheckoutUrl = getRedirectUrl( 'jetpack-ai-upgrade-url-for-jetpack-sites', {
 		site: getSiteFragment() as string,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
@@ -47,7 +47,7 @@ export default function useAICheckout(): {
 				query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
 		  } );
 
-	const jetpackRedirectToURL = `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/jetpack-ai`;
+	const jetpackRedirectToURL = `admin.php?page=my-jetpack#/jetpack-ai`;
 	const jetpackCheckoutUrl = getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
 		site: getSiteFragment() as string,
 		path: 'jetpack_ai_yearly',

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
@@ -47,11 +47,9 @@ export default function useAICheckout(): {
 				query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
 		  } );
 
-	const jetpackRedirectToURL = `admin.php?page=my-jetpack#/jetpack-ai`;
-	const jetpackCheckoutUrl = getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
+	const jetpackCheckoutUrl = getRedirectUrl( 'jetpack-ai-upgrade-url-for-jetpack-sites', {
 		site: getSiteFragment() as string,
 		path: 'jetpack_ai_yearly',
-		query: `redirect_to=${ encodeURIComponent( jetpackRedirectToURL ) }`,
 	} );
 
 	const checkoutUrl = isAtomicSite() || isSimpleSite() ? wpcomCheckoutUrl : jetpackCheckoutUrl;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-checkout/index.ts
@@ -47,10 +47,14 @@ export default function useAICheckout(): {
 				query: `redirect_to=${ encodeURIComponent( wpcomRedirectToURL ) }`,
 		  } );
 
-	const checkoutUrl =
-		isAtomicSite() || isSimpleSite()
-			? wpcomCheckoutUrl
-			: `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?redirect_to_referrer=1&page=my-jetpack#/add-jetpack-ai`;
+	const jetpackRedirectToURL = `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/jetpack-ai`;
+	const jetpackCheckoutUrl = getRedirectUrl( 'jetpack-ai-yearly-tier-upgrade-nudge', {
+		site: getSiteFragment() as string,
+		path: 'jetpack_ai_yearly',
+		query: `redirect_to=${ encodeURIComponent( jetpackRedirectToURL ) }`,
+	} );
+
+	const checkoutUrl = isAtomicSite() || isSimpleSite() ? wpcomCheckoutUrl : jetpackCheckoutUrl;
 
 	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( checkoutUrl );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39437.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the checkout URL for Jetpack sites, to use the raw checkout link instead of the product interstitial
* Small refactor on how the checkout URL is built on WPCOM sites

Note: this will not change the behavior of the "Upgrade" button on the My Jetpack AI card, that will keep linking to the product interstitial

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor on a site with the free Jetpack AI plan
* Use the Jetpack AI until you reach the free limit of requests
   * alternativelly, sandbox the `public-api` domain and configure your `0-sandbox.php` file to simulate this condition (see snippet below)
* We are going to check all upgrade buttons and links, to confirm they are redirecting the user to the checkout URL instead of the product interstitial page on My Jetpack
* Upgrade buttons and links to check:
   * on the sidebar
   * on the AI Assistant block
   * on the AI Extensions
   * on the image tools
      * featured (use the button on the Settings sidebar > Post tab)
      * general (use the button on the image block)
      * logo (use the button on the site logo block)
   * on the excerpt panel
* Click the links and confirm you land on the checkout for the Jetpack AI yearly plan
* When testing the last button/link, proceed with the checkout and confirm you are redirected back to your site, landing on the the Jetpack AI product page

| Before | After |
| --- | --- |
| <img width="600" alt="Screenshot 2024-09-19 at 15 35 47" src="https://github.com/user-attachments/assets/2e98fe20-f9a3-48e0-8ceb-6ab180bda026"> | <img width="600" alt="Screenshot 2024-09-19 at 15 34 05" src="https://github.com/user-attachments/assets/27ce7d83-939f-43be-a1da-28d398392066"> |

---

Snippet to force a free plan on the `0-sandbox.php` file:

```
add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 0; } );
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 20; } );
add_filter( 'jetpack_ai_all_time_requests_count', function() { return 20; } ); // on the limit
```
