### PR TITLE
AI Client: make fetch error retry optional

### DIFF
--- a/projects/js-packages/ai-client/changelog/change-jetpack-ai-fetch-error-retry-optional
+++ b/projects/js-packages/ai-client/changelog/change-jetpack-ai-fetch-error-retry-optional
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Client: make reload handler prop optional as it still works in a fuzzy way. The error notice (modal) will instruct to reload the page when the optional prop is not provided

--- a/projects/js-packages/ai-client/src/logo-generator/components/feature-fetch-failure-screen.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/feature-fetch-failure-screen.tsx
@@ -10,25 +10,34 @@ import type React from 'react';
 
 export const FeatureFetchFailureScreen: React.FC< {
 	onCancel: () => void;
-	onRetry: () => void;
+	onRetry?: () => void;
 } > = ( { onCancel, onRetry } ) => {
 	const errorMessage = __(
 		'We are sorry. There was an error loading your Jetpack AI plan data. Please, try again.',
 		'jetpack-ai-client'
 	);
 
+	const errorMessageWithoutRetry = __(
+		'We are sorry. There was an error loading your Jetpack AI plan data. Please, reload the page and try again.',
+		'jetpack-ai-client'
+	);
+
 	return (
 		<div className="jetpack-ai-logo-generator-modal__notice-message-wrapper">
 			<div className="jetpack-ai-logo-generator-modal__notice-message">
-				<span className="jetpack-ai-logo-generator-modal__loading-message">{ errorMessage }</span>
+				<span className="jetpack-ai-logo-generator-modal__loading-message">
+					{ onRetry ? errorMessage : errorMessageWithoutRetry }
+				</span>
 			</div>
 			<div className="jetpack-ai-logo-generator-modal__notice-actions">
 				<Button variant="tertiary" onClick={ onCancel }>
 					{ __( 'Cancel', 'jetpack-ai-client' ) }
 				</Button>
-				<Button variant="primary" onClick={ onRetry }>
-					{ __( 'Try again', 'jetpack-ai-client' ) }
-				</Button>
+				{ onRetry && (
+					<Button variant="primary" onClick={ onRetry }>
+						{ __( 'Try again', 'jetpack-ai-client' ) }
+					</Button>
+				) }
 			</div>
 		</div>
 	);

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -189,6 +189,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		isLogoHistoryEmpty,
 		siteId,
 		requireUpgrade,
+		setFeatureFetchError,
 	] );
 
 	const handleModalOpen = useCallback( async () => {
@@ -248,16 +249,16 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	// Handles modal opening logic
 	useEffect( () => {
 		// While the modal is not open, the siteId is not set, or the feature data is not available, do nothing.
-		// if ( ! isOpen || ! feature?.costs ) {
-		// 	return;
-		// }
+		if ( ! isOpen ) {
+			return;
+		}
 
 		// Prevent multiple calls of the handleModalOpen function
 		if ( needsToHandleModalOpen.current ) {
 			needsToHandleModalOpen.current = false;
 			handleModalOpen();
 		}
-	}, [ isOpen, siteId, handleModalOpen, feature ] );
+	}, [ isOpen, handleModalOpen ] );
 
 	let body: React.ReactNode;
 

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -45,7 +45,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	isOpen,
 	onClose,
 	onApplyLogo,
-	onReload,
+	onReload = null,
 	siteDetails,
 	context,
 	placement,
@@ -201,6 +201,15 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		recordTracksEvent( EVENT_MODAL_CLOSE, { context, placement } );
 	};
 
+	const handleReload = useCallback( () => {
+		if ( ! onReload ) {
+			return;
+		}
+		closeModal();
+		requestedFeatureData.current = false;
+		onReload();
+	}, [ onReload, closeModal ] );
+
 	const handleApplyLogo = ( mediaId: number ) => {
 		setLogoAccepted( true );
 		onApplyLogo?.( mediaId );
@@ -248,10 +257,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		body = (
 			<FeatureFetchFailureScreen
 				onCancel={ closeModal }
-				onRetry={ () => {
-					closeModal();
-					onReload?.();
-				} }
+				onRetry={ onReload ? handleReload : null }
 			/>
 		);
 	} else if ( needsFeature || needsMoreRequests ) {

--- a/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
+++ b/projects/js-packages/ai-client/src/logo-generator/components/generator-modal.tsx
@@ -73,7 +73,8 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		site,
 		requireUpgrade,
 	} = useLogoGenerator();
