### PR TITLE
Dashboard: Remove user connection nudge from stats at a glance

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -9,7 +9,7 @@ import analytics from 'lib/analytics';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
-import { isOdysseyStatsEnabled, isWoASite } from 'state/initial-state';
+import { isOdysseyStatsEnabled } from 'state/initial-state';
 
 class DashStatsBottom extends Component {
 	statsBottom() {
@@ -154,6 +154,5 @@ DashStatsBottom.defaultProps = {
 export default connect( state => {
 	return {
 		isOdysseyStatsEnabled: isOdysseyStatsEnabled( state ),
-		isWoASite: isWoASite( state ),
 	};
 } )( DashStatsBottom );

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -5,12 +5,11 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import Button from 'components/button';
-import ConnectButton from 'components/connect-button';
 import analytics from 'lib/analytics';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
-import { isOdysseyStatsEnabled, isWoASite, userCanConnectAccount } from 'state/initial-state';
+import { isOdysseyStatsEnabled, isWoASite } from 'state/initial-state';
 
 class DashStatsBottom extends Component {
 	statsBottom() {
@@ -108,16 +107,6 @@ class DashStatsBottom extends Component {
 								),
 							} )
 						}
-						{ ! this.props.isLinked && this.props.userCanConnectAccount && (
-							<ConnectButton
-								connectUser={ true }
-								from="unlinked-user-connect"
-								connectLegend={ __(
-									'Connect your WordPress.com account for more metrics',
-									'jetpack'
-								) }
-							/>
-						) }
 						{ this.props.isLinked &&
 							! this.props.isOdysseyStatsEnabled && // Only show if Odyssey Stats is disabled
 							createInterpolateElement(
@@ -166,6 +155,5 @@ export default connect( state => {
 	return {
 		isOdysseyStatsEnabled: isOdysseyStatsEnabled( state ),
 		isWoASite: isWoASite( state ),
-		userCanConnectAccount: userCanConnectAccount( state ),
 	};
 } )( DashStatsBottom );

--- a/projects/plugins/jetpack/changelog/remove-user-connection-nudge-from-stats-at-a-glance
+++ b/projects/plugins/jetpack/changelog/remove-user-connection-nudge-from-stats-at-a-glance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove user connection nudge from Stats module on the dashboard


### PR DESCRIPTION
## Proposed changes:

* Remove user-connection nudge from stats module on Dashboard At A Glance

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-bJy-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect your site, but not your user
3. Go to `/wp-admin/admin.php?page=jetpack#/dashboard`
4. Make sure you don't see the user connection CTA
Before:
![image](https://github.com/user-attachments/assets/d2cad628-bc29-497e-8240-12ab4f852a1b)
After:
![image](https://github.com/user-attachments/assets/48705c29-e115-432f-bb1c-2c93466f98d0)
