### PR TITLE
Jetpack: clean and deprecate unused functionality on Jetpack admin pages

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -108,7 +108,7 @@ return [
         '_inc/genericons.php' => ['PhanTypeMismatchArgumentProbablyReal'],
         '_inc/lib/admin-pages/class-jetpack-about-page.php' => ['PhanTypeMismatchArgument'],
         '_inc/lib/admin-pages/class-jetpack-redux-state-helper.php' => ['PhanParamTooMany', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDimAssignment'],
-        '_inc/lib/admin-pages/class.jetpack-admin-page.php' => ['PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
+        '_inc/lib/admin-pages/class.jetpack-admin-page.php' => ['PhanDeprecatedProperty', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredProperty'],
         '_inc/lib/class-jetpack-ai-helper.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchPropertyDefault'],
         '_inc/lib/class-jetpack-instagram-gallery-helper.php' => ['PhanTypeMismatchArgument'],
         '_inc/lib/class-jetpack-mapbox-helper.php' => ['PhanTypeMismatchArgumentNullable'],

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -140,14 +140,14 @@ abstract class Jetpack_Admin_Page {
 	 * @todo This may no longer be used.
 	 */
 	public function admin_help() {
-		$this->jetpack->admin_help();
+		Jetpack::init()->admin_help();
 	}
 
 	/**
 	 * Call the existing admin page events.
 	 */
 	public function admin_page_load() {
-		$this->jetpack->admin_page_load();
+		Jetpack::init()->admin_page_load();
 	}
 
 	/**
@@ -155,7 +155,7 @@ abstract class Jetpack_Admin_Page {
 	 */
 	public function admin_scripts() {
 		$this->page_admin_scripts(); // Delegate to inheriting class.
-		add_action( 'admin_footer', array( $this->jetpack, 'do_stats' ) );
+		add_action( 'admin_footer', array( Jetpack::init(), 'do_stats' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -18,7 +18,7 @@ abstract class Jetpack_Admin_Page {
 	 * Jetpack Object.
 	 *
 	 * @var Jetpack
-	 * @deprecated $$next-version$$ Use `Jetpack::init()` instead. Keeping it for a couple more versions to be safe.
+	 * @deprecated $$next-version$$ Use `Jetpack::init()` instead.
 	 */
 	public $jetpack;
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -18,6 +18,7 @@ abstract class Jetpack_Admin_Page {
 	 * Jetpack Object.
 	 *
 	 * @var Jetpack
+	 * @deprecated $$next-version$$ Use `Jetpack::init()` instead. Keeping it for a couple more versions to be safe.
 	 */
 	public $jetpack;
 
@@ -56,11 +57,19 @@ abstract class Jetpack_Admin_Page {
 	 * The constructor.
 	 */
 	public function __construct() {
+		/**
+		 * Keeping it for backward compatibility in case the `$jetpack` property is still in use.
+		 * To be removed.
+		 *
+		 * @deprecated $$next-version$$
+		 */
 		add_action( 'jetpack_loaded', array( $this, 'on_jetpack_loaded' ) );
 	}
 
 	/**
 	 * Runs on Jetpack being ready to load its packages.
+	 *
+	 * @deprecated $$next-version$$
 	 *
 	 * @param Jetpack $jetpack object.
 	 */
@@ -93,7 +102,6 @@ abstract class Jetpack_Admin_Page {
 		$hook = $this->get_page_hook();
 
 		// Attach hooks common to all Jetpack admin pages based on the created hook.
-		add_action( "load-$hook", array( $this, 'admin_help' ) );
 		add_action( "load-$hook", array( $this, 'admin_page_load' ) );
 		add_action( "admin_print_styles-$hook", array( $this, 'admin_styles' ) );
 		add_action( "admin_print_scripts-$hook", array( $this, 'admin_scripts' ) );
@@ -137,11 +145,9 @@ abstract class Jetpack_Admin_Page {
 	/**
 	 * Load Help tab.
 	 *
-	 * @todo This may no longer be used.
+	 * @deprecated $$next-version$$ No longer used.
 	 */
-	public function admin_help() {
-		Jetpack::init()->admin_help();
-	}
+	public function admin_help() {}
 
 	/**
 	 * Call the existing admin page events.

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -143,7 +143,7 @@ abstract class Jetpack_Admin_Page {
 	}
 
 	/**
-	 * Load Help tab.
+	 * Doesn't do anything anymore.
 	 *
 	 * @deprecated $$next-version$$ No longer used.
 	 */

--- a/projects/plugins/jetpack/changelog/remove-jetpack-page-excessive-hook
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-page-excessive-hook
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Clean and deprecate unused functionality on Jetpack admin pages.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3560,6 +3560,8 @@ p {
 	/**
 	 * Add help to the Jetpack page
 	 *
+	 * @deprecated $$next-version$$ We no longer show the "Help" button.
+	 *
 	 * @since Jetpack (1.2.3)
 	 * @return void
 	 */

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3558,56 +3558,14 @@ p {
 	}
 
 	/**
-	 * Add help to the Jetpack page
+	 * Doesn't do anything anymore.
 	 *
 	 * @deprecated $$next-version$$ We no longer show the "Help" button.
 	 *
 	 * @since Jetpack (1.2.3)
 	 * @return void
 	 */
-	public function admin_help() {
-		$current_screen = get_current_screen();
-
-		// Overview.
-		$current_screen->add_help_tab(
-			array(
-				'id'      => 'home',
-				'title'   => __( 'Home', 'jetpack' ),
-				'content' =>
-					'<p><strong>' . __( 'Jetpack', 'jetpack' ) . '</strong></p>' .
-					'<p>' . __( 'Jetpack supercharges your self-hosted WordPress site with the awesome cloud power of WordPress.com.', 'jetpack' ) . '</p>' .
-					'<p>' . __( 'On this page, you are able to view the modules available within Jetpack, learn more about them, and activate or deactivate them as needed.', 'jetpack' ) . '</p>',
-			)
-		);
-
-		// Screen Content.
-		if ( current_user_can( 'manage_options' ) ) {
-			$current_screen->add_help_tab(
-				array(
-					'id'      => 'settings',
-					'title'   => __( 'Settings', 'jetpack' ),
-					'content' =>
-						'<p><strong>' . __( 'Jetpack', 'jetpack' ) . '</strong></p>' .
-						'<p>' . __( 'You can activate or deactivate individual Jetpack modules to suit your needs.', 'jetpack' ) . '</p>' .
-						'<ol>' .
-							'<li>' . __( 'Each module has an Activate or Deactivate link so you can toggle one individually.', 'jetpack' ) . '</li>' .
-							'<li>' . __( 'Using the checkboxes next to each module, you can select multiple modules to toggle via the Bulk Actions menu at the top of the list.', 'jetpack' ) . '</li>' .
-						'</ol>' .
-						'<p>' . __( 'Using the tools on the right, you can search for specific modules, filter by module categories or which are active, or change the sorting order.', 'jetpack' ) . '</p>',
-				)
-			);
-		}
-
-		// Help Sidebar.
-		$support_url = Redirect::get_url( 'jetpack-support' );
-		$faq_url     = Redirect::get_url( 'jetpack-faq' );
-		$current_screen->set_help_sidebar(
-			'<p><strong>' . __( 'For more information:', 'jetpack' ) . '</strong></p>' .
-			'<p><a href="' . esc_url( $faq_url ) . '" rel="noopener noreferrer" target="_blank">' . __( 'Jetpack FAQ', 'jetpack' ) . '</a></p>' .
-			'<p><a href="' . esc_url( $support_url ) . '" rel="noopener noreferrer" target="_blank">' . __( 'Jetpack Support', 'jetpack' ) . '</a></p>' .
-			'<p><a href="' . esc_url( self::admin_url( array( 'page' => 'jetpack-debugger' ) ) ) . '">' . __( 'Jetpack Debugging Center', 'jetpack' ) . '</a></p>'
-		);
-	}
+	public function admin_help() {}
 
 	/**
 	 * Add action links for the Jetpack plugin.


### PR DESCRIPTION
## Proposed changes:
* Deprecate the "help tab" functionality, clean up what we can.
* Deprecate the callback hooked into `jetpack_loaded` so we could remove it in the next version.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/529

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Visit all the Jetpack admin pages and confirm they work as expected:
- Dashboard
- Settings
- About
- Privacy
- Modules
- Debug