### PR TITLE
Boost: Remove URL override from image guide

### DIFF
--- a/projects/plugins/boost/.phan/baseline.php
+++ b/projects/plugins/boost/.phan/baseline.php
@@ -30,7 +30,6 @@ return [
     // PhanImpossibleTypeComparison : 1 occurrence
     // PhanImpossibleTypeComparisonInGlobalScope : 1 occurrence
     // PhanPluginNeverReturnFunction : 1 occurrence
-    // PhanPluginSimplifyExpressionBool : 1 occurrence
     // PhanRedefineFunction : 1 occurrence
     // PhanTypeComparisonToArray : 1 occurrence
     // PhanTypeInvalidUnaryOperandIncOrDec : 1 occurrence
@@ -62,7 +61,6 @@ return [
         'app/lib/minify/functions-helpers.php' => ['PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDefault', 'PhanUndeclaredClassMethod', 'PhanUndeclaredClassReference', 'PhanUndeclaredConstant'],
         'app/lib/minify/functions-service.php' => ['PhanImpossibleTypeComparison', 'PhanPluginDuplicateConditionalNullCoalescing', 'PhanPluginNeverReturnFunction', 'PhanPluginUseReturnValueInternalKnown', 'PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition', 'PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentNullableInternal'],
         'app/modules/Modules_Setup.php' => ['PhanTypeMismatchPropertyDefault'],
-        'app/modules/image-guide/Image_Guide.php' => ['PhanPluginSimplifyExpressionBool'],
         'app/modules/image-guide/Image_Guide_Proxy.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'app/modules/image-size-analysis/data-sync/Image_Size_Analysis_Action_Fix.php' => ['PhanPossiblyUndeclaredVariable', 'PhanRedundantCondition'],
         'app/modules/optimizations/critical-css/CSS_Proxy.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide.php
@@ -9,7 +9,7 @@ use Automattic\Jetpack_Boost\Lib\Analytics;
 class Image_Guide implements Pluggable {
 
 	public function setup() {
-		if ( is_admin() || is_user_logged_in() || current_user_can( 'manage_options' ) ) {
+		if ( is_user_logged_in() && current_user_can( 'manage_options' ) ) {
 			Image_Guide_Proxy::init();
 		}
 

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide.php
@@ -21,6 +21,7 @@ class Image_Guide implements Pluggable {
 		// Enqueue the tracks library.
 		add_action( 'wp_enqueue_scripts', array( Analytics::class, 'init_tracks_scripts' ) );
 
+		// Enqueue the assets.
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
 		/**

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide.php
@@ -9,15 +9,12 @@ use Automattic\Jetpack_Boost\Lib\Analytics;
 class Image_Guide implements Pluggable {
 
 	public function setup() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$override = isset( $_GET['jb-debug-ig'] );
-
 		if ( is_admin() || is_user_logged_in() || current_user_can( 'manage_options' ) ) {
 			Image_Guide_Proxy::init();
 		}
 
 		// Show the UI only when the user is logged in, with sufficient permissions and isn't looking at the dashboard.
-		if ( true !== $override && ( is_admin() || ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) ) {
+		if ( is_admin() || ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
 

--- a/projects/plugins/boost/app/modules/image-guide/Image_Guide.php
+++ b/projects/plugins/boost/app/modules/image-guide/Image_Guide.php
@@ -21,7 +21,6 @@ class Image_Guide implements Pluggable {
 		// Enqueue the tracks library.
 		add_action( 'wp_enqueue_scripts', array( Analytics::class, 'init_tracks_scripts' ) );
 
-		// Enqueue the assets.
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
 		/**

--- a/projects/plugins/boost/changelog/remove-image-guide-override
+++ b/projects/plugins/boost/changelog/remove-image-guide-override
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Image Guide: Remove URL parameter based override.


### PR DESCRIPTION
## Proposed changes:
* Remove the URL based override from image guide. It was already currently broken and a bit risky in terms of security.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
No

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
The image guide functionality should work.
