### PR TITLE
wpcom_add_shopping_cart: Use new is_cart_empty function

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-admin-bar
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-wpcom-admin-bar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+wpcom_add_shopping_cart: Use Store_Shopping_Cart::is_cart_empty() when deciding to render icon for incrased performance

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -169,8 +169,7 @@ function wpcom_add_shopping_cart( $wp_admin_bar ) {
 	// Get the current blog ID.
 	$blog_id = get_current_blog_id();
 
-	// Retrieve the current user's shopping cart for the current blog.
-	$cart = \Store_Shopping_Cart::get_existing_cart(
+	$is_empty = \Store_Shopping_Cart::is_cart_empty(
 		array(
 			'blog_id' => $blog_id,
 			'user_id' => get_current_user_id(),
@@ -178,7 +177,7 @@ function wpcom_add_shopping_cart( $wp_admin_bar ) {
 	);
 
 	// If the cart is empty (no products), do not add the cart menu.
-	if ( ! $cart->get_product_slugs() ) {
+	if ( $is_empty ) {
 		return;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:

* In `wpcom_add_shopping_cart()`, use `is_cart_empty()` instead of `get_existing_cart()` when deciding to render the cart icon for increased performance. See D162397-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

* Apply the change on wpcom
* Visit a simple site, logged in, with both an empty cart and a cart with an item in it
* The cart icon should only appear when there is an item in the port

