### PR TITLE
Boost: Implement partial cloud CSS regeneration

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -27,6 +27,7 @@ use Automattic\Jetpack_Boost\Lib\Connection;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Generator;
+use Automattic\Jetpack_Boost\Lib\Foundation_Pages;
 use Automattic\Jetpack_Boost\Lib\Setup;
 use Automattic\Jetpack_Boost\Lib\Site_Health;
 use Automattic\Jetpack_Boost\Lib\Status;
@@ -107,6 +108,9 @@ class Jetpack_Boost {
 
 		$modules_setup = new Modules_Setup();
 		Setup::add( $modules_setup );
+
+		$foundation_pages = new Foundation_Pages();
+		Setup::add( $foundation_pages );
 
 		// Initialize the Admin experience.
 		$this->init_admin( $modules_setup );

--- a/projects/plugins/boost/app/lib/Foundation_Pages.php
+++ b/projects/plugins/boost/app/lib/Foundation_Pages.php
@@ -2,7 +2,26 @@
 
 namespace Automattic\Jetpack_Boost\Lib;
 
-class Foundation_Pages {
+use Automattic\Jetpack_Boost\Contracts\Has_Setup;
+
+class Foundation_Pages implements Has_Setup {
+
+	public function setup() {
+		add_filter( 'jetpack_boost_critical_css_providers', array( $this, 'remove_ccss_front_page_provider' ), 10, 2 );
+	}
+
+	public function remove_ccss_front_page_provider( $providers ) {
+		$filtered_providers = array();
+
+		foreach ( $providers as $provider ) {
+			if ( $provider['key'] !== 'core_front_page' ) {
+				$filtered_providers[] = $provider;
+			}
+		}
+
+		return $filtered_providers;
+	}
+
 	public function get_pages() {
 		return array();
 	}

--- a/projects/plugins/boost/app/lib/critical-css/Regenerate.php
+++ b/projects/plugins/boost/app/lib/critical-css/Regenerate.php
@@ -35,7 +35,7 @@ class Regenerate {
 			// If this is a cloud CSS request, we need to trigger the generation
 			// of the CSS and return the URL to the CSS file.
 			$cloud_css = new Cloud_CSS();
-			$cloud_css->regenerate_cloud_css( Cloud_CSS::REGENERATE_REASON_USER_REQUEST );
+			$cloud_css->regenerate_cloud_css( Cloud_CSS::REGENERATE_REASON_USER_REQUEST, $cloud_css->get_all_providers() );
 			Cloud_CSS_Followup::schedule();
 		}
 

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
@@ -113,10 +113,10 @@ class Source_Providers {
 	 *
 	 * @return array
 	 */
-	public function get_provider_sources() {
+	public function get_provider_sources( $context_posts = array() ) {
 		$sources = array();
 
-		$wp_core_provider_urls = WP_Core_Provider::get_critical_source_urls();
+		$wp_core_provider_urls = WP_Core_Provider::get_critical_source_urls( $context_posts );
 		$flat_wp_core_urls     = array();
 		foreach ( $wp_core_provider_urls as $urls ) {
 			$flat_wp_core_urls = array_merge( $flat_wp_core_urls, $urls );
@@ -127,7 +127,7 @@ class Source_Providers {
 
 			// For each provider,
 			// Gather a list of URLs that are going to be used as Critical CSS source.
-			foreach ( $provider::get_critical_source_urls() as $group => $urls ) {
+			foreach ( $provider::get_critical_source_urls( $context_posts ) as $group => $urls ) {
 				if ( empty( $urls ) ) {
 					continue;
 				}

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
@@ -164,7 +164,13 @@ class Source_Providers {
 			}
 		}
 
-		return $sources;
+		/**
+		 * Filters the list of Critical CSS source providers.
+		 *
+		 * @param array $sources The list of Critical CSS source providers.
+		 * @since $$next-version$$
+		 */
+		return apply_filters( 'jetpack_boost_critical_css_providers', $sources );
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/Source_Providers.php
@@ -146,19 +146,19 @@ class Source_Providers {
 
 				$key = $provider_name . '_' . $group;
 
-				// For each URL
+				// For each provider
 				// Track the state and errors in a state array.
 				$sources[] = array(
 					'key'           => $key,
 					'label'         => $provider::describe_key( $key ),
 					/**
-					 * Filters the URLs used by Critical CSS
+					 * Filters the URLs used by Critical CSS for each provider.
 					 *
 					 * @param array $urls The list of URLs to be used to generate critical CSS
-					 *
+					 * @param string $provider The provider name.
 					 * @since   1.0.0
 					 */
-					'urls'          => apply_filters( 'jetpack_boost_critical_css_urls', $urls ),
+					'urls'          => apply_filters( 'jetpack_boost_critical_css_urls', $urls, $provider ),
 					'success_ratio' => $provider::get_success_ratio(),
 				);
 			}

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
@@ -27,24 +27,27 @@ class WP_Core_Provider extends Provider {
 	public static function get_critical_source_urls( $context_posts = array() ) {
 		$urls = array();
 
-		// TODO: Limit to provided context posts.
-
 		$front_page = get_option( 'page_on_front' );
-		if ( ! empty( $front_page ) ) {
+		if ( ! empty( $front_page ) && empty( $context_posts ) ) {
 			$permalink = get_permalink( $front_page );
 			if ( ! empty( $permalink ) ) {
 				$urls['front_page'] = array( $permalink );
 			}
 		}
 
-		$posts_page = get_option( 'page_for_posts' );
-		if ( ! empty( $posts_page ) ) {
-			$permalink = get_permalink( $posts_page );
-			if ( ! empty( $permalink ) ) {
-				$urls['posts_page'] = array( $permalink );
+		$context_post_types = wp_list_pluck( $context_posts, 'post_type' );
+
+		// The blog page is only in context if the context posts include a 'post' post_type.
+		if ( empty( $context_post_types ) || in_array( 'post', $context_post_types, true ) ) {
+			$posts_page = get_option( 'page_for_posts' );
+			if ( ! empty( $posts_page ) ) {
+				$permalink = get_permalink( $posts_page );
+				if ( ! empty( $permalink ) ) {
+					$urls['posts_page'] = array( $permalink );
+				}
+			} else {
+				$urls['posts_page'] = (array) home_url( '/' );
 			}
-		} else {
-			$urls['posts_page'] = (array) home_url( '/' );
 		}
 
 		return $urls;

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
@@ -27,8 +27,8 @@ class WP_Core_Provider extends Provider {
 	public static function get_critical_source_urls( $context_posts = array() ) {
 		$urls = array();
 
-		$front_page = get_option( 'page_on_front' );
-		$posts_page = get_option( 'page_for_posts' );
+		$front_page = (int) get_option( 'page_on_front' );
+		$posts_page = (int) get_option( 'page_for_posts' );
 
 		if ( ! empty( $front_page ) && empty( $context_posts ) ) {
 			$permalink = get_permalink( $front_page );

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
@@ -28,6 +28,8 @@ class WP_Core_Provider extends Provider {
 		$urls = array();
 
 		$front_page = get_option( 'page_on_front' );
+		$posts_page = get_option( 'page_for_posts' );
+
 		if ( ! empty( $front_page ) && empty( $context_posts ) ) {
 			$permalink = get_permalink( $front_page );
 			if ( ! empty( $permalink ) ) {
@@ -36,10 +38,11 @@ class WP_Core_Provider extends Provider {
 		}
 
 		$context_post_types = wp_list_pluck( $context_posts, 'post_type' );
+		$context_post_ids   = wp_list_pluck( $context_posts, 'ID' );
 
 		// The blog page is only in context if the context posts include a 'post' post_type.
-		if ( empty( $context_post_types ) || in_array( 'post', $context_post_types, true ) ) {
-			$posts_page = get_option( 'page_for_posts' );
+		// Or, if the blog page itself is in context.
+		if ( empty( $context_post_types ) || in_array( 'post', $context_post_types, true ) || in_array( $posts_page, $context_post_ids, true ) ) {
 			if ( ! empty( $posts_page ) ) {
 				$permalink = get_permalink( $posts_page );
 				if ( ! empty( $permalink ) ) {

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS.php
@@ -155,11 +155,11 @@ class Cloud_CSS implements Pluggable, Has_Always_Available_Endpoints, Changes_Pa
 			return;
 		}
 
-		$this->regenerate_cloud_css( self::REGENERATE_REASON_SAVE_POST );
+		$this->regenerate_cloud_css( self::REGENERATE_REASON_SAVE_POST, $this->get_all_providers( array( $post ) ) );
 	}
 
-	public function regenerate_cloud_css( $reason ) {
-		$result = $this->generate_cloud_css( $reason, $this->get_existing_sources() );
+	public function regenerate_cloud_css( $reason, $providers ) {
+		$result = $this->generate_cloud_css( $reason, $providers );
 		if ( is_wp_error( $result ) ) {
 			$state = new Critical_CSS_State();
 			$state->set_error( $result->get_error_message() )->save();
@@ -171,8 +171,13 @@ class Cloud_CSS implements Pluggable, Has_Always_Available_Endpoints, Changes_Pa
 	 * Called when stored Critical CSS has been invalidated. Triggers a new Cloud CSS request.
 	 */
 	public function handle_critical_css_invalidated() {
-		$this->regenerate_cloud_css( self::REGENERATE_REASON_INVALIDATED );
+		$this->regenerate_cloud_css( self::REGENERATE_REASON_INVALIDATED, $this->get_all_providers() );
 		Cloud_CSS_Followup::schedule();
+	}
+
+	public function get_all_providers( $context_posts = array() ) {
+		$source_providers = new Source_Providers();
+		return $source_providers->get_provider_sources( $context_posts );
 	}
 
 	public function get_existing_sources() {
@@ -181,8 +186,7 @@ class Cloud_CSS implements Pluggable, Has_Always_Available_Endpoints, Changes_Pa
 		if ( ! empty( $data['providers'] ) ) {
 			$providers = $data['providers'];
 		} else {
-			$source_providers = new Source_Providers();
-			$providers        = $source_providers->get_provider_sources();
+			$providers = $this->get_all_providers();
 		}
 
 		return $providers;

--- a/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS_Followup.php
+++ b/projects/plugins/boost/app/modules/optimizations/cloud-css/Cloud_CSS_Followup.php
@@ -29,7 +29,7 @@ class Cloud_CSS_Followup {
 		$state = new Critical_CSS_State();
 		if ( $state->has_errors() ) {
 			$cloud_css = new Cloud_CSS();
-			$cloud_css->regenerate_cloud_css( Cloud_CSS::REGENERATE_REASON_FOLLOWUP );
+			$cloud_css->regenerate_cloud_css( Cloud_CSS::REGENERATE_REASON_FOLLOWUP, $cloud_css->get_existing_sources() );
 		}
 	}
 


### PR DESCRIPTION

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Introduce a new filter `jetpack_boost_critical_css_providers` to filter the providers list
* Remove the `core_front_page` provider when foundation pages is initiated
* Add `$context_posts` support for `WP_Core_Providers`. `$context_posts` is an array that you can provide to a source provider. The provider list will then only include provider keys that can be impacted by the posts in the array.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Regenerate cloud CSS
  * It shouldn't contain the provider for `core_front_page`.
* Update a post
  * It should only regenerate the URLs of the site that are likely to include that post. E.g.:
    * Updating a post will update the blog page, singular_post page, category, tag archive pages
    * Updating a page will only update the singular_page page.

