### PR TITLE
Jetpack AI: change logo generator styles source

### DIFF
--- a/projects/js-packages/ai-client/changelog/change-jetpack-ai-logo-generator-styles-source
+++ b/projects/js-packages/ai-client/changelog/change-jetpack-ai-logo-generator-styles-source
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Client: remove provision of image styles via flag prop and internal definition, take it from ai-assistant-feature payload now

--- a/projects/js-packages/ai-client/src/hooks/use-image-generator/constants.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-image-generator/constants.ts
@@ -1,5 +1,3 @@
-import { __ } from '@wordpress/i18n';
-
 // Styles
 export const IMAGE_STYLE_ENHANCE = 'enhance';
 export const IMAGE_STYLE_ANIME = 'anime';
@@ -20,25 +18,27 @@ export const IMAGE_STYLE_PIXEL_ART = 'pixel-art';
 export const IMAGE_STYLE_TEXTURE = 'texture';
 export const IMAGE_STYLE_MONTY_PYTHON = 'monty-python';
 
-export const IMAGE_STYLE_LABELS = {
-	[ IMAGE_STYLE_ENHANCE ]: __( 'Enhance', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_ANIME ]: __( 'Anime', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_PHOTOGRAPHIC ]: __( 'Photographic', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_DIGITAL_ART ]: __( 'Digital Art', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_COMICBOOK ]: __( 'Comicbook', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_FANTASY_ART ]: __( 'Fantasy Art', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_ANALOG_FILM ]: __( 'Analog Film', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_NEONPUNK ]: __( 'Neon Punk', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_ISOMETRIC ]: __( 'Isometric', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_LOWPOLY ]: __( 'Low Poly', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_ORIGAMI ]: __( 'Origami', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_LINE_ART ]: __( 'Line Art', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_CRAFT_CLAY ]: __( 'Craft Clay', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_CINEMATIC ]: __( 'Cinematic', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_3D_MODEL ]: __( '3D Model', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_PIXEL_ART ]: __( 'Pixel Art', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_TEXTURE ]: __( 'Texture', 'jetpack-ai-client' ),
-	[ IMAGE_STYLE_MONTY_PYTHON ]: __( 'Monty Python', 'jetpack-ai-client' ),
-};
+export type ImageStyle =
+	| typeof IMAGE_STYLE_ENHANCE
+	| typeof IMAGE_STYLE_ANIME
+	| typeof IMAGE_STYLE_PHOTOGRAPHIC
+	| typeof IMAGE_STYLE_DIGITAL_ART
+	| typeof IMAGE_STYLE_COMICBOOK
+	| typeof IMAGE_STYLE_FANTASY_ART
+	| typeof IMAGE_STYLE_ANALOG_FILM
+	| typeof IMAGE_STYLE_NEONPUNK
+	| typeof IMAGE_STYLE_ISOMETRIC
+	| typeof IMAGE_STYLE_LOWPOLY
+	| typeof IMAGE_STYLE_ORIGAMI
+	| typeof IMAGE_STYLE_LINE_ART
+	| typeof IMAGE_STYLE_CRAFT_CLAY
+	| typeof IMAGE_STYLE_CINEMATIC
+	| typeof IMAGE_STYLE_3D_MODEL
+	| typeof IMAGE_STYLE_PIXEL_ART
+	| typeof IMAGE_STYLE_TEXTURE
+	| typeof IMAGE_STYLE_MONTY_PYTHON;
 
-export type ImageStyle = keyof typeof IMAGE_STYLE_LABELS;
+export type ImageStyleObject = {
+	label: string;
+	value: ImageStyle;
+};

--- a/projects/js-packages/ai-client/src/hooks/use-image-generator/index.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-image-generator/index.ts
@@ -7,7 +7,6 @@ import debugFactory from 'debug';
  */
 import askQuestionSync from '../../ask-question/sync.js';
 import requestJwt from '../../jwt/index.js';
