### PR TITLE
My Jetpack: fix spacing between price and discount tag

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/style.module.scss
@@ -117,15 +117,12 @@
 	display: flex;
 	flex-wrap: wrap;
 	align-items: flex-end;
+	gap: calc( var( --spacing-base ) * 2 );
 	color: var( --jp-black );
 }
 
 .price {
 	position: relative;
-
-	&:first-child {
-		margin-right: calc( var( --spacing-base ) * 2 );
-	}
 
 	&.is-old {
 		color: var( --jp-gray-20 );

--- a/projects/packages/my-jetpack/changelog/fix-discount-tag-interstitials
+++ b/projects/packages/my-jetpack/changelog/fix-discount-tag-interstitials
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Minor change updating the discount tag spacing in the product interstitials
+
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR fixes the spacing between the prices and discount tag on medium screens in the interstitials

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this feature branch
* Go to `/wp-admin/admin.php?page=my-jetpack#/add-protect`
* Confirm it looks like below:

Before | After
--- | ---
<img width="902" alt="image" src="https://github.com/user-attachments/assets/34c69c3e-8390-4441-97a6-df8963361aeb">|<img width="902" alt="image" src="https://github.com/user-attachments/assets/1f9c9539-fdf2-4b0e-9143-f21bcade6d45">


