### PR TITLE
Revert "Newsletter: change default reply-to option from "no reply" to "comments""

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -410,9 +410,17 @@ const EmailSettings = props => {
 				</p>
 				<RadioControl
 					className="jp-form-radio-gap"
-					selected={ subscriptionReplyTo || 'comment' }
+					selected={ subscriptionReplyTo || 'no-reply' }
 					disabled={ replyToInputDisabled }
 					options={ [
+						{
+							label: (
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Replies are not allowed', 'jetpack' ) }
+								</span>
+							),
+							value: 'no-reply',
+						},
 						{
 							label: (
 								<span className="jp-form-toggle-explanation">
@@ -428,14 +436,6 @@ const EmailSettings = props => {
 								</span>
 							),
 							value: 'author',
-						},
-						{
-							label: (
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Replies are not allowed', 'jetpack' ) }
-								</span>
-							),
-							value: 'no-reply',
 						},
 					] }
 					onChange={ handleSubscriptionReplyToChange }

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -33,8 +33,6 @@ add_action( 'rest_api_init', array( 'Jetpack_Core_Json_Api_Endpoints', 'register
 // Each of these is a class that will register its own routes on 'rest_api_init'.
 require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/load-wpcom-endpoints.php';
 
-require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
-
 /**
  * Class Jetpack_Core_Json_Api_Endpoints
  *
@@ -2706,7 +2704,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'jetpack_subscriptions_reply_to'        => array(
 				'description'       => esc_html__( 'Reply to email behaviour for newsletters emails', 'jetpack' ),
 				'type'              => 'string',
-				'default'           => Automattic\Jetpack\Modules\Subscriptions\Settings::$default_reply_to,
+				'default'           => 'no-reply',
 				'validate_callback' => __CLASS__ . '::validate_subscriptions_reply_to',
 				'jp_group'          => 'subscriptions',
 			),

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -952,7 +952,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
 					$sub_value = Automattic\Jetpack\Modules\Subscriptions\Settings::is_valid_reply_to( $value )
 						? $value
-						: Automattic\Jetpack\Modules\Subscriptions\Settings::$default_reply_to;
+						: Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();
 
 						$updated = (string) get_option( $option ) !== (string) $sub_value ? update_option( $option, $sub_value ) : true;
 					break;

--- a/projects/plugins/jetpack/changelog/update-change-default-reply-to-option
+++ b/projects/plugins/jetpack/changelog/update-change-default-reply-to-option
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Newsletter: change default reply-to option from "no reply" to "comments"

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1003,7 +1003,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
 					$to_set_value = Automattic\Jetpack\Modules\Subscriptions\Settings::is_valid_reply_to( $value )
 						? (string) $value
-						: Automattic\Jetpack\Modules\Subscriptions\Settings::$default_reply_to;
+						: Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();
 
 					if ( update_option( $key, $to_set_value ) ) {
 						$updated[ $key ] = $to_set_value;
@@ -1302,7 +1302,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		$reply_to = get_option( 'jetpack_subscriptions_reply_to', null );
 		if ( $reply_to === null ) {
 			require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/class-settings.php';
-			return Automattic\Jetpack\Modules\Subscriptions\Settings::$default_reply_to;
+			return Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();
 		}
 		return $reply_to;
 	}

--- a/projects/plugins/jetpack/modules/subscriptions/class-settings.php
+++ b/projects/plugins/jetpack/modules/subscriptions/class-settings.php
@@ -9,16 +9,12 @@
 
 namespace Automattic\Jetpack\Modules\Subscriptions;
 
+use Automattic\Jetpack\Status\Host;
+
 /**
  * Class Settings
  */
 class Settings {
-	/**
-	 * The default reply-to option.
-	 *
-	 * @var string
-	 */
-	public static $default_reply_to = 'comment';
 
 	/**
 	 * Validate the reply-to option.
@@ -32,5 +28,17 @@ class Settings {
 			return true;
 		}
 		return false;
+	}
+	/**
+	 * Get the default reply-to option.
+	 *
+	 * @return string The default reply-to option.
+	 */
+	public static function get_default_reply_to() {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return 'comment';
+		}
+
+		return 'no-reply';
 	}
 }


### PR DESCRIPTION
Reverts Automattic/jetpack#39657

Found an issue in the PR on WP.com that I'll handle in different PR, but revert first.

There's one occurrence where we relied on `Automattic\Jetpack\Modules\Subscriptions\Settings::get_default_reply_to();` if option was `null`.