### PR TITLE
wpcomsh: Update wc-calypso-bridge to 2.7.1

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-wc-calypso-bridge-2.7.1
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-wc-calypso-bridge-2.7.1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update wc-calypso-bridge dependency to 2.7.1

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -9,7 +9,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "2.6.0",
+		"automattic/wc-calypso-bridge": "2.7.1",
 		"wordpress/classic-editor-plugin": "1.5",
 		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-post-list": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "abd021117ab176c49e44e4e54a122e75",
+    "content-hash": "8f11d469200ef552138a299a23db550e",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -1866,16 +1866,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.6.0",
+            "version": "v2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "cb8300f827fcf2dd1174822c08f0957f65f0e42e"
+                "reference": "b9e010c652befc8546cf20c7dabff9f600a5311a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/cb8300f827fcf2dd1174822c08f0957f65f0e42e",
-                "reference": "cb8300f827fcf2dd1174822c08f0957f65f0e42e",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/b9e010c652befc8546cf20c7dabff9f600a5311a",
+                "reference": "b9e010c652befc8546cf20c7dabff9f600a5311a",
                 "shasum": ""
             },
             "require": {
@@ -1916,7 +1916,7 @@
                     "phpcbf -p"
                 ]
             },
-            "time": "2024-09-10T04:10:28+00:00"
+            "time": "2024-09-27T01:56:08+00:00"
         },
         {
             "name": "composer/installers",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR bumps the version of `wc-calypso-bridge` to `2.7.1`, which includes the following change:

- https://github.com/Automattic/wc-calypso-bridge/pull/1523
- https://github.com/Automattic/wc-calypso-bridge/pull/1512
- https://github.com/Automattic/wc-calypso-bridge/pull/1521
- https://github.com/Automattic/wc-calypso-bridge/pull/1519
- https://github.com/Automattic/wc-calypso-bridge/pull/1518

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

The changes related to the wc-calypso-bridge were already tested in the linked PRs. Testing instructions can be found on the linked PRs above.

