### PR TITLE
Add/newsletter preview menu item

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter-preview-menu-item
+++ b/projects/plugins/jetpack/changelog/add-newsletter-preview-menu-item
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter: Add Preview Email to the Preview Menu 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/jetpack-analytics';
 import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
@@ -79,8 +80,10 @@ const useNewsletterPreview = () => {
 	const [ isPreviewModalOpen, setIsPreviewModalOpen ] = useState( false );
 	const postId = select( 'core/editor' ).getCurrentPostId();
 
-	const openPreviewModal = useCallback( () => {
+	const openPreviewModal = useCallback( source => {
 		setIsPreviewModalOpen( true );
+		// Add tracking event
+		recordTracksEvent( 'jetpack_newsletter_preview_opened', { source } );
 	}, [] );
 
 	const closePreviewModal = useCallback( () => {
@@ -99,7 +102,7 @@ const NewsletterEditor = () => {
 			<SubscribePanels />
 			{ shouldShowNewsletterMenu() && (
 				<>
-					<PluginPreviewMenuItem onClick={ openPreviewModal } icon={ send }>
+					<PluginPreviewMenuItem onClick={ () => openPreviewModal( 'preview_menu' ) } icon={ send }>
 						{ __( 'Email Preview', 'jetpack' ) }
 					</PluginPreviewMenuItem>
 					<NewsletterPreviewModal
@@ -107,7 +110,7 @@ const NewsletterEditor = () => {
 						onClose={ closePreviewModal }
 						postId={ postId }
 					/>
-					<NewsletterMenu openPreviewModal={ openPreviewModal } />
+					<NewsletterMenu openPreviewModal={ () => openPreviewModal( 'newsletter_menu' ) } />
 				</>
 			) }
 			<CommandPalette />

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -1,13 +1,17 @@
-import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
+import { registerJetpackPlugin, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
+import { PluginPreviewMenuItem } from '@wordpress/editor';
+import { useState } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
-import { atSymbol } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { atSymbol, send } from '@wordpress/icons';
 import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
 import metadata from './block.json';
 import CommandPalette from './command-palette';
 import deprecated from './deprecated';
 import edit from './edit';
+import { NewsletterPreviewModal } from './email-preview';
 import NewsletterMenu from './menu';
 import SubscribePanels from './panel';
 
@@ -71,13 +75,44 @@ const shouldShowNewsletterMenu = () => {
 	return isPost;
 };
 
+const SubscriptionsEditorAdditions = () => {
+	const [ isPreviewModalOpen, setIsPreviewModalOpen ] = useState( false );
+	const { tracks } = useAnalytics();
+
+	const postId = select( 'core/editor' ).getCurrentPostId();
+
+	return (
+		<>
+			<PluginPreviewMenuItem
+				onClick={ () => {
+					tracks.recordEvent( 'jetpack_newsletter_preview_menu_item_click' );
+					setIsPreviewModalOpen( true );
+				} }
+				icon={ send }
+			>
+				{ __( 'Email Preview', 'jetpack' ) }
+			</PluginPreviewMenuItem>
+			<NewsletterPreviewModal
+				isOpen={ isPreviewModalOpen }
+				onClose={ () => setIsPreviewModalOpen( false ) }
+				postId={ postId }
+			/>
+		</>
+	);
+};
+
 // Registers slot/fill panels defined via settings.render and command palette commands
 registerJetpackPlugin( blockName, {
 	render: () => {
 		return (
 			<>
 				<SubscribePanels />
-				{ shouldShowNewsletterMenu() && <NewsletterMenu /> }
+				{ shouldShowNewsletterMenu() && (
+					<>
+						<SubscriptionsEditorAdditions />
+						<NewsletterMenu />
+					</>
+				) }
 				<CommandPalette />
 			</>
 		);

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -104,9 +104,14 @@ const NewsletterEditor = () => {
 			<SubscribePanels />
 			{ shouldShowNewsletterMenu() && (
 				<>
-					<PluginPreviewMenuItem onClick={ () => openPreviewModal( 'preview_menu' ) } icon={ send }>
-						{ __( 'Email Preview', 'jetpack' ) }
-					</PluginPreviewMenuItem>
+					{ PluginPreviewMenuItem ? (
+						<PluginPreviewMenuItem
+							onClick={ () => openPreviewModal( 'preview_menu' ) }
+							icon={ send }
+						>
+							{ __( 'Email Preview', 'jetpack' ) }
+						</PluginPreviewMenuItem>
+					) : null }
 					<NewsletterPreviewModal
 						isOpen={ isPreviewModalOpen }
 						onClose={ closePreviewModal }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -1,5 +1,4 @@
-import { recordTracksEvent } from '@automattic/jetpack-analytics';
-import { registerJetpackPlugin } from '@automattic/jetpack-shared-extension-utils';
+import { registerJetpackPlugin, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
 import { PluginPreviewMenuItem } from '@wordpress/editor';
@@ -79,12 +78,15 @@ const shouldShowNewsletterMenu = () => {
 const useNewsletterPreview = () => {
 	const [ isPreviewModalOpen, setIsPreviewModalOpen ] = useState( false );
 	const postId = select( 'core/editor' ).getCurrentPostId();
+	const { tracks } = useAnalytics();
 
-	const openPreviewModal = useCallback( source => {
-		setIsPreviewModalOpen( true );
-		// Add tracking event
-		recordTracksEvent( 'jetpack_newsletter_preview_opened', { source } );
-	}, [] );
+	const openPreviewModal = useCallback(
+		source => {
+			setIsPreviewModalOpen( true );
+			tracks.recordEvent( 'jetpack_newsletter_preview_opened', { source } );
+		},
+		[ tracks ]
+	);
 
 	const closePreviewModal = useCallback( () => {
 		setIsPreviewModalOpen( false );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/editor.js
@@ -109,7 +109,7 @@ const NewsletterEditor = () => {
 							onClick={ () => openPreviewModal( 'preview_menu' ) }
 							icon={ send }
 						>
-							{ __( 'Email Preview', 'jetpack' ) }
+							{ __( 'Email preview', 'jetpack' ) }
 						</PluginPreviewMenuItem>
 					) : null }
 					<NewsletterPreviewModal

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -9,11 +9,10 @@ import { META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS } from '../../shared/memberships/
 import { useAccessLevel } from '../../shared/memberships/edit';
 import { NewsletterEmailDocumentSettings } from '../../shared/memberships/settings';
 import SubscribersAffirmation from '../../shared/memberships/subscribers-affirmation';
-import { NewsletterPreviewModal, NewsletterTestEmailModal } from './email-preview';
+import { NewsletterTestEmailModal } from './email-preview';
 import { SendIcon } from './icons';
 
-const NewsletterMenu = () => {
-	const [ isPreviewModalOpen, setIsPreviewModalOpen ] = useState( false );
+const NewsletterMenu = ( { openPreviewModal } ) => {
 	const [ isTestEmailModalOpen, setIsTestEmailModalOpen ] = useState( false );
 
 	const { postId, postType, postStatus, meta } = useSelect(
@@ -34,8 +33,6 @@ const NewsletterMenu = () => {
 	const connectUrl = `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/connection`;
 	const shouldPromptForConnection = ! isSimpleSite() && ! isUserConnected;
 
-	const openPreviewModal = () => setIsPreviewModalOpen( true );
-	const closePreviewModal = () => setIsPreviewModalOpen( false );
 	const openTestEmailModal = () => setIsTestEmailModalOpen( true );
 	const closeTestEmailModal = () => setIsTestEmailModalOpen( false );
 
@@ -74,11 +71,6 @@ const NewsletterMenu = () => {
 										{ __( 'Send test email', 'jetpack' ) }
 									</Button>
 								</HStack>
-								<NewsletterPreviewModal
-									isOpen={ isPreviewModalOpen }
-									onClose={ closePreviewModal }
-									postId={ postId }
-								/>
 								<NewsletterTestEmailModal
 									isOpen={ isTestEmailModalOpen }
 									onClose={ closeTestEmailModal }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add an Email Preview item to the Preview Menu

<img width="309" alt="Screenshot 2024-10-16 at 3 59 03 PM" src="https://github.com/user-attachments/assets/3834ff38-4247-4ab1-ac27-af01226b0def">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor and check that the ‘Preview Email’ menu appears. When you click it, the preview modal should open.
* Please check that there are no regressions in the Newsletter menu.
