### PR TITLE
AI Client: fix default initial state setting

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-jetpack-ai-default-initial-state-setting
+++ b/projects/js-packages/ai-client/changelog/fix-jetpack-ai-default-initial-state-setting
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+AI Client: fix initial state being mapped even when fetch fails, making the default state nonsensical

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -125,10 +125,10 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 					: currentLimit < currentUsage );
 
 			// If the site requires an upgrade, show the upgrade screen immediately.
-			setNeedsFeature( currentLimit === 0 );
+			setNeedsFeature( currentValue === 0 );
 			setNeedsMoreRequests( siteNeedsMoreRequests );
 
-			if ( currentLimit === 0 || siteNeedsMoreRequests ) {
+			if ( currentValue === 0 || siteNeedsMoreRequests ) {
 				setLoadingState( null );
 				return;
 			}

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.scss
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.scss
@@ -69,7 +69,7 @@
 			color: var(--studio-gray-50, #646970);
 		}
 
-		&[data-placeholder]:empty:focus::before {
+		&[data-placeholder]:empty:focus::before:not([contentEditable="false"]) {
 			content: "";
 		}
 	}

--- a/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/prompt.tsx
@@ -107,7 +107,7 @@ export const Prompt = ( { initialPrompt = '' }: PromptProps ) => {
 	}, [ prompt ] );
 
 	useEffect( () => {
-		if ( imageStyles.length > 0 ) {
+		if ( imageStyles && imageStyles.length > 0 ) {
 			// Sort styles to have "None" and "Auto" first
 			setStyles(
 				[

--- a/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/hooks/use-logo-generator.ts
@@ -92,7 +92,7 @@ const useLogoGenerator = () => {
 	const logoGeneratorControl = aiAssistantFeatureData?.featuresControl?.[
 		'logo-generator'
 	] as LogoGeneratorFeatureControl;
-	const imageStyles: Array< ImageStyleObject > = logoGeneratorControl?.styles;
+	const imageStyles: Array< ImageStyleObject > = logoGeneratorControl?.styles || [];
 
 	const generateFirstPrompt = useCallback(
 		async function (): Promise< string > {

--- a/projects/js-packages/ai-client/src/logo-generator/store/actions.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/actions.ts
@@ -93,6 +93,10 @@ const actions = {
 					query: 'force=wpcom',
 				} );
 
+				if ( response.data ) {
+					throw new Error( 'Failed to fetch' );
+				}
+
 				// Store the feature in the store.
 				dispatch(
 					actions.storeAiAssistantFeature( mapAiFeatureResponseToAiFeatureProps( response ) )

--- a/projects/js-packages/ai-client/src/logo-generator/store/reducer.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/reducer.ts
@@ -325,6 +325,16 @@ export default function reducer(
 		case ACTION_SET_FEATURE_FETCH_ERROR:
 			return {
 				...state,
+				features: {
+					...state.features,
+					aiAssistantFeature: {
+						...state?.features?.aiAssistantFeature,
+						_meta: {
+							...state?.features?.aiAssistantFeature?._meta,
+							isRequesting: false,
+						},
+					},
+				},
 				_meta: {
 					...( state._meta ?? {} ),
 					featureFetchError: action.error,

--- a/projects/js-packages/ai-client/src/logo-generator/store/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/store/types.ts
@@ -220,6 +220,7 @@ export type AiAssistantFeatureEndpointResponseProps = {
 		};
 	};
 	'features-control'?: FeaturesControl;
+	data?: string; // when WP responds with a 200 status code but it's the error wrap
 };
 
 export type SaveLogo = ( logo: Logo ) => Promise< { mediaId: number; mediaURL: string } >;


### PR DESCRIPTION

## Proposed changes:
This PR fixes a call to a mapped setting for initial state even when the fetch failed.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Sandbox the public API, but don't connect to the sandbox so the fetch for AI feature fails.
Insert a logo generator on the editor and use the AI toolbar button to open the generator modal.

Without this change, the block would just error out.

A warning notice should show. Note that hitting "Try again" has a bug and will open the modal anyways, this is being addressed on a separate [PR](39848).