### PR TITLE
Remove/connection nudges where not needed

### DIFF
--- a/projects/packages/blaze/changelog/remove-connection-nudges-where-not-needed
+++ b/projects/packages/blaze/changelog/remove-connection-nudges-where-not-needed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove user connection nudges where they aren't needed. Add user connection nudges where needed

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -61,7 +61,7 @@ class Blaze {
 	 * @return void
 	 */
 	public static function add_post_links_actions() {
-		if ( self::should_initialize() ) {
+		if ( self::should_initialize()['can_init'] ) {
 			add_filter( 'post_row_actions', array( __CLASS__, 'jetpack_blaze_row_action' ), 10, 2 );
 			add_filter( 'page_row_actions', array( __CLASS__, 'jetpack_blaze_row_action' ), 10, 2 );
 		}
@@ -97,7 +97,7 @@ class Blaze {
 	 * @return void
 	 */
 	public static function enable_blaze_menu() {
-		if ( ! self::should_initialize() ) {
+		if ( ! self::should_initialize()['can_init'] ) {
 			return;
 		}
 
@@ -195,7 +195,7 @@ class Blaze {
 	 * Determines if criteria is met to enable Blaze features.
 	 * Keep in mind that this makes remote requests, so we want to avoid calling it when unnecessary, like in the frontend.
 	 *
-	 * @return bool
+	 * @return array
 	 */
 	public static function should_initialize() {
 		$is_wpcom   = defined( 'IS_WPCOM' ) && IS_WPCOM;
@@ -204,7 +204,10 @@ class Blaze {
 
 		// Only admins should be able to Blaze posts on a site.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			return false;
+			return array(
+				'can_init' => false,
+				'reason'   => 'user_not_admin',
+			);
 		}
 
 		// Allow short-circuiting the Blaze initialization via a filter.
@@ -227,25 +230,49 @@ class Blaze {
 			*/
 			if (
 				is_wp_error( $site_id )
-				|| ! $connection->is_connected()
-				|| ! $connection->is_user_connected()
 			) {
-				return false;
+				return array(
+					'can_init' => false,
+					'reason'   => 'wp_error',
+				);
+			}
+
+			if ( ! $connection->is_connected() ) {
+				return array(
+					'can_init' => false,
+					'reason'   => 'site_not_connected',
+				);
+			}
+
+			if ( ! $connection->is_user_connected() ) {
+				return array(
+					'can_init' => false,
+					'reason'   => 'user_not_connected',
+				);
 			}
 
 			// The whole thing is powered by Sync!
 			if ( ! Sync_Settings::is_sync_enabled() ) {
-				return false;
+				return array(
+					'can_init' => false,
+					'reason'   => 'sync_disabled',
+				);
 			}
 		}
 
 		// Check if the site supports Blaze.
 		if ( is_numeric( $site_id ) && ! self::site_supports_blaze( $site_id ) ) {
-			return false;
+			return array(
+				'can_init' => false,
+				'reason'   => 'site_not_eligible',
+			);
 		}
 
 		// Final fallback.
-		return true;
+		return array(
+			'can_init' => true,
+			'reason'   => null,
+		);
 	}
 
 	/**
@@ -368,7 +395,7 @@ class Blaze {
 			return;
 		}
 		// Bail if criteria is not met to enable Blaze features.
-		if ( ! self::should_initialize() ) {
+		if ( ! self::should_initialize()['can_init'] ) {
 			return;
 		}
 

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -219,7 +219,12 @@ class Blaze {
 			 *
 			 * @param bool $should_initialize Whether Blaze should be enabled. Default to true.
 			 */
-			return apply_filters( 'jetpack_blaze_enabled', true );
+			$should_init = apply_filters( 'jetpack_blaze_enabled', true );
+
+			return array(
+				'can_init' => $should_init,
+				'reason'   => $should_init ? null : 'initialization_disabled',
+			);
 		}
 
 		// On self-hosted sites, we must do some additional checks.

--- a/projects/packages/blaze/tests/php/test-blaze.php
+++ b/projects/packages/blaze/tests/php/test-blaze.php
@@ -97,10 +97,10 @@ class Test_Blaze extends BaseTestCase {
 	 * @covers Automattic\Jetpack\Blaze::should_initialize
 	 */
 	public function test_filter_overwrites_eligibility() {
-		$this->assertFalse( Blaze::should_initialize() );
+		$this->assertFalse( Blaze::should_initialize()['can_init'] );
 		wp_set_current_user( $this->admin_id );
 		add_filter( 'jetpack_blaze_enabled', '__return_true' );
-		$this->assertTrue( Blaze::should_initialize() );
+		$this->assertTrue( Blaze::should_initialize()['can_init'] );
 		add_filter( 'jetpack_blaze_enabled', '__return_false' );
 	}
 
@@ -111,7 +111,7 @@ class Test_Blaze extends BaseTestCase {
 	 */
 	public function test_editor_not_eligible() {
 		wp_set_current_user( $this->editor_id );
-		$this->assertFalse( Blaze::should_initialize() );
+		$this->assertFalse( Blaze::should_initialize()['can_init'] );
 	}
 
 	/**

--- a/projects/packages/masterbar/changelog/remove-connection-nudges-where-not-needed
+++ b/projects/packages/masterbar/changelog/remove-connection-nudges-where-not-needed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove user connection nudges where they aren't needed. Add user connection nudges where needed

--- a/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-jetpack-admin-menu.php
@@ -265,7 +265,7 @@ class Jetpack_Admin_Menu extends Admin_Menu {
 		add_menu_page( esc_attr__( 'Tools', 'jetpack-masterbar' ), __( 'Tools', 'jetpack-masterbar' ), 'publish_posts', 'tools.php', null, 'dashicons-admin-tools', 75 );
 		add_submenu_page( 'tools.php', esc_attr__( 'Marketing', 'jetpack-masterbar' ), __( 'Marketing', 'jetpack-masterbar' ), 'publish_posts', 'https://wordpress.com/marketing/tools/' . $this->domain );
 
-		if ( Blaze::should_initialize() ) {
+		if ( Blaze::should_initialize()['can_init'] ) {
 			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
 			add_submenu_page( 'tools.php', esc_attr__( 'Advertising', 'jetpack-masterbar' ), __( 'Advertising', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/advertising/' . $this->domain, null, 1 );
 		}

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/akismet.jsx
@@ -13,10 +13,10 @@ import { getJetpackProductUpsellByFeature, FEATURE_SPAM_AKISMET_PLUS } from 'lib
 import { noop } from 'lodash';
 import { getProductDescriptionUrl } from 'product-descriptions/utils';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import { getAkismetData } from 'state/at-a-glance';
-import { hasConnectedOwner, isOfflineMode, connectUser } from 'state/connection';
+import { isOfflineMode, connectUser } from 'state/connection';
 import { getApiNonce, isAtomicSite } from 'state/initial-state';
 import { siteHasFeature } from 'state/site';
 
@@ -31,7 +31,6 @@ class DashAkismet extends Component {
 			.isRequired,
 		isOfflineMode: PropTypes.bool.isRequired,
 		upgradeUrl: PropTypes.string.isRequired,
-		hasConnectedOwner: PropTypes.bool.isRequired,
 	};
 
 	static defaultProps = {
@@ -133,25 +132,8 @@ class DashAkismet extends Component {
 			);
 		};
 
-		const getConnectBanner = () => {
-			return (
-				<JetpackBanner
-					callToAction={ __( 'Connect', 'jetpack' ) }
-					title={ __(
-						'Connect your WordPress.com account to upgrade and automatically clear spam from comments and forms',
-						'jetpack'
-					) }
-					disableHref="false"
-					onClick={ this.props.connectUser }
-					eventFeature="akismet"
-					path="dashboard"
-					plan={ getJetpackProductUpsellByFeature( FEATURE_SPAM_AKISMET_PLUS ) }
-				/>
-			);
-		};
-
 		const getBanner = () => {
-			return this.props.hasConnectedOwner ? getAkismetUpgradeBanner() : getConnectBanner();
+			return getAkismetUpgradeBanner();
 		};
 
 		const getAkismetCounter = () => {
@@ -270,7 +252,6 @@ export default connect(
 			isOfflineMode: isOfflineMode( state ),
 			upgradeUrl: getProductDescriptionUrl( state, 'akismet' ),
 			nonce: getApiNonce( state ),
-			hasConnectedOwner: hasConnectedOwner( state ),
 			hasAntiSpam: siteHasFeature( state, 'antispam' ),
 			hasAkismet: siteHasFeature( state, 'akismet' ),
 		};

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/index.jsx
@@ -9,7 +9,7 @@ import QuerySitePlugins from 'components/data/query-site-plugins';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import analytics from 'lib/analytics';
 import { chunk, get } from 'lodash';
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import { isOfflineMode, hasConnectedOwner, getConnectionStatus } from 'state/connection';
 import {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/protect.jsx
@@ -5,10 +5,10 @@ import Button from 'components/button';
 import DashItem from 'components/dash-item';
 import QueryProtectCount from 'components/data/query-dash-protect';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import { getProtectCount } from 'state/at-a-glance';
-import { isOfflineMode, hasConnectedOwner, connectUser } from 'state/connection';
+import { isOfflineMode, connectUser } from 'state/connection';
 import { isModuleAvailable } from 'state/modules';
 
 class DashProtect extends Component {
@@ -16,7 +16,6 @@ class DashProtect extends Component {
 		isOfflineMode: PropTypes.bool.isRequired,
 		protectCount: PropTypes.any.isRequired,
 		isModuleAvailable: PropTypes.bool.isRequired,
-		hasConnectedOwner: PropTypes.bool.isRequired,
 		connectUser: PropTypes.func.isRequired,
 	};
 
@@ -34,11 +33,7 @@ class DashProtect extends Component {
 			link: getRedirectUrl( 'jetpack-support-protect' ),
 		};
 
-		if (
-			this.props.getOptionValue( 'protect' ) &&
-			! this.props.isOfflineMode &&
-			this.props.hasConnectedOwner
-		) {
+		if ( this.props.getOptionValue( 'protect' ) && ! this.props.isOfflineMode ) {
 			const protectCount = this.props.protectCount;
 
 			if ( 'N/A' === protectCount ) {
@@ -87,25 +82,11 @@ class DashProtect extends Component {
 				module="protect"
 				support={ support }
 				className="jp-dash-item__is-inactive"
-				noToggle={ ! this.props.hasConnectedOwner }
 			>
 				<p className="jp-dash-item__description">
 					{ this.props.isOfflineMode && __( 'Unavailable in Offline Mode', 'jetpack' ) }
 
 					{ ! this.props.isOfflineMode &&
-						! this.props.hasConnectedOwner &&
-						createInterpolateElement(
-							__(
-								'<Button>Connect your WordPress.com</Button> account to keep your site protected from malicious sign in attempts.',
-								'jetpack'
-							),
-							{
-								Button: <Button className="jp-link-button" onClick={ this.connect } />,
-							}
-						) }
-
-					{ ! this.props.isOfflineMode &&
-						this.props.hasConnectedOwner &&
 						createInterpolateElement(
 							__(
 								'<Button>Activate Protect</Button> to keep your site protected from malicious sign in attempts.',
@@ -137,7 +118,6 @@ export default connect(
 		protectCount: getProtectCount( state ),
 		isOfflineMode: isOfflineMode( state ),
 		isModuleAvailable: isModuleAvailable( state, 'protect' ),
-		hasConnectedOwner: hasConnectedOwner( state ),
 	} ),
 	dispatch => ( {
 		connectUser: () => {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
@@ -379,11 +379,9 @@ class DashScan extends Component {
 	}
 
 	getUpgradeContent() {
-		const { hasConnectedOwner } = this.props;
-
 		return renderCard( {
 			className: 'jp-dash-item__is-inactive',
-			overrideContent: hasConnectedOwner ? this.getUpgradeBanner() : this.getConnectBanner(),
+			overrideContent: this.getUpgradeBanner(),
 		} );
 	}
 

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/search.jsx
@@ -119,7 +119,7 @@ class DashSearch extends Component {
 				className: 'jp-dash-item__is-inactive',
 				status: 'no-pro-uninstalled-or-inactive',
 				pro_inactive: true,
-				overrideContent: this.props.hasConnectedOwner ? (
+				overrideContent: (
 					<JetpackBanner
 						callToAction={
 							isSearchNewPricingLaunched202208()
@@ -134,19 +134,6 @@ class DashSearch extends Component {
 						plan={ getJetpackProductUpsellByFeature( FEATURE_SEARCH_JETPACK ) }
 						icon="search"
 						trackBannerDisplay={ this.props.trackUpgradeButtonView }
-					/>
-				) : (
-					<JetpackBanner
-						callToAction={ __( 'Connect', 'jetpack' ) }
-						title={ __(
-							'Connect your WordPress.com account to upgrade and get Jetpack Search, which helps your visitors instantly find the right content – right when they need it.',
-							'jetpack'
-						) }
-						disableHref="false"
-						onClick={ this.props.connectUser }
-						eventFeature="search"
-						path="dashboard"
-						plan={ getJetpackProductUpsellByFeature( FEATURE_SEARCH_JETPACK ) }
 					/>
 				),
 			} );

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -293,25 +293,13 @@ export const SettingsCard = inprops => {
 					return '';
 				}
 
-				return props.hasConnectedOwner ? (
+				return (
 					<JetpackBanner
 						callToAction={ upgradeLabel() }
 						title={ __( 'Automatically clear spam from comments and forms.', 'jetpack' ) }
 						plan={ getJetpackProductUpsellByFeature( FEATURE_SPAM_AKISMET_PLUS ) }
 						feature={ feature }
 						href={ props.spamUpgradeUrl }
-						rna
-					/>
-				) : (
-					<JetpackBanner
-						callToAction={ connectLabel() }
-						title={ __(
-							'Connect your WordPress.com account to upgrade and automatically clear spam from comments and forms.',
-							'jetpack'
-						) }
-						plan={ getJetpackProductUpsellByFeature( FEATURE_SPAM_AKISMET_PLUS ) }
-						feature={ feature }
-						onclick={ props.doConnectUser }
 						rna
 					/>
 				);

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -257,7 +257,7 @@ export const SettingsCard = inprops => {
 					return '';
 				}
 
-				return props.hasConnectedOwner ? (
+				return (
 					<JetpackBanner
 						callToAction={
 							isSearchNewPricingLaunched202208()
@@ -272,18 +272,6 @@ export const SettingsCard = inprops => {
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
 						href={ props.searchUpgradeUrl }
-						rna
-					/>
-				) : (
-					<JetpackBanner
-						callToAction={ connectLabel() }
-						title={ __(
-							'Connect your WordPress.com account to upgrade and help visitors quickly find answers with highly relevant instant search results and powerful filtering.',
-							'jetpack'
-						) }
-						plan={ getJetpackProductUpsellByFeature( FEATURE_SEARCH_JETPACK ) }
-						feature={ feature }
-						onClick={ handleConnectClick( feature ) }
 						rna
 					/>
 				);

--- a/projects/plugins/jetpack/_inc/client/security/antispam.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/antispam.jsx
@@ -11,7 +11,7 @@ import TextInput from 'components/text-input';
 import analytics from 'lib/analytics';
 import { FEATURE_SPAM_AKISMET_PLUS } from 'lib/plans/constants';
 import { assign, debounce, isEmpty, trim } from 'lodash';
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import { isAkismetKeyValid, checkAkismetKey, isCheckingAkismetKey } from 'state/at-a-glance';
 

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -713,10 +713,10 @@ export function isOdysseyStatsEnabled( state ) {
  * Returns true if Blaze can be used on the site.
  *
  * @param {object} state - Global state tree.
- * @return {boolean} True if Blaze is available on the site.
+ * @return {object} A boolean indicating if Blaze can be used and a reason why if it cannot.
  */
 export function shouldInitializeBlaze( state ) {
-	return !! state.jetpack.initialState.shouldInitializeBlaze;
+	return state.jetpack.initialState.shouldInitializeBlaze;
 }
 
 /**

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -41,6 +41,8 @@ function Blaze( props ) {
 		toggleModuleNow,
 	} = props;
 
+	const { can_init: canInit, reason } = blazeAvailable;
+
 	if ( isWoASite && ! blazeDashboardEnabled ) {
 		return null;
 	}
@@ -66,7 +68,16 @@ function Blaze( props ) {
 	};
 
 	const blazeToggle = () => {
-		if ( ! blazeAvailable ) {
+		if ( ! canInit && reason === 'user_not_connected' ) {
+			return (
+				<ToggleControl
+					disabled={ true }
+					label={ __( 'Attract high-quality traffic to your site using Blaze.', 'jetpack' ) }
+				/>
+			);
+		}
+
+		if ( ! canInit ) {
 			return (
 				<ToggleControl
 					disabled={ true }
@@ -103,12 +114,8 @@ function Blaze( props ) {
 			>
 				{ blazeToggle() }
 			</SettingsGroup>
-			{ blazeAvailable &&
-				blazeActive &&
-				hasConnectedOwner &&
-				! isOfflineMode &&
-				blazeDashboardLink() }
-			{ blazeAvailable && ! hasConnectedOwner && ! isOfflineMode && (
+			{ canInit && blazeActive && ! isOfflineMode && blazeDashboardLink() }
+			{ ! canInit && reason === 'user_not_connected' && ! isOfflineMode && (
 				<ConnectUserBar
 					feature="blaze"
 					featureLabel={ __( 'Blaze', 'jetpack' ) }

--- a/projects/plugins/jetpack/changelog/remove-connection-nudges-where-not-needed
+++ b/projects/plugins/jetpack/changelog/remove-connection-nudges-where-not-needed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove user connection nudges where they aren't needed. Add user connection nudges where needed


### PR DESCRIPTION
There are several places on the Jetpack Dashboard and within Jetpack Settings that either:
1. Ask for a user connection when it is not required
2. Does not ask for a user connection when it is required

## Proposed changes:

* Remove connection nudge from Akismet on the Dashboard and Settings
* Add connection nudge to Blaze when the reason it's disabled is only the missing user connection
* Remove connection nudge for Scan on the Dashboard
* Remove connection nudge for Brute Force Detection on Dashboard
* Remove user connection nudge from Search on Dashboard
     * User connection is required to access the Search Dashboard, but search can work without a user connection and we don't ask for it in settings if the site has a Search plan. I think we should keep that consistent on the dashboard

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-bHl-p2#comment-23715

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

NOTE: When looking at the code, pay close attention to the Blaze changes. The way the connection nudge was shown wasn't working so I had to go change some stuff on the Blaze backend. As far as I can tell, the stuff I changed was only used in the Settings of the frontend where this PR is updating. I had to edit a few instances where the `should_initialize` function was used, so it should work fine

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect the site without connecting your user account
3. Go to `/wp-admin/admin.php?page=jetpack#/dashboard`
4. Ensure the Scan and Akismet card do not ask for a user connection and make sure the cards work as expected (try links and CTAs)
![image](https://github.com/user-attachments/assets/3dde79fd-0913-4966-b96d-683b5e3ba1f6)
5. Ensure the Brute Force protection card does not ask for user connection
![image](https://github.com/user-attachments/assets/841faab9-79f8-40fe-a0ad-fd32a354a927)
6. In the Performance and Growth section, ensure that only the AI and VideoPress card ask for a user connection
![image](https://github.com/user-attachments/assets/282105ac-d339-495b-a55f-24a202abe393)
7. Now go to `/wp-admin/admin.php?page=jetpack#/security` and ensure the Akismet card does not ask for a user connection
![image](https://github.com/user-attachments/assets/aea6a56a-1159-4756-b6b2-3ee1f9140c45)
9. Go to `/wp-admin/admin.php?page=jetpack#/performance` and ensure the Search module does not ask for user connection
![image](https://github.com/user-attachments/assets/f552f10f-5137-4f50-879e-6c59d04b9f18)
10. Go to `/wp-admin/admin.php?page=jetpack#/traffic` and ensure the Blaze card asks for a user connection
![image](https://github.com/user-attachments/assets/22dd5bd2-202a-4342-a91b-e515460ebdd7)
11. Connect your user account and ensure all the cards looked at previously look good still
![image](https://github.com/user-attachments/assets/ce05cb1f-bc3f-43bc-b588-20f662e4b922)
![image](https://github.com/user-attachments/assets/2066057d-889c-4a08-a4fd-f84b51032e7a)
![image](https://github.com/user-attachments/assets/a558f028-c52d-420f-ad57-15bde6077230)
![image](https://github.com/user-attachments/assets/648b5c5f-3104-4e2a-b74f-90dba0a90b53)
![image](https://github.com/user-attachments/assets/d6a34c1f-f5f9-420f-b642-eede2a9dae49)
