### PR TITLE
Critical CSS Gen: Add missing build folder for production

### DIFF
--- a/projects/js-packages/critical-css-gen/.gitattributes
+++ b/projects/js-packages/critical-css-gen/.gitattributes
@@ -3,8 +3,7 @@
 node_modules           export-ignore
 
 # Files to include in the mirror repo
-/build-browser/**      production-include
-/build-node/**         production-include
+/build/**              production-include
 
 # Files to exclude from the mirror repo
 /changelog/**          production-exclude

--- a/projects/js-packages/critical-css-gen/changelog/fix-missing-build-folder
+++ b/projects/js-packages/critical-css-gen/changelog/fix-missing-build-folder
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add missing build folder to package.


### PR DESCRIPTION
## Proposed changes:

* Include `build` folder in release.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

n/a