### PR TITLE
Sync: avoid conflicts with other plugins using the filter

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-filter-null-array
+++ b/projects/packages/sync/changelog/fix-sync-filter-null-array
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update plugin action links filter parameter to avoid conflicts with other plugins.

--- a/projects/packages/sync/src/modules/class-callables.php
+++ b/projects/packages/sync/src/modules/class-callables.php
@@ -383,7 +383,7 @@ class Callables extends Module {
 		if ( ! empty( $plugins_lock ) && ( isset( $current_screeen->id ) && 'plugins' !== $current_screeen->id ) ) {
 			return;
 		}
-		$plugins = array_keys( Functions::get_plugins() );
+		$plugins = Functions::get_plugins();
 		foreach ( $plugins as $plugin_file => $plugin_data ) {
 			/**
 			 *  Plugins often like to unset things but things break if they are not able to.

--- a/projects/packages/sync/src/modules/class-callables.php
+++ b/projects/packages/sync/src/modules/class-callables.php
@@ -384,7 +384,7 @@ class Callables extends Module {
 			return;
 		}
 		$plugins = array_keys( Functions::get_plugins() );
-		foreach ( $plugins as $plugin_file ) {
+		foreach ( $plugins as $plugin_file => $plugin_data ) {
 			/**
 			 *  Plugins often like to unset things but things break if they are not able to.
 			 */
@@ -396,13 +396,13 @@ class Callables extends Module {
 				'edit'       => '',
 			);
 			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
-			$action_links = apply_filters( 'plugin_action_links', $action_links, $plugin_file, array(), 'all' );
+			$action_links = apply_filters( 'plugin_action_links', $action_links, $plugin_file, $plugin_data, 'all' );
 			// Verify $action_links is still an array.
 			if ( ! is_array( $action_links ) ) {
 				$action_links = array();
 			}
 			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
-			$action_links = apply_filters( "plugin_action_links_{$plugin_file}", $action_links, $plugin_file, array(), 'all' );
+			$action_links = apply_filters( "plugin_action_links_{$plugin_file}", $action_links, $plugin_file, $plugin_data, 'all' );
 			// Verify $action_links is still an array to resolve warnings from filters not returning an array.
 			if ( is_array( $action_links ) ) {
 				$action_links = array_filter( $action_links );

--- a/projects/packages/sync/src/modules/class-callables.php
+++ b/projects/packages/sync/src/modules/class-callables.php
@@ -396,13 +396,13 @@ class Callables extends Module {
 				'edit'       => '',
 			);
 			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
-			$action_links = apply_filters( 'plugin_action_links', $action_links, $plugin_file, null, 'all' );
+			$action_links = apply_filters( 'plugin_action_links', $action_links, $plugin_file, array(), 'all' );
 			// Verify $action_links is still an array.
 			if ( ! is_array( $action_links ) ) {
 				$action_links = array();
 			}
 			/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
-			$action_links = apply_filters( "plugin_action_links_{$plugin_file}", $action_links, $plugin_file, null, 'all' );
+			$action_links = apply_filters( "plugin_action_links_{$plugin_file}", $action_links, $plugin_file, array(), 'all' );
 			// Verify $action_links is still an array to resolve warnings from filters not returning an array.
 			if ( is_array( $action_links ) ) {
 				$action_links = array_filter( $action_links );

--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-sync-filter-null-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: update filter parameter to avoid conflicts with other plugins.
+
+

--- a/projects/plugins/backup/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/backup/changelog/fix-sync-filter-null-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: update filter parameter to avoid conflicts with other plugins.
+
+

--- a/projects/plugins/boost/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/boost/changelog/fix-sync-filter-null-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: update filter parameter to avoid conflicts with other plugins.
+
+

--- a/projects/plugins/jetpack/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/jetpack/changelog/fix-sync-filter-null-array
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Plugin action links filters: update parameter to avoid any conflicts with other plugins.

--- a/projects/plugins/migration/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/migration/changelog/fix-sync-filter-null-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: update filter parameter to avoid conflicts with other plugins.
+
+

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-sync-filter-null-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: update filter parameter to avoid conflicts with other plugins.
+
+

--- a/projects/plugins/protect/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/protect/changelog/fix-sync-filter-null-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: update filter parameter to avoid conflicts with other plugins.
+
+

--- a/projects/plugins/search/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/search/changelog/fix-sync-filter-null-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: update filter parameter to avoid conflicts with other plugins.
+
+

--- a/projects/plugins/social/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/social/changelog/fix-sync-filter-null-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: update filter parameter to avoid conflicts with other plugins.
+
+

--- a/projects/plugins/starter-plugin/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/starter-plugin/changelog/fix-sync-filter-null-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: update filter parameter to avoid conflicts with other plugins.
+
+

--- a/projects/plugins/videopress/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/videopress/changelog/fix-sync-filter-null-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: update filter parameter to avoid conflicts with other plugins.
+
+

--- a/projects/plugins/wpcomsh/changelog/fix-sync-filter-null-array
+++ b/projects/plugins/wpcomsh/changelog/fix-sync-filter-null-array
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Sync: update filter parameter to avoid conflicts with other plugins.
+
+


### PR DESCRIPTION
Fixes #39654

## Proposed changes:

As mentioned in the original issue:

> I did notice two locations where Jetpack code is calling the filter with a null value rather than the documented array for the $plugin_data parameter.
-- https://github.com/Automattic/jetpack/issues/39654#issuecomment-2397134979

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

I wasn't able to reproduce the issue on my end, so it makes this hard to test. It would be worth installing WooCommerce as well as the Tokenpay Payment Gateway plugin, and checking if the plugin action links from WooCommerce are still there and correct.
