### PR TITLE
Social: Fix Bluesky custom domain handle not being accepted

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-bluesky-custom-domain-handles-not-working
+++ b/projects/js-packages/publicize-components/changelog/fix-social-bluesky-custom-domain-handles-not-working
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed Bluesky custom domain handle not being accepted

--- a/projects/js-packages/publicize-components/src/components/services/use-request-access.ts
+++ b/projects/js-packages/publicize-components/src/components/services/use-request-access.ts
@@ -11,10 +11,10 @@ const isValidMastodonUsername = ( username: string ) =>
 
 /**
  * Example valid handles:
+ * - domain.tld
  * - username.bsky.social
  * - user-name.bsky.social
- * - my_domain.com.bsky.social
- * - my-domain.com.my-own-server.com
+ * - my-domain.com
  *
  * @param {string} handle - Handle to validate
  *
@@ -23,8 +23,8 @@ const isValidMastodonUsername = ( username: string ) =>
 function isValidBlueskyHandle( handle: string ) {
 	const parts = handle.split( '.' ).filter( Boolean );
 
-	// A valid handle should have at least 3 parts - username, domain, and tld
-	if ( parts.length < 3 ) {
+	// A valid handle should have at least 2 parts - domain, and tld
+	if ( parts.length < 2 ) {
 		return false;
 	}
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/95603

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update the handle validation for Bluesky to accept custom domains

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to connections management
* Enter a simple domain name in Bluesky handle input
* Confirm that the submission opens the connect window

