### PR TITLE
Protect: remove unused usePolling argument from credentials query hook

### DIFF
--- a/projects/plugins/protect/changelog/fix-protect-credentials-refetch-interval
+++ b/projects/plugins/protect/changelog/fix-protect-credentials-refetch-interval
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixed background refreshing of data when credentials modal opened.
+
+

--- a/projects/plugins/protect/src/js/components/credentials-needed-modal/index.jsx
+++ b/projects/plugins/protect/src/js/components/credentials-needed-modal/index.jsx
@@ -11,7 +11,7 @@ import styles from './styles.module.scss';
 const CredentialsNeededModal = () => {
 	const queryClient = useQueryClient();
 	const { setModal } = useModal();
-	const { data: credentials } = useCredentialsQuery( { usePolling: true } );
+	const { data: credentials } = useCredentialsQuery();
 	const { siteSuffix, blogID } = window.jetpackProtectInitialState;
 
 	const handleCancelClick = () => {

--- a/projects/plugins/protect/src/js/components/credentials-needed-modal/index.jsx
+++ b/projects/plugins/protect/src/js/components/credentials-needed-modal/index.jsx
@@ -11,7 +11,7 @@ import styles from './styles.module.scss';
 const CredentialsNeededModal = () => {
 	const queryClient = useQueryClient();
 	const { setModal } = useModal();
-	const { data: credentials } = useCredentialsQuery();
+	const { data: credentials } = useCredentialsQuery( { usePolling: true } );
 	const { siteSuffix, blogID } = window.jetpackProtectInitialState;
 
 	const handleCancelClick = () => {

--- a/projects/plugins/protect/src/js/data/use-credentials-query.ts
+++ b/projects/plugins/protect/src/js/data/use-credentials-query.ts
@@ -29,9 +29,6 @@ export default function useCredentialsQuery( {
 			if ( ! usePolling ) {
 				return false;
 			}
-			if ( ! query.state.data ) {
-				return false;
-			}
 			if ( query.state.data?.length ) {
 				return false;
 			}

--- a/projects/plugins/protect/src/js/data/use-credentials-query.ts
+++ b/projects/plugins/protect/src/js/data/use-credentials-query.ts
@@ -6,14 +6,9 @@ import { QUERY_CREDENTIALS_KEY } from '../constants';
 /**
  * Credentials Query Hook
  *
- * @param {object}  args            - Args.
- * @param {boolean} args.usePolling - Use polling.
- *
  * @return {UseQueryResult} useQuery result.
  */
-export default function useCredentialsQuery( {
-	usePolling,
-}: { usePolling?: boolean } = {} ): UseQueryResult< [ Record< string, unknown > ] > {
+export default function useCredentialsQuery(): UseQueryResult< [ Record< string, unknown > ] > {
 	const { isRegistered } = useConnection( {
 		autoTrigger: false,
 		from: 'protect',
@@ -25,16 +20,6 @@ export default function useCredentialsQuery( {
 		queryKey: [ QUERY_CREDENTIALS_KEY ],
 		queryFn: API.checkCredentials,
 		initialData: window?.jetpackProtectInitialState?.credentials,
-		refetchInterval: query => {
-			if ( ! usePolling ) {
-				return false;
-			}
-			if ( query.state.data?.length ) {
-				return false;
-			}
-
-			return 5_000;
-		},
 		enabled: isRegistered,
 	} );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Removes the unused `refetchInterval` argument from the credentials query hook. We are using query invalidation to achieve automatic refreshing when applicable (i.e. when the credentials needed modal is open).

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Protect upgraded with active fixable threats, no site credentials
* Click any "auto-fix" button
* Verify via the Network tab that the credentials are re-requested as long as the modal remains open, and no credentials are returned.
