### PR TITLE
Jetpack AI: add beta flag for style support on logo generator

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-image-generation-styles-beta-flag
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-image-generation-styles-beta-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: add beta flag to support styles dropdown on logo generator

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -197,3 +197,15 @@ add_action(
 		}
 	}
 );
+
+/**
+ * Register the `ai-logo-style-selector-support` extension.
+ */
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function () {
+		if ( apply_filters( 'jetpack_ai_enabled', true ) && apply_filters( 'jetpack_ai_logo_style_selector_enabled', false ) ) {
+			\Jetpack_Gutenberg::set_extension_available( 'ai-logo-style-selector-support' );
+		}
+	}
+);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -71,15 +71,15 @@
 		"ai-general-purpose-image-generator",
 		"ai-proofread-breve",
 		"ai-assistant-site-logo-support",
-		"ai-title-optimization-keywords-support",
-		"ai-logo-style-selector-support"
+		"ai-title-optimization-keywords-support"
 	],
 	"beta": [
 		"google-docs-embed",
 		"recipe",
 		"v6-video-frame-poster",
 		"videopress/video-chapters",
-		"ai-assistant-backend-prompts"
+		"ai-assistant-backend-prompts",
+		"ai-logo-style-selector-support"
 	],
 	"experimental": [],
 	"no-post-editor": [

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -71,7 +71,8 @@
 		"ai-general-purpose-image-generator",
 		"ai-proofread-breve",
 		"ai-assistant-site-logo-support",
-		"ai-title-optimization-keywords-support"
+		"ai-title-optimization-keywords-support",
+		"ai-logo-style-selector-support"
 	],
 	"beta": [
 		"google-docs-embed",


### PR DESCRIPTION


## Proposed changes:
This PR adds a new entry on the beta blocks/features list: `ai-logo-style-selector-support`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The flag will be hidden behind a filter. To test, checkout the branch, build/watch it, then go to the editor and open the console.
Look for `Jetpack_Editor_Initial_State.available_blocks['ai-logo-style-selector-support']`, it should read `{ available: false }`.

Now add the filter on a snippet or local env: `add_filter( 'jetpack_ai_logo_style_selector_enabled', '__return_true' );`. Reload the editor and check the value on the console again, it should read `{ available: true }`