### PR TITLE
Stats: Use option value instead of transient for cache buster

### DIFF
--- a/projects/packages/stats-admin/changelog/update-use-option-value-instead-of-transient
+++ b/projects/packages/stats-admin/changelog/update-use-option-value-instead-of-transient
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Odyssey Stats cache busting: use optioin instead of transient

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -90,6 +90,7 @@ class Odyssey_Assets {
 
 		if ( ! empty( $remote_asset_version ) ) {
 			$remote_asset_version = json_decode( $remote_asset_version, true );
+			// If cache buster is cached and not expired (valid in 15 min), return it.
 			if ( ! empty( $remote_asset_version['cache_buster'] ) && $remote_asset_version['cached_at'] > $now_in_ms - MINUTE_IN_SECONDS * 1000 * 15 ) {
 				return $remote_asset_version['cache_buster'];
 			}

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -118,7 +118,7 @@ class Odyssey_Assets {
 	/**
 	 * Get the cache buster option value.
 	 *
-	 * @param string|int $cache_buster The cache buster.
+	 * @param string|int|float $cache_buster The cache buster.
 	 * @return string|false
 	 */
 	protected function get_cache_buster_option_value( $cache_buster ) {

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -118,7 +118,7 @@ class Odyssey_Assets {
 	/**
 	 * Get the cache buster option value.
 	 *
-	 * @param string $cache_buster The cache buster.
+	 * @param string|int $cache_buster The cache buster.
 	 * @return string|false
 	 */
 	protected function get_cache_buster_option_value( $cache_buster ) {

--- a/projects/packages/stats-admin/tests/php/class-test-case.php
+++ b/projects/packages/stats-admin/tests/php/class-test-case.php
@@ -60,6 +60,7 @@ class Test_Case extends TestCase {
 
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10, 2 );
 		add_filter( 'pre_http_request', array( $this, 'plan_http_response_fixture' ), 10, 3 );
+		delete_option( Odyssey_Assets::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY );
 	}
 
 	/**
@@ -76,6 +77,7 @@ class Test_Case extends TestCase {
 
 		remove_filter( 'pre_http_request', array( $this, 'plan_http_response_fixture' ) );
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ) );
+		delete_option( Odyssey_Assets::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
+++ b/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
@@ -19,9 +19,9 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 	}
 
 	/**
-	 * Test remote cache buster breaking.
+	 * Test remote cache buster remote error.
 	 */
-	public function test_get_cdn_asset_cache_buster_force_refresh() {
+	public function test_get_cdn_asset_cache_buster_remote_error() {
 		add_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15, 3 );
 		$this->assertEquals( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
 		remove_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15 );

--- a/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
+++ b/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
@@ -97,10 +97,10 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 	/**
 	 * Test remote cache buster.
 	 *
-	 * @param mixed $response  The response array .
-	 * @param mixed $parsed_args  The parsed args .
-	 * @param mixed $url  The URL .
-	 * @return array | void
+	 * @param mixed $response  The response array.
+	 * @param mixed $parsed_args  The parsed args.
+	 * @param mixed $url  The URL.
+	 * @return WP_Error | void
 	 */
 	public function break_cdn_cache_buster_request( $response, $parsed_args, $url ) {
 		if ( strpos( $url, '/build_meta.json' ) !== false ) {

--- a/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
+++ b/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
@@ -2,6 +2,7 @@
 namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Stats_Admin\Test_Case as Stats_Test_Case;
+use WP_Error;
 
 /**
  * Unit tests for the Odyssey_Assets class.
@@ -9,13 +10,111 @@ use Automattic\Jetpack\Stats_Admin\Test_Case as Stats_Test_Case;
  * @package automattic/jetpack-stats-admin
  */
 class Test_Odyssey_Assets extends Stats_Test_Case {
+
 	/**
 	 * Test remote cache buster.
 	 */
 	public function test_get_cdn_asset_cache_buster() {
+		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
+		$this->assertEquals( 'calypso-4917-8664-g72a154d63a', $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) );
+	}
+
+	/**
+	 * Test remote cache buster breaking.
+	 */
+	public function test_get_cdn_asset_cache_buster_force_refresh() {
+		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
+		add_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15, 3 );
+		$this->assertEquals( time(), floor( $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) / 1000 ) );
+		remove_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15 );
+	}
+
+	/**
+	 * Test already cached cache buster.
+	 */
+	public function test_get_cdn_asset_cache_buster_already_cached() {
+		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
+		update_option(
+			Odyssey_Assets::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY,
+			wp_json_encode(
+				array(
+					'cache_buster' => 'calypso-4917-8664-123456',
+					'cached_at'    => floor( microtime( true ) * 1000 ), // milliseconds.
+				)
+			),
+			false
+		);
+		$this->assertEquals( 'calypso-4917-8664-123456', $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) );
+	}
+
+	/**
+	 * Test already cached cache buster expired.
+	 */
+	public function test_get_cdn_asset_cache_buster_already_cached_expired() {
+		update_option(
+			Odyssey_Assets::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY,
+			wp_json_encode(
+				array(
+					'cache_buster' => 'calypso-4917-8664-123456',
+					'cached_at'    => floor( microtime( true ) * 1000 - MINUTE_IN_SECONDS * 1000 * 20 ), // milliseconds.
+				)
+			),
+			false
+		);
+		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
+		$this->assertEquals( 'calypso-4917-8664-g72a154d63a', $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) );
+	}
+
+	/**
+	 * Test already cached cache buster expired and failed to fetch new one.
+	 */
+	public function test_get_cdn_asset_cache_buster_failed_to_fetch() {
+		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
+		add_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15, 3 );
+		update_option(
+			Odyssey_Assets::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY,
+			wp_json_encode(
+				array(
+					'cache_buster' => 'calypso-4917-8664-123456',
+					'cached_at'    => floor( microtime( true ) * 1000 - MINUTE_IN_SECONDS * 1000 * 20 ), // milliseconds.
+				)
+			),
+			false
+		);
+		$this->assertEquals( time(), floor( $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) / 1000 ) );
+		remove_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15 );
+	}
+
+	/**
+	 * Test force refresh cache buster.
+	 */
+	public function test_get_cdn_asset_cache_buster_force_refresh_expired() {
+		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
+		$_GET['force_refresh']                             = 1;
+		$this->assertEquals( time(), floor( $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) / 1000 ) );
+	}
+
+	/**
+	 * Test remote cache buster.
+	 *
+	 * @param mixed $response  The response array .
+	 * @param mixed $parsed_args  The parsed args .
+	 * @param mixed $url  The URL .
+	 * @return array | void
+	 */
+	public function break_cdn_cache_buster_request( $response, $parsed_args, $url ) {
+		if ( strpos( $url, '/build_meta.json' ) !== false ) {
+			return new WP_Error( 500, 'Internal Server Error' );
+		}
+	}
+
+	/**
+	 * Get CDN asset cache buster.
+	 */
+	protected function get_cdn_asset_cache_buster_callable() {
 		$odyssey_assets             = new Odyssey_Assets();
 		$get_cdn_asset_cache_buster = new \ReflectionMethod( $odyssey_assets, 'get_cdn_asset_cache_buster' );
 		$get_cdn_asset_cache_buster->setAccessible( true );
-		$this->assertEquals( 'calypso-4917-8664-g72a154d63a', $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) );
+		return array( $get_cdn_asset_cache_buster, $odyssey_assets );
 	}
 }

