### PR TITLE
Superadmin bar: always point to wp-admin even on Default admin interface style

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/admin-bar-dash-fix
+++ b/projects/packages/jetpack-mu-wpcom/changelog/admin-bar-dash-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Superadmin bar: always point to wp-admin even on Default admin interface style

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/class-wpcom-admin-bar.php
@@ -59,6 +59,10 @@ class WPCOM_Admin_Bar extends \WP_Admin_Bar {
 			parent::add_node( $args );
 			return;
 		}
+		if ( isset( $args['id'] ) && $args['id'] === 'wpcom-blog-dashboard' ) {
+			parent::add_node( $args );
+			return;
+		}
 		$home_url  = home_url( '/' );
 		$site_slug = wp_parse_url( $home_url, PHP_URL_HOST );
 		$href      = str_replace( $home_url, '', $args['href'] );


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/wp-calypso/issues/94836

## Proposed changes:

This fixes a regression where the superadmin Dash menu would point to My Home instead of wp-admin.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Be a superadmin.
1. Sandbox a Simple site.
2. Patch this to your sandbox.
1. Go to Settings -> General and set the Admin interface style to Default.
1. Go to the site's frontend.
1. Click the Dash superadmin menu.
2. Verify that you go to wp-admin.
