### PR TITLE
Port Daily Writing Prompt from My Home as Dashboard widget

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/blogging-prompts-widget
+++ b/projects/packages/jetpack-mu-wpcom/changelog/blogging-prompts-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Daily Writing Prompt as Dashboard widget

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blogging-prompts/hooks/use-blogging-prompts.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-blogging-prompts/hooks/use-blogging-prompts.js
@@ -1,0 +1,47 @@
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import moment from 'moment';
+import { useEffect, useState } from 'react';
+
+export const useBloggingPrompts = ( { isBloganuary = false } ) => {
+	const [ prompts, setPrompts ] = useState( [] );
+	const [ promptIndex, setPromptIndex ] = useState( 0 );
+
+	useEffect( () => {
+		apiFetch( {
+			path: addQueryArgs( `/wpcom/v3/blogging-prompts`, {
+				per_page: isBloganuary ? 31 : 10,
+				after: isBloganuary ? '--01-01' : moment().format( '--MM-DD' ),
+				order: 'desc',
+				force_year: new Date().getFullYear(),
+			} ),
+		} )
+			.then( result => {
+				return setPrompts( result );
+			} )
+			// eslint-disable-next-line no-console
+			.catch( () => console.error( 'Unable to fetch blogging prompts' ) );
+	}, [ isBloganuary ] );
+
+	const hasPreviousPrompt = promptIndex > 0;
+	const goToPreviousPrompt = () => {
+		setPromptIndex( hasPreviousPrompt ? promptIndex - 1 : prompts.length - 1 );
+	};
+
+	const hasNextPrompt = promptIndex < prompts.length - 1;
+	const goToNextPrompt = () => {
+		setPromptIndex( hasNextPrompt ? promptIndex + 1 : 0 );
+	};
+
+	const prompt = prompts?.[ promptIndex ];
+	const todayPrompt = prompts?.[ 0 ];
+
+	return {
+		prompt,
+		todayPrompt,
+		hasPreviousPrompt,
+		goToPreviousPrompt,
+		hasNextPrompt,
+		goToNextPrompt,
+	};
+};

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-blogging-prompts-widget/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-blogging-prompts-widget/index.js
@@ -1,0 +1,100 @@
+import { __ } from '@wordpress/i18n';
+import { wpcomTrackEvent } from '../../../common/tracks';
+import { useBloggingPrompts } from '../../wpcom-blogging-prompts/hooks/use-blogging-prompts';
+
+import './style.scss';
+
+const WpcomBloggingPromptsWidget = ( { siteId, siteAdminUrl } ) => {
+	const {
+		prompt,
+		todayPrompt,
+		hasPreviousPrompt,
+		goToPreviousPrompt,
+		hasNextPrompt,
+		goToNextPrompt,
+	} = useBloggingPrompts( { isBloganuary: false } );
+
+	const handlePromptClick = e => {
+		e.preventDefault();
+
+		if ( prompt.answered ) {
+			return;
+		}
+
+		// TODO: Track event
+		// eslint-disable-next-line no-constant-condition
+		if ( 1 === 0 ) {
+			wpcomTrackEvent( 'xxx_answer_prompt', {
+				site_id: siteId,
+				prompt_id: prompt.id,
+			} );
+		}
+
+		// Track if a user skipped todays prompt and choose to answer another prompt
+		const todayPromptId = todayPrompt.id;
+		const selectedPromptId = prompt.id;
+		if ( todayPromptId !== selectedPromptId ) {
+			// TODO: Track event
+			// eslint-disable-next-line no-constant-condition
+			if ( 1 === 0 ) {
+				wpcomTrackEvent( 'xxx_skip_prompt', {
+					site_id: siteId,
+					prompt_id: todayPromptId,
+				} );
+			}
+		}
+
+		window.location.href = `${ siteAdminUrl }post-new.php?answer_prompt=${ prompt.id }`;
+	};
+
+	if ( ! prompt ) {
+		return null;
+	}
+
+	return (
+		<>
+			<div className="wpcom-blogging-prompts-widget__prompt">
+				{ hasPreviousPrompt ? (
+					<a
+						href="#"
+						className="wpcom-blogging-prompts-widget__prompt--prev"
+						onClick={ goToPreviousPrompt }
+					></a>
+				) : (
+					<span className="wpcom-blogging-prompts-widget__prompt--prev disabled"></span>
+				) }
+				<p>{ prompt.text }</p>
+				{ hasNextPrompt ? (
+					<a
+						href="#"
+						className="wpcom-blogging-prompts-widget__prompt--next"
+						onClick={ goToNextPrompt }
+					></a>
+				) : (
+					<span className="wpcom-blogging-prompts-widget__prompt--next disabled"></span>
+				) }
+			</div>
+			<div className="wpcom-blogging-prompts-widget__actions">
+				<button className="button button-primary" onClick={ handlePromptClick }>
+					{ __( 'Post Answer', 'jetpack-mu-wpcom' ) }
+				</button>
+				{ prompt.answered_users_sample.length > 0 && (
+					<div className="wpcom-blogging-prompts-widget__responses">
+						<div className="wpcom-blogging-prompts-widget__responses-users">
+							{ prompt.answered_users_sample.map( sample => {
+								return <img alt="answered-users" src={ sample.avatar } key={ sample.avatar } />;
+							} ) }
+						</div>
+						{ prompt?.answered_users_count > 0 && (
+							<a href={ new URL( prompt.answered_link ) }>
+								{ __( 'View all responses', 'jetpack-mu-wpcom' ) }
+							</a>
+						) }
+					</div>
+				) }
+			</div>
+		</>
+	);
+};
+
+export default WpcomBloggingPromptsWidget;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-blogging-prompts-widget/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-blogging-prompts-widget/style.scss
@@ -1,0 +1,80 @@
+#wpcom-blogging-prompts-widget {
+	min-height: 132px;
+
+	h2 {
+		flex-grow: initial;
+
+		&::before {
+			font-family: dashicons;
+			content: "\f339";
+			margin-right: 5px;
+		}
+	}
+}
+
+.wpcom-blogging-prompts-widget {
+	&__prompt {
+		display: flex;
+		gap: 10px;
+		justify-content: space-between;
+		margin-bottom: 20px;
+
+		&--prev, &--next {
+			align-self: center;
+			font-family: dashicons;
+			font-size: 15px;
+			text-decoration: none;
+			border: 1px solid;
+			border-radius: 100%;
+			text-align: center;
+
+			&::before {
+				display: inline-block;
+				height: 21px;
+				width: 21px;
+			}
+
+			&.disabled {
+				color: #a7aaad;
+			}
+		}
+
+		&--prev:before {
+			content: "\f341";
+		}
+
+		&--next:before {
+			content: "\f345";
+		}
+
+		p {
+			flex-grow: 1;
+			margin: 0 0 0;
+			line-height: 21px;
+		}
+	}
+
+	&__actions {
+		display: flex;
+
+		.wpcom-blogging-prompts-widget__responses {
+			margin-left: auto;
+			height: 30px;
+
+			&-users {
+				display: inline-block;
+				vertical-align: middle;
+				margin-right: 5px;
+
+				img {
+					height: 22px;
+					width: 22px;
+					border: 2px solid white;
+					border-radius: 100%;
+					margin-top: 2px;
+					margin-left: -10px;
+				}
+			}
+		}
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.js
@@ -1,6 +1,7 @@
 import '../../common/public-path';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import WpcomBloggingPromptsWidget from './wpcom-blogging-prompts-widget';
 import WpcomSiteManagementWidget from './wpcom-site-management-widget';
 
 const data = typeof window === 'object' ? window.JETPACK_MU_WPCOM_DASHBOARD_WIDGETS : {};
@@ -9,6 +10,10 @@ const widgets = [
 	{
 		id: 'wpcom_site_management_widget_main',
 		Widget: WpcomSiteManagementWidget,
+	},
+	{
+		id: 'wpcom-blogging-prompts-widget_main',
+		Widget: WpcomBloggingPromptsWidget,
 	},
 ];
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -21,6 +21,11 @@ function load_wpcom_dashboard_widgets() {
 			'name'     => __( 'Site Management Panel', 'jetpack-mu-wpcom' ),
 			'priority' => 'high',
 		),
+		array(
+			'id'       => 'wpcom-blogging-prompts-widget',
+			'name'     => __( 'Daily Writing Prompt', 'jetpack-mu-wpcom' ),
+			'priority' => 'high',
+		),
 	);
 
 	foreach ( $wpcom_dashboard_widgets as $wpcom_dashboard_widget ) {
@@ -28,7 +33,7 @@ function load_wpcom_dashboard_widgets() {
 			$wpcom_dashboard_widget['id'],
 			$wpcom_dashboard_widget['name'],
 			'render_wpcom_dashboard_widget',
-			function () {},
+			null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
 			array(
 				'id'   => $wpcom_dashboard_widget['id'],
 				'name' => $wpcom_dashboard_widget['name'],
@@ -48,9 +53,11 @@ function enqueue_wpcom_dashboard_widgets() {
 
 	$data = wp_json_encode(
 		array(
-			'siteName'    => get_bloginfo( 'name' ),
-			'siteDomain'  => wp_parse_url( home_url(), PHP_URL_HOST ),
-			'siteIconUrl' => get_site_icon_url( 38 ),
+			'siteId'       => get_current_blog_id(),
+			'siteName'     => get_bloginfo( 'name' ),
+			'siteDomain'   => wp_parse_url( home_url(), PHP_URL_HOST ),
+			'siteIconUrl'  => get_site_icon_url( 38 ),
+			'siteAdminUrl' => get_admin_url(),
 		)
 	);
 
@@ -80,7 +87,7 @@ function render_wpcom_dashboard_widget( $post, $callback_args ) {
 	);
 
 	?>
-	<div style="min-height: 200px;">
+	<div>
 		<div class="hide-if-js">
 			<?php echo esc_html( $warning ); ?>
 		</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-site-management-widget/style.scss
@@ -1,9 +1,6 @@
 #wpcom_site_management_widget {
+	min-height: 200px;
 	color: #1e1e1e;
-
-	.postbox-title-action {
-		display: none;
-	}
 }
 
 #wpcom_site_management_widget_main {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:

- https://github.com/Automattic/dotcom-forge/issues/9432

## Proposed changes:

This PR reimplements the Daily Writing Prompt feature from My Home (Calypso) to Dashboard (WP Admin).

|My Home (before)|Dashboard (after)|
|-|-|
|<img width="595" alt="image" src="https://github.com/user-attachments/assets/4e148e59-9a91-496f-b0dd-4706a5aecef8">|<img width="438" alt="image" src="https://github.com/user-attachments/assets/a3277596-d465-4de9-98cc-905c4e6d861a">|

### TODO

- [ ] Show this widget by default only for sites with write intent.
- [ ] Supports Bloganuary logic
- [ ] Extract shared logic with the existing `wpcom-block-editor-nux`'s `BloggingPromptsModal`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

