### PR TITLE
Post-migration task list: Add new ssl task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-new-ssl-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-new-ssl-task
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: adding a wpcom task
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2810,12 +2810,12 @@ function wpcom_launchpad_is_ssl_task_disabled() {
 		return true;
 	}
 
-	// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
+	// @phan-suppress-next-line PhanUndeclaredClass -- Being checked before being called.
 	$primary_domain_mapping = Domain_Mapping::find_primary_by_blog_id( $blog_id );
 	$is_wpcom_domain        = true;
 
 	if ( null !== $primary_domain_mapping ) {
-		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
+		// @phan-suppress-next-line PhanUndeclaredClass -- Being checked before being called.
 		$wpcom_domain    = new WPCOM_Domain( $primary_domain_mapping->get_domain_name() );
 		$is_wpcom_domain = $wpcom_domain->is_wpcom_tld();
 	}
@@ -2847,7 +2847,7 @@ function wpcom_launchpad_is_ssl_task_completed() {
 
 	$blog_id = get_current_blog_id();
 
-	// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
+	// @phan-suppress-next-line PhanUndeclaredClass -- Being checked before being called.
 	$primary_domain_mapping = Domain_Mapping::find_primary_by_blog_id( $blog_id );
 
 	// If the site doesn't have a primary domain mapping, the task is not complete.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -835,7 +835,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_ssl_task_completed',
 			'is_visible_callback'  => '__return_true',
-			'is_disabled_callback' => 'wpcom_launchpad_is_ssl_task_disabled',
+			'is_disabled_callback' => 'wpcom_launchpad_is_primary_domain_wpcom',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				$domain = $data['site_slug_encoded'];
 				return '/domains/manage/' . $domain . '/edit/' . $domain;
@@ -2794,21 +2794,20 @@ function wpcom_launchpad_get_latest_draft_id() {
 }
 
 /**
- * Check if the SSL task should be disabled.
+ * Checks if the current site primary domain is a WPCOM domain.
  *
  * @return bool Will return true if the primary domain is a WPCOM domain.
  */
-function wpcom_launchpad_is_ssl_task_disabled() {
-	// Only run on WPCOM platform.
+function wpcom_launchpad_is_primary_domain_wpcom() {
 	if ( ! ( new Automattic\Jetpack\Status\Host() )->is_wpcom_platform() ) {
-		return true;
+		return false;
+	}
+
+	if ( ! class_exists( 'Domain_Mapping' ) || ! class_exists( 'WPCOM_Domain' ) ) {
+		return false;
 	}
 
 	$blog_id = get_current_blog_id();
-
-	if ( ! class_exists( 'Domain_Mapping' ) || ! class_exists( 'WPCOM_Domain' ) ) {
-		return true;
-	}
 
 	// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
 	$primary_domain_mapping = Domain_Mapping::find_primary_by_blog_id( $blog_id );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2799,16 +2799,23 @@ function wpcom_launchpad_get_latest_draft_id() {
  * @return bool Will return true if the primary domain is a WPCOM domain.
  */
 function wpcom_launchpad_is_ssl_task_disabled() {
+	// Only run on WPCOM platform.
+	if ( ! ( new Automattic\Jetpack\Status\Host() )->is_wpcom_platform() ) {
+		return true;
+	}
+
 	$blog_id = get_current_blog_id();
 
 	if ( ! class_exists( 'Domain_Mapping' ) || ! class_exists( 'WPCOM_Domain' ) ) {
 		return true;
 	}
 
+	// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
 	$primary_domain_mapping = Domain_Mapping::find_primary_by_blog_id( $blog_id );
 	$is_wpcom_domain        = true;
 
 	if ( null !== $primary_domain_mapping ) {
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
 		$wpcom_domain    = new WPCOM_Domain( $primary_domain_mapping->get_domain_name() );
 		$is_wpcom_domain = $wpcom_domain->is_wpcom_tld();
 	}
@@ -2822,10 +2829,15 @@ function wpcom_launchpad_is_ssl_task_disabled() {
  * @return bool
  */
 function wpcom_launchpad_is_ssl_task_completed() {
+	// Only run on WPCOM platform.
+	if ( ! ( new Automattic\Jetpack\Status\Host() )->is_wpcom_platform() ) {
+		return false;
+	}
+
 	$task_id = 'check_ssl_status';
 
 	// If the task is already complete, return true.
-	if ( wpcom_launchpad_is_task_option_completed( $task_id ) ) {
+	if ( wpcom_launchpad_is_task_option_completed( array( 'id' => $task_id ) ) ) {
 		return true;
 	}
 
@@ -2835,6 +2847,7 @@ function wpcom_launchpad_is_ssl_task_completed() {
 
 	$blog_id = get_current_blog_id();
 
+	// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
 	$primary_domain_mapping = Domain_Mapping::find_primary_by_blog_id( $blog_id );
 
 	// If the site doesn't have a primary domain mapping, the task is not complete.
@@ -2844,6 +2857,7 @@ function wpcom_launchpad_is_ssl_task_completed() {
 		return false;
 	}
 	// This way of checking for the certificate was extracted from the get_ssl_status function in wp-content/rest-api-plugins/endpoints/domains-ssl.php
+	// @phan-suppress-next-line PhanUndeclaredClass -- Being checked before being called.
 	$certificate_flag_manager = WPCOM\Container\DI::get( Domain_Certificate_Flags_Manager::class );
 	$certificate_flags        = $certificate_flag_manager->get_flags( $primary_domain_mapping->get_domain_name() );
 
@@ -2855,6 +2869,7 @@ function wpcom_launchpad_is_ssl_task_completed() {
 		return false;
 	}
 
+	// @phan-suppress-next-line PhanUndeclaredClass -- Being checked before being called.
 	if ( isset( $certificate_flags[ Domain_Certificate_Flag_Group::CERTIFICATE_PROVISIONED ] ) ) {
 		// Mark task as complete if the certificate is provisioned.
 		wpcom_mark_launchpad_task_complete( $task_id );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2810,12 +2810,12 @@ function wpcom_launchpad_is_ssl_task_disabled() {
 		return true;
 	}
 
-	// @phan-suppress-next-line PhanUndeclaredClass -- Being checked before being called.
+	// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
 	$primary_domain_mapping = Domain_Mapping::find_primary_by_blog_id( $blog_id );
 	$is_wpcom_domain        = true;
 
 	if ( null !== $primary_domain_mapping ) {
-		// @phan-suppress-next-line PhanUndeclaredClass -- Being checked before being called.
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
 		$wpcom_domain = new WPCOM_Domain( $primary_domain_mapping->get_domain_name() );
 		// @phan-suppress-next-line PhanUndeclaredClassMethod
 		$is_wpcom_domain = $wpcom_domain->is_wpcom_tld();
@@ -2848,7 +2848,7 @@ function wpcom_launchpad_is_ssl_task_completed() {
 
 	$blog_id = get_current_blog_id();
 
-	// @phan-suppress-next-line PhanUndeclaredClass -- Being checked before being called.
+	// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
 	$primary_domain_mapping = Domain_Mapping::find_primary_by_blog_id( $blog_id );
 
 	// If the site doesn't have a primary domain mapping, the task is not complete.
@@ -2858,7 +2858,7 @@ function wpcom_launchpad_is_ssl_task_completed() {
 		return false;
 	}
 	// This way of checking for the certificate was extracted from the get_ssl_status function in wp-content/rest-api-plugins/endpoints/domains-ssl.php
-	// @phan-suppress-next-line PhanUndeclaredClass, PhanUndeclaredClassMethod, PhanUndeclaredClassConstant
+	// @phan-suppress-next-line PhanUndeclaredClassMethod, PhanUndeclaredClassReference
 	$certificate_flag_manager = WPCOM\Container\DI::get( Domain_Certificate_Flags_Manager::class );
 	$certificate_flags        = $certificate_flag_manager->get_flags( $primary_domain_mapping->get_domain_name() );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2845,6 +2845,10 @@ function wpcom_launchpad_is_ssl_task_completed() {
 		return false;
 	}
 
+	if ( ! wpcom_launchpad_is_primary_domain_wpcom() ) {
+		return false;
+	}
+
 	$blog_id = get_current_blog_id();
 
 	// @phan-suppress-next-line PhanUndeclaredClassMethod -- Being checked before being called.
@@ -2859,22 +2863,13 @@ function wpcom_launchpad_is_ssl_task_completed() {
 	// This way of checking for the certificate was extracted from the get_ssl_status function in wp-content/rest-api-plugins/endpoints/domains-ssl.php
 	// @phan-suppress-next-line PhanUndeclaredClassMethod, PhanUndeclaredClassReference
 	$certificate_flag_manager = WPCOM\Container\DI::get( Domain_Certificate_Flags_Manager::class );
-	$certificate_flags        = $certificate_flag_manager->get_flags( $primary_domain_mapping->get_domain_name() );
+	$is_provisioned           = $certificate_flag_manager->has_certificate_provisioned_flag( $primary_domain_mapping->get_domain_name() );
 
-	if ( empty( $certificate_flags ) ) {
+	if ( ! $is_provisioned ) {
 		return false;
 	}
 
-	if ( count( $certificate_flags ) > 1 ) {
-		return false;
-	}
-
-	// @phan-suppress-next-line PhanUndeclaredClassConstant
-	if ( isset( $certificate_flags[ Domain_Certificate_Flag_Group::CERTIFICATE_PROVISIONED ] ) ) {
-		// Mark task as complete if the certificate is provisioned.
-		wpcom_mark_launchpad_task_complete( $task_id );
-		return true;
-	}
-
-	return false;
+	// Mark task as complete if the certificate is provisioned.
+	wpcom_mark_launchpad_task_complete( $task_id );
+	return true;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2795,5 +2795,15 @@ function wpcom_launchpad_get_latest_draft_id() {
  * @return bool Will return true if the primary domain is a WPCOM domain.
  */
 function wpcom_launchpad_is_ssl_task_disabled() {
-	return false;
+	$blog_id = get_current_blog_id();
+
+	$primary_domain_mapping = Domain_Mapping::find_primary_by_blog_id( $blog_id );
+	$is_wpcom_domain        = true;
+
+	if ( null !== $primary_domain_mapping ) {
+		$wpcom_domain    = new WPCOM_Domain( $primary_domain_mapping->get_domain_name() );
+		$is_wpcom_domain = $wpcom_domain->is_wpcom_tld();
+	}
+
+	return $is_wpcom_domain;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2801,6 +2801,10 @@ function wpcom_launchpad_get_latest_draft_id() {
 function wpcom_launchpad_is_ssl_task_disabled() {
 	$blog_id = get_current_blog_id();
 
+	if ( ! class_exists( 'Domain_Mapping' ) || ! class_exists( 'WPCOM_Domain' ) ) {
+		return true;
+	}
+
 	$primary_domain_mapping = Domain_Mapping::find_primary_by_blog_id( $blog_id );
 	$is_wpcom_domain        = true;
 
@@ -2823,6 +2827,10 @@ function wpcom_launchpad_is_ssl_task_completed() {
 	// If the task is already complete, return true.
 	if ( wpcom_launchpad_is_task_option_completed( $task_id ) ) {
 		return true;
+	}
+
+	if ( ! class_exists( 'Domain_Mapping' ) || ! class_exists( 'Domain_Certificate_Flag_Group' ) || ! class_exists( 'WPCOM\Container\DI' ) || ! class_exists( 'Domain_Certificate_Flags_Manager' ) ) {
+		return false;
 	}
 
 	$blog_id = get_current_blog_id();

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -829,6 +829,14 @@ function wpcom_launchpad_get_task_definitions() {
 				return admin_url( 'plugins.php' );
 			},
 		),
+		'check_ssl_status'                => array(
+			'get_title'            => function () {
+				return __( 'Check the SSL status', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => '__return_true',
+			'is_disabled_callback' => 'wpcom_launchpad_is_ssl_task_disabled',
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );
@@ -2779,4 +2787,13 @@ function wpcom_launchpad_get_latest_draft_id() {
 	$cached_draft_id = reset( $latest_draft_id );
 
 	return $cached_draft_id;
+}
+
+/**
+ * Check if the SSL task should be disabled.
+ *
+ * @return bool Will return true if the primary domain is a WPCOM domain.
+ */
+function wpcom_launchpad_is_ssl_task_disabled() {
+	return false;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2816,7 +2816,8 @@ function wpcom_launchpad_is_ssl_task_disabled() {
 
 	if ( null !== $primary_domain_mapping ) {
 		// @phan-suppress-next-line PhanUndeclaredClass -- Being checked before being called.
-		$wpcom_domain    = new WPCOM_Domain( $primary_domain_mapping->get_domain_name() );
+		$wpcom_domain = new WPCOM_Domain( $primary_domain_mapping->get_domain_name() );
+		// @phan-suppress-next-line PhanUndeclaredClassMethod
 		$is_wpcom_domain = $wpcom_domain->is_wpcom_tld();
 	}
 
@@ -2857,7 +2858,7 @@ function wpcom_launchpad_is_ssl_task_completed() {
 		return false;
 	}
 	// This way of checking for the certificate was extracted from the get_ssl_status function in wp-content/rest-api-plugins/endpoints/domains-ssl.php
-	// @phan-suppress-next-line PhanUndeclaredClass -- Being checked before being called.
+	// @phan-suppress-next-line PhanUndeclaredClass, PhanUndeclaredClassMethod, PhanUndeclaredClassConstant
 	$certificate_flag_manager = WPCOM\Container\DI::get( Domain_Certificate_Flags_Manager::class );
 	$certificate_flags        = $certificate_flag_manager->get_flags( $primary_domain_mapping->get_domain_name() );
 
@@ -2869,7 +2870,7 @@ function wpcom_launchpad_is_ssl_task_completed() {
 		return false;
 	}
 
-	// @phan-suppress-next-line PhanUndeclaredClass -- Being checked before being called.
+	// @phan-suppress-next-line PhanUndeclaredClassConstant
 	if ( isset( $certificate_flags[ Domain_Certificate_Flag_Group::CERTIFICATE_PROVISIONED ] ) ) {
 		// Mark task as complete if the certificate is provisioned.
 		wpcom_mark_launchpad_task_complete( $task_id );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -323,6 +323,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'migrating_site',
 				'review_site',
 				'review_plugins',
+				'check_ssl_status',
 			),
 		),
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


Fixes https://github.com/Automattic/wp-calypso/issues/95096

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This change adds a new task to guide the user to provision their SSL certificate.
* The task will be disabled if the site has no primary domain associated
* The task will be marked as complete if the site has a primary domain and it has an SSL certificate provisioned

The check to see if the cert is provisioned is running on every /home render. It doesn't seem to be an issue since the call to `get_flags` (file: `wp-content/lib/domains/domain-flags/domain-flags-store.php`) is cached. But I would like to get a green light from Nomado since it's my first time working with domains.


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This code runs on simple since it's called via public-api. Please see the instructions here on how to test a PR: PCYsg-Osp-p2

* Add the following filter to your `0-sandbox.php` file:
```
add_filter( 'is_launchpad_intent_post_migration_enabled', '__return_true' );
```
* Then, navigate to the Customer Home page and you should see a task named `Provision SSL certificate`.

**On a site with a WPCOM primary domain**
* Verify that the task is disabled

**On a site with a non WPCOM primary domain, but without provisioned SSL**
* Verify the task is enabled and when clicking on it you get redirected to `https://wordpress.com/domains/manage/[PRIMARY_DOMAIN]/edit/[PRIMARY_DOMAIN]`

**On a site with a non WPCOM primary domain, with provisioned SSL**
* The task should be marked complete.


