### PR TITLE
Blocks: load later to avoid doing it wrong notices

### DIFF
--- a/projects/plugins/jetpack/changelog/update-loading-blocks-earlier
+++ b/projects/plugins/jetpack/changelog/update-loading-blocks-earlier
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+yBlocks: ensure registering the blocks does not trigger a warning notice with the upcoming version of WordPress, 6.7.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -626,8 +626,8 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
-		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'load_independent_blocks' ) );
-		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'load_block_editor_extensions' ), 9 );
+		add_action( 'after_setup_theme', array( 'Jetpack_Gutenberg', 'load_independent_blocks' ) );
+		add_action( 'after_setup_theme', array( 'Jetpack_Gutenberg', 'load_block_editor_extensions' ), 9 );
 		/**
 		 * We've switched from enqueue_block_editor_assets to enqueue_block_assets in WP-Admin because the assets with the former are loaded on the main site-editor.php.
 		 *


### PR DESCRIPTION
## Proposed changes:

Let's load our blocks later to avoid any `_doing_it_wrong` notices introduced in the latest version of WordPress (6.7).

- Related discussion: p1728476310802029-slack-C0299DMPG
- Related ticket: https://core.trac.wordpress.org/ticket/44937
- Counterpart change on WordPress.com: D163434-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* Epic: #38902

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> You'll want to `tail` your site's error logs while testing this.

* On a free site, connected to WordPress.com,  install the WordPress Beta Tester plugin
* Go to Tools > Beta Testing, and set the plugin to use Bleeding edge
* Go to Dashboard > Updates, and update to the most recent version of WP.
* Go to Posts > Add New
* You should see the Jetpack sidebar and Jetpack blocks available in the inserter.
* Upgrade to a Paid plan.
    * You should have access to all blocks, including the paid blocks like Pay with PayPal.
    * None of the above should trigger a notice like this one:

```
PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>jetpack</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in /var/www/html/wp-includes/functions.php on line 6099
```