### PR TITLE
Boost: Properly update minimum required WP version to 6.5

### DIFF
--- a/projects/plugins/boost/changelog/update-required-wp-version
+++ b/projects/plugins/boost/changelog/update-required-wp-version
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-General: Update minimum required version to 6.5 in main plugin file. Previous release only changed plugin readme.
+General: Update minimum required WordPress version to 6.5 in main plugin file. Previous release only changed plugin readme.

--- a/projects/plugins/boost/changelog/update-required-wp-version
+++ b/projects/plugins/boost/changelog/update-required-wp-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+General: Update minimum required version to 6.5 in main plugin file. Previous release only changed plugin readme.

--- a/projects/plugins/boost/jetpack-boost.php
+++ b/projects/plugins/boost/jetpack-boost.php
@@ -16,7 +16,7 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       jetpack-boost
  * Domain Path:       /languages
- * Requires at least: 5.5
+ * Requires at least: 6.5
  * Requires PHP:      7.0
  *
  * @package automattic/jetpack-boost


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/39716. It now properly matches the Jetpack plugin.

## Proposed changes:

* Update version in main plugin file.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1728542939692289-slack-C016BBAFHHS

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

* Make sure minimum WP version in main jetpack-boost.php file and in readme.txt is the same.