### PR TITLE
My Jetpack: add slider for recommendations section in My Jetpack

### DIFF
--- a/projects/js-packages/components/changelog/add-my-jetpack-recommendations-slider
+++ b/projects/js-packages/components/changelog/add-my-jetpack-recommendations-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Components: add ref for container component

--- a/projects/js-packages/components/components/layout/container/index.tsx
+++ b/projects/js-packages/components/components/layout/container/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { createElement, useMemo } from 'react';
+import { createElement, forwardRef, useMemo } from 'react';
 import { ContainerProps } from '../types';
 import styles from './style.module.scss';
 import type React from 'react';
@@ -7,17 +7,21 @@ import type React from 'react';
 /**
  * JP Container
  *
- * @param {ContainerProps} props - Component properties.
+ * @param {ContainerProps}         props - Component properties.
+ * @param {React.MutableRefObject} ref   - Ref to the component
  * @return {React.ReactElement}   Container component.
  */
-const Container: React.FC< ContainerProps > = ( {
-	children,
-	fluid = false,
-	tagName = 'div',
-	className,
-	horizontalGap = 1,
-	horizontalSpacing = 1,
-} ) => {
+const Container = (
+	{
+		children,
+		fluid = false,
+		tagName = 'div',
+		className,
+		horizontalGap = 1,
+		horizontalSpacing = 1,
+	}: ContainerProps,
+	ref: React.MutableRefObject< HTMLElement | null >
+): React.ReactElement => {
 	const containerStyle = useMemo( () => {
 		const padding = `calc( var(--horizontal-spacing) * ${ horizontalSpacing } )`;
 		const rowGap = `calc( var(--horizontal-spacing) * ${ horizontalGap } )`;
@@ -38,9 +42,10 @@ const Container: React.FC< ContainerProps > = ( {
 		{
 			className: containerClassName,
 			style: containerStyle,
+			ref,
 		},
 		children
 	);
 };
 
-export default Container;
+export default forwardRef< HTMLElement, ContainerProps >( Container );

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
@@ -3,6 +3,7 @@ import { Icon, Flex, FlexItem, DropdownMenu, Button } from '@wordpress/component
 import { __, _n } from '@wordpress/i18n';
 import { moreHorizontalMobile } from '@wordpress/icons';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
+import clsx from 'clsx';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import useEvaluationRecommendations from '../../data/evaluation-recommendations/use-evaluation-recommendations';
 import useAnalytics from '../../hooks/use-analytics';
@@ -138,12 +139,24 @@ const EvaluationRecommendations: FC = () => {
 				</Container>
 				<Flex align="center" justify="center">
 					<FlexItem>
-						<Button onClick={ handlePrevSlide } disabled={ isAtStart } aria-disabled={ isAtStart }>
+						<Button
+							className={ clsx( styles[ 'slider-button' ], styles[ 'prev-button' ] ) }
+							onClick={ handlePrevSlide }
+							disabled={ isAtStart }
+							aria-disabled={ isAtStart }
+							aria-label={ __( 'Previous', 'jetpack-my-jetpack' ) }
+						>
 							<Icon icon={ chevronLeft } />
 						</Button>
 					</FlexItem>
 					<FlexItem>
-						<Button onClick={ handleNextSlide } disabled={ isAtEnd } aria-disabled={ isAtEnd }>
+						<Button
+							className={ clsx( styles[ 'slider-button' ], styles[ 'next-button' ] ) }
+							onClick={ handleNextSlide }
+							disabled={ isAtEnd }
+							aria-disabled={ isAtEnd }
+							aria-label={ __( 'Next', 'jetpack-my-jetpack' ) }
+						>
 							<Icon icon={ chevronRight } />
 						</Button>
 					</FlexItem>

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
@@ -44,11 +44,18 @@ const EvaluationRecommendations: FC = () => {
 
 	const handleNextSlide = useCallback( () => {
 		handleSlide( containerRef, 1 );
-	}, [ containerRef ] );
+
+		recordEvent( 'jetpack_myjetpack_recommendations_slide_arrow_click', {
+			direction: 'next',
+		} );
+	}, [ recordEvent, containerRef ] );
 
 	const handlePrevSlide = useCallback( () => {
 		handleSlide( containerRef, -1 );
-	}, [ containerRef ] );
+		recordEvent( 'jetpack_myjetpack_recommendations_slide_arrow_click', {
+			direction: 'previous',
+		} );
+	}, [ recordEvent, containerRef ] );
 
 	// We're defining each of these translations in separate variables here, otherwise optimizations in
 	// the build step end up breaking the translations and causing error.

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
@@ -3,7 +3,7 @@ import { Icon, Flex, FlexItem, DropdownMenu, Button } from '@wordpress/component
 import { __, _n } from '@wordpress/i18n';
 import { moreHorizontalMobile } from '@wordpress/icons';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import useEvaluationRecommendations from '../../data/evaluation-recommendations/use-evaluation-recommendations';
 import useAnalytics from '../../hooks/use-analytics';
 import { JetpackModuleToProductCard } from '../product-cards-section/all';
@@ -15,6 +15,16 @@ const EvaluationRecommendations: FC = () => {
 	const { recordEvent } = useAnalytics();
 	const { recommendedModules, redoEvaluation, removeEvaluationResult } =
 		useEvaluationRecommendations();
+	const [ isAtStart, setIsAtStart ] = useState( true );
+	const [ isAtEnd, setIsAtEnd ] = useState( false );
+
+	const checkScrollPosition = useCallback( () => {
+		if ( containerRef.current ) {
+			const { scrollLeft, scrollWidth, clientWidth } = containerRef.current;
+			setIsAtStart( scrollLeft === 0 );
+			setIsAtEnd( scrollLeft + clientWidth >= scrollWidth );
+		}
+	}, [ containerRef ] );
 
 	const handleSlide = (
 		cardContainerRef: React.RefObject< HTMLUListElement >,
@@ -49,6 +59,21 @@ const EvaluationRecommendations: FC = () => {
 	);
 	const menuRedoTitle = __( 'Redo', 'jetpack-my-jetpack' );
 	const menuDismissTitle = __( 'Dismiss', 'jetpack-my-jetpack' );
+
+	useEffect( () => {
+		const container = containerRef.current;
+
+		if ( container ) {
+			container.addEventListener( 'scroll', checkScrollPosition );
+			checkScrollPosition();
+		}
+
+		return () => {
+			if ( container ) {
+				container.removeEventListener( 'scroll', checkScrollPosition );
+			}
+		};
+	}, [ checkScrollPosition ] );
 
 	useEffect( () => {
 		recordEvent( 'jetpack_myjetpack_evaluation_recommendations_view', {
@@ -113,12 +138,12 @@ const EvaluationRecommendations: FC = () => {
 				</Container>
 				<Flex align="center" justify="center">
 					<FlexItem>
-						<Button onClick={ handlePrevSlide }>
+						<Button onClick={ handlePrevSlide } disabled={ isAtStart } aria-disabled={ isAtStart }>
 							<Icon icon={ chevronLeft } />
 						</Button>
 					</FlexItem>
 					<FlexItem>
-						<Button onClick={ handleNextSlide }>
+						<Button onClick={ handleNextSlide } disabled={ isAtEnd } aria-disabled={ isAtEnd }>
 							<Icon icon={ chevronRight } />
 						</Button>
 					</FlexItem>

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
@@ -9,7 +9,7 @@ import useEvaluationRecommendations from '../../data/evaluation-recommendations/
 import useAnalytics from '../../hooks/use-analytics';
 import { JetpackModuleToProductCard } from '../product-cards-section/all';
 import styles from './style.module.scss';
-import type { FC } from 'react';
+import type { FC, RefObject } from 'react';
 
 const EvaluationRecommendations: FC = () => {
 	const containerRef = useRef( null );
@@ -28,7 +28,7 @@ const EvaluationRecommendations: FC = () => {
 	}, [ containerRef ] );
 
 	const handleSlide = (
-		cardContainerRef: React.RefObject< HTMLUListElement >,
+		cardContainerRef: RefObject< HTMLUListElement >,
 		direction: number,
 		gap: number = 24
 	) => {
@@ -74,13 +74,11 @@ const EvaluationRecommendations: FC = () => {
 		if ( container ) {
 			container.addEventListener( 'scroll', checkScrollPosition );
 			checkScrollPosition();
-		}
 
-		return () => {
-			if ( container ) {
+			return () => {
 				container.removeEventListener( 'scroll', checkScrollPosition );
-			}
-		};
+			};
+		}
 	}, [ checkScrollPosition ] );
 
 	useEffect( () => {

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/index.tsx
@@ -1,8 +1,9 @@
 import { Container, Col, Text } from '@automattic/jetpack-components';
-import { Flex, FlexItem, DropdownMenu } from '@wordpress/components';
+import { Icon, Flex, FlexItem, DropdownMenu, Button } from '@wordpress/components';
 import { __, _n } from '@wordpress/i18n';
 import { moreHorizontalMobile } from '@wordpress/icons';
-import { useEffect } from 'react';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { useEffect, useCallback, useRef } from 'react';
 import useEvaluationRecommendations from '../../data/evaluation-recommendations/use-evaluation-recommendations';
 import useAnalytics from '../../hooks/use-analytics';
 import { JetpackModuleToProductCard } from '../product-cards-section/all';
@@ -10,9 +11,33 @@ import styles from './style.module.scss';
 import type { FC } from 'react';
 
 const EvaluationRecommendations: FC = () => {
+	const containerRef = useRef( null );
 	const { recordEvent } = useAnalytics();
 	const { recommendedModules, redoEvaluation, removeEvaluationResult } =
 		useEvaluationRecommendations();
+
+	const handleSlide = (
+		cardContainerRef: React.RefObject< HTMLUListElement >,
+		direction: number,
+		gap: number = 24
+	) => {
+		if ( cardContainerRef.current ) {
+			const cardWidth = cardContainerRef.current.querySelector( 'li' ).clientWidth;
+
+			cardContainerRef.current.scrollBy( {
+				left: direction * ( cardWidth + gap ),
+				behavior: 'smooth',
+			} );
+		}
+	};
+
+	const handleNextSlide = useCallback( () => {
+		handleSlide( containerRef, 1 );
+	}, [ containerRef ] );
+
+	const handlePrevSlide = useCallback( () => {
+		handleSlide( containerRef, -1 );
+	}, [ containerRef ] );
 
 	// We're defining each of these translations in separate variables here, otherwise optimizations in
 	// the build step end up breaking the translations and causing error.
@@ -68,6 +93,7 @@ const EvaluationRecommendations: FC = () => {
 			</Col>
 			<Col>
 				<Container
+					ref={ containerRef }
 					tagName="ul"
 					className={ styles[ 'recommendations-list' ] }
 					horizontalGap={ 4 }
@@ -85,6 +111,18 @@ const EvaluationRecommendations: FC = () => {
 						);
 					} ) }
 				</Container>
+				<Flex align="center" justify="center">
+					<FlexItem>
+						<Button onClick={ handlePrevSlide }>
+							<Icon icon={ chevronLeft } />
+						</Button>
+					</FlexItem>
+					<FlexItem>
+						<Button onClick={ handleNextSlide }>
+							<Icon icon={ chevronRight } />
+						</Button>
+					</FlexItem>
+				</Flex>
 			</Col>
 		</Container>
 	);

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
@@ -11,30 +11,29 @@
 }
 
 ul.recommendations-list {
-	grid-template-columns: repeat(6, calc( ( 100% / 3 ) - 16px ) );
+	grid-template-columns: 1fr;
 	grid-auto-flow: column;
 	overflow-x: auto;
 	scroll-snap-type: x mandatory;
 	scroll-behavior: smooth;
 
+	scrollbar-width: none;
+	-ms-overflow-style: none;
+
+	&::-webkit-scrollbar {
+	  display: none;
+	}
+
 	li {
+		min-width: 300px;
 		scroll-snap-align: start;
 		grid-column: unset;
 		grid-column-end: unset;
 	}
 
-	// Setting min-width of recommendation (product) cards to 300px; see: /components/product-cards-section/style.module.scss:62
-	@media screen and (min-width: 600px) and (max-width: 1290px) {
-		grid-template-columns: repeat( auto-fill, minmax( 300px, 1fr ) );
-		> li {
-			grid-column-end: auto;
-		}
-	}
-
-	@media screen and (max-width: 599px) {
-		grid-template-columns: repeat( auto-fill, minmax( 300px, 1fr ) );
-		> li {
-			grid-column-end: auto;
+	@media screen and (max-width: 1024px) {
+		li {
+			min-width: 450px;
 		}
 	}
 }

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
@@ -25,7 +25,7 @@ ul.recommendations-list {
 	}
 
 	li {
-		min-width: 300px;
+		min-width: 320px;
 		scroll-snap-align: start;
 		grid-column: unset;
 		grid-column-end: unset;

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
@@ -10,12 +10,31 @@
 	font-size: var( --font-body );
 }
 
-// Setting min-width of recommendation (product) cards to 300px; see: /components/product-cards-section/style.module.scss:62
-@media screen and (min-width: 599px) and (max-width: 1290px) {
-	ul.recommendations-list {
+ul.recommendations-list {
+	grid-template-columns: repeat(6, calc( ( 100% / 3 ) - 16px ) );
+	grid-auto-flow: column;
+	overflow-x: auto;
+	scroll-snap-type: x mandatory;
+	scroll-behavior: smooth;
+
+	li {
+		scroll-snap-align: start;
+		grid-column: unset;
+		grid-column-end: unset;
+	}
+
+	// Setting min-width of recommendation (product) cards to 300px; see: /components/product-cards-section/style.module.scss:62
+	@media screen and (min-width: 600px) and (max-width: 1290px) {
 		grid-template-columns: repeat( auto-fill, minmax( 300px, 1fr ) );
 		> li {
 			grid-column-end: auto;
 		}
-	}	
+	}
+
+	@media screen and (max-width: 599px) {
+		grid-template-columns: repeat( auto-fill, minmax( 300px, 1fr ) );
+		> li {
+			grid-column-end: auto;
+		}
+	}
 }

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
@@ -37,3 +37,15 @@ ul.recommendations-list {
 		}
 	}
 }
+
+.slider-button {
+	transition: all 0.3s ease;
+}
+
+.prev-button:not(:disabled):hover {
+	transform: translateX(-4px);
+}
+
+.next-button:not(:disabled):hover {
+	transform: translateX(4px);
+}

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
@@ -31,6 +31,14 @@ ul.recommendations-list {
 		grid-column-end: unset;
 	}
 
+	@media screen and (max-width: 600px) {
+		grid-template-columns: repeat( 5, 100% );
+
+		li {
+			min-width: unset;
+		}
+	}
+
 	@media screen and (max-width: 1024px) {
 		li {
 			min-width: 450px;

--- a/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/evaluation-recommendations/style.module.scss
@@ -11,7 +11,7 @@
 }
 
 ul.recommendations-list {
-	grid-template-columns: 1fr;
+	grid-template-columns: repeat( 5, 1fr );
 	grid-auto-flow: column;
 	overflow-x: auto;
 	scroll-snap-type: x mandatory;

--- a/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
+++ b/projects/packages/my-jetpack/_inc/data/evaluation-recommendations/use-evaluation-recommendations.ts
@@ -14,6 +14,8 @@ import { getMyJetpackWindowInitialState } from '../utils/get-my-jetpack-window-s
 import isJetpackUserNew from '../utils/is-jetpack-user-new';
 import useWelcomeBanner from '../welcome-banner/use-welcome-banner';
 
+const NUMBER_OF_RECOMMENDATIONS_TO_SHOW = 5;
+
 type SubmitRecommendationsResult = Record< string, number >;
 
 const getInitialRecommendedModules = (): JetpackModule[] | null => {
@@ -42,8 +44,10 @@ const useEvaluationRecommendations = () => {
 				? [ 'anti-spam', 'creator', 'extras', 'stats', 'jetpack-ai' ]
 				: getMyJetpackWindowInitialState( 'lifecycleStats' )?.ownedProducts || []
 		) as JetpackModule[];
-		// We filter out owned modules, and return top 3 recommendations
-		return recommendedModules?.filter( module => ! ownedProducts.includes( module ) ).slice( 0, 3 );
+		// We filter out owned modules, and return the top recommendations
+		return recommendedModules
+			?.filter( module => ! ownedProducts.includes( module ) )
+			.slice( 0, NUMBER_OF_RECOMMENDATIONS_TO_SHOW );
 	}, [ recommendedModules ] );
 
 	const isEligibleForRecommendations = useMemo( () => {

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-recommendations-slider
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-recommendations-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: update the recommendations section in My Jetpack to include a slider interaction for the cards.

--- a/projects/plugins/backup/changelog/add-my-jetpack-recommendations-slider
+++ b/projects/plugins/backup/changelog/add-my-jetpack-recommendations-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: update the recommendations section in My Jetpack to include a slider interaction for the cards.

--- a/projects/plugins/boost/changelog/add-my-jetpack-recommendations-slider
+++ b/projects/plugins/boost/changelog/add-my-jetpack-recommendations-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: update the recommendations section in My Jetpack to include a slider interaction for the cards.

--- a/projects/plugins/jetpack/changelog/add-my-jetpack-recommendations-slider
+++ b/projects/plugins/jetpack/changelog/add-my-jetpack-recommendations-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+My Jetpack: update the recommendations section in My Jetpack to include a slider interaction for the cards.

--- a/projects/plugins/migration/changelog/add-my-jetpack-recommendations-slider
+++ b/projects/plugins/migration/changelog/add-my-jetpack-recommendations-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: update the recommendations section in My Jetpack to include a slider interaction for the cards.

--- a/projects/plugins/protect/changelog/add-my-jetpack-recommendations-slider
+++ b/projects/plugins/protect/changelog/add-my-jetpack-recommendations-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: update the recommendations section in My Jetpack to include a slider interaction for the cards.

--- a/projects/plugins/search/changelog/add-my-jetpack-recommendations-slider
+++ b/projects/plugins/search/changelog/add-my-jetpack-recommendations-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: update the recommendations section in My Jetpack to include a slider interaction for the cards.

--- a/projects/plugins/social/changelog/add-my-jetpack-recommendations-slider
+++ b/projects/plugins/social/changelog/add-my-jetpack-recommendations-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: update the recommendations section in My Jetpack to include a slider interaction for the cards.

--- a/projects/plugins/starter-plugin/changelog/add-my-jetpack-recommendations-slider
+++ b/projects/plugins/starter-plugin/changelog/add-my-jetpack-recommendations-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: update the recommendations section in My Jetpack to include a slider interaction for the cards.

--- a/projects/plugins/videopress/changelog/add-my-jetpack-recommendations-slider
+++ b/projects/plugins/videopress/changelog/add-my-jetpack-recommendations-slider
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: update the recommendations section in My Jetpack to include a slider interaction for the cards.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* This PR updates the recommendations sections in My Jetpack and displays 5 cards instead of 3. With the overflowing content, we decided to display this section as a slider, so the user can see more cards if they want to.
* We also updated the `Container` component to accept `ref` as a prop


https://github.com/user-attachments/assets/c309e01f-7699-4493-b2fc-3e77ccf47517


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbNhbs-bvL-p2#comment-23588

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
It adds two tracks events, one to each arrow button.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch
* Go to My Jetpack, click to Activate Jetpack with one click
* After your site is connected, you'll see either a survey or the recommendations. If you see the survey, choose any option and submit it
* When you see the survey, make sure the slider works as expected on different screen sizes
