### PR TITLE
Jetpack Sync: Ensure Full Sync is only triggered on backend admin POST requests

### DIFF
--- a/projects/packages/sync/changelog/fix-full-sync-sending
+++ b/projects/packages/sync/changelog/fix-full-sync-sending
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Sync: Ensure Full Sync is only triggered on backend admin POST requests

--- a/projects/packages/sync/src/class-actions.php
+++ b/projects/packages/sync/src/class-actions.php
@@ -175,7 +175,9 @@ class Actions {
 		) ) {
 			self::initialize_sender();
 			add_action( 'shutdown', array( self::$sender, 'do_sync' ), 9998 );
-			add_action( 'shutdown', array( self::$sender, 'do_full_sync' ), 9999 );
+			if ( self::should_initialize_sender( true ) ) {
+				add_action( 'shutdown', array( self::$sender, 'do_full_sync' ), 9999 );
+			}
 		}
 	}
 
@@ -212,9 +214,11 @@ class Actions {
 	 * @access public
 	 * @static
 	 *
+	 * @param bool $full_sync Whether the Full Sync sender should run on shutdown for this request.
+	 *
 	 * @return bool
 	 */
-	public static function should_initialize_sender() {
+	public static function should_initialize_sender( $full_sync = false ) {
 
 		// Allow for explicit disable of Sync from request param jetpack_sync_read_only.
 		if ( isset( $_REQUEST['jetpack_sync_read_only'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
@@ -227,9 +231,10 @@ class Actions {
 		}
 
 		/**
-		 * For now, if dedicated Sync is enabled we will always initialize send, even for GET and unauthenticated requests.
+		 * For now, if dedicated Sync is enabled we will always initialize send, even for GET and unauthenticated requests
+		 * but not for Full Sync, since it will still happen on shutdown.
 		 */
-		if ( Settings::is_dedicated_sync_enabled() ) {
+		if ( false === $full_sync && Settings::is_dedicated_sync_enabled() ) {
 			return true;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes a bug, where Full Sync could get triggered on `shutdown` of frontend requests.
When we introduced the Dedicated Sync flow, aka sending the Sync queue to WPCOM via spawning a dedicated request vs on `shutdown` of the current one, we modified the previous logic of sending only on POST requests, admin requests, or requests by users who can `manage_options`.
Since sending would happen on a separate requests there was no reason to have this limit anymore.
However, this affected Full Sync as well: Full Sync is still happening on `shutdown` so we need to ensure that it will only get triggered on POST requests, admin requests, or requests by users who can `manage_options`, same as it were before introducing Dedicated Sync.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* `Automattic\Jetpack\Sync\Actions`: Introduce a boolean `$full_sync` parameter in `should_initialize_sender` to indicate if the sender should get initialized under the context of Full Syncs. 
* `Automattic\Jetpack\Sync\Actions`: Update `add_sender_shutdown` to only allow Full Syncs when `should_initialize_sender` returns `true` for Full Syncs.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Pre-requisites: A JP connected site.

* Disable `Sync via Cron` via the Sync Settings form in the Jetpack Debugger
* Trigger a Full Sync via the Jetpack Debugger
* Monitor the Full Sync actions in ES - 9a8886e157fe618f9430295d87ff1268-logstash. After the first ones are sent, we'll need to trigger the rest Full Sync queue to start sending
* On trunk, visit the homepage in Incognito mode. Verify that Full Sync actions are flowing
* On current branch, no Full Sync actions should be flowing
* On both trunk and current branch, Full Sync actions should be flowing when visiting any wp-admin page

Note: If your site doesn't have a lot of content, it's possible that when Full Sync gets triggered all Full Sync actions are sent at once. This is controlled by the max full sync duration allowed for sending Full Sync actions, aka the `full_sync_send_duration` [setting](https://github.com/Automattic/jetpack/blob/492773febbb0fa3103687f95935d02ffdf57a74b/projects/packages/sync/src/class-defaults.php#L1238). If needed, you can update this to a smaller value, like `3` via: `wp option update jetpack_sync_settings_full_sync_send_duration 3`.