### PR TITLE
Email preview: improve error state visually

### DIFF
--- a/projects/plugins/jetpack/changelog/update-email-preview-error-styles
+++ b/projects/plugins/jetpack/changelog/update-email-preview-error-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Email preview modal: visually improved error state

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.js
@@ -323,7 +323,12 @@ export function NewsletterPreviewModal( { isOpen, onClose, postId } ) {
 						>
 							<Icon icon={ warning } />
 							<h3>{ __( 'Oops, something went wrong showing the preview…', 'jetpack' ) }</h3>
-							<Button onClick={ fetchPreview } variant="primary">
+							<Button
+								onClick={ () => {
+									fetchPreview( selectedAccess );
+								} }
+								variant="primary"
+							>
 								{ __( 'Try again', 'jetpack' ) }
 							</Button>
 						</VStack>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.scss
@@ -1,14 +1,14 @@
 @import "@automattic/color-studio/dist/color-variables";
 
 .jetpack-newsletter-test-email-modal__email-sent {
-  color: $studio-jetpack-green-30;
-  svg {
-    fill: $studio-jetpack-green-30;
-  }
+	color: $studio-jetpack-green-30;
+		svg {
+			fill: $studio-jetpack-green-30;
+		}
 }
 
 .jetpack-newsletter-preview-modal {
-  h1 {
-    flex-shrink: 0;
-  }
+	h1 {
+		flex-shrink: 0;
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -59,13 +59,17 @@ const NewsletterMenu = () => {
 									) }
 								</p>
 								<HStack wrap={ true }>
-									<Button onClick={ openPreviewModal } variant="secondary" disabled={ isPublished }>
+									<Button
+										onClick={ openPreviewModal }
+										variant="secondary"
+										disabled={ isPublished || ! postId }
+									>
 										{ __( 'Preview email', 'jetpack' ) }
 									</Button>
 									<Button
 										onClick={ openTestEmailModal }
 										variant="secondary"
-										disabled={ isPublished }
+										disabled={ isPublished || ! postId }
 									>
 										{ __( 'Send test email', 'jetpack' ) }
 									</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As I was debugging some backend errors, I noticed the error state wasn't great looking, so this is just a quick update to it.

## Proposed changes:
* Adds better looking error state and ability to re-fetch the preview.
* Adds tracks for Errors

### Before

<img width="1503" alt="Screenshot 2024-09-20 at 14 12 15" src="https://github.com/user-attachments/assets/01bbf7da-c7ae-45a6-8bf5-9f2732927531">

### After

<img width="1279" alt="Screenshot 2024-10-01 at 13 31 23" src="https://github.com/user-attachments/assets/5887503c-17a4-46dd-a2af-093cc8929c51">

After 2nd fetch:

<img width="1275" alt="Screenshot 2024-10-01 at 13 31 40" src="https://github.com/user-attachments/assets/5b1511a6-b902-4f76-a9fb-3dee1816a6a5">

Linking to https://jetpack.com/support/


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Trigger error from backend e.g. by returning empty string, see D161896-code for the right file.
* Open the preview modal, see error.
* Remove the backend change, and re-fetch in modal.
* Refetching works.

