### PR TITLE
Post migration tasklist: Add/ssl provisioned task

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ssl-provisioned-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ssl-provisioned-task
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+adding a WPCOM task

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2826,48 +2826,7 @@ function wpcom_launchpad_is_primary_domain_wpcom() {
 		return false;
 	}
 
-	if ( ! class_exists( 'Domain_Mapping' ) || ! class_exists( 'WPCOM_Domain' ) ) {
-		return false;
-	}
-
-	$blog_id = get_current_blog_id();
-
-	$primary_domain  = wpcom_launchpad_get_primary_domain( $blog_id );
-	$is_wpcom_domain = true;
-
-	if ( null !== $primary_domain ) {
-		// @phan-suppress-next-line PhanUndeclaredClassMethod
-		$is_wpcom_domain = $primary_domain->is_wpcom_tld();
-	}
-
-	return $is_wpcom_domain;
-}
-
-/**
- * Returns the primary domain for a given blog ID.
- * This function caches the result for the current request.
- *
- * @param int $blog_id The blog ID.
- * @return WPCOM_Domain|null
- * @phan-suppress-next-line PhanUndeclaredTypeReturnType
- */
-function wpcom_launchpad_get_primary_domain( $blog_id ) {
-	static $last_blog_id;
-	static $primary_domain;
-
-	if ( $last_blog_id === $blog_id && $primary_domain !== null ) {
-		return $primary_domain;
-	}
-
-	// @phan-suppress-next-line PhanUndeclaredClassMethod
-	$primary_domain_mapping = Domain_Mapping::find_primary_by_blog_id( $blog_id );
-	if ( ! $primary_domain_mapping ) {
-		return null;
-	}
-
-	$last_blog_id = $blog_id;
-
-	// @phan-suppress-next-line PhanUndeclaredClassMethod
-	$primary_domain = new WPCOM_Domain( $primary_domain_mapping->get_domain_name() );
-	return $primary_domain;
+	$site_slug = wpcom_get_site_slug();
+	// If site_slug ends with wpcomstaging.com return true
+	return str_ends_with( $site_slug, 'wpcomstaging.com' );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2826,7 +2826,9 @@ function wpcom_launchpad_is_primary_domain_wpcom() {
 		return false;
 	}
 
-	$site_slug = wpcom_get_site_slug();
+	$url  = home_url();
+	$host = wp_parse_url( $url, PHP_URL_HOST );
+
 	// If site_slug ends with .wpcomstaging.com return true
-	return str_ends_with( $site_slug, '.wpcomstaging.com' );
+	return str_ends_with( $host, '.wpcomstaging.com' );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -2827,6 +2827,6 @@ function wpcom_launchpad_is_primary_domain_wpcom() {
 	}
 
 	$site_slug = wpcom_get_site_slug();
-	// If site_slug ends with wpcomstaging.com return true
-	return str_ends_with( $site_slug, 'wpcomstaging.com' );
+	// If site_slug ends with .wpcomstaging.com return true
+	return str_ends_with( $site_slug, '.wpcomstaging.com' );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -856,8 +856,7 @@ function wpcom_launchpad_get_task_definitions() {
 			'get_title'            => function () {
 				return __( 'Provision SSL certificate', 'jetpack-mu-wpcom' );
 			},
-			'is_complete_callback' => '__return_false',
-			'is_visible_callback'  => '__return_true',
+			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
 			'is_disabled_callback' => 'wpcom_launchpad_is_primary_domain_wpcom',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				$domain = $data['site_slug_encoded'];

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -325,6 +325,7 @@ function wpcom_launchpad_get_task_list_definitions() {
 				'review_plugins',
 				'connect_migration_domain',
 				'domain_dns_mapped',
+				'check_ssl_status',
 			),
 		),
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related https://github.com/Automattic/wp-calypso/issues/95096
https://github.com/Automattic/jetpack/pull/39686

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This change adds a new task to guide the user to provision their SSL certificate.
* The task will be disabled if the site has no primary domain associated
* The task will never be marked as complete, it will be done in a subsequent PR


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This should be tested on AT. Please follow the instructions to apply this on the comment below.

* On wpsh from your sandbox add the migration sticker to your site by running
```
> require_once ABSPATH . '/wp-content/lib/migration/migration-flow.php';
> migration_flow_add_status_sticker( YOUR_SITE_ID, 'migration-completed-diy' );
```
* Navigate to your site's home
* Verify you see the Provision SSL certificate task 
<img width="670" alt="image" src="https://github.com/user-attachments/assets/4cdc7dc2-98db-4723-ac4e-8cc4e3c24084">

* If the site you are testing with has a primary domain that doesn't end in `wpcomstaging.com` then the task should be enabled. Otherwise, it will be disabled.
* If the task is enabled, verify that when clicking on it you get redirected to `https://wordpress.com/domains/manage/[PRIMARY_DOMAIN]/edit/[PRIMARY_DOMAIN]`

