### PR TITLE
Jetpack AI: add general image generator style selector

### DIFF
--- a/projects/js-packages/ai-client/changelog/add-jetpack-ai-general-image-style-selector
+++ b/projects/js-packages/ai-client/changelog/add-jetpack-ai-general-image-style-selector
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Client: export image generator hook constants

--- a/projects/js-packages/ai-client/src/index.ts
+++ b/projects/js-packages/ai-client/src/index.ts
@@ -16,6 +16,7 @@ export { default as useAudioTranscription } from './hooks/use-audio-transcriptio
 export { default as useTranscriptionPostProcessing } from './hooks/use-transcription-post-processing/index.js';
 export { default as useAudioValidation } from './hooks/use-audio-validation/index.js';
 export { default as useImageGenerator } from './hooks/use-image-generator/index.js';
+export * from './hooks/use-image-generator/constants.js';
 
 /*
  * Components: Icons

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-general-image-style-selector
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-general-image-style-selector
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Jetpack AI: add styles dropdown on AI image generator modal

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.scss
@@ -4,7 +4,6 @@
 		margin-top: 32px;
 		flex-direction: column;
 		justify-content: center;
-		align-items: center;
 		gap: 8px;
 
 		.jetpack-ai-fair-usage-notice {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
@@ -175,6 +175,7 @@ export default function AiImageModal( {
 										value={ style }
 										options={ styles }
 										onChange={ updateStyle }
+										// TODO: disable when necessary
 										// disabled={ isBusy || requireUpgrade }
 									/>
 								</div>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/components/ai-image-modal.tsx
@@ -1,11 +1,19 @@
 /**
  * External dependencies
  */
