### PR TITLE
Boost: Add foundation pages UI

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/foundation-pages.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/foundation-pages.module.scss
@@ -1,0 +1,3 @@
+.content {
+	width: 100%;
+}

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/foundation-pages.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/foundation-pages.module.scss
@@ -1,3 +1,0 @@
-.content {
-	width: 100%;
-}

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/foundation-pages.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/foundation-pages.tsx
@@ -1,7 +1,23 @@
+import { __ } from '@wordpress/i18n';
 import Meta from './meta/meta';
+import SettingsItem from '../ui/settings-item/settings-item';
 
 const FoundationPages = () => {
-	return <Meta />;
+	return (
+		<SettingsItem
+			title={ __( 'Foundation Pages', 'jetpack-boost' ) }
+			description={
+				<p>
+					{ __(
+						'List the most important pages of your site. They will be optimized. The Page Speed scores are based on the first foundation page.',
+						'jetpack-boost'
+					) }
+				</p>
+			}
+		>
+			<Meta />
+		</SettingsItem>
+	);
 };
 
 export default FoundationPages;

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/foundation-pages.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/foundation-pages.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import Meta from './meta/meta';
-import SettingsItem from '../ui/settings-item/settings-item';
+import SettingsItem from '$features/ui/settings-item/settings-item';
 
 const FoundationPages = () => {
 	return (

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/foundation-pages.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/foundation-pages.tsx
@@ -1,0 +1,7 @@
+import Meta from './meta/meta';
+
+const FoundationPages = () => {
+	return <Meta />;
+};
+
+export default FoundationPages;

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/lib/stores/foundation-pages.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/lib/stores/foundation-pages.ts
@@ -1,0 +1,19 @@
+import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
+import { z } from 'zod';
+
+/**
+ * Hook to get the Foundation Pages.
+ */
+export function useFoundationPages(): [ string[], ( newValue: string[] ) => void ] {
+	const [ { data }, { mutate } ] = useDataSync(
+		'jetpack_boost_ds',
+		'foundation_pages',
+		z.array( z.string() )
+	);
+
+	function updatePages( newValue: string[] ) {
+		mutate( newValue );
+	}
+
+	return [ data || [], updatePages ];
+}

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/lib/stores/foundation-pages.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/lib/stores/foundation-pages.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 export function useFoundationPages(): [ string[], ( newValue: string[] ) => void ] {
 	const [ { data }, { mutate } ] = useDataSync(
 		'jetpack_boost_ds',
-		'foundation_pages',
+		'foundation_pages_list',
 		z.array( z.string() )
 	);
 
@@ -16,4 +16,17 @@ export function useFoundationPages(): [ string[], ( newValue: string[] ) => void
 	}
 
 	return [ data || [], updatePages ];
+}
+
+const FoundationPagesProperties = z.object( { max_pages: z.number() } );
+type FoundationPagesProperties = z.infer< typeof FoundationPagesProperties >;
+
+export function useFoundationPagesProperties(): FoundationPagesProperties | undefined {
+	const [ { data } ] = useDataSync(
+		'jetpack_boost_ds',
+		'foundation_pages_properties',
+		FoundationPagesProperties
+	);
+
+	return data;
 }

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.module.scss
@@ -1,0 +1,128 @@
+.wrapper {
+	font-size: 14px;
+	line-height: 22px;
+
+	:global(button ~ button) {
+		margin-left: 20px !important;
+	}
+
+	.head {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+
+		:global(svg) {
+			fill: var(--jetpack-green-40);
+		}
+
+		.summary {
+			flex-grow: 1;
+			margin-right: 5px;
+			color: var(--gray-40);
+		}
+	}
+
+	.body {
+		margin-top: 16px;
+
+		.section {
+			padding: 16px;
+			border-radius: 4px;
+			background-color: var(--gray-0);
+
+			& ~ .section {
+				margin-top: 16px;
+			}
+
+			&.has-error {
+				textarea {
+					border-color: var( --red-40 );
+				}
+
+				.error-message {
+					display: block;
+					color: var( --red-40 );
+				}
+			}
+
+			.title {
+				margin-bottom: 16px;
+				font-size: 16px;
+				line-height: 1;
+				font-weight: 600;
+			}
+
+			textarea {
+				display: block;
+				margin-bottom: 8px;
+				width: 100%;
+				padding: 12px 16px;
+				border-radius: 4px;
+				border: 1px solid var( --gray-10 );
+				background: var( --primary-white );
+				color: #000;
+			}
+
+			.error-message {
+				display: none;
+			}
+
+			.description {
+				margin-top: 8px;
+				font-size: 14px;
+				line-height: 1.5;
+				color: var( --gray-60 );
+				font-weight: 400;
+			}
+
+			label {
+				display: block;
+				font-size: 16px;
+				line-height: 1.5;
+
+				&:not(:last-child) {
+					margin-bottom: 8px;
+				}
+			}
+		}
+
+		.button {
+			margin-top: 16px;
+		}
+	}
+
+	.see-logs-link {
+		font-size: 16px;
+		line-height: 1.5;
+	}
+
+	.logging-toggle {
+		margin-right: 1em;
+		float: left;
+	}
+
+	.clearfix {
+		clear: both;
+	}
+}
+
+.example-wrapper {
+	position: relative;
+	display: inline;
+
+	.example-button {
+		position: relative;
+		z-index: 10;
+	}
+
+	.tooltip-wrapper {
+		position: absolute;
+		top: 0;
+		left: -10px;
+		z-index: 9;
+
+		.tooltip :global(.icon-tooltip-container .components-popover__content) {
+			width: 150px;
+		}
+	}
+}

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.module.scss
@@ -109,24 +109,3 @@
 		clear: both;
 	}
 }
