### PR TITLE
Fix site specific features passed to front-end for simple sites

### DIFF
--- a/projects/js-packages/script-data/changelog/fix-site-specific-features-for-simple-sites
+++ b/projects/js-packages/script-data/changelog/fix-site-specific-features-for-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the site features for Simple sites

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -57,3 +57,14 @@ export function getMyJetpackUrl( section = '' ) {
 export function getActiveFeatures() {
 	return getScriptData().site.plan?.features?.active ?? [];
 }
+
+/**
+ * Check if the site has a specific feature.
+ *
+ * @param {string} feature - The feature to check. e.g. "republicize".
+ *
+ * @return {boolean} Whether the site has the feature.
+ */
+export function siteHasFeature( feature: string ) {
+	return getActiveFeatures().includes( feature );
+}

--- a/projects/packages/plans/changelog/fix-site-specific-features-for-simple-sites
+++ b/projects/packages/plans/changelog/fix-site-specific-features-for-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the site features for Simple sites

--- a/projects/packages/publicize/changelog/fix-site-specific-features-for-simple-sites
+++ b/projects/packages/publicize/changelog/fix-site-specific-features-for-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed the site features for Simple sites

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -60,6 +60,11 @@ class Publicize_Script_Data {
 			$data['site']['plan'] = Current_Plan::get();
 		}
 
+		// Override features for simple sites.
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			$data['site']['plan']['features'] = Current_Plan::get_simple_site_specific_features();
+		}
+
 		return $data;
 	}
 


### PR DESCRIPTION
Prepares the ground for https://github.com/Automattic/jetpack-reach/issues/511

Now that we have started consolidating our initial state via our `script-data` package, there is something we still need to fix. We want to be able to check for specific features in our front-end code. Right now, that logic is used in a weird way - sometimes via [`getJetpackExtensionAvailability`](https://github.com/Automattic/jetpack/blob/2545c7dcdcb71672a518a97e9f7c303515573df1/projects/js-packages/shared-extension-utils/src/get-jetpack-extension-availability.js#L10) and sometimes the feature checks are passed from the backend as boolean flags and there are too many of them and often repeated at multiple places. On the backend, `Current_Plan:supports()` works fine for both Jetpack and Simple sites to check if a feature is available for a site or not but `Current_Plan::get()` doesn't work as expected. It returns an empty set of features for Simple sites.

So, in order to have a single source of truth to check features on client-side, we need to pass all the available features down to the client-side code via `script-data` package.

This PR extracts the logic used [here](https://github.com/Automattic/jetpack/blob/347b86a9713eb9909c698fb36cffcb7d2ce9bf29/projects/plugins/jetpack/class.jetpack-gutenberg.php#L1159-L1174)  to `Current_Plan::get_simple_site_specific_features()` and updates the script data to override features for simple sites using that function.

This allows us to have a utility function like `siteHasFeature` on client-side work reliably, both for Jetpack and Simple sites.

## Why do we need this?
We at Jetpack Reach are migrating all of our scattered initial to the consolidated initial state (script data) and thus we also want to move away from passing the boolean flags for features and the flags like `hasPaidPlan`, `hasPaidFeatures` etc. to avoid unintentional bugs when features are moved between plans (free/paid) and thus we want to explicitly check for exact feature availability, which is the recommended way. So, we need `siteHasFeature` utility.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Add `get_simple_site_specific_features` method to `Current_Plan`
* Update script-data to add `siteHasFeature` function
* Add features for simple sites to the script data

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to editor on Jetpack and Simple sites
* Open browser console
* Enter `JetpackScriptData.site.plan.features`
* Confirm that you see the active and available features

