### PR TITLE
Stats: optimize the Admin Bar hook

### DIFF
--- a/projects/plugins/jetpack/changelog/update-narrow-down-stats-bar-hook
+++ b/projects/plugins/jetpack/changelog/update-narrow-down-stats-bar-hook
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Optimize the Stats Admin Bar hook by narrowing down the callback.

--- a/projects/plugins/jetpack/modules/stats.php
+++ b/projects/plugins/jetpack/modules/stats.php
@@ -54,7 +54,10 @@ add_action( 'jetpack_modules_loaded', 'stats_load' );
 function stats_load() {
 	Jetpack::enable_module_configurable( __FILE__ );
 
-	add_action( 'wp_head', 'stats_admin_bar_head', 100 );
+	// Only run the callback for those who can see the stats.
+	if ( is_user_logged_in() && current_user_can( 'view_stats' ) ) {
+		add_action( 'wp_head', 'stats_admin_bar_head', 100 );
+	}
 
 	add_action( 'jetpack_admin_menu', 'stats_admin_menu' );
 


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Optimize the Stats Admin Bar hook by narrowing down the callback.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
https://github.com/Automattic/vulcan/issues/529

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
1. Connect Jetpack, switch to the branch.
2. Visit the site's frontend and confirm the Stats widget shows up on the top bar.
3. Create a non-admin user, sign in under that account. Confirm you no longer see the Stats widget on the top bar in frontend.