### PR TITLE
Override Modern color scheme's highlight color to Blueberry 2

### DIFF
--- a/projects/packages/masterbar/changelog/update-modern-scheme
+++ b/projects/packages/masterbar/changelog/update-modern-scheme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Override Modern color scheme's highlight color to Blueberry 2

--- a/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
+++ b/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
@@ -35,6 +35,7 @@ class Admin_Color_Schemes {
 		if ( ( new Host() )->is_wpcom_platform() ) { // Simple and Atomic sites.
 			add_filter( 'css_do_concat', array( $this, 'disable_css_concat_for_color_schemes' ), 10, 2 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_color_scheme_for_sidebar_notice' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_color_scheme_overrides' ) );
 		}
 	}
 
@@ -158,6 +159,18 @@ class Admin_Color_Schemes {
 		);
 
 		wp_admin_css_color(
+			'modern',
+			__( 'Modern', 'jetpack-masterbar' ),
+			admin_url( 'css/colors/modern/colors.css' ),
+			array( '#1e1e1e', '#3858e9', '#7b90ff' ),
+			array(
+				'base'    => '#f3f1f1',
+				'focus'   => '#fff',
+				'current' => '#fff',
+			)
+		);
+
+		wp_admin_css_color(
 			'nightfall',
 			__( 'Nightfall', 'jetpack-masterbar' ),
 			$this->get_admin_color_scheme_url( 'nightfall' ),
@@ -215,6 +228,21 @@ class Admin_Color_Schemes {
 			wp_enqueue_style(
 				'jetpack-core-color-schemes-overrides-sidebar-notice',
 				$this->get_admin_color_scheme_url( $color_scheme, 'sidebar-notice.css' ),
+				array(),
+				Main::PACKAGE_VERSION
+			);
+		}
+	}
+
+	/**
+	 * Enqueues dotcom-specific color scheme overrides.
+	 */
+	public function enqueue_color_scheme_overrides() {
+		$color_scheme = get_user_option( 'admin_color' );
+		if ( $color_scheme === 'modern' ) {
+			wp_enqueue_style(
+				'jetpack-core-color-schemes-overrides-modern',
+				$this->get_admin_color_scheme_url( $color_scheme ),
 				array(),
 				Main::PACKAGE_VERSION
 			);

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/modern/colors.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/modern/colors.scss
@@ -1,0 +1,95 @@
+$menu-submenu-focus-text: #7b90ff !important;
+
+/* Admin Menu: submenu */
+
+#adminmenu .wp-submenu a,
+#adminmenu .wp-has-current-submenu .wp-submenu a,
+#adminmenu a.wp-has-current-submenu:focus + .wp-submenu a,
+#adminmenu .wp-has-current-submenu.opensub .wp-submenu a {
+	&:focus, &:hover {
+		color: $menu-submenu-focus-text;
+	}
+}
+
+
+/* Admin Menu: current */
+
+#adminmenu .wp-submenu li.current a,
+#adminmenu a.wp-has-current-submenu:focus + .wp-submenu li.current a,
+#adminmenu .wp-has-current-submenu.opensub .wp-submenu li.current a {
+	&:hover, &:focus {
+		color: $menu-submenu-focus-text;
+	}
+}
+
+
+/* Admin Menu: collapse button */
+
+#collapse-button:hover,
+#collapse-button:focus {
+    color: $menu-submenu-focus-text;
+}
+
+
+/* Admin Bar */
+
+#wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item,
+#wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:focus,
+#wpadminbar.nojq .quicklinks .ab-top-menu > li > .ab-item:focus,
+#wpadminbar.nojs .ab-top-menu > li.menupop:hover > .ab-item,
+#wpadminbar .ab-top-menu > li.menupop.hover > .ab-item {
+	color: $menu-submenu-focus-text;
+}
+
+#wpadminbar:not(.mobile) > #wp-toolbar li:hover span.ab-label,
+#wpadminbar:not(.mobile) > #wp-toolbar li.hover span.ab-label,
+#wpadminbar:not(.mobile) > #wp-toolbar a:focus span.ab-label {
+	color: $menu-submenu-focus-text;
+}
+
+#wpadminbar:not(.mobile) li:hover .ab-icon:before,
+#wpadminbar:not(.mobile) li:hover .ab-item:before,
+#wpadminbar:not(.mobile) li:hover .ab-item:after,
+#wpadminbar:not(.mobile) li:hover #adminbarsearch:before {
+	color: $menu-submenu-focus-text;
+}
+
+
+/* Admin Bar: submenu */
+
+#wpadminbar .quicklinks .menupop ul li a:hover,
+#wpadminbar .quicklinks .menupop ul li a:focus,
+#wpadminbar .quicklinks .menupop ul li a:hover strong,
+#wpadminbar .quicklinks .menupop ul li a:focus strong,
+#wpadminbar .quicklinks .ab-sub-wrapper .menupop.hover > a,
+#wpadminbar .quicklinks .menupop.hover ul li a:hover,
+#wpadminbar .quicklinks .menupop.hover ul li a:focus,
+#wpadminbar.nojs .quicklinks .menupop:hover ul li a:hover,
+#wpadminbar.nojs .quicklinks .menupop:hover ul li a:focus,
+#wpadminbar li:hover .ab-icon:before,
+#wpadminbar li:hover .ab-item:before,
+#wpadminbar li a:focus .ab-icon:before,
+#wpadminbar li .ab-item:focus:before,
+#wpadminbar li .ab-item:focus .ab-icon:before,
+#wpadminbar li.hover .ab-icon:before,
+#wpadminbar li.hover .ab-item:before,
+#wpadminbar li:hover #adminbarsearch:before,
+#wpadminbar li #adminbarsearch.adminbar-focused:before {
+	color: $menu-submenu-focus-text;
+}
+
+#wpadminbar .quicklinks li a:hover .blavatar,
+#wpadminbar .quicklinks li a:focus .blavatar,
+#wpadminbar .quicklinks .ab-sub-wrapper .menupop.hover > a .blavatar,
+#wpadminbar .menupop .menupop > .ab-item:hover:before,
+#wpadminbar.mobile .quicklinks .ab-icon:before,
+#wpadminbar.mobile .quicklinks .ab-item:before {
+	color: $menu-submenu-focus-text;
+}
+
+
+/* Admin Bar: my account */
+
+#wpadminbar #wp-admin-bar-user-info a:hover .display-name {
+	color: $menu-submenu-focus-text;
+}

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/modern/colors.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/modern/colors.scss
@@ -1,4 +1,4 @@
-$menu-submenu-focus-text: #7b90ff !important;
+$menu-submenu-focus-text: #7b90ff;
 
 /* Admin Menu: submenu */
 


