### PR TITLE
WAF: Handle cases where outdated Waf_Rules_Manager has been autoloaded in standalone mode

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-autoloaded-runner-class-handling
+++ b/projects/packages/waf/changelog/fix-waf-autoloaded-runner-class-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve backwards compatibility for sites running in standalone mode.

--- a/projects/packages/waf/src/class-compatibility.php
+++ b/projects/packages/waf/src/class-compatibility.php
@@ -17,6 +17,46 @@ use Jetpack_Options;
 class Waf_Compatibility {
 
 	/**
+	 * Returns the name for the IP allow list enabled/disabled option.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string
+	 */
+	private static function get_ip_allow_list_enabled_option_name() {
+		/**
+		 * Patch: bootstrap script generated prior to 0.17.0 may have autoloaded Waf_Rules_Manager class during standalone mode execution.
+		 *
+		 * @see peb6dq-2HL-p2
+		 */
+		if ( ! defined( 'Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME' ) ) {
+			'jetpack_waf_ip_allow_list_enabled';
+		}
+
+		return Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME;
+	}
+
+	/**
+	 * Returns the name for the IP block list enabled/disabled option.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string
+	 */
+	private static function get_ip_block_list_enabled_option_name() {
+		/**
+		 * Patch: bootstrap script generated prior to 0.17.0 may have autoloaded Waf_Rules_Manager class during standalone mode execution.
+		 *
+		 * @see peb6dq-2HL-p2
+		 */
+		if ( ! defined( 'Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME' ) ) {
+			'jetpack_waf_ip_block_list_enabled';
+		}
+
+		return Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME;
+	}
+
+	/**
 	 * Add compatibilty hooks
 	 *
 	 * @since 0.8.0
@@ -28,8 +68,8 @@ class Waf_Compatibility {
 		add_filter( 'default_option_' . Waf_Initializer::NEEDS_UPDATE_OPTION_NAME, __CLASS__ . '::default_option_waf_needs_update', 10, 3 );
 		add_filter( 'default_option_' . Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME, __CLASS__ . '::default_option_waf_ip_allow_list', 10, 3 );
 		add_filter( 'option_' . Waf_Rules_Manager::IP_ALLOW_LIST_OPTION_NAME, __CLASS__ . '::filter_option_waf_ip_allow_list', 10, 1 );
-		add_filter( 'default_option_' . Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::default_option_waf_ip_allow_list_enabled', 10, 3 );
-		add_filter( 'default_option_' . Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME, __CLASS__ . '::default_option_waf_ip_block_list_enabled', 10, 3 );
+		add_filter( 'default_option_' . self::get_ip_allow_list_enabled_option_name(), __CLASS__ . '::default_option_waf_ip_allow_list_enabled', 10, 3 );
+		add_filter( 'default_option_' . self::get_ip_block_list_enabled_option_name(), __CLASS__ . '::default_option_waf_ip_block_list_enabled', 10, 3 );
 	}
 
 	/**

--- a/projects/packages/waf/src/class-compatibility.php
+++ b/projects/packages/waf/src/class-compatibility.php
@@ -30,7 +30,7 @@ class Waf_Compatibility {
 		 * @see peb6dq-2HL-p2
 		 */
 		if ( ! defined( 'Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME' ) ) {
-			'jetpack_waf_ip_allow_list_enabled';
+			return 'jetpack_waf_ip_allow_list_enabled';
 		}
 
 		return Waf_Rules_Manager::IP_ALLOW_LIST_ENABLED_OPTION_NAME;
@@ -50,7 +50,7 @@ class Waf_Compatibility {
 		 * @see peb6dq-2HL-p2
 		 */
 		if ( ! defined( 'Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME' ) ) {
-			'jetpack_waf_ip_block_list_enabled';
+			return 'jetpack_waf_ip_block_list_enabled';
 		}
 
 		return Waf_Rules_Manager::IP_BLOCK_LIST_ENABLED_OPTION_NAME;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds checks and fallbacks to ensure the allow and block list option name constants are available inside the `Waf_Compatibility` class, for cases where an older version of the `Waf_Rules_Manager` class has been autoloaded by standalone mode.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

peb6dq-2HL-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate Jetpack Protect 2.x via Jetpack Beta
* Set up automatic rules
* Enable standalone mode
* Install and activate the latest Jetpack
* Set your `bootstrap.php` file to require the WAF classes via `jetpack-protect`
* Validate the Protect admin page throws an error accessing the block and allow list option names
* Upgrade to this branch
* Validate the error is not being thrown

