### PR TITLE
Write Brief: Add language selector

### DIFF
--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-write-brief-language-selector
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-write-brief-language-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Write Brief: Add language selector

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/controls.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { SelectControl } from '@wordpress/components';
 import {
 	BaseControl,
 	PanelRow,
@@ -40,14 +41,24 @@ export const useInit = init => {
 
 const Controls = ( { blocks, disabledFeatures } ) => {
 	const [ gradeLevel, setGradeLevel ] = useState< string | null >( null );
-	const { toggleFeature, toggleProofread, setPopoverHover, setHighlightHover, setPopoverAnchor } =
-		useDispatch( 'jetpack/ai-breve' );
+	const {
+		toggleFeature,
+		toggleProofread,
+		setPopoverHover,
+		setHighlightHover,
+		setPopoverAnchor,
+		setLanguage,
+	} = useDispatch( 'jetpack/ai-breve' );
 	const { tracks } = useAnalytics();
 
-	const isProofreadEnabled = useSelect(
-		select => ( select( 'jetpack/ai-breve' ) as BreveSelect ).isProofreadEnabled(),
-		[]
-	);
+	const { isProofreadEnabled, language } = useSelect( select => {
+		const selectors: BreveSelect = select( 'jetpack/ai-breve' );
+
+		return {
+			isProofreadEnabled: selectors.isProofreadEnabled(),
+			language: selectors.getLanguage(),
+		};
+	}, [] );
 
 	const updateGradeLevel = useCallback( () => {
 		if ( ! isProofreadEnabled ) {
@@ -104,6 +115,16 @@ const Controls = ( { blocks, disabledFeatures } ) => {
 	return (
 		<div className="jetpack-ai-proofread">
 			<p> { __( 'Improve your writing with AI.', 'jetpack' ) }</p>
+			<SelectControl
+				__nextHasNoMarginBottom
+				label="Language"
+				value={ language }
+				options={ [
+					{ label: 'English (US)', value: 'en' },
+					{ label: 'English (GB)', value: 'en-gb' },
+				] }
+				onChange={ setLanguage }
+			/>
 			<PanelRow>
 				<BaseControl>
 					<div className="grade-level-container">

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/actions.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/actions.ts
@@ -4,7 +4,7 @@
 import { askQuestionSync } from '@automattic/jetpack-ai-client';
 import { select } from '@wordpress/data';
 import { BREVE_FEATURE_NAME } from '../constants';
-import { Anchor } from '../types';
+import { Anchor, BreveLanguage } from '../types';
 import { getRequestMessages } from '../utils/get-request-messages';
 
 // ACTIONS
@@ -27,6 +27,13 @@ export function setPopoverAnchor( anchor: Anchor ) {
 	return {
 		type: 'SET_POPOVER_ANCHOR',
 		anchor,
+	};
+}
+
+export function setLanguage( language: BreveLanguage ) {
+	return {
+		type: 'SET_LANGUAGE',
+		language,
 	};
 }
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/reducer.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/reducer.ts
@@ -9,7 +9,7 @@ import features from '../features';
 /**
  * Types
  */
-import type { Anchor, BreveState } from '../types';
+import type { Anchor, BreveLanguage, BreveState } from '../types';
 
 const enabledFromLocalStorage = window.localStorage.getItem( 'jetpack-ai-breve-enabled' );
 const disabledFeaturesFromLocalStorage = window.localStorage.getItem(
@@ -27,7 +27,13 @@ const initialConfiguration = {
 
 export function configuration(
 	state: BreveState[ 'configuration' ] = initialConfiguration,
-	action: { type: string; enabled?: boolean; feature?: string; loading?: boolean }
+	action: {
+		type: string;
+		enabled?: boolean;
+		feature?: string;
+		loading?: boolean;
+		language?: BreveLanguage;
+	}
 ) {
 	switch ( action.type ) {
 		case 'SET_PROOFREAD_ENABLED': {
@@ -37,6 +43,13 @@ export function configuration(
 			return {
 				...state,
 				enabled,
+			};
+		}
+
+		case 'SET_LANGUAGE': {
+			return {
+				...state,
+				language: action.language,
 			};
 		}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/selectors.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/store/selectors.ts
@@ -43,6 +43,10 @@ export function getReloadFlag( state: BreveState ) {
 	return state.configuration?.reload;
 }
 
+export function getLanguage( state: BreveState ) {
+	return state.configuration?.language;
+}
+
 // Suggestions
 
 export function getBlockMd5( state: BreveState, blockId: string ) {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/breve/types.ts
@@ -20,6 +20,7 @@ export type BreveState = {
 		disabled?: Array< string >;
 		loading?: Array< string >;
 		reload?: boolean;
+		language?: BreveLanguage;
 	};
 	suggestions?: {
 		[ key: string ]: {
@@ -46,6 +47,7 @@ export type BreveSelect = {
 	isFeatureDictionaryLoading: ( feature: string ) => boolean;
 	getDisabledFeatures: () => Array< string >;
 	getBlockMd5: ( blockId: string ) => string;
+	getLanguage: () => BreveLanguage;
 	getSuggestionsLoading: ( {
 		feature,
 		id,
@@ -142,3 +144,5 @@ export type FeatureControl = {
 	'min-jetpack-version': string;
 	[ key: string ]: FeatureControl | boolean | string;
 };
+
+export type BreveLanguage = 'en' | 'en-gb';


### PR DESCRIPTION


Fixes #40029

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds English (GB) to a selector and changes the dictionary according to the selected language

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor with a post in English and some words that are different, like "color" and "colour"
* Switch from one variant to the other and click the block
* Check that the highlights are changed

Known problem: A click is necessary to update the highlights

