### PR TITLE
Jetpack AI: Add instructions to general image generation with styles to to-test file

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-image-styles-instructions
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-image-styles-instructions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Add instructions to general image generation with styles to to-test file

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -38,6 +38,13 @@ The logo generator is not available for free users, test with a plan or subscrip
   - use `add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 0 | 100 | 1; } );` filter to mock free/tier100/unlimited plans
 	- sandbox the API, but then don't connect to sandbox to mock a disconnected situation
 
+### AI Image Generator
+
+The styles added to the logo generator are now also available on general image creation.
+It is currently available for a12s as well, but if you need to test with another account, the filter to enable it on your 0-sandbox.php file is: `add_filter( 'jetpack_ai_image_style_selector_enabled', '__return_true' );`
+
+The testing steps are the same as the logo generator steps above, except that now you should add an Image block instead and click on the "Generate with AI" button.
+
 ### And More!
 
 You can see a [full list of changes in this release here](https://github.com/Automattic/jetpack-production/blob/trunk/CHANGELOG.md). Please feel free to test any and all functionality mentioned!

--- a/projects/plugins/jetpack/to-test.md
+++ b/projects/plugins/jetpack/to-test.md
@@ -14,7 +14,7 @@
 
 On top of the already available AI Logo generator, we've now added a styles dropdown to allow more control for the user without depending entirely on the provided prompt.
 
-The logo generator is not available for free users, test with a plan or subscription. Also, it's currenlty available for a12s (and will soon be open to public), but if you need to test with another account and have access to a sandbox, you can add a filter to enable the styles on your 0-sandbox.php file: `add_filter( 'jetpack_ai_logo_style_selector_enabled', '__return_true' );`
+The logo generator is not available for free users, test with a plan or subscription. Also, it's currenlty available for a12s only (and will soon be open to public).
 
 - Load the editor and add a Logo block.
 - On the network tab you should see a request to `ai-assistant-feature`
@@ -35,13 +35,13 @@ The logo generator is not available for free users, test with a plan or subscrip
 - Feel free to play with the styles to achieve different results
 - Confirm that using style "Auto" will try to guess the style based on the prompt (AI query request) and set the style prior to sending the image generation request
 - If possible, try different combinations of plans and cases:
-  - use `add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 0 | 100 | 1; } );` filter to mock free/tier100/unlimited plans
+  - use `add_filter( 'jetpack_ai_tier_licensed_quantity', function() { return 0 | 100 | 1; } );` on your `0-sandbox.php` file filter to mock free/tier100/unlimited plans
 	- sandbox the API, but then don't connect to sandbox to mock a disconnected situation
 
 ### AI Image Generator
 
 The styles added to the logo generator are now also available on general image creation.
-It is currently available for a12s as well, but if you need to test with another account, the filter to enable it on your 0-sandbox.php file is: `add_filter( 'jetpack_ai_image_style_selector_enabled', '__return_true' );`
+It is currently only available for a12s as well, so test in a site where you are logged in with your A8c account.
 
 The testing steps are the same as the logo generator steps above, except that now you should add an Image block instead and click on the "Generate with AI" button.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes #

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds test information to the to-test file regarding general image generation with styles, meant for the CFT

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Docs only
