### PR TITLE
Jetpack AI Logo generator toolbar button label

### DIFF
--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-logo-generator-block-toolbar-button
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-logo-generator-block-toolbar-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: show button label on logo block toolbar if site's logo is empty

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/components/ai-toolbar-button.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/components/ai-toolbar-button.tsx
@@ -15,16 +15,21 @@ import type { ReactElement } from 'react';
  *
  * @param {object}   props              - The component props.
  * @param {Function} props.clickHandler - The handler for the click event.
+ * @param {boolean}  props.buttonText   - Use text for the button face or not.
  * @return {ReactElement} The toolbar button.
  */
 export default function AiToolbarButton( {
 	clickHandler,
+	buttonText = false,
 }: {
 	clickHandler?: () => void;
+	buttonText?: boolean;
 } ): ReactElement {
 	const toggleFromToolbar = useCallback( () => {
 		clickHandler?.();
 	}, [ clickHandler ] );
+
+	const text = buttonText ? __( 'Generate', 'jetpack' ) : '';
 
 	return (
 		<>
@@ -33,7 +38,9 @@ export default function AiToolbarButton( {
 				onClick={ toggleFromToolbar }
 				label={ __( 'Generate with AI', 'jetpack' ) }
 				icon={ aiAssistantIcon }
-			/>
+			>
+				{ text }
+			</ToolbarButton>
 		</>
 	);
 }

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/components/ai-toolbar-button.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/components/ai-toolbar-button.tsx
@@ -13,23 +13,23 @@ import type { ReactElement } from 'react';
 /**
  * The toolbar button that toggles the Logo Generator Modal.
  *
- * @param {object}   props              - The component props.
- * @param {Function} props.clickHandler - The handler for the click event.
- * @param {boolean}  props.buttonText   - Use text for the button face or not.
+ * @param {object}   props                - The component props.
+ * @param {Function} props.clickHandler   - The handler for the click event.
+ * @param {boolean}  props.showButtonText - Use text for the button face or not.
  * @return {ReactElement} The toolbar button.
  */
 export default function AiToolbarButton( {
 	clickHandler,
-	buttonText = false,
+	showButtonText = false,
 }: {
 	clickHandler?: () => void;
-	buttonText?: boolean;
+	showButtonText?: boolean;
 } ): ReactElement {
 	const toggleFromToolbar = useCallback( () => {
 		clickHandler?.();
 	}, [ clickHandler ] );
 
-	const text = buttonText ? __( 'Generate', 'jetpack' ) : '';
+	const text = showButtonText ? __( 'Generate', 'jetpack' ) : '';
 
 	return (
 		<>

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -26,6 +26,7 @@ type CoreSelect = {
 		url: string;
 		title: string;
 		description: string;
+		site_logo: number;
 	};
 };
 
@@ -80,6 +81,7 @@ const useSiteDetails = () => {
 		domain: window?.Jetpack_Editor_Initial_State?.siteFragment,
 		name: siteSettings?.title,
 		description: siteSettings?.description,
+		siteLogo: siteSettings?.site_logo || 0,
 	};
 };
 
@@ -129,7 +131,7 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			<>
 				<BlockEdit { ...props } />
 				<BlockControls group="block">
-					<AiToolbarButton clickHandler={ showModal } />
+					<AiToolbarButton buttonText={ ! siteDetails?.siteLogo } clickHandler={ showModal } />
 				</BlockControls>
 				<GeneratorModal
 					isOpen={ isLogoGeneratorModalVisible }

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -131,7 +131,7 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			<>
 				<BlockEdit { ...props } />
 				<BlockControls group="block">
-					<AiToolbarButton buttonText={ ! siteDetails?.siteLogo } clickHandler={ showModal } />
+					<AiToolbarButton showButtonText={ ! siteDetails?.siteLogo } clickHandler={ showModal } />
 				</BlockControls>
 				<GeneratorModal
 					isOpen={ isLogoGeneratorModalVisible }


### PR DESCRIPTION
## Proposed changes:
Use "Generate" label on logo block AI toolbar button when the site doesn't have a logo set

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-2Ms-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a logo block on the editor.

If your site has a logo set, the toolbar AI button will only show the icon. If not, then the button will read "Generate" alongside the icon.

<img width="332" alt="image" src="https://github.com/user-attachments/assets/21777225-7820-44ec-82ea-025b5ffce28b">
<img width="318" alt="image" src="https://github.com/user-attachments/assets/9786837b-7bcd-4f5e-a747-0b5f3e1330ca">

If you need to reset your site's logo, while editing a post, open the devtools console and run:

```js
wp.data.dispatch('core').editEntityRecord( 'root', 'site', undefined, { site_logo: 0 } )
```
Be reminded that this needs to be saved (you'll see the "Publish" button turn into "Save"). Once you save it, you'll see the changes in the logo block toolbar.