### PR TITLE
Change/at a glance unify connection ctas

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
@@ -71,7 +71,6 @@ export class DashConnections extends Component {
 							<Gridicon icon="globe" size={ 64 } />
 						) }
 						<div className="jp-connection-settings__text">
-							{ __( 'Your site is connected to WordPress.com.', 'jetpack' ) }
 							{ this.props.isConnectionOwner && (
 								<span className="jp-connection-settings__is-owner">
 									{ __( 'You are the Jetpack owner.', 'jetpack' ) }
@@ -102,7 +101,6 @@ export class DashConnections extends Component {
 		const maybeShowLinkUnlinkBtn = this.props.isConnectionOwner ? null : (
 			<ConnectButton asLink connectUser={ true } from="connection-settings" />
 		);
-
 		let cardContent = '';
 
 		if ( this.props.isOfflineMode ) {
@@ -131,14 +129,7 @@ export class DashConnections extends Component {
 		}
 
 		if ( ! this.props.isLinked ) {
-			cardContent = (
-				<div>
-					<div className="jp-connection-settings__info">
-						{ __( 'Get the most out of Jetpack.', 'jetpack' ) }
-					</div>
-					<div className="jp-connection-settings__actions">{ maybeShowLinkUnlinkBtn }</div>
-				</div>
-			);
+			cardContent = maybeShowLinkUnlinkBtn;
 		} else if ( this.props.isFetchingUserData ) {
 			cardContent = __( 'Loading…', 'jetpack' );
 		} else if ( ! this.props.wpComConnectedUser?.email ) {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/connections.jsx
@@ -129,7 +129,7 @@ export class DashConnections extends Component {
 		}
 
 		if ( ! this.props.isLinked ) {
-			cardContent = maybeShowLinkUnlinkBtn;
+			cardContent = <div className="jp-connection-settings__info">{ maybeShowLinkUnlinkBtn }</div>;
 		} else if ( this.props.isFetchingUserData ) {
 			cardContent = __( 'Loading…', 'jetpack' );
 		} else if ( ! this.props.wpComConnectedUser?.email ) {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/monitor.jsx
@@ -3,9 +3,10 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Button from 'components/button';
 import DashItem from 'components/dash-item';
+import JetpackBanner from 'components/jetpack-banner';
 import analytics from 'lib/analytics';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import { isOfflineMode, hasConnectedOwner, connectUser } from 'state/connection';
 import { isModuleAvailable } from 'state/modules';
@@ -78,26 +79,29 @@ class DashMonitor extends Component {
 				support={ support }
 				className="jp-dash-item__is-inactive"
 				noToggle={ ! this.props.hasConnectedOwner }
+				overrideContent={
+					( ! this.props.hasConnectedOwner && ! this.props.isOfflineMode && (
+						<JetpackBanner
+							title={ __(
+								'Connect your WordPress.com account to enable alerts if your site goes down.',
+								'jetpack'
+							) }
+							noIcon
+							callToAction={ __( 'Connect', 'jetpack' ) }
+							onClick={ this.props.connectUser }
+							eventFeature="monitor"
+							path="dashboard"
+							eventProps={ { type: 'connect' } }
+						/>
+					) ) ||
+					null
+				}
 			>
 				<p className="jp-dash-item__description">
 					{ this.props.isOfflineMode
 						? __( 'Unavailable in Offline Mode.', 'jetpack' )
 						: activateMessage }
 				</p>
-
-				{ ! this.props.isOfflineMode && ! this.props.hasConnectedOwner && (
-					<p className="jp-dash-item__description jp-dash-item__connect">
-						{ createInterpolateElement(
-							__(
-								'<Button>Connect your WordPress.com</Button> account to use this feature.',
-								'jetpack'
-							),
-							{
-								Button: <Button className="jp-link-button" onClick={ this.connect } />,
-							}
-						) }
-					</p>
-				) }
 			</DashItem>
 		);
 	}

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -723,7 +723,7 @@ a.jp-dash-item__manage-in-wpcom,
 	border-radius: 4px;
 
 	.jp-dash-item__card {
-		padding: 16px;
+		padding: 16px 16px 16px 24px;
 	}
 
 	.jp-dash-item__content {
@@ -743,7 +743,7 @@ a.jp-dash-item__manage-in-wpcom,
 		padding: 0;
 
 		&__title {
-			padding: 0 0.5rem;
+			padding: 0 0.5rem 0 0;
 		}
 	}
 

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -717,3 +717,18 @@ a.jp-dash-item__manage-in-wpcom,
 		border-top: 1px solid $gray-5;
 	}
 }
+
+.jp-dash-item.jp-connection-type {
+	.jp-dash-item__content,
+	.jp-connection-settings__text {
+		align-self: center;
+	}
+
+	.dops-banner {
+		padding: 0;
+
+		&__title {
+			padding: 0;
+		}
+	}
+}

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -719,7 +719,7 @@ a.jp-dash-item__manage-in-wpcom,
 }
 
 .jp-dash-item.jp-connection-type {
-	border: 1px solid var(--jp-gray);
+	border: 1px solid transparent;
 	border-radius: 4px;
 
 	.jp-dash-item__card {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -719,6 +719,9 @@ a.jp-dash-item__manage-in-wpcom,
 }
 
 .jp-dash-item.jp-connection-type {
+	border: 1px solid var(--jp-gray);
+	border-radius: 4px;
+
 	.jp-dash-item__card {
 		padding: 16px;
 	}

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -719,6 +719,14 @@ a.jp-dash-item__manage-in-wpcom,
 }
 
 .jp-dash-item.jp-connection-type {
+	.jp-dash-item__content {
+		display: block;
+	}
+
+	.jp-connection-settings__text {
+		flex-grow: 1;
+	}
+
 	.jp-dash-item__content,
 	.jp-connection-settings__text {
 		align-self: center;

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -719,6 +719,10 @@ a.jp-dash-item__manage-in-wpcom,
 }
 
 .jp-dash-item.jp-connection-type {
+	.jp-dash-item__card {
+		padding: 16px;
+	}
+
 	.jp-dash-item__content {
 		display: block;
 	}
@@ -736,7 +740,11 @@ a.jp-dash-item__manage-in-wpcom,
 		padding: 0;
 
 		&__title {
-			padding: 0;
+			padding: 0 0.5rem;
 		}
+	}
+
+	.dops-banner.dops-card {
+		display: block;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/test/component.js
@@ -84,7 +84,7 @@ describe( 'Connections', () => {
 		it( 'shows a disconnection link', () => {
 			render( <DashConnections { ...testProps } />, { initialState: buildInitialState() } );
 			expect(
-				withinCard( 'Site connection' ).getByRole( 'button', { name: 'Manage site connection' } )
+				withinCard( 'Site connection' ).getByRole( 'button', { name: 'Manage' } )
 			).toBeInTheDocument();
 		} );
 
@@ -128,8 +128,8 @@ describe( 'Connections', () => {
 				initialState: buildInitialState( { userIsLinked: false } ),
 			} );
 			expect(
-				withinCard( 'Account connection' ).getByRole( 'link', {
-					name: 'Connect your WordPress.com account',
+				withinCard( 'Account connection' ).getByRole( 'button', {
+					name: 'Connect',
 				} )
 			).toBeInTheDocument();
 		} );

--- a/projects/plugins/jetpack/_inc/client/components/banner/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/banner/index.jsx
@@ -62,6 +62,7 @@ export class Banner extends Component {
 			}
 			return `/plans/${ siteSlug }`;
 		}
+
 		return href;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -139,7 +139,7 @@ export class ConnectButton extends React.Component {
 		return (
 			<JetpackBanner
 				title={ __(
-					'Get the most out of Jetpack by connect your WordPress.com account',
+					'Get the most out of Jetpack by connecting your WordPress.com account',
 					'jetpack'
 				) }
 				noIcon

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/index.jsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { getFragment } from '@wordpress/url';
 import Button from 'components/button';
 import QuerySiteBenefits from 'components/data/query-site-benefits';
+import JetpackBanner from 'components/jetpack-banner';
 import analytics from 'lib/analytics';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -74,8 +75,10 @@ export class ConnectButton extends React.Component {
 	}
 
 	handleOpenModal = e => {
+		if ( e ) {
+			e.preventDefault();
+		}
 		analytics.tracks.recordJetpackClick( 'manage_site_connection' );
-		e.preventDefault();
 		this.toggleVisibility();
 	};
 
@@ -89,7 +92,9 @@ export class ConnectButton extends React.Component {
 	};
 
 	loadConnectionScreen = e => {
-		e.preventDefault();
+		if ( e ) {
+			e.preventDefault();
+		}
 		// If the iframe is already loaded or we don't have a connectUrl yet, return.
 		if ( this.props.isAuthorizing || this.props.fetchingConnectUrl ) {
 			return;
@@ -131,27 +136,19 @@ export class ConnectButton extends React.Component {
 			);
 		}
 
-		let connectUrl = this.props.connectUrl;
-		if ( this.props.from ) {
-			connectUrl += `&from=${ this.props.from }`;
-			connectUrl += '&additional-user';
-		}
-
-		const buttonProps = {
-				className: 'is-primary jp-jetpack-connect__button',
-				href: connectUrl,
-				disabled: this.props.fetchingConnectUrl || this.props.isAuthorizing,
-				onClick: this.loadConnectionScreen,
-			},
-			connectLegend =
-				this.props.connectLegend || __( 'Connect your WordPress.com account', 'jetpack' );
-
-		return this.props.asLink ? (
-			<a { ...buttonProps }>{ connectLegend }</a>
-		) : (
-			<Button rna={ this.props.rna } compact={ this.props.compact } { ...buttonProps }>
-				{ connectLegend }
-			</Button>
+		return (
+			<JetpackBanner
+				title={ __(
+					'Get the most out of Jetpack by connect your WordPress.com account',
+					'jetpack'
+				) }
+				noIcon
+				callToAction={ __( 'Connect', 'jetpack' ) }
+				onClick={ this.loadConnectionScreen }
+				eventFeature="connect-account"
+				path="dashboard"
+				eventProps={ { type: 'connect' } }
+			/>
 		);
 	};
 
@@ -162,15 +159,15 @@ export class ConnectButton extends React.Component {
 
 		if ( this.props.isSiteConnected ) {
 			return (
-				<a
-					role="button"
-					tabIndex="0"
-					onKeyDown={ onKeyDownCallback( this.handleOpenModal ) }
+				<JetpackBanner
+					title={ __( 'Your site is connected to WordPress.com.', 'jetpack' ) }
+					noIcon
+					callToAction={ this.props.connectLegend || __( 'Manage', 'jetpack' ) }
 					onClick={ this.handleOpenModal }
-					disabled={ this.props.isDisconnecting }
-				>
-					{ this.props.connectLegend || __( 'Manage site connection', 'jetpack' ) }
-				</a>
+					eventFeature="manage-site-connection"
+					path="dashboard"
+					eventProps={ { type: 'manage' } }
+				/>
 			);
 		}
 

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/test/component.js
@@ -1,8 +1,8 @@
 import { jest } from '@jest/globals';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { render, screen } from 'test/test-utils';
 import { ConnectButton } from '../index';
+import { buildInitialState } from './fixtures';
 
 // Mock components that do fetches in the background. We supply needed state directly.
 jest.mock( 'components/data/query-site-benefits', () => ( {
@@ -29,26 +29,10 @@ describe( 'ConnectButton', () => {
 
 	describe( 'Initially', () => {
 		it( 'renders a button to connect or link', () => {
-			render( <ConnectButton { ...testProps } fetchingConnectUrl={ true } /> );
-			expect(
-				screen.getByRole( 'link', { name: 'Connect your WordPress.com account' } )
-			).toBeInTheDocument();
-		} );
-
-		it( 'disables the button while fetching the connect URL', () => {
-			render( <ConnectButton { ...testProps } fetchingConnectUrl={ true } /> );
-			expect( screen.getByRole( 'link', { name: 'Connect your WordPress.com account' } ) )
-				// eslint-disable-next-line jest-dom/prefer-enabled-disabled -- `.toBeDisabled()` doesn't work on links.
-				.toHaveAttribute( 'disabled' );
-		} );
-	} );
-
-	describe( 'When it is used to link a user', () => {
-		it( 'has a link to jetpack.wordpress.com', () => {
-			render( <ConnectButton { ...testProps } /> );
-			expect(
-				screen.getByRole( 'link', { name: 'Connect your WordPress.com account' } )
-			).toHaveAttribute( 'href', 'https://jetpack.wordpress.com/jetpack.authorize/1/' );
+			render( <ConnectButton { ...testProps } fetchingConnectUrl={ true } />, {
+				initialState: buildInitialState(),
+			} );
+			expect( screen.getByRole( 'button', { name: 'Connect' } ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -62,15 +46,15 @@ describe( 'ConnectButton', () => {
 		};
 
 		it( 'has a link to jetpack.wordpress.com', () => {
-			render( <ConnectButton { ...currentTestProps } /> );
-			expect(
-				screen.getByRole( 'link', { name: 'Link your account to WordPress.com' } )
-			).toHaveAttribute( 'href', 'https://jetpack.wordpress.com/jetpack.authorize/1/' );
+			render( <ConnectButton { ...currentTestProps } />, {
+				initialState: buildInitialState(),
+			} );
+			expect( screen.getByRole( 'button', { name: 'Connect' } ) ).toBeInTheDocument();
 		} );
 
 		it( 'when clicked, loadConnectionScreen() is called once', async () => {
 			const user = userEvent.setup();
-			const loadConnectionScreen = jest.fn( e => e.preventDefault() );
+			const loadConnectionScreen = jest.fn();
 
 			class ConnectButtonMock extends ConnectButton {
 				constructor( props ) {
@@ -79,10 +63,10 @@ describe( 'ConnectButton', () => {
 				}
 			}
 
-			render( <ConnectButtonMock { ...currentTestProps } /> );
-			await user.click(
-				screen.getByRole( 'link', { name: 'Link your account to WordPress.com' } )
-			);
+			render( <ConnectButtonMock { ...currentTestProps } />, {
+				initialState: buildInitialState(),
+			} );
+			await user.click( screen.getByRole( 'button', { name: 'Connect' } ) );
 			expect( loadConnectionScreen ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
@@ -96,7 +80,9 @@ describe( 'ConnectButton', () => {
 		};
 
 		it( 'does not link to a URL', () => {
-			render( <ConnectButton { ...currentTestProps } /> );
+			render( <ConnectButton { ...currentTestProps } />, {
+				initialState: buildInitialState(),
+			} );
 			expect(
 				screen.getByRole( 'button', { name: 'Unlink your account from WordPress.com' } )
 			).not.toHaveAttribute( 'href' );
@@ -152,7 +138,9 @@ describe( 'ConnectButton', () => {
 		};
 
 		it( 'does not link to a URL', () => {
-			render( <ConnectButton { ...currentTestProps } /> );
+			render( <ConnectButton { ...currentTestProps } />, {
+				initialState: buildInitialState(),
+			} );
 			expect(
 				screen.getByRole( 'button', { name: 'Disconnect your site from WordPress.com' } )
 			).not.toHaveAttribute( 'href' );
@@ -160,7 +148,7 @@ describe( 'ConnectButton', () => {
 
 		it( 'when clicked, handleOpenModal() is called once', async () => {
 			const user = userEvent.setup();
-			const handleOpenModal = jest.fn( e => e.preventDefault() );
+			const handleOpenModal = jest.fn();
 
 			class ConnectButtonMock extends ConnectButton {
 				constructor( props ) {
@@ -169,7 +157,9 @@ describe( 'ConnectButton', () => {
 				}
 			}
 
-			render( <ConnectButtonMock { ...currentTestProps } /> );
+			render( <ConnectButtonMock { ...currentTestProps } />, {
+				initialState: buildInitialState(),
+			} );
 			await user.click(
 				screen.getByRole( 'button', { name: 'Disconnect your site from WordPress.com' } )
 			);

--- a/projects/plugins/jetpack/_inc/client/components/connect-button/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/components/connect-button/test/fixtures.js
@@ -1,0 +1,27 @@
+/**
+ * Build an object that can be used as a Redux store initial state.
+ *
+ * @return {object} – initial Redux state
+ */
+export function buildInitialState() {
+	return {
+		jetpack: {
+			initialState: {
+				userData: {
+					currentUser: {
+						permissions: {
+							manage_modules: true,
+						},
+					},
+				},
+			},
+			connection: {
+				user: {
+					currentUser: {
+						isConnected: true,
+					},
+				},
+			},
+		},
+	};
+}

--- a/projects/plugins/jetpack/changelog/change-at-a-glance-unify-connection-ctas
+++ b/projects/plugins/jetpack/changelog/change-at-a-glance-unify-connection-ctas
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Unify connection related CTAs on At A Glance

--- a/tools/e2e-commons/pages/wp-admin/jetpack-dashboard.js
+++ b/tools/e2e-commons/pages/wp-admin/jetpack-dashboard.js
@@ -48,8 +48,11 @@ export default class JetpackDashboardPage extends WpPage {
 	async isNotUserConnected() {
 		logger.step( 'Checking that WordPress.com user is not connected' );
 		const selector = `${ this.#connectionInfoContainerSel } >> nth=1`;
-		return ( await this.page.locator( selector ).innerText() ).includes(
-			'Get the most out of Jetpack by connect your WordPress.com account'
+		const locator = this.page.locator( selector );
+		const elementText = await locator.textContent();
+
+		return elementText.includes(
+			'Get the most out of Jetpack by connecting your WordPress.com account'
 		);
 	}
 }

--- a/tools/e2e-commons/pages/wp-admin/jetpack-dashboard.js
+++ b/tools/e2e-commons/pages/wp-admin/jetpack-dashboard.js
@@ -48,10 +48,7 @@ export default class JetpackDashboardPage extends WpPage {
 	async isNotUserConnected() {
 		logger.step( 'Checking that WordPress.com user is not connected' );
 		const selector = `${ this.#connectionInfoContainerSel } >> nth=1`;
-		const locator = this.page.locator( selector );
-		const elementText = await locator.textContent();
-
-		return elementText.includes(
+		return ( await this.page.locator( selector ).innerText() ).includes(
 			'Get the most out of Jetpack by connecting your WordPress.com account'
 		);
 	}

--- a/tools/e2e-commons/pages/wp-admin/jetpack-dashboard.js
+++ b/tools/e2e-commons/pages/wp-admin/jetpack-dashboard.js
@@ -49,7 +49,7 @@ export default class JetpackDashboardPage extends WpPage {
 		logger.step( 'Checking that WordPress.com user is not connected' );
 		const selector = `${ this.#connectionInfoContainerSel } >> nth=1`;
 		return ( await this.page.locator( selector ).innerText() ).includes(
-			'Get the most out of Jetpack'
+			'Get the most out of Jetpack by connect your WordPress.com account'
 		);
 	}
 }


### PR DESCRIPTION
## Proposed changes:

* Unify design on Connection related CTAs on At A Glance

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-bHl-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. With a site-only connection, go to `/wp-admin/admin.php?page=jetpack#/dashboard`
3. Make sure all the connection related CTAs look the same (below are screenshots of the updated ones). You can ignore the Brute Force Protection card, that connection CTA is being removed [here](https://github.com/Automattic/jetpack/pull/39533)
![image](https://github.com/user-attachments/assets/b7b5ed45-3412-4b76-b2c4-073f80a4880f)
![image](https://github.com/user-attachments/assets/50df18a0-947d-4b60-8cd8-51d463069aa6)
4. Connect your user account from one of the updated CTAs (to make sure they work) and ensure the connection section looks good afterward
![image](https://github.com/user-attachments/assets/df79982e-144c-4904-8b3f-a9aa46208822)

