### PR TITLE
Sharing: register menu even when user is not connected to wpcom.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-module-settings-non-connected-user
+++ b/projects/plugins/jetpack/changelog/fix-sharing-module-settings-non-connected-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: ensure the sharing settings can be accessed even when a user is not connected to WordPress.com.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -8,6 +8,7 @@
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- TODO: Move classes to appropriately-named class files.
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 
@@ -126,8 +127,13 @@ class Sharing_Admin {
 	 */
 	public function subscription_menu() {
 		$wpcom_is_wp_admin_interface = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
+		$is_user_connected           = ( new Connection_Manager() )->is_user_connected();
 
-		if ( ( new Status() )->is_offline_mode() || $wpcom_is_wp_admin_interface ) {
+		if (
+			( new Status() )->is_offline_mode()
+			|| $wpcom_is_wp_admin_interface
+			|| ! $is_user_connected
+		) {
 			add_submenu_page(
 				'options-general.php',
 				__( 'Sharing Settings', 'jetpack' ),


### PR DESCRIPTION
## Proposed changes:

The legacy sharing module can be used even when not connected to WordPress.com. However, when a user is connected to WordPress.com, we currently send them to the Calypso blue settings screen if they need to make changes to their sharing settings. Folks that are not connected to WordPress.com stil need to manage their sharing configuration though. Since they cannot access Calypso blue, let's register the local sharing settings menu so they can manage their sharing settings there.

> [!NOTE]
> In the future, we'll most likely want everyone to use that local menu instead of Calypso blue. **This is consequently a temporary work-around.**

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


Fixes p1728349589696649-slack-CDD9LQRSN

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* On a brand new site, go to Appearance > Themes
* Install and activate the Twenty Ten theme (or any other legacy theme)
* Go to Jetpack > My Jetpack
* Connect the site to WordPress.com, **but not your user**.
* Go to Jetpack > Settings > Sharing
* Enable the Sharing feature
* Click on the link to manage your sharing settings at the bottom of the card.
    * You should be redirected to the local settings at Settings > Sharing
    * That settings page should load properly.
