### PR TITLE
Connection: optimize admin_notices owner delete warning

### DIFF
--- a/projects/packages/connection/changelog/update-optimize-connection-admin-notice-hook
+++ b/projects/packages/connection/changelog/update-optimize-connection-admin-notice-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adjust conditions to optimize admin notices callback.

--- a/projects/packages/connection/src/class-connection-notice.php
+++ b/projects/packages/connection/src/class-connection-notice.php
@@ -40,7 +40,7 @@ class Connection_Notice {
 	 * @return void
 	 */
 	public function initialize_notices( $screen ) {
-		if ( ! in_array(
+		if ( in_array(
 			$screen->id,
 			array(
 				'jetpack_page_akismet-key-config',
@@ -48,6 +48,19 @@ class Connection_Notice {
 			),
 			true
 		) ) {
+			return;
+		}
+
+		/*
+		 * phpcs:disable WordPress.Security.NonceVerification.Recommended
+		 *
+		 * This function is firing within wp-admin and checks (below) if it is in the midst of a deletion on the users
+		 * page. Nonce will be already checked by WordPress, so we do not need to check ourselves.
+		 */
+
+		if ( isset( $screen->base ) && 'users' === $screen->base
+			&& isset( $_REQUEST['action'] ) && 'delete' === $_REQUEST['action']
+		) {
 			add_action( 'admin_notices', array( $this, 'delete_user_update_connection_owner_notice' ) );
 		}
 	}
@@ -57,23 +70,6 @@ class Connection_Notice {
 	 * the connection owner.
 	 */
 	public function delete_user_update_connection_owner_notice() {
-		global $current_screen;
-
-		/*
-		 * phpcs:disable WordPress.Security.NonceVerification.Recommended
-		 *
-		 * This function is firing within wp-admin and checks (below) if it is in the midst of a deletion on the users
-		 * page. Nonce will be already checked by WordPress, so we do not need to check ourselves.
-		 */
-
-		if ( ! isset( $current_screen->base ) || 'users' !== $current_screen->base ) {
-			return;
-		}
-
-		if ( ! isset( $_REQUEST['action'] ) || 'delete' !== $_REQUEST['action'] ) {
-			return;
-		}
-
 		// Get connection owner or bail.
 		$connection_manager  = new Manager();
 		$connection_owner_id = $connection_manager->get_connection_owner_id();


### PR DESCRIPTION
## Proposed changes:
* Optimize the `admin_notices` hook conditions to get rid of an excessive callback.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/529

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack, create another WP user.
2. Login under that user, go to "Users" and try to delete the connection owner. You should see a notice suggesting you to connect first.
3. Use the notice to connect as secondary user, try to delete connection owner again. Now you should see a notice suggesting you to switch connection owner to yourself.
4. Switch the connection owner, try to delete that ex-connection owner. You will see no notice and should be able to delete them easily.