### PR TITLE
AI Client: change logo generator upgrade message

### DIFF
--- a/projects/js-packages/ai-client/changelog/change-jetpack-ai-logo-generator-upgrade-message
+++ b/projects/js-packages/ai-client/changelog/change-jetpack-ai-logo-generator-upgrade-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Client: change upgrade copy edit and redirect URL

--- a/projects/js-packages/ai-client/src/logo-generator/components/upgrade-screen.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/upgrade-screen.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import getRedirectUrl from '../../../../components/tools/jp-redirect/index.js';
 import { EVENT_PLACEMENT_FREE_USER_SCREEN, EVENT_UPGRADE } from '../constants.js';
 import useLogoGenerator from '../hooks/use-logo-generator.js';
 /**
@@ -31,6 +32,10 @@ export const UpgradeScreen: React.FC< {
 		'jetpack-ai-client'
 	);
 
+	const upgradeInfoUrl = getRedirectUrl( 'ai-logo-generator-fair-usage-policy', {
+		anchor: 'usage-limitations-and-upgrades',
+	} );
+
 	const { context } = useLogoGenerator();
 
 	const handleUpgradeClick = () => {
@@ -45,7 +50,7 @@ export const UpgradeScreen: React.FC< {
 					{ reason === 'feature' ? upgradeMessageFeature : upgradeMessageRequests }
 				</span>
 				&nbsp;
-				<Button variant="link" href="https://jetpack.com/ai/" target="_blank">
+				<Button variant="link" href={ upgradeInfoUrl } target="_blank">
 					{ __( 'Learn more about Jetpack AI.', 'jetpack-ai-client' ) }
 				</Button>
 			</div>

--- a/projects/js-packages/ai-client/src/logo-generator/components/upgrade-screen.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/upgrade-screen.tsx
@@ -22,8 +22,9 @@ export const UpgradeScreen: React.FC< {
 } > = ( { onCancel, upgradeURL, reason } ) => {
 	const { tracks } = useAnalytics();
 	const { recordEvent: recordTracksEvent } = tracks;
+
 	const upgradeMessageFeature = __(
-		'The logo generator requires a paid Jetpack AI plan. Upgrade your plan to access exclusive features, including logo generation. The upgrade will also increase the amount of requests you can use in all AI-powered features.',
+		'Upgrade your Jetpack AI for access to logo generation. This upgrade will also increase the amount of monthly requests you can use in for all AI-powered features.',
 		'jetpack-ai-client'
 	);
 

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-fair-usage-notice-message.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-fair-usage-notice-message.tsx
@@ -1,6 +1,7 @@
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import getRedirectUrl from '../../../../components/tools/jp-redirect/index.js';
 /**
  * Internal dependencies
  */
@@ -52,14 +53,12 @@ const useFairUsageNoticeMessage = () => {
 	// Get the proper template based on the presence of the next usage period start date.
 	const fairUsageNoticeMessage = getFairUsageNoticeMessage( nextUsagePeriodStartDateString );
 
+	const upgradeInfoUrl = getRedirectUrl( 'ai-logo-generator-fair-usage-policy', {
+		anchor: 'jetpack-ai-usage-limit',
+	} );
+
 	const fairUsageNoticeMessageElement = createInterpolateElement( fairUsageNoticeMessage, {
-		link: (
-			<a
-				href="https://jetpack.com/redirect/?source=ai-logo-generator-fair-usage-policy"
-				target="_blank"
-				rel="noreferrer"
-			/>
-		),
+		link: <a href={ upgradeInfoUrl } target="_blank" rel="noreferrer" />,
 	} );
 
 	return fairUsageNoticeMessageElement;

--- a/projects/js-packages/components/changelog/change-jetpack-ai-logo-generator-upgrade-message
+++ b/projects/js-packages/components/changelog/change-jetpack-ai-logo-generator-upgrade-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Components - getRedirectUrl: use file extension on import for linter to find definitions

--- a/projects/js-packages/components/tools/jp-redirect/index.ts
+++ b/projects/js-packages/components/tools/jp-redirect/index.ts
@@ -1,6 +1,6 @@
 /* global jetpack_redirects */
 
-import { GetRedirectUrlArgs, QueryVars } from './types';
+import { GetRedirectUrlArgs, QueryVars } from './types.js';
 
 /**
  * Builds an URL using the jetpack.com/redirect/ service


### PR DESCRIPTION
## Proposed changes:
Change copy edit for the upgrade modal message
Use getRedirectUrl component

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-2Ms-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
With a free site (no AI plan or upgrade), add a logo block on the editor. Use the AI toolbar button to open the Logo generator modal. Confirm the upgrade modal shows up and the edit matches the proposal on the design P2.

Verify the "Learn more" link points to `https://jetpack.com/support/create-better-content-with-jetpack-ai/#jetpack-ai-usage-limit#usage-limitations-and-upgrades`.

NOTE: the anchor is wrong/doubled due to our redirect having a fixed anchor, we'll correct this after releasing the change

Mock an unlimited plan going over fair usage limit, sandbox the API and add these lines:

```php
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 3200; } );
add_filter( 'jetpack_ai_all_time_requests_count', function() { return 4300; } );
add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 1; } );
```

Reload the editor and open the Logo generator modal. See the fair usage warning, verify the link points to `https://jetpack.com/support/create-better-content-with-jetpack-ai/#jetpack-ai-usage-limit#jetpack-ai-usage-limit`

NOTE: the anchor is wrong/doubled due to our redirect having a fixed anchor, we'll correct this after releasing the change
