### PR TITLE
Protect: Improve optimistically scanning

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-optimistically-scanning
+++ b/projects/plugins/protect/changelog/update-protect-optimistically-scanning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Improves optimistic scanning

--- a/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
+++ b/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
@@ -79,7 +79,6 @@ export default function useScanStatusQuery( {
 
 			// Return cached data if conditions are met
 			if ( isRequestedScanNotStarted( data ) ) {
-				// Get cached data for the query
 				return queryClient.getQueryData( [ QUERY_SCAN_STATUS_KEY ] );
 			}
 

--- a/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
+++ b/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
@@ -80,9 +80,8 @@ export default function useScanStatusQuery( {
 			// Return cached data if conditions are met
 			if ( isRequestedScanNotStarted( data ) ) {
 				// Get cached data for the query
-				const cachedData = queryClient.getQueryData( [ QUERY_SCAN_STATUS_KEY ] );
+				return queryClient.getQueryData( [ QUERY_SCAN_STATUS_KEY ] );
 
-				return cachedData;
 			}
 
 			// If cached data is not applicable or expired, return the fresh API data

--- a/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
+++ b/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
@@ -81,7 +81,6 @@ export default function useScanStatusQuery( {
 			if ( isRequestedScanNotStarted( data ) ) {
 				// Get cached data for the query
 				return queryClient.getQueryData( [ QUERY_SCAN_STATUS_KEY ] );
-
 			}
 
 			// If cached data is not applicable or expired, return the fresh API data

--- a/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
+++ b/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
@@ -64,7 +64,7 @@ export default function useScanStatusQuery( {
 				lastRequestedScanTimestamp < Date.now() - 5 * 60 * 1000;
 
 			// Convert the lastChecked date string to a Unix timestamp
-			const lastCheckedTimestamp = new Date( data.lastChecked ).getTime();
+			const lastCheckedTimestamp = new Date( data.lastChecked + ' UTC' ).getTime();
 
 			// Check if the scan request is completed based on the last checked time
 			// TODO: Ensure the timestamps we are comparing are in the same timezone

--- a/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
+++ b/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
@@ -11,28 +11,22 @@ import { ScanStatus } from '../../types/scans';
 import { QUERY_SCAN_STATUS_KEY } from './../../constants';
 
 export const isRequestedScanNotStarted = ( status: ScanStatus ) => {
-	// If the scan status is not "idle", always return the fresh API data
 	if ( status.status !== 'idle' ) {
 		return false;
 	}
 
-	// Retrieve last scan timestamp from localStorage and convert to number
 	const lastRequestedScanTimestamp = Number( localStorage.getItem( 'last_requested_scan' ) );
 
-	// If there is no stored timestamp, return the API data
 	if ( ! lastRequestedScanTimestamp ) {
 		return false;
 	}
 
-	// Check if the last scan request is more than 5 minutes old
 	if ( lastRequestedScanTimestamp < Date.now() - 5 * 60 * 1000 ) {
 		return false;
 	}
 
-	// Convert the lastChecked date string to a Unix timestamp
 	const lastCheckedTimestamp = new Date( status.lastChecked + ' UTC' ).getTime();
 
-	// Check if the scan request is completed based on the last checked time
 	const isScanCompleted = lastCheckedTimestamp > lastRequestedScanTimestamp;
 	if ( isScanCompleted ) {
 		return false;

--- a/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
+++ b/projects/plugins/protect/src/js/data/scan/use-scan-status-query.ts
@@ -66,7 +66,7 @@ export default function useScanStatusQuery( {
 
 			// Return cached data if conditions are met
 			if (
-				'idle' === data.status &&
+				data.status === 'idle' &&
 				! islastRequestedScanTimestampExpired &&
 				! isScanRequestCompleted
 			) {

--- a/projects/plugins/protect/src/js/data/scan/use-start-scan-mutation.ts
+++ b/projects/plugins/protect/src/js/data/scan/use-start-scan-mutation.ts
@@ -24,6 +24,9 @@ export default function useStartScanMutation(): UseMutationResult {
 				...currentStatus,
 				status: SCAN_STATUS_OPTIMISTICALLY_SCANNING,
 			} ) );
+
+			// Set last_requested_scan timestamp in localStorage
+			localStorage.setItem( 'last_requested_scan', Date.now().toString() );
 		},
 		onError() {
 			// The scan failed to enqueue, invalidate the scan status query to reset the current status.

--- a/projects/plugins/protect/src/js/data/scan/use-start-scan-mutation.ts
+++ b/projects/plugins/protect/src/js/data/scan/use-start-scan-mutation.ts
@@ -25,7 +25,6 @@ export default function useStartScanMutation(): UseMutationResult {
 				status: SCAN_STATUS_OPTIMISTICALLY_SCANNING,
 			} ) );
 
-			// Set last_requested_scan timestamp in localStorage
 			localStorage.setItem( 'last_requested_scan', Date.now().toString() );
 		},
 		onError() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
If a scan isn't initiated immediately when queued in the UI we currently have a 5s second buffer where we set the UI to optimistically scanning. If the scan hasn't queued at that point we revert to an idle state.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Show progress if available right away without worrying about the "idle" state when we are optimistic
* Track optimistic time in local storage so it persists across page loads

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1424

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch and start up Jurassic Tube with Protect and an upgrade
* Ensure we remain in optimistic scanning state for 5 minutes after queueing a scan (across page loads) if we have not received a response from the Scan API that the scan is in progress
* Ensure no regressions are introduced in scanning functionality
