### PR TITLE
rolling release: Add timestamp to version numbers

### DIFF
--- a/.github/files/gh-autorelease/files/autorelease.sh
+++ b/.github/files/gh-autorelease/files/autorelease.sh
@@ -28,7 +28,7 @@ elif [[ "$GITHUB_REF" == "refs/heads/trunk" ]]; then
 	fi
 	ROLLING_MODE=true
 	CURRENT_VER=$( sed -nEe 's/^## \[?([^]]*)\]? - .*/\1/;T;p;q' CHANGELOG.md || true )
-	GIT_SUFFIX=$( git log -1 --format=%h . )
+	GIT_SUFFIX=$( git log -1 --format=%ct . ).g$( git log -1 --format=%h . )
 	TAG="$CURRENT_VER+rolling.$GIT_SUFFIX"
 else
 	echo "::error::Expected GITHUB_REF like \`refs/tags/v1.2.3\` or \`refs/tags/1.2.3\` or \`refs/heads/trunk\` for rolling releases, got \`$GITHUB_REF\`"

--- a/.github/files/gh-autorelease/files/autorelease.sh
+++ b/.github/files/gh-autorelease/files/autorelease.sh
@@ -28,7 +28,7 @@ elif [[ "$GITHUB_REF" == "refs/heads/trunk" ]]; then
 	fi
 	ROLLING_MODE=true
 	CURRENT_VER=$( sed -nEe 's/^## \[?([^]]*)\]? - .*/\1/;T;p;q' CHANGELOG.md || true )
-	GIT_SUFFIX=$( git log -1 --format=%ct . ).g$( git log -1 --format=%h . )
+	GIT_SUFFIX=$( git log -1 --format="%ct.g%h" . )
 	TAG="$CURRENT_VER+rolling.$GIT_SUFFIX"
 else
 	echo "::error::Expected GITHUB_REF like \`refs/tags/v1.2.3\` or \`refs/tags/1.2.3\` or \`refs/heads/trunk\` for rolling releases, got \`$GITHUB_REF\`"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Apparently Atomic doesn't just pick the latest release, they also require that the new version number compares greater than the old one as measured by `version_compare()`. So we'll have to throw a timestamp in after all.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1728470292667389-slack-C7YPW6K40

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