### PR TITLE
Related Posts: check for any single post without regard for post type.

### DIFF
--- a/projects/plugins/jetpack/changelog/add-rp-support-on-pages
+++ b/projects/plugins/jetpack/changelog/add-rp-support-on-pages
@@ -1,0 +1,4 @@
+Significance: minor
+Type: compat
+
+Related Posts: allow Related Posts on non-post CPTs where the block is already able to be used.

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1883,18 +1883,19 @@ EOT;
 	/**
 	 * Determines if the current post is able to use related posts.
 	 *
-	 * @uses self::get_options, is_admin, is_single, apply_filters
+	 * @since $$next-version$$ Checks for singular instead of single to allow usage on non-posts CPTs.
+	 * @uses self::get_options, is_admin, is_singular, apply_filters
 	 * @return bool
 	 */
 	protected function enabled_for_request() {
-		$enabled = is_single()
+		$enabled = is_singular()
 			&& ! is_attachment()
 			&& ! is_admin()
 			&& ! is_embed()
 			&& ( ! $this->allow_feature_toggle() || $this->get_option( 'enabled' ) );
 
 		/**
-		 * Filter the Enabled value to allow related posts to be shown on pages as well.
+		 * Filter the Enabled value to allow related posts to be selectively enabled/disabled.
 		 *
 		 * @module related-posts
 		 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39720

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Enable on "singular" not simply "single". In WP, the former is the single post query of any post type while the latter is only for the "post" post type.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Ideally on a connected site with enough content to utilize RPs with a block theme enabled.
* Modify the page and post template to add the RP block.
* The single post should work fine without this patch.
* The single page should break in the way mention in the bug report.
* Apply the patch. The post should continue to work and the page should now work.

