### PR TITLE
Boost: Update WP version requirement

### DIFF
--- a/projects/plugins/boost/changelog/update-required-wp-version
+++ b/projects/plugins/boost/changelog/update-required-wp-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Support: Increased minumum required PHP version to 6.5

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, xwp, adnan007, bjorsch, danwalmsley, davidlonjon, dilirity, donncha, ebinnion, exelero, jeherve, jpolakovic, karthikbhatb, kraftbj, luchad0res, pyronaur, rheinardkorf, scruffian, thingalon
 Donate link: https://automattic.com
 Tags: performance, speed, web vitals, critical css, cache
-Requires at least: 5.5
+Requires at least: 6.5
 Tested up to: 6.6
 Requires PHP: 7.0
 Stable tag: 3.5.0


### PR DESCRIPTION
## Proposed changes:
* Increase minimum required WP version from 5.5 to 6.5

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
None