### PR TITLE
Post-migration experience: Add domain DNS task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-domain-dns-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-domain-dns-task
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add new task for domain mapping in migration Launchpad

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -851,9 +851,6 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
-			'get_calypso_path'     => function () {
-				return '/support/domains/connect-existing-domain/#step-2-connect-your-domain';
-			},
 		),
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -851,7 +851,7 @@ function wpcom_launchpad_get_task_definitions() {
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
-			'get_calypso_path'      => function () {
+			'get_calypso_path'     => function () {
 				return 'https://wordpress.com/support/domains/connect-existing-domain/#step-2-connect-your-domain';
 			},
 		),

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -845,6 +845,16 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_domain_customize_completed',
 			'is_visible_callback'  => '__return_true',
 		),
+		'domain_dns_mapped'               => array(
+			'get_title'            => function () {
+				return __( "Update your domain's DNS", 'jetpack-mu-wpcom' );
+			},
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
+			'is_visible_callback'  => '__return_true',
+			'get_calypso_path'      => function () {
+				return 'https://wordpress.com/support/domains/connect-existing-domain/#step-2-connect-your-domain';
+			},
+		),
 	);
 
 	$extended_task_definitions = apply_filters( 'wpcom_launchpad_extended_task_definitions', array() );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -852,7 +852,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_visible_callback'  => '__return_true',
 			'get_calypso_path'     => function () {
-				return 'https://wordpress.com/support/domains/connect-existing-domain/#step-2-connect-your-domain';
+				return '/support/domains/connect-existing-domain/#step-2-connect-your-domain';
 			},
 		),
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -324,6 +324,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'review_site',
 				'review_plugins',
 				'connect_migration_domain',
+				'domain_dns_mapped',
 			),
 		),
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/wp-calypso/issues/95076

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds a new task to the migration Launchpad pointing to the custom domain setup instructions doc.
* Task completion will be handled by hooking into an existing async job separately.
* Task functionality is handled on the front end in https://github.com/Automattic/wp-calypso/pull/95362

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This should be ideally tested in an atomic site. Please see the instructions here on how to test a PR: PCYsg-Osp-p2

* Once you have set up your WoA site, add the following filter to your `0-sandbox.php` file:
```
add_filter( 'is_launchpad_intent_post_migration_enabled', '__return_true' );
```
* I also have to comment out line 321 of `public_html/wp-content/lib/home/views.php` on my sandbox because my test site doesn't have that sticker.
* Activate the Jetpack Beta plugin with this branch of the WordPress.com Features module enabled and ensure you add the constant to your WoA test site's `wp-config.php`: `define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );`
* Then, navigate to the Customer Home page and you should see the new task.
* Task functionality will be added on the front end in https://github.com/Automattic/wp-calypso/pull/95362