### PR TITLE
Sitemap: Make sitemap storing more efficient by not querying the full post content before saving

### DIFF
--- a/projects/plugins/jetpack/changelog/ 
+++ b/projects/plugins/jetpack/changelog/ 
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Make sitemap storing more efficient but not querying the full post content when storing the updated sitemap


### PR DESCRIPTION
This update tries to remediate a problem where the persistent object cache gets big with data that we will not use in the end.

We just need to get the id of the current sitemap post and if it exists, we update it.

Before, we were using `get_post()` and this polluted the cache running into OOM situations

In p9F6qB-g4Y-p2#comment-62552 it's noted that the current behavior is not efficient.

**Note:** this PR may need a follow-up cause there's further investigation in p9F6qB-g4Y-p2#comment-62583


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduced function`get_current_sitemap_post_id()`
* Updates `store_sitemap_data()` to use `get_current_sitemap_post_id()`.

## Jetpack product discussion

p9F6qB-g4Y-p2#comment-62552

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
* On a connected site ([Launch one with Jurassic Ninja and this branch](https://jurassic.ninja/create?jetpack-beta&branches.jetpack=update/sitemap-store-more-efficiently&wp-debug-log)), confirm the sitemap functionality is enabled under Jetpack → Settings → Traffic.
* checkout this branch `git checkout update/sitemap-store-more-efficiently`
* Navigate to your sitemap (typically at /sitemap.xml), and click the first one.
* Verify that all current content types (posts, pages, etc.) are correctly listed in the sitemap.