### PR TITLE
Jetpack: Remove WAF deprecation notice

### DIFF
--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -8,8 +8,6 @@ import { FormFieldset } from 'components/forms';
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import JetpackBanner from 'components/jetpack-banner';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
-import SimpleNotice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import {
@@ -501,18 +499,6 @@ export const Waf = class extends Component {
 				hideButton={ true }
 			>
 				{ isWafActive && <QueryWafSettings /> }
-				<SimpleNotice
-					showDismiss={ false }
-					status="is-info"
-					text={ __(
-						'The settings for the Firewall will be moved to Jetpack Protect in Jetpack version 13.10.',
-						'jetpack'
-					) }
-				>
-					<NoticeAction href={ this.props.getProtectUrl }>
-						{ __( 'Get Jetpack Protect', 'jetpack' ) }
-					</NoticeAction>
-				</SimpleNotice>
 				<SettingsGroup
 					disableInOfflineMode
 					module={ this.props.getModule( 'waf' ) }

--- a/projects/plugins/jetpack/changelog/remove-jetpack-waf-deprecation-notice
+++ b/projects/plugins/jetpack/changelog/remove-jetpack-waf-deprecation-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Removed deprecation notice as the firewall feature will not be removed in the next release.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the notice indicating the firewall will require the Protect plugin to be installed in future versions of Jetpack.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1727380908804139-slack-C029WFNV69M

p1HpG7-uiQ-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/wp-admin/admin.php?page=jetpack#/settings`
* Test that the notice is removed from the firewall settings, and the settings UI is functional.
* If you also have Protect active, you will still be shown a redirection message to the Protect screen.

## Screenshots:

Before:

<img width="1073" alt="Screenshot 2024-09-27 at 10 58 59 AM" src="https://github.com/user-attachments/assets/34081567-adb8-4a79-b936-01b536974f3a">

After:

<img width="1068" alt="Screenshot 2024-09-27 at 10 52 29 AM" src="https://github.com/user-attachments/assets/5d503709-b621-48a3-a05f-e31d4f4f2c89">

