### PR TITLE
WPCOM_JSON_API_Upload_Media_v1_1_Endpoint: Fix Fatals from uploads with invalid media type

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-upload-media-endpoint-fatal
+++ b/projects/plugins/jetpack/changelog/fix-upload-media-endpoint-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WPCOM_JSON_API_Upload_Media_v1_1_Endpoint: Fix Fatals from uploads with invalid media type

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
@@ -93,7 +93,7 @@ class WPCOM_JSON_API_Upload_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 
 		// We're splitting out videos for Jetpack sites.
 		foreach ( $media_files as $media_item ) {
-			if ( preg_match( '@^video/@', $media_item['type'] ) && $is_jetpack_site ) {
+			if ( isset( $media_item['type'] ) && preg_match( '@^video/@', $media_item['type'] ) && $is_jetpack_site ) {
 				if ( defined( 'IS_WPCOM' ) && IS_WPCOM &&
 					defined( 'VIDEOPRESS_JETPACK_VIDEO_ENABLED' ) && VIDEOPRESS_JETPACK_VIDEO_ENABLED
 				) {


### PR DESCRIPTION
Continuation of the check added by @mreishus in https://github.com/Automattic/jetpack/pull/36291

Fixes this fatal error:
```
 Fatal error: Uncaught TypeError: Cannot access offset of type string on string in (jetpack)/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php:96
```
This doesn't seem to happen in normal operation; it seems to only happen with malformed or suspicious posts.

## Proposed changes:

* In the case that `$media_item` is a string, or `$media_item['type']` is not set, exit early instead of running a regex against a non-existent `$media_item['type']`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1729527668833569-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See https://github.com/Automattic/jetpack/pull/36291