### PR TITLE
Tests: Use Ubuntu 22.04 runner for PHP 7.0 tests

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -71,9 +71,10 @@ foreach ( array( '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ) as $php ) {
 	);
 }
 
-// TODO: When WordPress 6.5 is no longer supported, this can be removed.
+// TODO: When WordPress 6.5 is no longer supported, this can be removed. Runs too slow on ubuntu-24.04 (ubuntu-latest).
 $matrix[] = array(
 	'name'                => 'PHP tests: PHP 7.0 WP previous',
+	'runner'              => 'ubuntu-22.04',
 	'script'              => 'test-php',
 	'php'                 => '7.0',
 	'wp'                  => 'previous',

--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -26,6 +26,9 @@ $default_matrix_vars = array(
 	// {string} Name for the job. Required, and must be unique.
 	'name'                => null,
 
+	// {string} Runner name as found in https://github.com/actions/runner-images/.
+	'runner'              => 'ubuntu-latest',
+
 	// {string} Composer script for the job. Required.
 	'script'              => null,
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
   run-tests:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: create-matrix
     services:
       database:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This uses the tests matrix to pass through `ubuntu-latest` as the default runner, with an override to use the `ubuntu-22.04` runner for PHP 7.0 tests.

## Proposed changes:

As of yesterday, our tests on `trunk` started timing out:

https://github.com/Automattic/jetpack/actions/workflows/tests.yml?query=branch%3Atrunk

We use `ubuntu-latest` in our workflows, and that runner is now using Ubuntu 24.04:

https://github.com/actions/runner-images/issues/10636

For some reason, PHP 7.0 + Ubuntu 24.04 has major network issues, which results in double the time to run (and in most cases, a timeout). Given nothing obvious from our end is causing this and support for PHP 7.0 will be dropped with WP 6.7 ([mid-November](https://make.wordpress.org/core/2024/09/03/roadmap-to-6-7/)), it's easiest to just switch to the old runner (`ubuntu-22.04`) for PHP 7.0 tests.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Verify the PHP 7.0 tests are on the `ubuntu-22.04` runner, e.g.:
https://github.com/Automattic/jetpack/actions/runs/11354027780/job/31580361443?pr=39779