### PR TITLE
WAF: Handle undefined entrypoint constant

### DIFF
--- a/projects/packages/waf/changelog/fix-waf-undefined-entrypoint-in-bootstrap
+++ b/projects/packages/waf/changelog/fix-waf-undefined-entrypoint-in-bootstrap
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Backwards compatibility fix for sites running standalone mode.
+Firewall: improve backwards compatibility for sites running outdated bootstrap scripts via standalone mode.

--- a/projects/packages/waf/changelog/fix-waf-undefined-entrypoint-in-bootstrap
+++ b/projects/packages/waf/changelog/fix-waf-undefined-entrypoint-in-bootstrap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Backwards compatibility fix for sites running standalone mode.

--- a/projects/packages/waf/src/class-waf-standalone-bootstrap.php
+++ b/projects/packages/waf/src/class-waf-standalone-bootstrap.php
@@ -121,6 +121,15 @@ class Waf_Standalone_Bootstrap {
 	}
 
 	/**
+	 * Gets the entrypoint file.
+	 *
+	 * @return string The entrypoint file.
+	 */
+	private function get_entrypoint() {
+		return defined( 'JETPACK_WAF_ENTRYPOINT' ) ? JETPACK_WAF_ENTRYPOINT : 'rules/rules.php';
+	}
+
+	/**
 	 * Generates the bootstrap file.
 	 *
 	 * @throws File_System_Exception If the filesystem is not available.
@@ -141,6 +150,7 @@ class Waf_Standalone_Bootstrap {
 		$autoloader_file = $this->locate_autoloader_file();
 
 		$bootstrap_file          = $this->get_bootstrap_file_path();
+		$entrypoint              = $this->get_entrypoint();
 		$mode_option             = get_option( Waf_Runner::MODE_OPTION_NAME, false );
 		$share_data_option       = get_option( Waf_Runner::SHARE_DATA_OPTION_NAME, false );
 		$share_debug_data_option = get_option( Waf_Runner::SHARE_DEBUG_DATA_OPTION_NAME, false );
@@ -154,7 +164,7 @@ class Waf_Standalone_Bootstrap {
 			. sprintf( "define( 'JETPACK_WAF_SHARE_DEBUG_DATA', %s );\n", var_export( $share_debug_data_option, true ) )
 			. sprintf( "define( 'JETPACK_WAF_DIR', %s );\n", var_export( JETPACK_WAF_DIR, true ) )
 			. sprintf( "define( 'JETPACK_WAF_WPCONFIG', %s );\n", var_export( JETPACK_WAF_WPCONFIG, true ) )
-			. sprintf( "define( 'JETPACK_WAF_ENTRYPOINT', %s );\n", var_export( JETPACK_WAF_ENTRYPOINT, true ) )
+			. sprintf( "define( 'JETPACK_WAF_ENTRYPOINT', %s );\n", var_export( $entrypoint, true ) )
 			. 'require_once ' . var_export( $autoloader_file, true ) . ";\n"
 			. "Automattic\Jetpack\Waf\Waf_Runner::initialize();\n";
 		// phpcs:enable


### PR DESCRIPTION
Fixes #39801
Fixes https://github.com/Automattic/jpop-issues/issues/9284#issue-2594942874

## Proposed changes:
* Fixes a potential backwards compatibility issue for sites running in standalone mode, with the bootstrap script providing outdated classes from the Jetpack vendor folder.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

p1729174210943489-slack-C029WFNV69M

## Does this pull request change what data or activity we track or use?


No

## Testing instructions:

* Install Protect 3.0.0
* Install Jetpack, configure standalone mode, ensure bootstrap script uses Jetpack packages and does not define WAF_ENTRYPOINT constant
* Upgrade Protect to this branch
* Ensure bootstrap file is regenerated on visit to wp-admin page, without error