### PR TITLE
Goodreads Block: Make sure we check for id attribute when rendering

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-missing-id-args-goodreads-block
+++ b/projects/plugins/jetpack/changelog/fix-missing-id-args-goodreads-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fixed rendering of goodreads block when there is not id attribute so to not result in a PHP warning

--- a/projects/plugins/jetpack/extensions/blocks/goodreads/goodreads.php
+++ b/projects/plugins/jetpack/extensions/blocks/goodreads/goodreads.php
@@ -35,19 +35,27 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 function load_assets( $attr ) {
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
-	if ( isset( $attr['link'] ) && isset( $attr['id'] ) ) {
-		wp_enqueue_script(
-			'jetpack-goodreads-' . esc_attr( $attr['id'] ),
-			esc_url_raw( $attr['link'] ),
-			array(),
-			JETPACK__VERSION,
-			true
-		);
+	if ( isset( $attr['id'] ) ) {
+		if ( isset( $attr['link'] ) ) {
+			wp_enqueue_script(
+				'jetpack-goodreads-' . esc_attr( $attr['id'] ),
+				esc_url_raw( $attr['link'] ),
+				array(),
+				JETPACK__VERSION,
+				true
+			);
+		}
+
+		$id = esc_attr( $attr['id'] );
+	} else {
+		$id = '';
 	}
+
+	$classes = esc_attr( Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr ) );
 
 	return sprintf(
 		'<div id="%1$s" class="%2$s"></div>',
-		esc_attr( $attr['id'] ),
-		esc_attr( Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr ) )
+		$id,
+		$classes
 	);
 }


### PR DESCRIPTION
We're not checking for presence of the id attribute when attempting to render the block


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates the renderer function for Goodreads block to not crash if the id attribute is absent.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1HpG7-uDe-p2

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:
* Add a goodreads block with a url lik `https://www.goodreads.com/user/show/6520961-sophia`
* Switch to code editor
* Remove the id attribute
* Save the post.
* Visit the rendered post while tailing the debug.log file
* Confirm there's now warning like `Undefined array key “id” in extensions/blocks/goodreads/goodreads.php on line 50`