### PR TITLE
Social: Update the check to see if Bluesky is already connected

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-bluesky-already-connected
+++ b/projects/js-packages/publicize-components/changelog/fix-social-bluesky-already-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Updated the check to see if Bluesky is already connected

--- a/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/connection-data.js
@@ -218,7 +218,7 @@ export function isMastodonAccountAlreadyConnected( state, username ) {
  */
 export function isBlueskyAccountAlreadyConnected( state, handle ) {
 	return getConnectionsByService( state, 'bluesky' ).some( connection => {
-		return connection.external_display === handle;
+		return connection.external_name === handle;
 	} );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes  the issue of Bluesky account being allowed to open the connect screen for an already connected account.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the check to see if Bluesky is already connected

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to connections management screen
* Remove the Bluesky connection if already present
* Now connect Bluesky afresh
* Now try to connect the same account again
* Confirm that you see the message that the account is already connected
* Confirm that the connect screen is not opened.

