### PR TITLE
Boost: Fix page cache e2e tests

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -262,7 +262,7 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 			$content
 		);
 
-		$result = self::get_wp_filesystem()->put_contents( $config_file, $content );
+		$result = self::write_to_file( $config_file, $content );
 		if ( $result === false ) {
 			return new \WP_Error( 'wp-config-not-writable' );
 		}
@@ -424,14 +424,15 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 		}
 	}
 
+	private static function write_to_file( $file, $content ) {
+		$filesystem = self::get_wp_filesystem();
+		$chmod      = $filesystem->getchmod( $file );
+		return $filesystem->put_contents( $file, $content, $chmod );
+	}
+
 	private static function get_wp_filesystem() {
-		global $wp_filesystem;
-
-		if ( ! isset( $wp_filesystem ) ) {
-			require_once ABSPATH . '/wp-admin/includes/file.php';
-			WP_Filesystem();
-		}
-
-		return $wp_filesystem;
+		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+		return new \WP_Filesystem_Direct( new \stdClass() );
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -438,6 +438,6 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 	private static function get_wp_filesystem() {
 		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
-		return new \WP_Filesystem_Direct( new \stdClass() );
+		return new \WP_Filesystem_Direct( null );
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -262,8 +262,8 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 			$content
 		);
 
-		$result = Filesystem_Utils::write_to_file( $config_file, $content );
-		if ( $result instanceof Boost_Cache_Error ) {
+		$result = self::get_wp_filesystem()->put_contents( $config_file, $content );
+		if ( $result === false ) {
 			return new \WP_Error( 'wp-config-not-writable' );
 		}
 		self::clear_opcache( $config_file );
@@ -422,5 +422,16 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 		if ( function_exists( 'opcache_invalidate' ) ) {
 			opcache_invalidate( $file, true );
 		}
+	}
+
+	private static function get_wp_filesystem() {
+		global $wp_filesystem;
+
+		if ( ! isset( $wp_filesystem ) ) {
+			require_once ABSPATH . '/wp-admin/includes/file.php';
+			WP_Filesystem();
+		}
+
+		return $wp_filesystem;
 	}
 }

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -262,7 +262,7 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 			$content
 		);
 
-		$result = self::write_to_file( $config_file, $content );
+		$result = self::write_to_file_direct( $config_file, $content );
 		if ( $result === false ) {
 			return new \WP_Error( 'wp-config-not-writable' );
 		}
@@ -424,7 +424,7 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 		}
 	}
 
-	private static function write_to_file( $file, $content ) {
+	private static function write_to_file_direct( $file, $content ) {
 		$filesystem = self::get_wp_filesystem();
 		$chmod      = $filesystem->getchmod( $file );
 		if ( $chmod === false ) {

--- a/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
+++ b/projects/plugins/boost/app/modules/optimizations/page-cache/Page_Cache_Setup.php
@@ -427,6 +427,11 @@ define( \'WP_CACHE\', true ); // ' . Page_Cache::ADVANCED_CACHE_SIGNATURE,
 	private static function write_to_file( $file, $content ) {
 		$filesystem = self::get_wp_filesystem();
 		$chmod      = $filesystem->getchmod( $file );
+		if ( $chmod === false ) {
+			$chmod = 0644; // Default to a common permission for files
+		} else {
+			$chmod = intval( '0' . $chmod, 8 ); // Ensure leading zero
+		}
 		return $filesystem->put_contents( $file, $content, $chmod );
 	}
 

--- a/projects/plugins/boost/changelog/fix-e2e-tests
+++ b/projects/plugins/boost/changelog/fix-e2e-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix e2e tests for page cache.
+
+

--- a/projects/plugins/boost/tests/e2e/lib/env/prerequisites.js
+++ b/projects/plugins/boost/tests/e2e/lib/env/prerequisites.js
@@ -1,5 +1,6 @@
 import logger from 'jetpack-e2e-commons/logger.js';
 import { execWpCommand } from 'jetpack-e2e-commons/helpers/utils-helper.js';
+import { ensureUserIsLoggedIn } from 'jetpack-e2e-commons/env/prerequisites.js';
 
 import { expect } from '@playwright/test';
 import { JetpackBoostPage } from '../pages/index.js';
@@ -8,6 +9,7 @@ export function boostPrerequisitesBuilder( page ) {
 	const state = {
 		testPostTitles: [],
 		clean: undefined,
+		loggedIn: undefined,
 		modules: { active: undefined, inactive: undefined },
 		connected: undefined,
 		jetpackDeactivated: undefined,
@@ -23,6 +25,10 @@ export function boostPrerequisitesBuilder( page ) {
 		},
 		withInactiveModules( modules = [] ) {
 			state.modules.inactive = modules;
+			return this;
+		},
+		withLoggedIn( shouldBeLoggedIn ) {
+			state.loggedIn = shouldBeLoggedIn;
 			return this;
 		},
 		withConnection( shouldBeConnected ) {
@@ -58,6 +64,7 @@ export function boostPrerequisitesBuilder( page ) {
 async function buildPrerequisites( state, page ) {
 	const functions = {
 		modules: () => ensureModulesState( state.modules ),
+		loggedIn: () => ensureUserIsLoggedIn( page ),
 		connected: () => ensureConnectedState( state.connected, page ),
 		testPostTitles: () => ensureTestPosts( state.testPostTitles ),
 		clean: () => ensureCleanState( state.clean ),

--- a/projects/plugins/boost/tests/e2e/specs/page-cache/page-cache.test.js
+++ b/projects/plugins/boost/tests/e2e/specs/page-cache/page-cache.test.js
@@ -12,6 +12,7 @@ test.describe( 'Cache module', () => {
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage( playwrightConfig.use );
 		await boostPrerequisitesBuilder( page )
+			.withLoggedIn( true )
 			.withInactiveModules( [
 				'page_cache', // Make sure it's inactive.
 			] )


### PR DESCRIPTION
This allows the page cache e2e test to be run independently every time
without issues.<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39348.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update page cache e2e tests pre-requisites to make sure the user is logged in;
* Update page cache setup to `wp-config.php` during initial setup, to happen via `WP_Filesystem_Direct` instead of creating a .tmp file and renaming it to `wp-config.php`. That way we can avoid asking users to update the root WP directory permissions.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup Boost;
* Make sure the `Cache Site Pages` module can be enabled/disabled and caching works.