### PR TITLE
WAF: Allow rules to specify body parser type

### DIFF
--- a/projects/packages/waf/changelog/add-waf-body-processor
+++ b/projects/packages/waf/changelog/add-waf-body-processor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Firewall Runtime: Added support for rule files to specify body parser type.

--- a/projects/packages/waf/src/class-waf-runtime.php
+++ b/projects/packages/waf/src/class-waf-runtime.php
@@ -39,6 +39,14 @@ class Waf_Runtime {
 	const NORMALIZE_ARRAY_MATCH_VALUES = 2;
 
 	/**
+	 * The version of this runtime class. Used by rule files to ensure compatibility.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var int
+	 */
+	public $version = 1;
+	/**
 	 * Last rule.
 	 *
 	 * @var string

--- a/projects/packages/waf/src/class-waf-runtime.php
+++ b/projects/packages/waf/src/class-waf-runtime.php
@@ -68,6 +68,12 @@ class Waf_Runtime {
 	 * @var string
 	 */
 	public $matched_var_name = '';
+	/**
+	 * Body Processor.
+	 *
+	 * @var string 'URLENCODED' | 'JSON' | ''
+	 */
+	private $body_processor = '';
 
 	/**
 	 * State.
@@ -438,7 +444,7 @@ class Waf_Runtime {
 					$value = $this->args_names( $this->meta( 'args_get' ) );
 					break;
 				case 'args_post':
-					$value = $this->request->get_post_vars();
+					$value = $this->request->get_post_vars( $this->get_body_processor() );
 					break;
 				case 'args_post_names':
 					$value = $this->args_names( $this->meta( 'args_post' ) );
@@ -486,6 +492,28 @@ class Waf_Runtime {
 		}
 
 		return $output;
+	}
+
+	/**
+	 * Get the body processor.
+	 *
+	 * @return string
+	 */
+	private function get_body_processor() {
+		return $this->body_processor;
+	}
+
+	/**
+	 * Set the body processor.
+	 *
+	 * @param string $processor Processor to set. Either 'URLENCODED' or 'JSON'.
+	 *
+	 * @return void
+	 */
+	public function set_body_processor( $processor ) {
+		if ( $processor === 'URLENCODED' || $processor === 'JSON' ) {
+			$this->body_processor = $processor;
+		}
 	}
 
 	/**

--- a/projects/packages/waf/tests/php/unit/test-waf-request.php
+++ b/projects/packages/waf/tests/php/unit/test-waf-request.php
@@ -304,6 +304,64 @@ class WafRequestTest extends PHPUnit\Framework\TestCase {
 	/**
 	 * Test that the Waf_Request class returns POST-ed data correctly decoded from JSON via Waf_Request::get_post_vars().
 	 */
+	public function testGetVarsPostWithJsonBodyProcessor() {
+		$_SERVER['CONTENT_TYPE'] = 'irrelevant';
+
+		$request = $this->mock_request(
+			array(
+				'body' => json_encode(
+					array(
+						'str' => 'value',
+						'arr' => array( 'a', 'b', 'c' ),
+						'obj' => (object) array( 'foo' => 'bar' ),
+					)
+				),
+			)
+		);
+		$value   = $request->get_post_vars( 'JSON' );
+		$this->assertIsArray( $value );
+		$this->assertContains( array( 'json.str', 'value' ), $value );
+		$this->assertContains( array( 'json.arr.0', 'a' ), $value );
+		$this->assertContains( array( 'json.arr.1', 'b' ), $value );
+		$this->assertContains( array( 'json.arr.2', 'c' ), $value );
+		$this->assertContains( array( 'json.obj.foo', 'bar' ), $value );
+
+		unset( $_SERVER['CONTENT_TYPE'] );
+	}
+
+	/**
+	 * Test that the Waf_Request class returns POST-ed data correctly decoded from JSON via Waf_Request::get_post_vars().
+	 */
+	public function testGetVarsPostWithUrlencodedBodyProcessor() {
+		$_SERVER['CONTENT_TYPE'] = 'irrelevant';
+
+		$request = $this->mock_request(
+			array(
+				'body' => (
+					http_build_query(
+						array(
+							'str' => 'value',
+							'arr' => array( 'a', 'b', 'c' ),
+							'obj' => (object) array( 'foo' => 'bar' ),
+						)
+					)
+				),
+			)
+		);
+		$value   = $request->get_post_vars( 'URLENCODED' );
+		$this->assertIsArray( $value );
+		$this->assertContains( array( 'str', 'value' ), $value );
+		$this->assertContains( array( 'arr[0]', 'a' ), $value );
+		$this->assertContains( array( 'arr[1]', 'b' ), $value );
+		$this->assertContains( array( 'arr[2]', 'c' ), $value );
+		$this->assertContains( array( 'obj[foo]', 'bar' ), $value );
+
+		unset( $_SERVER['CONTENT_TYPE'] );
+	}
+
+	/**
+	 * Test that the Waf_Request class returns POST-ed data correctly decoded from JSON via Waf_Request::get_post_vars().
+	 */
 	public function testGetVarsPostWithJson() {
 		$_SERVER['CONTENT_TYPE'] = 'application/json';
 

--- a/projects/packages/waf/tests/php/unit/test-waf-request.php
+++ b/projects/packages/waf/tests/php/unit/test-waf-request.php
@@ -330,7 +330,7 @@ class WafRequestTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	 * Test that the Waf_Request class returns POST-ed data correctly decoded from JSON via Waf_Request::get_post_vars().
+	 * Test that the Waf_Request class returns POST-ed data correctly decoded from URLENCODED body via Waf_Request::get_post_vars().
 	 */
 	public function testGetVarsPostWithUrlencodedBodyProcessor() {
 		$_SERVER['CONTENT_TYPE'] = 'irrelevant';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Resolves https://github.com/Automattic/jetpack-scan-team/issues/1423

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
1. Adds a `public $version` property to `Waf_Runtime`. The intention is for rule files to use this property, i.e. `if ( ( $waf->version ?? 0 ) >= 5 ) { .. }`.
2. Adds a `private string $body_processor` property to the `Waf_Runtime` class, along with a `public function set_body_processor( $processor )` to enable rule files the ability to manually specify the method by which to retrieve post values from the request.
3. Updates the `meta()` method in `Waf_Runtime` to provide `$this->body_processor` to the `$this->request->get_post_vars()` method, which has been updated to support that new argument.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack-scan-team/issues/1423

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

*  Test that requests are parsed and blocked correctly when containing a property with a string value of `<script>`.
* Manually insert `$waf->set_body_processor( 'JSON' );` at the top of your automatic rules file and repeat the test with a JSON body in your request, with any content type.
* Repeat with  `$waf->set_body_processor( 'URLENCODED' );` and repeat the test with applicable request body and content types.
