### PR TITLE
AI Client: add style guessing and prompt processing

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-jetpack-ai-style-guessing
+++ b/projects/js-packages/ai-client/changelog/add-jetpack-ai-style-guessing
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Client: add prompt processing and style guess function for logo generator

--- a/projects/js-packages/ai-client/src/logo-generator/constants.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/constants.ts
@@ -11,6 +11,7 @@ export const EVENT_NAVIGATE = 'jetpack_ai_logo_generator_navigate';
 export const EVENT_FEEDBACK = 'jetpack_ai_logo_generator_feedback';
 export const EVENT_UPGRADE = 'jetpack_ai_upgrade_button';
 export const EVENT_SWITCH_STYLE = 'jetpack_ai_logo_generator_switch_style';
+export const EVENT_GUESS_STYLE = 'jetpack_ai_logo_generator_guess_style';
 
 // Event placement constants
 export const EVENT_PLACEMENT_QUICK_LINKS = 'quick_links';

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -198,25 +198,70 @@ For example: user's prompt: A logo for an ice cream shop. Returned prompt: A log
 		}
 	};
 
-	const generateImage = useCallback( async function ( {
-		prompt,
-		style = null,
-	}: {
-		prompt: string;
-		style?: ImageStyle | null;
-	} ): Promise< { data: Array< { url: string } > } > {
-		setLogoFetchError( null );
-
-		try {
-			const tokenData = await requestJwt();
-
-			if ( ! tokenData || ! tokenData.token ) {
-				throw new Error( 'No token provided' );
+	const guessStyle = useCallback(
+		async function ( prompt: string ): Promise< ImageStyle | null > {
+			setLogoFetchError( null );
+			if ( ! imageStyles || ! imageStyles.length ) {
+				return null;
 			}
 
-			debug( 'Generating image with prompt', prompt );
+			const messages = [
+				{
+					role: 'jetpack-ai' as RoleType,
+					context: {
+						type: 'ai-assistant-guess-logo-style',
+						request: prompt,
+						name,
+						description,
+					},
+				},
+			];
 
-			const imageGenerationPrompt = `I NEED to test how the tool works with extremely simple prompts. DO NOT add any detail, just use it AS-IS:
+			try {
+				const style = await askQuestionSync( messages, { feature: 'jetpack-ai-logo-generator' } );
+
+				if ( ! style ) {
+					return null;
+				}
+				const styleObject = imageStyles.find( ( { value } ) => value === style );
+
+				if ( ! styleObject ) {
+					return null;
+				}
+
+				return styleObject.value;
+			} catch ( error ) {
+				debug( 'Error guessing style', error );
+				Promise.reject( error );
+			}
+		},
+		[ imageStyles, name, description ]
+	);
+
+	const generateImage = useCallback(
+		async function ( {
+			prompt,
+			style = null,
+		}: {
+			prompt: string;
+			style?: ImageStyle | null;
+		} ): Promise< { data: Array< { url: string } > } > {
+			setLogoFetchError( null );
+
+			try {
+				const tokenData = await requestJwt();
+
+				if ( ! tokenData || ! tokenData.token ) {
+					throw new Error( 'No token provided' );
+				}
+
+				if ( style === 'auto' ) {
+					throw new Error( 'Auto style is not supported' );
+				}
+
+				debug( 'Generating image with prompt', prompt );
+
+				const imageGenerationPrompt = `I NEED to test how the tool works with extremely simple prompts. DO NOT add any detail, just use it AS-IS:
 Create a single text-free iconic vector logo that symbolically represents the user request, using abstract or symbolic imagery.
 The design should be modern, with either a vivid color scheme full of gradients or a color scheme that's monochromatic. Use any of those styles based on the user request mood.
 Ensure the logo is set against a clean solid background.
@@ -226,21 +271,38 @@ The image should contain a single icon, without variations, color palettes or di
 
 User request:${ prompt }`;
 
-			const body = {
-				prompt: imageGenerationPrompt,
-				feature: 'jetpack-ai-logo-generator',
-				response_format: 'b64_json',
-				style: style || '', // backend expects an empty string if no style is provided
-			};
+				const body = {
+					prompt: imageGenerationPrompt,
+					// if style is set prompt is reworked at backend with messages
+					messages: style
+						? [
+								{
+									role: 'jetpack-ai',
+									context: {
+										type: 'ai-assistant-generate-logo',
+										request: prompt,
+										name,
+										description,
+										style,
+									},
+								},
+						  ]
+						: [],
+					feature: 'jetpack-ai-logo-generator',
+					response_format: 'b64_json',
+					style: style || '', // backend expects an empty string if no style is provided
+				};
 
-			const data = await generateImageWithParameters( body );
+				const data = await generateImageWithParameters( body );
 
-			return data as { data: { url: string }[] };
-		} catch ( error ) {
-			setLogoFetchError( error );
-			throw error;
-		}
-	}, [] );
+				return data as { data: { url: string }[] };
+			} catch ( error ) {
+				setLogoFetchError( error );
+				throw error;
+			}
+		},
+		[ name, description ]
+	);
 
 	const saveLogo = useCallback< SaveLogo >(
 		async logo => {
@@ -408,6 +470,7 @@ User request:${ prompt }`;
 		isLoadingHistory,
 		setIsLoadingHistory,
 		imageStyles,
+		guessStyle,
 	};
 };
 

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -7,6 +7,7 @@ import { useCallback } from 'react';
 /**
  * Internal dependencies
  */
+import askQuestionSync from '../../ask-question/sync.js';
 import useImageGenerator from '../../hooks/use-image-generator/index.js';
 import useSaveToMediaLibrary from '../../hooks/use-save-to-media-library/index.js';
 import requestJwt from '../../jwt/index.js';
@@ -18,6 +19,7 @@ import useRequestErrors from './use-request-errors.js';
  * Types
  */
 import type { ImageStyle, ImageStyleObject } from '../../hooks/use-image-generator/constants.js';
+import type { RoleType } from '../../types.js';
 import type { Logo, Selectors, SaveLogo, LogoGeneratorFeatureControl } from '../store/types.js';
 
 const debug = debugFactory( 'jetpack-ai-calypso:use-logo-generator' );

--- a/projects/js-packages/ai-client/src/types.ts
+++ b/projects/js-packages/ai-client/src/types.ts
@@ -17,11 +17,22 @@ export type SuggestionErrorCode =
 	| typeof ERROR_UNCLEAR_PROMPT
 	| typeof ERROR_RESPONSE;
 
+export const ROLE_SYSTEM = 'system' as const;
+export const ROLE_USER = 'user' as const;
+export const ROLE_ASSISTANT = 'assistant' as const;
+export const ROLE_JETPACK_AI = 'jetpack-ai' as const;
+
+export type RoleType =
+	| typeof ROLE_SYSTEM
+	| typeof ROLE_USER
+	| typeof ROLE_ASSISTANT
+	| typeof ROLE_JETPACK_AI;
+
 /*
  * Prompt types
  */
 export type PromptItemProps = {
-	role: 'system' | 'user' | 'assistant' | 'jetpack-ai';
+	role: RoleType;
 	content?: string;
 	context?: object;
 };


### PR DESCRIPTION
## Proposed changes:
This PR adds the style guessing flow for the logo generator. It also uses backend prompt processing now available at D163498-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pe4Cmx-2Ma-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Insert a logo block on the editor. The AI logo generator should work as usual if backend doesn't enable the new styles. Test that it works as usual.

Sandbox the API and test that even with the backend changes, if the feature is not enabled by the filter, everything remains functional. 

Add the filter: `add_filter( 'jetpack_ai_logo_style_selector_enabled', '__return_true' );` and reload the editor.

The logo generator should now show the style selector. Using style "auto" should force a roundtrip to backend to guess the style and then perform the image generation request.

Selecting any of the other styles should give you the best AI can do with the prompt/style combo.