### PR TITLE
Jetpack AI: turn all features on by default when Write Brief is enabled

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-write-brief-enabled-by-default-features
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-write-brief-enabled-by-default-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Write Brief: turn spelling mistakes and long sentences on by default when tool is enabled.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/long-sentences/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/long-sentences/index.ts
@@ -16,7 +16,7 @@ export const LONG_SENTENCES: BreveFeatureConfig = {
 	title: __( 'Long sentences', 'jetpack' ),
 	tagName: 'span',
 	className: 'jetpack-ai-breve__has-proofread-highlight--long-sentences',
-	defaultEnabled: false,
+	defaultEnabled: true,
 };
 
 const sentenceRegex = /[^\s][^.!?]+[.!?]+/g;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -28,7 +28,7 @@ export const SPELLING_MISTAKES: BreveFeatureConfig = {
 	title: __( 'Spelling mistakes', 'jetpack' ),
 	tagName: 'span',
 	className: 'jetpack-ai-breve__has-proofread-highlight--spelling-mistakes',
-	defaultEnabled: false,
+	defaultEnabled: true,
 };
 
 const spellCheckers: { [ key: string ]: SpellChecker } = {};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39438.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Change the `defaultEnabled` flag to `true` for all Write Brief features, so they are ON by default when the tool is enabled

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor of a fresh new site, or make sure you cleaned existing Write Brief preferences on the browser local storage (delete all just to make sure):

<img width="250" alt="Screenshot 2024-09-23 at 15 44 20" src="https://github.com/user-attachments/assets/f4c11b62-5921-4462-bdb9-b9f7210f71bd">

* Look for the AI Assistant section on the Jetpack sidebar
* On the Write Brief section, confirm you see all the features checked (but disabled, greyed):

| Before | After |
| --- | --- |
| <img width="200" alt="Screenshot 2024-09-23 at 15 24 33" src="https://github.com/user-attachments/assets/9b052a31-4a45-4026-a7a9-b7764cc67508"> |  <img width="200" alt="Screenshot 2024-09-23 at 15 29 57" src="https://github.com/user-attachments/assets/e6d09c95-6c23-4af9-bd7e-029ef2d38339"> |

* Toggle the Write Brief switch to enable the tool
* Confirm you see all the features checked and enabled:

| Before | After |
| --- | --- |
| <img width="200" alt="Screenshot 2024-09-23 at 15 24 43" src="https://github.com/user-attachments/assets/6efa653d-5d1f-48f1-9a41-f68b83df6049"> | <img width="236" alt="Screenshot 2024-09-23 at 15 30 03" src="https://github.com/user-attachments/assets/2ac8896b-95b3-4c80-86eb-440dca600318"> |

* Just in case, after enabling it, reload the editor and confirm all features stays enabled