### PR TITLE
VideoPress: Add missing check for empty video_info on get_media_item_v1_1

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-empty-video-info-warning
+++ b/projects/plugins/jetpack/changelog/fix-empty-video-info-warning
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add missing check for empty video_info on get_media_item_v1_1
+
+

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1739,7 +1739,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 				}
 
 				$thumbnail_query_data = array();
-				if ( isset( $info ) && function_exists( 'video_is_private' ) && video_is_private( $info ) ) {
+				if ( ! empty( $info ) && function_exists( 'video_is_private' ) && video_is_private( $info ) ) {
 					$thumbnail_query_data['metadata_token'] = video_generate_auth_token( $info );
 				}
 

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1739,7 +1739,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 				}
 
 				$thumbnail_query_data = array();
-				if ( function_exists( 'video_is_private' ) && video_is_private( $info ) ) {
+				if ( isset( $info ) && function_exists( 'video_is_private' ) && video_is_private( $info ) ) {
 					$thumbnail_query_data['metadata_token'] = video_generate_auth_token( $info );
 				}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/videopress/issues/1127

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add missing check for empty `video_info` on `get_media_item_v1_1`

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1727437228377389-slack-C02TCEHP3HA

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Using Jetpack Back plugin, activate this feature branch on an **Atomic site** (full instructions here: https://github.com/Automattic/jetpack/pull/39706#issuecomment-2403088778)
* It's easier testing on a site with a Business plan since VideoPress is needed (so you may need to purchase a plan if you don't have it)
* Make sure you are using the Calypso interface (if not, go to Settings > Interface, and set Default style)
* After that, enable VideoPress by going to Jetpack > Settings and toggle VideoPress on
* Go to Media and upload a video
* Wait for the whole process to finish (transcode and thumbnails)
* Refresh the page to see if the thumbnail is displayed as expected and check if the video plays correctly
* Perform a test uploading a video through the VideoPress Gutenberg block
  * Go to Posts > New Post and drop a video in the content area
  * It should also work as expected