### PR TITLE
profile.php: Make wpcom links more concise

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/profile-link-improvements
+++ b/projects/packages/jetpack-mu-wpcom/changelog/profile-link-improvements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+profile.php: Make wpcom links more concise

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
@@ -41,19 +41,27 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 		array(
 			'language'             => array(
 				'link' => esc_url( 'https://wordpress.com/me/account' ),
-				'text' => __( 'Your admin interface language is managed on WordPress.com Account settings', 'jetpack-mu-wpcom' ),
+				'text' => __( 'Manage your WordPress.com account language ↗', 'jetpack-mu-wpcom' ),
 			),
-			'synced'               => array(
+			'name'                 => array(
 				'link' => esc_url( 'https://wordpress.com/me' ),
-				'text' => __( 'You can manage your profile on WordPress.com Profile settings (First / Last / Display Names, Website, and Biographical Info)', 'jetpack-mu-wpcom' ),
+				'text' => __( 'Manage your WordPress.com profile ↗', 'jetpack-mu-wpcom' ),
+			),
+			'website'              => array(
+				'link' => esc_url( 'https://wordpress.com/me' ),
+				'text' => __( 'Manage your WordPress.com profile website ↗', 'jetpack-mu-wpcom' ),
+			),
+			'bio'                  => array(
+				'link' => esc_url( 'https://wordpress.com/me' ),
+				'text' => __( 'Manage your WordPress.com profile bio ↗', 'jetpack-mu-wpcom' ),
 			),
 			'email'                => array(
 				'link' => esc_url( 'https://wordpress.com/me/account' ),
-				'text' => __( 'Your WordPress.com email is managed on WordPress.com Account settings', 'jetpack-mu-wpcom' ),
+				'text' => __( 'Manage your WordPress.com account email ↗', 'jetpack-mu-wpcom' ),
 			),
 			'password'             => array(
 				'link' => esc_url( 'https://wordpress.com/me/security' ),
-				'text' => __( 'Your WordPress.com password is managed on WordPress.com Security settings', 'jetpack-mu-wpcom' ),
+				'text' => __( 'Manage your WordPress.com password ↗', 'jetpack-mu-wpcom' ),
 			),
 			'isWpcomAtomicClassic' => $is_wpcom_atomic_classic,
 		)

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -1,23 +1,116 @@
-/**
- * Disable the email field except on Atomic Classic sites.
- */
-const wpcom_profile_settings_disable_email_field = () => {
-	if ( window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomicClassic ) {
-		return;
+const wpcom_profile_settings_modify_language_section = () => {
+	const section = document.querySelector( '.user-language-wrap' )?.querySelector( 'td' );
+	const select = document.getElementById( 'locale' );
+	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.language?.link;
+	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.language?.text;
+	if ( settingsLink && settingsLinkText ) {
+		const notice = document.createElement( 'p' );
+		notice.className = 'description';
+		notice.innerHTML = `<a href="${ settingsLink }">${ settingsLinkText }</a>`;
+		section?.appendChild( notice );
+		select?.remove();
 	}
-	const emailField = document.getElementById( 'email' ) as HTMLInputElement;
-	if ( emailField ) {
-		emailField.readOnly = true;
-	}
-
-	const emailDescription = document.getElementById( 'email-description' ) as HTMLInputElement;
-	emailDescription?.remove();
 };
 
-/**
- * Add a link to the WordPress.com profile settings page.
- */
-const wpcom_profile_settings_add_links_to_wpcom = () => {
+const wpcom_profile_settings_modify_name_section = () => {
+	const table = document.querySelector( '.user-user-login-wrap' )?.parentElement;
+
+	const tr = document.createElement( 'tr' );
+	const th = document.createElement( 'th' );
+	const td = document.createElement( 'td' );
+
+	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.name?.link;
+	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.name?.text;
+	if ( table && settingsLink && settingsLinkText ) {
+		const h2 = document.createElement( 'h2' );
+		h2.innerHTML = 'Name';
+		h2.style = 'font-size: 1.2em';
+		th.appendChild( h2 );
+
+		const notice = document.createElement( 'p' );
+		notice.className = 'description';
+		notice.innerHTML = `<a href="${ settingsLink }">${ settingsLinkText }</a>`;
+		td.appendChild( notice );
+
+		tr.appendChild( th );
+		tr.appendChild( td );
+		table?.appendChild( tr );
+		table?.parentElement?.previousElementSibling?.remove();
+	}
+
+	[
+		'.user-user-login-wrap',
+		'.user-first-name-wrap',
+		'.user-last-name-wrap',
+		'.user-nickname-wrap',
+		'.user-display-name-wrap',
+	].forEach( selector => {
+		const field = document.querySelector( selector );
+		if ( field ) {
+			field.classList.add( 'hidden' );
+		}
+	} );
+};
+
+const wpcom_profile_settings_modify_email_section = () => {
+	// Hide the email field except on Atomic Classic sites.
+	if ( ! window.wpcomProfileSettingsLinkToWpcom?.isWpcomAtomicClassic ) {
+		const field = document.getElementById( 'email' ) as HTMLInputElement;
+		if ( field ) {
+			field.classList.add( 'hidden' );
+		}
+
+		const description = document.getElementById( 'email-description' ) as HTMLInputElement;
+		description?.remove();
+	}
+
+	const section = document.querySelector( '.user-email-wrap' )?.querySelector( 'td' );
+	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.email?.link;
+	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.email?.text;
+	if ( section && settingsLink && settingsLinkText ) {
+		const notice = document.createElement( 'p' );
+		notice.className = 'description';
+		notice.innerHTML = `<a href="${ settingsLink }">${ settingsLinkText }</a>`;
+		section.appendChild( notice );
+	}
+};
+
+const wpcom_profile_settings_modify_website_section = () => {
+	const section = document.querySelector( '.user-url-wrap' )?.querySelector( 'td' );
+	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.website?.link;
+	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.website?.text;
+	if ( section && settingsLink && settingsLinkText ) {
+		const notice = document.createElement( 'p' );
+		notice.className = 'description';
+		notice.innerHTML = `<a href="${ settingsLink }">${ settingsLinkText }</a>`;
+		section.appendChild( notice );
+	}
+
+	const field = section?.querySelector( 'input' );
+	if ( field ) {
+		field.classList.add( 'hidden' );
+	}
+};
+
+const wpcom_profile_settings_modify_bio_section = () => {
+	const section = document.querySelector( '.user-description-wrap' )?.querySelector( 'td' );
+	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.bio?.link;
+	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.bio?.text;
+	if ( section && settingsLink && settingsLinkText ) {
+		const notice = document.createElement( 'p' );
+		notice.className = 'description';
+		notice.innerHTML = `<a href="${ settingsLink }">${ settingsLinkText }</a>`;
+		section.appendChild( notice );
+	}
+
+	const field = section?.querySelector( 'textarea' );
+	if ( field ) {
+		field.classList.add( 'hidden' );
+	}
+	section?.querySelector( 'p' )?.remove();
+};
+
+const wpcom_profile_settings_modify_password_section = () => {
 	const userSessionSection = document.querySelector( '.user-sessions-wrap' );
 	userSessionSection?.remove();
 
@@ -27,69 +120,21 @@ const wpcom_profile_settings_add_links_to_wpcom = () => {
 		newPasswordSection.innerHTML = '';
 	}
 
-	const languageSection = document.querySelector( '.user-language-wrap' )?.querySelector( 'td' );
-	const languageSelect = document.getElementById( 'locale' );
-	const languageSettingsLink = window.wpcomProfileSettingsLinkToWpcom?.language?.link;
-	const languageSettingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.language?.text;
-	if ( languageSettingsLink && languageSettingsLinkText ) {
+	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.password?.link;
+	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.password?.text;
+	if ( newPasswordSection && settingsLink && settingsLinkText ) {
 		const notice = document.createElement( 'p' );
 		notice.className = 'description';
-		notice.innerHTML = `<a href="${ languageSettingsLink }">${ languageSettingsLinkText }</a>.`;
-		languageSection?.appendChild( notice );
-		languageSelect?.remove();
-	}
-
-	const emailSection = document.querySelector( '.user-email-wrap' )?.querySelector( 'td' );
-	const emailSettingsLink = window.wpcomProfileSettingsLinkToWpcom?.email?.link;
-	const emailSettingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.email?.text;
-	if ( emailSection && emailSettingsLink && emailSettingsLinkText ) {
-		const notice = document.createElement( 'p' );
-		notice.className = 'description';
-		notice.innerHTML = `<a href="${ emailSettingsLink }">${ emailSettingsLinkText }</a>.`;
-		emailSection.appendChild( notice );
-	}
-
-	const passwordSettingsLink = window.wpcomProfileSettingsLinkToWpcom?.password?.link;
-	const passwordSettingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.password?.text;
-	if ( newPasswordSection && passwordSettingsLink && passwordSettingsLinkText ) {
-		const notice = document.createElement( 'p' );
-		notice.className = 'description';
-		notice.innerHTML = `<a href="${ passwordSettingsLink }">${ passwordSettingsLinkText }</a>.`;
+		notice.innerHTML = `<a href="${ settingsLink }">${ settingsLinkText }</a>`;
 		newPasswordSection.appendChild( notice );
 	}
-
-	const usernameSection = document.querySelector( '.user-user-login-wrap' )?.querySelector( 'td' );
-	const syncedSettingsLink = window.wpcomProfileSettingsLinkToWpcom?.synced?.link;
-	const syncedSettingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.synced?.text;
-	if ( usernameSection && syncedSettingsLink && syncedSettingsLinkText ) {
-		const notice = document.createElement( 'p' );
-		notice.className = 'description';
-		notice.innerHTML = `<a href="${ syncedSettingsLink }">${ syncedSettingsLinkText }</a>.`;
-		usernameSection.appendChild( notice );
-	}
-};
-
-/**
- * Hide the fields that are synced from /me.
- */
-const wpcom_profile_settings_hide_synced_fields = () => {
-	[
-		'.user-first-name-wrap',
-		'.user-last-name-wrap',
-		'.user-nickname-wrap',
-		'.user-display-name-wrap',
-		'.user-url-wrap',
-		'.user-description-wrap',
-	].forEach( selector => {
-		const field = document.querySelector( selector );
-		if ( field ) {
-			field.classList.add( 'hidden' );
-		}
-	} );
 };
 
 document.addEventListener( 'DOMContentLoaded', () => {
-	wpcom_profile_settings_add_links_to_wpcom();
-	wpcom_profile_settings_disable_email_field();
-	wpcom_profile_settings_hide_synced_fields();
+	wpcom_profile_settings_modify_language_section();
+	wpcom_profile_settings_modify_name_section();
+	wpcom_profile_settings_modify_email_section();
+	wpcom_profile_settings_modify_website_section();
+	wpcom_profile_settings_modify_bio_section();
+	wpcom_profile_settings_modify_password_section();
 } );


### PR DESCRIPTION
Fixes:

- https://github.com/Automattic/wp-calypso/issues/94466

## Proposed changes:

This PR makes the links to `/me/*` in `profile.php` more concise, by restoring the individual fields (except the fields under `Name`). See the following screenshots for more clarity.

At this point, the notion of "links being too long" is a bit personal/subjective. I am proposing this, let's see if you like it 😄 

This also hides the username and email fields if not editable. Specifically for username, it's a bugfix actually, because you are actually able to change username on Calypso /me.

### Atomic Classic

|Before|After|
|-|-|
|<img width="1116" alt="image" src="https://github.com/user-attachments/assets/df3fd65d-9cec-4111-9ca1-b30d04259366">|<img width="701" alt="image" src="https://github.com/user-attachments/assets/53873e26-41db-4d94-b049-98fe40237eb9">|

### Atomic Default, Simple Classic, Simple Default

|Before|After|
|-|-|
|<img width="1043" alt="image" src="https://github.com/user-attachments/assets/2735063a-de37-41bf-a80f-c9edeabfdf36">|<img width="575" alt="image" src="https://github.com/user-attachments/assets/a369d7fb-c5fb-48de-abe0-b882187f59f2">|


### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Test the 4 cases above.
2. In each case, make sure you can update the color scheme.