### PR TITLE
Admin bar: ensure the Atomic debug bar is the leftmost menu

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/debug-bar-left
+++ b/projects/packages/jetpack-mu-wpcom/changelog/debug-bar-left
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: ensure the Atomic debug bar is the leftmost menu

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -57,25 +57,18 @@ function wpcom_enqueue_admin_bar_assets() {
 	);
 
 	/**
-	 * Hotfix the order of the admin menu items due to WP 6.6
-	 * See https://core.trac.wordpress.org/ticket/61615.
+	 * Force the Atomic debug bar menu to be the first menu at the top-right.
 	 */
-	$wp_version = get_bloginfo( 'version' );
-	if ( version_compare( $wp_version, '6.6', '<=' ) && version_compare( $wp_version, '6.6.RC', '>=' ) ) {
+	if ( defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST ) {
 		wp_add_inline_style(
 			'wpcom-admin-bar',
 			<<<CSS
 				#wpadminbar .quicklinks #wp-admin-bar-top-secondary {
 					display: flex;
-					flex-direction: row-reverse;
 				}
 
-				#wpadminbar .quicklinks #wp-admin-bar-top-secondary #wp-admin-bar-search {
+				#wpadminbar .quicklinks #wp-admin-bar-top-secondary #wp-admin-bar-debug-bar {
 					order: -1;
-				}
-
-				#wpadminbar .quicklinks #wp-admin-bar-top-secondary #wp-admin-bar-help-center {
-					order: 1;
 				}
 CSS
 		);


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/wp-calypso/issues/94472

## Proposed changes:

This PR ensures that the debug bar on Automattician's Atomic sites (under proxy) is the leftmost menu, similar to where it was before the "Nav Redesign".

One rationale is to avoid "masterbar jumps" when switching between Atomic and Simple sites.

Before

<img width="444" alt="image" src="https://github.com/user-attachments/assets/fb5f5687-0c6f-48a2-9bc1-4e7899471dd5">

After

<img width="444" alt="image" src="https://github.com/user-attachments/assets/fccadb66-fbc7-41b6-97ac-44249697b6f3">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Prepare an Atomic site with Jetpack Beta Tester.
2. Patch this PR.
3. Go to /wp-admin while proxied; verify that the Debug bar is on the left.
3. Go to /wp-admin while not proxied; verify that the Debug bar not there and everything still works.
4. Test on site frontend as well.

