### PR TITLE
Subcribe Block: add top margin to all instances of the notice

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscribe-notice-margin
+++ b/projects/plugins/jetpack/changelog/fix-subscribe-notice-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Subscribe Block: ensure that the number of subscribers is displayed nicely in the post sidebar.

--- a/projects/plugins/jetpack/extensions/shared/components/inspector-notice/style.scss
+++ b/projects/plugins/jetpack/extensions/shared/components/inspector-notice/style.scss
@@ -2,7 +2,7 @@
 
 .jetpack-inspector-notice {
 	padding: 24px;
-	margin: 0 16px 24px;
+	margin: 16px 24px;
 	background: $gray-100;
 	border-radius: 4px;
 	display: flex;
@@ -11,17 +11,5 @@
 
 	> .jetpack-logo {
 		margin-left: 12px;
-	}
-}
-
-/*
- * Add top-margin to the container,
- * necessary when using a block-theme and its styles tab
- */
-.components-tab-panel__tab-content {
-	div:first-child {
-		.jetpack-inspector-notice {
-			margin-top: 24px;
-		}
 	}
 }


### PR DESCRIPTION
Fixes #39873

## Proposed changes:

Instead of only adding the top margin to some instances of the notice, let's add them everywhere, since they now appear nicely in all situations.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Start with a site that's connected to WordPress.com, and where the Subscriptions feature is active. It's best if it's a site where you have a few subscribers.
2. Go to the Appearance > Themes menu and activate an old default theme such as Twenty Twenty.
3. Go to Posts > Add New
4. Insert a subscribe block.
5. In the sidebar, ensure the panel showing the number of subscribers is properly displayed, with the styles above.
6. Save this draft.
7. Go to Appearance > Themes, and switch to the Twenty Twenty Three theme
8. Go back to the post editor; the subscribe block settings should still look good, without the styles above.
