### PR TITLE
Blocks: initialize connection assets in Story block

### DIFF
--- a/projects/packages/connection/changelog/fix-jetpack-story-block-connection-assets
+++ b/projects/packages/connection/changelog/fix-jetpack-story-block-connection-assets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: PHPDoc comment change.
+
+

--- a/projects/packages/connection/src/class-connection-assets.php
+++ b/projects/packages/connection/src/class-connection-assets.php
@@ -25,6 +25,9 @@ class Connection_Assets {
 
 	/**
 	 * Register assets.
+	 *
+	 * NOTICE: Please think twice before including Connection scripts in the frontend.
+	 * Those scripts are intended to be used in WP admin area.
 	 */
 	public static function register_assets() {
 

--- a/projects/plugins/jetpack/changelog/fix-jetpack-story-block-connection-assets
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-story-block-connection-assets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Blocks: initialize connection assets in Story block.

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -444,6 +444,7 @@ function render_block( $attributes ) {
 	static $story_block_counter = 0;
 
 	if ( 0 === $story_block_counter ) {
+		// @todo Fix the webpack tree shaking so the block's view.js no longer depends on jetpack-connection, then remove this.
 		Connection_Assets::register_assets();
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/story/story.php
+++ b/projects/plugins/jetpack/extensions/blocks/story/story.php
@@ -10,6 +10,7 @@
 namespace Automattic\Jetpack\Extensions\Story;
 
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Connection\Connection_Assets;
 use Jetpack;
 use Jetpack_Gutenberg;
 use Jetpack_PostImages;
@@ -441,6 +442,10 @@ function render_pagination( $settings ) {
 function render_block( $attributes ) {
 	// Let's use a counter to have a different id for each story rendered in the same context.
 	static $story_block_counter = 0;
+
+	if ( 0 === $story_block_counter ) {
+		Connection_Assets::register_assets();
+	}
 
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/39829

## Proposed changes:
* Initialize connection assets in the Story block to fix the block assets loading issue.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1729620478710219-slack-C05PV073SG3

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Before you apply this fix, first reproduce [the issue](https://github.com/Automattic/jetpack/issues/39829).
Then confirm this PR fixes the problem.