### PR TITLE
Added null check post status obj in sal site class

### DIFF
--- a/projects/plugins/jetpack/changelog/update-added-null-check-post-status-obj-in-sal-site-class
+++ b/projects/plugins/jetpack/changelog/update-added-null-check-post-status-obj-in-sal-site-class
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+SAL_Site class: Added null check to posts_status_obj to avoid Warnings

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -758,15 +758,15 @@ abstract class SAL_Site {
 		if ( ! $post || is_wp_error( $post ) ) {
 			return false;
 		}
-
-		if ( 'inherit' === $post->post_status ) {
+		// If the post is of status inherit, check if the parent exists ( different to 0 ) to check for the parent status object.
+		if ( 'inherit' === $post->post_status && 0 !== (int) $post->post_parent ) {
 			$parent_post     = get_post( $post->post_parent );
 			$post_status_obj = get_post_status_object( $parent_post->post_status );
 		} else {
 			$post_status_obj = get_post_status_object( $post->post_status );
 		}
 
-		$authorized = null !== $post_status_obj && (
+		$authorized = (
 			$post_status_obj->public ||
 			( is_user_logged_in() &&
 				(

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -766,7 +766,7 @@ abstract class SAL_Site {
 			$post_status_obj = get_post_status_object( $post->post_status );
 		}
 
-		$authorized = (
+		$authorized = null !== $post_status_obj && (
 			$post_status_obj->public ||
 			( is_user_logged_in() &&
 				(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes Warnings related to `class.json-api-site-base.php` like 
```
Attempt to read property "public" on null
Attempt to read property "private" on null
Attempt to read property "post_status" on null
Attempt to read property "protected" on null
```

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added null check since `get_post_status_object` can return null.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Related logs f95ebb453440405af3826d85a96930ef-logstash
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
Code Review