### PR TITLE
Fix a case where wp_rand is undefined.

### DIFF
--- a/projects/packages/a8c-mc-stats/changelog/fix-mc-stats-wp-rand-undefined
+++ b/projects/packages/a8c-mc-stats/changelog/fix-mc-stats-wp-rand-undefined
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Added a check for function presence to avoid fatal errors.

--- a/projects/packages/a8c-mc-stats/src/class-a8c-mc-stats.php
+++ b/projects/packages/a8c-mc-stats/src/class-a8c-mc-stats.php
@@ -158,7 +158,8 @@ class A8c_Mc_Stats {
 	public function build_stats_url( $args ) {
 		$defaults = array(
 			'v'    => 'wpcom2',
-			'rand' => md5( wp_rand( 0, 999 ) . time() ),
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand -- There can be a case where pluggables are not yet loaded.
+			'rand' => md5( ( function_exists( 'wp_rand' ) ? wp_rand( 0, 999 ) : rand( 0, 999 ) ) . time() ),
 		);
 		$args     = wp_parse_args( $args, $defaults );
 		$gifname  = true === $this->use_transparent_pixel ? 'b.gif' : 'g.gif';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a fatal error that can occur when `wp_rand` is called too early.

## Proposed changes:
* Adds a check for the `wp_rand` function existence, replacing it with `rand` if necessary.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Add this action to your test site:
```php
add_action( 'plugin_loaded', function() {
    if ( class_exists( '\Automattic\Jetpack\A8c_Mc_Stats' ) ) {
        $stats = new \Automattic\Jetpack\A8c_Mc_Stats();
        $stats->add( 'bogus', 'stat' );
        error_log( print_r( $stats->get_stats_urls(), true ) );
    }
} );
```
* Observe fatal errors in regular usage.
* Use this PR.
* Observe no fatals, instead only correct stat URLs in the logs.

