### PR TITLE
Social | Initial State: Migrate URLs on Social admin page

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,7 +589,7 @@ importers:
         version: 4.9.1(webpack@5.94.0)
       webpack-dev-middleware:
         specifier: 5.3.4
-        version: 5.3.4(webpack@5.94.0)
+        version: 5.3.4(webpack@5.94.0(webpack-cli@4.9.1))
 
   projects/js-packages/eslint-changed:
     dependencies:
@@ -668,7 +668,7 @@ importers:
     devDependencies:
       '@wordpress/dependency-extraction-webpack-plugin':
         specifier: 6.9.0
-        version: 6.9.0(webpack@5.94.0)
+        version: 6.9.0(webpack@5.94.0(webpack-cli@4.9.1))
       '@wordpress/i18n':
         specifier: 5.9.0
         version: 5.9.0
@@ -1402,7 +1402,7 @@ importers:
         version: 8.3.5(storybook@8.3.5)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.3(webpack@5.94.0)
+        version: 3.0.3(webpack@5.94.0(webpack-cli@4.9.1))
       '@storybook/blocks':
         specifier: 8.3.5
         version: 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)
@@ -1417,7 +1417,7 @@ importers:
         version: 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)
       '@storybook/react-webpack5':
         specifier: 8.3.5
-        version: 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)
+        version: 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))
       '@storybook/source-loader':
         specifier: 8.3.5
         version: 8.3.5(storybook@8.3.5)
@@ -1456,16 +1456,16 @@ importers:
         version: 2.9.2
       babel-loader:
         specifier: 9.1.2
-        version: 9.1.2(@babel/core@7.24.7)(webpack@5.94.0)
+        version: 9.1.2(@babel/core@7.24.7)(webpack@5.94.0(webpack-cli@4.9.1))
       babel-plugin-inline-json-import:
         specifier: 0.3.2
         version: 0.3.2
       css-loader:
         specifier: 6.5.1
-        version: 6.5.1(webpack@5.94.0)
+        version: 6.5.1(webpack@5.94.0(webpack-cli@4.9.1))
       esbuild-loader:
         specifier: 3.0.1
-        version: 3.0.1(webpack@5.94.0)
+        version: 3.0.1(webpack@5.94.0(webpack-cli@4.9.1))
       jest:
         specifier: 29.7.0
         version: 29.7.0
@@ -1477,7 +1477,7 @@ importers:
         version: 8.4.31
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -1495,7 +1495,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       storybook:
         specifier: 8.3.5
         version: 8.3.5
@@ -1504,7 +1504,7 @@ importers:
         version: 5.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       style-loader:
         specifier: 2.0.0
-        version: 2.0.0(webpack@5.94.0)
+        version: 2.0.0(webpack@5.94.0(webpack-cli@4.9.1))
       ts-dedent:
         specifier: 2.2.0
         version: 2.2.0
@@ -1597,7 +1597,7 @@ importers:
         version: link:../i18n-loader-webpack-plugin
       '@automattic/webpack-rtl-plugin':
         specifier: 6.0.0
-        version: 6.0.0(webpack@5.94.0)
+        version: 6.0.0(webpack@5.94.0(webpack-cli@4.9.1))
       '@babel/compat-data':
         specifier: 7.24.7
         version: 7.24.7
@@ -1618,16 +1618,16 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@cerner/duplicate-package-checker-webpack-plugin':
         specifier: 2.3.0
-        version: 2.3.0(webpack@5.94.0)
+        version: 2.3.0(webpack@5.94.0(webpack-cli@4.9.1))
       '@wordpress/browserslist-config':
         specifier: 6.9.0
         version: 6.9.0
       '@wordpress/dependency-extraction-webpack-plugin':
         specifier: 6.9.0
-        version: 6.9.0(webpack@5.94.0)
+        version: 6.9.0(webpack@5.94.0(webpack-cli@4.9.1))
       babel-loader:
         specifier: 9.1.2
-        version: 9.1.2(@babel/core@7.24.7)(webpack@5.94.0)
+        version: 9.1.2(@babel/core@7.24.7)(webpack@5.94.0(webpack-cli@4.9.1))
       babel-plugin-polyfill-corejs3:
         specifier: 0.10.6
         version: 0.10.6(@babel/core@7.24.7)
@@ -1639,22 +1639,22 @@ importers:
         version: 3.38.1
       css-loader:
         specifier: 6.5.1
-        version: 6.5.1(webpack@5.94.0)
+        version: 6.5.1(webpack@5.94.0(webpack-cli@4.9.1))
       css-minimizer-webpack-plugin:
         specifier: 5.0.1
-        version: 5.0.1(webpack@5.94.0)
+        version: 5.0.1(webpack@5.94.0(webpack-cli@4.9.1))
       fork-ts-checker-webpack-plugin:
         specifier: 9.0.2
-        version: 9.0.2(typescript@5.0.4)(webpack@5.94.0)
+        version: 9.0.2(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1))
       mini-css-extract-plugin:
         specifier: 2.9.1
-        version: 2.9.1(webpack@5.94.0)
+        version: 2.9.1(webpack@5.94.0(webpack-cli@4.9.1))
       terser-webpack-plugin:
         specifier: 5.3.3
-        version: 5.3.3(webpack@5.94.0)
+        version: 5.3.3(webpack@5.94.0(webpack-cli@4.9.1))
       thread-loader:
         specifier: 3.0.4
-        version: 3.0.4(webpack@5.94.0)
+        version: 3.0.4(webpack@5.94.0(webpack-cli@4.9.1))
     devDependencies:
       '@babel/core':
         specifier: 7.24.7
@@ -1788,7 +1788,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -1858,7 +1858,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -1885,7 +1885,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -1923,13 +1923,13 @@ importers:
         version: 8.4.31
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
       sass:
         specifier: 1.64.1
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -1981,7 +1981,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -2081,7 +2081,7 @@ importers:
         version: 2.1.1
       copy-webpack-plugin:
         specifier: 11.0.0
-        version: 11.0.0(webpack@5.94.0)
+        version: 11.0.0(webpack@5.94.0(webpack-cli@4.9.1))
       email-validator:
         specifier: 2.0.4
         version: 2.0.4
@@ -2185,10 +2185,10 @@ importers:
         version: 8.4.31
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -2338,7 +2338,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -2362,7 +2362,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -2408,13 +2408,13 @@ importers:
         version: 8.4.31
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
       sass:
         specifier: 1.64.1
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -2550,7 +2550,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       storybook:
         specifier: 8.3.5
         version: 8.3.5
@@ -2576,7 +2576,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       tslib:
         specifier: 2.5.0
         version: 2.5.0
@@ -2753,7 +2753,7 @@ importers:
         version: 6.9.0
       '@wordpress/dependency-extraction-webpack-plugin':
         specifier: 6.9.0
