### PR TITLE
Revert "Jetpack Sync: Add 'woocommerce_analytics_first_activation' in options' whitelist"

### DIFF
--- a/projects/packages/sync/changelog/revert-39658-update-jetpack-sync-whitelist
+++ b/projects/packages/sync/changelog/revert-39658-update-jetpack-sync-whitelist
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Revert "Jetpack Sync: Add 'woocommerce_analytics_first_activation' in options' whitelist"
+
+

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -213,7 +213,6 @@ class Defaults {
 		'jetpack_waf_share_data',
 		'jetpack_waf_share_debug_data',
 		'jetpack_waf_automatic_rules_last_updated_timestamp',
-		'woocommerce_analytics_first_activation',
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/revert-39658-update-jetpack-sync-whitelist
+++ b/projects/plugins/jetpack/changelog/revert-39658-update-jetpack-sync-whitelist
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update unit tests
+
+

--- a/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/projects/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-options.php
@@ -277,7 +277,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'jetpack_waf_share_data'                       => true,
 			'jetpack_waf_share_debug_data'                 => false,
 			'jetpack_waf_automatic_rules_last_updated_timestamp' => 0,
-			'woocommerce_analytics_first_activation'       => false,
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
Reverts Automattic/jetpack#39658

WC Analytics is no longer using this option to indicate the plugin activation for the first time. An alternate WPCOM based approach is used instead to detect the first activation and trigger a Full Sync.

See D164099-code and p1728999721096319-slack-CK365S85V

WPCOM counterpart: D164175-code

## Does this pull request change what data or activity we track or use?
No
## Testing instructions:

Code review