### PR TITLE
Prevent welcome tour keyboard navigation from hijacking left right keys on the editor

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/prevent welcome tour keyboard navigation from hijacking left right keys on the editor 
+++ b/projects/packages/jetpack-mu-wpcom/changelog/prevent welcome tour keyboard navigation from hijacking left right keys on the editor 
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Prevent welcome tour keyboard navigation from hijacking left right keys on the editor 

--- a/projects/packages/jetpack-mu-wpcom/changelog/prevent welcome tour keyboard navigation from hijacking left right keys on the editor 
+++ b/projects/packages/jetpack-mu-wpcom/changelog/prevent welcome tour keyboard navigation from hijacking left right keys on the editor 
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent welcome tour keyboard navigation from hijacking left right keys on the editor 

--- a/projects/packages/jetpack-mu-wpcom/changelog/prevent-welcome-tour-keyboard-navigation-from-hijacking-left-right-keys-on-the-editor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/prevent-welcome-tour-keyboard-navigation-from-hijacking-left-right-keys-on-the-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent welcome tour keyboard navigation from hijacking left right keys on the editor

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/components/keyboard-navigation.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/components/keyboard-navigation.tsx
@@ -34,6 +34,7 @@ const KeyboardNavigation: React.FunctionComponent< Props > = ( {
 			onEscape: onMinimize,
 			onArrowRight: onNextStepProgression,
 			onArrowLeft: onPreviousStepProgression,
+			tourContainerRef,
 		} );
 		useFocusTrap( tourContainerRef );
 
