### PR TITLE
Social: Add Bluesky connection UI

### DIFF
--- a/projects/js-packages/publicize-components/changelog/add-bluesky-connection-ui
+++ b/projects/js-packages/publicize-components/changelog/add-bluesky-connection-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social: Added support for Bluesky

--- a/projects/js-packages/publicize-components/src/components/services/connect-form.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/connect-form.tsx
@@ -1,11 +1,12 @@
 import { Button } from '@automattic/jetpack-components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { useCallback } from 'react';
 import { store } from '../../social-store';
 import { KeyringResult } from '../../social-store/types';
 import { SupportedService } from '../services/use-supported-services';
+import { CustomInputs } from './custom-inputs';
 import styles from './style.module.scss';
 import { useRequestAccess } from './use-request-access';
 
@@ -63,6 +64,7 @@ export function ConnectForm( {
 			}
 
 			const formData = new FormData( event.target as HTMLFormElement );
+
 			requestAccess( formData );
 		},
 		[ onSubmit, requestAccess ]
@@ -74,31 +76,30 @@ export function ConnectForm( {
 			onSubmit={ onSubmitForm }
 		>
 			{ displayInputs ? (
-				<>
-					{ 'mastodon' === service.ID ? (
-						<input
-							required
-							type="text"
-							name="instance"
-							aria-label={ __( 'Mastodon username', 'jetpack' ) }
-							placeholder={ '@mastodon@mastodon.social' }
-						/>
-					) : null }
-				</>
+				<div className={ styles[ 'fields-wrapper' ] }>
+					<CustomInputs service={ service } />
+				</div>
 			) : null }
-			<Button
-				variant={ hasConnections ? 'secondary' : 'primary' }
-				type="submit"
-				className={ styles[ 'connect-button' ] }
-			>
-				{ ( label => {
-					if ( label ) {
-						return label;
-					}
 
-					return hasConnections ? _x( 'Connect more', '', 'jetpack' ) : __( 'Connect', 'jetpack' );
-				} )( buttonLabel ) }
-			</Button>
+			<div className={ styles[ 'fields-wrapper' ] }>
+				<div className={ styles[ 'fields-item' ] }>
+					<Button
+						variant={ hasConnections ? 'secondary' : 'primary' }
+						type="submit"
+						className={ styles[ 'connect-button' ] }
+					>
+						{ ( label => {
+							if ( label ) {
+								return label;
+							}
+
+							return hasConnections
+								? _x( 'Connect more', '', 'jetpack' )
+								: __( 'Connect', 'jetpack' );
+						} )( buttonLabel ) }
+					</Button>
+				</div>
+			</div>
 		</form>
 	);
 }

--- a/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
@@ -1,6 +1,6 @@
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement, useId } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { SupportedService } from '../services/use-supported-services';
 import styles from './style.module.scss';
 
