### PR TITLE
Boost: Add notice when updating a page from the foundation pages list

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
@@ -15,7 +15,7 @@ import { isFatalError } from '../lib/critical-css-errors';
 export default function CriticalCssMeta() {
 	const [ cssState ] = useCriticalCssState();
 	const [ hasRetried, retry ] = useRetryRegenerate();
-	const [ regenerateReason ] = useRegenerationReason();
+	const [ { data: regenerateReason } ] = useRegenerationReason();
 	const { progress } = useLocalCriticalCssGenerator();
 	const showFatalError = isFatalError( cssState );
 

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/suggest-regenerate.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/suggest-regenerate.ts
@@ -8,15 +8,19 @@ const allowedSuggestions = [
 	'switched_theme',
 	'plugin_change',
 	'foundation_page_saved',
+	'foundation_pages_list_updated',
 ] as const;
 
-export type RegenerationReason = ( typeof allowedSuggestions )[ number ];
+export type RegenerationReason = ( typeof allowedSuggestions )[ number ] | null;
 
 /**
  * Hook to get the reason why (if any) we should recommend users regenerate their Critical CSS.
  */
-export function useRegenerationReason(): [ RegenerationReason | null, () => void ] {
-	const [ { data }, { mutate } ] = useDataSync(
+export function useRegenerationReason(): [
+	{ data: RegenerationReason; refetch: () => void },
+	() => void,
+] {
+	const [ { data, refetch }, { mutate } ] = useDataSync(
 		'jetpack_boost_ds',
 		'critical_css_suggest_regenerate',
 		z.enum( allowedSuggestions ).nullable()
@@ -26,5 +30,5 @@ export function useRegenerationReason(): [ RegenerationReason | null, () => void
 		mutate( null );
 	}
 
-	return [ data || null, reset ];
+	return [ { data: data || null, refetch }, reset ];
 }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/suggest-regenerate.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/suggest-regenerate.ts
@@ -7,6 +7,7 @@ const allowedSuggestions = [
 	'post_saved',
 	'switched_theme',
 	'plugin_change',
+	'foundation_page_saved',
 ] as const;
 
 export type RegenerationReason = ( typeof allowedSuggestions )[ number ];

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/regenerate-critical-css-suggestion/regenerate-critical-css-suggestion.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/regenerate-critical-css-suggestion/regenerate-critical-css-suggestion.tsx
@@ -20,6 +20,7 @@ const suggestionMap: { [ key: string ]: string } = {
 		'jetpack-boost'
 	),
 	foundation_page_saved: __( 'A Foundation page was updated.', 'jetpack-boost' ),
+	foundation_pages_list_updated: __( 'The list of Foundation pages was updated.', 'jetpack-boost' ),
 };
 
 const getSuggestionMessage = ( type: RegenerationReason | null ) => {

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/regenerate-critical-css-suggestion/regenerate-critical-css-suggestion.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/regenerate-critical-css-suggestion/regenerate-critical-css-suggestion.tsx
@@ -19,6 +19,10 @@ const suggestionMap: { [ key: string ]: string } = {
 		"We noticed you've recently updated a plugin that may affect your site's HTML/CSS structure.",
 		'jetpack-boost'
 	),
+	foundation_page_saved: __(
+		"We noticed you've recently updated a Foundation page that may affect your site's HTML/CSS structure.",
+		'jetpack-boost'
+	),
 };
 
 const getSuggestionMessage = ( type: RegenerationReason | null ) => {

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/regenerate-critical-css-suggestion/regenerate-critical-css-suggestion.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/regenerate-critical-css-suggestion/regenerate-critical-css-suggestion.tsx
@@ -19,10 +19,7 @@ const suggestionMap: { [ key: string ]: string } = {
 		"We noticed you've recently updated a plugin that may affect your site's HTML/CSS structure.",
 		'jetpack-boost'
 	),
-	foundation_page_saved: __(
-		"We noticed you've recently updated a Foundation page that may affect your site's HTML/CSS structure.",
-		'jetpack-boost'
-	),
+	foundation_page_saved: __( 'A Foundation page was updated.', 'jetpack-boost' ),
 };
 
 const getSuggestionMessage = ( type: RegenerationReason | null ) => {

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/lib/stores/foundation-pages.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/lib/stores/foundation-pages.ts
@@ -4,15 +4,20 @@ import { z } from 'zod';
 /**
  * Hook to get the Foundation Pages.
  */
-export function useFoundationPages(): [ string[], ( newValue: string[] ) => void ] {
+export function useFoundationPages(): [
+	string[],
+	( newValue: string[], onSuccessCallback?: () => void ) => void,
+] {
 	const [ { data }, { mutate } ] = useDataSync(
 		'jetpack_boost_ds',
 		'foundation_pages_list',
 		z.array( z.string() )
 	);
 
-	function updatePages( newValue: string[] ) {
-		mutate( newValue );
+	function updatePages( newValue: string[], onSuccessCallback?: () => void ) {
+		mutate( newValue, {
+			onSuccess: onSuccessCallback,
+		} );
 	}
 
 	return [ data || [], updatePages ];

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -9,16 +9,20 @@ import { useFoundationPages, useFoundationPagesProperties } from '../lib/stores/
 import { createInterpolateElement } from '@wordpress/element';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import getSupportLink from '$lib/utils/get-support-link';
+import { useRegenerationReason } from '$features/critical-css/lib/stores/suggest-regenerate';
 
 const Meta = () => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ foundationPages, setFoundationPages ] = useFoundationPages();
 	const foundationPagesProperties = useFoundationPagesProperties();
+	const [ { refetch: refetchRegenerationReason } ] = useRegenerationReason();
 
 	const updateFoundationPages = ( newValue: string ) => {
 		const newItems = newValue.split( '\n' ).map( line => line.trim() );
 
-		setFoundationPages( newItems );
+		setFoundationPages( newItems, () => {
+			refetchRegenerationReason();
+		} );
 	};
 
 	let content = null;

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -33,7 +33,10 @@ const Meta = () => {
 					foundationPagesProperties.blog_url &&
 					sprintf(
 						/* translators: %s is the blog URL. */
-						__( 'No need to include the blog URL (%s), it is already included.', 'jetpack-boost' ),
+						__(
+							'No need to add the blog URL (%s) to the list, it is automatically kept up to date.',
+							'jetpack-boost'
+						),
 						foundationPagesProperties.blog_url
 					)
 				}

--- a/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack_Boost\Data_Sync;
 
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
+use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
 
 class Foundation_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 
@@ -26,7 +27,10 @@ class Foundation_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 	public function set( $value ) {
 		$value = $this->sanitize_value( $value );
 
-		update_option( $this->option_key, $value );
+		$updated = update_option( $this->option_key, $value );
+		if ( $updated ) {
+			( new Environment_Change_Detector() )->handle_foundation_pages_list_update();
+		}
 	}
 
 	private function sanitize_value( $value ) {

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -98,7 +98,7 @@ class Environment_Change_Detector {
 	/**
 	 * Get the type of change for a specific post.
 	 *
-	 * @param WP_Post $post The post object.
+	 * @param \WP_Post $post The post object.
 	 * @return string The change type.
 	 */
 	private function get_post_change_type( $post ) {

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -14,11 +14,12 @@ namespace Automattic\Jetpack_Boost\Lib;
  */
 class Environment_Change_Detector {
 
-	const ENV_CHANGE_LEGACY         = '1';
-	const ENV_CHANGE_PAGE_SAVED     = 'page_saved';
-	const ENV_CHANGE_POST_SAVED     = 'post_saved';
-	const ENV_CHANGE_SWITCHED_THEME = 'switched_theme';
-	const ENV_CHANGE_PLUGIN_CHANGE  = 'plugin_change';
+	const ENV_CHANGE_LEGACY                = '1';
+	const ENV_CHANGE_PAGE_SAVED            = 'page_saved';
+	const ENV_CHANGE_POST_SAVED            = 'post_saved';
+	const ENV_CHANGE_SWITCHED_THEME        = 'switched_theme';
+	const ENV_CHANGE_PLUGIN_CHANGE         = 'plugin_change';
+	const ENV_CHANGE_FOUNDATION_PAGE_SAVED = 'foundation_page_saved';
 
 	/**
 	 * Initialize the change detection hooks.
@@ -46,13 +47,7 @@ class Environment_Change_Detector {
 			return;
 		}
 
-		if ( 'page' === $post->post_type ) {
-			$change_type = $this::ENV_CHANGE_PAGE_SAVED;
-		} else {
-			$change_type = $this::ENV_CHANGE_POST_SAVED;
-		}
-
-		$this->do_action( false, $change_type );
+		$this->do_action( false, $this->get_post_change_type( $post ) );
 	}
 
 	public function handle_theme_change() {
@@ -98,5 +93,30 @@ class Environment_Change_Detector {
 		if ( is_post_type_viewable( $post_type ) ) {
 			return true;
 		}
+	}
+
+	/**
+	 * Get the type of change for a specific post.
+	 *
+	 * @param WP_Post $post The post object.
+	 * @return string The change type.
+	 */
+	private function get_post_change_type( $post ) {
+		$foundation_pages = ( new Foundation_Pages() )->get_pages();
+		if ( $foundation_pages ) {
+			$foundation_pages_sanitized = array_map( 'untrailingslashit', $foundation_pages );
+			$current_url                = untrailingslashit( get_permalink( $post ) );
+			if ( in_array( $current_url, $foundation_pages_sanitized, true ) ) {
+				return $this::ENV_CHANGE_FOUNDATION_PAGE_SAVED;
+			}
+		}
+
+		if ( 'page' === $post->post_type ) {
+			$change_type = $this::ENV_CHANGE_PAGE_SAVED;
+		} else {
+			$change_type = $this::ENV_CHANGE_POST_SAVED;
+		}
+
+		return $change_type;
 	}
 }

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -14,12 +14,13 @@ namespace Automattic\Jetpack_Boost\Lib;
  */
 class Environment_Change_Detector {
 
-	const ENV_CHANGE_LEGACY                = '1';
-	const ENV_CHANGE_PAGE_SAVED            = 'page_saved';
-	const ENV_CHANGE_POST_SAVED            = 'post_saved';
-	const ENV_CHANGE_SWITCHED_THEME        = 'switched_theme';
-	const ENV_CHANGE_PLUGIN_CHANGE         = 'plugin_change';
-	const ENV_CHANGE_FOUNDATION_PAGE_SAVED = 'foundation_page_saved';
+	const ENV_CHANGE_LEGACY                        = '1';
+	const ENV_CHANGE_PAGE_SAVED                    = 'page_saved';
+	const ENV_CHANGE_POST_SAVED                    = 'post_saved';
+	const ENV_CHANGE_SWITCHED_THEME                = 'switched_theme';
+	const ENV_CHANGE_PLUGIN_CHANGE                 = 'plugin_change';
+	const ENV_CHANGE_FOUNDATION_PAGE_SAVED         = 'foundation_page_saved';
+	const ENV_CHANGE_FOUNDATION_PAGES_LIST_UPDATED = 'foundation_pages_list_updated';
 
 	/**
 	 * Initialize the change detection hooks.
@@ -56,6 +57,10 @@ class Environment_Change_Detector {
 
 	public function handle_plugin_change() {
 		$this->do_action( false, $this::ENV_CHANGE_PLUGIN_CHANGE );
+	}
+
+	public function handle_foundation_pages_list_update() {
+		$this->do_action( false, $this::ENV_CHANGE_FOUNDATION_PAGES_LIST_UPDATED );
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
+++ b/projects/plugins/boost/app/lib/critical-css/source-providers/providers/WP_Core_Provider.php
@@ -49,7 +49,9 @@ class WP_Core_Provider extends Provider {
 					$urls['posts_page'] = array( $permalink );
 				}
 			}
-		} elseif ( ! $front_page ) {
+		}
+
+		if ( ! $front_page && ! isset( $urls['posts_page'] ) ) {
 			$urls['posts_page'] = array( home_url( '/' ) );
 		}
 

--- a/projects/plugins/boost/changelog/update-boost-foundation-pages-suggest-regenerate-list-updated
+++ b/projects/plugins/boost/changelog/update-boost-foundation-pages-suggest-regenerate-list-updated
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add a notice prompting critical css regen after updating foundation pages list.
+
+

--- a/projects/plugins/boost/changelog/update-boost-prompt-critical-css-regen-after-updating-foundation-page
+++ b/projects/plugins/boost/changelog/update-boost-prompt-critical-css-regen-after-updating-foundation-page
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add notice to prompt user to do critical css regeneration when they update a foundation page.
+
+

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -177,6 +177,7 @@ $critical_css_suggest_regenerate_schema = Schema::enum(
 		'switched_theme',
 		'plugin_change',
 		'foundation_page_saved',
+		'foundation_pages_list_updated',
 	)
 )->nullable();
 

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -176,6 +176,7 @@ $critical_css_suggest_regenerate_schema = Schema::enum(
 		'post_saved',
 		'switched_theme',
 		'plugin_change',
+		'foundation_page_saved',
 	)
 )->nullable();
 


### PR DESCRIPTION
## Proposed changes:

* Add a notice when updating a page from the foundation pages list;
* Update text under foundation pages input area.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Setup Boost free;
- Add a URL for an existing page, to the foundation pages box (or don't, the home page is present there by default);
- Update a page from the list;
- There should be a notice asking you to regenerate critical css:

<img width="785" alt="CleanShot 2024-10-23 at 15 41 51@2x" src="https://github.com/user-attachments/assets/f7857607-503e-4b88-a1d9-0db19566232a">
