### PR TITLE
Social: Fix the Instagram video max length

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-instagram-video-length
+++ b/projects/js-packages/publicize-components/changelog/fix-instagram-video-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed the Instagram max video length

--- a/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.ts
+++ b/projects/js-packages/publicize-components/src/hooks/use-media-restrictions/restrictions.ts
@@ -148,7 +148,7 @@ export const RESTRICTIONS = {
 			},
 		},
 		video: {
-			maxLength: 90,
+			maxLength: 900,
 			minLength: 3,
 			maxSize: 1000,
 			maxWidth: 1920,

--- a/projects/plugins/jetpack/changelog/fix-instagram-video-length
+++ b/projects/plugins/jetpack/changelog/fix-instagram-video-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Social: Fixed the Instagram max video length

--- a/projects/plugins/social/changelog/fix-instagram-video-length
+++ b/projects/plugins/social/changelog/fix-instagram-video-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed the Instagram max video length


### PR DESCRIPTION
As reported in this forum thread https://wordpress.org/support/topic/length-of-instagram-business-reels/ the validation of Instagram videos is incorrect. It is set to 90, rather than 900, so the max video length is 1.5 minutes rather than 15 minutes.

This change updates the value.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1730131876096989-slack-C02JJ910CNL
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect an Instagram Business account
* Try and attach a video longer than 90 seconds to a post for sharing
* You'll receive the error that the video is too long
* Apply this patch and videos can be shared up to 15 minutes long
