### PR TITLE
Masterbar: Remove User Info side-panel

### DIFF
--- a/projects/packages/masterbar/changelog/update-masterbar-remove-user-info-sidepanel
+++ b/projects/packages/masterbar/changelog/update-masterbar-remove-user-info-sidepanel
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Masterbar: Remove User Info side-panel

--- a/projects/packages/masterbar/src/masterbar/class-masterbar.php
+++ b/projects/packages/masterbar/src/masterbar/class-masterbar.php
@@ -723,16 +723,6 @@ class Masterbar {
 
 		$wp_admin_bar->add_group(
 			array(
-				'parent' => 'blog',
-				'id'     => 'blog-secondary',
-				'meta'   => array(
-					'class' => 'ab-sub-secondary',
-				),
-			)
-		);
-
-		$wp_admin_bar->add_group(
-			array(
 				'id'   => 'top-secondary',
 				'meta' => array(
 					'class' => 'ab-top-secondary',
@@ -764,69 +754,6 @@ class Masterbar {
 				'href'   => 'https://wordpress.com/me',
 				'meta'   => array(
 					'class' => $class,
-				),
-			)
-		);
-
-		/** This filter is documented in modules/masterbar.php */
-		if ( apply_filters( 'jetpack_load_admin_menu_class', false ) ) {
-			return;
-		}
-
-		$id = 'user-actions';
-		$wp_admin_bar->add_group(
-			array(
-				'parent' => 'my-account',
-				'id'     => $id,
-			)
-		);
-
-		$logout_url = wp_logout_url();
-		$logout_url = add_query_arg( 'context', 'masterbar', $logout_url );
-
-		$user_info  = get_avatar( $this->user_email, 128, 'mm', '', array( 'force_display' => true ) );
-		$user_info .= '<span class="display-name">' . $this->display_name . '</span>';
-		$user_info .= '<span class="username">' . $this->user_login . '</span>';
-
-		$blog_id = Connection_Manager::get_site_id( true );
-
-		$args = array();
-		if ( $blog_id ) {
-			$args['site'] = $blog_id;
-		}
-
-		$wp_admin_bar->add_menu(
-			array(
-				'parent' => $id,
-				'id'     => 'user-info',
-				'title'  => $user_info,
-				'meta'   => array(
-					'class'    => 'user-info user-info-item',
-					'tabindex' => -1,
-				),
-			)
-		);
-
-		$wp_admin_bar->add_menu(
-			array(
-				'parent' => $id,
-				'id'     => 'profile',
-				'title'  => esc_html__( 'Profile', 'jetpack-masterbar' ),
-				'href'   => Redirect::get_url( 'calypso-me', $args ),
-				'meta'   => array(
-					'class' => 'mb-icon',
-				),
-			)
-		);
-
-		$wp_admin_bar->add_menu(
-			array(
-				'parent' => $id,
-				'id'     => 'logout',
-				'title'  => esc_html__( 'Log Out', 'jetpack-masterbar' ),
-				'href'   => $logout_url,
-				'meta'   => array(
-					'class' => 'mb-icon',
 				),
 			)
 		);
@@ -870,15 +797,6 @@ class Masterbar {
 	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
 	 */
 	public function add_my_sites_submenu( $wp_admin_bar ) {
-		$blog_name = get_bloginfo( 'name' );
-		if ( empty( $blog_name ) ) {
-			$blog_name = $this->primary_site_slug;
-		}
-
-		if ( mb_strlen( $blog_name ) > 20 ) {
-			$blog_name = mb_substr( html_entity_decode( $blog_name, ENT_QUOTES ), 0, 20 ) . '&hellip;';
-		}
-
 		$my_site_url = 'https://wordpress.com/sites/' . $this->primary_site_url;
 		if ( 'wp-admin' === get_option( 'wpcom_admin_interface' ) ) {
 			$my_site_url = 'https://wordpress.com/sites';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Now that the `masterbar` module has been removed from self-hosted sites via https://github.com/Automattic/jetpack/pull/39406, we can wrap up the work done in https://github.com/Automattic/jetpack/pull/35199/
In that PR, the User Info and My Sites side-panels were removed however the PR had to be reverted as it introduced unwanted behaviour in self-hosted sites. See: p9Jlb4-R8-p2
Note that the task of removing the My Sites side-panel is already done via https://github.com/Automattic/jetpack/pull/37764
Therefore, this PR addresses the part of removing the User Info side panel
 
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Masterbar\Masterbar`: Update  `add_me_submenu` by removing sub-menu items.
* `Automattic\Jetpack\Masterbar\Masterbar`: Cleanup unused code in  `add_my_sites_submenu`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pfwV0U-3U-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Confirm that clicking on the user account icon in the top bar menu behaves the same on trunk/branch on:
- Self hosted sites
- WoA sites with admin interface set to 1) Classic and 2) Default
- Simple sites with admin interface set to 1) Classic and 2) Default

Finally, as per the corresponding reported issue in p9Jlb4-R8-p2 lets make sure that the left drawer is visible on mobile view (in all the above envs):

<img width="804" alt="Screenshot 2024-09-27 at 14 43 26" src="https://github.com/user-attachments/assets/91c4deb9-030e-4fe2-9eca-9c82212d3b42">
