### PR TITLE
Add/editor blocks add tracks for connection banner

### DIFF
--- a/projects/packages/videopress/changelog/add-editor-blocks-add-tracks-for-connection-banner
+++ b/projects/packages/videopress/changelog/add-editor-blocks-add-tracks-for-connection-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add tracks to connection banner

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { isBlobURL, getBlobByURL } from '@wordpress/blob';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import {
@@ -152,6 +153,7 @@ export default function VideoPressEdit( {
 	// Get the redirect URI for the connection flow.
 	const [ isRedirectingToMyJetpack, setIsRedirectingToMyJetpack ] = useState( false );
 	const hasUserConnection = isUserConnected();
+	const { tracks: analyticsTracks } = useAnalytics();
 
 	// Detect if the chapter file is auto-generated.
 	const chapter = tracks?.filter( track => track.kind === 'chapters' )?.[ 0 ];
@@ -405,8 +407,14 @@ export default function VideoPressEdit( {
 						onConnect={ () => {
 							setIsRedirectingToMyJetpack( true );
 							if ( ! hasUserConnection ) {
+								analyticsTracks.recordEvent( 'jetpack_editor_connect_banner_click', {
+									block: 'VideoPress',
+								} );
 								return ( window.location.href = myJetpackConnectUrl );
 							}
+							analyticsTracks.recordEvent( 'jetpack_editor_activate_banner_click', {
+								block: 'VideoPress',
+							} );
 							window.location.href = jetpackVideoPressSettingUrl;
 						} }
 					/>
@@ -602,9 +610,14 @@ export default function VideoPressEdit( {
 				onConnect={ () => {
 					setIsRedirectingToMyJetpack( true );
 					if ( ! hasUserConnection ) {
+						analyticsTracks.recordEvent( 'jetpack_editor_connect_banner_click', {
+							block: 'VideoPress',
+						} );
 						return ( window.location.href = myJetpackConnectUrl );
 					}
-
+					analyticsTracks.recordEvent( 'jetpack_editor_activate_banner_click', {
+						block: 'VideoPress',
+					} );
 					window.location.href = jetpackVideoPressSettingUrl;
 				} }
 			/>

--- a/projects/plugins/jetpack/changelog/add-editor-blocks-add-tracks-for-connection-banner
+++ b/projects/plugins/jetpack/changelog/add-editor-blocks-add-tracks-for-connection-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add tracks to connection banner

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/edit.js
@@ -305,7 +305,7 @@ export default function AIAssistantEdit( { attributes, setAttributes, clientId, 
 	const banner = (
 		<>
 			{ isOverLimit && isSelected && <QuotaExceededMessage placement="ai-assistant-block" /> }
-			{ ! connected && <ConnectBanner /> }
+			{ ! connected && <ConnectBanner block="AI Assistant" /> }
 		</>
 	);
 

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/edit.js
@@ -34,7 +34,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	);
 	return (
 		<div { ...blockProps }>
-			<ConnectBanner />
+			<ConnectBanner block="Jetpack AI Search" />
 			<EnableJetpackSearchPrompt />
 			<div className="jetpack-ai-chat-question-wrapper">
 				<TextControl

--- a/projects/plugins/jetpack/extensions/blocks/ai-chat/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/ai-chat/edit.js
@@ -13,6 +13,7 @@ import { useSelect } from '@wordpress/data';
  */
 import './editor.scss';
 import ConnectBanner from '../../shared/components/connect-banner';
+import useIsUserConnected from '../../shared/use-is-user-connected';
 import EnableJetpackSearchPrompt from './components/nudge-enable-search';
 import { DEFAULT_ASK_BUTTON_LABEL, DEFAULT_PLACEHOLDER } from './constants';
 import { AiChatControls } from './controls';
@@ -32,9 +33,11 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		},
 		[ clientId ]
 	);
+	const isUserConnected = useIsUserConnected();
+
 	return (
 		<div { ...blockProps }>
-			<ConnectBanner block="Jetpack AI Search" />
+			{ ! isUserConnected && <ConnectBanner block="Jetpack AI Search" /> }
 			<EnableJetpackSearchPrompt />
 			<div className="jetpack-ai-chat-question-wrapper">
 				<TextControl

--- a/projects/plugins/jetpack/extensions/blocks/blogroll/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/blogroll/edit.js
@@ -63,6 +63,7 @@ export function BlogRollEdit( { className, attributes, setAttributes, clientId }
 		return (
 			<>
 				<ConnectBanner
+					block="Blogroll"
 					explanation={ __(
 						'Connect your WordPress.com account to use the Blogroll block.',
 						'jetpack'

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -140,6 +140,7 @@ const Edit = props => {
 	if ( ! isUserConnected ) {
 		content = (
 			<ConnectBanner
+				block="Donations Form"
 				explanation={ __( 'Connect your WordPress.com account to enable donations.', 'jetpack' ) }
 			/>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/payment-buttons/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/payment-buttons/edit.js
@@ -80,6 +80,7 @@ function PaymentButtonsEdit( { clientId, attributes } ) {
 		return (
 			<div { ...blockProps }>
 				<ConnectBanner
+					block="Payment Buttons"
 					explanation={ __(
 						'Connect your WordPress.com account to enable payment buttons on your site.',
 						'jetpack'

--- a/projects/plugins/jetpack/extensions/blocks/payments-intro/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/payments-intro/edit.js
@@ -74,6 +74,7 @@ export default function JetpackPaymentsIntroEdit( { name, clientId } ) {
 	if ( ! isUserConnected ) {
 		content = (
 			<ConnectBanner
+				block="Payments"
 				explanation={ __(
 					'Connect your WordPress.com account to start using payments blocks.',
 					'jetpack'

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -50,6 +50,7 @@ function PaywallEdit() {
 		return (
 			<div { ...blockProps }>
 				<ConnectBanner
+					block="Paywall"
 					explanation={ __(
 						'Connect your WordPress.com account to enable a paywall for your site.',
 						'jetpack'

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/edit.js
@@ -106,6 +106,7 @@ function Edit( { clientId, isSelected, attributes, setAttributes } ) {
 		return (
 			<div { ...blockProps }>
 				<ConnectBanner
+					block="Paid Content"
 					explanation={ __(
 						'Connect your WordPress.com account to enable paid content.',
 						'jetpack'

--- a/projects/plugins/jetpack/extensions/shared/components/connect-banner/index.tsx
+++ b/projects/plugins/jetpack/extensions/shared/components/connect-banner/index.tsx
@@ -1,6 +1,7 @@
 /*
  * External dependencies
  */
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { __ } from '@wordpress/i18n';
 /*
  * Internal dependencies
@@ -10,16 +11,19 @@ import { Nudge } from '../upgrade-nudge';
 import type { MouseEvent, FC } from 'react';
 
 interface ConnectBannerProps {
+	block: string;
 	explanation?: string;
 }
 
 import './style.scss';
 
-const ConnectBanner: FC< ConnectBannerProps > = ( { explanation = null } ) => {
+const ConnectBanner: FC< ConnectBannerProps > = ( { block, explanation = null } ) => {
 	const checkoutUrl = `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/connection`;
 	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( checkoutUrl );
+	const { tracks } = useAnalytics();
 
 	const goToCheckoutPage = ( event: MouseEvent< HTMLButtonElement > ) => {
+		tracks.recordEvent( 'jetpack_editor_connect_banner_click', { block } );
 		autosaveAndRedirect( event );
 	};
 

--- a/projects/plugins/videopress/changelog/add-editor-blocks-add-tracks-for-connection-banner
+++ b/projects/plugins/videopress/changelog/add-editor-blocks-add-tracks-for-connection-banner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add tracks for connection banner


### PR DESCRIPTION
## Proposed changes:

* Add a tracks event for the connection banner in the editor

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-bHl-p2

## Does this pull request change what data or activity we track or use?

Yes, we will be tracking connection banner clicks from the blocks connection banner

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect your site but not user
3. Add a new post and go to the post editor
4. Add the Payments block and ensure you see a connection banner
5. Click the Connect button and ensure (via Tracks vigilante or however you look at tracks) that the `jetpack_editor_connect_banner_click` is recorded with the correct block
![image](https://github.com/user-attachments/assets/d9fb2e62-2935-4bea-9e24-c15833ceb419)
6. Do the same with other payment block such as 
 * Paywall
 * Donations Form
 * Paid Content
and VideoPress to ensure that block is working as well