### PR TITLE
VideoPress: Update VideoPress notice URL on Media Library

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-video-upload-media-notice
+++ b/projects/plugins/jetpack/changelog/fix-video-upload-media-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update VideoPress notice URL on Media Library

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -83,7 +83,7 @@ class Jetpack_VideoPress {
 				__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a> or the block editor using the Video block.', 'jetpack' ),
 				array( 'a' => array( 'href' => array() ) )
 			),
-			esc_url( admin_url( 'upload.php' ) )
+			esc_url( admin_url( 'upload.php?mode=grid&action=add-new' ) )
 		);
 		wp_admin_notice(
 			$message,


### PR DESCRIPTION
Closes https://github.com/Automattic/videopress/issues/1133

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update VideoPress notice URL on Media Library

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1728411800011669-slack-C02LT75D3

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* For testing, use either a Jetpack-connected or Atomic site **with VideoPress enabled**
* To reproduce the issue:
  * Go to Media, switch to List mode
  * Click on "Add New Media File"
  * You will be redirected to the upload page with a VideoPress notice
  * Click on the Media Library link from the notice
  * You should be redirected back to the list view and get stuck in the loop (unless you switch to the Grid view) 
* Testing the PR:
  * Apply this PR to your JT site, or apply this branch to your Atomic site using Jetpack Beta plugin
  * Go to Media, switch to List mode
  * You will be redirected to the upload page with a VideoPress notice
  * Click on the Media Library link from the notice
  * You should be redirected back to the Media Library, but now with the Grid view
  * You should also see the upload area already displayed

<img width="857" alt="image" src="https://github.com/user-attachments/assets/5cf903c9-6b81-4c3b-9a8a-6e6aea401941">
