### PR TITLE
Social: Fix Bluesky profile name connection management

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-bsky-profile-name-connection-management
+++ b/projects/js-packages/publicize-components/changelog/fix-social-bsky-profile-name-connection-management
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Bsky conneciton management profile name

--- a/projects/js-packages/publicize-components/src/components/connection-management/connection-name.tsx
+++ b/projects/js-packages/publicize-components/src/components/connection-management/connection-name.tsx
@@ -32,7 +32,7 @@ export function ConnectionName( { connection }: ConnectionNameProps ) {
 				</span>
 			) : (
 				<ExternalLink className={ styles[ 'profile-link' ] } href={ connection.profile_link }>
-					{ connection.display_name || connection.external_display }
+					{ connection.display_name || connection.external_display || connection.external_name }
 				</ExternalLink>
 			) }
 			{ isUpdating ? (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/jetpack-reach/issues/662

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to your Bluesky profile and clear your display name if you have one, so it will be defaulted to the handle
* Go to the connection management. You should see empty string at the name
![CleanShot 2024-10-24 at 12 04 02 png](https://github.com/user-attachments/assets/b27524a4-ec06-42cf-ac9e-a2e240dc5620)
* Now with this PR you should be able to see the handle

