### PR TITLE
'connect_url_redirect' hook: Redirect to the 'redirect_after_auth' url if already connected (for 'connect_after_checkout' flow)

### DIFF
--- a/projects/packages/connection/changelog/fix-connect-url-redirect-already-connected
+++ b/projects/packages/connection/changelog/fix-connect-url-redirect-already-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+In 'connect_url_redirect' hook, redirect to 'redirect_after_auth` url if already connected (for connect_after_checkout flow).

--- a/projects/packages/connection/src/class-webhooks.php
+++ b/projects/packages/connection/src/class-webhooks.php
@@ -199,6 +199,10 @@ class Webhooks {
 			wp_safe_redirect( $redirect );
 			$this->do_exit();
 		} else {
+			if ( 'connect-after-checkout' === $from && $redirect ) {
+				wp_safe_redirect( $redirect );
+				$this->do_exit();
+			}
 			$connect_url = add_query_arg(
 				array(
 					'from'               => $from,


### PR DESCRIPTION
This PR allows the `connect_after_checkout` flow to work still, even if the site is already fully connected.

Prior to this PR there was an issue where when attempting to purchase a product via the `connect-after-checkout` flow when the site was already fully connected and after purchase completed but during the "connection" step, Calypso would die with a fatal error (and end up showing the Calypso "We're sorry, an unexpected error occurred" error boundary page.

The problem was that when triggering the Jetpack connection from a URL via the `connect_url_redirect` hook (query_arg) from the Calypso dev environment when the site is already fully connected, the authorization url was still being returned (despite already being connected), when instead it should be returning the `redirect_after_auth` url.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* In the `connect_url_redirect` hook, when the site is already fully connected, redirect to the `redirect_after_auth` url instead of the authorization_url.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**To view the regression:**
1. Spin up a Jurassic Ninja site (with Jetpack Beta plugin, running Latest Stable or newer) or your local dev environment (monorepo docker). - We're Not running this PR branch yet.
2. Also spin up a Calypso blue dev environment (`http://calypso.localhost:3000/...`), with `yarn start` in Calypso repo root.
3. Make sure your Jetpack site is fully connected to wordpress.com (site and user connected).
4. Go to My Jetpack, in the top "Stats" product card click "Upgrade" button, then click "require a commercial license" link, then click "Get Stats to grow my site" button.
5. You should be redirected to wordpress.com checkout. Examine the checkout URL, and notice that the url query args that are required for the "connect-after-checkout" flow are present: `connect_after_checkout=true`, `admin_url=...`, and `from_site_slug=...`
    - I think ideally the Stats product shouldn't be linking to the connect-after-checkout flow if the site is already fully connected, but this is the way it is for now (and has been), so we'll use it to test for now. But maybe it should be changed in the near future.  I don't believe the other products within My Jetpack point to the connect-after-checkout flow when the site is already fully connected.
6. In the checkout url, replace `https://wordpress.com` with `http://calypso.localhost:3000` and press enter, reloading checkout in the dev environment.
7. Complete the Stats commercial purchase (using credits is fine).
8. Notice that after checkout processes, Calypso throws a fatal error and dies, showing the "We're sorry, an unexpected error occurred" error boundary page: (See screenshot)
![Screen Shot on 2024-09-28 at 23-29-52](https://github.com/user-attachments/assets/e47d3385-2107-4b51-98b1-a4b75cabaad1)

**To Test this PR:**
- Run this PR branch with the Jetpack beta plugin or your local dev environment.
- Perform steps 2 through 7 above ⬆️.
- After checkout processes, make sure that the fatal error does Not occur (like in the regression testing steps above) and that instead you are redirected to the licensing activation page and that your Stats product is auto-activated. (See screencast:)
![Screen Capture on 2024-09-29 at 10-19-43](https://github.com/user-attachments/assets/c75322a2-118a-4282-bb0f-77f4de2e70fe)

