### PR TITLE
Post migration experience: Hide ssl task on wpcomstaging.com

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-hide-ssl-task
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-hide-ssl-task
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Small detail on WPCOM list
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad-task-definitions.php
@@ -857,7 +857,7 @@ function wpcom_launchpad_get_task_definitions() {
 				return __( 'Provision SSL certificate', 'jetpack-mu-wpcom' );
 			},
 			'is_complete_callback' => 'wpcom_launchpad_is_task_option_completed',
-			'is_disabled_callback' => 'wpcom_launchpad_is_primary_domain_wpcom',
+			'is_visible_callback'  => 'wpcom_launchpad_is_ssl_task_visible',
 			'get_calypso_path'     => function ( $task, $default, $data ) {
 				$domain = $data['site_slug_encoded'];
 				return '/domains/manage/' . $domain . '/edit/' . $domain;
@@ -2813,6 +2813,15 @@ function wpcom_launchpad_get_latest_draft_id() {
 	$cached_draft_id = reset( $latest_draft_id );
 
 	return $cached_draft_id;
+}
+
+/**
+ * Will return true if the primary domain is not a WPCOM domain.
+ *
+ * @return bool
+ */
+function wpcom_launchpad_is_ssl_task_visible() {
+	return ! wpcom_launchpad_is_primary_domain_wpcom();
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
This change will hide the SSL check task when the primary domain for the site is `*.wpcomstaging.com`. The action of the task doesn't make sense on WPCOM domains, since we always provide SSL by default and there's no specific configuration screen to navigate to.

Extra context on this thread: paYKcK-5BN-p2#comment-4246

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow instructions to apply this PR on a WoA site in the comment below.
* Verify that the `Provision SSL certificate` task does not exists when the selected primary domain is `*.wpcomstaging.com`.
* Verify that the `Provision SSL certificate` task appears, is enabled and is in the correct state when a non WPCOM primary domain is selected.