-        version: 6.9.0(webpack@5.94.0)
+        version: 6.9.0(webpack@5.94.0(webpack-cli@4.9.1))
       autoprefixer:
         specifier: 10.4.14
         version: 10.4.14(postcss@8.4.31)
@@ -2780,7 +2780,7 @@ importers:
         version: 12.1.7(postcss@8.4.31)
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
       prettier:
         specifier: npm:wp-prettier@3.0.3
         version: wp-prettier@3.0.3
@@ -2789,7 +2789,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       size-limit:
         specifier: 11.1.6
         version: 11.1.6(@size-limit/preset-app@11.1.6)
@@ -2947,7 +2947,7 @@ importers:
         version: 10.4.14(postcss@8.4.31)
       copy-webpack-plugin:
         specifier: 11.0.0
-        version: 11.0.0(webpack@5.94.0)
+        version: 11.0.0(webpack@5.94.0(webpack-cli@4.9.1))
       jest:
         specifier: 29.7.0
         version: 29.7.0
@@ -2962,7 +2962,7 @@ importers:
         version: 12.1.7(postcss@8.4.31)
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
       require-from-string:
         specifier: 2.0.2
         version: 2.0.2
@@ -2971,7 +2971,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       storybook:
         specifier: 8.3.5
         version: 8.3.5
@@ -3128,7 +3128,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -3194,7 +3194,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -3279,7 +3279,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -3336,7 +3336,7 @@ importers:
         version: 2.1.1
       copy-webpack-plugin:
         specifier: 11.0.0
-        version: 11.0.0(webpack@5.94.0)
+        version: 11.0.0(webpack@5.94.0(webpack-cli@4.9.1))
       history:
         specifier: 5.3.0
         version: 5.3.0
@@ -3430,7 +3430,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       storybook:
         specifier: 8.3.5
         version: 8.3.5
@@ -3530,7 +3530,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -3639,7 +3639,7 @@ importers:
         version: 29.3.1(@babel/core@7.24.7)
       css-loader:
         specifier: 6.5.1
-        version: 6.5.1(webpack@5.94.0)
+        version: 6.5.1(webpack@5.94.0(webpack-cli@4.9.1))
       glob:
         specifier: 10.4.1
         version: 10.4.1
@@ -3654,7 +3654,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -3853,7 +3853,7 @@ importers:
         version: 0.7.0
       copy-webpack-plugin:
         specifier: 11.0.0
-        version: 11.0.0(webpack@5.94.0)
+        version: 11.0.0(webpack@5.94.0(webpack-cli@4.9.1))
       crypto-js:
         specifier: 4.2.0
         version: 4.2.0
@@ -4071,13 +4071,13 @@ importers:
         version: 8.4.31
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
       regenerator-runtime:
         specifier: 0.13.9
         version: 0.13.9
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -4165,7 +4165,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -4282,7 +4282,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -4420,13 +4420,13 @@ importers:
         version: 12.1.7(postcss@8.4.31)
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
       sass:
         specifier: 1.64.1
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -4517,7 +4517,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -4622,7 +4622,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -14311,7 +14311,7 @@ snapshots:
 
   '@automattic/viewport@1.0.0': {}
 
-  '@automattic/webpack-rtl-plugin@6.0.0(webpack@5.94.0)':
+  '@automattic/webpack-rtl-plugin@6.0.0(webpack@5.94.0(webpack-cli@4.9.1))':
     dependencies:
       rtlcss: 3.5.0
       webpack: 5.94.0(webpack-cli@4.9.1)
@@ -15195,7 +15195,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@cerner/duplicate-package-checker-webpack-plugin@2.3.0(webpack@5.94.0)':
+  '@cerner/duplicate-package-checker-webpack-plugin@2.3.0(webpack@5.94.0(webpack-cli@4.9.1))':
     dependencies:
       chalk: 4.1.2
       find-root: 1.1.0
@@ -16489,21 +16489,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@size-limit/file@11.1.6(size-limit@11.1.6)':
+  '@size-limit/file@11.1.6(size-limit@11.1.6(@size-limit/preset-app@11.1.6))':
     dependencies:
       size-limit: 11.1.6(@size-limit/preset-app@11.1.6)
 
   '@size-limit/preset-app@11.1.6(size-limit@11.1.6)':
     dependencies:
-      '@size-limit/file': 11.1.6(size-limit@11.1.6)
-      '@size-limit/time': 11.1.6(size-limit@11.1.6)
+      '@size-limit/file': 11.1.6(size-limit@11.1.6(@size-limit/preset-app@11.1.6))
+      '@size-limit/time': 11.1.6(size-limit@11.1.6(@size-limit/preset-app@11.1.6))
       size-limit: 11.1.6(@size-limit/preset-app@11.1.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@size-limit/time@11.1.6(size-limit@11.1.6)':
+  '@size-limit/time@11.1.6(size-limit@11.1.6(@size-limit/preset-app@11.1.6))':
     dependencies:
       estimo: 3.0.3
       size-limit: 11.1.6(@size-limit/preset-app@11.1.6)
@@ -16632,10 +16632,10 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.3.5
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.3(webpack@5.94.0)':
+  '@storybook/addon-webpack5-compiler-babel@3.0.3(webpack@5.94.0(webpack-cli@4.9.1))':
     dependencies:
       '@babel/core': 7.24.7
-      babel-loader: 9.2.1(@babel/core@7.24.7)(webpack@5.94.0)
+      babel-loader: 9.2.1(@babel/core@7.24.7)(webpack@5.94.0(webpack-cli@4.9.1))
     transitivePeerDependencies:
       - supports-color
       - webpack
@@ -16661,7 +16661,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-webpack5@8.3.5(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)':
+  '@storybook/builder-webpack5@8.3.5(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))':
     dependencies:
       '@storybook/core-webpack': 8.3.5(storybook@8.3.5)
       '@types/node': 22.7.4
@@ -16670,25 +16670,25 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.1
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.94.0)
+      css-loader: 6.11.0(webpack@5.94.0(webpack-cli@4.9.1))
       es-module-lexer: 1.5.4
       express: 4.21.1
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.0.4)(webpack@5.94.0)
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1))
       fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.0(webpack@5.94.0)
+      html-webpack-plugin: 5.6.0(webpack@5.94.0(webpack-cli@4.9.1))
       magic-string: 0.30.11
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.5.2
       storybook: 8.3.5
-      style-loader: 3.3.4(webpack@5.94.0)
-      terser-webpack-plugin: 5.3.3(webpack@5.94.0)
+      style-loader: 3.3.4(webpack@5.94.0(webpack-cli@4.9.1))
+      terser-webpack-plugin: 5.3.3(webpack@5.94.0(webpack-cli@4.9.1))
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
       util-deprecate: 1.0.2
       webpack: 5.94.0(webpack-cli@4.9.1)
