### PR TITLE
Jetpack AI: remove default style parameter from jetpack-ai-image requests

### DIFF
--- a/projects/js-packages/ai-client/changelog/remove-jetpack-ai-image-generator-style-parameter
+++ b/projects/js-packages/ai-client/changelog/remove-jetpack-ai-image-generator-style-parameter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Client: don't send a default style to jetpack-ai-image endpoint, default is handled in backend and we need to not send it until we're ready for it to be a user option

--- a/projects/js-packages/ai-client/src/hooks/use-image-generator/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-image-generator/index.ts
@@ -214,7 +214,6 @@ const useImageGenerator = () => {
 				prompt,
 				feature,
 				model: 'stable-diffusion',
-				style: 'photographic',
 			};
 
 			const data: ImageGenerationResponse = await executeImageGeneration( parameters );

--- a/projects/plugins/jetpack/changelog/remove-jetpack-ai-image-generator-style-parameter
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-ai-image-generator-style-parameter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: remove style parameter from image generation requests until we mean it

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -123,7 +123,6 @@ export default function useAiImage( {
 					feature,
 					size: '1792x1024', // the size, when the generation happens with DALL-E-3
 					responseFormat: 'b64_json', // the response format, when the generation happens with DALL-E-3
-					style: 'photographic', // the style of the image, when the generation happens with Stable Diffusion
 					messages: [
 						{
 							role: 'jetpack-ai',


### PR DESCRIPTION

## Proposed changes:
Stop sending a default `style` parameter on image (featured and general) generation requests. The default is handled on backend and we'll need the parameter to be optional yet deliberate once we implement the styles.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Sandbox public-api.

Without checking out the branch, I recommend you trigger an image generation from our usual 3 spots:
- logo block
- image block
- featured image sidebar

Then checkout the branch, build/watch both js-packages/ai-client and plugins/jetpack, then reload and repeat the 3 generation requests (same prompts).

Observe:
- while non-deterministic, images should look similar between the 2 generations (meaning the lack of `style` parameter didn't change anything)
- check the requests (`jetpack-ai-image`) payloads to see the `style` parameter is not present on the requests