### PR TITLE
Jetpack AI Logo Generator style support

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-jetpack-ai-logo-generator-style-option
+++ b/projects/js-packages/ai-client/changelog/add-jetpack-ai-logo-generator-style-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Client: add support for showStyleSelector on logo generator and use-image-generator

--- a/projects/js-packages/ai-client/src/hooks/use-image-generator/constants.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-image-generator/constants.ts
@@ -1,0 +1,44 @@
+import { __ } from '@wordpress/i18n';
+
+// Styles
+export const IMAGE_STYLE_ENHANCE = 'enhance';
+export const IMAGE_STYLE_ANIME = 'anime';
+export const IMAGE_STYLE_PHOTOGRAPHIC = 'photographic';
+export const IMAGE_STYLE_DIGITAL_ART = 'digital-art';
+export const IMAGE_STYLE_COMICBOOK = 'comicbook';
+export const IMAGE_STYLE_FANTASY_ART = 'fantasy-art';
+export const IMAGE_STYLE_ANALOG_FILM = 'analog-film';
+export const IMAGE_STYLE_NEONPUNK = 'neonpunk';
+export const IMAGE_STYLE_ISOMETRIC = 'isometric';
+export const IMAGE_STYLE_LOWPOLY = 'lowpoly';
+export const IMAGE_STYLE_ORIGAMI = 'origami';
+export const IMAGE_STYLE_LINE_ART = 'line-art';
+export const IMAGE_STYLE_CRAFT_CLAY = 'craft-clay';
+export const IMAGE_STYLE_CINEMATIC = 'cinematic';
+export const IMAGE_STYLE_3D_MODEL = '3d-model';
+export const IMAGE_STYLE_PIXEL_ART = 'pixel-art';
+export const IMAGE_STYLE_TEXTURE = 'texture';
+export const IMAGE_STYLE_MONTY_PYTHON = 'monty-python';
+
+export const IMAGE_STYLE_LABELS = {
+	[ IMAGE_STYLE_ENHANCE ]: __( 'Enhance', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_ANIME ]: __( 'Anime', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_PHOTOGRAPHIC ]: __( 'Photographic', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_DIGITAL_ART ]: __( 'Digital Art', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_COMICBOOK ]: __( 'Comicbook', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_FANTASY_ART ]: __( 'Fantasy Art', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_ANALOG_FILM ]: __( 'Analog Film', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_NEONPUNK ]: __( 'Neon Punk', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_ISOMETRIC ]: __( 'Isometric', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_LOWPOLY ]: __( 'Low Poly', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_ORIGAMI ]: __( 'Origami', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_LINE_ART ]: __( 'Line Art', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_CRAFT_CLAY ]: __( 'Craft Clay', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_CINEMATIC ]: __( 'Cinematic', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_3D_MODEL ]: __( '3D Model', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_PIXEL_ART ]: __( 'Pixel Art', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_TEXTURE ]: __( 'Texture', 'jetpack-ai-client' ),
+	[ IMAGE_STYLE_MONTY_PYTHON ]: __( 'Monty Python', 'jetpack-ai-client' ),
+};
+
+export type ImageStyle = keyof typeof IMAGE_STYLE_LABELS;

--- a/projects/js-packages/ai-client/src/hooks/use-image-generator/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-image-generator/index.ts
@@ -7,6 +7,7 @@ import debugFactory from 'debug';
  */
 import askQuestionSync from '../../ask-question/sync.js';
 import requestJwt from '../../jwt/index.js';
+import { IMAGE_STYLE_LABELS } from './constants.js';
 
 const debug = debugFactory( 'ai-client:use-image-generator' );
 
@@ -255,11 +256,22 @@ const useImageGenerator = () => {
 		}
 	};
 
+	/**
+	 * Get available styles.
+	 *
+	 * @return {object} with the styles {key:label} for the image generation.
+	 */
+	const getImageStyles = function (): object {
+		return IMAGE_STYLE_LABELS;
+	};
+
 	return {
 		generateImage,
 		generateImageWithStableDiffusion,
 		generateImageWithParameters: executeImageGeneration,
+		getImageStyles,
 	};
 };
 
 export default useImageGenerator;
+export * from './constants.js';

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.scss
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.scss
@@ -26,7 +26,9 @@
 
 		&.is-link {
 			text-decoration: none;
-			color: var(--color-link, #3858e9);
+			&:not(:disabled) {
+				color: var(--color-link, #3858e9);
+			}
 		}
 	}
 }

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -49,6 +49,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	siteDetails,
 	context,
 	placement,