-      webpack-dev-middleware: 6.1.3(webpack@5.94.0)
+      webpack-dev-middleware: 6.1.3(webpack@5.94.0(webpack-cli@4.9.1))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -16769,11 +16769,11 @@ snapshots:
     dependencies:
       storybook: 8.3.5
 
-  '@storybook/preset-react-webpack@8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)':
+  '@storybook/preset-react-webpack@8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))':
     dependencies:
       '@storybook/core-webpack': 8.3.5(storybook@8.3.5)
       '@storybook/react': 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.0.4)(webpack@5.94.0)
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1))
       '@types/node': 22.7.4
       '@types/semver': 7.5.8
       find-up: 5.0.0
@@ -16801,7 +16801,7 @@ snapshots:
     dependencies:
       storybook: 8.3.5
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.0.4)(webpack@5.94.0)':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1))':
     dependencies:
       debug: 4.3.4
       endent: 2.1.0
@@ -16821,10 +16821,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.3.5
 
-  '@storybook/react-webpack5@8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)':
+  '@storybook/react-webpack5@8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))':
     dependencies:
-      '@storybook/builder-webpack5': 8.3.5(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)
-      '@storybook/preset-react-webpack': 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)
+      '@storybook/builder-webpack5': 8.3.5(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))
+      '@storybook/preset-react-webpack': 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))
       '@storybook/react': 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)
       '@types/node': 22.7.4
       react: 18.3.1
@@ -17724,17 +17724,17 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@1.2.0(webpack-cli@4.9.1)(webpack@5.94.0)':
+  '@webpack-cli/configtest@1.2.0(webpack-cli@4.9.1(webpack@5.94.0))(webpack@5.94.0(webpack-cli@4.9.1))':
     dependencies:
       webpack: 5.94.0(webpack-cli@4.9.1)
       webpack-cli: 4.9.1(webpack@5.94.0)
 
-  '@webpack-cli/info@1.5.0(webpack-cli@4.9.1)':
+  '@webpack-cli/info@1.5.0(webpack-cli@4.9.1(webpack@5.94.0))':
     dependencies:
       envinfo: 7.14.0
       webpack-cli: 4.9.1(webpack@5.94.0)
 
-  '@webpack-cli/serve@1.7.0(webpack-cli@4.9.1)':
+  '@webpack-cli/serve@1.7.0(webpack-cli@4.9.1(webpack@5.94.0))':
     dependencies:
       webpack-cli: 4.9.1(webpack@5.94.0)
 
@@ -18558,7 +18558,7 @@ snapshots:
       moment: 2.29.4
       moment-timezone: 0.5.46
 
-  '@wordpress/dependency-extraction-webpack-plugin@6.9.0(webpack@5.94.0)':
+  '@wordpress/dependency-extraction-webpack-plugin@6.9.0(webpack@5.94.0(webpack-cli@4.9.1))':
     dependencies:
       json2php: 0.0.7
       webpack: 5.94.0(webpack-cli@4.9.1)
