### PR TITLE
Boost: Update upgrade page text

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/layout/card-page/card-page.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/card-page/card-page.tsx
@@ -11,7 +11,7 @@ type CardPageProps = {
 	showActivateLicense?: boolean;
 	showBackButton?: boolean;
 	sidebarItem?: React.ReactNode;
-	footerNote?: string;
+	footerNote?: React.ReactNode;
 };
 
 const CardPage = ( {

--- a/projects/plugins/boost/app/assets/src/js/pages/upgrade/upgrade.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/upgrade/upgrade.tsx
@@ -48,9 +48,14 @@ const Upgrade: React.FC = () => {
 					/>
 				)
 			}
-			footerNote={ __(
-				'Special introductory pricing, all renewals are at full price. 14 day money back guarantee.',
-				'jetpack-boost'
+			footerNote={ createInterpolateElement(
+				__(
+					'Special introductory pricing, all renewals are at full price. <strong>14 day money back guarantee.</strong>',
+					'jetpack-boost'
+				),
+				{
+					strong: <strong />,
+				}
 			) }
 		>
 			<h1 className="my-3">

--- a/projects/plugins/boost/app/assets/src/js/pages/upgrade/upgrade.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/upgrade/upgrade.tsx
@@ -110,7 +110,7 @@ const Upgrade: React.FC = () => {
 				<li>
 					{ createInterpolateElement(
 						__(
-							'<strong>Expert Support With a Personal Touch:</strong> Enjoy dedicated email support from our Happiness Engineers, ensuring a smoother experience and peace of mind.',
+							'<strong>Expert Support With Personal Assistance Available:</strong> Enjoy dedicated email support from our Happiness Engineers, ensuring a smoother experience and peace of mind.',
 							'jetpack-boost'
 						),
 						{

--- a/projects/plugins/boost/changelog/update-upgrade-page
+++ b/projects/plugins/boost/changelog/update-upgrade-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Updated text on upgrade page
+
+


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In the upsell card we say "Support with a Personal Touch". but it’s not guaranteed if they get a bot as a first reply. Changed the text to "Expert Support with Personal Assistance Available", which sets clearer expectations and avoids frustration if a bot responds first.
* Made the "14 day money back guarantee" bold

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pfln9p-Oi-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
It looks like this now
![image](https://github.com/user-attachments/assets/0faf0338-7064-414c-8642-7e3b2615acdc)
