### PR TITLE
Map block: Do not render the actual map if in block preview mode

### DIFF
--- a/projects/plugins/jetpack/changelog/display-map-block-as-preview-if-in-block-preview-mode
+++ b/projects/plugins/jetpack/changelog/display-map-block-as-preview-if-in-block-preview-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Map block: Use block editor store preview flag to determine whether or not to display the placeholder

--- a/projects/plugins/jetpack/changelog/display-map-block-as-preview-if-in-block-preview-mode
+++ b/projects/plugins/jetpack/changelog/display-map-block-as-preview-if-in-block-preview-mode
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Map block: Use block editor store preview flag to determine whether or not to display the placeholder
+Map block: Display a static map image when the block is rendered in a pattern preview

--- a/projects/plugins/jetpack/changelog/remove-preview-attribute-from-map-block
+++ b/projects/plugins/jetpack/changelog/remove-preview-attribute-from-map-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Map: remove preview attribute. The mechanism to determine if the block is in preview mode changed internally.

--- a/projects/plugins/jetpack/extensions/blocks/map/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/map/block.json
@@ -41,10 +41,6 @@
 			"type": "string",
 			"default": "red"
 		},
-		"preview": {
-			"type": "boolean",
-			"default": false
-		},
 		"scrollToZoom": {
 			"type": "boolean",
 			"default": false
@@ -57,9 +53,5 @@
 			"default": true
 		}
 	},
-	"example": {
-		"attributes": {
-			"preview": true
-		}
-	}
+	"example": {}
 }

--- a/projects/plugins/jetpack/extensions/blocks/map/deprecated/v1/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/deprecated/v1/index.js
@@ -40,10 +40,6 @@ const attributes = {
 		type: 'string',
 		default: 'red',
 	},
