### PR TITLE
Update VideoPress block connection banner, align with other blocks

### DIFF
--- a/projects/packages/videopress/changelog/update-jetpack-blocks-confusing-connection-nudges
+++ b/projects/packages/videopress/changelog/update-jetpack-blocks-confusing-connection-nudges
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update connection nudge for VideoPress connection banner in blocks

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
@@ -35,6 +35,8 @@ export default function ConnectBanner( {
 		return null;
 	}
 
+	const needsActivation = isConnected && ! isModuleActive;
+
 	let connectButtonText = __( 'Connect Jetpack', 'jetpack-videopress-pkg' );
 	if ( isConnecting ) {
 		connectButtonText = __( 'Redirecting…', 'jetpack-videopress-pkg' );
@@ -63,12 +65,12 @@ export default function ConnectBanner( {
 					disabled={ isConnecting }
 					isBusy={ isConnecting }
 				>
-					{ ! isModuleActive ? activateButtonText : connectButtonText }
+					{ needsActivation ? activateButtonText : connectButtonText }
 				</Button>
 			}
 			icon={ '' }
 		>
-			{ ! isModuleActive ? connectJetpackModuleMessage : connectYourAccountMessage }
+			{ needsActivation ? connectJetpackModuleMessage : connectYourAccountMessage }
 		</Banner>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
@@ -31,13 +31,18 @@ export default function ConnectBanner( {
 	isConnected,
 	isConnecting,
 }: ConnectBannerProps ): React.ReactElement {
-	if ( isConnected ) {
+	if ( isConnected && isModuleActive ) {
 		return null;
 	}
 
-	let connectButtonText = __( 'Connect', 'jetpack-videopress-pkg' );
+	let connectButtonText = __( 'Connect Jetpack', 'jetpack-videopress-pkg' );
 	if ( isConnecting ) {
 		connectButtonText = __( 'Redirecting…', 'jetpack-videopress-pkg' );
+	}
+
+	let activateButtonText = __( 'Activate VideoPress', 'jetpack-videopress-pkg' );
+	if ( isConnecting ) {
+		activateButtonText = __( 'Activating…', 'jetpack-videopress-pkg' );
 	}
 
 	const connectYourAccountMessage = __(
@@ -58,11 +63,12 @@ export default function ConnectBanner( {
 					disabled={ isConnecting }
 					isBusy={ isConnecting }
 				>
-					{ connectButtonText }
+					{ ! isModuleActive ? activateButtonText : connectButtonText }
 				</Button>
 			}
+			icon={ '' }
 		>
-			{ isModuleActive ? connectYourAccountMessage : connectJetpackModuleMessage }
+			{ ! isModuleActive ? connectJetpackModuleMessage : connectYourAccountMessage }
 		</Banner>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/index.tsx
@@ -34,7 +34,7 @@ export default function BlockBanner( {
 }: BlockBannerProps ): React.ReactElement {
 	return (
 		<div className="block-banner">
-			<Icon icon={ icon } />
+			{ icon && <Icon icon={ icon } /> }
 			<div className="block-banner__content">{ children }</div>
 			{ isLoading && <Spinner /> }
 			{ action && <div className="block-banner__action">{ action }</div> }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
@@ -1,15 +1,39 @@
 .block-banner {
 	display: flex;
-    height: 48px;
+    justify-content: space-between;
     font-size: 14px;
     align-self: center;
     align-items: center;
-    background: #F6F7F7;
-    padding: 0 16px;
+    background: black;
+    border-radius: 2px;
+    padding: 0 20px;
+    box-shadow: 0 0 1px inset white;
 
     .block-banner__content {
-        color: #01283d;
-        flex-grow: 2;
+        color: white;
         margin: 0 8px;
+    }
+
+    .block-banner__action {
+        padding: 0;
+
+        .components-button.is-primary {
+            background: white;
+            color: black;
+            font-weight: 600;
+            font-size: 14px;
+            padding: 4px 8px;
+            height: 28px;
+            margin: 8px 0 8px auto;
+
+            &:hover:not(:disabled) {
+                background: #F6F7F7;
+            }
+        }
+
+        .components-button.is-primary.is-busy {
+            background-size: 100px 100%;
+            background-image: linear-gradient(-45deg, #e34c84 28%, #ab235a 28%, #ab235a 72%, #e34c84 72%);
+        }
     }
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/style.scss
@@ -11,7 +11,7 @@
 
     .block-banner__content {
         color: white;
-        margin: 0 8px;
+        margin: 10px 10px 10px 0;
     }
 
     .block-banner__action {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -318,17 +318,17 @@ const VideoPressUploader = ( {
 		);
 	}
 
-	const needsConnectionText = __(
-		'Connect your WordPress.com account to enable high-quality, ad-free video.',
-		'jetpack-videopress-pkg'
-	);
-
-	const needsActivationText = __(
-		'Activate the VideoPress module to enable high-quality, ad-free video.',
-		'jetpack-videopress-pkg'
-	);
-
 	if ( ! isActive ) {
+		const needsConnectionText = __(
+			'Connect your WordPress.com account to enable high-quality, ad-free video.',
+			'jetpack-videopress-pkg'
+		);
+
+		const needsActivationText = __(
+			'Activate the VideoPress module to enable high-quality, ad-free video.',
+			'jetpack-videopress-pkg'
+		);
+
 		return (
 			<PlaceholderWrapper disableInstructions className="disabled">
 				<span>{ ! hasConnectedOwner ? needsConnectionText : needsActivationText }</span>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -29,6 +29,7 @@ const VideoPressUploader = ( {
 	fileToUpload,
 	isReplacing,
 	onReplaceCancel,
+	isActive,
 } ) => {
 	const [ uploadPaused, setUploadPaused ] = useState( false );
 	const [ uploadedVideoData, setUploadedVideoData ] = useState( false );
@@ -314,6 +315,19 @@ const VideoPressUploader = ( {
 		);
 	}
 
+	if ( ! isActive ) {
+		return (
+			<PlaceholderWrapper disableInstructions className="disabled">
+				<span>
+					{ __(
+						'Connect your WordPress.com account to enable high-quality, ad-free video.',
+						'jetpack-videopress-pkg'
+					) }
+				</span>
+			</PlaceholderWrapper>
+		);
+	}
+
 	// Default view to select file to upload
 	return (
 		<MediaPlaceholder
@@ -338,6 +352,7 @@ const VideoPressUploader = ( {
 				noticeOperations.removeAllNotices();
 				noticeOperations.createErrorNotice( error );
 			} }
+			disableDropZone={ ! isActive }
 		/>
 	);
 };

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -360,7 +360,6 @@ const VideoPressUploader = ( {
 				noticeOperations.removeAllNotices();
 				noticeOperations.createErrorNotice( error );
 			} }
-			disableDropZone={ ! isActive }
 		/>
 	);
 };

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { usePermission } from '../../../../../admin/hooks/use-permission';
 import useResumableUploader from '../../../../../hooks/use-resumable-uploader';
 import { uploadFromLibrary } from '../../../../../hooks/use-uploader';
 import { buildVideoPressURL, pickVideoBlockAttributesFromUrl } from '../../../../../lib/url';
@@ -35,6 +36,8 @@ const VideoPressUploader = ( {
 	const [ uploadedVideoData, setUploadedVideoData ] = useState( false );
 	const [ isUploadingInProgress, setIsUploadingInProgress ] = useState( false );
 	const [ isVerifyingLocalMedia, setIsVerifyingLocalMedia ] = useState( false );
+
+	const { hasConnectedOwner } = usePermission();
 
 	/*
 	 * When the file to upload is set, start the upload process
@@ -315,15 +318,20 @@ const VideoPressUploader = ( {
 		);
 	}
 
+	const needsConnectionText = __(
+		'Connect your WordPress.com account to enable high-quality, ad-free video.',
+		'jetpack-videopress-pkg'
+	);
+
+	const needsActivationText = __(
+		'Activate the VideoPress module to enable high-quality, ad-free video.',
+		'jetpack-videopress-pkg'
+	);
+
 	if ( ! isActive ) {
 		return (
 			<PlaceholderWrapper disableInstructions className="disabled">
-				<span>
-					{ __(
-						'Connect your WordPress.com account to enable high-quality, ad-free video.',
-						'jetpack-videopress-pkg'
-					) }
-				</span>
+				<span>{ ! hasConnectedOwner ? needsConnectionText : needsActivationText }</span>
 			</PlaceholderWrapper>
 		);
 	}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -21,6 +21,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import { usePermission } from '../../../admin/hooks/use-permission';
 import {
 	isStandaloneActive,
 	isVideoPressActive,
@@ -150,6 +151,7 @@ export default function VideoPressEdit( {
 
 	// Get the redirect URI for the connection flow.
 	const [ isRedirectingToMyJetpack, setIsRedirectingToMyJetpack ] = useState( false );
+	const { hasConnectedOwner } = usePermission();
 
 	// Detect if the chapter file is auto-generated.
 	const chapter = tracks?.filter( track => track.kind === 'chapters' )?.[ 0 ];
@@ -397,15 +399,15 @@ export default function VideoPressEdit( {
 			<div { ...blockProps } className={ blockMainClassName }>
 				<>
 					<ConnectBanner
-						isConnected={ isActive }
+						isConnected={ hasConnectedOwner }
 						isModuleActive={ isModuleActive || isStandalonePluginActive }
 						isConnecting={ isRedirectingToMyJetpack }
 						onConnect={ () => {
 							setIsRedirectingToMyJetpack( true );
-							if ( ! isStandalonePluginActive ) {
-								return ( window.location.href = jetpackVideoPressSettingUrl );
+							if ( ! hasConnectedOwner ) {
+								return ( window.location.href = myJetpackConnectUrl );
 							}
-							window.location.href = myJetpackConnectUrl;
+							window.location.href = jetpackVideoPressSettingUrl;
 						} }
 					/>
 
@@ -595,15 +597,15 @@ export default function VideoPressEdit( {
 
 			<ConnectBanner
 				isModuleActive={ isModuleActive || isStandalonePluginActive }
-				isConnected={ isActive }
+				isConnected={ hasConnectedOwner }
 				isConnecting={ isRedirectingToMyJetpack }
 				onConnect={ () => {
 					setIsRedirectingToMyJetpack( true );
-					if ( ! isStandalonePluginActive ) {
-						return ( window.location.href = jetpackVideoPressSettingUrl );
+					if ( ! hasConnectedOwner ) {
+						return ( window.location.href = myJetpackConnectUrl );
 					}
 
-					window.location.href = myJetpackConnectUrl;
+					window.location.href = jetpackVideoPressSettingUrl;
 				} }
 			/>
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -71,6 +71,7 @@ export const PlaceholderWrapper = withNotices( function ( {
 	noticeOperations,
 	instructions = description,
 	disableInstructions,
+	className,
 } ) {
 	useEffect( () => {
 		if ( ! errorMessage ) {
@@ -87,6 +88,7 @@ export const PlaceholderWrapper = withNotices( function ( {
 			label={ title }
 			instructions={ disableInstructions ? null : instructions }
 			notices={ noticeUI }
+			className={ className }
 		>
 			{ children }
 		</Placeholder>
@@ -414,6 +416,7 @@ export default function VideoPressEdit( {
 						fileToUpload={ fileToUpload }
 						isReplacing={ isReplacingFile?.isReplacing }
 						onReplaceCancel={ cancelReplacingVideoFile }
+						isActive={ isActive }
 					/>
 				</>
 			</div>

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/editor.scss
@@ -52,6 +52,10 @@
 	}
 }
 
+.components-placeholder.disabled {
+	min-height: 0;
+}
+
 .loading-wrapper {
 	display: flex;
 	width: 100%;


### PR DESCRIPTION
## Proposed changes:

* Update styling for VideoPress block connection banner to closely match Jetpack AI's nudge
* Update copy and functionality of banner to send to connection screen if no user is connected to the site, and to the settings page if only disabled (previously was always going to settings page)
* Disable controls on block until module is activated and site has a connected user

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-bHl-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Start by site-only connecting your site
3. Create a new blog post
4. Add a VideoPress and Jetpack AI block to the screen so you can compare the two. Save the blog post so you don't have to add the blocks every time
![image](https://github.com/user-attachments/assets/ce861ff5-ce09-4fb0-9c74-4567ae15ebec)
5. Make sure the design is the same and that both scale to mobile the same way

NOTE: The only styling I didn't align was the font. The VideoPress nudge uses Inter (which is what we want), the AI block does not use that, possibly will fix that in a future task on this project

6. Click on "Connect Jetpack" and ensure you are sent through the regular connection flow
![image](https://github.com/user-attachments/assets/8a2f6e7d-6733-464f-84d7-c35caf30d4c4)

NOTE: This connection flow is bad, and does not lead the user back to VideoPress in any way. I wrote about that in P2 (pbNhbs-bHl-p2#comment-23858) and regardless of the outcome of that conversation, fixing that will be outside the scope of this PR

7. After connecting your user, go back to your blog post ( you can delete the AI block now ). Confirm that you now see a nudge to "Activate" VideoPress
![image](https://github.com/user-attachments/assets/d57c2dab-d1ad-490f-b9ae-5cc3cf157b12)

8. Click on the CTA and ensure you are taken to settings where you can activate VideoPress
![image](https://github.com/user-attachments/assets/fbfb758e-0a62-487e-9802-6776572b3986)

9. Activate VideoPress and go back to your blog post. You should be able to use the block now
![image](https://github.com/user-attachments/assets/d8ea8067-9db1-4f20-aa4c-6789bd0e421d)

Bonus!

10. With VideoPress still activated, disconnect your user account from your site (but re-connect your site connection). Go back to your blog post and you should see the `Connect` CTA and copy, not `Activate`
![image](https://github.com/user-attachments/assets/ed449c8b-d220-4098-bf04-81b333c66ca0)
