### PR TITLE
eslint: Remove `jsx-a11y/label-has-associated-control` override

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-eslint-jsx-a11y-label-has-associated-control
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-eslint-jsx-a11y-label-has-associated-control
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Replace eslint:disable for `jsx-a11y/label-has-for` with `jsx-a11y/label-has-associated-control`.
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/recommended-tags-modal/form-label.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/recommended-tags-modal/form-label.tsx
@@ -21,7 +21,7 @@ const FormLabel: FunctionComponent< Props & LabelProps > = ( {
 	const hasChildren: boolean = Children.count( children ) > 0;
 
 	return (
-		// eslint-disable-next-line jsx-a11y/label-has-for
+		// eslint-disable-next-line jsx-a11y/label-has-associated-control
 		<label { ...labelProps } className={ clsx( className, 'form-label' ) }>
 			{ children }
 			{ hasChildren && required && (

--- a/projects/packages/search/changelog/add-eslint-jsx-a11y-label-has-associated-control
+++ b/projects/packages/search/changelog/add-eslint-jsx-a11y-label-has-associated-control
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Add auto-generated id in `MockedFilterOption`. No other change to functionality.
+
+

--- a/projects/packages/search/src/dashboard/components/mocked-search/mocked-instant-search.jsx
+++ b/projects/packages/search/src/dashboard/components/mocked-search/mocked-instant-search.jsx
@@ -1,6 +1,6 @@
 import { Gridicon } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
-import React from 'react';
+import React, { useId } from 'react';
 import TextRowPlaceHolder from './placeholder';
 import './mocked-instant-search.scss';
 
@@ -62,14 +62,18 @@ export default function MockedInstantSearch() {
 	);
 }
 
-const MockedFilterOption = () => (
-	<div className="jp-mocked-instant-search__search-filter">
-		<label>
-			<input type="checkbox" disabled="disabled" />{ ' ' }
-			<TextRowPlaceHolder style={ { width: '30%' } } />
-		</label>
-	</div>
-);
+const MockedFilterOption = () => {
+	const id = useId();
+
+	return (
+		<div className="jp-mocked-instant-search__search-filter">
+			<label htmlFor={ id }>
+				<input id={ id } type="checkbox" disabled="disabled" />{ ' ' }
+				<TextRowPlaceHolder style={ { width: '30%' } } />
+			</label>
+		</div>
+	);
+};
 
 const MockedSearchResult = () => (
 	<div className="jp-mocked-instant-search__search-result">

--- a/projects/plugins/jetpack/_inc/client/components/select-dropdown/label.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/select-dropdown/label.jsx
@@ -1,6 +1,6 @@
 /** @ssr-ready **/
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/label-has-for */
+/* eslint-disable jsx-a11y/label-has-associated-control */
 
 import React from 'react';
 

--- a/projects/plugins/jetpack/changelog/add-eslint-jsx-a11y-label-has-associated-control
+++ b/projects/plugins/jetpack/changelog/add-eslint-jsx-a11y-label-has-associated-control
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Replace eslint:disable for `jsx-a11y/label-has-for` with `jsx-a11y/label-has-associated-control`.
+
+

--- a/tools/js-tools/eslintrc/base.js
+++ b/tools/js-tools/eslintrc/base.js
@@ -140,14 +140,6 @@ module.exports = {
 
 		'jsx-a11y/anchor-has-content': 'off',
 		'jsx-a11y/anchor-is-valid': 'off',
-		'jsx-a11y/label-has-for': [
-			'error',
-			{
-				required: {
-					some: [ 'nesting', 'id' ],
-				},
-			},
-		],
 		// Redundant roles are sometimes necessary for screen reader support. For instance, VoiceOver
 		// on Safari requires `role=list` to announce the list if the style is overwritten.
 		'jsx-a11y/no-redundant-roles': 'off',
@@ -207,8 +199,6 @@ module.exports = {
 		// We may want to keep these overrides. To decide later.
 		eqeqeq: [ 'error', 'always', { null: 'ignore' } ],
 		'no-unused-expressions': [ 'error', { allowShortCircuit: true, allowTernary: true } ],
-		// Temporarily override plugin:@wordpress/* so we can clean up failing stuff in separate PRs.
-		'jsx-a11y/label-has-associated-control': [ 'error', { assert: 'either' } ],
 		'object-shorthand': 'off',
 	},
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
`@wordpress/eslint-plugin` sets `jsx-a11y/label-has-associated-control` to "htmlFor", while we had it overridden to "either". Turns out there was only place that wasn't already doing "htmlFor", so let's fix that one place and go for it.

This also removes `jsx-a11y/label-has-for` which is deprecated in favor of `jsx-a11y/label-has-associated-control`. The former config was equivalent to "either".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Followup to #38436 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* CI happy?
* That one Search thing still work?