### PR TITLE
Photon: avoid deprecation warnings when src is null

### DIFF
--- a/projects/packages/image-cdn/changelog/fix-photon-deprecation-notice
+++ b/projects/packages/image-cdn/changelog/fix-photon-deprecation-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid deprecation notice when an image URL does not have an expected format.

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -679,7 +679,12 @@ final class Image_CDN {
 						$processor->set_attribute( 'data-recalc-dims', '1' );
 					}
 				}
-			} elseif ( preg_match( '#^http(s)?://i[\d]{1}.wp.com#', $src ) && is_string( $nearest_preceding_href ) && self::validate_image_url( $nearest_preceding_href ) ) {
+			} elseif (
+				is_string( $src )
+				&& preg_match( '#^http(s)?://i[\d]{1}.wp.com#', $src )
+				&& is_string( $nearest_preceding_href )
+				&& self::validate_image_url( $nearest_preceding_href )
+			) {
 				$processor->seek( 'link' );
 				$processor->set_attribute( 'href', Image_CDN_Core::cdn_url( $nearest_preceding_href ) );
 				$processor->seek( 'image' );

--- a/projects/packages/image-cdn/src/class-image-cdn.php
+++ b/projects/packages/image-cdn/src/class-image-cdn.php
@@ -357,11 +357,21 @@ final class Image_CDN {
 				continue;
 			}
 
+			// Identify image source.
+			$src_orig = $processor->get_attribute( 'src' );
+			$src      = $src_orig;
+
 			/*
-			 * Only examine tags that are considered an image. If encountering
-			 * a closing tag then this is not the image being sought.
+			 * Only examine tags that are considered an image,
+			 * with a valid src attribute.
+			 * If encountering a closing tag then this is not the image being sought.
 			 */
-			if ( $processor->is_tag_closer() || ! in_array( $processor->get_tag(), $image_tags, true ) ) {
+			if (
+				$processor->is_tag_closer()
+				|| ! in_array( $processor->get_tag(), $image_tags, true )
+				|| ! is_string( $src )
+				|| $src === ''
+			) {
 				continue;
 			}
 
@@ -396,10 +406,6 @@ final class Image_CDN {
 
 			// Flag if we need to munge a fullsize URL.
 			$fullsize_url = false;
-
-			// Identify image source.
-			$src_orig = $processor->get_attribute( 'src' );
-			$src      = $src_orig;
 
 			/**
 			 * Allow specific images to be skipped by Photon.
@@ -680,8 +686,7 @@ final class Image_CDN {
 					}
 				}
 			} elseif (
-				is_string( $src )
-				&& preg_match( '#^http(s)?://i[\d]{1}.wp.com#', $src )
+				preg_match( '#^http(s)?://i[\d]{1}.wp.com#', $src )
 				&& is_string( $nearest_preceding_href )
 				&& self::validate_image_url( $nearest_preceding_href )
 			) {


### PR DESCRIPTION
## Proposed changes:

In some scenarios, one can run into the following deprecation notices:

```
Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /wordpress/plugins/jetpack/13.9-a.7/jetpack_vendor/automattic/jetpack-image-cdn/src/class-image-cdn.php on line 682
```

This should avoid those notices.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

This was originally reported here:
https://wordpress.org/support/topic/a-debug-on-the-page/

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

I wasn't able to reproduce the issue, but if tests pass we should be good to go.

