### PR TITLE
Jetpack mu wpcom: Remove import of class-wp-rest-wpcom-block-editor-sharing-modal-controller.php

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-sharing-modal-controller
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-sharing-modal-controller
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Removed import of the class-wp-rest-wpcom-block-editor-sharing-modal-controller.php controller

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
@@ -101,10 +101,6 @@ class WPCOM_Block_Editor_NUX {
 		require_once __DIR__ . '/class-wp-rest-wpcom-block-editor-video-celebration-modal-controller.php';
 		$video_celebration_modal_controller = new WP_REST_WPCOM_Block_Editor_Video_Celebration_Modal_Controller();
 		$video_celebration_modal_controller->register_rest_route();
-
-		require_once __DIR__ . '/class-wp-rest-wpcom-block-editor-sharing-modal-controller.php';
-		$sharing_modal_controller = new WP_REST_WPCOM_Block_Editor_Sharing_Modal_Controller();
-		$sharing_modal_controller->register_rest_route();
 	}
 }
 add_action( 'init', array( __NAMESPACE__ . '\WPCOM_Block_Editor_NUX', 'init' ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/class-wpcom-block-editor-nux.php
@@ -64,22 +64,6 @@ class WPCOM_Block_Editor_NUX {
 			"var launchpadOptions = $launchpad_options;",
 			'before'
 		);
-
-		/**
-		 * Enqueue the sharing modal options.
-		 */
-		$sharing_modal_options = wp_json_encode(
-			array(
-				'isDismissed' => WP_REST_WPCOM_Block_Editor_Sharing_Modal_Controller::get_wpcom_sharing_modal_dismissed(),
-			),
-			JSON_HEX_TAG | JSON_HEX_AMP
-		);
-
-		wp_add_inline_script(
-			$handle,
-			"var sharingModalOptions = $sharing_modal_options;",
-			'before'
-		);
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
This PR removes the import of class-wp-rest-wpcom-block-editor-sharing-modal-controller.php, in preparation for https://github.com/Automattic/jetpack/pull/39489, which will delete the files.

This is done since our deployment process require both to be separate operations. Note that this PR will make the endpoint /wpcom/v2/block-editor/sharing-modal-dismissed temporarily unavailable, so the deployment must be immediately followed by the next PR.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

N/A

