### PR TITLE
Jetpack outdated WP notices: avoid fatals on outdated WP versions

### DIFF
--- a/projects/plugins/backup/changelog/revert-admin_notice_37051
+++ b/projects/plugins/backup/changelog/revert-admin_notice_37051
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+General: ensure the notice displayed when running an old version of WordPress can always be displayed without errors.

--- a/projects/plugins/backup/jetpack-backup.php
+++ b/projects/plugins/backup/jetpack-backup.php
@@ -71,13 +71,15 @@ if ( is_wp_error( $jetpack_backup_meets_requirements ) ) {
 	add_action(
 		'admin_notices',
 		function () use ( $jetpack_backup_meets_requirements ) {
-			wp_admin_notice(
-				esc_html( $jetpack_backup_meets_requirements->get_error_message() ),
-				array(
-					'type'        => 'error',
-					'dismissible' => true,
-				)
-			);
+			?>
+		<div class="notice notice-error is-dismissible">
+			<p>
+				<?php
+				echo esc_html( $jetpack_backup_meets_requirements->get_error_message() );
+				?>
+			</p>
+		</div>
+			<?php
 		}
 	);
 

--- a/projects/plugins/jetpack/changelog/revert-admin_notice_37051
+++ b/projects/plugins/jetpack/changelog/revert-admin_notice_37051
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+General: ensure the notice displayed when running an old version of WordPress can always be displayed without errors.

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -116,13 +116,11 @@ if ( version_compare( $GLOBALS['wp_version'], JETPACK__MINIMUM_WP_VERSION, '<' )
 	 * @since 7.2.0
 	 */
 	function jetpack_admin_unsupported_wp_notice() {
-		wp_admin_notice(
-			esc_html__( 'Jetpack requires a more recent version of WordPress and has been paused. Please update WordPress to continue enjoying Jetpack.', 'jetpack' ),
-			array(
-				'type'        => 'error',
-				'dismissible' => true,
-			)
-		);
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p><?php esc_html_e( 'Jetpack requires a more recent version of WordPress and has been paused. Please update WordPress to continue enjoying Jetpack.', 'jetpack' ); ?></p>
+		</div>
+		<?php
 	}
 
 	add_action( 'admin_notices', 'jetpack_admin_unsupported_wp_notice' );


### PR DESCRIPTION
## Proposed changes:

Do not use the `wp_admin_notice` function to display that wp-admin notice. The notice is meant to be displayed on sites running an outdated version of WordPress, and it's possible that this version is 6.3-, which does not include the `wp_admin_notice` function.

> [!NOTE]
> This PR does not revert the entirety of #37051 ; it is only meant to revert the part that would load on sites running an outdated version of WP.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* Internal reference: p1728598216425289-slack-C03M3KD520Zd
* Related PR, where wp_admin_notice was introduced: #37051

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

* Start with a site running WordPress 6.3.5 (you can use the WP Downgrade plugin to help you with that).
* Install Jetpack version 13.3.1
* Connect the plugin to WordPress.com ; no problems at this point.
* Via FTP, replace the installation of Jetpack by Jetpack 13.4: https://downloads.wordpress.org/plugin/jetpack.13.4.zip
    * At this point, you should get a fatal error on the site, and an email about it.
* Now apply this patch to your installed version of Jetpack, or upload a zip from the Build action on this PR to replace it.
    * The Fatal will disappear and the wp-admin notice will be displayed.
 
<img width="1352" alt="Screenshot 2024-10-11 at 10 26 03" src="https://github.com/user-attachments/assets/fd4035e8-5a34-438d-b6fc-475c4cf54676">
