### PR TITLE
Newsletter: change default reply-to option from "no reply" to "comments"

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -410,17 +410,9 @@ const EmailSettings = props => {
 				</p>
 				<RadioControl
 					className="jp-form-radio-gap"
-					selected={ subscriptionReplyTo || 'no-reply' }
+					selected={ subscriptionReplyTo || 'comment' }
 					disabled={ replyToInputDisabled }
 					options={ [
-						{
-							label: (
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Replies are not allowed', 'jetpack' ) }
-								</span>
-							),
-							value: 'no-reply',
-						},
 						{
 							label: (
 								<span className="jp-form-toggle-explanation">
@@ -436,6 +428,14 @@ const EmailSettings = props => {
 								</span>
 							),
 							value: 'author',
+						},
+						{
+							label: (
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Replies are not allowed', 'jetpack' ) }
+								</span>
+							),
+							value: 'no-reply',
 						},
 					] }
 					onChange={ handleSubscriptionReplyToChange }

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -33,6 +33,8 @@ add_action( 'rest_api_init', array( 'Jetpack_Core_Json_Api_Endpoints', 'register
 // Each of these is a class that will register its own routes on 'rest_api_init'.
 require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/load-wpcom-endpoints.php';
 
+require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
+
 /**
  * Class Jetpack_Core_Json_Api_Endpoints
  *
@@ -2704,7 +2706,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'jetpack_subscriptions_reply_to'        => array(
 				'description'       => esc_html__( 'Reply to email behaviour for newsletters emails', 'jetpack' ),
 				'type'              => 'string',
-				'default'           => 'no-reply',
+				'default'           => Automattic\Jetpack\Modules\Subscriptions\Settings::$default_reply_to,
 				'validate_callback' => __CLASS__ . '::validate_subscriptions_reply_to',
 				'jp_group'          => 'subscriptions',
 			),

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -952,7 +952,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
 					$sub_value = Automattic\Jetpack\Modules\Subscriptions\Settings::is_valid_reply_to( $value )
 						? $value
-						: Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();
+						: Automattic\Jetpack\Modules\Subscriptions\Settings::$default_reply_to;
 
 						$updated = (string) get_option( $option ) !== (string) $sub_value ? update_option( $option, $sub_value ) : true;
 					break;

--- a/projects/plugins/jetpack/changelog/update-change-default-reply-to-option
+++ b/projects/plugins/jetpack/changelog/update-change-default-reply-to-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter: change default reply-to option from "no reply" to "comments"

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1003,7 +1003,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
 					$to_set_value = Automattic\Jetpack\Modules\Subscriptions\Settings::is_valid_reply_to( $value )
 						? (string) $value
-						: Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();
+						: Automattic\Jetpack\Modules\Subscriptions\Settings::$default_reply_to;
 
 					if ( update_option( $key, $to_set_value ) ) {
 						$updated[ $key ] = $to_set_value;
@@ -1302,7 +1302,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		$reply_to = get_option( 'jetpack_subscriptions_reply_to', null );
 		if ( $reply_to === null ) {
 			require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
-			return Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();
+			return Automattic\Jetpack\Modules\Subscriptions\Settings::$default_reply_to;
 		}
 		return $reply_to;
 	}

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -18,7 +18,7 @@ class Settings {
 	 *
 	 * @var string
 	 */
-	public $default_reply_to = 'comment';
+	public static $default_reply_to = 'comment';
 
 	/**
 	 * Validate the reply-to option.

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -9,12 +9,16 @@
 
 namespace Automattic\Jetpack\Modules\Subscriptions;
 
-use Automattic\Jetpack\Status\Host;
-
 /**
  * Class Settings
  */
 class Settings {
+	/**
+	 * The default reply-to option.
+	 *
+	 * @var string
+	 */
+	public $default_reply_to = 'comment';
 
 	/**
 	 * Validate the reply-to option.
@@ -28,17 +32,5 @@ class Settings {
 			return true;
 		}
 		return false;
-	}
-	/**
-	 * Get the default reply-to option.
-	 *
-	 * @return string The default reply-to option.
-	 */
-	public static function get_default_reply_to() {
-		if ( ( new Host() )->is_wpcom_simple() ) {
-			return 'comment';
-		}
-
-		return 'no-reply';
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Addresses https://github.com/Automattic/jetpack/issues/39655

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Changes  default from "no-reply" to "comment"
* Changes order of options in settings from "no reply, comment, author" to "comment, author, no reply". 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new site; it should default to "reply as comments" for newsletters
* Try changing the settings for reply-to

