### PR TITLE
Boost: Update foundation page list instructions

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/lib/stores/foundation-pages.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/lib/stores/foundation-pages.ts
@@ -25,7 +25,6 @@ export function useFoundationPages(): [
 
 const FoundationPagesProperties = z.object( {
 	max_pages: z.number(),
-	blog_url: z.string().nullable(),
 } );
 type FoundationPagesProperties = z.infer< typeof FoundationPagesProperties >;
 

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -33,17 +33,19 @@ const Meta = () => {
 				items={ foundationPages.join( '\n' ) }
 				setItems={ updateFoundationPages }
 				maxItems={ foundationPagesProperties.max_pages }
-				description={
-					foundationPagesProperties.blog_url &&
+				description={ createInterpolateElement(
 					sprintf(
-						/* translators: %s is the blog URL. */
+						/* translators: %s is the site URL. */
 						__(
-							'No need to add the blog URL (%s) to the list, it is automatically kept up to date.',
+							'Add one URL per line. Only URLs starting with <b>%s</b> will be included. Relative URLs are automatically expanded.',
 							'jetpack-boost'
 						),
-						foundationPagesProperties.blog_url
-					)
-				}
+						Jetpack_Boost.site.url
+					),
+					{
+						b: <b />,
+					}
+				) }
 			/>
 		);
 	} else {

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -168,8 +168,8 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems, description }
 					{ sprintf(
 						/* translators: %d is the maximum number of foundation page URLs. */
 						_n(
-							'You must provide %d foundation page URL.',
-							'You must provide between 1 and %d foundation page URLs.',
+							'You can add only %d foundation page URL.',
+							'You can add up to %d foundation page URLs.',
 							maxItems,
 							'jetpack-boost'
 						),

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -135,11 +135,6 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems, description }
 			.map( line => line.trim() )
 			.filter( line => line.trim() !== '' );
 
-		// There should always be at least one foundation page.
-		if ( lines.length === 0 ) {
-			return false;
-		}
-
 		// Check if the number of items exceeds maxItems
 		if ( lines.length > maxItems ) {
 			return false;

--- a/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/foundation-pages/meta/meta.tsx
@@ -170,12 +170,8 @@ const List: React.FC< ListProps > = ( { items, setItems, maxItems, description }
 				url.origin.replace( /\/$/, '' ) !== Jetpack_Boost.site.url.replace( /\/$/, '' )
 			) {
 				throw new Error(
-					sprintf(
-						/* translators: %1$s is the URL that didn't match the site URL, %2$s is the site URL */
-						__( 'The URL %1$s does not belong to the site %2$s.', 'jetpack-boost' ),
-						line,
-						Jetpack_Boost.site.url
-					)
+					/* translators: %s is the URL that didn't match the site URL */
+					sprintf( __( 'The URL seems to be a different site: %s', 'jetpack-boost' ), line )
 				);
 			}
 		}

--- a/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
+++ b/projects/plugins/boost/app/data-sync/Foundation_Pages_Entry.php
@@ -27,6 +27,11 @@ class Foundation_Pages_Entry implements Entry_Can_Get, Entry_Can_Set {
 	public function set( $value ) {
 		$value = $this->sanitize_value( $value );
 
+		if ( empty( $value ) || count( $value ) === 1 && $value[0] === '' ) {
+			delete_option( $this->option_key );
+			return;
+		}
+
 		$updated = update_option( $this->option_key, $value );
 		if ( $updated ) {
 			( new Environment_Change_Detector() )->handle_foundation_pages_list_update();

--- a/projects/plugins/boost/app/lib/Foundation_Pages.php
+++ b/projects/plugins/boost/app/lib/Foundation_Pages.php
@@ -38,7 +38,6 @@ class Foundation_Pages implements Has_Setup {
 	public function get_properties() {
 		return array(
 			'max_pages' => $this->get_max_pages(),
-			'blog_url'  => $this->get_blog_url(),
 		);
 	}
 
@@ -58,21 +57,6 @@ class Foundation_Pages implements Has_Setup {
 
 	private function get_max_pages() {
 		return Premium_Features::has_any() ? 10 : 1;
-	}
-
-	private function get_blog_url() {
-		$front_page = (int) get_option( 'page_on_front' );
-		$posts_page = (int) get_option( 'page_for_posts' );
-		if ( $posts_page ) {
-			$permalink = get_permalink( $posts_page );
-			if ( ! empty( $permalink ) ) {
-				return $permalink;
-			}
-		} elseif ( ! $front_page ) {
-			return home_url( '/' );
-		}
-
-		return null;
 	}
 
 	private function is_development_features_enabled() {


### PR DESCRIPTION
## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Update instructions under foundation page list input.
 > Add one URL per line. Only URLs starting with <b>%s</b> will be included. Relative URLs are automatically expanded.
* Reset list to default if empty list is submitted
* Update list limit error message:
 > You can add only %d foundation page URL.
 > You can add up to %d foundation page URLs.
* Validate absolute URLs and inform if they belong to a different site.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
None

## Does this pull request change what data or activity we track or use?
None

## Testing instructions:
None
