### PR TITLE
Issue templates: add new issue type option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Report issues with one of our products.
 labels: [ 'Needs triage', '[Type] Bug' ]
+type: 'Bug'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -2,6 +2,7 @@ name: Enhancement Request
 description: Suggest a change to a feature you like!
 title: "Enhancement:"
 labels: ["[Type] Enhancement"]
+type: 'Enhancement'
 body:
   - type: dropdown
     id: plugin-type

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,6 +2,7 @@ name: Feature Request
 description: Suggest an idea for this project!
 title: "Feature Request:"
 labels: ["[Type] Feature Request"]
+type: 'Enhancement'
 body:
   - type: dropdown
     id: plugin-type


### PR DESCRIPTION
## Proposed changes:

This was added as an option as part of this set of changes to GitHub issues:
https://github.blog/changelog/2024-10-01-evolving-github-issues-public-preview/

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

Once this is merged, when creating an issue with a template, the issue type will be added to the issue.
