### PR TITLE
Jetpack: remove excessive hooks from social logos and genericons

### DIFF
--- a/projects/plugins/jetpack/_inc/genericons.php
+++ b/projects/plugins/jetpack/_inc/genericons.php
@@ -7,8 +7,6 @@
  * @package automattic/jetpack
  */
 
-add_action( 'init', 'jetpack_register_genericons', 1 );
-
 /**
  * Registers Genericons if not already done so by other code.
  */

--- a/projects/plugins/jetpack/_inc/social-logos.php
+++ b/projects/plugins/jetpack/_inc/social-logos.php
@@ -28,4 +28,3 @@ function jetpack_register_social_logos() {
 		);
 	}
 }
-add_action( 'init', 'jetpack_register_social_logos', 1 );

--- a/projects/plugins/jetpack/changelog/fix-remove-excessive-social-logos-hook
+++ b/projects/plugins/jetpack/changelog/fix-remove-excessive-social-logos-hook
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Remove excessive hook from social logos.
+Remove excessive hook from social logos and genericons.

--- a/projects/plugins/jetpack/changelog/fix-remove-excessive-social-logos-hook
+++ b/projects/plugins/jetpack/changelog/fix-remove-excessive-social-logos-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove excessive hook from social logos.


### PR DESCRIPTION
## Proposed changes:
`jetpack_register_social_logos()` and `jetpack_register_genericons` is called directly, and the files are [loaded](https://github.com/Automattic/jetpack/blob/8d8e0e6ef75b32c52029a57740cb6e13c6312296/projects/plugins/jetpack/class.jetpack.php#L735) on `wp_loaded` after the `init` hook has already run.

Hooking them into `init` has no effect on self-hosted, and we added separate hooks for WPCOM in D162597-code.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/529

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack, activate the Sharing module.
2. Go to Jetpack Dashboard, check the source code and confirm the stylesheet `id='genericons-css'` is loaded.
3. Go to `/wp-admin/options-general.php?page=sharing`, check the source code and confirm the stylesheet `id='social-logos-css'` is loaded.