### PR TITLE
Fix Gravatar widget verified accounts

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-gravatar-widget
+++ b/projects/plugins/jetpack/changelog/fix-gravatar-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Gravatar Widget: fix verified accounts and remove broken resource

--- a/projects/plugins/jetpack/modules/widgets/gravatar-profile.css
+++ b/projects/plugins/jetpack/modules/widgets/gravatar-profile.css
@@ -45,26 +45,26 @@
 }
 
 .grofile .accounts_facebook {
-	background-image: url( 'https://gravatar.com/icons/facebook.svg' );
+	background-image: url( 'https://0.gravatar.com/icons/facebook.svg' );
 }
 .grofile .accounts_foursquare {
-	background-image: url( 'https://gravatar.com/icons/foursquare.svg' );
+	background-image: url( 'https://0.gravatar.com/icons/foursquare.svg' );
 }
 .grofile .accounts_tripit {
-	background-image: url( 'https://gravatar.com/icons/tripit.svg' );
+	background-image: url( 'https://0.gravatar.com/icons/tripit.svg' );
 }
 .grofile .accounts_tumblr {
-	background-image: url( 'https://gravatar.com/icons/tumblr.svg' );
+	background-image: url( 'https://0.gravatar.com/icons/tumblr.svg' );
 }
 .grofile .accounts_twitter {
-	background-image: url( 'https://gravatar.com/icons/twitter-alt.svg' );
+	background-image: url( 'https://0.gravatar.com/icons/twitter-alt.svg' );
 }
 .grofile .accounts_vimeo {
-	background-image: url( 'https://gravatar.com/icons/vimeo.svg' );
+	background-image: url( 'https://0.gravatar.com/icons/vimeo.svg' );
 }
 .grofile .accounts_wordpress {
-	background-image: url( 'https://gravatar.com/icons/wordpress.svg' );
+	background-image: url( 'https://0.gravatar.com/icons/wordpress.svg' );
 }
 .grofile .accounts_github {
-	background-image: url( 'https://gravatar.com/icons/github.svg' );
+	background-image: url( 'https://0.gravatar.com/icons/github.svg' );
 }

--- a/projects/plugins/jetpack/modules/widgets/gravatar-profile.css
+++ b/projects/plugins/jetpack/modules/widgets/gravatar-profile.css
@@ -1,46 +1,70 @@
 .widget-grofile {
 }
-	.widget-grofile h4 {
-		margin: 1em 0 .5em;
-	}
-	.widget-grofile ul.grofile-urls {
-		margin-left: 0;
-		overflow: hidden;
-	}
-		.widget-grofile ul.grofile-accounts li {
-			list-style: none;
-			display: inline;
-		}
+.widget-grofile h4 {
+	margin: 1em 0 0.5em;
+}
+.widget-grofile ul.grofile-urls {
+	margin-left: 0;
+	overflow: hidden;
+	display: flex;
+}
+.widget-grofile ul {
+	padding: 0;
+	margin: 0;
+}
+.widget-grofile ul.grofile-accounts li {
+	list-style: none;
+	display: inline;
+}
 
-		.widget-grofile ul.grofile-accounts li::before {
-			content: "" !important; /* Kubrick :( */
-		}
-		.widget-grofile .grofile-accounts-logo {
-			background-image: url('https://secure.gravatar.com/images/grav-share-sprite.png');
-			background-repeat: no-repeat;
-			/*background-position: -16px -16px;*/
-			width: 16px; /* So we don't show the topmost logo */
-			height: 16px; /* So we don't show the topmost logo */
-			float: left;
-			margin-right: 8px;
-			margin-bottom: 8px;
-		}
-		.rtl .widget-grofile .grofile-accounts-logo {
-			margin-left: 8px;
-			margin-right: 0;
-		}
+.widget-grofile ul.grofile-accounts li::before {
+	content: '' !important; /* Kubrick :( */
+}
+.widget-grofile .grofile-accounts-logo {
+	margin-right: 8px;
+	margin-bottom: 8px;
+}
+.rtl .widget-grofile .grofile-accounts-logo {
+	margin-left: 8px;
+	margin-right: 0;
+}
 
