### PR TITLE
Boost: Exclude shortcode produced scripts from deferred js

### DIFF
--- a/projects/plugins/boost/changelog/update-exclude-shortcode-scripts
+++ b/projects/plugins/boost/changelog/update-exclude-shortcode-scripts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Deferred JS: Exclude all scripts produced by a shortcode.


### PR DESCRIPTION
## Proposed changes:
* If a shortcode is trying to output a script, do not defer it. The script is possibly using the script to output a widget which we don't want to take to the footer.

> [!IMPORTANT]  
> Is it better to exclude all scripts coming from `the_content`?

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
8805033-zd-a8c

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Create a shortcode. Here is an example:
```php
function example_script_shortcode() {
	$script_url1 = home_url('js/example-script.js', __FILE__);
	$script_url2 = home_url('js/second-script.js', __FILE__);
	$script1 = '<script src="' . esc_url($script_url1) . '"></script>' . PHP_EOL;
	$script2 = '<script src="' . esc_url($script_url2) . '"></script>' . PHP_EOL;
	$script = $script1 . $script2;

	return $script;
}
add_shortcode('example_script', 'example_script_shortcode');
```

2. Place the shortcode in a page:
`[example_script]`

3. Make sure the scripts have the ignore attribute added:
e.g. `<script data-jetpack-boost="ignore" src="http://jetpack-boost.test/js/example-script.js"></script>`