### PR TITLE
wpcomsh: maybe_redirect_to_calypso_plugin_pages: quick exit for non-plugin pages

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: maybe_redirect_to_calypso_plugin_pages: quick exit for minor performance gain
+
+

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -286,6 +286,12 @@ add_filter( 'upload_mimes', 'wpcomsh_maybe_restrict_mimetypes', PHP_INT_MAX );
  * MANAGE_PLUGINS feature.
  */
 function wpcomsh_maybe_redirect_to_calypso_plugin_pages() {
+	$request_uri = wp_unslash( $_SERVER['REQUEST_URI'] ); // phpcs:ignore
+	// Quick exit if on non-plugin page.
+	if ( false === strpos( $request_uri, '/wp-admin/plugin' ) ) {
+		return;
+	}
+
 	if ( wpcom_site_has_feature( WPCOM_Features::MANAGE_PLUGINS ) ) {
 		return;
 	}
@@ -293,8 +299,6 @@ function wpcomsh_maybe_redirect_to_calypso_plugin_pages() {
 	if ( ! class_exists( 'Automattic\Jetpack\Status' ) ) {
 		return;
 	}
-
-	$request_uri = wp_unslash( $_SERVER['REQUEST_URI'] ); // phpcs:ignore
 
 	$site = ( new Automattic\Jetpack\Status() )->get_site_suffix();
 


### PR DESCRIPTION
## Proposed changes:

* Lets `wpcomsh_maybe_redirect_to_calypso_plugin_pages()` skip a few computations if we are not on a page where it can act.
  * This is very minor, but something is better than nothing.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Go to `wp-admin/plugins.php` - you should still be redirected to wordpress.com
* Visit other pages and use logging to make sure the quick exit is happening