-	preview: {
-		type: 'boolean',
-		default: false,
-	},
 	scrollToZoom: {
 		type: 'boolean',
 		default: false,

--- a/projects/plugins/jetpack/extensions/blocks/map/deprecated/v2/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/deprecated/v2/index.js
@@ -41,10 +41,6 @@ const attributes = {
 		type: 'string',
 		default: 'red',
 	},
-	preview: {
-		type: 'boolean',
-		default: false,
-	},
 	scrollToZoom: {
 		type: 'boolean',
 		default: false,

--- a/projects/plugins/jetpack/extensions/blocks/map/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/edit.js
@@ -243,7 +243,7 @@ const MapEdit = ( {
 				<img
 					alt={ __( 'Map Preview', 'jetpack' ) }
 					src={ mapStyleObject ? mapStyleObject.preview : previewPlaceholder }
-					style={ { width: '100%', maxHeight: '400px', objectFit: 'cover' } }
+					style={ { width: '100%', height: mapHeight || '400px', objectFit: 'cover' } }
 				/>
 			</div>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/map/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/edit.js
@@ -244,6 +244,7 @@ const MapEdit = ( {
 				<img
 					alt={ __( 'Map Preview', 'jetpack' ) }
 					src={ mapStyleObject ? mapStyleObject.preview : previewPlaceholder }
+					style={ { width: '100%', maxHeight: '400px', objectFit: 'cover' } }
 				/>
 			</div>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/map/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/edit.js
@@ -1,6 +1,11 @@
 import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
-import { BlockControls, InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	InspectorControls,
+	useBlockProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import {
 	Button,
 	ExternalLink,
@@ -10,7 +15,7 @@ import {
 	ResizableBox,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
-import { withDispatch } from '@wordpress/data';
+import { withDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { getActiveStyleName } from '../../shared/block-styles';
@@ -66,6 +71,14 @@ const MapEdit = ( {
 		mapHeight,
 		showFullscreenButton,
 	} = attributes;
+
+	const { isPreviewMode } = useSelect( select => {
+		const { getSettings } = select( blockEditorStore );
+		const settings = getSettings();
+		return {
+			isPreviewMode: settings.__unstableIsPreviewMode,
+		};
+	}, [] );
 
 	const [ addPointVisibility, setAddPointVisibility ] = useState( false );
 	const [ apiState, setApiState ] = useState( API_STATE_LOADING );
@@ -223,7 +236,7 @@ const MapEdit = ( {
 
 	let content;
 
-	if ( preview ) {
+	if ( preview || isPreviewMode ) {
 		const mapStyleObject = styles.find( styleObject => styleObject.name === mapStyle );
 
 		content = (

--- a/projects/plugins/jetpack/extensions/blocks/map/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/edit.js
@@ -67,7 +67,6 @@ const MapEdit = ( {
 		zoom,
 		mapCenter,
 		markerColor,
-		preview,
 		mapHeight,
 		showFullscreenButton,
 	} = attributes;
@@ -236,7 +235,7 @@ const MapEdit = ( {
 
 	let content;
 
-	if ( preview || isPreviewMode ) {
+	if ( isPreviewMode ) {
 		const mapStyleObject = styles.find( styleObject => styleObject.name === mapStyle );
 
 		content = (

--- a/projects/plugins/jetpack/extensions/blocks/map/test/fixtures/jetpack__map.json
+++ b/projects/plugins/jetpack/extensions/blocks/map/test/fixtures/jetpack__map.json
@@ -24,7 +24,6 @@
 				"lat": -43.391304
 			},
 			"markerColor": "red",
-			"preview": false,
 			"scrollToZoom": false,
 			"showFullscreenButton": true
 		},

--- a/projects/plugins/jetpack/extensions/blocks/map/test/fixtures/jetpack__map__deprecated-1.json
+++ b/projects/plugins/jetpack/extensions/blocks/map/test/fixtures/jetpack__map__deprecated-1.json
@@ -1,34 +1,33 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "jetpack/map",
-        "isValid": true,
-        "attributes": {
-            "points": [
-                {
-                    "placeTitle": "Williams Street",
-                    "title": "Williams Street",
-                    "caption": "15 Williams Street, Kaiapoi, The Pines Beach 7630, New Zealand",
-                    "id": "address.3454160499802812",
-                    "coordinates": {
-                        "longitude": 172.652908,
-                        "latitude": -43.391304
-                    }
-                }
-            ],
-            "mapDetails": true,
-            "zoom": 11.765903600711997,
-            "mapCenter": {
-                "lng": 172.652908,
-                "lat": -43.391304
-            },
-            "markerColor": "red",
-            "preview": false,
-            "scrollToZoom": false,
-            "className": "is-style-black-and-white",
-            "showFullscreenButton": true
-        },
-        "innerBlocks": [],
-        "originalContent": "<div class=\"wp-block-jetpack-map is-style-black-and-white\" data-map-style=\"black-and-white\" data-map-details=\"true\" data-points=\"[{&quot;placeTitle&quot;:&quot;Williams Street&quot;,&quot;title&quot;:&quot;Williams Street&quot;,&quot;caption&quot;:&quot;15 Williams Street, Kaiapoi, The Pines Beach 7630, New Zealand&quot;,&quot;id&quot;:&quot;address.3454160499802812&quot;,&quot;coordinates&quot;:{&quot;longitude&quot;:172.652908,&quot;latitude&quot;:-43.391304}}]\" data-zoom=\"11.765903600711997\" data-map-center=\"{&quot;lng&quot;:172.652908,&quot;lat&quot;:-43.391304}\" data-marker-color=\"red\"><ul><li><a href=\"https://www.google.com/maps/search/?api=1&amp;query=-43.391304,172.652908\">Williams Street</a></li></ul></div>"
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "jetpack/map",
+		"isValid": true,
+		"attributes": {
+			"points": [
+				{
+					"placeTitle": "Williams Street",
+					"title": "Williams Street",
+					"caption": "15 Williams Street, Kaiapoi, The Pines Beach 7630, New Zealand",
+					"id": "address.3454160499802812",
+					"coordinates": {
+						"longitude": 172.652908,
+						"latitude": -43.391304
+					}
+				}
+			],
+			"mapDetails": true,
+			"zoom": 11.765903600711997,
+			"mapCenter": {
+				"lng": 172.652908,
+				"lat": -43.391304
+			},
+			"markerColor": "red",
+			"scrollToZoom": false,
+			"className": "is-style-black-and-white",
+			"showFullscreenButton": true
+		},
+		"innerBlocks": [],
+		"originalContent": "<div class=\"wp-block-jetpack-map is-style-black-and-white\" data-map-style=\"black-and-white\" data-map-details=\"true\" data-points=\"[{&quot;placeTitle&quot;:&quot;Williams Street&quot;,&quot;title&quot;:&quot;Williams Street&quot;,&quot;caption&quot;:&quot;15 Williams Street, Kaiapoi, The Pines Beach 7630, New Zealand&quot;,&quot;id&quot;:&quot;address.3454160499802812&quot;,&quot;coordinates&quot;:{&quot;longitude&quot;:172.652908,&quot;latitude&quot;:-43.391304}}]\" data-zoom=\"11.765903600711997\" data-map-center=\"{&quot;lng&quot;:172.652908,&quot;lat&quot;:-43.391304}\" data-marker-color=\"red\"><ul><li><a href=\"https://www.google.com/maps/search/?api=1&amp;query=-43.391304,172.652908\">Williams Street</a></li></ul></div>"
+	}
 ]

--- a/projects/plugins/jetpack/extensions/blocks/map/test/fixtures/jetpack__map__deprecated-2.json
+++ b/projects/plugins/jetpack/extensions/blocks/map/test/fixtures/jetpack__map__deprecated-2.json
@@ -1,34 +1,33 @@
 [
-    {
-        "clientId": "_clientId_0",
-        "name": "jetpack/map",
-        "isValid": true,
-        "attributes": {
-            "points": [
-                {
-                    "placeTitle": "Williams Street",
-                    "title": "Williams Street",
-                    "caption": "15 Williams Street, Kaiapoi, The Pines Beach 7630, New Zealand",
-                    "id": "address.3454160499802812",
-                    "coordinates": {
-                        "longitude": 172.652908,
-                        "latitude": -43.391304
-                    }
-                }
-            ],
-            "mapDetails": true,
-            "zoom": 11.765903600711997,
-            "mapCenter": {
-                "lng": 172.652908,
-                "lat": -43.391304
-            },
-            "markerColor": "red",
-            "preview": false,
-            "scrollToZoom": false,
-            "showFullscreenButton": true,
-            "className": "is-style-black-and-white"
-        },
-        "innerBlocks": [],
-        "originalContent": "<div class=\"wp-block-jetpack-map is-style-black-and-white\" data-map-style=\"black-and-white\" data-map-details=\"true\" data-points=\"[{&quot;placeTitle&quot;:&quot;Williams Street&quot;,&quot;title&quot;:&quot;Williams Street&quot;,&quot;caption&quot;:&quot;15 Williams Street, Kaiapoi, The Pines Beach 7630, New Zealand&quot;,&quot;id&quot;:&quot;address.3454160499802812&quot;,&quot;coordinates&quot;:{&quot;longitude&quot;:172.652908,&quot;latitude&quot;:-43.391304}}]\" data-zoom=\"11.765903600711997\" data-map-center=\"{&quot;lng&quot;:172.652908,&quot;lat&quot;:-43.391304}\" data-marker-color=\"red\" data-show-fullscreen-button=\"true\"><ul><li><a href=\"https://www.google.com/maps/search/?api=1&amp;query=-43.391304,172.652908\">Williams Street</a></li></ul></div>"
-    }
+	{
+		"clientId": "_clientId_0",
+		"name": "jetpack/map",
+		"isValid": true,
+		"attributes": {
+			"points": [
+				{
+					"placeTitle": "Williams Street",
+					"title": "Williams Street",
+					"caption": "15 Williams Street, Kaiapoi, The Pines Beach 7630, New Zealand",
+					"id": "address.3454160499802812",
+					"coordinates": {
+						"longitude": 172.652908,
+						"latitude": -43.391304
+					}
+				}
+			],
+			"mapDetails": true,
+			"zoom": 11.765903600711997,
+			"mapCenter": {
+				"lng": 172.652908,
+				"lat": -43.391304
+			},
+			"markerColor": "red",
+			"scrollToZoom": false,
+			"showFullscreenButton": true,
+			"className": "is-style-black-and-white"
+		},
+		"innerBlocks": [],
+		"originalContent": "<div class=\"wp-block-jetpack-map is-style-black-and-white\" data-map-style=\"black-and-white\" data-map-details=\"true\" data-points=\"[{&quot;placeTitle&quot;:&quot;Williams Street&quot;,&quot;title&quot;:&quot;Williams Street&quot;,&quot;caption&quot;:&quot;15 Williams Street, Kaiapoi, The Pines Beach 7630, New Zealand&quot;,&quot;id&quot;:&quot;address.3454160499802812&quot;,&quot;coordinates&quot;:{&quot;longitude&quot;:172.652908,&quot;latitude&quot;:-43.391304}}]\" data-zoom=\"11.765903600711997\" data-map-center=\"{&quot;lng&quot;:172.652908,&quot;lat&quot;:-43.391304}\" data-marker-color=\"red\" data-show-fullscreen-button=\"true\"><ul><li><a href=\"https://www.google.com/maps/search/?api=1&amp;query=-43.391304,172.652908\">Williams Street</a></li></ul></div>"
+	}
 ]


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/93852.

## Proposed changes:

If rendering the Map block in preview mode (e.g., Patterns list) do not render the actual map but instead the placeholder image. This reduces the memory footprint and prevents crashes on iOS Safari.

https://github.com/user-attachments/assets/06cd3e24-550e-48a0-a9c7-70091ccbd3aa

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

https://github.com/Automattic/wp-calypso/issues/93852

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Follow the [Simple and Atomic instructions](https://github.com/Automattic/jetpack/pull/39768#issuecomment-2412208098) to get the correct Jetpack version running.

### Atomic

It's much easier to test the fix on mobile by testing on your WoA site. 

### Simple

Proxy `public-api.wordpress.com` and your `siteaddress.wordpress.com` on the web so you can see the map preview image within the patterns list.

| Before | After |
| ------ | ------ |
|  ![Screenshot 2024-10-14 alle 6 22 07 PM](https://github.com/user-attachments/assets/bcefb17b-89ca-463b-a916-8a7a6de96845) | ![Screenshot 2024-10-14 alle 6 21 27 PM](https://github.com/user-attachments/assets/937182d2-4500-4a03-82c2-7e74144d15a9) |