### PR TITLE
Jetpack AI: don't generate first logo without details

### DIFF
--- a/projects/js-packages/ai-client/changelog/change-jetpack-ai-logo-first-generation-condition
+++ b/projects/js-packages/ai-client/changelog/change-jetpack-ai-logo-first-generation-condition
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Client: if site details show empty or default, do not trigger a logo generation, use empty placeholders

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -137,7 +137,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			loadLogoHistory( siteId );
 
 			// If there is any logo, we do not need to generate a first logo again.
-			if ( ! isLogoHistoryEmpty( String( siteId ) ) ) {
+			if ( hasHistory ) {
 				setLoadingState( null );
 				setIsLoadingHistory( false );
 				return;

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -70,6 +70,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		generateLogo,
 		setContext,
 		tierPlansEnabled,
+		site,
 	} = useLogoGenerator();
 	const { featureFetchError, firstLogoPromptFetchError, clearErrors } = useRequestErrors();
 	const siteId = siteDetails?.ID;
@@ -142,8 +143,19 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 				return;
 			}
 
-			// If the site does not require an upgrade and has no logos stored, generate the first prompt based on the site's data.
-			generateFirstLogo();
+			// If the site does not require an upgrade and has no logos stored
+			// and has title and description, generate the first prompt based on the site's data.
+			if (
+				site &&
+				site.name &&
+				site.description &&
+				site.name !== __( 'Site Title', 'jetpack-ai-client' )
+			) {
+				generateFirstLogo();
+			} else {
+				setLoadingState( null );
+				setIsLoadingHistory( false );
+			}
 		} catch ( error ) {
 			debug( 'Error fetching feature', error );
 			setLoadingState( null );

--- a/projects/js-packages/ai-client/src/logo-generator/components/history-carousel.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/history-carousel.tsx
@@ -3,6 +3,7 @@
  */
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 /**
  * Internal dependencies
@@ -47,6 +48,9 @@ export const HistoryCarousel: React.FC = () => {
 				<Button disabled className={ clsx( 'jetpack-ai-logo-generator__carousel-logo' ) }>
 					<img height="48" width="48" src={ loader } alt={ 'loading' } />
 				</Button>
+			) }
+			{ ! logos.length && ! isLoadingHistory && (
+				<div>{ __( 'No logos generated history yet', 'jetpack-ai-client' ) }</div>
 			) }
 			{ logos.map( ( logo, index ) => (
 				<Button

--- a/projects/js-packages/ai-client/src/logo-generator/components/history-carousel.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/history-carousel.tsx
@@ -3,7 +3,6 @@
  */
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 /**
  * Internal dependencies
@@ -49,9 +48,7 @@ export const HistoryCarousel: React.FC = () => {
 					<img height="48" width="48" src={ loader } alt={ 'loading' } />
 				</Button>
 			) }
-			{ ! logos.length && ! isLoadingHistory && (
-				<div>{ __( 'No logos generated history yet', 'jetpack-ai-client' ) }</div>
-			) }
+			{ ! logos.length && ! isLoadingHistory && <div>&nbsp;</div> }
 			{ logos.map( ( logo, index ) => (
 				<Button
 					key={ logo.url }

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -111,6 +111,7 @@ const UseOnSiteButton: React.FC< { onApplyLogo: ( mediaId: number ) => void } > 
 			className="jetpack-ai-logo-generator-modal-presenter__action"
 			onClick={ handleClick }
 			disabled={ isSavingLogoToLibrary || ! selectedLogo?.mediaId }
+			variant="secondary"
 		>
 			<Icon icon={ <LogoIcon /> } />
 			<span className="action-text">{ __( 'Use on block', 'jetpack-ai-client' ) }</span>

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -141,6 +141,17 @@ const LogoFetching: React.FC = () => {
 	);
 };
 
+const LogoEmpty: React.FC = () => {
+	return (
+		<>
+			<div className="jetpack-ai-logo-generator-modal__loader jetpack-ai-logo-generator-modal-presenter__logo"></div>
+			<span className="jetpack-ai-logo-generator-modal-presenter__loading-text">
+				{ __( 'Once you generate a logo, it will show up here', 'jetpack-ai-client' ) }
+			</span>
+		</>
+	);
+};
+
 const LogoReady: React.FC< {
 	siteId: string;
 	logo: Logo;
@@ -195,7 +206,9 @@ export const LogoPresenter: React.FC< LogoPresenterProps > = ( {
 
 	let logoContent: React.ReactNode;
 
-	if ( ! logo ) {
+	if ( ! logo && ! loading ) {
+		logoContent = <LogoEmpty />;
+	} else if ( ! logo ) {
 		debug( 'No logo provided, history still loading or logo being generated' );
 		logoContent = <LogoFetching />;
 	} else if ( loading || isRequestingImage ) {

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -206,7 +206,7 @@ export const LogoPresenter: React.FC< LogoPresenterProps > = ( {
 
 	let logoContent: React.ReactNode;
 
-	if ( ! logo && ! loading ) {
+	if ( ! logo && ! isRequestingImage ) {
 		logoContent = <LogoEmpty />;
 	} else if ( ! logo ) {
 		debug( 'No logo provided, history still loading or logo being generated' );

--- a/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/logo-presenter.tsx
@@ -144,7 +144,7 @@ const LogoFetching: React.FC = () => {
 const LogoEmpty: React.FC = () => {
 	return (
 		<>
-			<div className="jetpack-ai-logo-generator-modal__loader jetpack-ai-logo-generator-modal-presenter__logo"></div>
+			<div style={ { width: 0, height: '229px' } }></div>
 			<span className="jetpack-ai-logo-generator-modal-presenter__loading-text">
 				{ __( 'Once you generate a logo, it will show up here', 'jetpack-ai-client' ) }
 			</span>

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -155,6 +155,13 @@ export const Prompt = ( { initialPrompt = '' }: PromptProps ) => {
 		[ context, setStyle, recordTracksEvent ]
 	);
 
+	const onKeyDown = ( event: React.KeyboardEvent ) => {
+		if ( event.key === 'Enter' ) {
+			event.preventDefault();
+			onGenerate();
+		}
+	};
+
 	return (
 		<div className="jetpack-ai-logo-generator__prompt">
 			<div className="jetpack-ai-logo-generator__prompt-header">
@@ -182,6 +189,8 @@ export const Prompt = ( { initialPrompt = '' }: PromptProps ) => {
 			</div>
 			<div className="jetpack-ai-logo-generator__prompt-query">
 				<div
+					role="textbox"
+					tabIndex={ 0 }
 					ref={ inputRef }
 					contentEditable={ ! isBusy && ! requireUpgrade }
 					// The content editable div is expected to be updated by the enhance prompt, so warnings are suppressed
@@ -189,6 +198,7 @@ export const Prompt = ( { initialPrompt = '' }: PromptProps ) => {
 					className="prompt-query__input"
 					onInput={ onPromptInput }
 					onPaste={ onPromptPaste }
+					onKeyDown={ onKeyDown }
 					data-placeholder={ __(
 						'Describe your site or simply ask for a logo specifying some details about it',
 						'jetpack-ai-client'

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-checkout.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-checkout.ts
@@ -7,7 +7,6 @@ import {
 	getSiteFragment,
 } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect } from '@wordpress/data';
-import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
@@ -16,8 +15,6 @@ import { STORE_NAME } from '../store/index.js';
  * Types
  */
 import type { Selectors } from '../store/types.js';
-
-const debug = debugFactory( 'ai-client:logo-generator:use-checkout' );
 
 export const useCheckout = () => {
 	const { nextTier, tierPlansEnabled } = useSelect( select => {
@@ -59,8 +56,6 @@ export const useCheckout = () => {
 	}
 
 	const nextTierCheckoutURL = checkoutUrl.toString();
-
-	debug( 'Next tier checkout URL: ', nextTierCheckoutURL );
 
 	return {
 		nextTierCheckoutURL,


### PR DESCRIPTION
## Proposed changes:
- remove noisy debug call
- add logo-presenter empty placeholder
- add logo-history empty placeholder
- check if we have site title and description
- check that site title is not the default (flaky)

The newly introduced empty placeholders need some design:
<img width="775" alt="image" src="https://github.com/user-attachments/assets/ab191606-231c-42a8-9f46-7315f0fc4e71">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-2Ma-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Use a fresh site (or delete logo history from the devtools application tab, localStorage). Go to site general settings and set an empty title and description.

Go to the editor and insert a logo block. Use the AI toolbar button to open the modal.

See that the modal doesn't trigger an immediate request to generate a logo.
See the empty placeholders.

Go back to settings and choose a title and description for the site, then back to the editor. Click the AI toolbar button on the logo block. This time, the modal should show a generation is in progress and eventually bring back the new logo.

See that the "Use on Site" button is now `variant=secondary`, making it more prominent.
