### PR TITLE
Jetpack Connection - REST API: Allow site-level authentication on POST requests to 'jetpack/v4/connection'

### DIFF
--- a/projects/packages/connection/changelog/update-rest-api-disconnect-allow-blog-token
+++ b/projects/packages/connection/changelog/update-rest-api-disconnect-allow-blog-token
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack Connection - REST API: Allow site-level authentication on POST requests to 'jetpack/v4/connection'

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -545,18 +545,18 @@ class REST_Connector {
 	 *
 	 * @since 1.30.1
 	 *
-	 * @return bool|WP_Error True if user is able to disconnect the site.
+	 * @since $$next-version$$ Modified the permission check to accept requests signed with blog tokens.
+	 *
+	 * @return bool|WP_Error True if user is able to disconnect the site or the request is signed with a blog token (aka a direct request from WPCOM).
 	 */
 	public static function disconnect_site_permission_check() {
 		if ( current_user_can( 'jetpack_disconnect' ) ) {
 			return true;
 		}
 
-		return new WP_Error(
-			'invalid_user_permission_jetpack_disconnect',
-			self::get_user_permissions_error_msg(),
-			array( 'status' => rest_authorization_required_code() )
-		);
+		return Rest_Authentication::is_signed_with_blog_token()
+			? true
+			: new WP_Error( 'invalid_user_permission_jetpack_disconnect', self::get_user_permissions_error_msg(), array( 'status' => rest_authorization_required_code() ) );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/test-rest-endpoints.php
+++ b/projects/packages/connection/tests/php/test-rest-endpoints.php
@@ -470,10 +470,7 @@ class Test_REST_Endpoints extends TestCase {
 
 		add_action( 'jetpack_updated_user_token', $action_hook, 10, 2 );
 
-		$token     = 'new:1:0';
-		$timestamp = (string) time();
-		$nonce     = 'testing123';
-		$body_hash = '';
+		$this->mock_signed_post_request_with_blog_token();
 
 		wp_cache_set(
 			1,
@@ -483,38 +480,6 @@ class Test_REST_Endpoints extends TestCase {
 			),
 			'users'
 		);
-
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-
-		$_GET['_for']      = 'jetpack';
-		$_GET['token']     = $token;
-		$_GET['timestamp'] = $timestamp;
-		$_GET['nonce']     = $nonce;
-		$_GET['body-hash'] = $body_hash;
-		// This is intentionally using base64_encode().
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		$_GET['signature'] = base64_encode(
-			hash_hmac(
-				'sha1',
-				implode(
-					"\n",
-					$data  = array(
-						$token,
-						$timestamp,
-						$nonce,
-						$body_hash,
-						'POST',
-						'anything.example',
-						'80',
-						'',
-					)
-				) . "\n",
-				'blogtoken',
-				true
-			)
-		);
-
-		Connection_Rest_Authentication::init()->wp_rest_authenticate( false );
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/user-token' );
 		$request->set_header( 'Content-Type', 'application/json' );
@@ -673,6 +638,33 @@ class Test_REST_Endpoints extends TestCase {
 
 		remove_filter( 'pre_http_request', array( $this, 'mock_xmlrpc_success' ), 10 );
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_options' ), 10 );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'success', $response_data['code'] );
+	}
+
+	/**
+	 * Testing the `POST /jetpack/v4/connection` endpoint, aka site disconnect endpoint, on success with a site-level connection (blog token).
+	 */
+	public function test_disconnect_site_site_connection_success() {
+		wp_set_current_user( 0 );
+		// Mock full connection established.
+		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10, 2 );
+
+		$this->mock_signed_post_request_with_blog_token();
+
+		// Mock site successfully disconnected on WPCOM.
+		add_filter( 'pre_http_request', array( $this, 'mock_xmlrpc_success' ), 10, 3 );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/connection' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'isActive' => false ) ) );
+
+		$response      = $this->server->dispatch( $request );
+		$response_data = $response->get_data();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_xmlrpc_success' ), 10 );
+		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10 );
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'success', $response_data['code'] );
@@ -942,37 +934,7 @@ class Test_REST_Endpoints extends TestCase {
 		// Mock full connection established.
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_options' ), 10, 2 );
 
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-
-		$_GET['_for']      = 'jetpack';
-		$_GET['token']     = 'new:1:0';
-		$_GET['timestamp'] = (string) time();
-		$_GET['nonce']     = 'testing123';
-		$_GET['body-hash'] = '';
-		// This is intentionally using base64_encode().
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		$_GET['signature'] = base64_encode(
-			hash_hmac(
-				'sha1',
-				implode(
-					"\n",
-					$data  = array(
-						$_GET['token'],
-						$_GET['timestamp'],
-						$_GET['nonce'],
-						$_GET['body-hash'],
-						'POST',
-						'anything.example',
-						'80',
-						'',
-					)
-				) . "\n",
-				'blogtoken',
-				true
-			)
-		);
-
-		Connection_Rest_Authentication::init()->wp_rest_authenticate( false );
+		$this->mock_signed_post_request_with_blog_token();
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/remote_register' );
 		$request->set_header( 'Content-Type', 'application/json' );
@@ -1027,37 +989,7 @@ class Test_REST_Endpoints extends TestCase {
 		// Mock full connection established.
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_options' ), 10, 2 );
 
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-
-		$_GET['_for']      = 'jetpack';
-		$_GET['token']     = 'new:1:0';
-		$_GET['timestamp'] = (string) time();
-		$_GET['nonce']     = 'testing123';
-		$_GET['body-hash'] = '';
-		// This is intentionally using base64_encode().
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		$_GET['signature'] = base64_encode(
-			hash_hmac(
-				'sha1',
-				implode(
-					"\n",
-					$data  = array(
-						$_GET['token'],
-						$_GET['timestamp'],
-						$_GET['nonce'],
-						$_GET['body-hash'],
-						'POST',
-						'anything.example',
-						'80',
-						'',
-					)
-				) . "\n",
-				'blogtoken',
-				true
-			)
-		);
-
-		Connection_Rest_Authentication::init()->wp_rest_authenticate( false );
+		$this->mock_signed_post_request_with_blog_token();
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/remote_provision' );
 		$request->set_header( 'Content-Type', 'application/json' );
@@ -1108,37 +1040,7 @@ class Test_REST_Endpoints extends TestCase {
 		// Mock full connection established.
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_options' ), 10, 2 );
 
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-
-		$_GET['_for']      = 'jetpack';
-		$_GET['token']     = 'new:1:0';
-		$_GET['timestamp'] = (string) time();
-		$_GET['nonce']     = 'testing123';
-		$_GET['body-hash'] = '';
-		// This is intentionally using base64_encode().
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		$_GET['signature'] = base64_encode(
-			hash_hmac(
-				'sha1',
-				implode(
-					"\n",
-					$data  = array(
-						$_GET['token'],
-						$_GET['timestamp'],
-						$_GET['nonce'],
-						$_GET['body-hash'],
-						'POST',
-						'anything.example',
-						'80',
-						'',
-					)
-				) . "\n",
-				'blogtoken',
-				true
-			)
-		);
-
-		Connection_Rest_Authentication::init()->wp_rest_authenticate( false );
+		$this->mock_signed_post_request_with_blog_token();
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/remote_connect' );
 		$request->set_header( 'Content-Type', 'application/json' );
@@ -1195,37 +1097,7 @@ class Test_REST_Endpoints extends TestCase {
 		// Mock full connection established.
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_options' ), 10, 2 );
 
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-
-		$_GET['_for']      = 'jetpack';
-		$_GET['token']     = 'new:1:0';
-		$_GET['timestamp'] = (string) time();
-		$_GET['nonce']     = 'testing123';
-		$_GET['body-hash'] = '';
-		// This is intentionally using base64_encode().
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		$_GET['signature'] = base64_encode(
-			hash_hmac(
-				'sha1',
-				implode(
-					"\n",
-					array(
-						$_GET['token'],
-						$_GET['timestamp'],
-						$_GET['nonce'],
-						$_GET['body-hash'],
-						'POST',
-						'anything.example',
-						'80',
-						'',
-					)
-				) . "\n",
-				'blogtoken',
-				true
-			)
-		);
-
-		Connection_Rest_Authentication::init()->wp_rest_authenticate( false );
+		$this->mock_signed_post_request_with_blog_token();
 
 		$request = new WP_REST_Request( 'GET', '/jetpack/v4/heartbeat/data' );
 		$request->set_header( 'Content-Type', 'application/json' );
@@ -1269,37 +1141,7 @@ class Test_REST_Endpoints extends TestCase {
 		// Mock full connection established.
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_options' ), 10, 2 );
 
-		$_SERVER['REQUEST_METHOD'] = 'POST';
-
-		$_GET['_for']      = 'jetpack';
-		$_GET['token']     = 'new:1:0';
-		$_GET['timestamp'] = (string) time();
-		$_GET['nonce']     = 'testing123';
-		$_GET['body-hash'] = '';
-		// This is intentionally using base64_encode().
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		$_GET['signature'] = base64_encode(
-			hash_hmac(
-				'sha1',
-				implode(
-					"\n",
-					array(
-						$_GET['token'],
-						$_GET['timestamp'],
-						$_GET['nonce'],
-						$_GET['body-hash'],
-						'POST',
-						'anything.example',
-						'80',
-						'',
-					)
-				) . "\n",
-				'blogtoken',
-				true
-			)
-		);
-
-		Connection_Rest_Authentication::init()->wp_rest_authenticate( false );
+		$this->mock_signed_post_request_with_blog_token();
 
 		$request = new WP_REST_Request( 'GET', '/jetpack/v4/connection/check' );
 		$request->set_header( 'Content-Type', 'application/json' );
@@ -1816,5 +1658,44 @@ class Test_REST_Endpoints extends TestCase {
 		}
 
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_options' ), 10 );
+	}
+
+	private function mock_signed_post_request_with_blog_token() {
+		$token     = 'new:1:0';
+		$timestamp = (string) time();
+		$nonce     = 'testing123';
+		$body_hash = '';
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+
+		$_GET['_for']      = 'jetpack';
+		$_GET['token']     = $token;
+		$_GET['timestamp'] = $timestamp;
+		$_GET['nonce']     = $nonce;
+		$_GET['body-hash'] = $body_hash;
+		// This is intentionally using base64_encode().
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$_GET['signature'] = base64_encode(
+			hash_hmac(
+				'sha1',
+				implode(
+					"\n",
+					$data  = array(
+						$token,
+						$timestamp,
+						$nonce,
+						$body_hash,
+						'POST',
+						'anything.example',
+						'80',
+						'',
+					)
+				) . "\n",
+				'blogtoken',
+				true
+			)
+		);
+
+		Connection_Rest_Authentication::init()->wp_rest_authenticate( false );
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Jetpack Connection - REST API: Allow site-level authentication on POST requests to 'jetpack/v4/connection'.
Useful when directly disconnecting a site from WPCOM for troubleshooting purposes.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Connection\REST_Connector`: Update `disconnect_site_permission_check` to allow requests signed with blog tokens

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf5801-18d-p2#comment-552

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
D162088-code