### PR TITLE
wpcomsh: Move `load_muplugin_textdomain` call to `after_setup_theme` hook

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-load_muplugin_textdomain-too-early
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-load_muplugin_textdomain-too-early
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Move `load_muplugin_textdomain` call to `after_setup_theme` hook.

--- a/projects/plugins/wpcomsh/i18n.php
+++ b/projects/plugins/wpcomsh/i18n.php
@@ -63,7 +63,7 @@ add_filter( 'load_textdomain_mofile', 'wpcomsh_wporg_to_wpcom_locale_mo_file', 9
 
 // Load translations for wpcomsh itself via MO file.
 add_action(
-	'plugins_loaded',
+	'after_setup_theme',
 	function () {
 		load_muplugin_textdomain( 'wpcomsh', 'wpcomsh/languages' );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
If `load_muplugin_textdomain` is called too early, it can cause problems because it gets called before the user is determined. Core added a doing-it-wrong check to the function that requires it be during or after the `after_setup_theme` hook, which comes slightly after `plugins_loaded` that we had been using.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None. But see https://core.trac.wordpress.org/changeset/59127

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* wpcomsh still works?