### PR TITLE
Set wpcom_required_scope for Odie chat completions REST endpoints

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-odie-chat-scope
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-odie-chat-scope
@@ -1,0 +1,4 @@
+Significance: minor
+Type: security
+
+Add a dedicated 'chat' OAuth scope for Odie chat endpoints.

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-odie.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-odie.php
@@ -32,10 +32,11 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 			array(
 				// Get a chat. Supports pagination of messages.
 				array(
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_chat' ),
-					'permission_callback' => 'is_user_logged_in',
-					'args'                => array(
+					'wpcom_required_scope' => 'chat',
+					'methods'              => \WP_REST_Server::READABLE,
+					'callback'             => array( $this, 'get_chat' ),
+					'permission_callback'  => 'is_user_logged_in',
+					'args'                 => array(
 						'bot_id'           => array(
 							'description' => __( 'The bot id to get the chat for.', 'jetpack-mu-wpcom' ),
 							'type'        => 'string',
@@ -67,10 +68,11 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 				),
 				// Add a message to a chat.
 				array(
-					'methods'             => \WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'send_chat_message' ),
-					'permission_callback' => 'is_user_logged_in',
-					'args'                => array(
+					'wpcom_required_scope' => 'chat',
+					'methods'              => \WP_REST_Server::CREATABLE,
+					'callback'             => array( $this, 'send_chat_message' ),
+					'permission_callback'  => 'is_user_logged_in',
+					'args'                 => array(
 						'bot_id'  => array(
 							'description' => __( 'The bot id to chat with.', 'jetpack-mu-wpcom' ),
 							'type'        => 'string',
@@ -103,15 +105,17 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 			// Get last chat ID.
 			array(
 				array(
-					'methods'             => \WP_REST_Server::READABLE,
-					'callback'            => array( $this, 'get_last_chat_id' ),
-					'permission_callback' => 'is_user_logged_in',
+					'wpcom_required_scope' => 'chat',
+					'methods'              => \WP_REST_Server::READABLE,
+					'callback'             => array( $this, 'get_last_chat_id' ),
+					'permission_callback'  => 'is_user_logged_in',
 				),
 				// Set last chat ID.
 				array(
-					'methods'             => \WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'set_last_chat_id' ),
-					'permission_callback' => 'is_user_logged_in',
+					'wpcom_required_scope' => 'chat',
+					'methods'              => \WP_REST_Server::CREATABLE,
+					'callback'             => array( $this, 'set_last_chat_id' ),
+					'permission_callback'  => 'is_user_logged_in',
 				),
 			)
 		);
@@ -121,10 +125,11 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 			$this->rest_base . '/chat/(?P<bot_id>[a-zA-Z0-9-]+)/(?P<chat_id>\d+)/(?P<message_id>\d+)/feedback',
 			array(
 				array(
-					'methods'             => \WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'save_chat_message_feedback' ),
-					'permission_callback' => 'is_user_logged_in',
-					'args'                => array(
+					'wpcom_required_scope' => 'chat',
+					'methods'              => \WP_REST_Server::CREATABLE,
+					'callback'             => array( $this, 'save_chat_message_feedback' ),
+					'permission_callback'  => 'is_user_logged_in',
+					'args'                 => array(
 						'bot_id'       => array(
 							'description' => __( 'The bot id to chat with.', 'jetpack-mu-wpcom' ),
 							'type'        => 'string',
@@ -155,10 +160,11 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 			$this->rest_base . '/chat/(?P<bot_id>[a-zA-Z0-9-]+)',
 			array(
 				array(
-					'methods'             => \WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'send_chat_message' ),
-					'permission_callback' => 'is_user_logged_in',
-					'args'                => array(
+					'wpcom_required_scope' => 'chat',
+					'methods'              => \WP_REST_Server::CREATABLE,
+					'callback'             => array( $this, 'send_chat_message' ),
+					'permission_callback'  => 'is_user_logged_in',
+					'args'                 => array(
 						'bot_id'  => array(
 							'description' => __( 'The bot id to chat with.', 'jetpack-mu-wpcom' ),
 							'type'        => 'string',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Add a dedicated 'chat' auth scope to Odie endpoints, to allow for generating keys with access to only those endpoints.

See 155092-ghe-Automattic/wpcom-a8c-themes and D164543-code for more context.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See 155092-ghe-Automattic/wpcom-a8c-themes. These changes should be fully backwards compatible and not affect any existing functionality.
