### PR TITLE
Protect: Fix last_checked conversions

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-last-checked-conversions
+++ b/projects/plugins/protect/changelog/fix-protect-last-checked-conversions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fixes lastChecked conversions

--- a/projects/plugins/protect/src/js/components/summary/index.jsx
+++ b/projects/plugins/protect/src/js/components/summary/index.jsx
@@ -18,7 +18,7 @@ const Summary = () => {
 	const { hasPlan } = usePlan();
 
 	// Convert the last checked UTC date to a local timestamp
-	const localTimestamp = new Date( lastChecked + ' UTC' ).getTime();
+	const lastCheckedLocalTimestamp = new Date( lastChecked + ' UTC' ).getTime();
 
 	// Popover anchors
 	const [ dailyScansPopoverAnchor, setDailyScansPopoverAnchor ] = useState( null );
@@ -41,7 +41,7 @@ const Summary = () => {
 						{ sprintf(
 							/* translators: %s: Latest check date  */
 							__( 'Latest results as of %s', 'jetpack-protect' ),
-							dateI18n( 'F jS', localTimestamp )
+							dateI18n( 'F jS', lastCheckedLocalTimestamp )
 						) }
 					</div>
 					{ ! hasPlan && (

--- a/projects/plugins/protect/src/js/components/summary/index.jsx
+++ b/projects/plugins/protect/src/js/components/summary/index.jsx
@@ -17,6 +17,9 @@ const Summary = () => {
 	} = useProtectData();
 	const { hasPlan } = usePlan();
 
+	// Convert the last checked UTC date to a local timestamp
+	const localTimestamp = new Date( lastChecked + ' UTC' ).getTime();
+
 	// Popover anchors
 	const [ dailyScansPopoverAnchor, setDailyScansPopoverAnchor ] = useState( null );
 
@@ -38,7 +41,7 @@ const Summary = () => {
 						{ sprintf(
 							/* translators: %s: Latest check date  */
 							__( 'Latest results as of %s', 'jetpack-protect' ),
-							dateI18n( 'F jS', lastChecked )
+							dateI18n( 'F jS', localTimestamp )
 						) }
 					</div>
 					{ ! hasPlan && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
The `last_checked` value we retrieve from the scan API is a reformatted UTC date time value - in the scanning UI its treated as though it is in local time and therefor double converted based on the WP installation timezone settings.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Convert the timestamp to local time before passing it to the WP timezone conversion function

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1439

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch running Jurassic Tube with Protect installed and a scan upgrade
* Set your WP installation timezone settings to your local time
* Within the `Summary` component log out the value of `dateI18n( 'F jS H:i:s', lastChecked )`
   * Include `H:i:s` for better clarity
* Load the scan UI after running a successful scan
* Verify that the date value provided is incorrect
* Log out `dateI18n( 'F jS H:i:s', lastCheckedLocalTimestamp )` and verify that it aligns with the time of the last successful in the timezone you have set
* Update your installation timezone settings and ensure the value changes and the UI updates accordingly

