### PR TITLE
Components: Add optional hover support to the IconTooltip component

### DIFF
--- a/projects/js-packages/components/changelog/icon-tooltip-add-hover-support
+++ b/projects/js-packages/components/changelog/icon-tooltip-add-hover-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+IconTooltip: add support for showing tooltip on hover.

--- a/projects/js-packages/components/components/icon-tooltip/index.tsx
+++ b/projects/js-packages/components/components/icon-tooltip/index.tsx
@@ -38,12 +38,14 @@ const IconTooltip: React.FC< IconTooltipProps > = ( {
 	children,
 	popoverAnchorStyle = 'icon',
 	forceShow = false,
+	hoverShow = false,
 	wide = false,
 	inline = true,
 	shift = false,
 } ) => {
 	const POPOVER_HELPER_WIDTH = 124;
 	const [ isVisible, setIsVisible ] = useState( false );
+	const [ hoverTimeout, setHoverTimeout ] = useState( null );
 	const hideTooltip = useCallback( () => setIsVisible( false ), [ setIsVisible ] );
 	const toggleTooltip = useCallback(
 		e => {
@@ -78,8 +80,33 @@ const IconTooltip: React.FC< IconTooltipProps > = ( {
 
 	const isForcedToShow = isAnchorWrapper && forceShow;
 
+	const handleMouseEnter = useCallback( () => {
+		if ( hoverShow ) {
+			if ( hoverTimeout ) {
+				clearTimeout( hoverTimeout );
+				setHoverTimeout( null );
+			}
+			setIsVisible( true );
+		}
+	}, [ hoverShow, hoverTimeout ] );
+
+	const handleMouseLeave = useCallback( () => {
+		if ( hoverShow ) {
+			const id = setTimeout( () => {
+				setIsVisible( false );
+				setHoverTimeout( null );
+			}, 100 );
+			setHoverTimeout( id );
+		}
+	}, [ hoverShow ] );
+
 	return (
-		<div className={ wrapperClassNames } data-testid="icon-tooltip_wrapper">
+		<div
+			className={ wrapperClassNames }
+			data-testid="icon-tooltip_wrapper"
+			onMouseEnter={ handleMouseEnter }
+			onMouseLeave={ handleMouseLeave }
+		>
 			{ ! isAnchorWrapper && (
 				<Button variant="link" onMouseDown={ toggleTooltip }>
 					<Gridicon className={ iconClassName } icon={ iconCode } size={ iconSize } />

--- a/projects/js-packages/components/components/icon-tooltip/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/icon-tooltip/stories/index.stories.tsx
@@ -46,6 +46,9 @@ export default {
 		wide: {
 			control: { type: 'boolean' },
 		},
+		hoverShow: {
+			control: { type: 'boolean' },
+		},
 	},
 };
 
@@ -105,4 +108,12 @@ Wide.args = {
 	children: <div>This is a wide tooltip!</div>,
 	wide: true,
 	placement: 'bottom-start',
+};
+
+export const HoverShow = Template.bind( {} );
+HoverShow.args = {
+	title: 'This is title!',
+	children: <div>This is a hover tooltip!</div>,
+	placement: 'bottom-start',
+	hoverShow: true,
 };

--- a/projects/js-packages/components/components/icon-tooltip/types.ts
+++ b/projects/js-packages/components/components/icon-tooltip/types.ts
@@ -70,6 +70,11 @@ export type IconTooltipProps = {
 	forceShow?: boolean;
 
 	/**
+	 * Enables the Popover to show on hover.
+	 */
+	hoverShow?: boolean;
+
+	/**
 	 * Uses a wider content area when enabled.
 	 */
 	wide?: boolean;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Originally removed in https://github.com/Automattic/jetpack/pull/26457, this PR restores the ability for `IconTooltip` components to show the tooltip on hover (enabled by a new`hoverShow` prop).

This change came from @dkmyta while working on https://github.com/Automattic/jetpack/pull/39754. We're hoping that by adding hover support to this component, we can use it in Jetpack Protect as well as in other scan components.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds an optional `hoverShow` prop to the `IconTooltip` component.
* Registers `onMouseEnter` and `onMouseLeave` event listeners, which show and hide the tooltip when `hoverShow` is enabled.
* Uses a `timeout` to provide a short delay before hiding the tooltip on mouse leave.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

https://github.com/Automattic/jetpack-scan-team/issues/1475

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Review and test the `IconTooltip` component's storybooks: `cd projects/js-packages/storybook && npm run storybook:dev`

## Screenshots:

<img width="1048" alt="Screenshot 2024-10-27 at 1 54 46 PM" src="https://github.com/user-attachments/assets/ac1e586d-30a1-4426-909a-5c87dba5d54e">