@@ -21,11 +21,7 @@ export function CustomInputs( { service }: CustomInputsProps ) {
 		return (
 			<div className={ styles[ 'fields-item' ] }>
 				<label htmlFor={ `${ id }-handle` }>
-					{ __(
-						/* translators: The handle of a social media account. */
-						'Handle',
-						'jetpack'
-					) }
+					{ _x( 'Handle', 'The handle of a social media account.', 'jetpack' ) }
 				</label>
 				<p className="description" id={ `${ id }-handle-description` }>
 					{ __( 'You can find the handle in your Mastodon profile.', 'jetpack' ) }
@@ -52,11 +48,7 @@ export function CustomInputs( { service }: CustomInputsProps ) {
 			<>
 				<div className={ styles[ 'fields-item' ] }>
 					<label htmlFor={ `${ id }-handle` }>
-						{ __(
-							/* translators: The handle of a social media account. */
-							'Handle',
-							'jetpack'
-						) }
+						{ _x( 'Handle', 'The handle of a social media account.', 'jetpack' ) }
 					</label>
 					<p className="description" id={ `${ id }-handle-description` }>
 						{ __( 'You can find the handle in your Bluesky profile.', 'jetpack' ) }

--- a/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
@@ -1,0 +1,110 @@
+import { ExternalLink } from '@wordpress/components';
+import { createInterpolateElement, useId } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { SupportedService } from '../services/use-supported-services';
+import styles from './style.module.scss';
+
+type CustomInputsProps = {
+	service: SupportedService;
+};
+
+/**
+ * Custom inputs component
+ * @param {CustomInputsProps} props - Component props
+ *
+ * @return {import('react').ReactNode} Custom inputs component
+ */
+export function CustomInputs( { service }: CustomInputsProps ) {
+	const id = useId();
+
+	if ( 'mastodon' === service.ID ) {
+		return (
+			<div className={ styles[ 'fields-item' ] }>
+				<label htmlFor={ `${ id }-handle` }>
+					{ __(
+						/* translators: The handle of a social media account. */
+						'Handle',
+						'jetpack'
+					) }
+				</label>
+				<p className="description" id={ `${ id }-handle-description` }>
+					{ __( 'You can find the handle in your Mastodon profile.', 'jetpack' ) }
+				</p>
+				<input
+					id={ `${ id }-handle` }
+					required
+					type="text"
+					name="instance"
+					autoComplete="off"
+					autoCapitalize="off"
+					autoCorrect="off"
+					spellCheck="false"
+					aria-label={ __( 'Mastodon handle', 'jetpack' ) }
+					aria-describedby={ `${ id }-handle-description` }
+					placeholder={ '@mastodon@mastodon.social' }
+				/>
+			</div>
+		);
+	}
+
+	if ( 'bluesky' === service.ID ) {
+		return (
+			<>
+				<div className={ styles[ 'fields-item' ] }>
+					<label htmlFor={ `${ id }-handle` }>
+						{ __(
+							/* translators: The handle of a social media account. */
+							'Handle',
+							'jetpack'
+						) }
+					</label>
+					<p className="description" id={ `${ id }-handle-description` }>
+						{ __( 'You can find the handle in your Bluesky profile.', 'jetpack' ) }
+					</p>
+					<input
+						id={ `${ id }-handle` }
+						required
+						type="text"
+						name="handle"
+						autoComplete="off"
+						autoCapitalize="off"
+						autoCorrect="off"
+						spellCheck="false"
+						aria-label={ __( 'Bluesky handle', 'jetpack' ) }
+						aria-describedby={ `${ id }-handle-description` }
+						placeholder={ 'username.bsky.social' }
+					/>
+				</div>
+				<div className={ styles[ 'fields-item' ] }>
+					<label htmlFor={ `${ id }-password` }>{ __( 'App password', 'jetpack' ) }</label>
+					<p className="description" id={ `${ id }-password-description` }>
+						{ createInterpolateElement(
+							__(
+								'App password is needed to safely connect your account. App password is different from your account password. You can <link>generate it in Bluesky</link>.',
+								'jetpack'
+							),
+							{
+								link: <ExternalLink href="https://bsky.app/settings/app-passwords" />,
+							}
+						) }
+					</p>
+					<input
+						id={ `${ id }-password` }
+						required
+						type="password"
+						name="app_password"
+						autoComplete="off"
+						autoCapitalize="off"
+						autoCorrect="off"
+						spellCheck="false"
+						aria-label={ __( 'App password', 'jetpack' ) }
+						aria-describedby={ `${ id }-password-description` }
+						placeholder={ 'xxxx-xxxx-xxxx-xxxx' }
+					/>
+				</div>
+			</>
+		);
+	}
+
+	return null;
+}

--- a/projects/js-packages/publicize-components/src/components/services/service-item.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/service-item.tsx
@@ -22,7 +22,7 @@ export function ServiceItem( { service, serviceConnections }: ServicesItemProps 
 
 	const [ isPanelOpen, togglePanel ] = useReducer( state => ! state, false );
 
-	const isMastodonPanelOpen = isPanelOpen && service.ID === 'mastodon';
+	const areCustomInputsVisible = isPanelOpen && service.needsCustomInputs;
 
 	const brokenConnections = serviceConnections.filter( ( { status } ) => status === 'broken' );
 
@@ -31,9 +31,9 @@ export function ServiceItem( { service, serviceConnections }: ServicesItemProps 
 	);
 
 	const hideInitialConnectForm =
-		// For Mastodon, the initial connect form opens the panel,
+		// For services with custom inputs, the initial Connect button opens the panel,
 		// so we don't want to show it if the panel is already open
-		isMastodonPanelOpen ||
+		areCustomInputsVisible ||
 		// For services with broken connections, we want to show the "Fix connections" button
 		// which opens the panel, so we don't want to show the initial connect form when the panel is already open
 		( hasOwnBrokenConnections && isPanelOpen );
@@ -97,18 +97,20 @@ export function ServiceItem( { service, serviceConnections }: ServicesItemProps 
 			<Panel className={ styles[ 'service-panel' ] }>
 				<PanelBody opened={ isPanelOpen } onToggle={ togglePanel }>
 					<ServiceItemDetails service={ service } serviceConnections={ serviceConnections } />
-
-					{ /* Only show the connect form for Mastodon if there are no broken connections */ }
-					{ service.ID === 'mastodon' && ! hasOwnBrokenConnections ? (
-						<div className={ styles[ 'connect-form-wrapper' ] }>
-							<ConnectForm
-								service={ service }
-								displayInputs
-								isSmall={ false }
-								buttonLabel={ __( 'Connect', 'jetpack' ) }
-							/>
-						</div>
-					) : null }
+					{
+						// Connect form for services that need custom inputs
+						// should be shown only if there are no broken connections
+						service.needsCustomInputs && ! hasOwnBrokenConnections ? (
+							<div className={ styles[ 'connect-form-wrapper' ] }>
+								<ConnectForm
+									service={ service }
+									displayInputs
+									isSmall={ false }
+									buttonLabel={ __( 'Connect', 'jetpack' ) }
+								/>
+							</div>
+						) : null
+					}
 				</PanelBody>
 			</Panel>
 		</div>

--- a/projects/js-packages/publicize-components/src/components/services/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/services/style.module.scss
@@ -211,7 +211,6 @@
 
 		@include break-small {
 			flex-direction: row;
-			// width: auto;
 		}
 	}
 
@@ -220,10 +219,6 @@
 		flex-direction: column;
 		gap: 0.5rem;
 		width: 100%;
-
-		@include break-medium {
-			// width: auto;
-		}
 	}
 
 	label {

--- a/projects/js-packages/publicize-components/src/components/services/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/services/style.module.scss
@@ -1,7 +1,5 @@
 @import '@automattic/jetpack-base-styles/gutenberg-base-styles';
 
-
-
 .services {
 	outline: 1px solid var(--jp-gray-5);
 	border-radius: 4px;
@@ -95,23 +93,6 @@
 		:global(.components-panel__body.is-opened) {
 			margin-top: 1rem;
 		}
-
-		.connect-form-wrapper {
-			margin-top: 1rem;
-			display: flex;
-
-			form {
-				display: flex;
-				gap: 1rem;
-				flex-direction: column;
-				justify-content: flex-end;
-				width: 100%;
-
-				@include break-small {
-					flex-direction: row;
-				}
-			}
-		}
 	}
 
 	.active-connection {
@@ -194,7 +175,23 @@
 	}
 }
 
+.connect-form-wrapper {
+	margin-top: 2rem;
+	display: flex;
+	justify-content: flex-end;
+}
+
 .connect-form {
+	display: flex;
+	gap: 1.5rem;
+	flex-direction: column;
+	justify-content: flex-end;
+	width: 100%;
+
+	@include break-medium {
+		max-width: 25rem;
+	}
+
 	.connect-button {
 		&:global(.components-button) {
 			padding: 6px 16px;
@@ -204,12 +201,44 @@
 		}
 	}
 
+	.fields-wrapper {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		flex-wrap: wrap;
+		width: 100%;
+		gap: 1rem;
+
+		@include break-small {
+			flex-direction: row;
+			// width: auto;
+		}
+	}
+
+	.fields-item {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		width: 100%;
+
+		@include break-medium {
+			// width: auto;
+		}
+	}
+
+	label {
+		font-weight: 600;
+	}
+
 	input {
 		min-width: 220px;
+		height: auto;
+		font-size: var(--font-body);
+		line-height: 22px;
+		padding: var(--spacing-base) calc(var(--spacing-base)* 3); // To make the inputs of the same size as the Connect button
 
 		// Override the default input styles for small screens
 		@media (max-width: #{ ($break-medium) }) {
-			min-height: 30px;
 			padding: 0 8px;
 			font-size: 14px;
 		}

--- a/projects/js-packages/publicize-components/src/components/services/use-supported-services.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/use-supported-services.tsx
@@ -120,7 +120,6 @@ export function useSupportedServices(): Array< SupportedService > {
 			...availableServices.threads,
 			icon: props => <SocialServiceIcon serviceName="threads" { ...props } />,
 			description: __( 'Share posts to your Threads feed.', 'jetpack' ),
-			badges: [ badgeNew ],
 			examples: [
 				() => (
 					<>
@@ -202,6 +201,23 @@ export function useSupportedServices(): Array< SupportedService > {
 					<>
 						{ __(
 							'To share to Mastodon please enter your Mastodon username below, then click connect.',
+							'jetpack'
+						) }
+					</>
+				),
+			],
+		},
+		{
+			...availableServices.bluesky,
+			needsCustomInputs: true,
+			icon: props => <SocialServiceIcon serviceName="bluesky" { ...props } />,
+			badges: [ badgeNew ],
+			description: __( 'Share with your network.', 'jetpack' ),
+			examples: [
+				() => (
+					<>
+						{ __(
+							'To share to Bluesky please enter your Bluesky handle and app password below, then click connect.',
 							'jetpack'
 						) }
 					</>

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.js
@@ -209,6 +209,20 @@ export function isMastodonAccountAlreadyConnected( state, username ) {
 }
 
 /**
+ * Whether a Bluesky account is already connected.
+ *
+ * @param {import("../types").SocialStoreState} state  - State object.
+ * @param {string}                              handle - The Bluesky handle.
+ *
+ * @return {boolean} Whether the Bluesky account is already connected.
+ */
+export function isBlueskyAccountAlreadyConnected( state, handle ) {
+	return getConnectionsByService( state, 'bluesky' ).some( connection => {
+		return connection.external_display === handle;
+	} );
+}
+
+/**
  * Returns the latest KeyringResult from the store.
  *
  * @param {import("../types").SocialStoreState} state - State object.

--- a/projects/plugins/jetpack/changelog/add-bluesky-connection-ui
+++ b/projects/plugins/jetpack/changelog/add-bluesky-connection-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Social: Added support for Bluesky 🎉

--- a/projects/plugins/social/changelog/add-bluesky-connection-ui
+++ b/projects/plugins/social/changelog/add-bluesky-connection-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added support for Bluesky 🎉


### PR DESCRIPTION
We are adding Bluesky to Social 🎉 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add Bluesky to the supported connections in Social
* Update the corresponding UIs for Mastodon to make the UI consistent

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox D162453-code and follow the instructions given there
* Goto connections management UI on Social admin, Jetpack setting and post editor pages
* Open the connections modal
* Confirm that you see the Bluesky service
* Confirm that the UI looks fine both on Desktop and mobile
* Confirm that the instructions and links are fine
* Try connecting an account
* Confirm that the account shows up in the list
* Confirm that Mastodon works fine as before


- Desktop
    <img width="1388" alt="Screenshot 2024-09-27 at 5 55 59 PM" src="https://github.com/user-attachments/assets/2a557547-043b-4ba2-a40a-e81f5c98673c">
- Mobile
    <img width="445" alt="Screenshot 2024-09-27 at 5 56 51 PM" src="https://github.com/user-attachments/assets/621bb70f-25d7-4de6-95fa-28bdd2bd8207">