### PR TITLE
AI Client: add image styles auto and none

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-jetpack-ai-image-styles-auto-none
+++ b/projects/js-packages/ai-client/changelog/add-jetpack-ai-image-styles-auto-none
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Client - Logo generator: add image styles 'auto' and 'none'. Order styles so those are on top in the dropdown selector

--- a/projects/js-packages/ai-client/src/hooks/use-image-generator/constants.ts
+++ b/projects/js-packages/ai-client/src/hooks/use-image-generator/constants.ts
@@ -17,6 +17,8 @@ export const IMAGE_STYLE_3D_MODEL = '3d-model';
 export const IMAGE_STYLE_PIXEL_ART = 'pixel-art';
 export const IMAGE_STYLE_TEXTURE = 'texture';
 export const IMAGE_STYLE_MONTY_PYTHON = 'monty-python';
+export const IMAGE_STYLE_AUTO = 'auto';
+export const IMAGE_STYLE_NONE = 'none';
 
 export type ImageStyle =
 	| typeof IMAGE_STYLE_ENHANCE
@@ -36,7 +38,9 @@ export type ImageStyle =
 	| typeof IMAGE_STYLE_3D_MODEL
 	| typeof IMAGE_STYLE_PIXEL_ART
 	| typeof IMAGE_STYLE_TEXTURE
-	| typeof IMAGE_STYLE_MONTY_PYTHON;
+	| typeof IMAGE_STYLE_MONTY_PYTHON
+	| typeof IMAGE_STYLE_AUTO
+	| typeof IMAGE_STYLE_NONE;
 
 export type ImageStyleObject = {
 	label: string;

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useState, useRef } from 'react';
 /**
  * Internal dependencies
  */
-import { IMAGE_STYLE_LINE_ART } from '../../hooks/use-image-generator/constants.js';
+import { IMAGE_STYLE_NONE, IMAGE_STYLE_AUTO } from '../../hooks/use-image-generator/constants.js';
 import AiIcon from '../assets/icons/ai.js';
 import {
 	EVENT_GENERATE,
@@ -28,7 +28,7 @@ import './prompt.scss';
 /**
  * Types
  */
-import type { ImageStyle } from '../../hooks/use-image-generator/constants.js';
+import type { ImageStyle, ImageStyleObject } from '../../hooks/use-image-generator/constants.js';
 
 const debug = debugFactory( 'jetpack-ai-calypso:prompt-box' );
 
@@ -46,6 +46,7 @@ export const Prompt = ( { initialPrompt = '' }: PromptProps ) => {
 	const hasPrompt = prompt?.length >= MINIMUM_PROMPT_LENGTH;
 	const [ showStyleSelector, setShowStyleSelector ] = useState( false );
 	const [ style, setStyle ] = useState< ImageStyle >( null );
+	const [ styles, setStyles ] = useState< Array< ImageStyleObject > >( [] );
 
 	const {
 		generateLogo,
@@ -105,9 +106,20 @@ export const Prompt = ( { initialPrompt = '' }: PromptProps ) => {
 
 	useEffect( () => {
 		if ( imageStyles.length > 0 ) {
+			// Sort styles to have "None" and "Auto" first
+			setStyles(
+				[
+					imageStyles.find( ( { value } ) => value === IMAGE_STYLE_NONE ),
+					imageStyles.find( ( { value } ) => value === IMAGE_STYLE_AUTO ),
+					...imageStyles.filter(
+						( { value } ) => ! [ IMAGE_STYLE_NONE, IMAGE_STYLE_AUTO ].includes( value )
+					),
+				].filter( v => v ) // simplest way to get rid of empty values
+			);
 			setShowStyleSelector( true );
-			setStyle( IMAGE_STYLE_LINE_ART );
+			setStyle( IMAGE_STYLE_NONE );
 		} else {
+			setStyles( [] );
 			setShowStyleSelector( false );
 			setStyle( null );
 		}
@@ -175,7 +187,7 @@ export const Prompt = ( { initialPrompt = '' }: PromptProps ) => {
 					<SelectControl
 						__nextHasNoMarginBottom
 						value={ style }
-						options={ imageStyles }
+						options={ styles }
 						onChange={ updateStyle }
 					/>
 				) }

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -87,6 +87,10 @@ const useLogoGenerator = () => {
 
 	const aiAssistantFeatureData = getAiAssistantFeature( siteId );
 	const logoGenerationCost = aiAssistantFeatureData?.costs?.[ 'jetpack-ai-logo-generator' ]?.logo;
+	const logoGeneratorControl = aiAssistantFeatureData?.featuresControl?.[
+		'logo-generator'
+	] as LogoGeneratorFeatureControl;
+	const imageStyles: Array< ImageStyleObject > = logoGeneratorControl?.styles;
 
 	const generateFirstPrompt = useCallback(
 		async function (): Promise< string > {
@@ -367,11 +371,6 @@ User request:${ prompt }`;
 		},
 		[ logoGenerationCost, increaseAiAssistantRequestsCount, saveLogo, storeLogo, generateImage ]
 	);
-
-	const logoGeneratorControl = aiAssistantFeatureData?.featuresControl?.[
-		'logo-generator'
-	] as LogoGeneratorFeatureControl;
-	const imageStyles: Array< ImageStyleObject > = logoGeneratorControl?.styles;
 
 	return {
 		logos,


### PR DESCRIPTION


## Proposed changes:
This PR simply adds the styles "auto" and "none" as part of the defined types and attempts to place them at the top before feeding the array to the SelectControl

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Sandbox the public API and enable the filter: `add_filter( 'jetpack_ai_logo_style_selector_enabled', '__return_true' );`

Add a logo block on the editor and open the Logo generator modal, see that it has the styles dropdown on the top right corner.

Now go to the sandbox and enable both `auto` and `none` styles at `wp-content/lib/jetpack-ai/image-styles.php`.

Reload the editor window and open the Logo generator modal. Now that `auto` and `none` styles are enabled, those should be on top of the styles dropdown.