### PR TITLE
repo-gardening: Update AI prompt for labelling

### DIFF
--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -66,11 +66,21 @@ ${ repoLabels
 	.join( '\n' ) }
 
 Analyze the issue and suggest relevant labels. Rules:
+# Updated prompt: Ensures 'Product', 'Platform' and 'Type' issues are always added.
 - Use only existing labels provided.
+- Include 1 '[Product]' label.
 - Include 1 '[Feature Group]' label.
 - Include 1 to 3 '[Feature]' labels.
+- Include the "[Platform] Simple" AND/OR "[Platform] Atomic" labels as appropriate.
+- Only if NOT present: Add 1 of the following labels based on your assessment of the issue type: '[Type] Bug', '[Type] Enhancement', or '[Type] Feature'.
 - Briefly explain each label choice in 1 sentence.
-- Format your response as a JSON object, with each suggested label as a key, and your explanation of the label choice as the value.
+- Format your response as a JSON object, with 'labels' and 'explanations' keys.- Use only existing labels provided.
+
+# Original prompt
+#- Include 1 '[Feature Group]' label.
+#- Include 1 to 3 '[Feature]' labels.
+#- Briefly explain each label choice in 1 sentence.
+#- Format your response as a JSON object, with each suggested label as a key, and your explanation of the label choice as the value.
 
 Example response format:
 {

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.js
@@ -60,27 +60,18 @@ You must analyze this content, and suggest labels related to the content.
 The labels you will suggest must all come from the list below.
 Each item on the list of labels below follows the following format: - <label name>: <label description if it exists>
 
-
 ${ repoLabels
 	.map( label => `- ${ label.name }${ label?.description ? `: ${ label.description }` : '' }` )
 	.join( '\n' ) }
 
 Analyze the issue and suggest relevant labels. Rules:
-# Updated prompt: Ensures 'Product', 'Platform' and 'Type' issues are always added.
 - Use only existing labels provided.
-- Include 1 '[Product]' label.
 - Include 1 '[Feature Group]' label.
 - Include 1 to 3 '[Feature]' labels.
 - Include the "[Platform] Simple" AND/OR "[Platform] Atomic" labels as appropriate.
-- Only if NOT present: Add 1 of the following labels based on your assessment of the issue type: '[Type] Bug', '[Type] Enhancement', or '[Type] Feature'.
 - Briefly explain each label choice in 1 sentence.
-- Format your response as a JSON object, with 'labels' and 'explanations' keys.- Use only existing labels provided.
-
-# Original prompt
-#- Include 1 '[Feature Group]' label.
-#- Include 1 to 3 '[Feature]' labels.
-#- Briefly explain each label choice in 1 sentence.
-#- Format your response as a JSON object, with each suggested label as a key, and your explanation of the label choice as the value.
+- Format your response as a JSON object, with 'labels' and 'explanations' keys.
+- Use only existing labels provided.
 
 Example response format:
 {


### PR DESCRIPTION
Following further tests, I updated the OpenAI prompt to ensure the 'Product,' 'Platform', and 'Type' labels are added.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
*

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

