### PR TITLE
Stats: Fix top post card on the Insight page

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-add-required-fields-to-stats-single-post-endpiont
+++ b/projects/packages/stats-admin/changelog/fix-add-required-fields-to-stats-single-post-endpiont
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Added missing fields for stats single post endpoint

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -606,9 +606,13 @@ class REST_Controller {
 
 		// It shouldn't be a problem because only title and ID are exposed.
 		return array(
-			'ID'    => $post->ID,
-			'title' => $post->post_title,
-			'URL'   => get_permalink( $post->ID ),
+			'ID'       => $post->ID,
+			'site_ID'  => Jetpack_Options::get_option( 'id' ),
+			'title'    => $post->post_title,
+			'URL'      => get_permalink( $post->ID ),
+			'type'     => $post->post_type,
+			'status'   => $post->post_status,
+			'comments' => intval( $post->comment_count ),
 		);
 	}
 

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -606,13 +606,15 @@ class REST_Controller {
 
 		// It shouldn't be a problem because only title and ID are exposed.
 		return array(
-			'ID'       => $post->ID,
-			'site_ID'  => Jetpack_Options::get_option( 'id' ),
-			'title'    => $post->post_title,
-			'URL'      => get_permalink( $post->ID ),
-			'type'     => $post->post_type,
-			'status'   => $post->post_status,
-			'comments' => intval( $post->comment_count ),
+			'ID'             => $post->ID,
+			'site_ID'        => Jetpack_Options::get_option( 'id' ),
+			'title'          => $post->post_title,
+			'URL'            => get_permalink( $post->ID ),
+			'type'           => $post->post_type,
+			'status'         => $post->post_status,
+			'discussion'     => array( 'comment_count' => intval( $post->comment_count ) ),
+			'date'           => $post->post_date,
+			'post_thumbnail' => array( 'URL' => get_the_post_thumbnail_url( $post->ID ) ),
 		);
 	}
 

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -604,7 +604,9 @@ class REST_Controller {
 			return $post;
 		}
 
-		// It shouldn't be a problem because only title and ID are exposed.
+		// The endpoint should be as compatible as possible with `/sites/$site_id/posts/$post_id`.
+		// The reason we are not forwarding the request is that `/sites/$site_id/posts/$post_id` might require user tokens for private posts/sites, which is not possible for users without a WordPress.com account.
+		// 'like_count' is not included in the response because it's available through another endpoint `/sites/$site_id/posts/$post_id/likes`.
 		return array(
 			'ID'             => $post->ID,
 			'site_ID'        => Jetpack_Options::get_option( 'id' ),

--- a/projects/plugins/jetpack/changelog/fix-add-required-fields-to-stats-single-post-endpiont
+++ b/projects/plugins/jetpack/changelog/fix-add-required-fields-to-stats-single-post-endpiont
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Stats: Fix top post card on the Insight page

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-add-required-fields-to-stats-single-post-endpiont
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-add-required-fields-to-stats-single-post-endpiont
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Fix top post card on the Insight page

--- a/projects/plugins/wpcomsh/changelog/fix-add-required-fields-to-stats-single-post-endpiont
+++ b/projects/plugins/wpcomsh/changelog/fix-add-required-fields-to-stats-single-post-endpiont
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Fix top post card on the Insight page


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/88005

## Proposed changes:

* Adding missing fields to the single post endpoint

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Build Odyssey Stats and Jetpack locally
* Open `/wp-admin/admin.php?page=stats#!/stats/insights/:siteSlug`
* Ensure Top post is showing up

<img width="1252" alt="image" src="https://github.com/user-attachments/assets/c8179f0b-d400-44ad-beb5-c9c2f11081bb">

Note: likes is not working and will be fixed with another PR

