### PR TITLE
Fix button white-space issues

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscription-white-space
+++ b/projects/plugins/jetpack/changelog/fix-subscription-white-space
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SubscribeBlock: fix white-space issues

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -60,7 +60,7 @@
 			cursor: pointer;
 		}
 
-		button {
+		.wp-block-jetpack-subscriptions__button {
 			// Prevent white-space issues on Firefox
 			white-space: pre-wrap !important;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -60,8 +60,8 @@
 			cursor: pointer;
 		}
 
-		.wp-block-jetpack-subscriptions__button {
-			// Prevent white-space issues on Firefox
+		// Prevent white-space issues on Firefox
+		.wp-block-jetpack-subscriptions__button[contenteditable="true"] {
 			white-space: pre-wrap !important;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/view.scss
@@ -60,6 +60,11 @@
 			cursor: pointer;
 		}
 
+		button {
+			// Prevent white-space issues on Firefox
+			white-space: pre-wrap !important;
+		}
+
 		input[type="email"]::placeholder,
 		input[type="email"]:disabled {
 			color: currentColor;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
https://github.com/Automattic/jetpack/issues/32837

https://github.com/Automattic/jetpack/assets/6549265/c41c02ff-6026-4811-ac98-e8b779b94972

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Editing the button text of the subscribe block, removes the whitespace characters in firefox.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
- Launch the editor in Firefox.
- Insert the Subscribe block.
- Click on the button text.
- Attempt to enter text that has spaces (eg. I'm in!). The whitespace characters should be kept.
