### PR TITLE
Story Block: be more defensive to avoid error in block previews

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-story-block-fatal
+++ b/projects/plugins/jetpack/changelog/fix-story-block-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Story Block: avoid error when previewing block styles in development version of the Gutenberg plugin.

--- a/projects/plugins/jetpack/extensions/blocks/story/player/modal/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/story/player/modal/index.js
@@ -69,7 +69,10 @@ class Modal extends Component {
 	 * Removes the specific mounting point for this modal from the DOM.
 	 */
 	cleanDOM() {
-		parentElement.removeChild( this.node );
+		if ( this.node && parentElement && parentElement.contains( this.node ) ) {
+			parentElement.removeChild( this.node );
+		}
+		this.node = null;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #39694

## Proposed changes:

This should avoid this error when previewing the block's styles in the site editor.

```
Uncaught DOMException: Node.removeChild: The node to be removed is not a child of this node

The above error occurred in the <Modal> component:

Zg@http://localhost/wp-content/plugins/gutenberg/build/vendors/react-dom.js?ver=18:1:217152
Zg@http://localhost/wp-content/plugins/gutenberg/build/vendors/react-dom.js?ver=18:1:217854
ExpandableSandbox@http://localhost/wp-content/plugins/jetpack/_inc/blocks/editor-beta.js?minify=false&ver=f3e463dd15d69dcf859c:74666:27
StoryPlayer@http://localhost/wp-content/plugins/jetpack/_inc/blocks/editor-beta.js?minify=false&ver=f3e463dd15d69dcf859c:74771:21
div
StoryEdit@http://localhost/wp-content/plugins/jetpack/_inc/blocks/editor-beta.js?minify=false&ver=f3e463dd15d69dcf859c:73921:151

```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* No

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> This can only be tested if your site runs Gutenberg `trunk` right now.

You can see how the error can be reproduced in this video: https://github.com/Automattic/jetpack/issues/39694#issue-2575622974

1. Go to Appearance > Site Editor
2. Click on the Style icon in the top right corner.
3. Click on the Eye icon in the Styles sidebar.
4. Click on the Media tab to preview the Story block
    * You should be able to see the Story block with no issues
