### PR TITLE
My Jetpack: add post-activation experiment

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
@@ -35,11 +35,14 @@ const ConnectionStep = ( {
 	const { recordEvent } = useAnalytics();
 	const { setNotice, resetNotice } = useContext( NoticeContext );
 
-	const { siteUrl, adminUrl } = getMyJetpackWindowInitialState();
+	const { siteSuffix, siteUrl, adminUrl } = getMyJetpackWindowInitialState();
 	const redirectUri = `?redirect_uri=${ encodeURIComponent( window.location.href ) }`;
 	const connectAfterCheckoutUrl = `&connect_after_checkout=true&from_site_slug=${ siteUrl }&admin_url=${ adminUrl }`;
 	const query = `${ redirectUri }${ connectAfterCheckoutUrl }`;
-	const jetpackPlansPath = getRedirectUrl( 'jetpack-nav-plans-no-site', { query } );
+	const jetpackPlansPath = getRedirectUrl( 'jetpack-my-jetpack-site-only-plans', {
+		site: siteSuffix,
+		query,
+	} );
 
 	const activationButtonLabel = __( 'Activate Jetpack in one click', 'jetpack-my-jetpack' );
 	const { refetch: refetchOwnershipData } = useProductsByOwnership();

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
@@ -35,10 +35,10 @@ const ConnectionStep = ( {
 	const { recordEvent } = useAnalytics();
 	const { setNotice, resetNotice } = useContext( NoticeContext );
 
-	const { purchaseToken, siteUrl, adminUrl } = getMyJetpackWindowInitialState();
+	const { siteUrl, adminUrl } = getMyJetpackWindowInitialState();
 	const redirectUri = `?redirect_uri=${ encodeURIComponent( window.location.href ) }`;
 	const connectAfterCheckoutUrl = `&connect_after_checkout=true&from_site_slug=${ siteUrl }&admin_url=${ adminUrl }`;
-	const query = `${ redirectUri }${ purchaseToken }${ connectAfterCheckoutUrl }`;
+	const query = `${ redirectUri }${ connectAfterCheckoutUrl }`;
 	const jetpackPlansPath = getRedirectUrl( 'jetpack-nav-plans-no-site', { query } );
 
 	const activationButtonLabel = __( 'Activate Jetpack in one click', 'jetpack-my-jetpack' );

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
@@ -35,14 +35,13 @@ const ConnectionStep = ( {
 	const { recordEvent } = useAnalytics();
 	const { setNotice, resetNotice } = useContext( NoticeContext );
 
-	const { siteSuffix, siteUrl, adminUrl } = getMyJetpackWindowInitialState();
-	const redirectUri = `?redirect_uri=${ encodeURIComponent( window.location.href ) }`;
-	const connectAfterCheckoutUrl = `&connect_after_checkout=true&from_site_slug=${ siteUrl }&admin_url=${ adminUrl }`;
-	const query = `${ redirectUri }${ connectAfterCheckoutUrl }`;
-	const jetpackPlansPath = getRedirectUrl( 'jetpack-my-jetpack-site-only-plans', {
-		site: siteSuffix,
-		query,
-	} );
+	const { siteSuffix, adminUrl } = getMyJetpackWindowInitialState();
+	const connectAfterCheckoutUrl = `?connect_after_checkout=true&admin_url=${ encodeURIComponent(
+		adminUrl
+	) }&from_site_slug=${ siteSuffix }&source=my-jetpack`;
+	const redirectUri = `&redirect_to=${ encodeURIComponent( window.location.href ) }`;
+	const query = `${ connectAfterCheckoutUrl }${ redirectUri }&unlinked=1`;
+	const jetpackPlansPath = getRedirectUrl( 'jetpack-my-jetpack-site-only-plans', { query } );
 
 	const activationButtonLabel = __( 'Activate Jetpack in one click', 'jetpack-my-jetpack' );
 	const { refetch: refetchOwnershipData } = useProductsByOwnership();
@@ -75,6 +74,8 @@ const ConnectionStep = ( {
 			resetNotice();
 			setNotice( NOTICE_SITE_CONNECTED, resetNotice );
 			refetchOwnershipData();
+
+			onUpdateWelcomeFlowExperiment( state => ( { ...state, isLoading: false } ) );
 		}
 	}, [
 		jetpackPlansPath,

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
@@ -9,21 +9,29 @@ import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-
 import useAnalytics from '../../hooks/use-analytics';
 import sideloadTracks from '../../utils/side-load-tracks';
 import styles from './style.module.scss';
+import { WelcomeFlowExperiment } from '.';
+import type { Dispatch, SetStateAction } from 'react';
 
 type ConnectionStepProps = {
 	onActivateSite: ( e?: Event ) => Promise< void >;
+	onUpdateWelcomeFlowExperiment: Dispatch< SetStateAction< WelcomeFlowExperiment > >;
 	isActivating: boolean;
 };
 
 /**
  * Component that renders the Welcome banner on My Jetpack.
  *
- * @param {object}   props                - ConnectioStepProps
- * @param {Function} props.onActivateSite - Alias for handleRegisterSite
- * @param {boolean}  props.isActivating   - Alias for siteIsRegistering
+ * @param {object}   props                               - ConnectioStepProps
+ * @param {Function} props.onActivateSite                - Alias for handleRegisterSite
+ * @param {boolean}  props.isActivating                  - Alias for siteIsRegistering
+ * @param {Function} props.onUpdateWelcomeFlowExperiment - Function to update the welcomeFlowExperiment state
  * @return {object} The ConnectionStep component.
  */
-const ConnectionStep = ( { onActivateSite, isActivating }: ConnectionStepProps ) => {
+const ConnectionStep = ( {
+	onActivateSite,
+	onUpdateWelcomeFlowExperiment,
+	isActivating,
+}: ConnectionStepProps ) => {
 	const { recordEvent } = useAnalytics();
 	const { setNotice, resetNotice } = useContext( NoticeContext );
 
@@ -38,6 +46,7 @@ const ConnectionStep = ( { onActivateSite, isActivating }: ConnectionStepProps )
 
 	const onConnectSiteClick = useCallback( async () => {
 		recordEvent( 'jetpack_myjetpack_welcome_banner_connect_site_click' );
+		onUpdateWelcomeFlowExperiment( state => ( { ...state, isLoading: true } ) );
 		await onActivateSite();
 
 		recordEvent( 'jetpack_myjetpack_welcome_banner_connect_site_success' );
@@ -51,6 +60,11 @@ const ConnectionStep = ( { onActivateSite, isActivating }: ConnectionStepProps )
 				'jetpack_my_jetpack_recommendations_pricing_page_202411'
 			);
 
+			onUpdateWelcomeFlowExperiment( state => ( {
+				...state,
+				variation: ( variationName ?? 'control' ) as WelcomeFlowExperiment[ 'variation' ], // casting to 'control' or 'treatment'
+			} ) );
+
 			if ( variationName === 'treatment' ) {
 				window.location.href = jetpackPlansPath;
 			}
@@ -62,6 +76,7 @@ const ConnectionStep = ( { onActivateSite, isActivating }: ConnectionStepProps )
 	}, [
 		jetpackPlansPath,
 		onActivateSite,
+		onUpdateWelcomeFlowExperiment,
 		recordEvent,
 		refetchOwnershipData,
 		resetNotice,

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
@@ -1,45 +1,43 @@
-import { Col, Button, Text, TermsOfService } from '@automattic/jetpack-components';
+import { Col, Button, Text, TermsOfService, getRedirectUrl } from '@automattic/jetpack-components';
 import { initializeExPlat, loadExperimentAssignment } from '@automattic/jetpack-explat';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useContext } from 'react';
 import { NoticeContext } from '../../context/notices/noticeContext';
 import { NOTICE_SITE_CONNECTED } from '../../context/notices/noticeTemplates';
 import useProductsByOwnership from '../../data/products/use-products-by-ownership';
+import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
 import useAnalytics from '../../hooks/use-analytics';
 import sideloadTracks from '../../utils/side-load-tracks';
 import styles from './style.module.scss';
-import type { WelcomeFlowExperiment } from '.';
-import type { Dispatch, SetStateAction } from 'react';
 
 type ConnectionStepProps = {
 	onActivateSite: ( e?: Event ) => Promise< void >;
-	onUpdateWelcomeFlowExperiment: Dispatch< SetStateAction< WelcomeFlowExperiment > >;
 	isActivating: boolean;
 };
 
 /**
  * Component that renders the Welcome banner on My Jetpack.
  *
- * @param {object}   props                               - ConnectioStepProps
- * @param {Function} props.onActivateSite                - Alias for handleRegisterSite
- * @param {Function} props.onUpdateWelcomeFlowExperiment - Updating the welcomeFlowExperiment state
- * @param {boolean}  props.isActivating                  - Alias for siteIsRegistering
+ * @param {object}   props                - ConnectioStepProps
+ * @param {Function} props.onActivateSite - Alias for handleRegisterSite
+ * @param {boolean}  props.isActivating   - Alias for siteIsRegistering
  * @return {object} The ConnectionStep component.
  */
-const ConnectionStep = ( {
-	onActivateSite,
-	onUpdateWelcomeFlowExperiment,
-	isActivating,
-}: ConnectionStepProps ) => {
+const ConnectionStep = ( { onActivateSite, isActivating }: ConnectionStepProps ) => {
 	const { recordEvent } = useAnalytics();
 	const { setNotice, resetNotice } = useContext( NoticeContext );
+
+	const { purchaseToken, siteUrl, adminUrl } = getMyJetpackWindowInitialState();
+	const redirectUri = `?redirect_uri=${ encodeURIComponent( window.location.href ) }`;
+	const connectAfterCheckoutUrl = `&connect_after_checkout=true&from_site_slug=${ siteUrl }&admin_url=${ adminUrl }`;
+	const query = `${ redirectUri }${ purchaseToken }${ connectAfterCheckoutUrl }`;
+	const jetpackPlansPath = getRedirectUrl( 'jetpack-plans', { query } );
 
 	const activationButtonLabel = __( 'Activate Jetpack in one click', 'jetpack-my-jetpack' );
 	const { refetch: refetchOwnershipData } = useProductsByOwnership();
 
 	const onConnectSiteClick = useCallback( async () => {
 		recordEvent( 'jetpack_myjetpack_welcome_banner_connect_site_click' );
-		onUpdateWelcomeFlowExperiment( state => ( { ...state, isLoading: true } ) );
 		await onActivateSite();
 
 		recordEvent( 'jetpack_myjetpack_welcome_banner_connect_site_success' );
@@ -50,23 +48,20 @@ const ConnectionStep = ( {
 			initializeExPlat();
 
 			const { variationName } = await loadExperimentAssignment(
-				'jetpack_my_jetpack_welcome_flow_display_default_recommendations_upfront_202410'
+				'jetpack_my_jetpack_recommendations_pricing_page_202411'
 			);
 
-			onUpdateWelcomeFlowExperiment( state => ( {
-				...state,
-				variation: ( variationName ?? 'control' ) as WelcomeFlowExperiment[ 'variation' ], // casting to 'control' or 'treatment'
-			} ) );
+			if ( variationName === 'treatment' ) {
+				window.location.href = jetpackPlansPath;
+			}
 		} finally {
 			resetNotice();
 			setNotice( NOTICE_SITE_CONNECTED, resetNotice );
 			refetchOwnershipData();
-
-			onUpdateWelcomeFlowExperiment( state => ( { ...state, isLoading: false } ) );
 		}
 	}, [
+		jetpackPlansPath,
 		onActivateSite,
-		onUpdateWelcomeFlowExperiment,
 		recordEvent,
 		refetchOwnershipData,
 		resetNotice,

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/ConnectionStep.tsx
@@ -39,7 +39,7 @@ const ConnectionStep = ( {
 	const redirectUri = `?redirect_uri=${ encodeURIComponent( window.location.href ) }`;
 	const connectAfterCheckoutUrl = `&connect_after_checkout=true&from_site_slug=${ siteUrl }&admin_url=${ adminUrl }`;
 	const query = `${ redirectUri }${ purchaseToken }${ connectAfterCheckoutUrl }`;
-	const jetpackPlansPath = getRedirectUrl( 'jetpack-plans', { query } );
+	const jetpackPlansPath = getRedirectUrl( 'jetpack-nav-plans-no-site', { query } );
 
 	const activationButtonLabel = __( 'Activate Jetpack in one click', 'jetpack-my-jetpack' );
 	const { refetch: refetchOwnershipData } = useProductsByOwnership();

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
@@ -56,6 +56,9 @@ const WelcomeFlow: FC< Props > = ( {
 				return null;
 			}
 
+			if ( ! recommendedModules && isJetpackUserNew() ) {
+				return 'evaluation-processing';
+			}
 			// Otherwise, it means user is either new or just repeats the recommendation
 			return 'evaluation';
 		}

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
@@ -56,9 +56,6 @@ const WelcomeFlow: FC< Props > = ( {
 				return null;
 			}
 
-			if ( ! recommendedModules && isJetpackUserNew() ) {
-				return 'evaluation-processing';
-			}
 			// Otherwise, it means user is either new or just repeats the recommendation
 			return 'evaluation';
 		}

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
@@ -47,17 +47,13 @@ const WelcomeFlow: FC< Props > = ( {
 	const [ prevStep, setPrevStep ] = useState( '' );
 
 	const currentStep = useMemo( () => {
-		if ( ! siteIsRegistered ) {
+		if ( ! siteIsRegistered || welcomeFlowExperiment.isLoading ) {
 			return 'connection';
 		} else if ( ! isProcessingEvaluation ) {
 			if ( ! recommendedModules && ! isJetpackUserNew() ) {
 				// If user is not new but doesn't have recommendations, we skip evaluation
 				// If user has recommendations, it means they redo the evaluation
 				return null;
-			}
-
-			if ( welcomeFlowExperiment.isLoading ) {
-				return 'evaluation-processing';
 			}
 
 			// Otherwise, it means user is either new or just repeats the recommendation

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
@@ -25,11 +25,7 @@ interface Props extends PropsWithChildren {
 	setWelcomeFlowExperiment: React.Dispatch< React.SetStateAction< WelcomeFlowExperiment > >;
 }
 
-const WelcomeFlow: FC< Props > = ( {
-	welcomeFlowExperiment,
-	setWelcomeFlowExperiment,
-	children,
-} ) => {
+const WelcomeFlow: FC< Props > = ( { children } ) => {
 	const { recordEvent } = useAnalytics();
 	const { dismissWelcomeBanner } = useWelcomeBanner();
 	const { recommendedModules, submitEvaluation, saveEvaluationResult } =
@@ -131,8 +127,7 @@ const WelcomeFlow: FC< Props > = ( {
 						{ 'connection' === currentStep && (
 							<ConnectionStep
 								onActivateSite={ handleRegisterSite }
-								onUpdateWelcomeFlowExperiment={ setWelcomeFlowExperiment }
-								isActivating={ siteIsRegistering || welcomeFlowExperiment.isLoading }
+								isActivating={ siteIsRegistering }
 							/>
 						) }
 						{ 'evaluation' === currentStep && (

--- a/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/welcome-flow/index.tsx
@@ -25,7 +25,11 @@ interface Props extends PropsWithChildren {
 	setWelcomeFlowExperiment: React.Dispatch< React.SetStateAction< WelcomeFlowExperiment > >;
 }
 
-const WelcomeFlow: FC< Props > = ( { children } ) => {
+const WelcomeFlow: FC< Props > = ( {
+	welcomeFlowExperiment,
+	setWelcomeFlowExperiment,
+	children,
+} ) => {
 	const { recordEvent } = useAnalytics();
 	const { dismissWelcomeBanner } = useWelcomeBanner();
 	const { recommendedModules, submitEvaluation, saveEvaluationResult } =
@@ -52,12 +56,21 @@ const WelcomeFlow: FC< Props > = ( { children } ) => {
 				return null;
 			}
 
+			if ( welcomeFlowExperiment.isLoading ) {
+				return 'evaluation-processing';
+			}
+
 			// Otherwise, it means user is either new or just repeats the recommendation
 			return 'evaluation';
 		}
 
 		return 'evaluation-processing';
-	}, [ isProcessingEvaluation, recommendedModules, siteIsRegistered ] );
+	}, [
+		isProcessingEvaluation,
+		recommendedModules,
+		siteIsRegistered,
+		welcomeFlowExperiment.isLoading,
+	] );
 
 	useEffect( () => {
 		if ( prevStep !== currentStep ) {
@@ -127,7 +140,8 @@ const WelcomeFlow: FC< Props > = ( { children } ) => {
 						{ 'connection' === currentStep && (
 							<ConnectionStep
 								onActivateSite={ handleRegisterSite }
-								isActivating={ siteIsRegistering }
+								onUpdateWelcomeFlowExperiment={ setWelcomeFlowExperiment }
+								isActivating={ siteIsRegistering || welcomeFlowExperiment.isLoading }
 							/>
 						) }
 						{ 'evaluation' === currentStep && (

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-pricing-page-experiment
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-pricing-page-experiment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+My Jetpack: add experiment to the post-connection flow in My Jetpack.

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -99,6 +99,7 @@ interface Window {
 			showFullJetpackStatsCard: boolean;
 			videoPressStats: boolean;
 		};
+		purchaseToken: string;
 		lifecycleStats: {
 			historicallyActiveModules: JetpackModule[];
 			brokenModules: {

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -203,27 +203,6 @@ class Initializer {
 	}
 
 	/**
-	 * Gets a purchase token that is used for Jetpack logged out visitor checkout.
-	 * The purchase token should be appended to all CTA url's that lead to checkout.
-	 *
-	 * @return string|boolean
-	 */
-	protected static function get_purchase_token() {
-		if ( ! self::current_user_can_purchase() ) {
-			return false;
-		}
-
-		$purchase_token = \Jetpack_Options::get_option( 'purchase_token', false );
-
-		if ( $purchase_token ) {
-			return $purchase_token;
-		}
-		// If the purchase token is not saved in the options table yet, then add it.
-		\Jetpack_Options::update_option( 'purchase_token', self::generate_purchase_token(), true );
-		return \Jetpack_Options::get_option( 'purchase_token', false );
-	}
-
-	/**
 	 * Enqueue admin page assets.
 	 *
 	 * @return void
@@ -287,7 +266,6 @@ class Initializer {
 				'loadAddLicenseScreen'   => self::is_licensing_ui_enabled(),
 				'adminUrl'               => esc_url( admin_url() ),
 				'IDCContainerID'         => static::get_idc_container_id(),
-				'purchaseToken'          => self::get_purchase_token(),
 				'userIsAdmin'            => current_user_can( 'manage_options' ),
 				'userIsNewToJetpack'     => self::is_jetpack_user_new(),
 				'lifecycleStats'         => array(
@@ -989,28 +967,5 @@ class Initializer {
 		}
 
 		return $red_bubble_slugs;
-	}
-
-	/**
-	 * Generates a purchase token that is used for Jetpack logged out visitor checkout.
-	 *
-	 * @return string
-	 */
-	protected static function generate_purchase_token() {
-		return wp_generate_password( 12, false );
-	}
-
-	/**
-	 * Determine if the current user is allowed to make Jetpack purchases.
-	 *
-	 * @return boolean True if the user can make purchases, false if not
-	 */
-	public static function current_user_can_purchase() {
-		// Make sure only administrators can make purchases.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return false;
-		}
-
-		return true;
 	}
 }

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -1001,19 +1001,11 @@ class Initializer {
 	}
 
 	/**
-	 * Determine if the current user is allowed to make Jetpack purchases without
-	 * a WordPress.com account
+	 * Determine if the current user is allowed to make Jetpack purchases.
 	 *
 	 * @return boolean True if the user can make purchases, false if not
 	 */
 	public static function current_user_can_purchase() {
-		// The site must be site-connected to Jetpack (no users connected).
-		$connection_manager = new Connection_Manager();
-
-		if ( ! $connection_manager->is_site_connection() ) {
-			return false;
-		}
-
 		// Make sure only administrators can make purchases.
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return false;

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -201,6 +201,28 @@ class Initializer {
 
 		return $tracking->should_enable_tracking( new Terms_Of_Service(), $status );
 	}
+
+	/**
+	 * Gets a purchase token that is used for Jetpack logged out visitor checkout.
+	 * The purchase token should be appended to all CTA url's that lead to checkout.
+	 *
+	 * @return string|boolean
+	 */
+	protected static function get_purchase_token() {
+		if ( ! self::current_user_can_purchase() ) {
+			return false;
+		}
+
+		$purchase_token = \Jetpack_Options::get_option( 'purchase_token', false );
+
+		if ( $purchase_token ) {
+			return $purchase_token;
+		}
+		// If the purchase token is not saved in the options table yet, then add it.
+		\Jetpack_Options::update_option( 'purchase_token', self::generate_purchase_token(), true );
+		return \Jetpack_Options::get_option( 'purchase_token', false );
+	}
+
 	/**
 	 * Enqueue admin page assets.
 	 *
@@ -265,6 +287,7 @@ class Initializer {
 				'loadAddLicenseScreen'   => self::is_licensing_ui_enabled(),
 				'adminUrl'               => esc_url( admin_url() ),
 				'IDCContainerID'         => static::get_idc_container_id(),
+				'purchaseToken'          => self::get_purchase_token(),
 				'userIsAdmin'            => current_user_can( 'manage_options' ),
 				'userIsNewToJetpack'     => self::is_jetpack_user_new(),
 				'lifecycleStats'         => array(
@@ -966,5 +989,36 @@ class Initializer {
 		}
 
 		return $red_bubble_slugs;
+	}
+
+	/**
+	 * Generates a purchase token that is used for Jetpack logged out visitor checkout.
+	 *
+	 * @return string
+	 */
+	protected static function generate_purchase_token() {
+		return wp_generate_password( 12, false );
+	}
+
+	/**
+	 * Determine if the current user is allowed to make Jetpack purchases without
+	 * a WordPress.com account
+	 *
+	 * @return boolean True if the user can make purchases, false if not
+	 */
+	public static function current_user_can_purchase() {
+		// The site must be site-connected to Jetpack (no users connected).
+		$connection_manager = new Connection_Manager();
+
+		if ( ! $connection_manager->is_site_connection() ) {
+			return false;
+		}
+
+		// Make sure only administrators can make purchases.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Implemented 2 different welcome flow experiences:

**Control**: After user connects the site, they are presented with a survey asking what their site goals are. Upon submission of the survey, the user given product recommendations based on their site goals.
**Treatment**: After the site is connect, they'll be redirected to the pricing page immediately. 


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Spin up a JN site with Jetpack Beta pointing to this branch and Enable Sandbox Access
* Go to `/wp-admin/options-general.php?page=companion_settings` and point `JETPACK__SANDBOX_DOMAIN` to your sandbox
* Visit the experiment page on 22057-explat-experiment, go to the Audience section on the experiment overview page and hover the “Bookmarklet” link of `treatment`.
* Make sure your sandbox has the most recent `trunk`
* Go back to My Jetpack and click on "Activate Jetpack with on click"
* After your site is connected, you'll be redirected to the pricing page
* If you complete a purchase, you'll be redirected to My Jetpack after you connect your site and the license is attached