### PR TITLE
Floating subscribe button: add source for stats

### DIFF
--- a/projects/plugins/jetpack/changelog/update-floating-subscribe-button-source
+++ b/projects/plugins/jetpack/changelog/update-floating-subscribe-button-source
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Floating subscribe button: add source attribute for stats

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-floating-button/class-jetpack-subscribe-floating-button.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-floating-button/class-jetpack-subscribe-floating-button.php
@@ -111,7 +111,7 @@ class Jetpack_Subscribe_Floating_Button {
 	public function get_floating_subscribe_button_template_content() {
 		$block_name = esc_attr__( 'Floating subscribe button', 'jetpack' );
 
-		return '<!-- wp:jetpack/subscriptions {"className":"is-style-button","appSource":"floating-subscribe-button","lock":{"move":false,"remove":true},"style":{"spacing":{"margin":{"right":"20px","left":"20px","top":"20px","bottom":"20px"}}},"metadata":{"name":"' . $block_name . '"}} /-->';
+		return '<!-- wp:jetpack/subscriptions {"className":"is-style-button","appSource":"subscribe-floating-button","lock":{"move":false,"remove":true},"style":{"spacing":{"margin":{"right":"20px","left":"20px","top":"20px","bottom":"20px"}}},"metadata":{"name":"' . $block_name . '"}} /-->';
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-floating-button/class-jetpack-subscribe-floating-button.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-floating-button/class-jetpack-subscribe-floating-button.php
@@ -111,7 +111,7 @@ class Jetpack_Subscribe_Floating_Button {
 	public function get_floating_subscribe_button_template_content() {
 		$block_name = esc_attr__( 'Floating subscribe button', 'jetpack' );
 
-		return '<!-- wp:jetpack/subscriptions {"className":"is-style-button","lock":{"move":false,"remove":true},"style":{"spacing":{"margin":{"right":"20px","left":"20px","top":"20px","bottom":"20px"}}},"metadata":{"name":"' . $block_name . '"}} /-->';
+		return '<!-- wp:jetpack/subscriptions {"className":"is-style-button","appSource":"floating-subscribe-button","lock":{"move":false,"remove":true},"style":{"spacing":{"margin":{"right":"20px","left":"20px","top":"20px","bottom":"20px"}}},"metadata":{"name":"' . $block_name . '"}} /-->';
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

<!--- Explain what functional changes your PR includes -->
* Add source attribute to the floating subscribe button to track its performance


<img width="941" alt="image" src="https://github.com/user-attachments/assets/d884e710-15c2-4378-a0e2-72753821ced8">

Needs a backend change to whitelist the source value: D164339-code

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable toggle from Settings -> Newsletter
* The block doesn't break in the template


