### PR TITLE
Social | Fix Bluesky display name when it's not set in user profile

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-bluesky-display-name
+++ b/projects/js-packages/publicize-components/changelog/fix-social-bluesky-display-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed Bluesky display name when it's not set in Bluesky profile

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-name.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-name.tsx
@@ -27,7 +27,9 @@ export function ConnectionName( { connection }: ConnectionNameProps ) {
 	return (
 		<div className={ styles[ 'connection-name' ] }>
 			{ ! connection.profile_link ? (
-				<span className={ styles[ 'profile-link' ] }>{ connection.display_name }</span>
+				<span className={ styles[ 'profile-link' ] }>
+					{ connection.display_name || connection.external_name }
+				</span>
 			) : (
 				<ExternalLink className={ styles[ 'profile-link' ] } href={ connection.profile_link }>
 					{ connection.display_name || connection.external_display }


### PR DESCRIPTION
Bluesky allows the display name to be left empty, which results in a blank name in the connections management UI.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Fallback to `external_name` if `external_display` is empty

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Edit your Bluesky profile, and remove Display Name
* Goto connections management - Social admin page, Jetpack Settings page > Sharing and the editor
* Connect the above Bluesky account
* Confirm that the connection is displayed with the handle
* Remove the just account 
* Now Add back the display name in Bluesky profile
* Connect the account again
* Confirm that you now see the display name instead of handle

| BEFORE | AFTER |
|--------|--------|
| <img width="606" alt="Screenshot 2024-10-21 at 3 12 20 PM" src="https://github.com/user-attachments/assets/16b09585-eead-42ab-aa86-71e551221646"> |<img width="606" alt="Screenshot 2024-10-21 at 3 12 24 PM" src="https://github.com/user-attachments/assets/389e9373-60a0-48aa-979d-b367cff1c7a3"> | 

