### PR TITLE
Fix parameters to allow for connectAfterCheckout flow from recommendation card

### DIFF
--- a/projects/js-packages/connection/changelog/fix-recommendations-connect-after-checkout
+++ b/projects/js-packages/connection/changelog/fix-recommendations-connect-after-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fetch adminUrl current value on function run

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.jsx
@@ -15,7 +15,7 @@ const {
 	apiNonce,
 	siteSuffix: defaultSiteSuffix,
 } = window?.JP_CONNECTION_INITIAL_STATE || getScriptData()?.connection || {};
-const defaultAdminUrl =
+const defaultAdminUrl = () =>
 	typeof window !== 'undefined' ? window?.myJetpackInitialState?.adminUrl : null;
 
 /**
@@ -38,7 +38,7 @@ export default function useProductCheckoutWorkflow( {
 	productSlug,
 	redirectUrl,
 	siteSuffix = defaultSiteSuffix,
-	adminUrl = defaultAdminUrl,
+	adminUrl = defaultAdminUrl(),
 	connectAfterCheckout = false,
 	siteProductAvailabilityHandler = null,
 	quantity = null,

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -88,10 +88,11 @@ const usePricingData = ( slug: string ) => {
 	);
 
 	const { isUserConnected } = useMyJetpackConnection();
-	const { myJetpackUrl, siteSuffix } = getMyJetpackWindowInitialState();
+	const { myJetpackUrl, siteSuffix, adminUrl } = getMyJetpackWindowInitialState();
 	const { activate, isPending: isActivating } = useActivate( slug );
 	const { run: runCheckout } = useProductCheckoutWorkflow( {
 		from: 'my-jetpack',
+		adminUrl,
 		productSlug: wpcomProductSlug,
 		redirectUrl: myJetpackUrl,
 		connectAfterCheckout: ! isUserConnected,
@@ -99,6 +100,7 @@ const usePricingData = ( slug: string ) => {
 	} );
 	const { run: runFreeCheckout } = useProductCheckoutWorkflow( {
 		from: 'my-jetpack',
+		adminUrl,
 		productSlug: wpcomFreeProductSlug,
 		redirectUrl: myJetpackUrl,
 		connectAfterCheckout: ! isUserConnected,

--- a/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-card/use-pricing-data.ts
@@ -88,11 +88,10 @@ const usePricingData = ( slug: string ) => {
 	);
 
 	const { isUserConnected } = useMyJetpackConnection();
-	const { myJetpackUrl, siteSuffix, adminUrl } = getMyJetpackWindowInitialState();
+	const { myJetpackUrl, siteSuffix } = getMyJetpackWindowInitialState();
 	const { activate, isPending: isActivating } = useActivate( slug );
 	const { run: runCheckout } = useProductCheckoutWorkflow( {
 		from: 'my-jetpack',
-		adminUrl,
 		productSlug: wpcomProductSlug,
 		redirectUrl: myJetpackUrl,
 		connectAfterCheckout: ! isUserConnected,
@@ -100,7 +99,6 @@ const usePricingData = ( slug: string ) => {
 	} );
 	const { run: runFreeCheckout } = useProductCheckoutWorkflow( {
 		from: 'my-jetpack',
-		adminUrl,
 		productSlug: wpcomFreeProductSlug,
 		redirectUrl: myJetpackUrl,
 		connectAfterCheckout: ! isUserConnected,

--- a/projects/packages/my-jetpack/changelog/fix-recommendations-connect-after-checkout
+++ b/projects/packages/my-jetpack/changelog/fix-recommendations-connect-after-checkout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fix parameters to allow for connectAfterCheckout flow from recommendation card


### PR DESCRIPTION
## Proposed changes:
We've been working recently on improving connectAfterCheckout flow from My Jetpack. This change ensure that adminUrl is send over on "Purchase" action so to provide all the information needed for successful flow run.

Although `useProductCheckoutWorkflow` should get `adminUrl` value from the `window` object, in rare cases the values are not available at the beginning of the runtime. This makes sure we always have the value available at the time of the action.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run JN with the active branch as Jetpack plugin
* Connect your site, and submit survey to get recommendations
* Select recommendation "Purchase" action, and go to the checkout
* Make sure that `adminUrl` is not "undefined"
* Proceed with the purchase and make sure you're connecting your user account successfully.

