### PR TITLE
Post-migration Experience: Add "Connect your domain" task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-domain-tasks-post-migration
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-domain-tasks-post-migration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new task for domain connection to post-migration checklist.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -834,6 +834,9 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Connect your domain', 'jetpack-mu-wpcom' );
 			},
+			'get_calypso_path'      => function ( $task, $default, $data ) {
+				return '/domains/add/use-my-domain/' . $data['site_slug_encoded'];
+			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
 		),

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -836,7 +836,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				// Attempt to get the domain from the pre-transfer site option if the function exists, otherwise check the current site option.
-				// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
+				// @phan-suppress-next-line PhanUndeclaredFunction -- Being checked before being called.
   				$domain = function_exists( 'wpcom_get_migration_source_site_domain' ) ? wpcom_get_migration_source_site_domain( $data['site_id'] ) : get_option( 'migration_source_site_domain', null );
 				$path   = $domain ? '/domains/add/use-my-domain/' . $data['site_slug_encoded'] . '/?initialQuery=' . $domain : '/domains/add/use-my-domain/' . $data['site_slug_encoded'];
 				return $path;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -839,7 +839,7 @@ function wpcom_launchpad_get_task_definitions() {
 				$path   = $domain ? '/domains/add/use-my-domain/' . $data['site_slug_encoded'] . '/?initialQuery=' . $domain : '/domains/add/use-my-domain/' . $data['site_slug_encoded'];
 				return $path;
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_domain_customize_completed',
 			'is_visible_callback'  => '__return_true',
 		),
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -834,7 +834,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Connect your domain', 'jetpack-mu-wpcom' );
 			},
-			'get_calypso_path'      => function ( $task, $default, $data ) {
+			'get_calypso_path'     => function ( $task, $default, $data ) {
 				$domain = get_option( 'migration_source_site_domain', null );
 				$path   = $domain ? '/domains/add/use-my-domain/' . $data['site_slug_encoded'] . '/?initialQuery=' . $domain : '/domains/add/use-my-domain/' . $data['site_slug_encoded'];
 				return $path;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -842,7 +842,7 @@ function wpcom_launchpad_get_task_definitions() {
 				$path   = $domain ? '/domains/add/use-my-domain/' . $data['site_slug_encoded'] . '/?initialQuery=' . $domain : '/domains/add/use-my-domain/' . $data['site_slug_encoded'];
 				return $path;
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_connect_migration_domain_completed',
+			'is_complete_callback' => 'wpcom_launchpad_is_domain_customize_completed',
 			'is_visible_callback'  => '__return_true',
 		),
 	);
@@ -2638,38 +2638,6 @@ function wpcom_launchpad_domain_customize_check_purchases() {
 	}
 
 	return array( $has_bundle, $has_domain );
-}
-
-/**
- * Determines whether or not the migrated domain is connected.
- *
- * @return bool True if connect migrated domain task is complete.
- */
-function wpcom_launchpad_is_connect_migration_domain_completed() {
-	// Only run on WPCOM platform.
-	if ( ! ( new Automattic\Jetpack\Status\Host() )->is_wpcom_platform() ) {
-		return false;
-	}
-
-	$blog_id = get_current_blog_id();
-
-	if ( ! class_exists( 'Domain_Mapping' ) || ! class_exists( 'WPCOM_Domain' ) ) {
-		return false;
-	}
-
-	// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
-	$primary_domain_mapping = Domain_Mapping::find_primary_by_blog_id( $blog_id );
-	$is_wpcom_domain        = true;
-
-	if ( null !== $primary_domain_mapping ) {
-		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
-		$wpcom_domain = new WPCOM_Domain( $primary_domain_mapping->get_domain_name() );
-		// @phan-suppress-next-line PhanUndeclaredClassMethod
-		$is_wpcom_domain = $wpcom_domain->is_wpcom_tld();
-	}
-
-	// The primary mapped domain is not a WPCOM domain, so the task is complete.
-	return ! $is_wpcom_domain;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -809,6 +809,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
 		),
