### PR TITLE
Add an expected notice to wpcomsh tests to fix trunk tests.

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-expected-notice-wpcomsh
+++ b/projects/plugins/wpcomsh/changelog/add-expected-notice-wpcomsh
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Added a test notice expectation.
+
+

--- a/projects/plugins/wpcomsh/tests/test-functions.php
+++ b/projects/plugins/wpcomsh/tests/test-functions.php
@@ -26,6 +26,7 @@ class FunctionsTest extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_wpcomsh_get_atomic_client_id_defined() {
+		$this->expectNotice();
 		define( 'ATOMIC_CLIENT_ID', '2' );
 		add_filter(
 			'wpcomsh_get_atomic_client_id',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes WordPress trunk test failures for wpcomsh.

## Proposed changes:
* Adds an expected notice for a test that's failing because of a Notice.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Verify CI tests pass.

