### PR TITLE
Verbum Comments: fix gravatar width in nested comments for block themes

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-comment-gravatar-width
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-comment-gravatar-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verbum Comments: fix gravatar width in nested comments

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
@@ -60,7 +60,7 @@
 }
 
 /* This prevents images from overflowing the comment area. */
-:not(.wp-block-comment-template) .comment img, .wp-block-comment-content img {
+.comment img:not(.wp-block-comment-template .comment img), .wp-block-comment-content img {
 	max-width: 100%;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
@@ -60,7 +60,7 @@
 }
 
 /* This prevents images from overflowing the comment area. */
-.comment img {
+.wp-block-comment-content img {
 	max-width: 100%;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
@@ -60,7 +60,7 @@
 }
 
 /* This prevents images from overflowing the comment area. */
-.wp-block-comment-content img {
+:not(.wp-block-comment-template) .comment img, .wp-block-comment-content img {
 	max-width: 100%;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
@@ -59,8 +59,11 @@
 
 }
 
-/* This prevents images from overflowing the comment area. */
-.comment img:not(.wp-block-comment-template .comment img), .wp-block-comment-content img {
+// This prevents images from overflowing the comment area. The :not() selector
+// handles comments in non-block themes, but is too general for block themes,
+// breaking flex layouts.
+.comment img:not(.wp-block-comment-template .comment img),
+.wp-block-comment-content img {
 	max-width: 100%;
 }
 


### PR DESCRIPTION
The `max-width` applied to images inside comments is aimed to prevent an image from overflowing the comment area. The rule uses the overly-general `.comment` selector however, which causes comment avatars to break as nested replies cause the avatar container to compress because of the flex rules used to float avatars beside the comment content.

| Before      | After |
| ----------- | ----------- |
| <img width="748" alt="Screenshot 2024-10-13 at 2 12 36 PM" src="https://github.com/user-attachments/assets/bfbaf342-eba3-451d-bd39-bb93df0aeaca"> | <img width="725" alt="Screenshot 2024-10-13 at 2 22 31 PM" src="https://github.com/user-attachments/assets/33a3922f-8aa4-46a1-bcc8-726d49add59d"> |

## Proposed changes:
This diff changes the selector for the `max-width` rule to more specifically apply to images inside the content area of a comment.

## Testing instructions:
- Apply this patch to your sandbox by running `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/verbum-comment-gravatar-width`
- Sandbox a site with block theme (e.g. Reverie).
- Add comments to a post that are more than one level deep, with a longer comment reply (that wraps onto multiple lines).
- Verify that the avatar of the parent comment is the correct size and scale (not stretched or compressed).
- Add a large image to a comment.
- Verify that the image doesn't overflow the comment content.
- Switch your theme to a non-block theme (e.g. TwentyThirteen) and visit the same post with comments.
- Verify that the avatar images look correct and the comment image doesn't overflow the comment content.

## Does this pull request change what data or activity we track or use?
No
