### PR TITLE
Add check to update post json api to handle null input type

### DIFF
--- a/projects/plugins/jetpack/changelog/update-add-check-to-update-post-json-api-to-avoid-warning
+++ b/projects/plugins/jetpack/changelog/update-add-check-to-update-post-json-api-to-avoid-warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+JSON Endpoints: Handle null input for update post endpoint

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -955,7 +955,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 	protected function should_load_theme_functions( $post_id = null ) {
 		if ( empty( $post_id ) ) {
 			$input = $this->input( true );
-			$type  = $input['type'];
+			$type  = $input['type'] ?? null;
 		} else {
 			$type = get_post_type( $post_id );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Warnings like 89c2e6d6ca95cf3c7c3f2a957ebb3a09-logstash

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a check to handle null when accessing the `type` key in `input`. `input`  comes from the [input](https://github.com/Automattic/jetpack/blob/plugins/jetpack%4013.9/projects/plugins/jetpack/class.json-api-endpoints.php#L416) method and can return `null`.
### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Mined this Warning from the Grafana dashboard created here -> p9dueE-8lr-p2
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Code Review