### PR TITLE
Social: Fix share status tooltip text overflow

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-share-status-tooltip-text-overflow
+++ b/projects/js-packages/publicize-components/changelog/fix-social-share-status-tooltip-text-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed share status tooltip text overflow

--- a/projects/js-packages/publicize-components/src/components/share-status/share-status-label.tsx
+++ b/projects/js-packages/publicize-components/src/components/share-status/share-status-label.tsx
@@ -26,7 +26,9 @@ export function ShareStatusLabel( { status, message } ) {
 			title={ __( 'Sharing failed with the following message:', 'jetpack' ) }
 			className={ styles[ 'share-status-icon-tooltip' ] }
 		>
-			<Text variant="body-small">{ message }</Text>
+			<Text variant="body-small" className={ styles[ 'tooltip-text' ] }>
+				{ message }
+			</Text>
 		</IconTooltip>
 	);
 

--- a/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
+++ b/projects/js-packages/publicize-components/src/components/share-status/styles.module.scss
@@ -56,6 +56,10 @@
 	}
 }
 
+.tooltip-text {
+	word-break: break-word;
+}
+
 .share-status-icon {
 	fill: var(--jp-green-50);
 }

--- a/projects/plugins/jetpack/changelog/fix-social-share-status-tooltip-text-overflow
+++ b/projects/plugins/jetpack/changelog/fix-social-share-status-tooltip-text-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Fixed share status tooltip text overflow

--- a/projects/plugins/social/changelog/fix-social-share-status-tooltip-text-overflow
+++ b/projects/plugins/social/changelog/fix-social-share-status-tooltip-text-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed share status tooltip text overflow


### PR DESCRIPTION

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Ensure that the tooltip text of failed share status info does not overflow

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to post editor
* Share a post triggering a failure by sharing a post to Facebook or Instagram after removing Jetpack from [here](https://www.facebook.com/settings/?tab=business_tools).
* Open share status modal
* Click on Failed info toolip
* Inspect the text (Watch the video below)

<details>
<summary>
Replace the <code>&lt;p&gt;</code> content with this (Click to expand)
</summary>

<code>The image container could not be created. Error: Error 400 (Only photo or video can be accepted as media type.) -- Media download has failed. The media URI doesn't meet our requirements.: The media could not be fetched from this URI: https://some-test-site.com/wp-content/uploads/2024/10/Screenshot-2024-10-01-at-12.08.48PM.png. Please check the limitations section in our development document for more information: https://developers.facebook.com/docs/instagram-platform/instagram-graph-api/reference/ig-user/media#creating [2207052]</code>
</details>

* Confirm that the text (link) doesn't overflow

| BEFORE | AFTER |
|--------|--------|
| <img width="1171" alt="Screenshot 2024-10-01 at 12 16 24 PM" src="https://github.com/user-attachments/assets/2349f293-881c-4de1-bccf-64fa54984eec"> | <img width="639" alt="Screenshot 2024-10-01 at 12 17 54 PM" src="https://github.com/user-attachments/assets/f2a8e02b-c6bd-4824-9b9b-d50a931f4910"> | 


https://github.com/user-attachments/assets/ebaaa6de-c04d-429b-98ef-2e16c21e7e08

