### PR TITLE
My Jetpack: fix the 'Missing site connection' notice

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-missing-site-connection-notice
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-missing-site-connection-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the "Missing site connection" notice.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -940,17 +940,18 @@ class Initializer {
 		$broken_modules = self::check_for_broken_modules();
 		$connection     = new Connection_Manager();
 
-		if ( ! empty( $broken_modules['needs_user_connection'] ) ) {
+		// Checking for site connection issues first.
+		if ( ! empty( $broken_modules['needs_site_connection'] ) ) {
 			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
-				'type'     => 'user',
+				'type'     => 'site',
 				'is_error' => true,
 			);
 			return $red_bubble_slugs;
 		}
 
-		if ( ! empty( $broken_modules['needs_site_connection'] ) ) {
+		if ( ! empty( $broken_modules['needs_user_connection'] ) ) {
 			$red_bubble_slugs[ self::MISSING_CONNECTION_NOTIFICATION_KEY ] = array(
-				'type'     => 'site',
+				'type'     => 'user',
 				'is_error' => true,
 			);
 			return $red_bubble_slugs;


### PR DESCRIPTION
## Proposed changes:
My Jetpack will ask to establish user connection even if site connection is missing (since #37908).
This PR will give the "missing site connection" notice more priority so it would show up on non-connected sites.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect site, then disconnect it.
2. Go to My Jetpack, the notice will appear asking you to establish site connection.
3. Click on the button, site should get connected successfully.
4. Reload the page, it should now ask you to connect the user.
5. Click on the button, connect the user, confirm it got connected successfully.