### PR TITLE
AI Assistant: Make Write Brief no longer flag single quotes as spelling errors

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-breve-spellcheck-ignore-single-quotes
+++ b/projects/plugins/jetpack/changelog/fix-breve-spellcheck-ignore-single-quotes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Make Breve no longer flag single quotes as spelling errors

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/features/spelling-mistakes/index.ts
@@ -203,6 +203,9 @@ export default function spellingMistakes( text: string ): Array< HighlightedText
 		const subWords = word.split( /[-/]/ );
 
 		subWords.forEach( subWord => {
+			// remove single quotes from beginning/end
+			subWord = subWord.replace( /^'+|'+$/g, '' );
+
 			if ( ! spellChecker.correct( subWord ) ) {
 				const subWordStartIndex = startIndex + word.indexOf( subWord );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Partial #39415

## Proposed changes:
* Previously the spell checker handled single quotes poorly:
![screenshot-2024-10-10-at-10 18 18e280afam](https://github.com/user-attachments/assets/9a31236d-67b6-49c4-8630-641aa4e81748)
* After this change:
![Screenshot 2024-10-10 at 3 16 45 PM](https://github.com/user-attachments/assets/a7c3ba25-37a8-433b-be95-a102ef2b8a6c)

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
* Create a new post and make sure Write Brief is making spelling suggestions:
![Screenshot 2024-10-10 at 3 19 53 PM](https://github.com/user-attachments/assets/fed22ae8-7a57-402d-aa7b-63a849cebe4c)
* Type up some text and add single quotes at the beginning/end of words that are correctly spelled. These words should be underlined in red.
* Check out this branch and rebuild ai-assistant
* Reload your post. The previously red underlined words should no longer be underlined. The spell checker should still be underlining words that have incorrect spelling, if the words are quoted or not.