--- a/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
+++ b/projects/packages/stats-admin/tests/php/test-odyssey-assets.php
@@ -15,17 +15,15 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 	 * Test remote cache buster.
 	 */
 	public function test_get_cdn_asset_cache_buster() {
-		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
-		$this->assertEquals( 'calypso-4917-8664-g72a154d63a', $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) );
+		$this->assertEquals( 'calypso-4917-8664-g72a154d63a', $this->get_cdn_asset_cache_buster_callable() );
 	}
 
 	/**
 	 * Test remote cache buster breaking.
 	 */
 	public function test_get_cdn_asset_cache_buster_force_refresh() {
-		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
 		add_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15, 3 );
-		$this->assertEquals( time(), floor( $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) / 1000 ) );
+		$this->assertEquals( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
 		remove_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15 );
 	}
 
@@ -33,7 +31,6 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 	 * Test already cached cache buster.
 	 */
 	public function test_get_cdn_asset_cache_buster_already_cached() {
-		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
 		update_option(
 			Odyssey_Assets::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY,
 			wp_json_encode(
@@ -44,7 +41,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 			),
 			false
 		);
-		$this->assertEquals( 'calypso-4917-8664-123456', $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) );
+		$this->assertEquals( 'calypso-4917-8664-123456', $this->get_cdn_asset_cache_buster_callable() );
 	}
 
 	/**
@@ -61,15 +58,13 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 			),
 			false
 		);
-		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
-		$this->assertEquals( 'calypso-4917-8664-g72a154d63a', $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) );
+		$this->assertEquals( 'calypso-4917-8664-g72a154d63a', $this->get_cdn_asset_cache_buster_callable() );
 	}
 
 	/**
 	 * Test already cached cache buster expired and failed to fetch new one.
 	 */
 	public function test_get_cdn_asset_cache_buster_failed_to_fetch() {
-		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
 		add_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15, 3 );
 		update_option(
 			Odyssey_Assets::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY,
@@ -81,7 +76,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 			),
 			false
 		);
-		$this->assertEquals( time(), floor( $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) / 1000 ) );
+		$this->assertEquals( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
 		remove_filter( 'pre_http_request', array( $this, 'break_cdn_cache_buster_request' ), 15 );
 	}
 
@@ -89,9 +84,8 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 	 * Test force refresh cache buster.
 	 */
 	public function test_get_cdn_asset_cache_buster_force_refresh_expired() {
-		list($get_cdn_asset_cache_buster, $odyssey_assets) = $this->get_cdn_asset_cache_buster_callable();
-		$_GET['force_refresh']                             = 1;
-		$this->assertEquals( time(), floor( $get_cdn_asset_cache_buster->invoke( $odyssey_assets ) / 1000 ) );
+		$_GET['force_refresh'] = 1;
+		$this->assertEquals( time(), floor( $this->get_cdn_asset_cache_buster_callable() / 1000 ) );
 	}
 
 	/**
@@ -115,6 +109,7 @@ class Test_Odyssey_Assets extends Stats_Test_Case {
 		$odyssey_assets             = new Odyssey_Assets();
 		$get_cdn_asset_cache_buster = new \ReflectionMethod( $odyssey_assets, 'get_cdn_asset_cache_buster' );
 		$get_cdn_asset_cache_buster->setAccessible( true );
-		return array( $get_cdn_asset_cache_buster, $odyssey_assets );
+
+		return $get_cdn_asset_cache_buster->invoke( $odyssey_assets );
 	}
 }


### PR DESCRIPTION
Related: https://github.com/Automattic/jpop-issues/issues/9290

## Proposed changes:

* Use option for cached cache buster
  * The reason is that transients are sometimes managed by hosting providers, and the expiry time is hard to control.
* Use more aggressive cache refreshing - fallback to timestamp wherever fails

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Build and test Jetpack locally
* Ensure `wp-admin/admin.php?page=stats` works well
* Ensure all tests pass

