### PR TITLE
Jetpack AI: use custom input placeholders on the Jetpack Form AI Extension

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-add-custom-placeholders-on-form-extension
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-add-custom-placeholders-on-form-extension
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: use custom placeholders on the Jetpack Form AI extension input component.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/block-handler.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/block-handler.tsx
@@ -98,7 +98,7 @@ export class BlockHandler {
 	 *
 	 * @return {string | null} the custom placeholder.
 	 */
-	public getCustomPlaceholder(): string | null {
+	public getExtensionInputPlaceholder(): string | null {
 		return null;
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/block-handler.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/block-handler.tsx
@@ -92,4 +92,13 @@ export class BlockHandler {
 		__unstableMarkNextChangeAsNotPersistent();
 		replaceInnerBlocks( this.clientId, newBlock.innerBlocks );
 	}
+
+	/**
+	 * Produces a custom placeholder for the AI Assistant Input component.
+	 *
+	 * @return {string | null} the custom placeholder.
+	 */
+	public getCustomPlaceholder(): string | null {
+		return null;
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-input/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/components/ai-assistant-input/index.tsx
@@ -21,6 +21,7 @@ import type { RequestingErrorProps, RequestingStateProp } from '@automattic/jetp
 import type { ReactElement } from 'react';
 
 export type AiAssistantInputProps = {
+	customPlaceholder?: string;
 	className?: string;
 	requestingState: RequestingStateProp;
 	requestingError?: RequestingErrorProps;
@@ -42,6 +43,7 @@ const defaultClassNames = clsx(
 );
 
 export default function AiAssistantInput( {
+	customPlaceholder,
 	className,
 	requestingState,
 	requestingError,
@@ -56,8 +58,11 @@ export default function AiAssistantInput( {
 	undo,
 	tryAgain,
 }: AiAssistantInputProps ): ReactElement {
+	const defaultPlaceholder = customPlaceholder
+		? customPlaceholder
+		: __( 'Ask Jetpack AI to edit…', 'jetpack' );
 	const [ value, setValue ] = useState( '' );
-	const [ placeholder, setPlaceholder ] = useState( __( 'Ask Jetpack AI to edit…', 'jetpack' ) );
+	const [ placeholder, setPlaceholder ] = useState( defaultPlaceholder );
 	const { checkoutUrl } = useAICheckout();
 	const { tracks } = useAnalytics();
 	const [ requestsRemaining, setRequestsRemaining ] = useState( 0 );
@@ -137,13 +142,13 @@ export default function AiAssistantInput( {
 
 	// Sets the placeholder to the quick action text once it changes and clear the input value.
 	useEffect( () => {
-		setPlaceholder( action || __( 'Ask Jetpack AI to edit…', 'jetpack' ) );
+		setPlaceholder( action || defaultPlaceholder );
 
 		// Clear the input value when the action changes.
 		if ( action ) {
 			setValue( '' );
 		}
-	}, [ action ] );
+	}, [ action, defaultPlaceholder ] );
 
 	// Changes the displayed message according to the input value.
 	useEffect( () => {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/get-block-handler.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/get-block-handler.tsx
@@ -58,7 +58,7 @@ export function getBlockHandler( blockType: ExtendedBlockProp, clientId: string 
 		onSuggestion: handler.onSuggestion.bind( handler ),
 		onDone: handler.onDone.bind( handler ),
 		getContent: handler.getContent.bind( handler ),
-		getCustomPlaceholder: handler.getCustomPlaceholder.bind( handler ),
+		getExtensionInputPlaceholder: handler.getExtensionInputPlaceholder.bind( handler ),
 		behavior: handler.behavior,
 		isChildBlock: handler.isChildBlock,
 		feature: handler.feature,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/get-block-handler.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/get-block-handler.tsx
@@ -58,6 +58,7 @@ export function getBlockHandler( blockType: ExtendedBlockProp, clientId: string 
 		onSuggestion: handler.onSuggestion.bind( handler ),
 		onDone: handler.onDone.bind( handler ),
 		getContent: handler.getContent.bind( handler ),
+		getCustomPlaceholder: handler.getCustomPlaceholder.bind( handler ),
 		behavior: handler.behavior,
 		isChildBlock: handler.isChildBlock,
 		feature: handler.feature,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-form/index.tsx
@@ -125,7 +125,7 @@ export class JetpackFormHandler extends BlockHandler {
 		}
 	}
 
-	public getCustomPlaceholder(): string {
+	public getExtensionInputPlaceholder(): string {
 		const content = this.getContent();
 
 		if ( ! content ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/jetpack-form/index.tsx
@@ -125,6 +125,32 @@ export class JetpackFormHandler extends BlockHandler {
 		}
 	}
 
+	public getCustomPlaceholder(): string {
+		const content = this.getContent();
+
+		if ( ! content ) {
+			// If the block is empty, return a random example for creating a form.
+			const createExamples = [
+				__( 'Example: a contact form with name, email, and message fields', 'jetpack' ),
+				__(
+					'Example: a pizza ordering form with name, address, phone number and toppings',
+					'jetpack'
+				),
+				__( 'Example: a survey form with multiple choice questions', 'jetpack' ),
+			];
+
+			return createExamples[ Math.floor( Math.random() * createExamples.length ) ];
+		}
+		// If the block has content, return a random example for editing a form.
+		const editExamples = [
+			__( 'Example: remove email field', 'jetpack' ),
+			__( 'Example: make email optional', 'jetpack' ),
+			__( 'Example: add message field and make it required', 'jetpack' ),
+		];
+
+		return editExamples[ Math.floor( Math.random() * editExamples.length ) ];
+	}
+
 	public getContent() {
 		const block = this.getBlock();
 		if ( ! block ) {

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/types.ts
@@ -16,6 +16,7 @@ export interface IBlockHandler {
 	onSuggestion: OnSuggestion;
 	onDone: ( suggestion: string ) => void;
 	getContent: () => string;
+	getCustomPlaceholder: () => string | null;
 	behavior: BlockBehavior;
 	isChildBlock?: boolean;
 	feature: string;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/types.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/types.ts
@@ -16,7 +16,7 @@ export interface IBlockHandler {
 	onSuggestion: OnSuggestion;
 	onDone: ( suggestion: string ) => void;
 	getContent: () => string;
-	getCustomPlaceholder: () => string | null;
+	getExtensionInputPlaceholder: () => string | null;
 	behavior: BlockBehavior;
 	isChildBlock?: boolean;
 	feature: string;

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
@@ -500,7 +500,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 				{ showAiControl && (
 					<AiAssistantInput
-						customPlaceholder={ customPlaceholder ? customPlaceholder : undefined }
+						customPlaceholder={ customPlaceholder ? customPlaceholder : null }
 						className={ className }
 						requestingState={ requestingState }
 						requestingError={ error }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
@@ -123,6 +123,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			onSuggestion: onBlockSuggestion,
 			onDone: onBlockDone,
 			getContent,
+			getCustomPlaceholder,
 			behavior,
 			isChildBlock,
 			feature,
@@ -130,6 +131,8 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			startOpen,
 			hideOnBlockFocus,
 		} = useMemo( () => getBlockHandler( blockName, clientId ), [ blockName, clientId ] );
+
+		const customPlaceholder = getCustomPlaceholder();
 
 		// State to display the AI Control or not.
 		const [ showAiControl, setShowAiControl ] = useState( startOpen );
@@ -497,6 +500,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 				{ showAiControl && (
 					<AiAssistantInput
+						customPlaceholder={ customPlaceholder ? customPlaceholder : undefined }
 						className={ className }
 						requestingState={ requestingState }
 						requestingError={ error }

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/with-ai-extension.tsx
@@ -123,7 +123,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			onSuggestion: onBlockSuggestion,
 			onDone: onBlockDone,
 			getContent,
-			getCustomPlaceholder,
+			getExtensionInputPlaceholder,
 			behavior,
 			isChildBlock,
 			feature,
@@ -132,7 +132,7 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			hideOnBlockFocus,
 		} = useMemo( () => getBlockHandler( blockName, clientId ), [ blockName, clientId ] );
 
-		const customPlaceholder = getCustomPlaceholder();
+		const customPlaceholder = getExtensionInputPlaceholder();
 
 		// State to display the AI Control or not.
 		const [ showAiControl, setShowAiControl ] = useState( startOpen );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39439.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Support custom placeholders on the AI Assistant input component
* Support custom placeholders on the Block Handler class
* Add custom placeholders on the Jetpack Form Block Handler class, aware of the form block context, so we can switch between form creation and form edition placeholders

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* There are two things to test:
   * the extension keeps working as before for all other blocks except the form block
   * the form block behavior is correct and appropriate

Let's start testing the extension behavior on all other blocks.

* Ask the AI Assistant block to generate some sample content about a topic, including headings, paragaphs and lists
* Test all the cases below:
   * paragraph block
   * list block
   * list item block
   * heading block
* On all the cases, confirm:
   * the AI extension will load as expected
   * the placeholder is still `Ask Jetpack AI to edit…`
   * the placeholder of the quick actions is being set as expected (Example, `Simplify` for the respective action)

Now, let's test the new placeholder for the Jetpack Form block

* Add a Jetpack Form block
* Open the AI extension on it
* Confirm you see a different placeholder, one of the following:
   * `Example: a contact form with name, email, and message fields`
   * `Example: a pizza ordering form with name, address, phone number and toppings`
   * `Example: a survey form with multiple choice questions`
   * the value is random, so when you close the extension and open it again, you may see a different value
* Ask for a form and, when it is ready, check the placeholder on the extension
* It will be one of the following:
   * `Example: remove email field`
   * `Example: make email optional`
   * `Example: add message field and make it required`
   * again, the value is random, so when you close the extension and open it again, you may see a different value
* Confirm the examples and the behavior make sense 