### PR TITLE
Performance: remove filter calls that are no longer needed (imploding CSS)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-imploding-css-filter-uses
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-imploding-css-filter-uses
@@ -1,0 +1,5 @@
+Significance: patch
+Type: deprecated
+Comment: Removed filter call that is no longer needed.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/coming-soon/coming-soon.php
@@ -136,7 +136,6 @@ function render_fallback_coming_soon_page() {
 	add_filter( 'jetpack_disable_eu_cookie_law_widget', '__return_true', 1 );
 	add_filter( 'wpcom_disable_logged_out_follow', '__return_true', 10, 1 ); // Disable follow actionbar.
 	add_filter( 'wpl_is_enabled_sitewide', '__return_false', 10, 1 ); // Disable likes.
-	add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 ); // Jetpack "implodes" all registered CSS files into one file.
 	add_filter( 'woocommerce_demo_store', '__return_false' ); // Prevent the the wocommerce demo store notice from displaying.
 	add_filter( 'jetpack_open_graph_image_default', __NAMESPACE__ . '\coming_soon_share_image' ); // Set the default OG image.
 	add_filter( 'jetpack_twitter_cards_image_default', __NAMESPACE__ . '\coming_soon_share_image' ); // Set the default Twitter Card image.

--- a/projects/plugins/wpcomsh/changelog/remove-imploding-css-filter-uses
+++ b/projects/plugins/wpcomsh/changelog/remove-imploding-css-filter-uses
@@ -1,0 +1,5 @@
+Significance: patch
+Type: deprecated
+Comment: Removed filter call that is no longer needed.
+
+

--- a/projects/plugins/wpcomsh/private-site/access-denied-coming-soon-template.php
+++ b/projects/plugins/wpcomsh/private-site/access-denied-coming-soon-template.php
@@ -7,8 +7,6 @@
 
 namespace Private_Site;
 
-add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 );
-
 nocache_headers();
 header( 'Content-Type: ' . get_bloginfo( 'html_type' ) . '; charset=' . get_bloginfo( 'charset' ) );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

As we deprecate the jetpack.css concat (#39486), the default behavior is now "false" so both these filters are no longer needed. Removing them now before marking the filter as deprecated.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Remove calls to a filter to change it to the now-default value.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On WordPress.com, setup a new WoA site with Coming Soon enabled.
* Activate as much of Jetpack as you want, at least three of the imploded modules ('carousel', 'contact-form', 'infinite-scroll', 'likes', 'related-posts', 'sharedaddy', 'shortcodes', 'subscriptions', 'tiled-gallery', 'widgets')
* Visit the front page with the Coming Soon landing page.
* Confirm, without and without patch, `jetpack.css` is not enqueued on the page.

