### PR TITLE
Performance: change default imploding to false

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-imploding-css
+++ b/projects/plugins/jetpack/changelog/remove-imploding-css
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Performance: set the concatenated CSS to false by default. The era where this was helpful is passing.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -5688,9 +5688,10 @@ endif;
 	 * @param bool $travis_test Is this a test run.
 	 *
 	 * @since 3.2
+	 * @since $$next-version$$ Default to not imploding. Requires a filter to enable. This may be temporary before dropping completely.
 	 */
 	public function implode_frontend_css( $travis_test = false ) {
-		$do_implode = true;
+		$do_implode = false;
 		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
 			$do_implode = false;
 		}

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -5692,13 +5692,15 @@ endif;
 	 */
 	public function implode_frontend_css( $travis_test = false ) {
 		$do_implode = false;
-		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
-			$do_implode = false;
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
+			// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+			// $do_implode = false;
 		}
 
 		// Do not implode CSS when the page loads via the AMP plugin.
-		if ( class_exists( Jetpack_AMP_Support::class ) && Jetpack_AMP_Support::is_amp_request() ) {
-			$do_implode = false;
+		if ( class_exists( Jetpack_AMP_Support::class ) && Jetpack_AMP_Support::is_amp_request() ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
+			// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+			// $do_implode = false;
 		}
 
 		/*
@@ -5709,8 +5711,9 @@ endif;
 		$active_modules                = self::get_active_modules();
 		$modules_with_concatenated_css = $this->modules_with_concatenated_css;
 		$active_module_with_css_count  = count( array_intersect( $active_modules, $modules_with_concatenated_css ) );
-		if ( $active_module_with_css_count < 2 ) {
-			$do_implode = false;
+		if ( $active_module_with_css_count < 2 ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedIf
+			// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+			// $do_implode = false;
 		}
 
 		/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Initial work re p1HpG7-uqh-p2#comment-74006

## Proposed changes:
* The large CSS file is not as effective as it once was, so this changes the default behavior to not enqueue the large file instead of individual CSS files.
* At this stage, the existing functionality is still included if `add_filter( 'jetpack_implode_frontend_css', '__return_true' );`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-uqh-p2#comment-74006

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Before patch, enable a few modules from this list: 	'carousel', 'contact-form', 'infinite-scroll', 'likes', 'related-posts', 'sharedaddy', 'shortcodes', 'subscriptions', 'tiled-gallery', 'widgets',
* Ensuring `SCRIPT_DEBUG` is not enabled, visit the frontend and check the sources for `jetpack.css` (the imploded file)
* With this patch, repeat and confirm there is not a `jetpack.css` file, but are CSS for the modules you enabled.
* With this patch, add `add_filter( 'jetpack_implode_frontend_css', '__return_true' );` to your site and repeat. You should see the `jetpack.css` file included again.