### PR TITLE
Fix/bug where connection banner shows in p2

### DIFF
--- a/projects/packages/videopress/changelog/fix-bug-where-connection-banner-shows-in-p2
+++ b/projects/packages/videopress/changelog/fix-bug-where-connection-banner-shows-in-p2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix bug where connection banner was showing in P2s and other atomic/simple sites

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.js
@@ -10,9 +10,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { usePermission } from '../../../../../admin/hooks/use-permission';
 import useResumableUploader from '../../../../../hooks/use-resumable-uploader';
 import { uploadFromLibrary } from '../../../../../hooks/use-uploader';
+import { isUserConnected } from '../../../../../lib/connection';
 import { buildVideoPressURL, pickVideoBlockAttributesFromUrl } from '../../../../../lib/url';
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../../constants';
 import { PlaceholderWrapper } from '../../edit';
@@ -37,7 +37,7 @@ const VideoPressUploader = ( {
 	const [ isUploadingInProgress, setIsUploadingInProgress ] = useState( false );
 	const [ isVerifyingLocalMedia, setIsVerifyingLocalMedia ] = useState( false );
 
-	const { hasConnectedOwner } = usePermission();
+	const hasUserConnection = isUserConnected();
 
 	/*
 	 * When the file to upload is set, start the upload process
@@ -331,7 +331,7 @@ const VideoPressUploader = ( {
 
 		return (
 			<PlaceholderWrapper disableInstructions className="disabled">
-				<span>{ ! hasConnectedOwner ? needsConnectionText : needsActivationText }</span>
+				<span>{ ! hasUserConnection ? needsConnectionText : needsActivationText }</span>
 			</PlaceholderWrapper>
 		);
 	}

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -21,12 +21,12 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { usePermission } from '../../../admin/hooks/use-permission';
 import {
 	isStandaloneActive,
 	isVideoPressActive,
 	isVideoPressModuleActive,
 } from '../../../lib/connection';
+import { isUserConnected } from '../../../lib/connection';
 import { buildVideoPressURL, getVideoPressUrl } from '../../../lib/url';
 import { usePreview } from '../../hooks/use-preview';
 import { useSyncMedia } from '../../hooks/use-sync-media';
@@ -151,7 +151,7 @@ export default function VideoPressEdit( {
 
 	// Get the redirect URI for the connection flow.
 	const [ isRedirectingToMyJetpack, setIsRedirectingToMyJetpack ] = useState( false );
-	const { hasConnectedOwner } = usePermission();
+	const hasUserConnection = isUserConnected();
 
 	// Detect if the chapter file is auto-generated.
 	const chapter = tracks?.filter( track => track.kind === 'chapters' )?.[ 0 ];
@@ -399,12 +399,12 @@ export default function VideoPressEdit( {
 			<div { ...blockProps } className={ blockMainClassName }>
 				<>
 					<ConnectBanner
-						isConnected={ hasConnectedOwner }
+						isConnected={ hasUserConnection }
 						isModuleActive={ isModuleActive || isStandalonePluginActive }
 						isConnecting={ isRedirectingToMyJetpack }
 						onConnect={ () => {
 							setIsRedirectingToMyJetpack( true );
-							if ( ! hasConnectedOwner ) {
+							if ( ! hasUserConnection ) {
 								return ( window.location.href = myJetpackConnectUrl );
 							}
 							window.location.href = jetpackVideoPressSettingUrl;
@@ -597,11 +597,11 @@ export default function VideoPressEdit( {
 
 			<ConnectBanner
 				isModuleActive={ isModuleActive || isStandalonePluginActive }
-				isConnected={ hasConnectedOwner }
+				isConnected={ hasUserConnection }
 				isConnecting={ isRedirectingToMyJetpack }
 				onConnect={ () => {
 					setIsRedirectingToMyJetpack( true );
-					if ( ! hasConnectedOwner ) {
+					if ( ! hasUserConnection ) {
 						return ( window.location.href = myJetpackConnectUrl );
 					}
 

--- a/projects/packages/videopress/src/client/lib/connection/index.ts
+++ b/projects/packages/videopress/src/client/lib/connection/index.ts
@@ -1,12 +1,11 @@
 /**
  * External dependencies
  */
+import { isAtomicSite, isSimpleSite } from '@automattic/jetpack-shared-extension-utils';
 import debugFactory from 'debug';
 
 // Get connection initial state from the global window object.
 const initialState = window?.JP_CONNECTION_INITIAL_STATE;
-
-const { siteType = '' } = window?.videoPressEditorState || {};
 
 const debug = debugFactory( 'videopress:connection' );
 
@@ -20,8 +19,13 @@ const debug = debugFactory( 'videopress:connection' );
  * @return {boolean} True if the user is connected, false otherwise.
  */
 export function isUserConnected(): boolean {
-	if ( siteType === 'simple' ) {
+	if ( isSimpleSite() ) {
 		debug( 'Simple site connected ✅' );
+		return true;
+	}
+
+	if ( isAtomicSite() ) {
+		debug( 'Atomic site connected ✅' );
 		return true;
 	}
 


### PR DESCRIPTION
## Proposed changes:

* Check for atomic and simple sites when determining whether to show connection banner or not
* Check if current user is connection instead of checking if the site has a connected owner

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-bHl-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Create a WOA developer blog (fg: PCYsg-Sjz-p2)
2. Purchase a business plan with credits for your blog (you'll need it to upload the jetpack beta tester plugin)
3. Upload the Jetpack Beta tester ( you can get the ZIP file here https://jetpack.com/download-jetpack-beta/ )
4. Checkout this branch with the beta tester
5. Go to create a new post and try to use the VideoPress plugin. Ensure you can use it and you don't see a connection banner
![image](https://github.com/user-attachments/assets/1a312bb0-4ff7-49c4-ad03-577e2f781033)

Bonus!

You can also test out these instructions: https://github.com/Automattic/jetpack/pull/39628 to make sure they still work correctly.

Try adding a new author to your site and logging in as that author without a user connection from that author to ensure you still see the connection banner as expected