### PR TITLE
Boost: Use `jetpack-assets` to load main script

### DIFF
--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -9,6 +9,7 @@
 namespace Automattic\Jetpack_Boost\Admin;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
+use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score;
 use Automattic\Jetpack_Boost\Lib\Analytics;
 use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
@@ -66,31 +67,7 @@ class Admin {
 		// Clear premium features cache when the plugin settings page is loaded.
 		Premium_Features::clear_cache();
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-	}
-
-	/**
-	 * Register the stylesheets for the admin area.
-	 *
-	 * @since    1.0.0
-	 */
-	public function enqueue_styles() {
-		/**
-		 * Filters the internal path to the distributed assets used by the plugin
-		 *
-		 * @param string $path the path to the assets
-		 *
-		 * @since   1.0.0
-		 */
-		$internal_path = apply_filters( 'jetpack_boost_asset_internal_path', 'app/assets/dist/' );
-
-		wp_enqueue_style(
-			'jetpack-boost-css',
-			plugins_url( $internal_path . 'jetpack-boost.css', JETPACK_BOOST_PATH ),
-			array( 'wp-components' ),
-			JETPACK_BOOST_VERSION
-		);
 	}
 
 	/**
@@ -108,12 +85,13 @@ class Admin {
 
 		$critical_css_gen_handle = 'jetpack-boost-critical-css-gen';
 
-		wp_register_script(
+		Assets::register_script(
 			$critical_css_gen_handle,
-			plugins_url( $internal_path . 'critical-css-gen.js', JETPACK_BOOST_PATH ),
-			array(),
-			JETPACK_BOOST_VERSION,
-			true
+			$internal_path . 'critical-css-gen.js',
+			JETPACK_BOOST_PATH,
+			array(
+				'in_footer' => true,
+			)
 		);
 
 		$admin_js_handle = 'jetpack-boost-admin';
@@ -128,12 +106,16 @@ class Admin {
 			$admin_js_dependencies[] = $critical_css_gen_handle;
 		}
 
-		wp_register_script(
+		Assets::register_script(
 			$admin_js_handle,
-			plugins_url( $internal_path . 'jetpack-boost.js', JETPACK_BOOST_PATH ),
-			$admin_js_dependencies,
-			JETPACK_BOOST_VERSION,
-			true
+			$internal_path . 'jetpack-boost.js',
+			JETPACK_BOOST_PATH,
+			array(
+				'dependencies' => $admin_js_dependencies,
+				'in_footer'    => true,
+				'textdomain'   => 'jetpack-boost',
+				'css_path'     => $internal_path . 'jetpack-boost.css',
+			)
 		);
 
 		wp_localize_script(
@@ -142,9 +124,7 @@ class Admin {
 			( new Config() )->constants()
 		);
 
-		wp_set_script_translations( $admin_js_handle, 'jetpack-boost' );
-
-		wp_enqueue_script( $admin_js_handle );
+		Assets::enqueue_script( $admin_js_handle );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/fix-boost-react-jsx
+++ b/projects/plugins/boost/changelog/fix-boost-react-jsx
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Compatibility: Ensure React JSX polifil is loaded for WP <= 6.5.5 support
+Compatibility: Ensure React JSX polyfill is loaded for pre WP 6.6 support

--- a/projects/plugins/boost/changelog/fix-boost-react-jsx
+++ b/projects/plugins/boost/changelog/fix-boost-react-jsx
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Compatibility: Ensure React JSX polifil is loaded for WP <= 6.5.5 support


### PR DESCRIPTION
## Proposed changes:
This PR replaces Boost's main script enqueuing with jetpack-assets, switching from using WP's default asset enqueuing functions (e.g., wp_enqueue_script).

This was prompted by the breakage of Boost in pre-WP 6.6 due to missing polyfills for React JSX. The assets package handles the polyfills.

Related: #38424

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Test Boost using both WP 6.5.5 and the latest(6.6.2) and make sure all functionality in Boost's dashboard load and work correctly.

