### PR TITLE
Boost: Don't add a posts page if front page is set but not the posts page

### DIFF
--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
@@ -43,8 +43,8 @@ class WP_Core_Provider extends Provider {
 			if ( ! empty( $permalink ) ) {
 				$urls['posts_page'] = array( $permalink );
 			}
-		} else {
-			$urls['posts_page'] = (array) home_url( '/' );
+		} elseif ( ! $front_page ) {
+			$urls['posts_page'] = array( home_url( '/' ) );
 		}
 
 		return $urls;

--- a/projects/plugins/boost/changelog/update-ccss-core-providers
+++ b/projects/plugins/boost/changelog/update-ccss-core-providers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Critical CSS: Make the list of critical CSS URLs more efficient.


### PR DESCRIPTION
Fixes #39861 

## Proposed changes:
* If a static front-page is set, but no blog page, skip the core_blog_page provider

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
* Set a static front page, don't set a blog page.
* Check http://jetpack-boost.test/wp-json/jetpack-boost/v1/list-source-providers.
* It should not have a 'core_posts_page' provider.
* Other combination of this setting should have a `core_posts_page` provider with the URL pointing to the page that lists the blog posts.