-import { IMAGE_STYLE_LABELS } from './constants.js';
 
 const debug = debugFactory( 'ai-client:use-image-generator' );
 
@@ -256,20 +255,10 @@ const useImageGenerator = () => {
 		}
 	};
 
-	/**
-	 * Get available styles.
-	 *
-	 * @return {object} with the styles {key:label} for the image generation.
-	 */
-	const getImageStyles = function (): object {
-		return IMAGE_STYLE_LABELS;
-	};
-
 	return {
 		generateImage,
 		generateImageWithStableDiffusion,
 		generateImageWithParameters: executeImageGeneration,
-		getImageStyles,
 	};
 };
 

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -49,7 +49,6 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	siteDetails,
 	context,
 	placement,
-	showStyleSelector,
 } ) => {
 	const { tracks } = useAnalytics();
 	const { recordEvent: recordTracksEvent } = tracks;
@@ -243,9 +242,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	} else {
 		body = (
 			<>
-				{ ! logoAccepted && (
-					<Prompt initialPrompt={ initialPrompt } showStyleSelector={ showStyleSelector } />
-				) }
+				{ ! logoAccepted && <Prompt initialPrompt={ initialPrompt } /> }
 
 				<LogoPresenter
 					logo={ selectedLogo }

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -17,8 +17,8 @@ import useRequestErrors from './use-request-errors.js';
 /**
  * Types
  */
-import type { ImageStyle } from '../../hooks/use-image-generator/constants.js';
-import type { Logo, Selectors, SaveLogo } from '../store/types.js';
+import type { ImageStyle, ImageStyleObject } from '../../hooks/use-image-generator/constants.js';
+import type { Logo, Selectors, SaveLogo, LogoGeneratorFeatureControl } from '../store/types.js';
 
 const debug = debugFactory( 'jetpack-ai-calypso:use-logo-generator' );
 
@@ -79,7 +79,7 @@ const useLogoGenerator = () => {
 		setLogoUpdateError,
 	} = useRequestErrors();
 
-	const { generateImageWithParameters, getImageStyles } = useImageGenerator();
+	const { generateImageWithParameters } = useImageGenerator();
 	const { saveToMediaLibrary } = useSaveToMediaLibrary();
 
 	const { ID = null, name = null, description = null } = siteDetails || {};
@@ -368,6 +368,11 @@ User request:${ prompt }`;
 		[ logoGenerationCost, increaseAiAssistantRequestsCount, saveLogo, storeLogo, generateImage ]
 	);
 
+	const logoGeneratorControl = aiAssistantFeatureData?.featuresControl?.[
+		'logo-generator'
+	] as LogoGeneratorFeatureControl;
+	const imageStyles: Array< ImageStyleObject > = logoGeneratorControl?.styles;
+
 	return {
 		logos,
 		selectedLogoIndex,
@@ -401,7 +406,7 @@ User request:${ prompt }`;
 		tierPlansEnabled,
 		isLoadingHistory,
 		setIsLoadingHistory,
-		getImageStyles,
+		imageStyles,
 	};
 };
 

