### PR TITLE
Post-migration Experience: Add the plugin review task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-plugin-review-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-plugin-review-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the Plugin Review task for the Post-migration launchpad experience

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -816,14 +816,17 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
 		),
-		'review_plugins'                => array(
-			'get_title'            => function () {
+		'review_plugins'                  => array(
+			'get_title'             => function () {
 				return __( 'Review the migrated plugins', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'is_visible_callback'  => '__return_true',
+			'is_complete_callback'  => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'   => '__return_true',
 			'add_listener_callback' => function () {
 				add_action( 'pre_current_active_plugins', 'wpcom_launchpad_mark_review_plugins_complete' );
+			},
+			'get_calypso_path'      => function () {
+				return admin_url( 'plugins.php' );
 			},
 		),
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -816,6 +816,16 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
 		),
+		'review_plugins'                => array(
+			'get_title'            => function () {
+				return __( 'Review the migrated plugins', 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => '__return_true',
+			'add_listener_callback' => function () {
+				add_action( 'pre_current_active_plugins', 'wpcom_launchpad_mark_review_plugins_complete' );
+			},
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );
@@ -1774,6 +1784,14 @@ function wpcom_track_site_launch_task() {
 	}
 }
 
+/**
+ * Mark the plugins reviewed task as complete.
+ *
+ * @return void
+ */
+function wpcom_launchpad_mark_review_plugins_complete() {
+	wpcom_mark_launchpad_task_complete( 'review_plugins' );
+}
 /**
  * Callback that conditionally adds the site launch listener based on platform.
  *

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -322,6 +322,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 			'task_ids'  => array(
 				'migrating_site',
 				'review_site',
+				'review_plugins',
 			),
 		),
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/95075
Closes https://github.com/Automattic/jetpack/pull/39643

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* As part of the Post-migration Experience project, we want to add the "Review Plugin" task to invite the users to check the plugins page to validate if there were any important plugins missing.
* This PR adds the task and its completion logic.
* I used the `pre_current_active_plugins` hook to mark the task as complete. This action is fired when the user visits the plugin page.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the public API is sandboxed
* Add the following filter to your `0-sandbox.php` file:
```
add_filter( 'is_launchpad_intent_post_migration_enabled', '__return_true' );
```
* Create a new WoA site or use an existing one
* Apply this PR to your WoA site, I used the `jetpack rsync` command(ensure you have the JETPACK_AUTOLOAD_DEV constant set on your wp-config.php file or JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN if you decide to use the Jetpack Beta plugin)
* Navigate to `wordpress.com/home/{YOUR_ATOMIC_SITE}` and make sure you see the "Review the migrated plugins" task.
* Click on it, and you should be redirected to the plugins page
* Go back to the Customer Home and the task should be marked as complete

