### PR TITLE
Social Notes: add support for the ActivityPub reply-to block when the plugin is present

### DIFF
--- a/projects/plugins/social/changelog/add-reply-to-support-social-notes
+++ b/projects/plugins/social/changelog/add-reply-to-support-social-notes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social Notes: add support for the ActivityPub Reply-To block.

--- a/projects/plugins/social/src/class-note.php
+++ b/projects/plugins/social/src/class-note.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Social;
 
+use Automattic\Jetpack\Constants;
+
 /**
  * Register the Jetpack Social Note custom post type.
  */
@@ -30,6 +32,19 @@ class Note {
 			return;
 		}
 		add_filter( 'allowed_block_types', array( $this, 'restrict_blocks_for_social_note' ), 10, 2 );
+
+		/*
+		 * The ActivityPub plugin has a block to set a Fediverse post that a new post is in reply to. This is perfect for Social Notes.
+		 */
+		if ( Constants::get_constant( 'ACTIVITYPUB_PLUGIN_VERSION' ) ) {
+			add_filter(
+				'jetpack_social_allowed_blocks',
+				function ( $allowed_blocks ) {
+					$allowed_blocks[] = 'activitypub/reply';
+					return $allowed_blocks;
+				}
+			);
+		}
 
 		self::register_cpt();
 		add_action( 'wp_insert_post_data', array( $this, 'set_empty_title' ), 10, 2 );
@@ -148,7 +163,16 @@ class Note {
 			);
 		}
 
-		return $allowed_blocks;
+		/**
+		 * Filters the blocks available to the Social Notes CPT.
+		 *
+		 * Default is ['core/paragraph', 'core/post-featured-image']
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $allowed_blocks A linear array of blocks allowed by the CPT.
+		 */
+		return apply_filters( 'jetpack_social_allowed_blocks', $allowed_blocks );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Social Notes is a perfect way to post small things that are sent out to the Fediverse via the ActivityPub plugin. One feature of the AP plugin is the ability to add a reference to a Fediverse-enabled URL that you're replying to. This is done by adding a block with the URL. The Social Notes CPT is locked down. This adds that block when both plugins are active. Additionally, it adds a filter for other plugins to do similar.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a filter `jetpack_social_allowed_blocks`
* Adds an implementation of the filter to add the `activitypub/reply` block to the allowed list when the AP plugin is active.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* pending
* On a site with Jetpack Social (connected) and the ActivityPub plugin, see if you can add the in reply to block.
* Visit the Tools WP page and add the ActivityPub bookmarklet for replying. Update the URL to include `?post_type=jetpack-social-note&` so the reply opens a new Social Notes post. (As a follow-up, I'll want to add a way to indicate which post type should be used in the AP plugin).
* Confirm it brings over the URL.

