### PR TITLE
Jetpack: Stats: Fix csv trailing newline handling

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-stats-explode-trailing-newline
+++ b/projects/plugins/jetpack/changelog/fix-stats-explode-trailing-newline
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix bug in #39665 related to a trailing newline in the CSV data.
+
+

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -1668,7 +1668,7 @@ function stats_get_remote_csv( $url ) {
  */
 function stats_str_getcsv( $csv ) {
 	// @todo Correctly handle embedded newlines. Note, despite claims online, `str_getcsv( $csv, "\n" )` does not actually work.
-	$lines = explode( "\n", $csv );
+	$lines = explode( "\n", rtrim( $csv, "\n" ) );
 	return array_map(
 		function ( $line ) {
 			// @todo When we drop support for PHP <7.4, consider passing empty-string for `$escape` here for better spec compatibility.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
When #39665 switched from incorrectly using `str_getcsv( $csv, "\n" )` to `explode()`, a minor difference between the two was unnoticed: the former does not produce an empty element at the end of the result on a trailing newline, while the latter does.

Add an `rtrim` on the data to ensure there isn't a trailing newline.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1729086256595799/1729061294.312889-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not sure how to correctly trigger this, but I found going to `/wp-admin/admin.php?page=stats&noheader=1&dashboard=1` seems to do it. Note you also need at least some visits to the site. You'll also have to make sure the 'stats_cache' option is cleared.