### PR TITLE
Jetpack Sync: Move 'jetpack_plugins_updated' action to shutdown

### DIFF
--- a/projects/packages/sync/changelog/update-jetpack-sync-delay-jetpack_plugins_updated-hook
+++ b/projects/packages/sync/changelog/update-jetpack-sync-delay-jetpack_plugins_updated-hook
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Jetpack Sync: Move 'jetpack_plugins_updated' action to shutdown to decrease its associated lag
+
+

--- a/projects/packages/sync/src/modules/class-plugins.php
+++ b/projects/packages/sync/src/modules/class-plugins.php
@@ -42,6 +42,24 @@ class Plugins extends Module {
 	private $plugins = array();
 
 	/**
+	 * List of all updated plugins.
+	 *
+	 * @access private
+	 *
+	 * @var array
+	 */
+	private $plugins_updated = array();
+
+	/**
+	 * State
+	 *
+	 * @access private
+	 *
+	 * @var array
+	 */
+	private $state = array();
+
+	/**
 	 * Sync module name.
 	 *
 	 * @access public
@@ -131,10 +149,10 @@ class Plugins extends Module {
 
 		switch ( $details['action'] ) {
 			case 'update':
-				$state  = array(
+				$this->state = array(
 					'is_autoupdate' => Jetpack_Constants::is_true( 'JETPACK_PLUGIN_AUTOUPDATE' ),
 				);
-				$errors = $this->get_errors( $upgrader->skin );
+				$errors      = $this->get_errors( $upgrader->skin );
 				if ( $errors ) {
 					foreach ( $plugins as $slug ) {
 						/**
@@ -149,13 +167,20 @@ class Plugins extends Module {
 						 * @param        string  Error code
 						 * @param        string  Error message
 						 */
-						do_action( 'jetpack_plugin_update_failed', $this->get_plugin_info( $slug ), $errors['code'], $errors['message'], $state );
+						do_action( 'jetpack_plugin_update_failed', $this->get_plugin_info( $slug ), $errors['code'], $errors['message'], $this->state );
 					}
 
 					return;
 				}
+
+				$this->plugins_updated = array_map( array( $this, 'get_plugin_info' ), $plugins );
+				add_action( 'shutdown', array( $this, 'sync_plugins_updated' ), 9 );
+
+				break;
+			case 'install':
 				/**
-				 * Sync that a plugin update
+				 * Signals to the sync listener that a plugin was installed and a sync action
+				 * reflecting the installation and the plugin info should be sent
 				 *
 				 * @since 1.6.3
 				 * @since-jetpack 5.8.0
@@ -164,26 +189,7 @@ class Plugins extends Module {
 				 *
 				 * @param array () $plugin, Plugin Data
 				 */
-				do_action( 'jetpack_plugins_updated', array_map( array( $this, 'get_plugin_info' ), $plugins ), $state );
-				break;
-			case 'install':
-		}
-
-		if ( 'install' === $details['action'] ) {
-			/**
-			 * Signals to the sync listener that a plugin was installed and a sync action
-			 * reflecting the installation and the plugin info should be sent
-			 *
-			 * @since 1.6.3
-			 * @since-jetpack 5.8.0
-			 *
-			 * @module sync
-			 *
-			 * @param array () $plugin, Plugin Data
-			 */
-			do_action( 'jetpack_plugin_installed', array_map( array( $this, 'get_plugin_info' ), $plugins ) );
-
-			return;
+				do_action( 'jetpack_plugin_installed', array_map( array( $this, 'get_plugin_info' ), $plugins ) );
 		}
 	}
 
@@ -378,5 +384,22 @@ class Plugins extends Module {
 			$args[1],
 			$plugin_data,
 		);
+	}
+
+	/**
+	 * Helper method for firing the 'jetpack_plugins_updated' action on shutdown.
+	 */
+	public function sync_plugins_updated() {
+		/**
+		 * Sync that a plugin update
+		 *
+		 * @since 1.6.3
+		 * @since-jetpack 5.8.0
+		 *
+		 * @module sync
+		 *
+		 * @param array () $plugin, Plugin Data
+		 */
+		do_action( 'jetpack_plugins_updated', $this->plugins_updated, $this->state );
 	}
 }