-
-.example-wrapper {
-	position: relative;
-	display: inline;
-
-	.example-button {
-		position: relative;
-		z-index: 10;
-	}
-
-	.tooltip-wrapper {
-		position: absolute;
-		top: 0;
-		left: -10px;
-		z-index: 9;
-
-		.tooltip :global(.icon-tooltip-container .components-popover__content) {
-			width: 150px;
-		}
-	}
-}

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.module.scss
@@ -43,6 +43,10 @@
 					display: block;
 					color: var( --red-40 );
 				}
+
+				.error {
+					color: var( --red-40 );
+				}
 			}
 
 			.title {

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -144,7 +144,7 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems } ) => {
 		>
 			<textarea
 				value={ inputValue }
-				rows={ 3 }
+				rows={ maxItems }
 				onChange={ e => validateInputValue( e.target.value ) }
 				id="jb-foundation-pages"
 			/>

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/jetpack-components';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import React, { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import styles from './meta.module.scss';
@@ -17,7 +17,11 @@ const Meta = () => {
 	return (
 		<div className={ styles.wrapper } data-testid="foundation-pages-meta">
 			<div className={ styles.body }>
-				<BypassPatterns patterns={ foundationPages.join( '\n' ) } setPatterns={ updatePatterns } />
+				<BypassPatterns
+					patterns={ foundationPages.join( '\n' ) }
+					setPatterns={ updatePatterns }
+					maxPatterns={ 1 }
+				/>
 			</div>
 		</div>
 	);
@@ -26,9 +30,14 @@ const Meta = () => {
 type BypassPatternsProps = {
 	patterns: string;
 	setPatterns: ( newValue: string ) => void;
+	maxPatterns: number;
 };
 
-const BypassPatterns: React.FC< BypassPatternsProps > = ( { patterns, setPatterns } ) => {
+const BypassPatterns: React.FC< BypassPatternsProps > = ( {
+	patterns,
+	setPatterns,
+	maxPatterns,
+} ) => {
 	const [ inputValue, setInputValue ] = useState( patterns );
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [ inputInvalid, setInputInvalid ] = useState( false );
@@ -46,6 +55,11 @@ const BypassPatterns: React.FC< BypassPatternsProps > = ( { patterns, setPattern
 
 		// There should always be at least one foundation page.
 		if ( lines.length === 0 ) {
+			return false;
+		}
+
+		// Check if the number of patterns exceeds maxPatterns
+		if ( lines.length > maxPatterns ) {
 			return false;
 		}
 
@@ -79,6 +93,20 @@ const BypassPatterns: React.FC< BypassPatternsProps > = ( { patterns, setPattern
 			>
 				{ __( 'Save', 'jetpack-boost' ) }
 			</Button>
+			{ inputInvalid && (
+				<p className={ styles.error }>
+					{ sprintf(
+						/* translators: %d is the maximum number of foundation pages. */
+						_n(
+							'You can have only %d foundation page.',
+							'You can have only %d foundation pages.',
+							maxPatterns,
+							'jetpack-boost'
+						),
+						maxPatterns
+					) }
+				</p>
+			) }
 		</div>
 	);
 };

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -104,6 +104,8 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems } ) => {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [ inputInvalid, setInputInvalid ] = useState( false );
 
+	const inputRows = Math.min( maxItems, 10 );
+
 	const validateInputValue = ( value: string ) => {
 		setInputValue( value );
 		setInputInvalid( ! validateItems( value ) );
@@ -144,7 +146,7 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems } ) => {
 		>
 			<textarea
 				value={ inputValue }
-				rows={ maxItems }
+				rows={ inputRows }
 				onChange={ e => validateInputValue( e.target.value ) }
 				id="jb-foundation-pages"
 			/>

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -1,5 +1,7 @@
 import { Button } from '@automattic/jetpack-components';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import ChevronDown from '$svg/chevron-down';
+import ChevronUp from '$svg/chevron-up';
 import React, { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import styles from './meta.module.scss';
@@ -7,6 +9,7 @@ import { useFoundationPages } from '../lib/stores/foundation-pages';
 import { usePremiumFeatures } from '$lib/stores/premium-features';
 
 const Meta = () => {
+	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ foundationPages, setFoundationPages ] = useFoundationPages();
 	const premiumFeatures = usePremiumFeatures();
 	const maxPatterns = premiumFeatures.includes( 'cloud-critical-css' ) ? 10 : 1;
@@ -19,13 +22,37 @@ const Meta = () => {
 
 	return (
 		<div className={ styles.wrapper } data-testid="foundation-pages-meta">
-			<div className={ styles.body }>
-				<BypassPatterns
-					patterns={ foundationPages.join( '\n' ) }
-					setPatterns={ updatePatterns }
-					maxPatterns={ maxPatterns }
-				/>
+			<div className={ styles.head }>
+				<div className={ styles.summary }>
+					{ sprintf(
+						/* translators: %1$d is the number of foundation pages added, %2$d is the maximum number allowed */
+						__( '%1$d / %2$d added', 'jetpack-boost' ),
+						foundationPages.length,
+						maxPatterns
+					) }
+				</div>
+				<div className={ styles.actions }>
+					<Button
+						variant="link"
+						size="small"
+						weight="regular"
+						iconSize={ 16 }
+						icon={ isExpanded ? <ChevronUp /> : <ChevronDown /> }
+						onClick={ () => setIsExpanded( ! isExpanded ) }
+					>
+						{ __( 'Show Options', 'jetpack-boost' ) }
+					</Button>
+				</div>
 			</div>
+			{ isExpanded && (
+				<div className={ styles.body }>
+					<BypassPatterns
+						patterns={ foundationPages.join( '\n' ) }
+						setPatterns={ updatePatterns }
+						maxPatterns={ maxPatterns }
+					/>
+				</div>
+			) }
 		</div>
 	);
 };
@@ -89,13 +116,6 @@ const BypassPatterns: React.FC< BypassPatternsProps > = ( {
 				onChange={ e => validateInputValue( e.target.value ) }
 				id="jb-foundation-pages"
 			/>
-			<Button
-				disabled={ patterns === inputValue || inputInvalid }
-				onClick={ save }
-				className={ styles.button }
-			>
-				{ __( 'Save', 'jetpack-boost' ) }
-			</Button>
 			{ inputInvalid && (
 				<p className={ styles.error }>
 					{ sprintf(
@@ -110,6 +130,13 @@ const BypassPatterns: React.FC< BypassPatternsProps > = ( {
 					) }
 				</p>
 			) }
+			<Button
+				disabled={ patterns === inputValue || inputInvalid }
+				onClick={ save }
+				className={ styles.button }
+			>
+				{ __( 'Save', 'jetpack-boost' ) }
+			</Button>
 		</div>
 	);
 };

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -155,10 +155,10 @@ const BypassPatterns: React.FC< BypassPatternsProps > = ( {
 			{ inputInvalid && (
 				<p className={ styles.error }>
 					{ sprintf(
-						/* translators: %d is the maximum number of foundation pages. */
+						/* translators: %d is the maximum number of foundation page URLs. */
 						_n(
-							'You can have only %d foundation page.',
-							'You can have only %d foundation pages.',
+							'You must provide %d foundation page URL.',
+							'You must provide between 1 and %d foundation page URLs.',
 							maxPatterns,
 							'jetpack-boost'
 						),

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import React, { useEffect, useState } from 'react';
-import clsx from 'clsx';
 import styles from './meta.module.scss';
 import { useFoundationPages } from '../lib/stores/foundation-pages';
 
@@ -30,28 +29,9 @@ type BypassPatternsProps = {
 
 const BypassPatterns: React.FC< BypassPatternsProps > = ( { patterns, setPatterns } ) => {
 	const [ inputValue, setInputValue ] = useState( patterns );
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const [ inputInvalid, setInputInvalid ] = useState( false );
 
 	const validateInputValue = ( value: string ) => {
 		setInputValue( value );
-		setInputInvalid( ! validatePatterns( value ) );
-	};
-
-	const validatePatterns = ( value: string ) => {
-		const lines = value
-			.split( '\n' )
-			.map( line => line.trim() )
-			.filter( line => line.trim() !== '' );
-
-		// check if it's a valid regex
-		try {
-			lines.forEach( line => new RegExp( line ) );
-		} catch ( e ) {
-			return false;
-		}
-
-		return true;
 	};
 
 	useEffect( () => {
@@ -63,22 +43,14 @@ const BypassPatterns: React.FC< BypassPatternsProps > = ( { patterns, setPattern
 	}
 
 	return (
-		<div
-			className={ clsx( styles.section, {
-				[ styles[ 'has-error' ] ]: inputInvalid,
-			} ) }
-		>
+		<div className={ styles.section }>
 			<textarea
 				value={ inputValue }
 				rows={ 3 }
 				onChange={ e => validateInputValue( e.target.value ) }
 				id="jb-foundation-pages"
 			/>
-			<Button
-				disabled={ patterns === inputValue || inputInvalid }
-				onClick={ save }
-				className={ styles.button }
-			>
+			<Button disabled={ patterns === inputValue } onClick={ save } className={ styles.button }>
 				{ __( 'Save', 'jetpack-boost' ) }
 			</Button>
 		</div>

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -1,0 +1,88 @@
+import { Button } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+import React, { useEffect, useState } from 'react';
+import clsx from 'clsx';
+import styles from './meta.module.scss';
+import { useFoundationPages } from '../lib/stores/foundation-pages';
+
+const Meta = () => {
+	const [ foundationPages, setFoundationPages ] = useFoundationPages();
+
+	const updatePatterns = ( newValue: string ) => {
+		const newPatterns = newValue.split( '\n' ).map( line => line.trim() );
+
+		setFoundationPages( newPatterns );
+	};
+
+	return (
+		<div className={ styles.wrapper } data-testid="foundation-pages-meta">
+			<div className={ styles.body }>
+				<BypassPatterns patterns={ foundationPages.join( '\n' ) } setPatterns={ updatePatterns } />
+			</div>
+		</div>
+	);
+};
+
+type BypassPatternsProps = {
+	patterns: string;
+	setPatterns: ( newValue: string ) => void;
+};
+
+const BypassPatterns: React.FC< BypassPatternsProps > = ( { patterns, setPatterns } ) => {
+	const [ inputValue, setInputValue ] = useState( patterns );
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [ inputInvalid, setInputInvalid ] = useState( false );
+
+	const validateInputValue = ( value: string ) => {
+		setInputValue( value );
+		setInputInvalid( ! validatePatterns( value ) );
+	};
+
+	const validatePatterns = ( value: string ) => {
+		const lines = value
+			.split( '\n' )
+			.map( line => line.trim() )
+			.filter( line => line.trim() !== '' );
+
+		// check if it's a valid regex
+		try {
+			lines.forEach( line => new RegExp( line ) );
+		} catch ( e ) {
+			return false;
+		}
+
+		return true;
+	};
+
+	useEffect( () => {
+		setInputValue( patterns );
+	}, [ patterns ] );
+
+	function save() {
+		setPatterns( inputValue );
+	}
+
+	return (
+		<div
+			className={ clsx( styles.section, {
+				[ styles[ 'has-error' ] ]: inputInvalid,
+			} ) }
+		>
+			<textarea
+				value={ inputValue }
+				rows={ 3 }
+				onChange={ e => validateInputValue( e.target.value ) }
+				id="jb-foundation-pages"
+			/>
+			<Button
+				disabled={ patterns === inputValue || inputInvalid }
+				onClick={ save }
+				className={ styles.button }
+			>
+				{ __( 'Save', 'jetpack-boost' ) }
+			</Button>
+		</div>
+	);
+};
+
+export default Meta;

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -15,20 +15,20 @@ const Meta = () => {
 	const [ foundationPages, setFoundationPages ] = useFoundationPages();
 	const foundationPagesProperties = useFoundationPagesProperties();
 
-	const updatePatterns = ( newValue: string ) => {
-		const newPatterns = newValue.split( '\n' ).map( line => line.trim() );
+	const updateFoundationPages = ( newValue: string ) => {
+		const newItems = newValue.split( '\n' ).map( line => line.trim() );
 
-		setFoundationPages( newPatterns );
+		setFoundationPages( newItems );
 	};
 
 	let content = null;
 
 	if ( foundationPagesProperties !== undefined ) {
 		content = (
-			<BypassPatterns
-				patterns={ foundationPages.join( '\n' ) }
-				setPatterns={ updatePatterns }
-				maxPatterns={ foundationPagesProperties.max_pages }
+			<List
+				items={ foundationPages.join( '\n' ) }
+				setItems={ updateFoundationPages }
+				maxItems={ foundationPagesProperties.max_pages }
 			/>
 		);
 	} else {
@@ -93,27 +93,23 @@ const Meta = () => {
 	);
 };
 
-type BypassPatternsProps = {
-	patterns: string;
-	setPatterns: ( newValue: string ) => void;
-	maxPatterns: number;
+type ListProps = {
+	items: string;
+	setItems: ( newValue: string ) => void;
+	maxItems: number;
 };
 
-const BypassPatterns: React.FC< BypassPatternsProps > = ( {
-	patterns,
-	setPatterns,
-	maxPatterns,
-} ) => {
-	const [ inputValue, setInputValue ] = useState( patterns );
+const List: React.FC< ListProps > = ( { items, setItems, maxItems } ) => {
+	const [ inputValue, setInputValue ] = useState( items );
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [ inputInvalid, setInputInvalid ] = useState( false );
 
 	const validateInputValue = ( value: string ) => {
 		setInputValue( value );
-		setInputInvalid( ! validatePatterns( value ) );
+		setInputInvalid( ! validateItems( value ) );
 	};
 
-	const validatePatterns = ( value: string ) => {
+	const validateItems = ( value: string ) => {
 		const lines = value
 			.split( '\n' )
 			.map( line => line.trim() )
@@ -124,8 +120,8 @@ const BypassPatterns: React.FC< BypassPatternsProps > = ( {
 			return false;
 		}
 
-		// Check if the number of patterns exceeds maxPatterns
-		if ( lines.length > maxPatterns ) {
+		// Check if the number of items exceeds maxItems
+		if ( lines.length > maxItems ) {
 			return false;
 		}
 
@@ -133,11 +129,11 @@ const BypassPatterns: React.FC< BypassPatternsProps > = ( {
 	};
 
 	useEffect( () => {
-		setInputValue( patterns );
-	}, [ patterns ] );
+		setInputValue( items );
+	}, [ items ] );
 
 	function save() {
-		setPatterns( inputValue );
+		setItems( inputValue );
 	}
 
 	return (
@@ -159,15 +155,15 @@ const BypassPatterns: React.FC< BypassPatternsProps > = ( {
 						_n(
 							'You must provide %d foundation page URL.',
 							'You must provide between 1 and %d foundation page URLs.',
-							maxPatterns,
+							maxItems,
 							'jetpack-boost'
 						),
-						maxPatterns
+						maxItems
 					) }
 				</p>
 			) }
 			<Button
-				disabled={ patterns === inputValue || inputInvalid }
+				disabled={ items === inputValue || inputInvalid }
 				onClick={ save }
 				className={ styles.button }
 			>

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -4,9 +4,12 @@ import React, { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import styles from './meta.module.scss';
 import { useFoundationPages } from '../lib/stores/foundation-pages';
+import { usePremiumFeatures } from '$lib/stores/premium-features';
 
 const Meta = () => {
 	const [ foundationPages, setFoundationPages ] = useFoundationPages();
+	const premiumFeatures = usePremiumFeatures();
+	const maxPatterns = premiumFeatures.includes( 'cloud-critical-css' ) ? 10 : 1;
 
 	const updatePatterns = ( newValue: string ) => {
 		const newPatterns = newValue.split( '\n' ).map( line => line.trim() );
@@ -20,7 +23,7 @@ const Meta = () => {
 				<BypassPatterns
 					patterns={ foundationPages.join( '\n' ) }
 					setPatterns={ updatePatterns }
-					maxPatterns={ 1 }
+					maxPatterns={ maxPatterns }
 				/>
 			</div>
 		</div>

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import React, { useEffect, useState } from 'react';
+import clsx from 'clsx';
 import styles from './meta.module.scss';
 import { useFoundationPages } from '../lib/stores/foundation-pages';
 
@@ -29,9 +30,26 @@ type BypassPatternsProps = {
 
 const BypassPatterns: React.FC< BypassPatternsProps > = ( { patterns, setPatterns } ) => {
 	const [ inputValue, setInputValue ] = useState( patterns );
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [ inputInvalid, setInputInvalid ] = useState( false );
 
 	const validateInputValue = ( value: string ) => {
 		setInputValue( value );
+		setInputInvalid( ! validatePatterns( value ) );
+	};
+
+	const validatePatterns = ( value: string ) => {
+		const lines = value
+			.split( '\n' )
+			.map( line => line.trim() )
+			.filter( line => line.trim() !== '' );
+
+		// There should always be at least one foundation page.
+		if ( lines.length === 0 ) {
+			return false;
+		}
+
+		return true;
 	};
 
 	useEffect( () => {
@@ -43,14 +61,22 @@ const BypassPatterns: React.FC< BypassPatternsProps > = ( { patterns, setPattern
 	}
 
 	return (
-		<div className={ styles.section }>
+		<div
+			className={ clsx( styles.section, {
+				[ styles[ 'has-error' ] ]: inputInvalid,
+			} ) }
+		>
 			<textarea
 				value={ inputValue }
 				rows={ 3 }
 				onChange={ e => validateInputValue( e.target.value ) }
 				id="jb-foundation-pages"
 			/>
-			<Button disabled={ patterns === inputValue } onClick={ save } className={ styles.button }>
+			<Button
+				disabled={ patterns === inputValue || inputInvalid }
+				onClick={ save }
+				className={ styles.button }
+			>
 				{ __( 'Save', 'jetpack-boost' ) }
 			</Button>
 		</div>

--- a/projects/plugins/boost/app/assets/src/js/features/module/module.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/module/module.module.scss
@@ -30,3 +30,7 @@
 	margin-right: 2em;
 	min-width: 36px;
 }
+
+.content {
+	width: 100%;
+}

--- a/projects/plugins/boost/app/assets/src/js/features/ui/settings-item/settings-item.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/settings-item/settings-item.module.scss
@@ -1,0 +1,28 @@
+.wrapper {
+	margin-bottom: 2em;
+	display: flex;
+	margin-left: auto;
+	margin-right: auto;
+
+
+	a {
+		text-decoration: underline;
+	}
+
+	h2 {
+		font-size: 22px;
+		margin-top: 0;
+	}
+
+	p {
+		margin: 1em 0;
+	}
+
+	.content {
+		width: 100%;
+	}
+
+	.content h3:focus-visible {
+		outline: none;
+	}
+}

--- a/projects/plugins/boost/app/assets/src/js/features/ui/settings-item/settings-item.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/settings-item/settings-item.tsx
@@ -1,0 +1,23 @@
+import styles from './settings-item.module.scss';
+
+type SettingsItemProps = {
+	title: string;
+	description: React.ReactNode;
+	children: React.ReactNode;
+};
+
+const SettingsItem = ( { title, description, children }: SettingsItemProps ) => {
+	return (
+		<div className={ styles.wrapper }>
+			<div className={ styles.content }>
+				<h3>{ title }</h3>
+
+				<div className={ styles.description }>{ description }</div>
+
+				{ children }
+			</div>
+		</div>
+	);
+};
+
+export default SettingsItem;

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/get-support-link.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/get-support-link.ts
@@ -1,0 +1,10 @@
+import { usePremiumFeatures } from '$lib/stores/premium-features';
+
+export default function getSupportLink() {
+	const premiumFeatures = usePremiumFeatures();
+	if ( premiumFeatures.includes( 'support' ) ) {
+		return 'https://jetpack.com/contact-support/';
+	}
+
+	return 'https://wordpress.org/support/plugin/jetpack-boost/';
+}

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -11,6 +11,7 @@ import MinifyMeta from '$features/minify-meta/minify-meta';
 import { QualitySettings, ImageCdnLiar } from '$features/image-cdn';
 import styles from './index.module.scss';
 import { RecommendationsMeta } from '$features/image-size-analysis';
+import FoundationPages from '$features/foundation-pages/foundation-pages';
 import { useRegenerateCriticalCssAction } from '$features/critical-css/lib/stores/critical-css-state';
 import PremiumTooltip from '$features/premium-tooltip/premium-tooltip';
 import Upgraded from '$features/ui/upgraded/upgraded';
@@ -36,6 +37,7 @@ const Index = () => {
 
 	return (
 		<div className="jb-container--narrow">
+			<FoundationPages />
 			<Module
 				slug="critical_css"
 				title={ __( 'Optimize Critical CSS Loading (manual)', 'jetpack-boost' ) }

--- a/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack_Boost\Data_Sync;
 
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
+use Automattic\Jetpack_Boost\Lib\Premium_Features;
 
 class Foundation_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 
@@ -22,6 +23,12 @@ class Foundation_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 	}
 	public function set( $value ) {
 		$value = $this->sanitize_value( $value );
+
+		// Free users get 1 and premium users get 10.
+		$max_patterns = Premium_Features::has_any() ? 10 : 1;
+		if ( count( $value ) > $max_patterns ) {
+			$value = array_slice( $value, 0, $max_patterns );
+		}
 
 		update_option( $this->option_key, $value );
 	}

--- a/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
@@ -4,7 +4,6 @@ namespace Automattic\Jetpack_Boost\Data_Sync;
 
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
-use Automattic\Jetpack_Boost\Lib\Premium_Features;
 
 class Foundation_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 
@@ -23,12 +22,6 @@ class Foundation_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 	}
 	public function set( $value ) {
 		$value = $this->sanitize_value( $value );
-
-		// Free users get 1 and premium users get 10.
-		$max_patterns = Premium_Features::has_any() ? 10 : 1;
-		if ( count( $value ) > $max_patterns ) {
-			$value = array_slice( $value, 0, $max_patterns );
-		}
 
 		update_option( $this->option_key, $value );
 	}

--- a/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Data_Sync;
+
+use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
+use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
+
+class Foundation_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
+
+	private $option_key;
+
+	public function __construct( $option_key ) {
+		$this->option_key = 'jetpack_boost_ds_' . $option_key;
+	}
+
+	public function get( $fallback_value = false ) {
+		if ( $fallback_value !== false ) {
+			return get_option( $this->option_key, $fallback_value );
+		}
+
+		return get_option( $this->option_key );
+	}
+	public function set( $value ) {
+		$value = $this->sanitize_value( $value );
+
+		update_option( $this->option_key, $value );
+	}
+	private function sanitize_value( $value ) {
+		if ( is_array( $value ) ) {
+			$value = array_values( array_unique( array_filter( array_map( 'trim', $value ) ) ) );
+		} else {
+			$value = array();
+		}
+
+		return $value;
+	}
+}

--- a/projects/plugins/boost/app/lib/Foundation_Pages.php
+++ b/projects/plugins/boost/app/lib/Foundation_Pages.php
@@ -25,4 +25,14 @@ class Foundation_Pages implements Has_Setup {
 	public function get_pages() {
 		return array();
 	}
+
+	public function get_properties() {
+		return array(
+			'max_pages' => $this->get_max_pages(),
+		);
+	}
+
+	private function get_max_pages() {
+		return Premium_Features::has_any() ? 10 : 1;
+	}
 }

--- a/projects/plugins/boost/changelog/add-foundation-pages-ui
+++ b/projects/plugins/boost/changelog/add-foundation-pages-ui
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add UI for Foundation pages.
+
+

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -7,6 +7,7 @@ use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Data_Sync_Entry;
 use Automattic\Jetpack\WP_JS_Data_Sync\Data_Sync;
 use Automattic\Jetpack\WP_JS_Data_Sync\Data_Sync_Readonly;
 use Automattic\Jetpack_Boost\Data_Sync\Critical_CSS_Meta_Entry;
+use Automattic\Jetpack_Boost\Data_Sync\Foundation_Pages_Entry;
 use Automattic\Jetpack_Boost\Data_Sync\Getting_Started_Entry;
 use Automattic\Jetpack_Boost\Data_Sync\Mergeable_Array_Entry;
 use Automattic\Jetpack_Boost\Data_Sync\Minify_Excludes_State_Entry;
@@ -383,3 +384,5 @@ jetpack_boost_register_action( 'page_cache', 'clear-page-cache', Schema::as_void
 jetpack_boost_register_action( 'page_cache', 'deactivate-wpsc', Schema::as_void(), new Deactivate_WPSC() );
 
 jetpack_boost_register_option( 'image_cdn_liar', Schema::as_boolean()->fallback( false ), new Status( Liar::get_slug() ) );
+
+jetpack_boost_register_option( 'foundation_pages', Schema::as_array( Schema::as_string() )->fallback( array() ), new Foundation_Pages_Entry( 'foundation_pages' ) );

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -17,6 +17,7 @@ use Automattic\Jetpack_Boost\Lib\Critical_CSS\Data_Sync_Actions\Regenerate_CSS;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Data_Sync_Actions\Set_Provider_CSS;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Data_Sync_Actions\Set_Provider_Error_Dismissed;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Data_Sync_Actions\Set_Provider_Errors;
+use Automattic\Jetpack_Boost\Lib\Foundation_Pages;
 use Automattic\Jetpack_Boost\Lib\My_Jetpack;
 use Automattic\Jetpack_Boost\Lib\Premium_Features;
 use Automattic\Jetpack_Boost\Lib\Premium_Pricing;
@@ -385,4 +386,6 @@ jetpack_boost_register_action( 'page_cache', 'deactivate-wpsc', Schema::as_void(
 
 jetpack_boost_register_option( 'image_cdn_liar', Schema::as_boolean()->fallback( false ), new Status( Liar::get_slug() ) );
 
-jetpack_boost_register_option( 'foundation_pages', Schema::as_array( Schema::as_string() )->fallback( array() ), new Foundation_Pages_Entry( 'foundation_pages' ) );
+jetpack_boost_register_option( 'foundation_pages_list', Schema::as_array( Schema::as_string() )->fallback( array( '/' ) ), new Foundation_Pages_Entry( 'foundation_pages_list' ) );
+
+jetpack_boost_register_readonly_option( 'foundation_pages_properties', array( new Foundation_Pages(), 'get_properties' ) );


### PR DESCRIPTION
## Proposed changes:

* Adds a basic UI with save functionality for the foundation pages.
* No validation, nothing. Pretty things will be added later. Code is also re-used so that will be fixed later as well.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Make sure you can add text to the lonely textarea and save that text.