### PR TITLE
Fix Jetpack AI features control types

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-jetpack-ai-features-control-types
+++ b/projects/js-packages/ai-client/changelog/add-jetpack-ai-features-control-types
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Client: add types for AI assistant feature payload data branch featuresControl

--- a/projects/js-packages/ai-client/src/logo-generator/store/initial-state.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/initial-state.ts
@@ -34,6 +34,12 @@ const INITIAL_STATE: LogoGeneratorStateProp = {
 				asyncRequestTimerId: 0,
 				isRequestingImage: false,
 			},
+			featuresControl: {
+				'logo-generator': {
+					enabled: false,
+					styles: [],
+				},
+			},
 		},
 	},
 	history: [],

--- a/projects/js-packages/ai-client/src/logo-generator/store/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/types.ts
@@ -95,11 +95,11 @@ export type LogoGeneratorFeatureControl = FeatureControl & {
 
 export type FeatureControl = {
 	enabled: boolean;
-	'min-jetpack-version': string;
-	[ key: string ]: FeatureControl | LogoGeneratorFeatureControl | boolean | string;
 };
 
-export type FeaturesControl = { [ key: string ]: FeatureControl };
+export type FeaturesControl = {
+	[ key: string ]: FeatureControl | LogoGeneratorFeatureControl;
+};
 
 export type AiFeatureProps = {
 	hasFeature: boolean;


### PR DESCRIPTION
This PR aims to cleanup the types for the new data branch `featuresControl`

## Proposed changes:
Add correct ts type definitions
Add default value for featuresControl['logo-generator']

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Run `jetpack watch js-packages/ai-client`, see that it doesn't throw any errors.
Insert a logo block on the editor, smoke test it