### PR TITLE
Jetpack-mu-wpcom plugin banner - update copies

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-plugins-banner-copies
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-plugins-banner-copies
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Updated copies used in the plugins banner for wpcom sites plugins.php page.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-plugins-banner-copies
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-plugins-banner-copies
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Updated copies used in the plugins banner for wpcom sites plugins.php page.
+Updated copies used in the plugins banner for wpcom sites plugin-install.php page.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-plugins.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-plugins.php
@@ -24,6 +24,34 @@ function wpcom_plugins_show_banner() {
 
 	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-plugins-banner/wpcom-plugins-banner.asset.php';
 
+	/**
+	 * Check to see if a string has been translated. This is for the purposes of changing the banner
+	 * copies below, this function and checks can be removed after new copies are translated.
+	 *
+	 * @param string $string The string to check.
+	 * @return bool True if the string has been translated, false otherwise.
+	 */
+	function should_use_new_translation( $string ) { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
+		if ( function_exists( 'wpcom_launchpad_has_translation' ) ) {
+			return wpcom_launchpad_has_translation( $string );
+		}
+		// If that function no longer exists in this context, we can assume the new strings have
+		// been translated by now.
+		return true;
+	}
+
+	$banner_title = should_use_new_translation( 'Unlock more with premium and free plugins' ) ?
+		esc_html__( 'Unlock more with premium and free plugins', 'jetpack-mu-wpcom' ) :
+		esc_html__( "Flex your site's features with plugins", 'jetpack-mu-wpcom' );
+
+	$banner_description = should_use_new_translation( "Discover a curated selection of free and premium plugins designed to enhance your site's functionality and features." ) ?
+		esc_html__( "Discover a curated selection of free and premium plugins designed to enhance your site's functionality and features.", 'jetpack-mu-wpcom' ) :
+		esc_html__( "Access a variety of free and paid plugins that can enhance your site's functionality and features.", 'jetpack-mu-wpcom' );
+
+	$banner_cta = should_use_new_translation( 'Explore marketplace plugins' ) ?
+		esc_html__( 'Explore marketplace plugins', 'jetpack-mu-wpcom' ) :
+		esc_html__( 'Explore plugins', 'jetpack-mu-wpcom' );
+
 	wp_enqueue_script(
 		'wpcom-plugins-banner',
 		plugins_url( 'build/wpcom-plugins-banner/wpcom-plugins-banner.js', Jetpack_Mu_Wpcom::BASE_FILE ),
@@ -39,10 +67,10 @@ function wpcom_plugins_show_banner() {
 		'wpcomPluginsBanner',
 		array(
 			'logo'             => esc_url( $wpcom_logo ),
-			'title'            => esc_html__( 'Unlock more with premium and free plugins', 'jetpack-mu-wpcom' ),
-			'description'      => esc_html__( "Discover a curated selection of free and premium plugins designed to enhance your site's functionality and features.", 'jetpack-mu-wpcom' ),
+			'title'            => $banner_title,
+			'description'      => $banner_description,
 			'actionUrl'        => esc_url( "https://wordpress.com/plugins/$site_slug?ref=woa-plugin-banner" ),
-			'actionText'       => esc_html__( 'Explore marketplace plugins', 'jetpack-mu-wpcom' ),
+			'actionText'       => $banner_cta,
 			'bannerBackground' => esc_url( $background_image ),
 		)
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-plugins.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-plugins.php
@@ -39,10 +39,10 @@ function wpcom_plugins_show_banner() {
 		'wpcomPluginsBanner',
 		array(
 			'logo'             => esc_url( $wpcom_logo ),
-			'title'            => esc_html__( "Flex your site's features with plugins", 'jetpack-mu-wpcom' ),
-			'description'      => esc_html__( "Access a variety of free and paid plugins that can enhance your site's functionality and features.", 'jetpack-mu-wpcom' ),
+			'title'            => esc_html__( 'Unlock more with premium and free plugins', 'jetpack-mu-wpcom' ),
+			'description'      => esc_html__( "Discover a curated selection of free and premium plugins designed to enhance your site's functionality and features.", 'jetpack-mu-wpcom' ),
 			'actionUrl'        => esc_url( "https://wordpress.com/plugins/$site_slug?ref=woa-plugin-banner" ),
-			'actionText'       => esc_html__( 'Explore plugins', 'jetpack-mu-wpcom' ),
+			'actionText'       => esc_html__( 'Explore marketplace plugins', 'jetpack-mu-wpcom' ),
 			'bannerBackground' => esc_url( $background_image ),
 		)
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-plugins.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-plugins.php
@@ -33,7 +33,7 @@ function wpcom_plugins_show_banner() {
 	 */
 	function should_use_new_translation( $string ) { // phpcs:ignore MediaWiki.Usage.NestedFunctions.NestedFunction
 		if ( function_exists( 'wpcom_launchpad_has_translation' ) ) {
-			return wpcom_launchpad_has_translation( $string );
+			return wpcom_launchpad_has_translation( $string, 'jetpack-mu-wpcom' );
 		}
 		// If that function no longer exists in this context, we can assume the new strings have
 		// been translated by now.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes # Automattic/dotcom-forge#8740

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Updates copies on the plugins banner as outlined in the issue.

BEFORE
<img width="621" alt="Screenshot 2024-10-10 at 8 46 02 AM" src="https://github.com/user-attachments/assets/4207617f-518a-4bf6-a687-ac03192ffbe0">


AFTER
<img width="623" alt="Screenshot 2024-10-10 at 8 45 17 AM" src="https://github.com/user-attachments/assets/b0586861-56f3-4079-969c-a951a50901f9">

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow instructions on automated comment below to get this on your WoA site for testing https://github.com/Automattic/jetpack/pull/39725#issuecomment-2404979510 
* Go to plugins -> add new plugin, verify the copy changes are as expected and banner still works.
* Switch your user language in your account profile to another mag16 language (i used spanish this time)
* Reload the plugins page with the spanish locale setting.
* Verify the banner is still translated appropriately and not rendering in english.
<img width="638" alt="Screenshot 2024-10-10 at 11 12 27 AM" src="https://github.com/user-attachments/assets/8f41a61e-e9dc-48b9-86a2-a810c1670d82">

(in other languages these are still the current/old copies and should auto update to the new copies once translations are ready)

Note - this banner does not show up on simple sites. I did a smoke test on simple with the following steps:
* activated this branch on simple using instructions below https://github.com/Automattic/jetpack/pull/39725#issuecomment-2404979510 
* sandboxed the simple test site
* go to the install plugins page.
* there should be no errors, warnings, or other issues as a result of this change.