-		.grofile-thumbnail {
-			width: 500px;
-			max-width: 100%;
-		}
-		@media
-only screen and (-webkit-min-device-pixel-ratio: 1.5),
-only screen and (-o-min-device-pixel-ratio: 3/2),
-only screen and (min--moz-device-pixel-ratio: 1.5),
-only screen and (min-device-pixel-ratio: 1.5) {
-		.widget-grofile .grofile-accounts-logo {
-			background-image: url('https://secure.gravatar.com/images/grav-share-sprite-2x.png');
-			background-size: 16px 784px;
-			}
+.grofile-thumbnail {
+	width: 500px;
+	max-width: 100%;
+}
+
+.grofile .profile {
+	background-size: contain;
+}
+
+.grofile-accounts-logo {
+	display: block;
+	width: 24px;
+	height: 24px;
+}
+
+.grofile .accounts_facebook {
+	background-image: url( 'https://gravatar.com/icons/facebook.svg' );
+}
+.grofile .accounts_foursquare {
+	background-image: url( 'https://gravatar.com/icons/foursquare.svg' );
+}
+.grofile .accounts_tripit {
+	background-image: url( 'https://gravatar.com/icons/tripit.svg' );
+}
+.grofile .accounts_tumblr {
+	background-image: url( 'https://gravatar.com/icons/tumblr.svg' );
+}
+.grofile .accounts_twitter {
+	background-image: url( 'https://gravatar.com/icons/twitter-alt.svg' );
+}
+.grofile .accounts_vimeo {
+	background-image: url( 'https://gravatar.com/icons/vimeo.svg' );
+}
+.grofile .accounts_wordpress {
+	background-image: url( 'https://gravatar.com/icons/wordpress.svg' );
+}
+.grofile .accounts_github {
+	background-image: url( 'https://gravatar.com/icons/github.svg' );
 }

--- a/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
+++ b/projects/plugins/jetpack/modules/widgets/gravatar-profile.php
@@ -267,7 +267,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 
 		<?php
 		foreach ( $accounts as $account ) :
-			if ( 'true' !== $account['verified'] ) {
+			if ( true !== $account['verified'] ) {
 				continue;
 			}
 
@@ -304,13 +304,6 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 			array(),
 			'20120711'
 		);
-
-		wp_enqueue_style(
-			'gravatar-card-services',
-			'https://secure.gravatar.com/css/services.css',
-			array(),
-			defined( 'GROFILES__CACHE_BUSTER' ) ? GROFILES__CACHE_BUSTER : gmdate( 'YW' )
-		);
 	}
 
 	/**
@@ -324,7 +317,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 		$email_user          = isset( $instance['email_user'] ) ? $instance['email_user'] : get_current_user_id();
 		$show_personal_links = isset( $instance['show_personal_links'] ) ? (bool) $instance['show_personal_links'] : '';
 		$show_account_links  = isset( $instance['show_account_links'] ) ? (bool) $instance['show_account_links'] : '';
-		$profile_url         = 'https://gravatar.com/profile/edit';
+		$profile_url         = 'https://gravatar.com/profile';
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$profile_url = admin_url( 'profile.php' );
@@ -449,7 +442,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 
 		if ( ! $profile ) {
 			$profile_url = sprintf(
-				'https://secure.gravatar.com/%s.json',
+				'https://gravatar.com/%s.json',
 				$hashed_email
 			);
 


### PR DESCRIPTION
Performs some cleanup of the Gravatar widget, fixing the display of verified accounts.

## Proposed changes:

- Fixes broken display of verified accounts because of a comparison with a string and a bool
- Removes broken `services.css` load. Not sure when this stopped working,
- Remove sprites from CSS. These don't appear to have worked for a long time. The CSS has been modified to directly reference the icons on Gravatar
- Clean up deprecated URLs to account edit page and profile JSON

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

- Add a Gravatar widget and get it to display a profile with verified accounts
- Confirm that the accounts are shown, both in the editor and on the site
![image](https://github.com/user-attachments/assets/c628846b-4091-493d-a842-76c1a9e6cd04)
- Confirm that no broken resources are loaded
