### PR TITLE
Social: Fix OG tag conflicts with Jetpack Beta

### DIFF
--- a/projects/plugins/social/changelog/fix-social-og-tags-jetpack-dev-path
+++ b/projects/plugins/social/changelog/fix-social-og-tags-jetpack-dev-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Added Jetpack Beta's slug to Social OG conflicting plugins

--- a/projects/plugins/social/src/class-meta-tags.php
+++ b/projects/plugins/social/src/class-meta-tags.php
@@ -23,6 +23,7 @@ class Meta_Tags {
 	 */
 	private $open_graph_conflicting_plugins = array(
 		'jetpack/jetpack.php',                                   // The Jetpack plugin adds its own meta tags.
+		'jetpack-dev/jetpack.php',                               // Jetpack's location with the beta plugin.
 		'2-click-socialmedia-buttons/2-click-socialmedia-buttons.php', // 2 Click Social Media Buttons.
 		'add-link-to-facebook/add-link-to-facebook.php',         // Add Link to Facebook.
 		'add-meta-tags/add-meta-tags.php',                       // Add Meta Tags.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes an issue when with Jetpack Beta's Jetpack version Social still echos it's own OG tags.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added the other Jetpack path

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1729105462136409-slack-C02JJ910CNL
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On your JT/JN site have Social active, and Jetpack active via the Jetpack Beta plugin.
* Without this change you should have duplicated OG tags, one pack for Social, one for Jetpack
* With this change applied you should only see Jetpack's

#### Before
![CleanShot 2024-10-16 at 22 10 40 png](https://github.com/user-attachments/assets/cd75a17d-6dc7-496d-a66e-6b831b7cfe42)

#### After
![CleanShot 2024-10-16 at 22 10 04 png](https://github.com/user-attachments/assets/7b0d7642-1a4f-4313-9c69-c8e1816bb88e)
