### PR TITLE
Protect: Fix blockedRequests destructuring fallback

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-stats-property-naming
+++ b/projects/plugins/protect/changelog/fix-protect-stats-property-naming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fixes blockedRequests destructuring fallback

--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -130,9 +130,8 @@ const ConnectedFirewallHeader = () => {
 	const { hasPlan } = usePlan();
 	const isSupportedWafFeatureEnabled = wafSupported ? isEnabled : bruteForceProtection;
 	const currentStatus = isSupportedWafFeatureEnabled ? 'on' : 'off';
-	const { currentDay: currentDayBlockCount, thirtyDays: thirtyDaysBlockCounts } = stats
-		? stats.blockedRequests
-		: { currentDay: 0, thirtyDays: 0 };
+	const { currentDay: currentDayBlockCount = 0, thirtyDays: thirtyDaysBlockCounts = 0 } =
+		stats.blockedRequests || {};
 
 	return (
 		<FirewallHeader

--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -130,9 +130,9 @@ const ConnectedFirewallHeader = () => {
 	const { hasPlan } = usePlan();
 	const isSupportedWafFeatureEnabled = wafSupported ? isEnabled : bruteForceProtection;
 	const currentStatus = isSupportedWafFeatureEnabled ? 'on' : 'off';
-	const { currentDay: currentDayBlockCount, thirtyDays: thirtyDayBlockCounts } = stats
+	const { currentDay: currentDayBlockCount, thirtyDays: thirtyDaysBlockCounts } = stats
 		? stats.blockedRequests
-		: { currentDayStats: 0, thirtyDaysStats: 0 };
+		: { currentDay: 0, thirtyDays: 0 };
 
 	return (
 		<FirewallHeader
@@ -145,7 +145,7 @@ const ConnectedFirewallHeader = () => {
 			bruteForceProtectionIsEnabled={ bruteForceProtection }
 			wafSupported={ wafSupported }
 			currentDayStats={ currentDayBlockCount }
-			thirtyDaysStats={ thirtyDayBlockCounts }
+			thirtyDaysStats={ thirtyDaysBlockCounts }
 			standaloneMode={ standaloneMode }
 		/>
 	);

--- a/projects/plugins/protect/src/js/components/firewall-header/index.jsx
+++ b/projects/plugins/protect/src/js/components/firewall-header/index.jsx
@@ -131,7 +131,7 @@ const ConnectedFirewallHeader = () => {
 	const isSupportedWafFeatureEnabled = wafSupported ? isEnabled : bruteForceProtection;
 	const currentStatus = isSupportedWafFeatureEnabled ? 'on' : 'off';
 	const { currentDay: currentDayBlockCount = 0, thirtyDays: thirtyDaysBlockCounts = 0 } =
-		stats.blockedRequests || {};
+		stats?.blockedRequests || {};
 
 	return (
 		<FirewallHeader


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #
When blockedRequests property is not set in the initial state we should fallback to returning 0 for each stat, with the current configuration it will error out

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fix prop naming the destructuring process to supply a valid fallback

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
- https://github.com/Automattic/jetpack-scan-team/issues/1447

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
- No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using Jurassic Tube on the trunk version of Protect
* Update line 134 of the `ConnectedFirewallHeader` component update the property value to force the fallback and verify the error occurs
* Checkout this branch and ensure the error no longer occurs and that the StatCard renders 0 for each stat

