### PR TITLE
Jetpack: remove deprecated IDC flag from admin pages

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -15,7 +15,7 @@ return [
     // PhanTypeMismatchArgumentProbablyReal : 200+ occurrences
     // PhanTypeMismatchReturn : 150+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 130+ occurrences
-    // PhanDeprecatedFunction : 110+ occurrences
+    // PhanDeprecatedFunction : 120+ occurrences
     // PhanTypePossiblyInvalidDimOffset : 95+ occurrences
     // PhanRedundantCondition : 70+ occurrences
     // PhanPossiblyUndeclaredVariable : 60+ occurrences
@@ -108,7 +108,7 @@ return [
         '_inc/genericons.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/admin-pages/class-jetpack-about-page.php' => ['PhanTypeMismatchArgument'],
         '_inc/lib/admin-pages/class-jetpack-redux-state-helper.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimAssignment'],
-        '_inc/lib/admin-pages/class.jetpack-admin-page.php' => ['PhanDeprecatedProperty', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
+        '_inc/lib/admin-pages/class.jetpack-admin-page.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
         '_inc/lib/class-jetpack-ai-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyDefault'],
         '_inc/lib/class-jetpack-instagram-gallery-helper.php' => ['PhanTypeMismatchArgument'],
         '_inc/lib/class-jetpack-mapbox-helper.php' => ['PhanTypeMismatchArgumentNullable'],

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -46,16 +46,6 @@ abstract class Jetpack_Admin_Page {
 	abstract public function page_render();
 
 	/**
-	 * Should we block the page rendering because the site is in IDC?
-	 * Beware that the property is set early on, and might not always reflect the actual value.
-	 *
-	 * @var bool
-	 *
-	 * @deprecated 13.2 Use `$this->block_page_rendering_for_idc()` instead.
-	 */
-	public static $block_page_rendering_for_idc;
-
-	/**
 	 * Function called after admin_styles to load any additional needed styles.
 	 *
 	 * @since 4.3.0
@@ -76,10 +66,6 @@ abstract class Jetpack_Admin_Page {
 	 */
 	public function on_jetpack_loaded( $jetpack ) {
 		$this->jetpack = $jetpack;
-
-		self::$block_page_rendering_for_idc = (
-			Jetpack::is_connection_ready() && Identity_Crisis::validate_sync_error_idc_option() && ! Jetpack_Options::get_option( 'safe_mode_confirmed' )
-		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/remove-jetpack-page-deprecated-idc-flag
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-page-deprecated-idc-flag
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Remove deprecated IDC flag from admin pages.


### PR DESCRIPTION
## Proposed changes:
The `$block_page_rendering_for_idc` static property was deprecated and replaced with a method in #35470 to resolve a bug with IDC status not updating properly.
This PR will remove the property-related code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack.
2. Use Jetpack Debug plugin to activate IDC mode. Confirm Jetpack Dashboard and Settings only render the IDC notice, the page content itself is hidden.
3. Deactivate IDC mode and clear the IDC status. Confirm Jetpack Dashboard and Settings show up as they're supposed to, with no IDC notice in sight.
