### PR TITLE
SSO: optimize `admin_notices` action callback

### DIFF
--- a/projects/packages/connection/changelog/update-sso-optimize-admin-notices-callback
+++ b/projects/packages/connection/changelog/update-sso-optimize-admin-notices-callback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+SSO: optimize 'admin_notices' action callback.

--- a/projects/packages/connection/src/sso/class-user-admin.php
+++ b/projects/packages/connection/src/sso/class-user-admin.php
@@ -59,7 +59,11 @@ class User_Admin {
 		add_filter( 'manage_users_columns', array( $this, 'jetpack_user_connected_th' ) );
 		add_filter( 'manage_users_custom_column', array( $this, 'jetpack_show_connection_status' ), 10, 3 );
 		add_action( 'user_row_actions', array( $this, 'jetpack_user_table_row_actions' ), 10, 2 );
-		add_action( 'admin_notices', array( $this, 'handle_invitation_results' ) );
+
+		if ( isset( $_GET['jetpack-sso-invite-user'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			add_action( 'admin_notices', array( $this, 'handle_invitation_results' ) );
+		}
+
 		add_action( 'admin_post_jetpack_invite_user_to_wpcom', array( $this, 'invite_user_to_wpcom' ) );
 		add_action( 'admin_post_jetpack_revoke_invite_user_to_wpcom', array( $this, 'handle_request_revoke_invite' ) );
 		add_action( 'admin_post_jetpack_resend_invite_user_to_wpcom', array( $this, 'handle_request_resend_invite' ) );


### PR DESCRIPTION
## Proposed changes:
* Make SSO admin class only hook into `admin_notices` when necessary.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/529

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack.
2. Go to "Jetpack -> Settings" and activate SSO ("WordPress.com login").
3. Create new WP user. Then go to the list of users and click "Send invite" in the "SSO Status" column.
4. Confirm you see the "User was invited successfully" notice.