### PR TITLE
required-review: Avoid requesting reviews from bots

### DIFF
--- a/projects/github-actions/required-review/changelog/fix-required-review-no-request-review-from-bot
+++ b/projects/github-actions/required-review/changelog/fix-required-review-no-request-review-from-bot
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid trying to request reviews from bot accounts.

--- a/projects/github-actions/required-review/src/request-review.js
+++ b/projects/github-actions/required-review/src/request-review.js
@@ -21,7 +21,9 @@ async function requestReviewer( teams ) {
 	const teamReviews = [];
 
 	for ( const t of teams ) {
-		if ( t.startsWith( '@' ) ) {
+		if ( t.startsWith( '@' ) && t.endsWith( '[bot]' ) ) {
+			core.info( `Skipping ${ t }, appears to be a bot` );
+		} else if ( t.startsWith( '@' ) ) {
 			userReviews.push( t.slice( 1 ) );
 		} else {
 			teamReviews.push( t );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Attempting to request a review from a bot account will likely fail, as bot accounts are not "collaborators".

Fortunately a bot account is probably going to look like `@something[bot]`, so we can look for that to exclude them without having to make extra API queries.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Fixes #37058


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* 🤷