### PR TITLE
WPCOMSH: Remove redirection from /wp-admin/plugin.php to /plugins/manage/<site>

### DIFF
--- a/projects/plugins/wpcomsh/changelog/test-redirect
+++ b/projects/plugins/wpcomsh/changelog/test-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+test remove redirection

--- a/projects/plugins/wpcomsh/feature-plugins/hooks.php
+++ b/projects/plugins/wpcomsh/feature-plugins/hooks.php
@@ -307,11 +307,6 @@ function wpcomsh_maybe_redirect_to_calypso_plugin_pages() {
 		wp_safe_redirect( 'https://wordpress.com/plugins/' . $site );
 		exit;
 	}
-
-	if ( 0 === strpos( $request_uri, '/wp-admin/plugins.php' ) ) {
-		wp_safe_redirect( 'https://wordpress.com/plugins/manage/' . $site );
-		exit;
-	}
 }
 add_action( 'plugins_loaded', 'wpcomsh_maybe_redirect_to_calypso_plugin_pages' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/pull/95050

## Proposed changes:

This PR removes the redirection from /wp-admin/plugins.php to /plugins/manage/<site>. 

### Context
The original intent of this redirection was to force users to manage plugins via Calypso when their Atomic site was on an unsupported plan: https://github.com/Automattic/wpcomsh/pull/825. However, it has now been confirmed that users without the appropriate permissions or plans (e.g., free) are already blocked from accessing /wp-admin/plugins.php. Therefore, this redirection is no longer necessary.
Additionally, the plugins page is not linked in the sidebar for users on unsupported plans, reducing their chance of visiting this page.

This change is initiated to remove the plugin activation congrats page: https://github.com/Automattic/dotcom-forge/issues/9180, https://github.com/Automattic/wp-calypso/pull/95050.

Slack convo: p1727837802627229-slack-CRWCHQGUB

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Prepare a WoA dev site
- Patch this change via WordPress.com Site Helper in Jetpack Beta
- Remove the Business plan subscription via SA
- Click "Sync Purchase" on SA
	- <img width="963" alt="Screenshot 2024-10-04 at 14 39 18" src="https://github.com/user-attachments/assets/23d460df-e164-4341-84c7-a720c5ef8477">
- Go to /wp-admin/plugins.php.
- You should not be redirected to /plugins/manage/<site>, but you should see an "Access Denied" message since the site is on an unsupported plan.
	- <img width="1435" alt="Screenshot 2024-10-04 at 14 39 51" src="https://github.com/user-attachments/assets/b6be7355-eea2-4e46-8d45-0da2ec416ffb">
