### PR TITLE
Help Center: use Zendesk staging when proxied

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/zendesk-client-use-staging
+++ b/projects/packages/jetpack-mu-wpcom/changelog/zendesk-client-use-staging
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Help Center: use Zendesk staging when proxied

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -164,6 +164,7 @@ class Help_Center {
 				'help-center',
 				'const helpCenterData = ' . wp_json_encode(
 					array(
+						'isProxied'   => boolval( self::is_proxied() ),
 						'currentUser' => array(
 							'ID'           => $user_id,
 							'username'     => $username,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/9274

## Proposed changes:

Pass proxied status into Help Center data. We need this to correctly choose the Zendesk environment and keys based on the users proxy status.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This doesn't directly modify anything so there shouldn't be anything to test. If we want to be extra safe you could just open Help Center from this branch to make sure there is no regression. But that is not technically needed to add a variable that is not being consumed.