--- a/projects/packages/sync/src/modules/class-plugins.php
+++ b/projects/packages/sync/src/modules/class-plugins.php
@@ -388,6 +388,8 @@ class Plugins extends Module {
 
 	/**
 	 * Helper method for firing the 'jetpack_plugins_updated' action on shutdown.
+	 *
+	 * @access public
 	 */
 	public function sync_plugins_updated() {
 		/**

--- a/projects/plugins/jetpack/changelog/update-jetpack-sync-delay-jetpack_plugins_updated-hook
+++ b/projects/plugins/jetpack/changelog/update-jetpack-sync-delay-jetpack_plugins_updated-hook
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Jetpack plugin: Update Sync related unit tests
+
+

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-plugins-updates.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Sync\Modules;
 
 require_once __DIR__ . '/test_class.jetpack-sync-plugins.php';
 require_once __DIR__ . '/class.silent-upgrader-skin.php';
@@ -50,18 +51,28 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 
 	public function test_updating_a_plugin_is_synced() {
 		$this->update_the_plugin( new Silent_Upgrader_Skin() );
+		$plugins_module = Modules::get_module( 'plugins' );
+		'@phan-var \Automattic\Jetpack\Sync\Modules\Plugins $plugins_module';
+		$plugins_module->sync_plugins_updated();
+		$has_action = has_action( 'shutdown', array( $plugins_module, 'sync_plugins_updated' ) );
 		$this->sender->do_sync();
 		$updated_plugin = $this->server_event_storage->get_most_recent_event( 'jetpack_plugins_updated' );
 
 		$this->assertEquals( 'the/the.php', $updated_plugin->args[0][0]['slug'] );
+		$this->assertTrue( (bool) $has_action );
 		$this->server_event_storage->reset();
 	}
 
 	public function test_updating_plugin_in_bulk_is_synced() {
 		$this->update_bulk_plugins( new Silent_Upgrader_Skin() );
+		$plugins_module = Modules::get_module( 'plugins' );
+		'@phan-var \Automattic\Jetpack\Sync\Modules\Plugins $plugins_module';
+		$plugins_module->sync_plugins_updated();
+		$has_action = has_action( 'shutdown', array( $plugins_module, 'sync_plugins_updated' ) );
 		$this->sender->do_sync();
 		$updated_plugin = $this->server_event_storage->get_most_recent_event( 'jetpack_plugins_updated' );
 		$this->assertEquals( 'the/the.php', $updated_plugin->args[0][0]['slug'] );
+		$this->assertTrue( (bool) $has_action );
 		$this->server_event_storage->reset();
 	}
 
@@ -121,9 +132,14 @@ class WP_Test_Jetpack_Sync_Plugins_Updates extends WP_Test_Jetpack_Sync_Base {
 	public function test_updating_with_autoupdate_constant_results_in_proper_state() {
 		Constants::set_constant( 'JETPACK_PLUGIN_AUTOUPDATE', true );
 		$this->update_bulk_plugins( new Silent_Upgrader_Skin() );
+		$plugins_module = Modules::get_module( 'plugins' );
+		'@phan-var \Automattic\Jetpack\Sync\Modules\Plugins $plugins_module';
+		$plugins_module->sync_plugins_updated();
+		$has_action = has_action( 'shutdown', array( $plugins_module, 'sync_plugins_updated' ) );
 		$this->sender->do_sync();
 		$updated_plugin = $this->server_event_storage->get_most_recent_event( 'jetpack_plugins_updated' );
 		$this->assertTrue( $updated_plugin->args[1]['is_autoupdate'] );
+		$this->assertTrue( (bool) $has_action );
 		$this->server_event_storage->reset();
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Moves the  `jetpack_plugins_updated` action to shutdown to decrease its associated lag.

As of the latest WordPress core release, 6.6.1 we noticed a notable increase in Sync’s queue lag (90p). Further analysis revealed that the `jetpack_plugins_updated` action was the one contributing to this increase.
More specifically, [this change in core](https://github.com/WordPress/wordpress-develop/pull/5287/files) introduced an extra step in plugin auto-updates, making it now possible to roll back a plugin auto-update with a fatal error.
However, the check itself for a Fatal error will perform a [loopback request](https://github.com/WordPress/wordpress-develop/pull/5287/files#diff-2fa8082614112a01275df9d232f9e7a611028979428a37be1ded694c27b300cfR1698) in order to scrape the home page.
The `jetpack_plugins_updated` is triggered by the `upgrader_process_complete` action.
Sync lag is defined as the time between adding an action to Sync's queue and sending that action to WPCOM.
In this case, since the auto-update is triggered via cron, the Sync lag for the `jetpack_plugins_updated` action is essentially the time between firing the `upgrader_process_complete` action and the `shutdown` action.
With core introducing the aforementioned loopback request on auto-updates Sync's lag for the `jetpack_plugins_updated` action was significantly increased.
And this also affected the 90p of our overall Sync Lag KPI.

In this PR, we attempt to fix this issue by simply moving `jetpack_plugins_updated` action to shutdown to decrease its associated lag.

Noting that we also attempted to fix this in the past via https://github.com/Automattic/jetpack/pull/39296

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Modules\Plugins`: Move `jetpack_plugins_updated` action to shutdown. To make this possible we introduced two extra private class properties: `state` and `updated_plugins` in order to store the data associated with this action.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pf5801-17n-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Pre-requisites: A JP connected site with the **WP Rollback** and **WP Crontrol** plugins active. You'll need to enable sandbox access and input your sandbox domain in Settings -> Jetpack Constants -> `JETPACK__SANDBOX_DOMAIN`
* Rollback a plugin to a previous version via the WP Rollback plugin
* For the same plugin that you rolled back make sure to enable auto-updates
* To speed things up go Tools->Cron Events and trigger the `wp_version_check` hook (Triggers plugin auto-updates, normally runs twice per day)
* Monitor the action in your sandbox and ensure the corresponding arguments are exactly the same on trunk/feature branch
* Confirm the Sync lag of the `jetpack_plugins_updated` action on the feature branch is much smaller.
* Repeat the process for more than one plugins (by rolling back and enabling auto-updates) and confirm the same
* Finally, manually update a few plugins and confirm that the behaviour is the same as with trunk

**Test assuming `WP_Automatic_Updater` detected an error and is doing a plugin roll-back:** 
In order to test this locally I modified `WP_Automatic_Updater` to return `true` in `has_fatal_error` [here](https://github.com/WordPress/wordpress-develop/blob/655125af1b371eae7c0c0bd154404ab8ed9182c8/src/wp-admin/includes/class-wp-automatic-updater.php#L1804).
In this case, without the branch we'd see two `jetpack_plugins_updated` actions, both exactly the same.
With the PR, we'll see only one.