### PR DESCRIPTION
Related to: pfsHM7-1qe-p2#comment-1787

## Proposed changes:

We would like to propose updating the Modern color scheme, so that the highlight color, which is present in the admin bar and sidebar, becomes blue (Blueberry 2) instead of green:

|Before|After|
|-|-|
|<img width="203" alt="image" src="https://github.com/user-attachments/assets/1c6f6c9c-3673-475e-9fa1-5351af30ebd8">|<img width="203" alt="image" src="https://github.com/user-attachments/assets/ef98903d-4121-48b7-ada6-d024a785b7d2">|
|<img width="320" alt="image" src="https://github.com/user-attachments/assets/3208a9eb-c37f-445a-818c-d773fe9976dc">|<img width="315" alt="image" src="https://github.com/user-attachments/assets/aa806258-c0e3-4e5f-9e9e-348e20e2fd12">|

The color is chosen to follow the navbar menu item's active state color in the WordPress.org website:

<img width="830" alt="image" src="https://github.com/user-attachments/assets/a93c6ddb-d977-427b-9e6e-60db85df9649">

This PR is to have the change faster in dotcom. If we like it, we can propose the change back to dotorg.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Patch this to your site.
2. Go to `wp-admin/profile.php`.
3. Select the Modern scheme and click Update.
4. Verify that the hover text color in the admin bar and sidebar is now blu-ish as per screenshot above.