-	const { featureFetchError, firstLogoPromptFetchError, clearErrors } = useRequestErrors();
+	const { featureFetchError, setFeatureFetchError, firstLogoPromptFetchError, clearErrors } =
+		useRequestErrors();
 	const siteId = siteDetails?.ID;
 	const [ logoAccepted, setLogoAccepted ] = useState( false );
 	const { nextTierCheckoutURL: upgradeURL } = useCheckout();
@@ -105,6 +106,15 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	 */
 	const initializeModal = useCallback( async () => {
 		try {
+			if ( ! siteId ) {
+				throw new Error( 'Site ID is missing' );
+			}
+
+			if ( ! feature?.featuresControl?.[ 'logo-generator' ]?.enabled ) {
+				setFeatureFetchError( 'Failed to fetch feature data' );
+				throw new Error( 'Failed to fetch feature data' );
+			}
+
 			const hasHistory = ! isLogoHistoryEmpty( String( siteId ) );
 
 			const logoCost = feature?.costs?.[ 'jetpack-ai-logo-generator' ]?.logo ?? DEFAULT_LOGO_COST;
@@ -238,9 +248,9 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	// Handles modal opening logic
 	useEffect( () => {
 		// While the modal is not open, the siteId is not set, or the feature data is not available, do nothing.
-		if ( ! isOpen || ! siteId || ! feature?.costs ) {
-			return;
-		}
+		// if ( ! isOpen || ! feature?.costs ) {
+		// 	return;
+		// }
 
 		// Prevent multiple calls of the handleModalOpen function
 		if ( needsToHandleModalOpen.current ) {

--- a/projects/js-packages/ai-client/src/logo-generator/types.ts
+++ b/projects/js-packages/ai-client/src/logo-generator/types.ts
@@ -16,7 +16,7 @@ export interface GeneratorModalProps {
 	isOpen: boolean;
 	onClose: () => void;
 	onApplyLogo: ( mediaId: number ) => void;
-	onReload: () => void;
+	onReload?: () => void;
 	context: string;
 	placement: string;
 }

--- a/projects/plugins/jetpack/changelog/change-jetpack-ai-fetch-error-retry-optional
+++ b/projects/plugins/jetpack/changelog/change-jetpack-ai-fetch-error-retry-optional
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: remove reload handler for logo generator modal call

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -102,10 +102,10 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 			setIsLogoGeneratorModalVisible( false );
 		}, [] );
 
-		const reloadModal = useCallback( () => {
-			closeModal();
-			showModal();
-		}, [ closeModal, showModal ] );
+		// const reloadModal = useCallback( () => {
+		// 	closeModal();
+		// 	showModal();
+		// }, [ closeModal, showModal ] );
 
 		const applyLogoHandler = useCallback(
 			( mediaId: number ) => {
@@ -135,7 +135,8 @@ const siteLogoEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 					isOpen={ isLogoGeneratorModalVisible }
 					onClose={ closeModal }
 					onApplyLogo={ applyLogoHandler }
-					onReload={ reloadModal }
+					// reload is not working right and can end up showing a non functional modal
+					// onReload={ reloadModal }
 					context={ PLACEMENT_CONTEXT }
 					placement={ TOOL_PLACEMENT }
 					siteDetails={ siteDetails }


### PR DESCRIPTION
Related to #39846

## Proposed changes:
This PR will turn `onReload` prop to optional as we cancel the handler from Jetpack AI.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Sandbox the public API, but don't connect to the sandbox so the fetch for AI feature fails.
Insert a logo generator on the editor and use the AI toolbar button to open the generator modal.

See the error notice modal doesn't offer a "Try again" button and the instructions state to reload the page as opposed to use the "Try again" button.

Then connect to sandbox to get actual responses from the endpoint. No need to reload, you can call `wp.data.dispatch('jetpack-ai/logo-generator').fetchAiAssistantFeature()` and the component should update (maybe close and re-open modal between fetch calls).

Try different plans/cases and open and close the modal to confirm it's consistent. You can use this snippet p1729593811040589-slack-C02TQF5VAJD and call 