### PR TITLE
Jetpack: remove unused infinite scroll code

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-cleanup-infinite-scroll
+++ b/projects/plugins/jetpack/changelog/remove-cleanup-infinite-scroll
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Infinite scroll: remove unused code.

--- a/projects/plugins/jetpack/modules/theme-tools/infinite-scroll.php
+++ b/projects/plugins/jetpack/modules/theme-tools/infinite-scroll.php
@@ -25,4 +25,3 @@ function jetpack_load_infinite_scroll_annotation() {}
 function jetpack_can_activate_infinite_scroll() {
 	return (bool) current_theme_supports( 'infinite-scroll' );
 }
-add_filter( 'jetpack_can_activate_infinite-scroll', 'jetpack_can_activate_infinite_scroll' );

--- a/projects/plugins/jetpack/modules/theme-tools/infinite-scroll.php
+++ b/projects/plugins/jetpack/modules/theme-tools/infinite-scroll.php
@@ -6,41 +6,18 @@
  */
 
 /**
- * Load theme's infinite scroll annotation file, if present in the IS plugin.
- * The `setup_theme` action is used because the annotation files should be using `after_setup_theme` to register support for IS.
+ * The function doesn't do anything.
  *
- * As released in Jetpack 2.0, a child theme's parent wasn't checked for in the plugin's bundled support, hence the convoluted way the parent is checked for now.
+ * @deprecated $$next-version$$
  *
- * @uses is_admin, wp_get_theme, apply_filters
- * @action setup_theme
- * @return null
+ * @return void
  */
-function jetpack_load_infinite_scroll_annotation() {
-	if ( is_admin() && isset( $_GET['page'] ) && 'jetpack' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Function loads theme specific IS file provided by Jetpack if possible.
-		$theme = wp_get_theme();
-
-		if ( ! is_a( $theme, 'WP_Theme' ) && ! is_array( $theme ) ) {
-			return;
-		}
-
-		/** This filter is already documented in modules/infinite-scroll/infinity.php */
-		$customization_file = apply_filters( 'infinite_scroll_customization_file', __DIR__ . "/infinite-scroll/themes/{$theme['Stylesheet']}.php", $theme['Stylesheet'] );
-
-		if ( is_readable( $customization_file ) ) {
-			require_once $customization_file;
-		} elseif ( ! empty( $theme['Template'] ) ) {
-			$customization_file = __DIR__ . "/infinite-scroll/themes/{$theme['Template']}.php";
-
-			if ( is_readable( $customization_file ) ) {
-				require_once $customization_file;
-			}
-		}
-	}
-}
-add_action( 'setup_theme', 'jetpack_load_infinite_scroll_annotation' );
+function jetpack_load_infinite_scroll_annotation() {}
 
 /**
  * Prevent IS from being activated if theme doesn't support it
+ *
+ * @deprecated $$next-version$$ The function is no longer in use.
  *
  * @filter jetpack_can_activate_infinite-scroll
  * @return bool


### PR DESCRIPTION
## Proposed changes:
* Remove unused and non-working code.
* Deprecate functions that are no longer needed to be removed later.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1727447154463329-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Switch to a theme with an annotations file (e.g. Twenty Eleven).
2. Connect Jetpack, activate Infinite Scroll module.
3. Create a bunch of posts if needed.
4. Go to the frontpage or a post list page.
5. Scroll to an end, confirm the posts get loaded automatically.