### PR TITLE
Boost: show a simplified getting started page if pricing is not available

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/boost-pricing-table.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/boost-pricing-table.tsx
@@ -1,6 +1,7 @@
 import { type PricingSchema, usePricing } from '$lib/stores/pricing';
 import {
 	Button,
+	Notice,
 	PricingTable,
 	PricingTableColumn,
 	PricingTableHeader,
@@ -33,54 +34,67 @@ export const BoostPricingTable = ( {
 	const isDiscounted = pricing?.priceBefore && pricing?.priceBefore > pricing?.priceAfter;
 
 	return (
-		<PricingTable
-			title={ __( 'The easiest speed optimization plugin for WordPress', 'jetpack-boost' ) }
-			items={ boostFeatureList.map( feature => feature.description ) }
-		>
-			<PricingTableColumn primary>
-				{ [
-					<PricingTableHeader key="premium-header">
-						<ProductPrice
-							price={ ( pricing?.priceBefore ?? 0 ) / 12 }
-							offPrice={ isDiscounted ? ( pricing?.priceAfter ?? 0 ) / 12 : undefined }
-							currency={ pricing?.currencyCode }
-							hideDiscountLabel={ false }
-							legend={ legend }
-						/>
-						<Button
-							onClick={ onPremiumCTA }
-							isLoading={ chosenPaidPlan }
-							disabled={ chosenFreePlan || chosenPaidPlan }
-							fullWidth
-						>
-							{ __( 'Get Boost', 'jetpack-boost' ) }
-						</Button>
-					</PricingTableHeader>,
-					...boostFeatureList.map( feature => feature.premium ),
-				] }
-			</PricingTableColumn>
-			<PricingTableColumn>
-				{ [
-					<PricingTableHeader key="free-header">
-						<ProductPrice
-							price={ 0 }
-							legend=""
-							currency={ pricing?.currencyCode }
-							hidePriceFraction
-						/>
-						<Button
-							onClick={ onFreeCTA }
-							isLoading={ chosenFreePlan }
-							disabled={ chosenFreePlan || chosenPaidPlan }
-							fullWidth
-							variant="secondary"
-						>
-							{ __( 'Start for free', 'jetpack-boost' ) }
-						</Button>
-					</PricingTableHeader>,
-					...boostFeatureList.map( feature => feature.free ),
-				] }
-			</PricingTableColumn>
-		</PricingTable>
+		<>
+			{ ! pricing && (
+				<Notice
+					level="warning"
+					title={ __( 'Warning: Your website is offline or private.', 'jetpack-boost' ) }
+					children={ __(
+						'Boost may not work as expected. Please check your site status and try again.',
+						'jetpack-boost'
+					) }
+				></Notice>
+			) }
+
+			<PricingTable
+				title={ __( 'The easiest speed optimization plugin for WordPress', 'jetpack-boost' ) }
+				items={ boostFeatureList.map( feature => feature.description ) }
+			>
+				<PricingTableColumn primary>
+					{ [
+						<PricingTableHeader key="premium-header">
+							<ProductPrice
+								price={ ( pricing?.priceBefore ?? 0 ) / 12 }
+								offPrice={ isDiscounted ? ( pricing?.priceAfter ?? 0 ) / 12 : undefined }
+								currency={ pricing?.currencyCode }
+								hideDiscountLabel={ false }
+								legend={ legend }
+							/>
+							<Button
+								onClick={ onPremiumCTA }
+								isLoading={ chosenPaidPlan }
+								disabled={ chosenFreePlan || chosenPaidPlan }
+								fullWidth
+							>
+								{ __( 'Get Boost', 'jetpack-boost' ) }
+							</Button>
+						</PricingTableHeader>,
+						...boostFeatureList.map( feature => feature.premium ),
+					] }
+				</PricingTableColumn>
+				<PricingTableColumn>
+					{ [
+						<PricingTableHeader key="free-header">
+							<ProductPrice
+								price={ 0 }
+								legend=""
+								currency={ pricing?.currencyCode }
+								hidePriceFraction
+							/>
+							<Button
+								onClick={ onFreeCTA }
+								isLoading={ chosenFreePlan }
+								disabled={ chosenFreePlan || chosenPaidPlan }
+								fullWidth
+								variant="secondary"
+							>
+								{ __( 'Start for free', 'jetpack-boost' ) }
+							</Button>
+						</PricingTableHeader>,
+						...boostFeatureList.map( feature => feature.free ),
+					] }
+				</PricingTableColumn>
+			</PricingTable>
+		</>
 	);
 };

--- a/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/boost-pricing-table.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/boost-pricing-table/boost-pricing-table.tsx
@@ -38,7 +38,8 @@ export const BoostPricingTable = ( {
 			{ ! pricing && (
 				<Notice
 					level="warning"
-					title={ __( 'Warning: Your website is offline or private.', 'jetpack-boost' ) }
+					hideCloseButton={ true }
+					title={ __( 'Warning: There was a problem fetching pricing data', 'jetpack-boost' ) }
 					children={ __(
 						'Boost may not work as expected. Please check your site status and try again.',
 						'jetpack-boost'

--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/getting-started.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/getting-started.tsx
@@ -83,35 +83,29 @@ const GettingStarted: React.FC = () => {
 	}
 
 	return (
-		pricing && (
-			<div id="jb-dashboard" className="jb-dashboard jb-dashboard--main">
-				<Header>
-					<ActivateLicense />
-				</Header>
+		<div id="jb-dashboard" className="jb-dashboard jb-dashboard--main">
+			<Header>
+				<ActivateLicense />
+			</Header>
 
-				<div className="jb-section jb-section--alt">
-					<div className="jb-container">
-						<div className={ styles[ 'pricing-table' ] }>
-							<BoostPricingTable
-								pricing={ pricing }
-								onPremiumCTA={ () => initialize( 'premium' ) }
-								onFreeCTA={ () => initialize( 'free' ) }
-								chosenFreePlan={ selectedPlan === 'free' }
-								chosenPaidPlan={ selectedPlan === 'premium' }
-							/>
-							{ snackbarMessage !== '' && (
-								<Snackbar
-									children={ snackbarMessage }
-									onDismiss={ () => setSnackbarMessage( '' ) }
-								/>
-							) }
-						</div>
+			<div className="jb-section jb-section--alt">
+				<div className="jb-container">
+					<div className={ styles[ 'pricing-table' ] }>
+						<BoostPricingTable
+							pricing={ pricing }
+							onPremiumCTA={ () => initialize( 'premium' ) }
+							onFreeCTA={ () => initialize( 'free' ) }
+							chosenFreePlan={ selectedPlan === 'free' }
+							chosenPaidPlan={ selectedPlan === 'premium' }
+						/>
+						{ snackbarMessage !== '' && (
+							<Snackbar children={ snackbarMessage } onDismiss={ () => setSnackbarMessage( '' ) } />
+						) }
 					</div>
 				</div>
-
-				<Footer />
 			</div>
-		)
+			<Footer />
+		</div>
 	);
 };
 

--- a/projects/plugins/boost/changelog/update-boost-handle-null-price
+++ b/projects/plugins/boost/changelog/update-boost-handle-null-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: show a simplified getting started page if the pricing is not available


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->
If the pricing isn't available, make sure to show a pricing page that will allow the user to go to the settings page.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a warning notice to the pricing table if pricing isn't available.
* Remove check of pricing object before showing the table.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Edit app/lib/Premium_Pricing.php and add `return null` to get_yearly_pricing()
* Load up the #/getting-started url of the setting page and confirm you can see the pricing table.
* 