@@ -19893,14 +19893,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.1.2(@babel/core@7.24.7)(webpack@5.94.0):
+  babel-loader@9.1.2(@babel/core@7.24.7)(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 3.3.2
       schema-utils: 4.2.0
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  babel-loader@9.2.1(@babel/core@7.24.7)(webpack@5.94.0):
+  babel-loader@9.2.1(@babel/core@7.24.7)(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 4.0.0
@@ -20510,7 +20510,7 @@ snapshots:
 
   cookie@0.7.1: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.94.0):
+  copy-webpack-plugin@11.0.0(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -20589,7 +20589,7 @@ snapshots:
     dependencies:
       postcss: 8.4.31
 
-  css-loader@6.11.0(webpack@5.94.0):
+  css-loader@6.11.0(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
@@ -20602,7 +20602,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  css-loader@6.5.1(webpack@5.94.0):
+  css-loader@6.5.1(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -20614,7 +20614,7 @@ snapshots:
       semver: 7.5.2
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  css-minimizer-webpack-plugin@5.0.1(webpack@5.94.0):
+  css-minimizer-webpack-plugin@5.0.1(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       cssnano: 6.1.2(postcss@8.4.31)
@@ -21160,7 +21160,7 @@ snapshots:
 
   es6-error@4.1.1: {}
 
-  esbuild-loader@3.0.1(webpack@5.94.0):
+  esbuild-loader@3.0.1(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       esbuild: 0.17.19
       get-tsconfig: 4.8.1
@@ -21813,7 +21813,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.0.4)(webpack@5.94.0):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       '@babel/code-frame': 7.25.7
       chalk: 4.1.2
@@ -21830,7 +21830,7 @@ snapshots:
       typescript: 5.0.4
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.0.4)(webpack@5.94.0):
+  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       '@babel/code-frame': 7.25.7
       chalk: 4.1.2
@@ -22176,7 +22176,7 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0):
+  html-webpack-plugin@5.6.0(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -23796,7 +23796,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.1(webpack@5.94.0):
+  mini-css-extract-plugin@2.9.1(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
@@ -24327,7 +24327,7 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.47
 
-  postcss-loader@6.2.0(postcss@8.4.31)(webpack@5.94.0):
+  postcss-loader@6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
@@ -25288,7 +25288,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@12.4.0(sass@1.64.1)(webpack@5.94.0):
+  sass-loader@12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
@@ -25747,13 +25747,13 @@ snapshots:
 
   style-inject@0.3.0: {}
 
-  style-loader@2.0.0(webpack@5.94.0):
+  style-loader@2.0.0(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  style-loader@3.3.4(webpack@5.94.0):
+  style-loader@3.3.4(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       webpack: 5.94.0(webpack-cli@4.9.1)
 
@@ -25920,7 +25920,7 @@ snapshots:
     dependencies:
       memoizerific: 1.11.3
 
-  terser-webpack-plugin@5.3.10(webpack@5.94.0):
+  terser-webpack-plugin@5.3.10(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -25929,7 +25929,7 @@ snapshots:
       terser: 5.34.1
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  terser-webpack-plugin@5.3.3(webpack@5.94.0):
+  terser-webpack-plugin@5.3.3(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -25959,7 +25959,7 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  thread-loader@3.0.4(webpack@5.94.0):
+  thread-loader@3.0.4(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.0
@@ -26415,9 +26415,9 @@ snapshots:
   webpack-cli@4.9.1(webpack@5.94.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.9.1)(webpack@5.94.0)
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.9.1)
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.9.1)
+      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.9.1(webpack@5.94.0))(webpack@5.94.0(webpack-cli@4.9.1))
+      '@webpack-cli/info': 1.5.0(webpack-cli@4.9.1(webpack@5.94.0))
+      '@webpack-cli/serve': 1.7.0(webpack-cli@4.9.1(webpack@5.94.0))
       colorette: 2.0.20
       commander: 7.2.0
       execa: 5.1.1
@@ -26428,7 +26428,7 @@ snapshots:
       webpack: 5.94.0(webpack-cli@4.9.1)
       webpack-merge: 5.10.0
 
-  webpack-dev-middleware@5.3.4(webpack@5.94.0):
+  webpack-dev-middleware@5.3.4(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -26437,7 +26437,7 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  webpack-dev-middleware@6.1.3(webpack@5.94.0):
+  webpack-dev-middleware@6.1.3(webpack@5.94.0(webpack-cli@4.9.1)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -26490,7 +26490,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
+      terser-webpack-plugin: 5.3.10(webpack@5.94.0(webpack-cli@4.9.1))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,7 +589,7 @@ importers:
         version: 4.9.1(webpack@5.94.0)
       webpack-dev-middleware:
         specifier: 5.3.4
-        version: 5.3.4(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 5.3.4(webpack@5.94.0)
 
   projects/js-packages/eslint-changed:
     dependencies:
@@ -668,7 +668,7 @@ importers:
     devDependencies:
       '@wordpress/dependency-extraction-webpack-plugin':
         specifier: 6.9.0
-        version: 6.9.0(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.9.0(webpack@5.94.0)
       '@wordpress/i18n':
         specifier: 5.9.0
         version: 5.9.0
@@ -1402,7 +1402,7 @@ importers:
         version: 8.3.5(storybook@8.3.5)
       '@storybook/addon-webpack5-compiler-babel':
         specifier: ^3.0.3
-        version: 3.0.3(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 3.0.3(webpack@5.94.0)
       '@storybook/blocks':
         specifier: 8.3.5
         version: 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)
@@ -1417,7 +1417,7 @@ importers:
         version: 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)
       '@storybook/react-webpack5':
         specifier: 8.3.5
-        version: 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))
+        version: 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)
       '@storybook/source-loader':
         specifier: 8.3.5
         version: 8.3.5(storybook@8.3.5)
@@ -1456,16 +1456,16 @@ importers:
         version: 2.9.2
       babel-loader:
         specifier: 9.1.2
-        version: 9.1.2(@babel/core@7.24.7)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 9.1.2(@babel/core@7.24.7)(webpack@5.94.0)
       babel-plugin-inline-json-import:
         specifier: 0.3.2
         version: 0.3.2
       css-loader:
         specifier: 6.5.1
-        version: 6.5.1(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.5.1(webpack@5.94.0)
       esbuild-loader:
         specifier: 3.0.1
-        version: 3.0.1(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 3.0.1(webpack@5.94.0)
       jest:
         specifier: 29.7.0
         version: 29.7.0
@@ -1477,7 +1477,7 @@ importers:
         version: 8.4.31
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -1495,7 +1495,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       storybook:
         specifier: 8.3.5
         version: 8.3.5
@@ -1504,7 +1504,7 @@ importers:
         version: 5.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       style-loader:
         specifier: 2.0.0
-        version: 2.0.0(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 2.0.0(webpack@5.94.0)
       ts-dedent:
         specifier: 2.2.0
         version: 2.2.0
@@ -1597,7 +1597,7 @@ importers:
         version: link:../i18n-loader-webpack-plugin
       '@automattic/webpack-rtl-plugin':
         specifier: 6.0.0
-        version: 6.0.0(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.0.0(webpack@5.94.0)
       '@babel/compat-data':
         specifier: 7.24.7
         version: 7.24.7
@@ -1618,16 +1618,16 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@cerner/duplicate-package-checker-webpack-plugin':
         specifier: 2.3.0
-        version: 2.3.0(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 2.3.0(webpack@5.94.0)
       '@wordpress/browserslist-config':
         specifier: 6.9.0
         version: 6.9.0
       '@wordpress/dependency-extraction-webpack-plugin':
         specifier: 6.9.0
-        version: 6.9.0(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.9.0(webpack@5.94.0)
       babel-loader:
         specifier: 9.1.2
-        version: 9.1.2(@babel/core@7.24.7)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 9.1.2(@babel/core@7.24.7)(webpack@5.94.0)
       babel-plugin-polyfill-corejs3:
         specifier: 0.10.6
         version: 0.10.6(@babel/core@7.24.7)
@@ -1639,22 +1639,22 @@ importers:
         version: 3.38.1
       css-loader:
         specifier: 6.5.1
-        version: 6.5.1(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.5.1(webpack@5.94.0)
       css-minimizer-webpack-plugin:
         specifier: 5.0.1
-        version: 5.0.1(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 5.0.1(webpack@5.94.0)
       fork-ts-checker-webpack-plugin:
         specifier: 9.0.2
-        version: 9.0.2(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 9.0.2(typescript@5.0.4)(webpack@5.94.0)
       mini-css-extract-plugin:
         specifier: 2.9.1
-        version: 2.9.1(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 2.9.1(webpack@5.94.0)
       terser-webpack-plugin:
         specifier: 5.3.3
-        version: 5.3.3(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 5.3.3(webpack@5.94.0)
       thread-loader:
         specifier: 3.0.4
-        version: 3.0.4(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 3.0.4(webpack@5.94.0)
     devDependencies:
       '@babel/core':
         specifier: 7.24.7
@@ -1788,7 +1788,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -1858,7 +1858,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -1885,7 +1885,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -1923,13 +1923,13 @@ importers:
         version: 8.4.31
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
       sass:
         specifier: 1.64.1
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -1981,7 +1981,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -2081,7 +2081,7 @@ importers:
         version: 2.1.1
       copy-webpack-plugin:
         specifier: 11.0.0
-        version: 11.0.0(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 11.0.0(webpack@5.94.0)
       email-validator:
         specifier: 2.0.4
         version: 2.0.4
@@ -2185,10 +2185,10 @@ importers:
         version: 8.4.31
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -2338,7 +2338,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
@@ -2362,7 +2362,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -2408,13 +2408,13 @@ importers:
         version: 8.4.31
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
       sass:
         specifier: 1.64.1
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -2550,7 +2550,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       storybook:
         specifier: 8.3.5
         version: 8.3.5
@@ -2576,7 +2576,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       tslib:
         specifier: 2.5.0
         version: 2.5.0
@@ -2753,7 +2753,7 @@ importers:
         version: 6.9.0
       '@wordpress/dependency-extraction-webpack-plugin':
         specifier: 6.9.0
-        version: 6.9.0(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.9.0(webpack@5.94.0)
       autoprefixer:
         specifier: 10.4.14
         version: 10.4.14(postcss@8.4.31)
@@ -2780,7 +2780,7 @@ importers:
         version: 12.1.7(postcss@8.4.31)
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
       prettier:
         specifier: npm:wp-prettier@3.0.3
         version: wp-prettier@3.0.3
@@ -2789,7 +2789,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       size-limit:
         specifier: 11.1.6
         version: 11.1.6(@size-limit/preset-app@11.1.6)
@@ -2947,7 +2947,7 @@ importers:
         version: 10.4.14(postcss@8.4.31)
       copy-webpack-plugin:
         specifier: 11.0.0
-        version: 11.0.0(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 11.0.0(webpack@5.94.0)
       jest:
         specifier: 29.7.0
         version: 29.7.0
@@ -2962,7 +2962,7 @@ importers:
         version: 12.1.7(postcss@8.4.31)
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
       require-from-string:
         specifier: 2.0.2
         version: 2.0.2
@@ -2971,7 +2971,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       storybook:
         specifier: 8.3.5
         version: 8.3.5
@@ -3128,7 +3128,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -3194,7 +3194,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -3279,7 +3279,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -3336,7 +3336,7 @@ importers:
         version: 2.1.1
       copy-webpack-plugin:
         specifier: 11.0.0
-        version: 11.0.0(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 11.0.0(webpack@5.94.0)
       history:
         specifier: 5.3.0
         version: 5.3.0
@@ -3430,7 +3430,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       storybook:
         specifier: 8.3.5
         version: 8.3.5
@@ -3530,7 +3530,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -3639,7 +3639,7 @@ importers:
         version: 29.3.1(@babel/core@7.24.7)
       css-loader:
         specifier: 6.5.1
-        version: 6.5.1(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.5.1(webpack@5.94.0)
       glob:
         specifier: 10.4.1
         version: 10.4.1
@@ -3654,7 +3654,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -3853,7 +3853,7 @@ importers:
         version: 0.7.0
       copy-webpack-plugin:
         specifier: 11.0.0
-        version: 11.0.0(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 11.0.0(webpack@5.94.0)
       crypto-js:
         specifier: 4.2.0
         version: 4.2.0
@@ -4071,13 +4071,13 @@ importers:
         version: 8.4.31
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
       regenerator-runtime:
         specifier: 0.13.9
         version: 0.13.9
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -4165,7 +4165,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -4282,7 +4282,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       typescript:
         specifier: 5.0.4
         version: 5.0.4
@@ -4324,6 +4324,9 @@ importers:
       '@automattic/jetpack-publicize-components':
         specifier: workspace:*
         version: link:../../js-packages/publicize-components
+      '@automattic/jetpack-script-data':
+        specifier: workspace:*
+        version: link:../../js-packages/script-data
       '@automattic/jetpack-shared-extension-utils':
         specifier: workspace:*
         version: link:../../js-packages/shared-extension-utils
@@ -4417,13 +4420,13 @@ importers:
         version: 12.1.7(postcss@8.4.31)
       postcss-loader:
         specifier: 6.2.0
-        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 6.2.0(postcss@8.4.31)(webpack@5.94.0)
       sass:
         specifier: 1.64.1
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -4514,7 +4517,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -4619,7 +4622,7 @@ importers:
         version: 1.64.1
       sass-loader:
         specifier: 12.4.0
-        version: 12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1))
+        version: 12.4.0(sass@1.64.1)(webpack@5.94.0)
       webpack:
         specifier: 5.94.0
         version: 5.94.0(webpack-cli@4.9.1)
@@ -14308,7 +14311,7 @@ snapshots:
 
   '@automattic/viewport@1.0.0': {}
 
-  '@automattic/webpack-rtl-plugin@6.0.0(webpack@5.94.0(webpack-cli@4.9.1))':
+  '@automattic/webpack-rtl-plugin@6.0.0(webpack@5.94.0)':
     dependencies:
       rtlcss: 3.5.0
       webpack: 5.94.0(webpack-cli@4.9.1)
@@ -15192,7 +15195,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@cerner/duplicate-package-checker-webpack-plugin@2.3.0(webpack@5.94.0(webpack-cli@4.9.1))':
+  '@cerner/duplicate-package-checker-webpack-plugin@2.3.0(webpack@5.94.0)':
     dependencies:
       chalk: 4.1.2
       find-root: 1.1.0
@@ -16486,21 +16489,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@size-limit/file@11.1.6(size-limit@11.1.6(@size-limit/preset-app@11.1.6))':
+  '@size-limit/file@11.1.6(size-limit@11.1.6)':
     dependencies:
       size-limit: 11.1.6(@size-limit/preset-app@11.1.6)
 
   '@size-limit/preset-app@11.1.6(size-limit@11.1.6)':
     dependencies:
-      '@size-limit/file': 11.1.6(size-limit@11.1.6(@size-limit/preset-app@11.1.6))
-      '@size-limit/time': 11.1.6(size-limit@11.1.6(@size-limit/preset-app@11.1.6))
+      '@size-limit/file': 11.1.6(size-limit@11.1.6)
+      '@size-limit/time': 11.1.6(size-limit@11.1.6)
       size-limit: 11.1.6(@size-limit/preset-app@11.1.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@size-limit/time@11.1.6(size-limit@11.1.6(@size-limit/preset-app@11.1.6))':
+  '@size-limit/time@11.1.6(size-limit@11.1.6)':
     dependencies:
       estimo: 3.0.3
       size-limit: 11.1.6(@size-limit/preset-app@11.1.6)
@@ -16629,10 +16632,10 @@ snapshots:
       memoizerific: 1.11.3
       storybook: 8.3.5
 
-  '@storybook/addon-webpack5-compiler-babel@3.0.3(webpack@5.94.0(webpack-cli@4.9.1))':
+  '@storybook/addon-webpack5-compiler-babel@3.0.3(webpack@5.94.0)':
     dependencies:
       '@babel/core': 7.24.7
-      babel-loader: 9.2.1(@babel/core@7.24.7)(webpack@5.94.0(webpack-cli@4.9.1))
+      babel-loader: 9.2.1(@babel/core@7.24.7)(webpack@5.94.0)
     transitivePeerDependencies:
       - supports-color
       - webpack
@@ -16658,7 +16661,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-webpack5@8.3.5(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))':
+  '@storybook/builder-webpack5@8.3.5(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)':
     dependencies:
       '@storybook/core-webpack': 8.3.5(storybook@8.3.5)
       '@types/node': 22.7.4
@@ -16667,25 +16670,25 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.1
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.94.0(webpack-cli@4.9.1))
+      css-loader: 6.11.0(webpack@5.94.0)
       es-module-lexer: 1.5.4
       express: 4.21.1
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.0.4)(webpack@5.94.0)
       fs-extra: 11.2.0
-      html-webpack-plugin: 5.6.0(webpack@5.94.0(webpack-cli@4.9.1))
+      html-webpack-plugin: 5.6.0(webpack@5.94.0)
       magic-string: 0.30.11
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.5.2
       storybook: 8.3.5
-      style-loader: 3.3.4(webpack@5.94.0(webpack-cli@4.9.1))
-      terser-webpack-plugin: 5.3.3(webpack@5.94.0(webpack-cli@4.9.1))
+      style-loader: 3.3.4(webpack@5.94.0)
+      terser-webpack-plugin: 5.3.3(webpack@5.94.0)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
       util-deprecate: 1.0.2
       webpack: 5.94.0(webpack-cli@4.9.1)
-      webpack-dev-middleware: 6.1.3(webpack@5.94.0(webpack-cli@4.9.1))
+      webpack-dev-middleware: 6.1.3(webpack@5.94.0)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -16766,11 +16769,11 @@ snapshots:
     dependencies:
       storybook: 8.3.5
 
-  '@storybook/preset-react-webpack@8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))':
+  '@storybook/preset-react-webpack@8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)':
     dependencies:
       '@storybook/core-webpack': 8.3.5(storybook@8.3.5)
       '@storybook/react': 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.0.4)(webpack@5.94.0)
       '@types/node': 22.7.4
       '@types/semver': 7.5.8
       find-up: 5.0.0
@@ -16798,7 +16801,7 @@ snapshots:
     dependencies:
       storybook: 8.3.5
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.0.4)(webpack@5.94.0)':
     dependencies:
       debug: 4.3.4
       endent: 2.1.0
@@ -16818,10 +16821,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.3.5
 
-  '@storybook/react-webpack5@8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))':
+  '@storybook/react-webpack5@8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)':
     dependencies:
-      '@storybook/builder-webpack5': 8.3.5(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))
-      '@storybook/preset-react-webpack': 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1(webpack@5.94.0))
+      '@storybook/builder-webpack5': 8.3.5(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)
+      '@storybook/preset-react-webpack': 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)(webpack-cli@4.9.1)
       '@storybook/react': 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)(typescript@5.0.4)
       '@types/node': 22.7.4
       react: 18.3.1
@@ -17721,17 +17724,17 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@1.2.0(webpack-cli@4.9.1(webpack@5.94.0))(webpack@5.94.0(webpack-cli@4.9.1))':
+  '@webpack-cli/configtest@1.2.0(webpack-cli@4.9.1)(webpack@5.94.0)':
     dependencies:
       webpack: 5.94.0(webpack-cli@4.9.1)
       webpack-cli: 4.9.1(webpack@5.94.0)
 
-  '@webpack-cli/info@1.5.0(webpack-cli@4.9.1(webpack@5.94.0))':
+  '@webpack-cli/info@1.5.0(webpack-cli@4.9.1)':
     dependencies:
       envinfo: 7.14.0
       webpack-cli: 4.9.1(webpack@5.94.0)
 
-  '@webpack-cli/serve@1.7.0(webpack-cli@4.9.1(webpack@5.94.0))':
+  '@webpack-cli/serve@1.7.0(webpack-cli@4.9.1)':
     dependencies:
       webpack-cli: 4.9.1(webpack@5.94.0)
 
@@ -18555,7 +18558,7 @@ snapshots:
       moment: 2.29.4
       moment-timezone: 0.5.46
 
-  '@wordpress/dependency-extraction-webpack-plugin@6.9.0(webpack@5.94.0(webpack-cli@4.9.1))':
+  '@wordpress/dependency-extraction-webpack-plugin@6.9.0(webpack@5.94.0)':
     dependencies:
       json2php: 0.0.7
       webpack: 5.94.0(webpack-cli@4.9.1)
@@ -19890,14 +19893,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.1.2(@babel/core@7.24.7)(webpack@5.94.0(webpack-cli@4.9.1)):
+  babel-loader@9.1.2(@babel/core@7.24.7)(webpack@5.94.0):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 3.3.2
       schema-utils: 4.2.0
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  babel-loader@9.2.1(@babel/core@7.24.7)(webpack@5.94.0(webpack-cli@4.9.1)):
+  babel-loader@9.2.1(@babel/core@7.24.7)(webpack@5.94.0):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 4.0.0
@@ -20507,7 +20510,7 @@ snapshots:
 
   cookie@0.7.1: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.94.0(webpack-cli@4.9.1)):
+  copy-webpack-plugin@11.0.0(webpack@5.94.0):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -20586,7 +20589,7 @@ snapshots:
     dependencies:
       postcss: 8.4.31
 
-  css-loader@6.11.0(webpack@5.94.0(webpack-cli@4.9.1)):
+  css-loader@6.11.0(webpack@5.94.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
@@ -20599,7 +20602,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  css-loader@6.5.1(webpack@5.94.0(webpack-cli@4.9.1)):
+  css-loader@6.5.1(webpack@5.94.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.31)
       postcss: 8.4.31
@@ -20611,7 +20614,7 @@ snapshots:
       semver: 7.5.2
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  css-minimizer-webpack-plugin@5.0.1(webpack@5.94.0(webpack-cli@4.9.1)):
+  css-minimizer-webpack-plugin@5.0.1(webpack@5.94.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       cssnano: 6.1.2(postcss@8.4.31)
@@ -21157,7 +21160,7 @@ snapshots:
 
   es6-error@4.1.1: {}
 
-  esbuild-loader@3.0.1(webpack@5.94.0(webpack-cli@4.9.1)):
+  esbuild-loader@3.0.1(webpack@5.94.0):
     dependencies:
       esbuild: 0.17.19
       get-tsconfig: 4.8.1
@@ -21810,7 +21813,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.0.4)(webpack@5.94.0):
     dependencies:
       '@babel/code-frame': 7.25.7
       chalk: 4.1.2
@@ -21827,7 +21830,7 @@ snapshots:
       typescript: 5.0.4
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.0.4)(webpack@5.94.0(webpack-cli@4.9.1)):
+  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.0.4)(webpack@5.94.0):
     dependencies:
       '@babel/code-frame': 7.25.7
       chalk: 4.1.2
@@ -22173,7 +22176,7 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.6.0(webpack@5.94.0(webpack-cli@4.9.1)):
+  html-webpack-plugin@5.6.0(webpack@5.94.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -23793,7 +23796,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.1(webpack@5.94.0(webpack-cli@4.9.1)):
+  mini-css-extract-plugin@2.9.1(webpack@5.94.0):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
@@ -24324,7 +24327,7 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.47
 
-  postcss-loader@6.2.0(postcss@8.4.31)(webpack@5.94.0(webpack-cli@4.9.1)):
+  postcss-loader@6.2.0(postcss@8.4.31)(webpack@5.94.0):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
@@ -25285,7 +25288,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@12.4.0(sass@1.64.1)(webpack@5.94.0(webpack-cli@4.9.1)):
+  sass-loader@12.4.0(sass@1.64.1)(webpack@5.94.0):
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
@@ -25744,13 +25747,13 @@ snapshots:
 
   style-inject@0.3.0: {}
 
-  style-loader@2.0.0(webpack@5.94.0(webpack-cli@4.9.1)):
+  style-loader@2.0.0(webpack@5.94.0):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  style-loader@3.3.4(webpack@5.94.0(webpack-cli@4.9.1)):
+  style-loader@3.3.4(webpack@5.94.0):
     dependencies:
       webpack: 5.94.0(webpack-cli@4.9.1)
 
@@ -25917,7 +25920,7 @@ snapshots:
     dependencies:
       memoizerific: 1.11.3
 
-  terser-webpack-plugin@5.3.10(webpack@5.94.0(webpack-cli@4.9.1)):
+  terser-webpack-plugin@5.3.10(webpack@5.94.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -25926,7 +25929,7 @@ snapshots:
       terser: 5.34.1
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  terser-webpack-plugin@5.3.3(webpack@5.94.0(webpack-cli@4.9.1)):
+  terser-webpack-plugin@5.3.3(webpack@5.94.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -25956,7 +25959,7 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  thread-loader@3.0.4(webpack@5.94.0(webpack-cli@4.9.1)):
+  thread-loader@3.0.4(webpack@5.94.0):
     dependencies:
       json-parse-better-errors: 1.0.2
       loader-runner: 4.3.0
@@ -26412,9 +26415,9 @@ snapshots:
   webpack-cli@4.9.1(webpack@5.94.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.9.1(webpack@5.94.0))(webpack@5.94.0(webpack-cli@4.9.1))
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.9.1(webpack@5.94.0))
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.9.1(webpack@5.94.0))
+      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.9.1)(webpack@5.94.0)
+      '@webpack-cli/info': 1.5.0(webpack-cli@4.9.1)
+      '@webpack-cli/serve': 1.7.0(webpack-cli@4.9.1)
       colorette: 2.0.20
       commander: 7.2.0
       execa: 5.1.1
@@ -26425,7 +26428,7 @@ snapshots:
       webpack: 5.94.0(webpack-cli@4.9.1)
       webpack-merge: 5.10.0
 
-  webpack-dev-middleware@5.3.4(webpack@5.94.0(webpack-cli@4.9.1)):
+  webpack-dev-middleware@5.3.4(webpack@5.94.0):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -26434,7 +26437,7 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.94.0(webpack-cli@4.9.1)
 
-  webpack-dev-middleware@6.1.3(webpack@5.94.0(webpack-cli@4.9.1)):
+  webpack-dev-middleware@6.1.3(webpack@5.94.0):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -26487,7 +26490,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.94.0(webpack-cli@4.9.1))
+      terser-webpack-plugin: 5.3.10(webpack@5.94.0)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:

--- a/projects/js-packages/publicize-components/changelog/update-social-initial-state-migrate-urls-on-social-admin
+++ b/projects/js-packages/publicize-components/changelog/update-social-initial-state-migrate-urls-on-social-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Initial State: Migrated URLs to script data

--- a/projects/js-packages/publicize-components/src/types/types.ts
+++ b/projects/js-packages/publicize-components/src/types/types.ts
@@ -1,3 +1,7 @@
+export interface SocialUrls {
+	connectionsManagementPage: string;
+}
+
 export type SharesData = {
 	to_be_publicized_count: number;
 	publicized_count: number;
@@ -31,6 +35,7 @@ export interface SocialScriptData {
 	feature_flags: FeatureFlags;
 	supported_services: Array< ConnectionService >;
 	shares_data: SharesData;
+	urls: SocialUrls;
 }
 
 type JetpackSettingsSelectors = {

--- a/projects/js-packages/publicize-components/src/utils/index.js
+++ b/projects/js-packages/publicize-components/src/utils/index.js
@@ -2,3 +2,4 @@ export * from './get-share-message-max-length';
 export * from './get-supported-additional-connections';
 export * from './request-external-access';
 export * from './types';
+export * from './script-data';

--- a/projects/packages/publicize/changelog/update-social-initial-state-migrate-urls-on-social-admin
+++ b/projects/packages/publicize/changelog/update-social-initial-state-migrate-urls-on-social-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Initial State: Migrated URLs to script data

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -86,6 +86,7 @@ class Publicize_Script_Data {
 			'feature_flags'        => self::get_feature_flags(),
 			'supported_services'   => array(),
 			'shares_data'          => array(),
+			'urls'                 => array(),
 		);
 
 		if ( ! Utils::is_publicize_active() ) {
@@ -105,9 +106,9 @@ class Publicize_Script_Data {
 				'api_paths'          => self::get_api_paths(),
 				'supported_services' => self::get_supported_services(),
 				'shares_data'        => self::get_shares_data(),
+				'urls'               => self::get_urls(),
 				/**
 				 * 'store'       => self::get_store_script_data(),
-				 * 'urls'        => self::get_urls(),
 				 */
 			)
 		);
@@ -215,5 +216,24 @@ class Publicize_Script_Data {
 			'refreshConnections' => '/jetpack/v4/publicize/connections?test_connections=1',
 			'resharePost'        => '/jetpack/v4/publicize/{postId}',
 		);
+	}
+
+	/**
+	 * Get the URLs.
+	 *
+	 * @return array
+	 */
+	public static function get_urls() {
+
+		$urls = array(
+			'connectionsManagementPage' => self::publicize()->publicize_connections_url(
+				'jetpack-social-connections-admin-page'
+			),
+		);
+
+		// Escape the URLs.
+		array_walk( $urls, 'esc_url_raw' );
+
+		return $urls;
 	}
 }

--- a/projects/plugins/social/changelog/update-social-initial-state-migrate-urls-on-social-admin
+++ b/projects/plugins/social/changelog/update-social-initial-state-migrate-urls-on-social-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Initial State: Migrated URLs to script data

--- a/projects/plugins/social/package.json
+++ b/projects/plugins/social/package.json
@@ -30,6 +30,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-publicize-components": "workspace:*",
+		"@automattic/jetpack-script-data": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@wordpress/api-fetch": "7.9.0",
 		"@wordpress/components": "28.9.0",

--- a/projects/plugins/social/src/js/components/admin-page/header/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/header/index.jsx
@@ -1,4 +1,5 @@
 import { SOCIAL_STORE_ID } from '@automattic/jetpack-publicize-components';
+import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -6,14 +7,14 @@ import Logo from './../../logo';
 import styles from './styles.module.scss';
 
 const AdminPageHeader = () => {
-	const { showPricingPage, activateLicenseUrl } = useSelect( select => {
+	const { showPricingPage } = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID );
 
 		return {
 			showPricingPage: store.showPricingPage(),
-			activateLicenseUrl: `${ store.getAdminUrl() }admin.php?page=my-jetpack#/add-license`,
 		};
 	} );
+	const activateLicenseUrl = getMyJetpackUrl( '#/add-license' );
 
 	return (
 		<div className={ styles.header }>

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -13,6 +13,7 @@ import {
 	getSharedPostsCount,
 	store as socialStore,
 } from '@automattic/jetpack-publicize-components';
+import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, postList } from '@wordpress/icons';
@@ -20,24 +21,18 @@ import StatCards from '../stat-cards';
 import styles from './styles.module.scss';
 
 const Header = () => {
-	const connectionData = window.jetpackSocialInitialState.connectionData ?? {};
-	const {
-		// TODO - Replace some of these with data from initial state
-		connectionsAdminUrl,
-		hasConnections,
-		isModuleEnabled,
-		newPostUrl,
-	} = useSelect( select => {
+	const { hasConnections, isModuleEnabled } = useSelect( select => {
 		const store = select( socialStore );
 		return {
-			connectionsAdminUrl: connectionData.adminUrl,
 			hasConnections: store.getConnections().length > 0,
 			isModuleEnabled: store.isModuleEnabled(),
 			newPostUrl: `${ store.getAdminUrl() }post-new.php`,
 		};
 	} );
 
-	const { useAdminUiV1 } = getSocialScriptData().feature_flags;
+	const { urls, feature_flags } = getSocialScriptData();
+
+	const useAdminUiV1 = feature_flags.useAdminUiV1;
 
 	const { hasConnectionError } = useConnectionErrorNotice();
 
@@ -71,13 +66,16 @@ const Header = () => {
 										{ __( 'Connect accounts', 'jetpack-social' ) }
 									</Button>
 								) : (
-									<Button href={ connectionsAdminUrl } isExternalLink={ true }>
+									<Button href={ urls.connectionsManagementPage } isExternalLink={ true }>
 										{ __( 'Connect accounts', 'jetpack-social' ) }
 									</Button>
 								) }
 							</>
 						) }
-						<Button href={ newPostUrl } variant={ hasConnections ? 'primary' : 'secondary' }>
+						<Button
+							href={ getAdminUrl( 'post-new.php' ) }
+							variant={ hasConnections ? 'primary' : 'secondary' }
+						>
 							{ __( 'Write a post', 'jetpack-social' ) }
 						</Button>
 					</div>

--- a/projects/plugins/social/src/js/components/header/index.js
+++ b/projects/plugins/social/src/js/components/header/index.js
@@ -26,7 +26,6 @@ const Header = () => {
 		return {
 			hasConnections: store.getConnections().length > 0,
 			isModuleEnabled: store.isModuleEnabled(),
-			newPostUrl: `${ store.getAdminUrl() }post-new.php`,
 		};
 	} );
 

--- a/projects/plugins/social/src/js/components/social-module-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-module-toggle/index.tsx
@@ -22,7 +22,6 @@ import styles from './styles.module.scss';
 const SocialModuleToggle: React.FC = () => {
 	const {
 		// TODO - replace some of these with values from initial state
-		connectionsAdminUrl,
 		isModuleEnabled,
 		isUpdating,
 		siteSuffix,
@@ -33,14 +32,15 @@ const SocialModuleToggle: React.FC = () => {
 		return {
 			isModuleEnabled: store.isModuleEnabled(),
 			isUpdating: store.isUpdatingJetpackSettings(),
-			connectionsAdminUrl: store.getConnectionsAdminUrl(),
 			siteSuffix: store.getSiteSuffix(),
 			blogID: store.getBlogID(),
 			hasPaidFeatures: store.hasPaidFeatures(),
 		};
 	}, [] );
 
-	const { useAdminUiV1 } = getSocialScriptData().feature_flags;
+	const { urls, feature_flags } = getSocialScriptData();
+
+	const useAdminUiV1 = feature_flags.useAdminUiV1;
 
 	const updateOptions = useDispatch( SOCIAL_STORE_ID ).updateJetpackSettings;
 
@@ -65,13 +65,13 @@ const SocialModuleToggle: React.FC = () => {
 			) : null;
 		}
 
-		return connectionsAdminUrl ? (
+		return urls.connectionsManagementPage ? (
 			<Button
 				fullWidth={ isSmall }
 				className={ styles.button }
 				variant="secondary"
 				isExternalLink={ true }
-				href={ connectionsAdminUrl }
+				href={ urls.connectionsManagementPage }
 				disabled={ isUpdating || ! isModuleEnabled }
 				target="_blank"
 			>

--- a/projects/plugins/social/src/js/components/social-notes-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-notes-toggle/index.tsx
@@ -1,5 +1,6 @@
 import { Text, Button, useBreakpointMatch } from '@automattic/jetpack-components';
 import { store as socialStore } from '@automattic/jetpack-publicize-components';
+import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { ExternalLink, SelectControl, ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
@@ -29,16 +30,17 @@ const handleStateUpdating = ( updateFunction, updatingStateSetter, ...args ) => 
 };
 
 const SocialNotesToggle: React.FC< SocialNotesToggleProps > = ( { disabled } ) => {
-	const { isEnabled, notesConfig, newNoteUrl } = useSelect( select => {
+	const { isEnabled, notesConfig } = useSelect( select => {
 		const store = select( socialStore );
 		return {
 			isEnabled: store.isSocialNotesEnabled(),
 			notesConfig: store.getSocialNotesConfig(),
-			newNoteUrl: `${ store.getAdminUrl() }post-new.php?post_type=jetpack-social-note`,
 			// Temporarily we disable forever after action to wait for the page to reload.
 			// isUpdating: store.isSocialNotesSettingsUpdating(),
 		};
 	}, [] );
+
+	const newNoteUrl = getAdminUrl( 'post-new.php?post_type=jetpack-social-note' );
 
 	const [ isUpdating, setIsUpdating ] = useState( false );
 	const [ isAppendLinkToggleUpdating, setIsAppendLinkToggleUpdating ] = useState( false );

--- a/projects/plugins/social/src/js/components/types/types.ts
+++ b/projects/plugins/social/src/js/components/types/types.ts
@@ -13,7 +13,6 @@ type JetpackSettingsSelectors = {
 
 type ConnectionDataSelectors = {
 	getConnections: () => Array< object >;
-	getConnectionsAdminUrl: () => string;
 	hasConnections: () => boolean;
 };
 


### PR DESCRIPTION
Extracted out of #38983 to split it into smaller PRs.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Migrate URLs on the Social admin page to the new script data

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Social plugin
* Goto Social admin page
* Confirm that the license activation link works correctly
    <img width="482" alt="Screenshot 2024-10-17 at 10 54 03 AM" src="https://github.com/user-attachments/assets/f699f119-0d57-43d1-9e30-12ab57c9b191">
* Confirm that "Create a note" link works correctly
    <img width="423" alt="image" src="https://github.com/user-attachments/assets/decb89ed-0ba6-43bb-8c5f-e5fa88bf7464">
* There are also the changes to connection management URLs which point to Calypso but those URLs are no longer used but if you want to test them, you can hardcode to negate `useAdminUiV1` flag in the front-end code.
* Verify that editor loads fine on Simple and Atomic sites