+	showStyleSelector,
 } ) => {
 	const { tracks } = useAnalytics();
 	const { recordEvent: recordTracksEvent } = tracks;
@@ -242,7 +243,9 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	} else {
 		body = (
 			<>
-				{ ! logoAccepted && <Prompt initialPrompt={ initialPrompt } /> }
+				{ ! logoAccepted && (
+					<Prompt initialPrompt={ initialPrompt } showStyleSelector={ showStyleSelector } />
+				) }
 
 				<LogoPresenter
 					logo={ selectedLogo }

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.scss
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.scss
@@ -9,12 +9,12 @@
 
 .jetpack-ai-logo-generator__prompt-header {
 	display: flex;
-	justify-content: space-between;
-	align-items: flex-start;
-	align-self: stretch;
+	gap: 16px;
+	align-items: center;
 
 	.jetpack-ai-logo-generator__prompt-label {
 		font-weight: 500;
+		flex-grow: 1;
 	}
 
 	.jetpack-ai-logo-generator__prompt-actions {
@@ -24,6 +24,8 @@
 
 		.jetpack-ai-logo-generator-icon {
 			margin-right: 4px;
+			// the svg icon with this class has no fill, only paths
+			stroke: currentColor;
 		}
 	}
 }

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -48,7 +48,7 @@ export const Prompt = ( { initialPrompt = '', showStyleSelector = false }: Promp
 	const { enhancePromptFetchError, logoFetchError } = useRequestErrors();
 	const { nextTierCheckoutURL: checkoutUrl, hasNextTier } = useCheckout();
 	const hasPrompt = prompt?.length >= MINIMUM_PROMPT_LENGTH;
-	const [ style, setStyle ] = useState< string >( IMAGE_STYLE_LINE_ART );
+	const [ style, setStyle ] = useState< ImageStyle >( IMAGE_STYLE_LINE_ART );
 
 	const {
 		generateLogo,

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -48,7 +48,9 @@ export const Prompt = ( { initialPrompt = '', showStyleSelector = false }: Promp
 	const { enhancePromptFetchError, logoFetchError } = useRequestErrors();
 	const { nextTierCheckoutURL: checkoutUrl, hasNextTier } = useCheckout();
 	const hasPrompt = prompt?.length >= MINIMUM_PROMPT_LENGTH;
-	const [ style, setStyle ] = useState< ImageStyle >( IMAGE_STYLE_LINE_ART );
+	const [ style, setStyle ] = useState< ImageStyle >(
+		showStyleSelector ? IMAGE_STYLE_LINE_ART : null
+	);
 
 	const {
 		generateLogo,

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { Button, Tooltip } from '@wordpress/components';
+import { Button, Tooltip, SelectControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
 import debugFactory from 'debug';
@@ -10,12 +10,17 @@ import { useCallback, useEffect, useState, useRef } from 'react';
 /**
  * Internal dependencies
  */
+import {
+	IMAGE_STYLE_MONTY_PYTHON,
+	IMAGE_STYLE_LINE_ART,
+} from '../../hooks/use-image-generator/constants.js';
 import AiIcon from '../assets/icons/ai.js';
 import {
 	EVENT_GENERATE,
 	MINIMUM_PROMPT_LENGTH,
 	EVENT_UPGRADE,
 	EVENT_PLACEMENT_INPUT_FOOTER,
+	EVENT_SWITCH_STYLE,
 } from '../constants.js';
 import { useCheckout } from '../hooks/use-checkout.js';
 import useLogoGenerator from '../hooks/use-logo-generator.js';
@@ -23,10 +28,19 @@ import useRequestErrors from '../hooks/use-request-errors.js';
 import { FairUsageNotice } from './fair-usage-notice.js';
 import { UpgradeNudge } from './upgrade-nudge.js';
 import './prompt.scss';
+/**
+ * Types
+ */
+import type { ImageStyle } from '../../hooks/use-image-generator/constants.js';
 
 const debug = debugFactory( 'jetpack-ai-calypso:prompt-box' );
 
-export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt = '' } ) => {
+type PromptProps = {
+	initialPrompt?: string;
+	showStyleSelector?: boolean;
+};
+
+export const Prompt = ( { initialPrompt = '', showStyleSelector = false }: PromptProps ) => {
 	const { tracks } = useAnalytics();
 	const { recordEvent: recordTracksEvent } = tracks;
 	const [ prompt, setPrompt ] = useState< string >( initialPrompt );
@@ -34,6 +48,7 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 	const { enhancePromptFetchError, logoFetchError } = useRequestErrors();
 	const { nextTierCheckoutURL: checkoutUrl, hasNextTier } = useCheckout();
 	const hasPrompt = prompt?.length >= MINIMUM_PROMPT_LENGTH;
+	const [ style, setStyle ] = useState< string >( IMAGE_STYLE_LINE_ART );
 
 	const {
 		generateLogo,
@@ -46,6 +61,7 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 		requireUpgrade,
 		context,
 		tierPlansEnabled,
+		getImageStyles,
 	} = useLogoGenerator();
 
 	const enhancingLabel = __( 'Enhancing…', 'jetpack-ai-client' );
@@ -91,9 +107,10 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 	}, [ prompt ] );
 
 	const onGenerate = useCallback( async () => {
-		recordTracksEvent( EVENT_GENERATE, { context, tool: 'image' } );
-		generateLogo( { prompt } );
-	}, [ context, generateLogo, prompt ] );
+		// shouldn't tool be "logo-generator" to be more specific?
+		recordTracksEvent( EVENT_GENERATE, { context, tool: 'image', style } );
+		generateLogo( { prompt, style } );
+	}, [ context, generateLogo, prompt, style ] );
 
 	const onPromptInput = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		setPrompt( event.target.textContent || '' );
@@ -122,6 +139,20 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 		recordTracksEvent( EVENT_UPGRADE, { context, placement: EVENT_PLACEMENT_INPUT_FOOTER } );
 	};
 
+	const updateStyle = useCallback(
+		( imageStyle: ImageStyle ) => {
+			debug( 'change style', imageStyle );
+			setStyle( imageStyle );
+			recordTracksEvent( EVENT_SWITCH_STYLE, { context, style: imageStyle } );
+		},
+		[ context, setStyle, recordTracksEvent ]
+	);
+
+	const imageStyles = getImageStyles();
+	const availableStyles = Object.keys( imageStyles ).filter(
+		( styleKey: ImageStyle ) => styleKey !== IMAGE_STYLE_MONTY_PYTHON
+	);
+
 	return (
 		<div className="jetpack-ai-logo-generator__prompt">
 			<div className="jetpack-ai-logo-generator__prompt-header">
@@ -135,9 +166,21 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 						onClick={ onEnhance }
 					>
 						<AiIcon />
-						<span>{ enhanceButtonLabel }</span>
+						{ enhanceButtonLabel }
 					</Button>
 				</div>
+				{ showStyleSelector && availableStyles && (
+					<SelectControl
+						// label={ __( 'Style', 'jetpack-ai-client' ) }
+						__nextHasNoMarginBottom
+						value={ style }
+						options={ availableStyles.map( imageStyle => ( {
+							label: imageStyles[ imageStyle ],
+							value: imageStyle,
+						} ) ) }
+						onChange={ updateStyle }
+					/>
+				) }
 			</div>
 			<div className="jetpack-ai-logo-generator__prompt-query">
 				<div

--- a/projects/js-packages/ai-client/src/logo-generator/constants.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/constants.ts
@@ -10,6 +10,7 @@ export const EVENT_USE = 'jetpack_ai_logo_generator_use';
 export const EVENT_NAVIGATE = 'jetpack_ai_logo_generator_navigate';
 export const EVENT_FEEDBACK = 'jetpack_ai_logo_generator_feedback';
 export const EVENT_UPGRADE = 'jetpack_ai_upgrade_button';
+export const EVENT_SWITCH_STYLE = 'jetpack_ai_logo_generator_switch_style';
 
 // Event placement constants
 export const EVENT_PLACEMENT_QUICK_LINKS = 'quick_links';

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -224,7 +224,7 @@ User request:${ prompt }`;
 				prompt: imageGenerationPrompt,
 				feature: 'jetpack-ai-logo-generator',
 				response_format: 'b64_json',
-				style,
+				style: style || '', // backend expects an empty string if no style is provided
 			};
 
 			const data = await generateImageWithParameters( body );

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -17,6 +17,7 @@ import useRequestErrors from './use-request-errors.js';
 /**
  * Types
  */
+import type { ImageStyle } from '../../hooks/use-image-generator/constants.js';
 import type { Logo, Selectors, SaveLogo } from '../store/types.js';
 
 const debug = debugFactory( 'jetpack-ai-calypso:use-logo-generator' );
@@ -78,7 +79,7 @@ const useLogoGenerator = () => {
 		setLogoUpdateError,
 	} = useRequestErrors();
 
-	const { generateImageWithParameters } = useImageGenerator();
+	const { generateImageWithParameters, getImageStyles } = useImageGenerator();
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 
 	const { ID = null, name = null, description = null } = siteDetails || {};
@@ -193,8 +194,10 @@ For example: user's prompt: A logo for an ice cream shop. Returned prompt: A log
 
 	const generateImage = useCallback( async function ( {
 		prompt,
+		style = null,
 	}: {
 		prompt: string;
+		style?: ImageStyle | null;
 	} ): Promise< { data: Array< { url: string } > } > {
 		setLogoFetchError( null );
 
@@ -221,6 +224,7 @@ User request:${ prompt }`;
 				prompt: imageGenerationPrompt,
 				feature: 'jetpack-ai-logo-generator',
 				response_format: 'b64_json',
+				style,
 			};
 
 			const data = await generateImageWithParameters( body );
@@ -309,7 +313,13 @@ User request:${ prompt }`;
 	);
 
 	const generateLogo = useCallback(
-		async function ( { prompt }: { prompt: string } ): Promise< void > {
+		async function ( {
+			prompt,
+			style,
+		}: {
+			prompt: string;
+			style: ImageStyle | null;
+		} ): Promise< void > {
 			debug( 'Generating logo for site' );
 
 			setIsRequestingImage( true );
@@ -324,7 +334,7 @@ User request:${ prompt }`;
 				let image;
 
 				try {
-					image = await generateImage( { prompt } );
+					image = await generateImage( { prompt, style } );
 
 					if ( ! image || ! image.data.length ) {
 						throw new Error( 'No image returned' );
@@ -391,6 +401,7 @@ User request:${ prompt }`;
 		tierPlansEnabled,
 		isLoadingHistory,
 		setIsLoadingHistory,
+		getImageStyles,
 	};
 };
 

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -318,7 +318,7 @@ User request:${ prompt }`;
 			style,
 		}: {
 			prompt: string;
-			style: ImageStyle | null;
+			style?: ImageStyle | null;
 		} ): Promise< void > {
 			debug( 'Generating logo for site' );
 

--- a/projects/js-packages/ai-client/src/logo-generator/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/types.ts
@@ -19,6 +19,7 @@ export interface GeneratorModalProps {
 	onReload: () => void;
 	context: string;
 	placement: string;
+	showStyleSelector?: boolean;
 }
 
 export interface LogoPresenterProps {

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-logo-generator-style-option
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-logo-generator-style-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: pass prop/flag to showStyleSelector on logo generator modal

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -123,6 +123,8 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 		const siteDetails = useSiteDetails();
 
+		const styleLogoFeatureEnabled = getFeatureAvailability( 'ai-logo-style-selector-support' );
+
 		return (
 			<>
 				<BlockEdit { ...props } />
@@ -137,6 +139,7 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					context={ PLACEMENT_CONTEXT }
 					placement={ TOOL_PLACEMENT }
 					siteDetails={ siteDetails }
+					showStyleSelector={ styleLogoFeatureEnabled }
 				/>
 			</>
 		);


### PR DESCRIPTION
Providing support for styles spreads from the component usage on plugin and then into the package to properly support the option when present but without changing current functionality

## Proposed changes:
- add a generic getImageStyles on useImageGenerator hook
- add all image styles and types
- add (and pass on) showStyleSelector from the main component and down to Prompt component
- add tracking event `jetpack_ai_logo_generator_switch_style` for every dropdown change
- add support for `style` parameter on generateLogo and generateImage underlying functions


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-2Ma-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Checkout and see that without changing to beta or adding the filter, Logo and Image blocks and Featured Post Image AI generation continue to work as usual with no new features or hiccups.

Switch to beta and add the filter snippet: `add_filter( 'jetpack_ai_logo_style_selector_enabled', '__return_true' );` and enable debug with `localStorage.setItem( 'debug', '*' );` on the browser console.

Reload the editor.
Image block and Featured Post Image should show no changes on their AI generation modals.
Logo block should now show a dropdown on the generation modal. See that it continues to work (though the dropdown doesn't affect the image yet).

Every time the style dropdown changes a track event should be fired, you'll see it in the console as `Record event "jetpack_ai_logo_generator_switch_style" called with props {"context":"block-editor","style":"origami","blog_id": ...`