### PR TITLE
Admin bar: replace 'Edit Profile' and 'My Account' with 'My Profile'

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/edit-profile-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/edit-profile-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin bar: replace 'Edit Profile' and 'My Account' with 'My Profile'

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -236,52 +236,25 @@ function wpcom_add_reader_menu( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'wpcom_add_reader_menu', 11 );
 
 /**
- * Points the "Edit Profile" and "Howdy,..." to /me when appropriate.
+ * Points the "Edit Profile" and "Howdy,..." to /me.
  *
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
-function wpcom_maybe_replace_edit_profile_menu_to_me( $wp_admin_bar ) {
+function wpcom_replace_edit_profile_menu_to_me( $wp_admin_bar ) {
 	$edit_profile_node = $wp_admin_bar->get_node( 'user-info' );
 	if ( $edit_profile_node ) {
-		/**
-		 * The Edit Profile menu should point to /me, instead of the site's profile.php
-		 * if the user is not a member of the current site
-		 */
-		if ( ! is_user_member_of_blog() ) {
-			$edit_profile_node->href = maybe_add_origin_site_id_to_url( 'https://wordpress.com/me' );
-			$wp_admin_bar->add_node( (array) $edit_profile_node );
-		}
+		$edit_profile_node->href  = maybe_add_origin_site_id_to_url( 'https://wordpress.com/me' );
+		$edit_profile_node->title = preg_replace( "/(<span class='display-name edit-profile'>)(.*?)(<\/span>)/", '$1' . __( 'My Profile', 'jetpack-mu-wpcom' ) . '$3', $edit_profile_node->title );
+		$wp_admin_bar->add_node( (array) $edit_profile_node );
+	}
+	$my_account_node = $wp_admin_bar->get_node( 'my-account' );
+	if ( $my_account_node ) {
+		$my_account_node->href = maybe_add_origin_site_id_to_url( 'https://wordpress.com/me' );
+		$wp_admin_bar->add_node( (array) $my_account_node );
 	}
 }
 // Run this function later than Core: https://github.com/WordPress/wordpress-develop/blob/5a30482419f1b0bcc713a7fdee3a14afd67a1bca/src/wp-includes/class-wp-admin-bar.php#L651
-add_action( 'admin_bar_menu', 'wpcom_maybe_replace_edit_profile_menu_to_me', 9999 );
-
-/**
- * Adds (Profile) -> My Account menu pointing to /me.
- *
- * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
- */
-function wpcom_add_my_account_item_to_profile_menu( $wp_admin_bar ) {
-	$logout_node = $wp_admin_bar->get_node( 'logout' );
-	if ( $logout_node ) {
-		// Adds the 'My Account' menu item before 'Log Out'.
-		$wp_admin_bar->remove_node( 'logout' );
-	}
-
-	$wp_admin_bar->add_node(
-		array(
-			'id'     => 'wpcom-profile',
-			'parent' => 'user-actions',
-			'title'  => __( 'My Account', 'jetpack-mu-wpcom' ),
-			'href'   => maybe_add_origin_site_id_to_url( 'https://wordpress.com/me' ),
-		)
-	);
-
-	if ( $logout_node ) {
-		$wp_admin_bar->add_node( (array) $logout_node );
-	}
-}
-add_action( 'admin_bar_menu', 'wpcom_add_my_account_item_to_profile_menu' );
+add_action( 'admin_bar_menu', 'wpcom_replace_edit_profile_menu_to_me', 9999 );
 
 /**
  * Replaces the default admin bar class with our own.


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/95055

Calypso counterpart:

- https://github.com/Automattic/wp-calypso/pull/95062

## Proposed changes:

This PR modifies the following submenus in the `Howdy, {display menu}` menu in the admin bar:

- Point the `Edit Profile` submenu to `/me` always (and rename it to `My Profile` to match the Calypso page name).
- Remove the `My Account` submenu.

|Before|After|
|-|-|
|<img width="265" alt="image" src="https://github.com/user-attachments/assets/7dc5a792-98dc-4f65-a7ad-4371564bd37e">|<img width="265" alt="image" src="https://github.com/user-attachments/assets/11a9a0e2-76cf-4181-91e1-5e81a62152a5">|


The reason is that the `profile.php` wp-admin page that the `Edit Profile` currently points to, contains mostly links back to Calypso. The most useful fields (display names, language, email) can only be done at user level in Calypso. So, to reduce jumps between Calypso <> wp-admin interface, this PR proposes that the submenu should point to Calypso.

We'll address how to direct user to the `profile.php` page from `/me` (e.g. to update the color scheme) in a later PR.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this PR to Simple / Atomic.
2. Go to any wp-admin screen.
3. Click the `Howdy` menu; verify it points to `/me`.
4. Click the `Howdy` -> `My Profile` submenu; verify it points to `/me`.

