### PR TITLE
My Jetpack: update notice style on mobile

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -62,7 +62,6 @@ const GlobalNotice = ( { message, title, options } ) => {
 		<div
 			className={ clsx( styles.notice, {
 				[ styles[ 'bigger-than-medium' ] ]: isBiggerThanMedium,
-				[ styles[ 'no-title' ] ]: ! title,
 			} ) }
 		>
 			<Notice hideCloseButton={ true } { ...options } title={ title } actions={ actionButtons }>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -62,6 +62,7 @@ const GlobalNotice = ( { message, title, options } ) => {
 		<div
 			className={ clsx( styles.notice, {
 				[ styles[ 'bigger-than-medium' ] ]: isBiggerThanMedium,
+				[ styles[ 'no-title' ] ]: ! title,
 			} ) }
 		>
 			<Notice hideCloseButton={ true } { ...options } title={ title } actions={ actionButtons }>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -69,10 +69,7 @@
 				align-items: center;
 			}
 		}
-	}
 
-
-	&.no-title > div {
 		@media screen and ( max-width: 600px ) {
 			padding-top: 24px;
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/styles.module.scss
@@ -71,6 +71,18 @@
 		}
 	}
 
+
+	&.no-title > div {
+		@media screen and ( max-width: 600px ) {
+			padding-top: 24px;
+
+			// this is the selector for `.icon-wrapper` in the .notice component
+			& > div:has(svg) {
+				position: initial;
+			}
+		}
+	}
+
 	.cta {
 		min-width: auto;
 	}

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-notice-mobile-style
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-notice-mobile-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: visual update to make the GlobalNotice component look better on mobile.

--- a/projects/plugins/backup/changelog/update-my-jetpack-notice-mobile-style
+++ b/projects/plugins/backup/changelog/update-my-jetpack-notice-mobile-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: visual update to the GlobalNotice component look better on mobile.

--- a/projects/plugins/boost/changelog/update-my-jetpack-notice-mobile-style
+++ b/projects/plugins/boost/changelog/update-my-jetpack-notice-mobile-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: visual update to the GlobalNotice component look better on mobile.

--- a/projects/plugins/jetpack/changelog/update-my-jetpack-notice-mobile-style
+++ b/projects/plugins/jetpack/changelog/update-my-jetpack-notice-mobile-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+My Jetpack: visual update to the GlobalNotice component look better on mobile.

--- a/projects/plugins/migration/changelog/update-my-jetpack-notice-mobile-style
+++ b/projects/plugins/migration/changelog/update-my-jetpack-notice-mobile-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: visual update to the GlobalNotice component look better on mobile.

--- a/projects/plugins/protect/changelog/update-my-jetpack-notice-mobile-style
+++ b/projects/plugins/protect/changelog/update-my-jetpack-notice-mobile-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: visual update to the GlobalNotice component look better on mobile.

--- a/projects/plugins/search/changelog/update-my-jetpack-notice-mobile-style
+++ b/projects/plugins/search/changelog/update-my-jetpack-notice-mobile-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: visual update to the GlobalNotice component look better on mobile.

--- a/projects/plugins/social/changelog/update-my-jetpack-notice-mobile-style
+++ b/projects/plugins/social/changelog/update-my-jetpack-notice-mobile-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: visual update to the GlobalNotice component look better on mobile.

--- a/projects/plugins/starter-plugin/changelog/update-my-jetpack-notice-mobile-style
+++ b/projects/plugins/starter-plugin/changelog/update-my-jetpack-notice-mobile-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: visual update to the GlobalNotice component look better on mobile.

--- a/projects/plugins/videopress/changelog/update-my-jetpack-notice-mobile-style
+++ b/projects/plugins/videopress/changelog/update-my-jetpack-notice-mobile-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: visual update to the GlobalNotice component look better on mobile.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a small issue where the notices in My Jetpack looked a bit off on mobile

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the style so the message and the icon are in the same line, similar to how it is on desktop

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch
* Go to My Jetpack and Activate Jetpack with one click
* Confirm that the success notice looks good on desktop mode and on mobile
* Dismiss the Welcome banner, scroll down to the connections section, and click on "Manage" to disconnect Jetpack
* Refresh the page and you'll see an error notice (with a title)
* Confirm that the same change works in this case

Before | After
--- | ---
<img width="437" alt="image" src="https://github.com/user-attachments/assets/57bdac9e-a376-4097-ae9d-d1db43f8793d">|<img width="444" alt="image" src="https://github.com/user-attachments/assets/48582a64-0ff6-4d4e-93e0-12c94c0da30f">
<img width="439" alt="image" src="https://github.com/user-attachments/assets/97386ae0-ae2f-4fed-b6b7-e274817fcf33">|<img width="443" alt="image" src="https://github.com/user-attachments/assets/f9a41aa1-444e-4fc0-a9e0-d7ae48af15d4">
