### PR TITLE
Initial State: Migrate `hasPaidFeatures` with feature check on front-end

### DIFF
--- a/projects/js-packages/publicize-components/changelog/update-social-replace-has-paid-features-check
+++ b/projects/js-packages/publicize-components/changelog/update-social-replace-has-paid-features-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Initial State: Migrated hasPaidFeatures flag with feature check on front-end
+
+

--- a/projects/js-packages/publicize-components/src/components/form/enhanced-features-nudge.tsx
+++ b/projects/js-packages/publicize-components/src/components/form/enhanced-features-nudge.tsx
@@ -5,20 +5,17 @@ import {
 	isSimpleSite,
 } from '@automattic/jetpack-shared-extension-utils';
 import { Button, PanelRow } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { _x } from '@wordpress/i18n';
-import { store as socialStore } from '../../social-store';
+import { hasSocialPaidFeatures } from '../../utils';
 import styles from './styles.module.scss';
 import { useAutoSaveAndRedirect } from './use-auto-save-and-redirect';
 
 export const EnhancedFeaturesNudge: React.FC = () => {
-	const hasPaidFeatures = useSelect( select => select( socialStore ).hasPaidFeatures(), [] );
-
 	const autosaveAndRedirect = useAutoSaveAndRedirect();
 
 	const isWpcom = isSimpleSite() || isAtomicSite();
 
-	if ( isWpcom || hasPaidFeatures ) {
+	if ( isWpcom || hasSocialPaidFeatures() ) {
 		return null;
 	}
 

--- a/projects/js-packages/publicize-components/src/social-store/reducer/index.js
+++ b/projects/js-packages/publicize-components/src/social-store/reducer/index.js
@@ -12,7 +12,6 @@ const reducer = combineReducers( {
 	socialImageGeneratorSettings,
 	shareStatus,
 	hasPaidPlan: ( state = false ) => state,
-	hasPaidFeatures: ( state = false ) => state,
 } );
 
 export default reducer;

--- a/projects/js-packages/publicize-components/src/social-store/selectors/index.js
+++ b/projects/js-packages/publicize-components/src/social-store/selectors/index.js
@@ -10,7 +10,6 @@ const selectors = {
 	...jetpackSettingSelectors,
 	...socialImageGeneratorSettingsSelectors,
 	...shareStatusSelectors,
-	hasPaidFeatures: state => state.hasPaidFeatures,
 };
 
 export default selectors;

--- a/projects/js-packages/publicize-components/src/utils/script-data.ts
+++ b/projects/js-packages/publicize-components/src/utils/script-data.ts
@@ -1,4 +1,4 @@
-import { getScriptData } from '@automattic/jetpack-script-data';
+import { getScriptData, siteHasFeature } from '@automattic/jetpack-script-data';
 import { SocialScriptData } from '../types/types';
 
 /**
@@ -8,4 +8,13 @@ import { SocialScriptData } from '../types/types';
  */
 export function getSocialScriptData(): SocialScriptData {
 	return getScriptData().social;
+}
+
+/**
+ * Check if the site has social paid features.
+ *
+ * @return {boolean} Whether the site has social paid features.
+ */
+export function hasSocialPaidFeatures() {
+	return siteHasFeature( 'social-enhanced-publishing' );
 }

--- a/projects/plugins/jetpack/_inc/client/sharing/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/index.jsx
@@ -1,4 +1,7 @@
-import { getSocialScriptData } from '@automattic/jetpack-publicize-components';
+import {
+	getSocialScriptData,
+	hasSocialPaidFeatures,
+} from '@automattic/jetpack-publicize-components';
 import { __ } from '@wordpress/i18n';
 import QuerySite from 'components/data/query-site';
 import React, { Component } from 'react';
@@ -97,7 +100,7 @@ export default connect( state => {
 		blogID: getSiteId( state ),
 		siteAdminUrl: getSiteAdminUrl( state ),
 		activeFeatures: getActiveFeatures( state ),
-		hasPaidFeatures: siteHasFeature( state, 'social-enhanced-publishing' ),
+		hasPaidFeatures: hasSocialPaidFeatures(),
 		hasSocialImageGenerator: siteHasFeature( state, 'social-image-generator' ),
 		userCanManageModules: userCanManageModules( state ),
 		isAtomicSite: isAtomicSite( state ),

--- a/projects/plugins/jetpack/changelog/update-social-replace-has-paid-features-check
+++ b/projects/plugins/jetpack/changelog/update-social-replace-has-paid-features-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Initial State: Migrated hasPaidFeatures flag with feature check on front-end
+
+

--- a/projects/plugins/social/changelog/update-social-replace-has-paid-features-check
+++ b/projects/plugins/social/changelog/update-social-replace-has-paid-features-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Initial State: Migrated hasPaidFeatures flag with feature check on front-end
+
+

--- a/projects/plugins/social/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/social/src/js/components/admin-page/index.jsx
@@ -7,7 +7,10 @@ import {
 	GlobalNotices,
 } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
-import { store as socialStore } from '@automattic/jetpack-publicize-components';
+import {
+	hasSocialPaidFeatures,
+	store as socialStore,
+} from '@automattic/jetpack-publicize-components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
 import React from 'react';
@@ -34,7 +37,6 @@ const Admin = () => {
 	const {
 		isModuleEnabled,
 		showPricingPage,
-		hasPaidFeatures,
 		pluginVersion,
 		isSocialImageGeneratorAvailable,
 		isUpdatingJetpackSettings,
@@ -43,7 +45,6 @@ const Admin = () => {
 		return {
 			isModuleEnabled: store.isModuleEnabled(),
 			showPricingPage: store.showPricingPage(),
-			hasPaidFeatures: store.hasPaidFeatures(),
 			pluginVersion: store.getPluginVersion(),
 			isSocialImageGeneratorAvailable: store.isSocialImageGeneratorAvailable(),
 			isUpdatingJetpackSettings: store.isUpdatingJetpackSettings(),
@@ -76,7 +77,7 @@ const Admin = () => {
 	return (
 		<AdminPage moduleName={ moduleName } header={ <AdminPageHeader /> }>
 			<GlobalNotices />
-			{ ( ! hasPaidFeatures && showPricingPage ) || forceDisplayPricingPage ? (
+			{ ( ! hasSocialPaidFeatures() && showPricingPage ) || forceDisplayPricingPage ? (
 				<AdminSectionHero>
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 						<Col>

--- a/projects/plugins/social/src/js/components/social-module-toggle/index.tsx
+++ b/projects/plugins/social/src/js/components/social-module-toggle/index.tsx
@@ -9,6 +9,7 @@ import {
 	ConnectionManagement,
 	SOCIAL_STORE_ID,
 	getSocialScriptData,
+	hasSocialPaidFeatures,
 } from '@automattic/jetpack-publicize-components';
 import { ExternalLink } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -26,7 +27,6 @@ const SocialModuleToggle: React.FC = () => {
 		isUpdating,
 		siteSuffix,
 		blogID,
-		hasPaidFeatures,
 	} = useSelect( select => {
 		const store = select( SOCIAL_STORE_ID ) as SocialStoreSelectors;
 		return {
@@ -34,7 +34,6 @@ const SocialModuleToggle: React.FC = () => {
 			isUpdating: store.isUpdatingJetpackSettings(),
 			siteSuffix: store.getSiteSuffix(),
 			blogID: store.getBlogID(),
-			hasPaidFeatures: store.hasPaidFeatures(),
 		};
 	}, [] );
 
@@ -97,7 +96,7 @@ const SocialModuleToggle: React.FC = () => {
 					{ __( 'Learn more', 'jetpack-social' ) }
 				</ExternalLink>
 			</Text>
-			{ ! hasPaidFeatures ? (
+			{ ! hasSocialPaidFeatures() ? (
 				<ContextualUpgradeTrigger
 					className={ clsx( styles.cut, { [ styles.small ]: isSmall } ) }
 					description={ __( 'Unlock advanced sharing options', 'jetpack-social' ) }

--- a/projects/plugins/social/src/js/components/support-section/index.js
+++ b/projects/plugins/social/src/js/components/support-section/index.js
@@ -4,9 +4,8 @@ import {
 	getRedirectUrl,
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
-import { SOCIAL_STORE_ID } from '@automattic/jetpack-publicize-components';
+import { hasSocialPaidFeatures } from '@automattic/jetpack-publicize-components';
 import { ExternalLink } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Icon, lifesaver } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -15,9 +14,8 @@ import styles from './styles.module.scss';
 
 const SupportSection = () => {
 	const [ isAtLeastMedium ] = useBreakpointMatch( 'md', '>=' );
-	const hasPaidPlan = useSelect( select => select( SOCIAL_STORE_ID ).hasPaidPlan() );
 
-	if ( ! hasPaidPlan ) {
+	if ( ! hasSocialPaidFeatures() ) {
 		return null;
 	}
 

--- a/projects/plugins/social/src/js/components/types/types.ts
+++ b/projects/plugins/social/src/js/components/types/types.ts
@@ -8,7 +8,6 @@ type JetpackSettingsSelectors = {
 	showPricingPage: () => boolean;
 	isUpdatingJetpackSettings: () => boolean;
 	hasPaidPlan: () => boolean;
-	hasPaidFeatures: () => boolean;
 };
 
 type ConnectionDataSelectors = {


### PR DESCRIPTION

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Migrate `hasPaidFeatures` with feature check on front-end

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* For a Jetpack site with a free plan
    - Go to Social admin page
    - Confirm that you see the upgrade nudge

    <img width="670" alt="image" src="https://github.com/user-attachments/assets/81fa1580-164b-41c9-a70b-e0263bc59e1e">

    - Confirm that you don't see this support section
    
    <img width="400" alt="Screenshot 2024-10-21 at 1 10 59 PM" src="https://github.com/user-attachments/assets/dd6aa610-6975-4a1c-a9e9-1daa21680378">

    - Goto Jetpack Settings > Sharing
    - Confirm that you see the upgrade nudge

    <img width="449" alt="image" src="https://github.com/user-attachments/assets/204f285e-3054-4108-861d-b10b079ce873">

    - Goto the editor
    - Open Jetpack/Social sidebar
    - Confirm that you see the upgrade nudge

    <img width="255" alt="image" src="https://github.com/user-attachments/assets/f3dde355-8ed9-44b9-a3ae-573ca1bba423">

* For a Jetpack site with a paid plan and for a Simple (free/paid) and Atomic sites
    - Confirm that you don't see the above upgrade nudges
    - Goto social admin page
    - Confirm that you see this support section
    
    <img width="400" alt="Screenshot 2024-10-21 at 1 10 59 PM" src="https://github.com/user-attachments/assets/dd6aa610-6975-4a1c-a9e9-1daa21680378">
    

