### PR TITLE
VideoPress: Update notice for disabled VideoPress module to show Enable instead of Connect

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-block-enable-button
+++ b/projects/packages/videopress/changelog/fix-videopress-block-enable-button
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update notice for disabled VideoPress module to show Enable instead of Connect
+
+

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/banner/connect-banner.tsx
@@ -35,7 +35,7 @@ export default function ConnectBanner( {
 		return null;
 	}
 
-	let connectButtonText = __( 'Connect', 'jetpack-videopress-pkg' );
+	let connectButtonText = __( 'Enable', 'jetpack-videopress-pkg' );
 	if ( isConnecting ) {
 		connectButtonText = __( 'Redirecting…', 'jetpack-videopress-pkg' );
 	}


### PR DESCRIPTION
## Proposed changes:

* Update notice for disabled VideoPress module to show Enable instead of Connect

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

