### PR TITLE
Fix content clickable when having HTML attributes with "<" in the value

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-content-clickable
+++ b/projects/plugins/wpcomsh/changelog/fix-content-clickable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix function that add links to URLs in the page when having HTML attributes with "<" in the value

--- a/projects/plugins/wpcomsh/tests/test-wpcomsh.php
+++ b/projects/plugins/wpcomsh/tests/test-wpcomsh.php
@@ -29,6 +29,7 @@ class WpcomshTest extends WP_UnitTestCase {
 		$div_skip                       = '<div class="skip-make-clickable test">https://wp.com</div>';
 		$custom_element                 = '<custom-element>https://wp.com</custom-element>';
 		$custom_element_starts_with_pre = '<presto-player>https://wp.com</presto-player>';
+		$link_inside_tag_inside_attr    = "\n" . '<li data-test="<a href=\&quot;https://wp.com\&quot;&gt;Link</a&gt;"></li>';
 
 		$original_content = '' .
 		$script .
@@ -40,7 +41,8 @@ class WpcomshTest extends WP_UnitTestCase {
 		$textarea .
 		$div_skip .
 		$custom_element .
-		$custom_element_starts_with_pre;
+		$custom_element_starts_with_pre .
+		$link_inside_tag_inside_attr;
 
 		$expected_output = '' .
 		'<script>https://wp.com</script>' .
@@ -52,7 +54,8 @@ class WpcomshTest extends WP_UnitTestCase {
 		'<textarea>https://wp.com</textarea>' .
 		'<div class="skip-make-clickable test">https://wp.com</div>' .
 		'<custom-element><a href="https://wp.com" rel="nofollow">https://wp.com</a></custom-element>' . // Made clickable
-		'<presto-player><a href="https://wp.com" rel="nofollow">https://wp.com</a></presto-player>'; // Made clickable even if it starts with `<pre`
+		'<presto-player><a href="https://wp.com" rel="nofollow">https://wp.com</a></presto-player>' . // Made clickable even if it starts with `<pre`
+		"\n" . '<li data-test="<a href=\&quot;https://wp.com\&quot;&gt;Link</a&gt;"></li>'; // Don't make clickable if it's inside a tag inside an attribute.
 
 		$this->assertEquals( $expected_output, wpcomsh_make_content_clickable( $original_content ) );
 	}

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -387,7 +387,7 @@ function wpcomsh_make_content_clickable( $content ) {
 	// don't look in <a></a>, <pre></pre>, <script></script> and <style></style>
 	// use <div class="skip-make-clickable"> in support docs where linkifying
 	// breaks shortcodes, etc.
-	$_split  = preg_split( '/(<[^<>]+>)/i', $content, -1, PREG_SPLIT_DELIM_CAPTURE );
+	$_split  = preg_split( '/(<[^>]+>)/i', $content, -1, PREG_SPLIT_DELIM_CAPTURE );
 	$end     = '';
 	$out     = '';
 	$combine = '';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related to https://github.com/Automattic/sensei-pro/issues/2574

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* It fixes the regex that splits the content to add the anchor tag in the URLs.

This regex was introduced years ago: https://github.com/Automattic/wpcomsh/pull/375/files#diff-617829ac2bd62b94e204d12538c81a709caa5671cc2471c1051b2b8e272e6b50R982. Notice that it tries to split the pieces starting with "<" and ending with ">" to handle them in chunks.

But with the previous regex, if we have "<" inside the tag (an attribute), it doesn't get the chunks properly. If I'm not missing anything, we don't need to skip the "<" from inside the tags because "<" wouldn't never be there. `<this<isnotexpected>`.

So removing that char from the excluding portion of the regex, fixes the issue.

To be more clear, see the following examples:

The current regex:

```
php > print_r( preg_split( '/(<[^<>]+>)/i', '<li data-test="<test&gt;"></li>', -1, PREG_SPLIT_DELIM_CAPTURE ) );
Array
(
    [0] => <li data-test="
    [1] => <test&gt;">
    [2] =>
    [3] => </li>
    [4] =>
)
```

The new regex:

```
php > print_r( preg_split( '/(<[^>]+>)/i', '<li data-test="<test&gt;"></li>', -1, PREG_SPLIT_DELIM_CAPTURE ) );
Array
(
    [0] =>
    [1] => <li data-test="<test&gt;">
    [2] =>
    [3] => </li>
    [4] =>
)
```

Notice that we could also have issues with the `>` inside the attributes, but this doesn't happen because of this: https://github.com/WordPress/gutenberg/pull/9963.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Sensei Interactive Blocks https://github.com/Automattic/sensei-pro/releases/tag/version%2Fsensei-interactive-blocks-1.4.5.
* Add the block Tasklist to a post.
* Add a task to the list.
* In the task, add an inline link.
* Check it in the frontend, and make sure it works properly (you don't see pieces of HTML rendered in the page).

Known issue: https://github.com/Automattic/sensei-pro/issues/2609