### PR TITLE
Jetpack: optimize the 'admin_init' hook callback for Sharing module

### DIFF
--- a/projects/plugins/jetpack/changelog/update-optimize-sharing-init-hook
+++ b/projects/plugins/jetpack/changelog/update-optimize-sharing-init-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Optimize the 'admin_init' hook callback for Sharing module.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -29,7 +29,11 @@ class Sharing_Admin {
 	public function __construct() {
 		require_once WP_SHARING_PLUGIN_DIR . 'sharing-service.php';
 
-		add_action( 'admin_init', array( $this, 'admin_init' ) );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonces are handled in process_requests.
+		if ( isset( $_GET['page'] ) && ( $_GET['page'] === 'sharing.php' || $_GET['page'] === 'sharing' ) ) {
+			add_action( 'admin_init', array( $this, 'admin_init' ) );
+		}
+
 		add_action( 'admin_menu', array( $this, 'subscription_menu' ) );
 
 		// Insert our CSS and JS
@@ -91,9 +95,7 @@ class Sharing_Admin {
 	 * @return void
 	 */
 	public function admin_init() {
-		if ( isset( $_GET['page'] ) && ( $_GET['page'] === 'sharing.php' || $_GET['page'] === 'sharing' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonces are handled in process_requests.
-			$this->process_requests();
-		}
+		$this->process_requests();
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes:
Jetpack sharing module: do not add the form processing callback to `admin_init` hook unless we actually need it.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/529

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack in site-only mode.
2. Enable "Sharing" in Jetpack Settings, disable the "Blocks" module.
3. Got to "Settings -> Sharing", edit the settings (e.g. add/remove available services). Save the changes, confirm they got saved.