+		// Post-migration tasks.
 		'review_site'                     => array(
 			'get_title'            => function () {
 				return __( "Review the site's content", 'jetpack-mu-wpcom' );
@@ -828,6 +829,13 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_calypso_path'      => function () {
 				return admin_url( 'plugins.php' );
 			},
+		),
+		'connect_migration_domain'        => array(
+			'get_title'            => function () {
+				return __( 'Connect your domain', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => '__return_true',
 		),
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2642,11 +2642,9 @@ function wpcom_launchpad_domain_customize_check_purchases() {
 /**
  * Determines whether or not the migrated domain is connected.
  *
- * @param Task  $task    The Task object.
- * @param mixed $default The default value.
  * @return bool True if connect migrated domain task is complete.
  */
-function wpcom_launchpad_is_connect_migration_domain_completed( $task, $default ) {
+function wpcom_launchpad_is_connect_migration_domain_completed() {
 	// Only run on WPCOM platform.
 	if ( ! ( new Automattic\Jetpack\Status\Host() )->is_wpcom_platform() ) {
 		return false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -835,9 +835,10 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Connect your domain', 'jetpack-mu-wpcom' );
 			},
 			'get_calypso_path'     => function ( $task, $default, $data ) {
+				$site_id = get_current_blog_id();
 				// Attempt to get the domain from the pre-transfer site option if the function exists, otherwise check the current site option.
 				// @phan-suppress-next-line PhanUndeclaredFunction -- Being checked before being called.
-				$domain = function_exists( 'wpcom_get_migration_source_site_domain' ) ? wpcom_get_migration_source_site_domain( $data['site_id'] ) : get_option( 'migration_source_site_domain', null );
+				$domain = function_exists( 'wpcom_get_migration_source_site_domain' ) ? wpcom_get_migration_source_site_domain( $site_id ) : get_option( 'migration_source_site_domain', null );
 				$path   = $domain ? '/domains/add/use-my-domain/' . $data['site_slug_encoded'] . '/?initialQuery=' . $domain : '/domains/add/use-my-domain/' . $data['site_slug_encoded'];
 				return $path;
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -835,7 +835,9 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Connect your domain', 'jetpack-mu-wpcom' );
 			},
 			'get_calypso_path'      => function ( $task, $default, $data ) {
-				return '/domains/add/use-my-domain/' . $data['site_slug_encoded'];
+				$domain = get_option( 'migration_source_site_domain', null );
+				$path   = $domain ? '/domains/add/use-my-domain/' . $data['site_slug_encoded'] . '/?initialQuery=' . $domain : '/domains/add/use-my-domain/' . $data['site_slug_encoded'];
+				return $path;
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -837,7 +837,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				// Attempt to get the domain from the pre-transfer site option if the function exists, otherwise check the current site option.
 				// @phan-suppress-next-line PhanUndeclaredFunction -- Being checked before being called.
-  				$domain = function_exists( 'wpcom_get_migration_source_site_domain' ) ? wpcom_get_migration_source_site_domain( $data['site_id'] ) : get_option( 'migration_source_site_domain', null );
+				$domain = function_exists( 'wpcom_get_migration_source_site_domain' ) ? wpcom_get_migration_source_site_domain( $data['site_id'] ) : get_option( 'migration_source_site_domain', null );
 				$path   = $domain ? '/domains/add/use-my-domain/' . $data['site_slug_encoded'] . '/?initialQuery=' . $domain : '/domains/add/use-my-domain/' . $data['site_slug_encoded'];
 				return $path;
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -323,6 +323,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'migrating_site',
 				'review_site',
 				'review_plugins',
+				'connect_migration_domain',
 			),
 		),
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/95076 

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a task to connect a site's domain post-migration pointing to `/domains/add/use-my-domain/siteSlug` or `/domains/add/use-my-domain/siteSlug/?initialQuery=example.com` if you have a source site option available.
* Also adds completion logic that borrows from the customize domain task to see if the user has connected a domain.
* The copy/task name are up in the air somewhat. Suggestions welcome!

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This should be ideally tested in an atomic site. Please see the instructions here on how to test a PR: PCYsg-Osp-p2

* Once you have set up your WoA site, add the following filter to your `0-sandbox.php` file:
```
add_filter( 'is_launchpad_intent_post_migration_enabled', '__return_true' );
```
* I also have to comment out line 321 of `public_html/wp-content/lib/home/views.php` on my sandbox because my test site doesn't have that sticker.
* Activate the Jetpack Beta plugin with this branch of the WordPress.com Features module enabled and ensure you add the constant to your WoA test site's `wp-config.php`: define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );
* Then, navigate to the Customer Home page and you should see the new task.
* Clicking on the task should bring you to `/domains/add/use-my-domain/siteSlug`
* Type in a custom domain name and connect it to the site.
* The task should be marked complete.