### PR TITLE
Jetpack Sync: Fix a bug in syncing HPOS 'woocommerce_delete_order' actions

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-woocommerce_delete_order-action
+++ b/projects/packages/sync/changelog/fix-sync-woocommerce_delete_order-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Sync: Fix a bug in syncing HPOS 'woocommerce_delete_order' actions

--- a/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
+++ b/projects/packages/sync/src/modules/class-woocommerce-hpos-orders.php
@@ -118,9 +118,9 @@ class WooCommerce_HPOS_Orders extends Module {
 			add_filter( "jetpack_sync_before_enqueue_woocommerce_after_{$type}_object_save", array( $this, 'expand_order_object' ) );
 		}
 		add_action( 'woocommerce_delete_order', $callable );
-		add_filter( 'jetpack_sync_before_enqueue_woocommerce_delete_order', array( $this, 'expand_order_object' ) );
+		add_filter( 'jetpack_sync_before_enqueue_woocommerce_delete_order', array( $this, 'on_before_enqueue_order_trash_delete' ) );
 		add_action( 'woocommerce_trash_order', $callable );
-		add_filter( 'jetpack_sync_before_enqueue_woocommerce_trash_order', array( $this, 'expand_order_object' ) );
+		add_filter( 'jetpack_sync_before_enqueue_woocommerce_trash_order', array( $this, 'on_before_enqueue_order_trash_delete' ) );
 	}
 
 	/**
@@ -257,6 +257,28 @@ class WooCommerce_HPOS_Orders extends Module {
 		}
 
 		return $this->filter_order_data( $order_object );
+	}
+
+	/**
+	 * Convert order ID to array.
+	 *
+	 * @access public
+	 *
+	 * @param array $args Order ID.
+	 *
+	 * @return array
+	 */
+	public function on_before_enqueue_order_trash_delete( $args ) {
+		if ( ! is_array( $args ) || ! isset( $args[0] ) ) {
+			return false;
+		}
+		$order_id = $args[0];
+
+		if ( ! is_int( $order_id ) ) {
+			return false;
+		}
+
+		return array( 'id' => $order_id );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a bug in syncing HPOS `woocommerce_delete_order` actions: Using `wc_get_order` via `expand_order_object` after an order is deleted returns `false`, therefore the `woocommerce_delete_order` action was never added to the sync queue.

At the same time we simplify the `before_enqueue_` filters for both `woocommerce_delete_order` and `woocommerce_trash_order` actions as we simply need to send the order ID for those actions.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\WooCommerce_HPOS_Orders`: Introduce `on_before_enqueue_order_trash_delete` method and use it when applying the `jetpack_sync_before_enqueue_woocommerce_delete_order` and `jetpack_sync_before_enqueue_woocommerce_trash_order` filters instead of `expand_order_object`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1727388904238509-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
See D162556-code