### PR TITLE
WAF: Include waf_supported and automatic_rules_last_updated in the jetpack/v4/waf REST API endpoint response

### DIFF
--- a/projects/packages/waf/changelog/add-waf-api-new-properties
+++ b/projects/packages/waf/changelog/add-waf-api-new-properties
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+WAF: Add new properties to the WAF feature's REST API endpoint.

--- a/projects/packages/waf/src/class-rest-controller.php
+++ b/projects/packages/waf/src/class-rest-controller.php
@@ -90,7 +90,15 @@ class REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public static function waf() {
-		return rest_ensure_response( Waf_Runner::get_config() );
+		return rest_ensure_response(
+			array_merge(
+				Waf_Runner::get_config(),
+				array(
+					'waf_supported'                => Waf_Runner::is_supported_environment(),
+					'automatic_rules_last_updated' => Waf_Stats::get_automatic_rules_last_updated(),
+				)
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Supports https://github.com/Automattic/wp-calypso/pull/94217

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `waf_supported` and `automatic_rules_last_updated` values to the `jetpack/v4/waf` endpoint, to allow these values to be used by Calypso for sites without the core Jetpack plugin installed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

peb6dq-2TM-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify the `jetpack/v4/waf` endpoint includes the new fields.