### PR TITLE
Update Jetpack Scan link

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-scan-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-jetpack-scan-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Jetpack Scan link

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -176,7 +176,7 @@ function wpcom_add_jetpack_submenu() {
 	$monetize_url     = 'https://wordpress.com/earn/' . $domain;
 	$subscribers_url  = 'https://wordpress.com/subscribers/' . $domain;
 	$newsletter_url   = 'https://wordpress.com/settings/newsletter/' . $domain;
-	$scan_url         = 'https://wordpress.com/scan/history/' . $domain;
+	$scan_url         = 'https://wordpress.com/scan/' . $domain;
 
 	// Add submenu items that link to WordPress.com.
 	add_submenu_page(

--- a/projects/packages/masterbar/changelog/update-jetpack-scan-link
+++ b/projects/packages/masterbar/changelog/update-jetpack-scan-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Jetpack Scan link

--- a/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-atomic-admin-menu.php
@@ -339,7 +339,7 @@ class Atomic_Admin_Menu extends Admin_Menu {
 		}
 
 		// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539.
-		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack-masterbar' ), __( 'Scan', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/scan/history/' . $this->domain, null, $scan_position );
+		add_submenu_page( 'jetpack', esc_attr__( 'Scan', 'jetpack-masterbar' ), __( 'Scan', 'jetpack-masterbar' ), 'manage_options', 'https://wordpress.com/scan/' . $this->domain, null, $scan_position );
 
 		/**
 		 * Prevent duplicate menu items that link to Jetpack Backup.

--- a/projects/packages/masterbar/tests/php/test-class-atomic-admin-menu.php
+++ b/projects/packages/masterbar/tests/php/test-class-atomic-admin-menu.php
@@ -384,6 +384,6 @@ class Test_Atomic_Admin_Menu extends TestCase {
 		static::$admin_menu->add_jetpack_menu();
 		$links = wp_list_pluck( array_values( $submenu['jetpack'] ), 2 );
 
-		$this->assertContains( 'https://wordpress.com/scan/history/' . static::$domain, $links );
+		$this->assertContains( 'https://wordpress.com/scan/' . static::$domain, $links );
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-jetpack-scan-link
+++ b/projects/plugins/jetpack/changelog/update-jetpack-scan-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update Jetpack Scan link

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-scan-link
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-jetpack-scan-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Jetpack Scan link

--- a/projects/plugins/wpcomsh/changelog/update-jetpack-scan-link
+++ b/projects/plugins/wpcomsh/changelog/update-jetpack-scan-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Jetpack Scan link


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/7891#issuecomment-2386732409

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Jetpack > Scan should now point to /scan/:site instead of /scan/history/:site
![image](https://github.com/user-attachments/assets/cf82f711-f23e-4a7c-acb1-68b43295bb07)


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* [Follow the instructions](https://github.com/Automattic/jetpack/pull/39619#issuecomment-2387899387) here to test for Atomic sites
* Check the sidebar menu Jetpack > Scan is pointing to /scan/:site
* Check for Classic view and Default view

