### PR TITLE
Add review plugins task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-post-migration-task-review-plugins
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-post-migration-task-review-plugins
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a new task for plugins review post migration

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/class-launchpad-task-lists.php
@@ -822,11 +822,12 @@ class Launchpad_Task_Lists {
 	 * among several tasks, calling several completion IDs from the same callback.
 	 *
 	 * @param string $task_id The task ID.
+	 * @param string $task_list_id Optional. The task list ID.
 	 * @return bool True if successful, false if not.
 	 */
-	public function mark_task_complete_if_active( $task_id ) {
+	public function mark_task_complete_if_active( $task_id, $task_list_id = null ) {
 		// Ensure that the task is an active one
-		$active_tasks_by_task_id = wp_list_filter( $this->get_active_tasks(), array( 'id' => $task_id ) );
+		$active_tasks_by_task_id = wp_list_filter( $this->get_active_tasks( $task_list_id ), array( 'id' => $task_id ) );
 		if ( empty( $active_tasks_by_task_id ) ) {
 			return false;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -809,7 +809,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
 		),
-		'migrating_review_plugins'        => array(
+		'review_plugins'                  => array(
 			'get_title'             => function () {
 				return __( 'Review the plugins', 'jetpack-mu-wpcom' );
 			},
@@ -2776,6 +2776,6 @@ function wpcom_launchpad_get_latest_draft_id() {
  */
 function wpcom_launchpad_track_review_plugins_task( $current_screen ) {
 	if ( $current_screen->id === 'plugins' ) {
-		wpcom_launchpad_mark_launchpad_task_complete_if_active( 'migrating_review_plugins', 'post-migration' );
+		wpcom_launchpad_mark_launchpad_task_complete_if_active( 'review_plugins', 'post-migration' );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -1092,10 +1092,11 @@ add_action( 'init', 'wpcom_launchpad_init_task_definitions', 11 );
  * among several tasks, calling several completion IDs from the same callback.
  *
  * @param string $task_id The task ID.
+ * @param string $task_list_id Optional. The task list ID.
  * @return bool True if successful, false if not.
  */
-function wpcom_launchpad_mark_launchpad_task_complete_if_active( $task_id ) {
-	if ( wpcom_launchpad_checklists()->mark_task_complete_if_active( $task_id ) ) {
+function wpcom_launchpad_mark_launchpad_task_complete_if_active( $task_id, $task_list_id = null ) {
+	if ( wpcom_launchpad_checklists()->mark_task_complete_if_active( $task_id, $task_list_id ) ) {
 		wpcom_launchpad_track_completed_task( $task_id );
 		return true;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -809,6 +809,19 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
 		),
+		'migrating_review_plugins'        => array(
+			'get_title'             => function () {
+				return __( 'Review the plugins', 'jetpack-mu-wpcom' );
+			},
+			'is_visible_callback'   => '__return_true',
+			'is_complete_callback'  => 'wpcom_launchpad_is_task_option_completed',
+			'add_listener_callback' => function () {
+				add_action( 'current_screen', 'wpcom_launchpad_track_review_plugins_task' );
+			},
+			'get_calypso_path'      => function () {
+				return admin_url( 'plugins.php' );
+			},
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );
@@ -2752,4 +2765,17 @@ function wpcom_launchpad_get_latest_draft_id() {
 	$cached_draft_id = reset( $latest_draft_id );
 
 	return $cached_draft_id;
+}
+
+/**
+ * Callback for completing review plugins task when the plugins page is loaded.
+ *
+ * @param WP_Screen $current_screen The current screen object.
+ *
+ * @return void
+ */
+function wpcom_launchpad_track_review_plugins_task( $current_screen ) {
+	if ( $current_screen->id === 'plugins' ) {
+		wpcom_launchpad_mark_launchpad_task_complete_if_active( 'migrating_review_plugins', 'post-migration' );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -321,7 +321,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'  => array(
 				'migrating_site',
-				'migrating_review_plugins',
+				'review_plugins',
 			),
 		),
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -321,6 +321,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			},
 			'task_ids'  => array(
 				'migrating_site',
+				'migrating_review_plugins',
 			),
 		),
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/95075

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Add a review plugins task on post migration.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

pfuQfP-IF-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test it on atomic. (paYKcK-5uh-p2)
* Navigate to the home menu and make sure it has the "Review the plugins" task.
* Navigate directly to the plugins page `yoursite/wp-admin/plugins.php`.
* Return the the home menu and make sure the task is complete.

## Screenshots

<img width="988" alt="Screenshot 2024-10-04 at 12 06 20" src="https://github.com/user-attachments/assets/7e72999e-28b6-4fe6-b5d6-8919ac63ccb8">
