### PR TITLE
Title Optimization: improve button behavior on error screen

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-reset-error-on-title-optimization
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-reset-error-on-title-optimization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Title Optimization: improve button behaviors when handling errors.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
@@ -204,6 +204,7 @@ export default function TitleOptimization( {
 	);
 
 	const handleClose = useCallback( () => {
+		setError( null );
 		toggleTitleOptimizationModal();
 		setOptimizationKeywords( '' );
 		stopSuggestion();
@@ -275,7 +276,7 @@ export default function TitleOptimization( {
 								</>
 							) }
 							<div className="jetpack-ai-title-optimization__cta">
-								<Button variant="secondary" onClick={ toggleTitleOptimizationModal }>
+								<Button variant="secondary" onClick={ handleClose }>
 									{ __( 'Cancel', 'jetpack' ) }
 								</Button>
 								{ showTryAgainButton && (

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
@@ -177,8 +177,16 @@ export default function TitleOptimization( {
 
 	const handleTryAgain = useCallback( () => {
 		setError( null );
-		handleRequest( true ); // retry the generation
-	}, [ handleRequest ] );
+
+		/**
+		 * Only try to generate again if there are no options available.
+		 * If there are options, show them so the user can choose one
+		 * or ask for new suggestions.
+		 */
+		if ( options.length === 0 ) {
+			handleRequest( true ); // retry the generation
+		}
+	}, [ handleRequest, options ] );
 
 	const handleTitleOptimizationWithKeywords = useCallback( () => {
 		handleRequest();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes p8oabR-1Af-p2#comment-8236.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Properly clean error state when closing the modal or clicking the "Cancel" button; this is necessary so the user can get rid of the error message and start again when closing the modal and opening it again
* Improve how we handle the "Try again" button:
   * when there are old options to show, simply show them and let the user request a new generation (with keywords or not)
   * when there are no old options (the error happened before the first 3 got generated), then try the generation again (may help solve transient errors)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

First, let's simulate an error after the first 3 suggestions 

* Go to the block editor and add some content to it
* On the Jetpack sidebar, look for the "Improve title for SEO" button and click it
* After the modal shows the suggestions, type some random keywords on the keyword field (example: "pwoieopqweiqopweiq") and request a new generation
* You should see the "Unclear request" error message:

<img width="600" alt="Screenshot 2024-09-26 at 17 15 26" src="https://github.com/user-attachments/assets/65d067f8-f162-4159-b3d6-1aac8b377f33">

* Click the "Try again" button and:
   * confirm you see the old suggestions
   * confirm you are able to type new keywords and request a new generation
* Type another random keyword and click "Generate again" to get to the error UI once more
* On the error UI, click "Cancel"
* This will close the modal and clean up the tool state
* Go to the sidebar and click "Improve title for SEO" again
* Confirm a new generation starts and you see 3 new suggestions

Now let's simulate an error before the first generation.

* Close the modal and set the connection throttling setting of your browser to "Offline"
* Click the "Improve title for SEO" button on the Jetpack sidebar
* You will see another error message:

<img width="600" alt="Screenshot 2024-09-26 at 17 55 01" src="https://github.com/user-attachments/assets/275ddd9b-90ad-4376-bf0a-f1331f3ed8e2">

* Click "Try again"
* This time, since there is no previous suggestions to show, the tool will try the generation another time
* Since you are still offline, you will see the error again
* Change the throttling setting to be back online
* Click "Try again"
* Confirm the tool will properly start a new generation and show 3 new suggestion for you

<img width="600" alt="Screenshot 2024-09-26 at 17 55 09" src="https://github.com/user-attachments/assets/130cf83f-5c9d-49ef-964e-682e06496a84">