### PR TITLE
Newsletter: Fix "subscription_emails_use_excerpt" api.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-settings-api
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-settings-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: Fix use excerpt setting.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -474,7 +474,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'jetpack_subscriptions_subscribe_navigation_enabled' => (bool) get_option( 'jetpack_subscriptions_subscribe_navigation_enabled' ),
 						'wpcom_gifting_subscription'       => (bool) get_option( 'wpcom_gifting_subscription', $this->get_wpcom_gifting_subscription_default() ),
 						'wpcom_reader_views_enabled'       => (bool) get_option( 'wpcom_reader_views_enabled', true ),
-						'wpcom_subscription_emails_use_excerpt' => $this->get_wpcom_subscription_emails_use_excerpt_option(),
+						'wpcom_subscription_emails_use_excerpt' => (bool) get_option( 'wpcom_subscription_emails_use_excerpt' ),
 						'jetpack_subscriptions_reply_to'   => (string) $this->get_subscriptions_reply_to_option(),
 						'jetpack_subscriptions_from_name'  => (string) get_option( 'jetpack_subscriptions_from_name' ),
 						'show_on_front'                    => (string) get_option( 'show_on_front' ),
@@ -1273,23 +1273,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		return array(
 			'updated' => $updated,
 		);
-	}
-
-	/**
-	 * Get the value of the wpcom_subscription_emails_use_excerpt option.
-	 * When the option is not set, it will return the value of the rss_use_excerpt option.
-	 *
-	 * @return bool
-	 */
-	protected function get_wpcom_subscription_emails_use_excerpt_option() {
-		$wpcom_subscription_emails_use_excerpt = get_option( 'wpcom_subscription_emails_use_excerpt', null );
-
-		if ( $wpcom_subscription_emails_use_excerpt === null ) {
-			$rss_use_excerpt                       = get_option( 'rss_use_excerpt', null );
-			$wpcom_subscription_emails_use_excerpt = $rss_use_excerpt === null ? false : $rss_use_excerpt;
-		}
-
-		return (bool) $wpcom_subscription_emails_use_excerpt;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/wp-calypso/issues/95469

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We deprecated the use of the RSS setting as a fallback for newsletter excerpts, but we overlooked how this API calculates the value.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sandbox this PR in WPCOM
* Play with these settings:
<img width="285" alt="Screenshot 2024-10-17 at 4 10 46 PM" src="https://github.com/user-attachments/assets/2e052f86-8f57-44ed-8783-4d5f346463e5">

