### PR TITLE
Newsletters: allow skipping subscription modals with URL query arg

### DIFF
--- a/projects/plugins/jetpack/changelog/update-subscriptions-skip-modal
+++ b/projects/plugins/jetpack/changelog/update-subscriptions-skip-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletters: allow skipping modals with URL query param

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -9,7 +9,20 @@ domReady( () => {
 		return lastDismissed ? Date.now() - lastDismissed > Jetpack_Subscriptions.modalInterval : true;
 	}
 
-	if ( ! modal || ! hasEnoughTimePassed() ) {
+	// Subscriber ended up here e.g. from emails:
+	// we won't show the modal to them in future since they most likely are already a subscriber.
+	function skipModal() {
+		const urlParams = new URLSearchParams( window.location.search );
+		const skip = urlParams.get( 'jetpack_skip_subscription_popup' );
+		if ( skip ) {
+			storeCloseTimestamp();
+			return true;
+		}
+
+		return false;
+	}
+
+	if ( ! modal || ! hasEnoughTimePassed() || skipModal() ) {
 		return;
 	}
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -16,7 +16,7 @@ domReady( () => {
 		const url = new URL( window.location.href );
 		if ( url.searchParams.has( skipUrlParam ) ) {
 			url.searchParams.delete( skipUrlParam );
-			window.history.pushState( {}, '', url );
+			window.history.replaceState( {}, '', url );
 			storeCloseTimestamp();
 			return true;
 		}

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -3,6 +3,7 @@ const { domReady } = wp;
 domReady( () => {
 	const modal = document.querySelector( '.jetpack-subscribe-modal' );
 	const modalDismissedCookie = 'jetpack_post_subscribe_modal_dismissed';
+	const skipUrlParam = 'jetpack_skip_subscription_popup';
 
 	function hasEnoughTimePassed() {
 		const lastDismissed = localStorage.getItem( modalDismissedCookie );
@@ -12,9 +13,10 @@ domReady( () => {
 	// Subscriber ended up here e.g. from emails:
 	// we won't show the modal to them in future since they most likely are already a subscriber.
 	function skipModal() {
-		const urlParams = new URLSearchParams( window.location.search );
-		const skip = urlParams.get( 'jetpack_skip_subscription_popup' );
-		if ( skip ) {
+		const url = new URL( window.location.href );
+		if ( url.searchParams.has( skipUrlParam ) ) {
+			url.searchParams.delete( skipUrlParam );
+			window.history.pushState( {}, '', url );
 			storeCloseTimestamp();
 			return true;
 		}

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.js
@@ -6,7 +6,20 @@ domReady( function () {
 	const hasOverlayDismissedCookie =
 		document.cookie && document.cookie.indexOf( overlayDismissedCookie ) > -1;
 
-	if ( ! overlay || hasOverlayDismissedCookie ) {
+	// Subscriber ended up here e.g. from emails:
+	// we won't show the overlay to them in future since they most likely are already a subscriber.
+	function skipOverlay() {
+		const urlParams = new URLSearchParams( window.location.search );
+		const skip = urlParams.get( 'jetpack_skip_subscription_popup' );
+		if ( skip ) {
+			setOverlayDismissedCookie();
+			return true;
+		}
+
+		return false;
+	}
+
+	if ( ! overlay || hasOverlayDismissedCookie || skipOverlay() ) {
 		return;
 	}
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.js
@@ -3,15 +3,17 @@ const { domReady } = wp;
 domReady( function () {
 	const overlay = document.querySelector( '.jetpack-subscribe-overlay' );
 	const overlayDismissedCookie = 'jetpack_post_subscribe_overlay_dismissed';
+	const skipUrlParam = 'jetpack_skip_subscription_popup';
 	const hasOverlayDismissedCookie =
 		document.cookie && document.cookie.indexOf( overlayDismissedCookie ) > -1;
 
 	// Subscriber ended up here e.g. from emails:
 	// we won't show the overlay to them in future since they most likely are already a subscriber.
 	function skipOverlay() {
-		const urlParams = new URLSearchParams( window.location.search );
-		const skip = urlParams.get( 'jetpack_skip_subscription_popup' );
-		if ( skip ) {
+		const url = new URL( window.location.href );
+		if ( url.searchParams.has( skipUrlParam ) ) {
+			url.searchParams.delete( skipUrlParam );
+			window.history.pushState( {}, '', url );
 			setOverlayDismissedCookie();
 			return true;
 		}

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.js
@@ -13,7 +13,7 @@ domReady( function () {
 		const url = new URL( window.location.href );
 		if ( url.searchParams.has( skipUrlParam ) ) {
 			url.searchParams.delete( skipUrlParam );
-			window.history.pushState( {}, '', url );
+			window.history.replaceState( {}, '', url );
 			setOverlayDismissedCookie();
 			return true;
 		}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack/issues/39580

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Disables showing "overlay" and post "popup" when the URL argument is in place and remembers the choice as if they dismissed the popup.

We'll use the URL query in links to the site in the emails (backend: D161941-code); if they're clicking to the site from emails, they are a subscriber already so no point showing them popups.

When clicking links in emails:

<img width="1214" src="https://github.com/user-attachments/assets/d3b0835b-3276-4139-82e4-5b76649a2fb1"/>


These won't show up:

<img width="1214" alt="image" src="https://github.com/user-attachments/assets/4376fd19-1cd5-46f6-b58c-98ce019c4a81">

<img width="1216" alt="image" src="https://github.com/user-attachments/assets/88de78ad-b869-4ccd-b70f-578ec748047b">

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable subscription modals on post ("popup") and frontend ("overlay")
* Test loading a post and frontpage with `?jetpack_skip_subscription_popup` and see that:
  * Modal doesn't get loaded
  * Cookie gets set as if they dismissed the modal
* If you want to test full flow from emails, see D161941-code

