### PR TITLE
My Jetpack: Fix recommendations VideoPress product card not showing "Purchase" button.

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
@@ -18,7 +18,7 @@ import './style.scss';
 
 const slug = PRODUCT_SLUGS.VIDEOPRESS;
 
-const VideopressCard: ProductCardComponent = ( { admin } ) => {
+const VideopressCard: ProductCardComponent = props => {
 	const { detail } = useProduct( slug );
 	const { status } = detail || {};
 	const { videopress: data } = getMyJetpackWindowInitialState();
@@ -70,9 +70,9 @@ const VideopressCard: ProductCardComponent = ( { admin } ) => {
 
 	return (
 		<ProductCard
+			{ ...props }
 			slug={ slug }
 			showMenu
-			admin={ admin }
 			Description={ Description }
 			customLoadTracks={ customLoadTracks }
 		>

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-recommentations-videopress-card-cta
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-recommentations-videopress-card-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed My Jetpack recommendations VideoPress product card not showing Purchase and Learn more buttons.


### PR DESCRIPTION
This PR fixes the CTA's in the My Jetpack Recommendations VideoPress product card. Prior to this PR, the VideoPress card was showing an unclickable "Learn more about VideoPress" link as well as a "Needs user connection" status (See "Before" screenshot). This is incorrect. So to be consistent with all the other recommendation product cards, the VideoPress card should be showing a primary "Purchase" button, and a secondary "Learn more" button. This PR fixes and accomplishes this. (See "After" screenshot)

### Screenshots:

**BEFORE:**

![Screen Shot 2024-10-01 at 17 38 22](https://github.com/user-attachments/assets/11a5e6f3-a114-4bb5-9d21-93e8439a29ef)

.

**AFTER:**

![Screen Shot 2024-10-01 at 17 35 01](https://github.com/user-attachments/assets/426f8ff6-91e1-4580-8554-b7cd646ad3e4)




<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-marketing/issues/1027

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* VideopressCard component: Remove the destructured `admin` prop argument, and instead allow the component to take in `props`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch via the Jetpack Beta plugin (on a new Jurassic Ninja site)
* Go to My Jetpack and click the "Activate Jetpack in one click" button in the top welcome banner.
* When the recommendation Survey form appears, choose "Grow my audience" and "Create quality content" and click the "See solutions" button.
* After the recommended products appear, one of them should be the VideoPress product card.  Verify the VideoPress product card does not look like the "Before" screenshot above, but instead is showing a primary "Purchase" button, and a secondary "Learn more" button (like the "After screenshot above).
* Verify the VideoPress CTA buttons function as intended.

