### PR TITLE
Boost: Fix photon URL check

### DIFF
--- a/projects/packages/image-cdn/changelog/add-photon-url-check-method
+++ b/projects/packages/image-cdn/changelog/add-photon-url-check-method
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Added a public method to check if a URL is CDN url

--- a/projects/packages/image-cdn/changelog/add-photon-url-check-method
+++ b/projects/packages/image-cdn/changelog/add-photon-url-check-method
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: added
 
 Added a public method to check if a URL is CDN url

--- a/projects/packages/image-cdn/src/class-image-cdn-core.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-core.php
@@ -161,7 +161,7 @@ class Image_CDN_Core {
 		// Alternately, if it's a *.files.wordpress.com url or an image on a private WordPress.com Simple site,
 		// then keep the domain as is.
 		if (
-			self::is_photon_url( $image_url )
+			self::is_cdn_url( $image_url )
 			|| $is_wpcom_image
 			|| $is_wpcom_private_site
 		) {
@@ -246,7 +246,7 @@ class Image_CDN_Core {
 	 * @param string $url The URL to check.
 	 * @return bool True if the URL is a Photon URL, false otherwise.
 	 */
-	public static function is_photon_url( $url ) {
+	public static function is_cdn_url( $url ) {
 		$parsed_url = wp_parse_url( $url );
 
 		if ( ! $parsed_url ) {

--- a/projects/packages/image-cdn/src/class-image-cdn-core.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-core.php
@@ -243,6 +243,7 @@ class Image_CDN_Core {
 	/**
 	 * Checks if a given URL is a Photon URL.
 	 *
+	 * @since $$next-version$$
 	 * @param string $url The URL to check.
 	 * @return bool True if the URL is a Photon URL, false otherwise.
 	 */

--- a/projects/packages/image-cdn/src/class-image-cdn-core.php
+++ b/projects/packages/image-cdn/src/class-image-cdn-core.php
@@ -156,17 +156,12 @@ class Image_CDN_Core {
 			}
 		}
 
-		/** This filter is documented below. */
-		$custom_photon_url = apply_filters( 'jetpack_photon_domain', '', $image_url );
-		$custom_photon_url = esc_url( $custom_photon_url );
-
 		// You can't run a Photon URL through Photon again because query strings are stripped.
 		// So if the image is already a Photon URL, append the new arguments to the existing URL.
 		// Alternately, if it's a *.files.wordpress.com url or an image on a private WordPress.com Simple site,
 		// then keep the domain as is.
 		if (
-			in_array( $image_url_parts['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ), true )
-			|| wp_parse_url( $custom_photon_url, PHP_URL_HOST ) === $image_url_parts['host']
+			self::is_photon_url( $image_url )
 			|| $is_wpcom_image
 			|| $is_wpcom_private_site
 		) {
@@ -243,6 +238,27 @@ class Image_CDN_Core {
 		}
 
 		return self::cdn_url_scheme( $photon_url, $scheme );
+	}
+
+	/**
+	 * Checks if a given URL is a Photon URL.
+	 *
+	 * @param string $url The URL to check.
+	 * @return bool True if the URL is a Photon URL, false otherwise.
+	 */
+	public static function is_photon_url( $url ) {
+		$parsed_url = wp_parse_url( $url );
+
+		if ( ! $parsed_url ) {
+			return false;
+		}
+
+		// See usage in ::cdn_url for documentation of this filter
+		$custom_photon_url = apply_filters( 'jetpack_photon_domain', '', $url );
+		$custom_photon_url = esc_url( $custom_photon_url );
+
+		return in_array( $parsed_url['host'], array( 'i0.wp.com', 'i1.wp.com', 'i2.wp.com' ), true )
+			|| wp_parse_url( $custom_photon_url, PHP_URL_HOST ) === $parsed_url['host'];
 	}
 
 	/**

--- a/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
+++ b/projects/packages/image-cdn/tests/php/test_class.image_cdn_core.php
@@ -266,6 +266,24 @@ class WP_Test_Image_CDN_Core extends BaseTestCase {
 	}
 
 	/**
+	 * @covers ::Image_CDN_Core::is_cdn_url
+	 * @since  $$next-version$$
+	 * @group  jetpack_photon_filter_network_path
+	 */
+	public function test_is_cdn_url_method() {
+		$this->apply_custom_domain( '//photon.test' );
+		$this->assertTrue( Image_CDN_Core::is_cdn_url( '//photon.test/example.com/img.jpg' ) );
+
+		$this->assertTrue( Image_CDN_Core::is_cdn_url( 'https://i0.wp.com/example.com/img.jpg' ) );
+		$this->assertTrue( Image_CDN_Core::is_cdn_url( 'http://i1.wp.com/example.com/img.jpg' ) );
+		$this->assertTrue( Image_CDN_Core::is_cdn_url( '//i2.wp.com/example.com/img.jpg' ) );
+		$this->assertFalse( Image_CDN_Core::is_cdn_url( '//i3.wp.com/example.com/img.jpg' ) );
+		$this->assertFalse( Image_CDN_Core::is_cdn_url( 'http://example.com/img.jpg' ) );
+		$this->assertFalse( Image_CDN_Core::is_cdn_url( 'https://example.com/img.jpg' ) );
+		$this->assertFalse( Image_CDN_Core::is_cdn_url( '//example.com/img.jpg' ) );
+	}
+
+	/**
 	 * @author aduth
 	 * @covers ::Image_CDN_Core::cdn_url_scheme
 	 * @since  4.5.0

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -36,10 +36,8 @@ class Image_Guide_Proxy {
 			wp_send_json_error( 'Invalid URL', 400 );
 		}
 
-		$photon_url        = Image_CDN_Core::cdn_url( $proxy_url );
-		$photon_url_domain = wp_parse_url( $photon_url, PHP_URL_HOST );
-		$photon_domain     = wp_parse_url( apply_filters( 'jetpack_photon_domain', 'https://i0.wp.com' ), PHP_URL_HOST );
-		if ( $photon_url_domain !== $photon_domain ) {
+		$photon_url = Image_CDN_Core::cdn_url( $proxy_url );
+		if ( ! Image_CDN_Core::is_photon_url( $proxy_url ) ) {
 			wp_send_json_error( 'Failed to proxy the image.', 400 );
 		}
 

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide_Proxy.php
@@ -37,7 +37,7 @@ class Image_Guide_Proxy {
 		}
 
 		$photon_url = Image_CDN_Core::cdn_url( $proxy_url );
-		if ( ! Image_CDN_Core::is_photon_url( $proxy_url ) ) {
+		if ( ! Image_CDN_Core::is_cdn_url( $proxy_url ) ) {
 			wp_send_json_error( 'Failed to proxy the image.', 400 );
 		}
 

--- a/projects/plugins/boost/changelog/improve-cdn-url-check
+++ b/projects/plugins/boost/changelog/improve-cdn-url-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image Guide: Improve check for Jetpack Image CDN URLs


### PR DESCRIPTION
## Proposed changes:
* Image CDN: New public method to check if a URL is already an image CDN url.
* Boost: Use the new public method while validating URLs for proxying images in image guide.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1727887159263839-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
- Add a new gallery with Jetpack's tiled gallery block
- Enable image guide in Boost
- Check if image guide works on the tiled gallery