### PR TITLE
Boost: Add "Foundation Page" state in WP's page listing scree

### DIFF
--- a/projects/plugins/boost/app/lib/Foundation_Pages.php
+++ b/projects/plugins/boost/app/lib/Foundation_Pages.php
@@ -12,6 +12,7 @@ class Foundation_Pages implements Has_Setup {
 		}
 
 		add_filter( 'jetpack_boost_critical_css_providers', array( $this, 'remove_ccss_front_page_provider' ), 10, 2 );
+		add_filter( 'display_post_states', array( $this, 'add_display_post_states' ), 10, 2 );
 	}
 
 	public function remove_ccss_front_page_provider( $providers ) {
@@ -39,6 +40,20 @@ class Foundation_Pages implements Has_Setup {
 			'max_pages' => $this->get_max_pages(),
 			'blog_url'  => $this->get_blog_url(),
 		);
+	}
+
+	public function add_display_post_states( $post_states, $post ) {
+		$foundation_pages = $this->get_pages();
+		if ( ! empty( $foundation_pages ) ) {
+			$post_url         = untrailingslashit( get_permalink( $post ) );
+			$foundation_pages = array_map( 'untrailingslashit', $foundation_pages );
+
+			if ( in_array( $post_url, $foundation_pages, true ) ) {
+				$post_states[] = __( 'Foundation Page', 'jetpack-boost' );
+			}
+		}
+
+		return $post_states;
 	}
 
 	private function get_max_pages() {

--- a/projects/plugins/boost/changelog/update-boost-indicate-foundation-page-in-wp-post-listing
+++ b/projects/plugins/boost/changelog/update-boost-indicate-foundation-page-in-wp-post-listing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add "Foundation Page" indication next to pages in WPs page listing screen.
+
+


### PR DESCRIPTION
## Proposed changes:

* Indicate Foundation Pages on page listing in WordPress.

<img width="359" alt="CleanShot 2024-10-23 at 15 57 33@2x" src="https://github.com/user-attachments/assets/b6ab18ce-2166-4f15-94fc-0443d96ea791">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Install Boost free;
- Add a page to the foundation pages list;
- Check the page listing to make sure there's a "Foundation Page".