### PR TITLE
Related Posts: only enable on all singular views in block themes

### DIFF
--- a/projects/plugins/jetpack/changelog/update-related-posts-availability-singular-views
+++ b/projects/plugins/jetpack/changelog/update-related-posts-availability-singular-views
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Related Posts: refine how related posts are made available on singular views in block themes.

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -1883,12 +1883,20 @@ EOT;
 	/**
 	 * Determines if the current post is able to use related posts.
 	 *
-	 * @since 14.0 Checks for singular instead of single to allow usage on non-posts CPTs.
+	 * @since 14.0 Checks for singular instead of single to allow usage on non-posts CPTs in block themes.
 	 * @uses self::get_options, is_admin, is_singular, apply_filters
 	 * @return bool
 	 */
 	protected function enabled_for_request() {
-		$enabled = is_singular()
+		/*
+		 * On block themes, allow usage on any singular view (post, page, CPT).
+		 * On classic themes, only allow usage on single posts by default.
+		 */
+		$enabled_on_singular_views = wp_is_block_theme()
+			? is_singular()
+			: is_single();
+
+		$enabled = $enabled_on_singular_views
 			&& ! is_attachment()
 			&& ! is_admin()
 			&& ! is_embed()


### PR DESCRIPTION
Fixes #39783

## Proposed changes:

This is a follow-up to #39730. Instead of enabling related posts in all singular views for every theme, keep relying on the `jetpack_relatedposts_filter_enabled_for_request` filter to enable theme in classic themes. Block themes will get them for every singular view by default, but classic themes will continue to only get them only for posts.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> This will need to be tested with a classic theme like Twenty Ten, and a block-based theme like Twenty Twenty Four.

* Start with a site that's connected to WordPress.com, with many published posts and pages, and where you've activated the Related Posts module.
* Activate the Twenty Ten theme.
* Visit the frontend for any page.
    * You should not see any Related Posts at the bottom of the page.
* Visit the frontend for any post.
    * You should see Related Posts, with the adequate styling, there.
* Now switch to the Twenty Twenty Four theme
* Go to Appearance > Editor > Templates > Single Posts
* Add a Related Posts block at the bottom of the posts.
* Go to Appearance > Editor > Templates > Pages
* Add a Related Posts block at the bottom of the pages.
* Visit the frontend for both a post and a page.
    * The related posts should be displayed nicely there.
