### PR TITLE
Boost: Prompt c.css regen when updating foundation pages list

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/critical-css-meta/critical-css-meta.tsx
@@ -15,7 +15,7 @@ import { isFatalError } from '../lib/critical-css-errors';
 export default function CriticalCssMeta() {
 	const [ cssState ] = useCriticalCssState();
 	const [ hasRetried, retry ] = useRetryRegenerate();
-	const [ regenerateReason ] = useRegenerationReason();
+	const [ { data: regenerateReason } ] = useRegenerationReason();
 	const { progress } = useLocalCriticalCssGenerator();
 	const showFatalError = isFatalError( cssState );
 

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state.ts
@@ -152,8 +152,8 @@ export function useSetProviderErrorsAction() {
  * Hook which creates a callable action for regenerating Critical CSS.
  */
 export function useRegenerateCriticalCssAction() {
-	const [ , resetReason ] = useRegenerationReason();
-	return useCriticalCssAction( 'request-regenerate', z.void(), resetReason );
+	const [ , updateReason ] = useRegenerationReason();
+	return useCriticalCssAction( 'request-regenerate', z.void(), () => updateReason( null ) );
 }
 
 /**

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/critical-css-state.ts
@@ -152,8 +152,8 @@ export function useSetProviderErrorsAction() {
  * Hook which creates a callable action for regenerating Critical CSS.
  */
 export function useRegenerateCriticalCssAction() {
-	const [ , updateReason ] = useRegenerationReason();
-	return useCriticalCssAction( 'request-regenerate', z.void(), () => updateReason( null ) );
+	const [ , resetReason ] = useRegenerationReason();
+	return useCriticalCssAction( 'request-regenerate', z.void(), resetReason );
 }
 
 /**

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/suggest-regenerate.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/suggest-regenerate.ts
@@ -8,23 +8,27 @@ const allowedSuggestions = [
 	'switched_theme',
 	'plugin_change',
 	'foundation_page_saved',
+	'foundation_pages_list_updated',
 ] as const;
 
-export type RegenerationReason = ( typeof allowedSuggestions )[ number ];
+export type RegenerationReason = ( typeof allowedSuggestions )[ number ] | null;
 
 /**
  * Hook to get the reason why (if any) we should recommend users regenerate their Critical CSS.
  */
-export function useRegenerationReason(): [ RegenerationReason | null, () => void ] {
+export function useRegenerationReason(): [
+	RegenerationReason,
+	( reason: RegenerationReason ) => void,
+] {
 	const [ { data }, { mutate } ] = useDataSync(
 		'jetpack_boost_ds',
 		'critical_css_suggest_regenerate',
 		z.enum( allowedSuggestions ).nullable()
 	);
 
-	function reset() {
-		mutate( null );
-	}
+	const updateReason = ( reason: RegenerationReason ) => {
+		mutate( reason );
+	};
 
-	return [ data || null, reset ];
+	return [ data || null, updateReason ];
 }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/suggest-regenerate.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/lib/stores/suggest-regenerate.ts
@@ -17,18 +17,18 @@ export type RegenerationReason = ( typeof allowedSuggestions )[ number ] | null;
  * Hook to get the reason why (if any) we should recommend users regenerate their Critical CSS.
  */
 export function useRegenerationReason(): [
-	RegenerationReason,
-	( reason: RegenerationReason ) => void,
+	{ data: RegenerationReason; refetch: () => void },
+	() => void,
 ] {
-	const [ { data }, { mutate } ] = useDataSync(
+	const [ { data, refetch }, { mutate } ] = useDataSync(
 		'jetpack_boost_ds',
 		'critical_css_suggest_regenerate',
 		z.enum( allowedSuggestions ).nullable()
 	);
 
-	const updateReason = ( reason: RegenerationReason ) => {
-		mutate( reason );
-	};
+	function reset() {
+		mutate( null );
+	}
 
-	return [ data || null, updateReason ];
+	return [ { data: data || null, refetch }, reset ];
 }

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/regenerate-critical-css-suggestion/regenerate-critical-css-suggestion.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/regenerate-critical-css-suggestion/regenerate-critical-css-suggestion.tsx
@@ -20,6 +20,7 @@ const suggestionMap: { [ key: string ]: string } = {
 		'jetpack-boost'
 	),
 	foundation_page_saved: __( 'A Foundation page was updated.', 'jetpack-boost' ),
+	foundation_pages_list_updated: __( 'The list of Foundation pages was updated.', 'jetpack-boost' ),
 };
 
 const getSuggestionMessage = ( type: RegenerationReason | null ) => {

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/lib/stores/foundation-pages.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/lib/stores/foundation-pages.ts
@@ -4,15 +4,20 @@ import { z } from 'zod';
 /**
  * Hook to get the Foundation Pages.
  */
-export function useFoundationPages(): [ string[], ( newValue: string[] ) => void ] {
+export function useFoundationPages(): [
+	string[],
+	( newValue: string[], onSuccessCallback?: () => void ) => void,
+] {
 	const [ { data }, { mutate } ] = useDataSync(
 		'jetpack_boost_ds',
 		'foundation_pages_list',
 		z.array( z.string() )
 	);
 
-	function updatePages( newValue: string[] ) {
-		mutate( newValue );
+	function updatePages( newValue: string[], onSuccessCallback?: () => void ) {
+		mutate( newValue, {
+			onSuccess: onSuccessCallback,
+		} );
 	}
 
 	return [ data || [], updatePages ];

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -20,10 +20,9 @@ const Meta = () => {
 	const updateFoundationPages = ( newValue: string ) => {
 		const newItems = newValue.split( '\n' ).map( line => line.trim() );
 
-		setFoundationPages( newItems );
-		// @todo - Running setFoundationPages does not necessarily mean that the value was updated.
-		// This should happen only IF the value got updated.
-		updateRegenerateReason( 'foundation_pages_list_updated' );
+		setFoundationPages( newItems, () => {
+			updateRegenerateReason( 'foundation_pages_list_updated' );
+		} );
 	};
 
 	let content = null;

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -15,13 +15,13 @@ const Meta = () => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ foundationPages, setFoundationPages ] = useFoundationPages();
 	const foundationPagesProperties = useFoundationPagesProperties();
-	const [ , updateRegenerateReason ] = useRegenerationReason();
+	const [ { refetch: refetchRegenerationReason } ] = useRegenerationReason();
 
 	const updateFoundationPages = ( newValue: string ) => {
 		const newItems = newValue.split( '\n' ).map( line => line.trim() );
 
 		setFoundationPages( newItems, () => {
-			updateRegenerateReason( 'foundation_pages_list_updated' );
+			refetchRegenerationReason();
 		} );
 	};
 

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -9,16 +9,21 @@ import { useFoundationPages, useFoundationPagesProperties } from '../lib/stores/
 import { createInterpolateElement } from '@wordpress/element';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import getSupportLink from '$lib/utils/get-support-link';
+import { useRegenerationReason } from '$features/critical-css/lib/stores/suggest-regenerate';
 
 const Meta = () => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ foundationPages, setFoundationPages ] = useFoundationPages();
 	const foundationPagesProperties = useFoundationPagesProperties();
+	const [ , updateRegenerateReason ] = useRegenerationReason();
 
 	const updateFoundationPages = ( newValue: string ) => {
 		const newItems = newValue.split( '\n' ).map( line => line.trim() );
 
 		setFoundationPages( newItems );
+		// @todo - Running setFoundationPages does not necessarily mean that the value was updated.
+		// This should happen only IF the value got updated.
+		updateRegenerateReason( 'foundation_pages_list_updated' );
 	};
 
 	let content = null;

--- a/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack_Boost\Data_Sync;
 
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Get;
 use Automattic\Jetpack\WP_JS_Data_Sync\Contracts\Entry_Can_Set;
+use Automattic\Jetpack_Boost\Lib\Environment_Change_Detector;
 
 class Foundation_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 
@@ -26,7 +27,10 @@ class Foundation_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 	public function set( $value ) {
 		$value = $this->sanitize_value( $value );
 
-		update_option( $this->option_key, $value );
+		$updated = update_option( $this->option_key, $value );
+		if ( $updated ) {
+			( new Environment_Change_Detector() )->handle_foundation_pages_list_update();
+		}
 	}
 
 	private function sanitize_value( $value ) {

--- a/projects/plugins/boost/app/lib/Environment_Change_Detector.php
+++ b/projects/plugins/boost/app/lib/Environment_Change_Detector.php
@@ -14,12 +14,13 @@ namespace Automattic\Jetpack_Boost\Lib;
  */
 class Environment_Change_Detector {
 
-	const ENV_CHANGE_LEGACY                = '1';
-	const ENV_CHANGE_PAGE_SAVED            = 'page_saved';
-	const ENV_CHANGE_POST_SAVED            = 'post_saved';
-	const ENV_CHANGE_SWITCHED_THEME        = 'switched_theme';
-	const ENV_CHANGE_PLUGIN_CHANGE         = 'plugin_change';
-	const ENV_CHANGE_FOUNDATION_PAGE_SAVED = 'foundation_page_saved';
+	const ENV_CHANGE_LEGACY                        = '1';
+	const ENV_CHANGE_PAGE_SAVED                    = 'page_saved';
+	const ENV_CHANGE_POST_SAVED                    = 'post_saved';
+	const ENV_CHANGE_SWITCHED_THEME                = 'switched_theme';
+	const ENV_CHANGE_PLUGIN_CHANGE                 = 'plugin_change';
+	const ENV_CHANGE_FOUNDATION_PAGE_SAVED         = 'foundation_page_saved';
+	const ENV_CHANGE_FOUNDATION_PAGES_LIST_UPDATED = 'foundation_pages_list_updated';
 
 	/**
 	 * Initialize the change detection hooks.
@@ -56,6 +57,10 @@ class Environment_Change_Detector {
 
 	public function handle_plugin_change() {
 		$this->do_action( false, $this::ENV_CHANGE_PLUGIN_CHANGE );
+	}
+
+	public function handle_foundation_pages_list_update() {
+		$this->do_action( false, $this::ENV_CHANGE_FOUNDATION_PAGES_LIST_UPDATED );
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/update-boost-foundation-pages-suggest-regenerate-list-updated
+++ b/projects/plugins/boost/changelog/update-boost-foundation-pages-suggest-regenerate-list-updated
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add a notice prompting critical css regen after updating foundation pages list.
+
+

--- a/projects/plugins/boost/wp-js-data-sync.php
+++ b/projects/plugins/boost/wp-js-data-sync.php
@@ -177,6 +177,7 @@ $critical_css_suggest_regenerate_schema = Schema::enum(
 		'switched_theme',
 		'plugin_change',
 		'foundation_page_saved',
+		'foundation_pages_list_updated',
 	)
 )->nullable();
 


### PR DESCRIPTION
## Proposed changes:

* Show a "regenerate critical css" notice when updating foundation pages list.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

n/a

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

- Setup Boost (free);
- Enable critical css and generate;
- Add a few URLs to the foundation pages list;
- The notice prompting critical regen should show.