### PR TITLE
Social: Fix Bluesky not showing up on page load

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-bluesky-does-not-show-up-on-load
+++ b/projects/packages/publicize/changelog/fix-social-bluesky-does-not-show-up-on-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed Bluesky not showing up on page load

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -566,6 +566,7 @@ class Publicize extends Publicize_Base {
 			'instagram-business' => array(),
 			'nextdoor'           => array(),
 			'threads'            => array(),
+			'bluesky'            => array(),
 		);
 
 		if ( 'all' === $filter ) {


### PR DESCRIPTION
When you have a Bluesky connection, the editor doesn't show it on page load and is rather shown only after connection test results finish.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that Bluesky connections are loaded in the initial connections

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox D162453-code and follow the instructions given there
* Add a Bluesky connection on the Jetpack or Social admin page
* Goto post editor
* Open Jetpack/Social sidebar
* Confirm that Bluesky connection shows up correctly