### PR TITLE
Post-migration Experience: Add the "Review the site's content" task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-review-site-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-review-site-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the Review site task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -815,9 +815,6 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
-			'get_calypso_path'     => function () {
-				return site_url( '/' );
-			},
 		),
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -809,6 +809,16 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
 		),
+		'review_site'                     => array(
+			'get_title'            => function () {
+				return __( "Review the site's content", 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => '__return_true',
+			'get_calypso_path'     => function () {
+				return site_url( '/' );
+			},
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -321,6 +321,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'  => array(
 				'migrating_site',
+				'review_site',
 			),
 		),
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jetpack/issues/39611

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR adds the "Review the site's content" task to the Post-migration launchpad. This task should take the user to the home page of their site so they can validate that the site works as expected.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

This should be ideally tested in an atomic site. Please see the instructions here on how to test a PR: PCYsg-Osp-p2

* Once you have set up your WoA site, add the following filter to your `0-sandbox.php` file:
```
add_filter( 'is_launchpad_intent_post_migration_enabled', '__return_true' );
```
* Then, navigate to the Customer Home page, and you should see the new task.
* The completion and redirect logic will be handled on Calypso.