### PR TITLE
Incompatible Plugins: removes duplicator pro.

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-allows-duplicator-plugin
+++ b/projects/plugins/wpcomsh/changelog/update-allows-duplicator-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Incompatible Plugins: whitelist duplicator, duplicator pro.

--- a/projects/plugins/wpcomsh/changelog/update-allows-duplicator-plugin
+++ b/projects/plugins/wpcomsh/changelog/update-allows-duplicator-plugin
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Incompatible Plugins: whitelist duplicator, duplicator pro.
+Incompatible Plugins: whitelist duplicator pro.

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -27,8 +27,6 @@ class Jetpack_Plugin_Compatibility {
 		'better-wp-security/better-wp-security.php'        => '"better-wp-security" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'cf7-pipedrive-integration/class-cf7-pipedrive.php' => '"cf7-pipedrive-integration" has been deactivated, it interferes with site operation and is not supported on WordPress.com.',
 		'database-browser/database-browser.php'            => '"database-browser" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
-		'duplicator/duplicator.php'                        => '"duplicator" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
-		'duplicator-pro/duplicator-pro.php'                => '"duplicator-pro" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'extended-wp-reset/extended-wp-reset.php'          => '"extended-wp-reset" has been deactivated, it interferes with site operation and is not supported on WordPress.com.',
 		'file-manager-advanced/file_manager_advanced.php'  => '"file-manager-advanced" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'file-manager/file-manager.php'                    => '"file-manager" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',

--- a/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
+++ b/projects/plugins/wpcomsh/class-jetpack-plugin-compatibility.php
@@ -27,6 +27,7 @@ class Jetpack_Plugin_Compatibility {
 		'better-wp-security/better-wp-security.php'        => '"better-wp-security" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'cf7-pipedrive-integration/class-cf7-pipedrive.php' => '"cf7-pipedrive-integration" has been deactivated, it interferes with site operation and is not supported on WordPress.com.',
 		'database-browser/database-browser.php'            => '"database-browser" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
+		'duplicator/duplicator.php'                        => '"duplicator" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'extended-wp-reset/extended-wp-reset.php'          => '"extended-wp-reset" has been deactivated, it interferes with site operation and is not supported on WordPress.com.',
 		'file-manager-advanced/file_manager_advanced.php'  => '"file-manager-advanced" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',
 		'file-manager/file-manager.php'                    => '"file-manager" has been deactivated, it deletes data necessary to manage your site and is not supported on WordPress.com.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR is a collection of changes needed to enable `duplicator` and `duplicator-pro` installations in WordPress.com.
Related discussion p1728637897603379-slack-C07QQD54LKU

**WordPress.com Team**

- [ ] Calypso https://github.com/Automattic/wp-calypso/pull/95392
- [ ] WPCOM D163888-code
- [ ] [Documentation needs to be updated after a merge](https://wordpress.com/support/plugins/incompatible-plugins/#backup-plugins) 

**Duplicator Team**

- [x] `duplicator-pro` breaks  `wp-cli` commands in WordPress.com.

![image](https://github.com/user-attachments/assets/71f47d5b-5c6e-4609-b0c3-f41769d44aed)

- [x] When importing a backup the [WordPress.com](http://wordpress.com/) user wasn’t preserved and Jetpack was deactivated. Perhaps something goes off with the `wp_users` table. Solved with a workaround 

> disabled the ability to import backups created on other websites when operating on wp.com.

- [ ] `duplicator` uses `ABSPATH` to define the location of the `wp-content` directory ( or other directories ).

```
if (!function_exists('duplicator_get_abs_path')) {
    function duplicator_get_abs_path() {
        static $absPath = null;
        if (is_null($absPath)) {
            $absPath = wp_normalize_path(ABSPATH);
            if ($absPath == '//' || $absPath == '') {
                $absPath = '/';
            } else {
                $absPath = rtrim($absPath, '/');
            }
        }
        return $absPath;
    }
}
```

can be modified to

```
define('PRESSABLE_SITE_ROOT', str_replace( 'wp-content', '', WP_CONTENT_DIR));
if (!function_exists('duplicator_get_abs_path')) {
    function duplicator_get_abs_path() {
        static $absPath = null;
        if (is_null($absPath)) {
            $absPath = wp_normalize_path(PRESSABLE_SITE_ROOT);
            if ($absPath == '//' || $absPath == '') {
                $absPath = '/';
            } else {
                $absPath = rtrim($absPath, '/');
            }
        }
        return $absPath;
    }
}
```

- [ ] When extracting/installing the duplicated site, the default filename that the plugin generates is named `installer.php` and must be uploaded and then accessed directly via URL to complete the install process. This filename is blocked for security reasons by Atomic and will return a 403 Forbidden error when you attempt to access it. This can default to anything else such as `duplicator.php` or `install.php` and then the file will be accessible.

- [ ] Nice to have - Backups tend to fill storage quickly if you make multiple backups or scheduled backups. It would be cool educating the user about storage implications of multiple backups.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

* Allows `duplicator-pro` to be installed in WordPress.com. `duplicator` was not deemed as a priority for now.

## Testing instructions:
The following are related to the changes introduced from this PR, **not** related to whether all `duplicator` issues are fixed.

* Boot a WordPress.com woa developer blog and sync the code OR follow the instructions in https://github.com/Automattic/jetpack/blob/5d37c1f09ce5083c1f150ab74ff9699211988e83/projects/plugins/wpcomsh/README.md#L1-L328
* Upload `duplicator-pro` plugin ( ping me for the zip )
* Make sure you can activate it

## Does this pull request change what data or activity we track or use?
No