### PR TITLE
Forms: fix Single and Multiple Choice fields view styles

### DIFF
--- a/projects/packages/forms/changelog/fix-choice-fields-styles
+++ b/projects/packages/forms/changelog/fix-choice-fields-styles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Single and Multiple Choice fields: fix view styles
+
+

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -399,6 +399,7 @@
 				border-radius: var(--jetpack--contact-form--button-outline--border-radius);
 				padding: var(--jetpack--contact-form--button-outline--padding);
 				line-height: var(--jetpack--contact-form--button-outline--line-height);
+				align-items: center;
 
 				&.field-option-radio {
 					position: relative;
@@ -470,8 +471,9 @@
 		}
 	}
 
-	.jetpack-field-option {
-		&.field-option-radio .jetpack-option__type {
+	.jetpack-field-option.field-option-radio,
+	.wp-block-jetpack-field-option-radio {
+		.jetpack-option__type {
 			transform: translateY(15%); /* Small offset to compensate the slightly odd perceived alignment that's due to the circular shape */
 		}
 	}

--- a/projects/packages/forms/src/contact-form/css/grunion.css
+++ b/projects/packages/forms/src/contact-form/css/grunion.css
@@ -72,6 +72,7 @@
 .contact-form input[type='checkbox'] {
 	top: 0;
 	margin-left: 0;
+	border-radius: 4px;
 }
 
 .contact-form label {
@@ -580,7 +581,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	padding: 0;
 
 	appearance: none;
-	border: solid 1px var(--jetpack--contact-form--text-color);
+	border: solid 1px currentColor;
 
 	outline-offset: 4px;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This PR updates the styles of the _Single Choice_ and _Multiple Choice_ fields so they match in the editor and view.

| Editor | View |
| - | - |
|<img width="146" alt="Screenshot 2024-09-19 at 4 19 35 PM" src="https://github.com/user-attachments/assets/4c6c4d9c-7fdc-4325-812e-45e8708c89ae">|<img width="149" alt="Screenshot 2024-09-19 at 4 21 41 PM" src="https://github.com/user-attachments/assets/a94073bb-c66f-4545-b183-2958739d8930">|
|<img width="164" alt="Screenshot 2024-09-19 at 4 28 53 PM" src="https://github.com/user-attachments/assets/322c5553-8bb7-4c8d-be78-c005a6af1999">|<img width="161" alt="Screenshot 2024-09-19 at 4 28 58 PM" src="https://github.com/user-attachments/assets/f7231352-0ade-4db0-904f-c22f7c6fabff">|

Ideally, we'd prevent code duplication but that's out of scope here.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Spin up a test Jetpack site
- Create a new post
- Add the _Single Choice_ and _Multiple Choice_ fields in a form
- Open the preview
- Notice the fields look like they do in the editor
- Back in the editor, select the _Button_ style from the block sidebar
<img width="282" alt="Screenshot 2024-09-19 at 4 52 44 PM" src="https://github.com/user-attachments/assets/0ad2e0b7-42ca-4b91-add3-753aa610dc2f">


- Open the preview
- Notice the fields look like they do in the editor

