### PR TITLE
jetpack: Render Slideshow block correctly in iframed editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-slideshow-block-in-iframe-editor
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-slideshow-block-in-iframe-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Slideshow block: Render correctly in iframed editor.

--- a/projects/plugins/jetpack/tools/webpack.config.extensions.js
+++ b/projects/plugins/jetpack/tools/webpack.config.extensions.js
@@ -112,6 +112,30 @@ const sharedWebpackConfig = {
 	plugins: [
 		...jetpackWebpackConfig.StandardPlugins( {
 			DependencyExtractionPlugin: { injectPolyfill: true },
+			MiniCssExtractPlugin: {
+				// This is a bit of a hack to handle simple cases of `import( './file.css' )` in block editor scripts.
+				// If we're ever able to get rid of the monolithic editor.js files, this should go away in favor
+				// of doing the `import()` from inside the `script` (not `editorScript` or `viewScript`).
+				insert: linkTag => {
+					// Insert at the top level, in the way minicss does normally.
+					/* global oldTag */
+					if ( oldTag ) {
+						oldTag.parentNode.insertBefore( linkTag, oldTag.nextSibling );
+					} else {
+						document.head.appendChild( linkTag );
+					}
+
+					// Also insert into any editor-canvas iframes.
+					for ( const iframe of document.querySelectorAll( 'iframe[name=editor-canvas]' ) ) {
+						try {
+							const iframeDoc = iframe.contentDocument;
+							iframeDoc.head.appendChild( iframeDoc.importNode( linkTag ) );
+						} catch {
+							// Browser won't allow access. Never mind.
+						}
+					}
+				},
+			},
 		} ),
 	],
 	externals: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When the block editor uses an iframe, our monolithic `editor.js` script is only loaded and run at the top level, not inside the iframe. Thus, any dynamic `import()` also only runs at the top level, and in particular the loaded CSS does not affect the content inside the iframe.

The real solution to this would be to have the content-related code in block.json "script" where it gets loaded everywhere (frontend, editor top-level, and iframe) (unfortunately there's no option that runs only on frontend+iframe, or only iframe) and run the code doing the `import()` inside the iframe, so it adds the CSS inside the iframe. But we can't really do that without a ton of refactoring that's largely blocked on Gutenberg implementing lazy block loading.

So, in the mean time, let's configure mini-css-extract-plugin to add any imported CSS into the iframe (if one exists) in addition to the top level. That won't work for JS (e.g. the Map block, which has its own hack), but that's ok for now.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #39459

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In an iframed editor (e.g. post editor with an FSE theme), add a Slideshow block. It should render correctly.
* Also check in a non-iframed editor and on the frontend. It should continue to render correctly there too.