### PR TITLE
Improve image carousel accessibility

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-carousel-a11y
+++ b/projects/plugins/jetpack/changelog/improve-carousel-a11y
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: Further improve accessibility by being more selective over which images to apply attributes to

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -481,6 +481,7 @@ class Jetpack_Carousel {
 				'post_comment'                    => __( 'Post Comment', 'jetpack' ),
 				'write_comment'                   => __( 'Write a Comment...', 'jetpack' ),
 				'loading_comments'                => __( 'Loading Comments...', 'jetpack' ),
+				'image_label'                     => __( 'Open image in full-screen.', 'jetpack' ),
 				'download_original'               => sprintf(
 					/* translators: %1s is the full-size image width, and %2s is the height. */
 					__( 'View full size <span class="photo-size">%1$s<span class="photo-size-times">&times;</span>%2$s</span>', 'jetpack' ),
@@ -993,8 +994,6 @@ class Jetpack_Carousel {
 		$attr['data-image-caption']     = esc_attr( htmlspecialchars( $attachment_caption, ENT_COMPAT ) );
 		$attr['data-medium-file']       = esc_attr( $medium_file );
 		$attr['data-large-file']        = esc_attr( $large_file );
-		$attr['tabindex']               = '0';
-		$attr['role']                   = 'button';
 		return $attr;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #39908

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Accessibility has been improved by reducing which images receive a tab index and an aria role of button.

This has been done by moving it out of PHP - where it applied the two attributes to all images in the post, and into javascript where it can be added when applying the interactivity which makes the attributes necessary.

An aria-label has been added for good measure.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

### GB
1. Create a post containing:
 * An image block linking to the images attachment page
 * An image block not linking to anywhere
 * An image block linking to itself
 * A tiled gallery
 * A slideshow
2. View the post, notice that all of the mentioned images have a `role=button` and a `tabIndex=0` regardless of whether they do act as a button
3. Apply this patch and build
4. View the post again, notice that only the interactive images - those launching a full-window "lightbox" have a `role=button` and a `tabIndex=0` and additionally, they don't have a warning about not being labelled.


### TinyMCE
 1. Install the classic editor plugin
 2. Use the "Add media" button to add images as before, and also a gallery
 3. View the post and as before notice that only the interactive images have aria attributes etc.
