### PR TITLE
Add/skip pricing page when connecting from editor blocks

### DIFF
--- a/projects/js-packages/connection/changelog/add-skip-pricing-page-when-connecting-from-editor-blocks
+++ b/projects/js-packages/connection/changelog/add-skip-pricing-page-when-connecting-from-editor-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Skip pricing page when connecting via block editor

--- a/projects/js-packages/connection/components/connect-screen/basic/index.tsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/index.tsx
@@ -30,6 +30,8 @@ export type Props = {
 	assetBaseUrl?: string;
 	// Whether to not require a user connection and just redirect after site connection
 	skipUserConnection?: boolean;
+	// Whether to skip the pricing page after the connection screen
+	skipPricingPage?: boolean;
 	// Additional page elements to show after the call to action
 	footer?: React.ReactNode;
 	// The logo to display at the top of the component
@@ -54,8 +56,10 @@ const ConnectScreen: React.FC< Props > = ( {
 	autoTrigger,
 	footer,
 	skipUserConnection,
+	skipPricingPage,
 	logo,
 } ) => {
+	console.log( skipPricingPage );
 	const {
 		handleRegisterSite,
 		siteIsRegistering,
@@ -70,6 +74,7 @@ const ConnectScreen: React.FC< Props > = ( {
 		autoTrigger,
 		from,
 		skipUserConnection,
+		skipPricingPage,
 	} );
 
 	const displayButtonError = Boolean( registrationError );

--- a/projects/js-packages/connection/components/connect-screen/basic/index.tsx
+++ b/projects/js-packages/connection/components/connect-screen/basic/index.tsx
@@ -59,7 +59,6 @@ const ConnectScreen: React.FC< Props > = ( {
 	skipPricingPage,
 	logo,
 } ) => {
-	console.log( skipPricingPage );
 	const {
 		handleRegisterSite,
 		siteIsRegistering,

--- a/projects/js-packages/connection/components/use-connection/index.jsx
+++ b/projects/js-packages/connection/components/use-connection/index.jsx
@@ -14,6 +14,7 @@ export default ( {
 	autoTrigger,
 	from,
 	skipUserConnection,
+	skipPricingPage,
 } = {} ) => {
 	const { registerSite, connectUser, refreshConnectedPlugins } = useDispatch( STORE_ID );
 
@@ -45,7 +46,7 @@ export default ( {
 	 */
 	const handleConnectUser = () => {
 		if ( ! skipUserConnection ) {
-			return connectUser( { from, redirectUri } );
+			return connectUser( { from, redirectUri, skipPricingPage } );
 		} else if ( redirectUri ) {
 			window.location = redirectUri;
 			return Promise.resolve( redirectUri );

--- a/projects/js-packages/connection/state/actions.jsx
+++ b/projects/js-packages/connection/state/actions.jsx
@@ -72,15 +72,16 @@ const setIsOfflineMode = isOfflineMode => {
 /**
  * Connect site with wp.com user
  *
- * @param {object}   Object               - contains from and redirectFunc
- * @param {string}   Object.from          - Value that represents the redirect origin
- * @param {Function} Object.redirectFunc  - A function to handle the redirect, defaults to location.assign
- * @param {string}   [Object.redirectUri] - A URI that the user will be redirected to
+ * @param {object}   Object                   - contains from and redirectFunc
+ * @param {string}   Object.from              - Value that represents the redirect origin
+ * @param {Function} Object.redirectFunc      - A function to handle the redirect, defaults to location.assign
+ * @param {string}   [Object.redirectUri]     - A URI that the user will be redirected to
+ * @param {boolean}  [Object.skipPricingPage] - A flag to skip the pricing page in the connection flow
  * @yield {object} Action object that will be yielded
  */
-function* connectUser( { from, redirectFunc, redirectUri } = {} ) {
+function* connectUser( { from, redirectFunc, redirectUri, skipPricingPage } = {} ) {
 	yield setUserIsConnecting( true );
-	yield { type: CONNECT_USER, from, redirectFunc, redirectUri };
+	yield { type: CONNECT_USER, from, redirectFunc, redirectUri, skipPricingPage };
 }
 
 /**

--- a/projects/js-packages/connection/state/controls.jsx
+++ b/projects/js-packages/connection/state/controls.jsx
@@ -7,7 +7,7 @@ const REGISTER_SITE = ( { registrationNonce, redirectUri, from } ) =>
 
 const CONNECT_USER = createRegistryControl(
 	( { resolveSelect } ) =>
-		( { from, redirectFunc, redirectUri } = {} ) => {
+		( { from, redirectFunc, redirectUri, skipPricingPage } = {} ) => {
 			return new Promise( ( resolve, reject ) => {
 				resolveSelect( STORE_ID )
 					.getAuthorizationUrl( redirectUri )
@@ -15,6 +15,10 @@ const CONNECT_USER = createRegistryControl(
 						const redirect = redirectFunc || ( url => window.location.assign( url ) );
 
 						const url = new URL( authorizationUrl );
+
+						if ( skipPricingPage ) {
+							url.searchParams.set( 'skip_pricing', 'true' );
+						}
 
 						if ( from ) {
 							url.searchParams.set( 'from', encodeURIComponent( from ) );

--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -4,7 +4,7 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createRoot } from '@wordpress/element';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { HashRouter, Navigate, Routes, Route, useLocation } from 'react-router-dom';
 /**
  * Internal dependencies

--- a/projects/packages/my-jetpack/_inc/components/connection-screen/body.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/body.tsx
@@ -5,9 +5,47 @@ import { __ } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
 import connectImage from './connect.png';
 import styles from './styles.module.scss';
-import type { Props as ConnectScreenProps } from '@automattic/jetpack-connection';
+import type { FC } from 'react';
 
-const ConnectionScreenBody: React.FC< ConnectScreenProps > = props => {
+// This is copied from the connection package.
+// The connection package main file is not TypeScript currently and therefore cannot export types.
+// Doing this here to avoid editing the connection package too much as it is widely used.
+interface ConnectScreenProps {
+	// API root
+	apiRoot: string;
+	// API nonce
+	apiNonce: string;
+	// Registration nonce
+	registrationNonce: string;
+	// The redirect admin UR
+	redirectUri: string;
+	// Additional page elements to show before the call to action
+	children?: React.ReactNode;
+	// The Title
+	title?: string;
+	// The Connect Button label
+	buttonLabel?: string;
+	// The text read by screen readers when connecting
+	loadingLabel?: string;
+	// Where the connection request is coming from
+	from?: string;
+	// Whether to initiate the connection process automatically upon rendering the component
+	autoTrigger?: boolean;
+	// Images to display on the right side
+	images?: string[];
+	// The assets base URL
+	assetBaseUrl?: string;
+	// Whether to not require a user connection and just redirect after site connection
+	skipUserConnection?: boolean;
+	// Whether to skip the pricing page after the connection screen
+	skipPricingPage?: boolean;
+	// Additional page elements to show after the call to action
+	footer?: React.ReactNode;
+	// The logo to display at the top of the component
+	logo?: React.ReactNode;
+}
+
+const ConnectionScreenBody: FC< ConnectScreenProps > = props => {
 	const { title } = props;
 
 	return (

--- a/projects/packages/my-jetpack/_inc/components/connection-screen/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/index.tsx
@@ -6,8 +6,9 @@ import CloseLink from '../close-link';
 import ConnectionScreenBody from './body';
 import ConnectionScreenFooter from './footer';
 import styles from './styles.module.scss';
+import type { FC } from 'react';
 
-const ConnectionScreen: React.FC = () => {
+const ConnectionScreen: FC = () => {
 	const returnToPage = useMyJetpackReturnToPage();
 	const { apiRoot, apiNonce, registrationNonce } = useMyJetpackConnection();
 

--- a/projects/packages/my-jetpack/changelog/add-skip-pricing-page-when-connecting-from-editor-blocks
+++ b/projects/packages/my-jetpack/changelog/add-skip-pricing-page-when-connecting-from-editor-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Skip pricing page when connecting via block editor

--- a/projects/plugins/jetpack/changelog/add-skip-pricing-page-when-connecting-from-editor-blocks
+++ b/projects/plugins/jetpack/changelog/add-skip-pricing-page-when-connecting-from-editor-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Skip pricing page when connecting from editor blocks

--- a/projects/plugins/jetpack/extensions/shared/components/connect-banner/index.tsx
+++ b/projects/plugins/jetpack/extensions/shared/components/connect-banner/index.tsx
@@ -1,6 +1,7 @@
 /*
  * External dependencies
  */
+import { useConnection } from '@automattic/jetpack-connection';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { __ } from '@wordpress/i18n';
 /*
@@ -17,12 +18,25 @@ interface ConnectBannerProps {
 
 import './style.scss';
 
+const getRedirectUri = () => {
+	const pathname = window?.location?.pathname.replace( 'wp-admin/', '' );
+	const search = window?.location?.search;
+
+	return `${ pathname }${ search }`;
+};
+
 const ConnectBanner: FC< ConnectBannerProps > = ( { block, explanation = null } ) => {
-	const checkoutUrl = `${ window?.Jetpack_Editor_Initial_State?.adminUrl }admin.php?page=my-jetpack#/connection`;
-	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( checkoutUrl );
+	const { handleConnectUser } = useConnection( {
+		from: 'editor',
+		redirectUri: getRedirectUri(),
+		autoTrigger: false,
+		skipPricingPage: true,
+	} );
+	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect();
 	const { tracks } = useAnalytics();
 
 	const goToCheckoutPage = ( event: MouseEvent< HTMLButtonElement > ) => {
+		handleConnectUser();
 		tracks.recordEvent( 'jetpack_editor_connect_banner_click', { block } );
 		autosaveAndRedirect( event );
 	};
@@ -31,10 +45,10 @@ const ConnectBanner: FC< ConnectBannerProps > = ( { block, explanation = null } 
 		<div>
 			<Nudge
 				buttonText={ __( 'Connect Jetpack', 'jetpack' ) }
-				checkoutUrl={ checkoutUrl }
 				className="jetpack-connect-banner-nudge"
 				description={ __( 'Your account is not connected to Jetpack at the moment.', 'jetpack' ) }
 				goToCheckoutPage={ goToCheckoutPage }
+				checkoutUrl={ '#' }
 				isRedirecting={ isRedirecting }
 			/>
 			<div className="jetpack-connect-banner">

--- a/projects/plugins/jetpack/extensions/shared/components/connect-banner/index.tsx
+++ b/projects/plugins/jetpack/extensions/shared/components/connect-banner/index.tsx
@@ -4,6 +4,7 @@
 import { useConnection } from '@automattic/jetpack-connection';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from 'react';
 /*
  * Internal dependencies
  */
@@ -26,20 +27,34 @@ const getRedirectUri = () => {
 };
 
 const ConnectBanner: FC< ConnectBannerProps > = ( { block, explanation = null } ) => {
+	const [ isRedirecting, setIsRedirecting ] = useState( false );
+	const [ isSaving, setIsSaving ] = useState( false );
 	const { handleConnectUser } = useConnection( {
 		from: 'editor',
 		redirectUri: getRedirectUri(),
 		autoTrigger: false,
 		skipPricingPage: true,
 	} );
-	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect();
+	const { autosave } = useAutosaveAndRedirect();
 	const { tracks } = useAnalytics();
 
 	const goToCheckoutPage = ( event: MouseEvent< HTMLButtonElement > ) => {
-		handleConnectUser();
-		tracks.recordEvent( 'jetpack_editor_connect_banner_click', { block } );
-		autosaveAndRedirect( event );
+		setIsSaving( true );
+		autosave( event ).then( () => {
+			tracks.recordEvent( 'jetpack_editor_connect_banner_click', { block } );
+			setIsRedirecting( true );
+			setIsSaving( false );
+		} );
 	};
+
+	useEffect( () => {
+		// The redirection is handled this way to ensure we get the right redirectUri
+		// In the case that the post is new and unsaved, the component requires a re-render
+		// in order to get the correct URI when the handler is called.
+		if ( isRedirecting ) {
+			handleConnectUser();
+		}
+	}, [ isRedirecting, handleConnectUser ] );
 
 	return (
 		<div>
@@ -49,7 +64,7 @@ const ConnectBanner: FC< ConnectBannerProps > = ( { block, explanation = null } 
 				description={ __( 'Your account is not connected to Jetpack at the moment.', 'jetpack' ) }
 				goToCheckoutPage={ goToCheckoutPage }
 				checkoutUrl={ '#' }
-				isRedirecting={ isRedirecting }
+				isRedirecting={ isRedirecting || isSaving }
 			/>
 			<div className="jetpack-connect-banner">
 				{ explanation && (

--- a/projects/plugins/jetpack/extensions/shared/components/connect-banner/index.tsx
+++ b/projects/plugins/jetpack/extensions/shared/components/connect-banner/index.tsx
@@ -27,7 +27,7 @@ const getRedirectUri = () => {
 };
 
 const ConnectBanner: FC< ConnectBannerProps > = ( { block, explanation = null } ) => {
-	const [ isRedirecting, setIsRedirecting ] = useState( false );
+	const [ isReadyToRedirect, setIsReadyToRedirect ] = useState( false );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const { handleConnectUser } = useConnection( {
 		from: 'editor',
@@ -38,11 +38,11 @@ const ConnectBanner: FC< ConnectBannerProps > = ( { block, explanation = null } 
 	const { autosave } = useAutosaveAndRedirect();
 	const { tracks } = useAnalytics();
 
-	const goToCheckoutPage = ( event: MouseEvent< HTMLButtonElement > ) => {
+	const goToConnectPage = ( event: MouseEvent< HTMLButtonElement > ) => {
 		setIsSaving( true );
 		autosave( event ).then( () => {
 			tracks.recordEvent( 'jetpack_editor_connect_banner_click', { block } );
-			setIsRedirecting( true );
+			setIsReadyToRedirect( true );
 			setIsSaving( false );
 		} );
 	};
@@ -51,10 +51,10 @@ const ConnectBanner: FC< ConnectBannerProps > = ( { block, explanation = null } 
 		// The redirection is handled this way to ensure we get the right redirectUri
 		// In the case that the post is new and unsaved, the component requires a re-render
 		// in order to get the correct URI when the handler is called.
-		if ( isRedirecting ) {
+		if ( isReadyToRedirect ) {
 			handleConnectUser();
 		}
-	}, [ isRedirecting, handleConnectUser ] );
+	}, [ isReadyToRedirect, handleConnectUser ] );
 
 	return (
 		<div>
@@ -62,9 +62,9 @@ const ConnectBanner: FC< ConnectBannerProps > = ( { block, explanation = null } 
 				buttonText={ __( 'Connect Jetpack', 'jetpack' ) }
 				className="jetpack-connect-banner-nudge"
 				description={ __( 'Your account is not connected to Jetpack at the moment.', 'jetpack' ) }
-				goToCheckoutPage={ goToCheckoutPage }
+				goToCheckoutPage={ goToConnectPage }
 				checkoutUrl={ '#' }
-				isRedirecting={ isRedirecting || isSaving }
+				isRedirecting={ isReadyToRedirect || isSaving }
 			/>
 			<div className="jetpack-connect-banner">
 				{ explanation && (


### PR DESCRIPTION
## Proposed changes:

* Add `skipPricingPage` prop to the useConnection hook that passes the `skip_pricing` param to the connection page
* In the connect banner on editor components, go directly to connect page instead of redirecting to My Jetpack. This allows the user to connect and get back to what they were doing as quickly as possible

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

P2: pbNhbs-bQ3-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Checkout this branch via the Jetpack Beta plugin or your local dev environment
2. Connect your site but not your user account
3. Go to `wp-admin/post-new.php` to create a new post
4. Add any block that requires user connection (AI Assistant, for example)
![image](https://github.com/user-attachments/assets/72d12cdd-c7e5-45c3-81cc-df961ee7de54)
5. Click on the Connection CTA, ensure you are sent to the main connection screen at `https://wordpress.com/jetpack/connect/authorize`
7. Ensure that the `skip_pricing` query parameter exists in the URL
8. Approve the connection or log-in if necessary
9. Ensure you are redirected back to the same post you were editing
![image](https://github.com/user-attachments/assets/c84d0d45-f080-4dc0-a95e-b0b55579579f)