-import { AiModalPromptInput } from '@automattic/jetpack-ai-client';
-import { Button } from '@wordpress/components';
+import {
+	AiModalPromptInput,
+	IMAGE_STYLE_NONE,
+	IMAGE_STYLE_AUTO,
+	ImageStyleObject,
+	ImageStyle,
+} from '@automattic/jetpack-ai-client';
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { Button, SelectControl } from '@wordpress/components';
 import { useCallback, useRef, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
+import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
@@ -16,6 +24,8 @@ import Carrousel, { CarrouselImages } from './carrousel';
 import UsageCounter from './usage-counter';
 
 const FEATURED_IMAGE_UPGRADE_PROMPT_PLACEMENT = 'ai-image-generator';
+
+const debug = debugFactory( 'jetpack-ai:ai-image-modal' );
 
 export default function AiImageModal( {
 	title,
@@ -41,6 +51,8 @@ export default function AiImageModal( {
 	autoStart = false,
 	autoStartAction = null,
 	instructionsPlaceholder = null,
+	imageStyles = [],
+	onGuessStyle = null,
 }: {
 	title: string;
 	cost: number;
@@ -49,8 +61,8 @@ export default function AiImageModal( {
 	images: CarrouselImages;
 	currentIndex: number;
 	onClose: () => void;
-	onTryAgain: ( { userPrompt }: { userPrompt?: string } ) => void;
-	onGenerate: ( { userPrompt }: { userPrompt?: string } ) => void;
+	onTryAgain: ( { userPrompt, style }: { userPrompt?: string; style?: string } ) => void;
+	onGenerate: ( { userPrompt, style }: { userPrompt?: string; style?: string } ) => void;
 	generating: boolean;
 	notEnoughRequests: boolean;
 	requireUpgrade: boolean;
@@ -64,20 +76,50 @@ export default function AiImageModal( {
 	handleNextImage: () => void;
 	acceptButton: React.JSX.Element;
 	autoStart?: boolean;
-	autoStartAction?: ( { userPrompt }: { userPrompt?: string } ) => void;
+	autoStartAction?: ( { userPrompt, style }: { userPrompt?: string; style?: string } ) => void;
 	generateButtonLabel: string;
 	instructionsPlaceholder: string;
+	imageStyles?: Array< ImageStyleObject >;
+	onGuessStyle?: ( userPrompt: string ) => Promise< ImageStyle >;
 } ) {
+	const { tracks } = useAnalytics();
+	const { recordEvent: recordTracksEvent } = tracks;
 	const [ userPrompt, setUserPrompt ] = useState( '' );
 	const triggeredAutoGeneration = useRef( false );
+	const [ showStyleSelector, setShowStyleSelector ] = useState( false );
+	const [ style, setStyle ] = useState< ImageStyle >( null );
+	const [ styles, setStyles ] = useState< Array< ImageStyleObject > >( imageStyles || [] );
 
 	const handleTryAgain = useCallback( () => {
-		onTryAgain?.( { userPrompt } );
-	}, [ onTryAgain, userPrompt ] );
+		onTryAgain?.( { userPrompt, style } );
+	}, [ onTryAgain, userPrompt, style ] );
 
-	const handleGenerate = useCallback( () => {
-		onGenerate?.( { userPrompt } );
-	}, [ onGenerate, userPrompt ] );
+	const handleGenerate = useCallback( async () => {
+		if ( style === IMAGE_STYLE_AUTO ) {
+			recordTracksEvent( 'jetpack_ai_general_image_guess_style', {
+				context: 'block-editor',
+				tool: 'image',
+			} );
+			const guessedStyle = ( await onGuessStyle( userPrompt ) ) || IMAGE_STYLE_NONE;
+			setStyle( guessedStyle );
+			debug( 'guessed style', guessedStyle );
+			onGenerate?.( { userPrompt, style: guessedStyle } );
+		} else {
+			onGenerate?.( { userPrompt, style } );
+		}
+	}, [ onGenerate, userPrompt, style, onGuessStyle, recordTracksEvent ] );
+
+	const updateStyle = useCallback(
+		( imageStyle: ImageStyle ) => {
+			debug( 'change style', imageStyle );
+			setStyle( imageStyle );
+			recordTracksEvent( 'jetpack_ai_image_generator_switch_style', {
+				context: 'block-editor',
+				style: imageStyle,
+			} );
+		},
+		[ setStyle, recordTracksEvent ]
+	);
 
 	// Controllers
 	const instructionsDisabled = notEnoughRequests || generating || requireUpgrade;
@@ -99,11 +141,45 @@ export default function AiImageModal( {
 		}
 	}, [ placement, handleGenerate, autoStart, autoStartAction, userPrompt, open ] );
 
+	// initialize styles dropdown
+	useEffect( () => {
+		if ( imageStyles && imageStyles.length > 0 ) {
+			// Sort styles to have "None" and "Auto" first
+			setStyles(
+				[
+					imageStyles.find( ( { value } ) => value === IMAGE_STYLE_NONE ),
+					imageStyles.find( ( { value } ) => value === IMAGE_STYLE_AUTO ),
+					...imageStyles.filter(
+						( { value } ) => ! [ IMAGE_STYLE_NONE, IMAGE_STYLE_AUTO ].includes( value )
+					),
+				].filter( v => v ) // simplest way to get rid of empty values
+			);
+			setShowStyleSelector( true );
+			setStyle( IMAGE_STYLE_NONE );
+		}
+	}, [ imageStyles ] );
+
 	return (
 		<>
 			{ open && (
 				<AiAssistantModal handleClose={ onClose } title={ title }>
 					<div className="ai-image-modal__content">
+						{ showStyleSelector && (
+							<div style={ { display: 'flex', alignItems: 'center', gap: 16 } }>
+								<div style={ { fontWeight: 500, flexGrow: 1 } }>
+									{ __( 'Generate image', 'jetpack' ) }
+								</div>
+								<div>
+									<SelectControl
+										__nextHasNoMarginBottom
+										value={ style }
+										options={ styles }
+										onChange={ updateStyle }
+										// disabled={ isBusy || requireUpgrade }
+									/>
+								</div>
+							</div>
+						) }
 						<AiModalPromptInput
 							prompt={ userPrompt }
 							setPrompt={ setUserPrompt }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
@@ -5,6 +5,7 @@ import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
@@ -29,6 +30,8 @@ type SetImageCallbackProps = {
 	id: number;
 	url: string;
 };
+
+const debug = debugFactory( 'jetpack-ai:general-purpose-image' );
 
 export default function GeneralPurposeImage( {
 	placement,
@@ -68,6 +71,8 @@ export default function GeneralPurposeImage( {
 		currentPointer,
 		images,
 		pointer,
+		imageStyles,
+		guessStyle,
 	} = useAiImage( {
 		cost: generalImageCost,
 		autoStart: false,
@@ -81,22 +86,27 @@ export default function GeneralPurposeImage( {
 	}, [ onClose ] );
 
 	const handleGenerate = useCallback(
-		( { userPrompt }: { userPrompt?: string } ) => {
+		async ( { userPrompt, style }: { userPrompt?: string; style?: string } ) => {
+			debug( userPrompt, style );
+
 			// track the generate image event
 			recordEvent( 'jetpack_ai_general_image_generation_generate_image', {
 				placement,
 				model: generalImageActiveModel,
 				site_type: siteType,
+				style,
 			} );
-
-			processImageGeneration( { userPrompt, postContent, notEnoughRequests } ).catch( error => {
-				recordEvent( 'jetpack_ai_general_image_generation_error', {
-					placement,
-					error: error?.message,
-					model: generalImageActiveModel,
-					site_type: siteType,
-				} );
-			} );
+			processImageGeneration( { userPrompt, postContent, notEnoughRequests, style } ).catch(
+				error => {
+					recordEvent( 'jetpack_ai_general_image_generation_error', {
+						placement,
+						error: error?.message,
+						model: generalImageActiveModel,
+						site_type: siteType,
+						style,
+					} );
+				}
+			);
 		},
 		[
 			recordEvent,
@@ -255,6 +265,8 @@ export default function GeneralPurposeImage( {
 			acceptButton={ acceptButton }
 			generateButtonLabel={ pointer?.current > 0 ? generateAgainText : generateText }
 			instructionsPlaceholder={ __( "Describe the image you'd like to create.", 'jetpack' ) }
+			imageStyles={ imageStyles }
+			onGuessStyle={ guessStyle }
 		/>
 	);
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/general-purpose-image.tsx
@@ -87,7 +87,7 @@ export default function GeneralPurposeImage( {
 
 	const handleGenerate = useCallback(
 		async ( { userPrompt, style }: { userPrompt?: string; style?: string } ) => {
-			debug( userPrompt, style );
+			debug( 'handleGenerate', userPrompt, style );
 
 			// track the generate image event
 			recordEvent( 'jetpack_ai_general_image_generation_generate_image', {
@@ -120,23 +120,27 @@ export default function GeneralPurposeImage( {
 	);
 
 	const handleRegenerate = useCallback(
-		( { userPrompt }: { userPrompt?: string } ) => {
+		( { userPrompt, style }: { userPrompt?: string; style?: string } ) => {
+			debug( 'handleRegenerate', userPrompt );
 			// track the regenerate image event
 			recordEvent( 'jetpack_ai_general_image_generation_generate_another_image', {
 				placement,
 				model: generalImageActiveModel,
 				site_type: siteType,
+				style,
 			} );
 
 			setCurrent( crrt => crrt + 1 );
-			processImageGeneration( { userPrompt, postContent, notEnoughRequests } ).catch( error => {
-				recordEvent( 'jetpack_ai_general_image_generation_error', {
-					placement,
-					error: error?.message,
-					model: generalImageActiveModel,
-					site_type: siteType,
-				} );
-			} );
+			processImageGeneration( { userPrompt, postContent, notEnoughRequests, style } ).catch(
+				error => {
+					recordEvent( 'jetpack_ai_general_image_generation_error', {
+						placement,
+						error: error?.message,
+						model: generalImageActiveModel,
+						site_type: siteType,
+					} );
+				}
+			);
 		},
 		[
 			recordEvent,
@@ -151,22 +155,26 @@ export default function GeneralPurposeImage( {
 	);
 
 	const handleTryAgain = useCallback(
-		( { userPrompt }: { userPrompt?: string } ) => {
+		( { userPrompt, style }: { userPrompt?: string; style?: string } ) => {
+			debug( 'handleTryAgain', userPrompt );
 			// track the try again event
 			recordEvent( 'jetpack_ai_general_image_generation_try_again', {
 				placement,
 				model: generalImageActiveModel,
 				site_type: siteType,
+				style,
 			} );
 
-			processImageGeneration( { userPrompt, postContent, notEnoughRequests } ).catch( error => {
-				recordEvent( 'jetpack_ai_general_image_generation_error', {
-					placement,
-					error: error?.message,
-					model: generalImageActiveModel,
-					site_type: siteType,
-				} );
-			} );
+			processImageGeneration( { userPrompt, postContent, notEnoughRequests, style } ).catch(
+				error => {
+					recordEvent( 'jetpack_ai_general_image_generation_error', {
+						placement,
+						error: error?.message,
+						model: generalImageActiveModel,
+						site_type: siteType,
+					} );
+				}
+			);
 		},
 		[
 			recordEvent,

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { useImageGenerator } from '@automattic/jetpack-ai-client';
+import {
+	useImageGenerator,
+	ImageStyleObject,
+	ImageStyle,
+	askQuestionSync,
+} from '@automattic/jetpack-ai-client';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -16,6 +21,12 @@ import useSaveToMediaLibrary from '../../../hooks/use-save-to-media-library';
  */
 import { FEATURED_IMAGE_FEATURE_NAME, GENERAL_IMAGE_FEATURE_NAME } from '../types';
 import type { CarrouselImageData, CarrouselImages } from '../components/carrousel';
+import type { RoleType } from '@automattic/jetpack-ai-client';
+import type { FeatureControl } from 'extensions/store/wordpress-com/types.js';
+
+type ImageFeatureControl = FeatureControl & {
+	styles: Array< ImageStyleObject > | [];
+};
 
 type AiImageType = 'featured-image-generation' | 'general-image-generation';
 type AiImageFeature = typeof FEATURED_IMAGE_FEATURE_NAME | typeof GENERAL_IMAGE_FEATURE_NAME;
@@ -40,6 +51,10 @@ export default function useAiImage( {
 	const pointer = useRef( 0 );
 	const [ current, setCurrent ] = useState( 0 );
 	const [ images, setImages ] = useState< CarrouselImages >( [ { generating: autoStart } ] );
+
+	const { featuresControl } = useAiFeature();
+	const imageFeatureControl = featuresControl?.image as ImageFeatureControl;
+	const imageStyles: Array< ImageStyleObject > = imageFeatureControl?.styles;
 
 	/* Merge the image data with the new data. */
 	const updateImages = useCallback( ( data: CarrouselImageData, index ) => {
@@ -190,6 +205,42 @@ export default function useAiImage( {
 		setCurrent( Math.min( current + 1, images.length - 1 ) );
 	}, [ current, images.length ] );
 
+	const guessStyle = useCallback(
+		async function ( prompt: string ): Promise< ImageStyle | null > {
+			if ( ! imageStyles || ! imageStyles.length ) {
+				return null;
+			}
+
+			const messages = [
+				{
+					role: 'jetpack-ai' as RoleType,
+					context: {
+						type: 'general-image-guess-style',
+						request: prompt,
+					},
+				},
+			];
+
+			try {
+				const style = await askQuestionSync( messages, { feature: 'jetpack-ai-image-generator' } );
+
+				if ( ! style ) {
+					return null;
+				}
+				const styleObject = imageStyles.find( ( { value } ) => value === style );
+
+				if ( ! styleObject ) {
+					return null;
+				}
+
+				return styleObject.value;
+			} catch ( error ) {
+				Promise.reject( error );
+			}
+		},
+		[ imageStyles ]
+	);
+
 	return {
 		current,
 		setCurrent,
@@ -200,5 +251,7 @@ export default function useAiImage( {
 		currentPointer: images[ pointer.current ],
 		images,
 		pointer,
+		imageStyles,
+		guessStyle,
 	};
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-image/hooks/use-ai-image.ts
@@ -108,10 +108,12 @@ export default function useAiImage( {
 			userPrompt,
 			postContent,
 			notEnoughRequests,
+			style = null,
 		}: {
 			userPrompt?: string | null;
 			postContent?: string | null;
 			notEnoughRequests: boolean;
+			style?: string;
 		} ) => {
 			return new Promise( ( resolve, reject ) => {
 				updateImages( { generating: true, error: null }, pointer.current );
@@ -145,9 +147,11 @@ export default function useAiImage( {
 								type,
 								request: userPrompt ? userPrompt : null,
 								content: postContent,
+								style,
 							},
 						},
 					],
+					style: style || '',
 				} );
 
 				const name = getImageNameSuggestion( userPrompt );


### PR DESCRIPTION
This PR brings the styles dropdown to the general image generator modal. It depends on D164775-code but should not affect functionality if backend changes are not present.

## Proposed changes:
Add style dropdown
Modify handlers to accept and deal with style parameter

<img width="831" alt="image" src="https://github.com/user-attachments/assets/3bf90640-a641-4490-9294-c7cb84899b84">


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
TBD