### PR TITLE
Shortcodes: Fix warning when attachment src is false in shortcodes module

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-warning-attachnment-src-shortcodes-module
+++ b/projects/plugins/jetpack/changelog/update-fix-warning-attachnment-src-shortcodes-module
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Minor check to avoid Warnings
+
+

--- a/projects/plugins/jetpack/modules/shortcodes/slideshow.php
+++ b/projects/plugins/jetpack/modules/shortcodes/slideshow.php
@@ -139,7 +139,7 @@ class Jetpack_Slideshow_Shortcode {
 		$gallery = array();
 		foreach ( $attachments as $attachment ) {
 			$attachment_image_src   = wp_get_attachment_image_src( $attachment->ID, $attr['size'] );
-			$attachment_image_src   = $attachment_image_src[0]; // [url, width, height].
+			$attachment_image_src   = false !== $attachment_image_src ? $attachment_image_src[0] : ''; // [url, width, height].
 			$attachment_image_title = get_the_title( $attachment->ID );
 			$attachment_image_alt   = get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true );
 			/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Warnings with message `Trying to access array offset on value of type bool`


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Check if the `attachment_image_src` is not false to avoid accessing an array on value of type bool

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Code Review should be sufficient