--- a/projects/js-packages/ai-client/src/logo-generator/store/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/types.ts
@@ -1,3 +1,4 @@
+import type { ImageStyleObject } from '../../hooks/use-image-generator/constants.js';
 import type { SiteDetails } from '../types.js';
 
 /**
@@ -88,10 +89,14 @@ export type TierValueProp =
 	| Tier750Props[ 'value' ]
 	| Tier1000Props[ 'value' ];
 
+export type LogoGeneratorFeatureControl = FeatureControl & {
+	styles: Array< ImageStyleObject > | [];
+};
+
 export type FeatureControl = {
 	enabled: boolean;
 	'min-jetpack-version': string;
-	[ key: string ]: FeatureControl | boolean | string;
+	[ key: string ]: FeatureControl | LogoGeneratorFeatureControl | boolean | string;
 };
 
 export type FeaturesControl = { [ key: string ]: FeatureControl };

--- a/projects/js-packages/ai-client/src/logo-generator/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/types.ts
@@ -19,7 +19,6 @@ export interface GeneratorModalProps {
 	onReload: () => void;
 	context: string;
 	placement: string;
-	showStyleSelector?: boolean;
 }
 
 export interface LogoPresenterProps {

--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-logo-generator-styles-source
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-logo-generator-styles-source
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Janitorial: add siteFragment to JP initial state definition, avoid linter warnings

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -197,15 +197,3 @@ add_action(
 		}
 	}
 );
-
-/**
- * Register the `ai-logo-style-selector-support` extension.
- */
-add_action(
-	'jetpack_register_gutenberg_extensions',
-	function () {
-		if ( apply_filters( 'jetpack_ai_enabled', true ) && apply_filters( 'jetpack_ai_logo_style_selector_enabled', false ) ) {
-			\Jetpack_Gutenberg::set_extension_available( 'ai-logo-style-selector-support' );
-		}
-	}
-);

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/index.d.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/index.d.ts
@@ -1,5 +1,6 @@
 interface Window {
 	Jetpack_Editor_Initial_State: {
+		siteFragment: string;
 		siteLocale: string;
 		adminUrl: string;
 		available_blocks: {

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -125,8 +125,6 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 
 		const siteDetails = useSiteDetails();
 
-		const styleLogoFeatureEnabled = getFeatureAvailability( 'ai-logo-style-selector-support' );
-
 		return (
 			<>
 				<BlockEdit { ...props } />
@@ -141,7 +139,6 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					context={ PLACEMENT_CONTEXT }
 					placement={ TOOL_PLACEMENT }
 					siteDetails={ siteDetails }
-					showStyleSelector={ styleLogoFeatureEnabled }
 				/>
 			</>
 		);

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -78,8 +78,7 @@
 		"recipe",
 		"v6-video-frame-poster",
 		"videopress/video-chapters",
-		"ai-assistant-backend-prompts",
-		"ai-logo-style-selector-support"
+		"ai-assistant-backend-prompts"
 	],
 	"experimental": [],
 	"no-post-editor": [


### PR DESCRIPTION
This PR switches where the styles are taken from

## Proposed changes:
Add types and definitions on use-image-generator hook
Remove `showStylesDropdown` prop
Add image styles array from ai-assistant-feature payload

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1727276354617789-slack-C054LN8RNVA

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Checkout the branch, build both `jetpack build plugins/jetpack` and `jetpack build js-packages/ai-client`

- Open the block editor and add a logo block. Click on the AI toolbar button, the Logo generator modal will open.

- The modal should show no changes.

- Request a logo generation and inspect the request on the devtools network tab. It should show `style` property as empty:
<img width="498" alt="image" src="https://github.com/user-attachments/assets/0c341156-d1c6-4e8a-a6aa-69f972aebe54">

- Trigger the ai-assistant-feature fetch, check that `features-control['logo-generator'].styles` is an empty array:
```js
wp.data.dispatch('jetpack-ai/logo-generator').fetchAiAssistantFeature()
```
<img width="484" alt="image" src="https://github.com/user-attachments/assets/28d0938a-390c-42df-9f38-70930f64a2f5">

- Now sandbox the public-api, add the filter on your sandbox: `add_filter( 'jetpack_ai_logo_style_selector_enabled', '__return_true' );`

- Without reloading the editor, trigger the fetch again:
```js
wp.data.dispatch('jetpack-ai/logo-generator').fetchAiAssistantFeature()
```
- See that now `features-control['logo-generator'].styles` holds the styles array:
<img width="489" alt="image" src="https://github.com/user-attachments/assets/3e989eb5-e6b4-47f4-b2b4-045c11f70c43">


- Close the Logo generator modal and open it again.

- You should now see the styles dropdown on top of the prompt input, with "Line Art" selected by default.

- Trigger logo generations with different styles, check both the network request and the generated image to see the style selection is taking place.