### PR TITLE
Initial State: Replace `isEnhancedPublishingEnabled` with `siteHasFeature` call

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-enhances-publishing-feature-check
+++ b/projects/js-packages/publicize-components/changelog/update-enhances-publishing-feature-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Initial state: Migrated isEnhancedPublishingEnabled to feature check

--- a/projects/js-packages/publicize-components/src/components/form/instagram-no-media-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/instagram-no-media-notice.tsx
@@ -2,10 +2,11 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { features } from '../../utils/constants';
 import Notice from '../notice';
 
 export const InstagramNoMediaNotice: React.FC = () => {
-	return siteHasFeature( 'social-enhanced-publishing' ) ? (
+	return siteHasFeature( features.ENHANCED_PUBLISHING ) ? (
 		<Notice type={ 'warning' }>
 			{ __(
 				'To share to Instagram, add an image/video, or enable Social Image Generator.',

--- a/projects/js-packages/publicize-components/src/components/form/instagram-no-media-notice.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/instagram-no-media-notice.tsx
@@ -1,13 +1,11 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { usePublicizeConfig } from '../../..';
 import Notice from '../notice';
 
 export const InstagramNoMediaNotice: React.FC = () => {
-	const { isEnhancedPublishingEnabled } = usePublicizeConfig();
-
-	return isEnhancedPublishingEnabled ? (
+	return siteHasFeature( 'social-enhanced-publishing' ) ? (
 		<Notice type={ 'warning' }>
 			{ __(
 				'To share to Instagram, add an image/video, or enable Social Image Generator.',

--- a/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
@@ -1,5 +1,6 @@
 import { siteHasFeature } from '@automattic/jetpack-script-data';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
+import { features } from '../../utils/constants';
 import MediaSection from '../media-section';
 import MessageBoxControl from '../message-box-control';
 
@@ -24,7 +25,7 @@ export const SharePostForm: React.FC< SharePostFormProps > = ( { analyticsData =
 				message={ message }
 				analyticsData={ analyticsData }
 			/>
-			{ siteHasFeature( 'social-enhanced-publishing' ) && (
+			{ siteHasFeature( features.ENHANCED_PUBLISHING ) && (
 				<MediaSection analyticsData={ analyticsData } />
 			) }
 		</>

--- a/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/share-post-form.tsx
@@ -1,4 +1,4 @@
-import { usePublicizeConfig } from '../../..';
+import { siteHasFeature } from '@automattic/jetpack-script-data';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import MediaSection from '../media-section';
 import MessageBoxControl from '../message-box-control';
@@ -16,8 +16,6 @@ type SharePostFormProps = {
 export const SharePostForm: React.FC< SharePostFormProps > = ( { analyticsData = null } ) => {
 	const { message, updateMessage, maxLength } = useSocialMediaMessage();
 
-	const { isEnhancedPublishingEnabled } = usePublicizeConfig();
-
 	return (
 		<>
 			<MessageBoxControl
@@ -26,7 +24,9 @@ export const SharePostForm: React.FC< SharePostFormProps > = ( { analyticsData =
 				message={ message }
 				analyticsData={ analyticsData }
 			/>
-			{ isEnhancedPublishingEnabled && <MediaSection analyticsData={ analyticsData } /> }
+			{ siteHasFeature( 'social-enhanced-publishing' ) && (
+				<MediaSection analyticsData={ analyticsData } />
+			) }
 		</>
 	);
 };

--- a/projects/js-packages/publicize-components/src/components/social-previews/instagram.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/instagram.js
@@ -7,6 +7,7 @@ import { __, _x } from '@wordpress/i18n';
 import React from 'react';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import { SOCIAL_STORE_ID, CONNECTION_SERVICE_INSTAGRAM_BUSINESS } from '../../social-store';
+import { features } from '../../utils/constants';
 
 /**
  * The Instagram tab component.
@@ -41,7 +42,7 @@ export function Instagram( props ) {
 					</ExternalLink>,
 				] }
 			>
-				{ siteHasFeature( 'social-enhanced-publishing' )
+				{ siteHasFeature( features.ENHANCED_PUBLISHING )
 					? __(
 							'To share to Instagram, add an image/video, or enable Social Image Generator.',
 							'jetpack'

--- a/projects/js-packages/publicize-components/src/components/social-previews/instagram.js
+++ b/projects/js-packages/publicize-components/src/components/social-previews/instagram.js
@@ -1,10 +1,10 @@
 import { Notice, getRedirectUrl } from '@automattic/jetpack-components';
+import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { InstagramPreviews } from '@automattic/social-previews';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import React from 'react';
-import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useSocialMediaMessage from '../../hooks/use-social-media-message';
 import { SOCIAL_STORE_ID, CONNECTION_SERVICE_INSTAGRAM_BUSINESS } from '../../social-store';
 
@@ -19,7 +19,6 @@ export function Instagram( props ) {
 	const { username: name, profileImage } = useSelect( select =>
 		select( SOCIAL_STORE_ID ).getConnectionProfileDetails( CONNECTION_SERVICE_INSTAGRAM_BUSINESS )
 	);
-	const { isEnhancedPublishingEnabled } = usePublicizeConfig();
 
 	const { message: text } = useSocialMediaMessage();
 
@@ -42,7 +41,7 @@ export function Instagram( props ) {
 					</ExternalLink>,
 				] }
 			>
-				{ isEnhancedPublishingEnabled
+				{ siteHasFeature( 'social-enhanced-publishing' )
 					? __(
 							'To share to Instagram, add an image/video, or enable Social Image Generator.',
 							'jetpack'

--- a/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
+++ b/projects/js-packages/publicize-components/src/hooks/use-publicize-config/index.js
@@ -86,13 +86,6 @@ export default function usePublicizeConfig() {
 	 */
 	const hasPaidPlan = !! getJetpackData()?.social?.hasPaidPlan;
 
-	/**
-	 * isEnhancedPublishingEnabled:
-	 * Whether the site has the enhanced publishing feature enabled. If true, it means that
-	 * the site has the Advanced plan.
-	 */
-	const isEnhancedPublishingEnabled = !! getJetpackData()?.social?.isEnhancedPublishingEnabled;
-
 	/**\
 	 * Returns true if the post type is a Jetpack Social Note.
 	 */
@@ -110,7 +103,6 @@ export default function usePublicizeConfig() {
 		hidePublicizeFeature,
 		isPostAlreadyShared,
 		hasPaidPlan,
-		isEnhancedPublishingEnabled,
 		isSocialImageGeneratorAvailable:
 			!! getJetpackData()?.social?.isSocialImageGeneratorAvailable && ! isJetpackSocialNote,
 		isSocialImageGeneratorEnabled: !! getJetpackData()?.social?.isSocialImageGeneratorEnabled,

--- a/projects/js-packages/publicize-components/src/social-store/selectors/jetpack-settings.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/jetpack-settings.js
@@ -4,7 +4,6 @@ const jetpackSettingSelectors = {
 	showPricingPage: state => state.jetpackSettings.show_pricing_page,
 	isUpdatingJetpackSettings: state => state.jetpackSettings.is_updating,
 	hasPaidPlan: state => ! ( state.jetpackSettings?.showNudge ?? true ),
-	isEnhancedPublishingEnabled: state => state.jetpackSettings?.isEnhancedPublishingEnabled ?? false,
 	getDismissedNotices: state => state.jetpackSettings?.dismissedNotices,
 	isSocialNotesEnabled: state => state.jetpackSettings?.social_notes_enabled,
 	isSocialNotesSettingsUpdating: state => state.jetpackSettings?.social_notes_is_updating,

--- a/projects/js-packages/publicize-components/src/utils/constants.ts
+++ b/projects/js-packages/publicize-components/src/utils/constants.ts
@@ -1,0 +1,3 @@
+export const features = {
+	ENHANCED_PUBLISHING: 'social-enhanced-publishing',
+};


### PR DESCRIPTION

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Replace `isEnhancedPublishingEnabled` with `siteHasFeature` call

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On Jetpack and Simple sites with a free plan
    - Create a new post
    - Open Jetpack sidebar
    - Confirm that the custom media input does not show up
    - Confirm the same in "Preview social posts" modal
    - Connect an Instagram account
    - Remove any featured image for the post
    - Confirm that the Instagram not media notice says, `You need a featured image to share to Instagram.`
    -  Open Social Previews and goto Instagram tab
    - Confirm that you see the message, `You need a featured image to share to Instagram.`

* On Simple sites with a paid plan and on Atomic sites 
    - Create a new post
    - Open Jetpack sidebar
    - Confirm that the custom media input does NOT show up
    - Connect an Instagram account
    - Remove any featured image for the post
    - Confirm that the Instagram not media notice says, `You need a featured image to share to Instagram.`
    -  Open Social Previews and goto the Instagram tab
    - Confirm that you see the message, `You need a featured image to share to Instagram.`

* On Jetpack sites with a paid plan
    - Create a new post
    - Open Jetpack sidebar
    - Confirm that the custom media input DOES show up
    - Connect an Instagram account
    - Remove any featured image for the post and turn OFF Social Image Generator
    - Confirm that the Instagram not media notice says, `To share to Instagram, add an image/video, or enable Social Image Generator.`
    -  Open Social Previews and goto the Instagram tab
    - Confirm that you see the message, `To share to Instagram, add an image/video, or enable Social Image Generator.`
    - Turn SIG back ON
    - That message should disappear
