### PR TITLE
Protect: Add a 30 second timeout argument to the threat history request

### DIFF
--- a/projects/plugins/protect/changelog/add-protect-history-request-timeout
+++ b/projects/plugins/protect/changelog/add-protect-history-request-timeout
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Increased threat history request timeout limit from 10 to 30 seconds.
+
+

--- a/projects/plugins/protect/src/class-scan-history.php
+++ b/projects/plugins/protect/src/class-scan-history.php
@@ -182,7 +182,7 @@ class Scan_History {
 		$response = Client::wpcom_json_api_request_as_blog(
 			$api_url,
 			'2',
-			array( 'method' => 'GET' ),
+			array( 'method' => 'GET', 'timeout' => 30 ),
 			null,
 			'wpcom'
 		);

--- a/projects/plugins/protect/src/class-scan-history.php
+++ b/projects/plugins/protect/src/class-scan-history.php
@@ -182,7 +182,10 @@ class Scan_History {
 		$response = Client::wpcom_json_api_request_as_blog(
 			$api_url,
 			'2',
-			array( 'method' => 'GET', 'timeout' => 30 ),
+			array(
+				'method'  => 'GET',
+				'timeout' => 30,
+			),
 			null,
 			'wpcom'
 		);


### PR DESCRIPTION
The default timeout is 10 seconds, which is insufficient for sites with significant threat history. While this is being fixed on the server side, increasing the timeout here will ensure slower requests are less likely to fail.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/jpop-issues/issues/9274

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add a `timeout: 30` argument to the `Client::wpcom_json_api_request_as_blog` method, to override the default value of `10` seconds.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

p1728629160314609-slack-C029WFNV69M

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the loading of threat history in Jetpack Protect, with the history request taking between 11-30 seconds to complete.
  * Sandbox the history endpoint, and add a `sleep(10)` to simulate a long request.