@@ -44,7 +45,7 @@ const KeyboardNavigation: React.FunctionComponent< Props > = ( {
 	 * Minimize Tour Nav
 	 */
 	function MinimizedTourNav() {
-		useKeydownHandler( { onEscape: onDismiss( 'esc-key-minimized' ) } );
+		useKeydownHandler( { onEscape: onDismiss( 'esc-key-minimized' ), tourContainerRef } );
 
 		return null;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/components/tour-kit-frame.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/components/tour-kit-frame.tsx
@@ -247,6 +247,7 @@ const TourKitFrame: React.FunctionComponent< Props > = ( { config } ) => {
 				<div
 					className="tour-kit-frame__container"
 					ref={ setPopperElement }
+					tabIndex={ -1 }
 					{ ...( stepRepositionProps as React.HTMLAttributes< HTMLDivElement > ) }
 				>
 					{ showArrowIndicator() && (

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/hooks/use-keydown-handler.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/hooks/use-keydown-handler.ts
@@ -8,12 +8,25 @@ interface Props {
 	onEscape?: () => void;
 	onArrowRight?: () => void;
 	onArrowLeft?: () => void;
+	tourContainerRef: React.MutableRefObject< null | HTMLElement >;
 }
 
 /**
  * A hook the applies the respective callbacks in response to keydown events.
  */
-const useKeydownHandler = ( { onEscape, onArrowRight, onArrowLeft }: Props ): void => {
+const useKeydownHandler = ( {
+	onEscape,
+	onArrowRight,
+	onArrowLeft,
+	tourContainerRef,
+}: Props ): void => {
+	const isActiveElementOutsideTourContainer = useCallback( (): boolean => {
+		return !! (
+			tourContainerRef.current &&
+			! tourContainerRef.current.contains( tourContainerRef.current.ownerDocument.activeElement )
+		);
+	}, [ tourContainerRef ] );
+
 	const handleKeydown = useCallback(
 		( event: KeyboardEvent ) => {
 			let handled = false;
@@ -21,18 +34,30 @@ const useKeydownHandler = ( { onEscape, onArrowRight, onArrowLeft }: Props ): vo
 			switch ( event.key ) {
 				case 'Escape':
 					if ( onEscape ) {
+						if ( isActiveElementOutsideTourContainer() ) {
+							return;
+						}
+
 						onEscape();
 						handled = true;
 					}
 					break;
 				case 'ArrowRight':
 					if ( onArrowRight ) {
+						if ( isActiveElementOutsideTourContainer() ) {
+							return;
+						}
+
 						onArrowRight();
 						handled = true;
 					}
 					break;
 				case 'ArrowLeft':
 					if ( onArrowLeft ) {
+						if ( isActiveElementOutsideTourContainer() ) {
+							return;
+						}
+
 						onArrowLeft();
 						handled = true;
 					}
@@ -46,7 +71,7 @@ const useKeydownHandler = ( { onEscape, onArrowRight, onArrowLeft }: Props ): vo
 				event.stopPropagation();
 			}
 		},
-		[ onEscape, onArrowRight, onArrowLeft ]
+		[ isActiveElementOutsideTourContainer, onEscape, onArrowRight, onArrowLeft ]
 	);
 
 	useEffect( () => {

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/hooks/use-keydown-handler.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/hooks/use-keydown-handler.ts
@@ -74,13 +74,39 @@ const useKeydownHandler = ( {
 		[ isActiveElementOutsideTourContainer, onEscape, onArrowRight, onArrowLeft ]
 	);
 
+	const isFocusable = ( element: HTMLElement ) => {
+		const focusableElements = [ 'A', 'INPUT', 'BUTTON', 'TEXTAREA', 'SELECT' ];
+
+		// Check if the element is focusable by its tag or has a tabindex >= 0
+		return focusableElements.includes( element?.tagName ) || element?.tabIndex >= 0;
+	};
+
+	// when clicking on the container, if the target is not a focusable element,
+	// force focus on the first children so keyboard navigation works
+	const handleTourContainerClick = useCallback(
+		( event: MouseEvent ) => {
+			if ( isFocusable( event.target as HTMLElement ) ) {
+				return;
+			}
+
+			(
+				tourContainerRef.current?.querySelector( '.tour-kit-frame__container' ) as HTMLElement
+			 )?.focus();
+		},
+		[ tourContainerRef ]
+	);
+
 	useEffect( () => {
+		const tourContainer = tourContainerRef.current;
+
 		document.addEventListener( 'keydown', handleKeydown );
+		tourContainer?.addEventListener( 'click', handleTourContainerClick );
 
 		return () => {
 			document.removeEventListener( 'keydown', handleKeydown );
+			tourContainer?.removeEventListener( 'click', handleTourContainerClick );
 		};
-	}, [ handleKeydown ] );
+	}, [ handleKeydown, handleTourContainerClick, tourContainerRef ] );
 };
 
 export default useKeydownHandler;

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/hooks/use-keydown-handler.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/hooks/use-keydown-handler.ts
@@ -27,6 +27,12 @@ const useKeydownHandler = ( {
 		);
 	}, [ tourContainerRef ] );
 
+	const focusTourContainer = useCallback( () => {
+		(
+			tourContainerRef.current?.querySelector( '.tour-kit-frame__container' ) as HTMLElement
+		 )?.focus();
+	}, [ tourContainerRef ] );
+
 	const handleKeydown = useCallback(
 		( event: KeyboardEvent ) => {
 			let handled = false;
@@ -39,6 +45,8 @@ const useKeydownHandler = ( {
 						}
 
 						onEscape();
+						// focus the container after minimizing so the user can dismiss it
+						focusTourContainer();
 						handled = true;
 					}
 					break;
@@ -71,29 +79,27 @@ const useKeydownHandler = ( {
 				event.stopPropagation();
 			}
 		},
-		[ isActiveElementOutsideTourContainer, onEscape, onArrowRight, onArrowLeft ]
+		[ onEscape, onArrowRight, onArrowLeft, isActiveElementOutsideTourContainer, focusTourContainer ]
 	);
-
-	const isFocusable = ( element: HTMLElement ) => {
-		const focusableElements = [ 'A', 'INPUT', 'BUTTON', 'TEXTAREA', 'SELECT' ];
-
-		// Check if the element is focusable by its tag or has a tabindex >= 0
-		return focusableElements.includes( element?.tagName ) || element?.tabIndex >= 0;
-	};
 
 	// when clicking on the container, if the target is not a focusable element,
 	// force focus on the first children so keyboard navigation works
 	const handleTourContainerClick = useCallback(
 		( event: MouseEvent ) => {
+			const isFocusable = ( element: HTMLElement ) => {
+				const focusableElements = [ 'A', 'INPUT', 'BUTTON', 'TEXTAREA', 'SELECT' ];
+
+				// Check if the element is focusable by its tag or has a tabindex >= 0
+				return focusableElements.includes( element?.tagName ) || element?.tabIndex >= 0;
+			};
+
 			if ( isFocusable( event.target as HTMLElement ) ) {
 				return;
 			}
 
-			(
-				tourContainerRef.current?.querySelector( '.tour-kit-frame__container' ) as HTMLElement
-			 )?.focus();
+			focusTourContainer();
 		},
-		[ tourContainerRef ]
+		[ focusTourContainer ]
 	);
 
 	useEffect( () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/93904

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Currently, when you go to the post editor and the `WelcomeTour` component is shown, its keyboard navigation takes precedence over anything, so that pressing the left/right keys on your post's title shows you the previous/next slide on the tour instead of moving the cursor across characters, as the user would expect.
* This PR fixes that behavior, so that the slides navigation only happens when the user is focused on the `WelcomeTour`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch on your sandbox
* Create a new account, and with it, create a new site without getting to launch it
* Sandbox the new site
* Go to `/post/{siteSlug}.wordpress.com`
* Check that pressing the left/right keys navigates the slides on the welcome tour shown on the bottom left corner
* Check that you can write something on the editor and move across the characters with the left/right keys
* Check that clicking on the welcome tour lets you left/right navigate it
* Check that pressing the `ESC` key minimizes the welcome tour
* Check that clicking on the minimized welcome tour maximizes it again
* Check that you can still left/right navigate the welcome tour
* Check that minimizing with `ESC`, and then pressing `ESC` again gets rid of the tour

