### PR TITLE
Stats: Always refresh cache on success

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-always-replace-cache-value-on-success
+++ b/projects/packages/stats-admin/changelog/fix-always-replace-cache-value-on-success
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+

--- a/projects/packages/stats-admin/changelog/fix-always-replace-cache-value-on-success
+++ b/projects/packages/stats-admin/changelog/fix-always-replace-cache-value-on-success
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
-
+Stats: API cache not refreshing when cache is bypassed
 

--- a/projects/packages/stats-admin/changelog/fix-always-replace-cache-value-on-success
+++ b/projects/packages/stats-admin/changelog/fix-always-replace-cache-value-on-success
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
-Stats: API cache not refreshing when cache is bypassed
+API cache not refreshing when cache is bypassed
 

--- a/projects/packages/stats-admin/changelog/fix-always-replace-cache-value-on-success
+++ b/projects/packages/stats-admin/changelog/fix-always-replace-cache-value-on-success
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
-API cache not refreshing when cache is bypassed
 
+API cache not refreshing when cache is bypassed

--- a/projects/packages/stats-admin/src/class-wpcom-client.php
+++ b/projects/packages/stats-admin/src/class-wpcom-client.php
@@ -48,10 +48,8 @@ class WPCOM_Client {
 			return $response_body;
 		}
 
-		if ( $use_cache ) {
-			// Cache the successful JSON response for 5 minutes.
-			set_transient( $cache_key, wp_json_encode( $response_body ), 5 * MINUTE_IN_SECONDS );
-		}
+		// Cache the response for 5 minutes.
+		set_transient( $cache_key, wp_json_encode( $response_body ), 5 * MINUTE_IN_SECONDS );
 
 		return $response_body;
 	}


### PR DESCRIPTION
Fixes p1730131641897179-slack-C82FZ5T4G

## Proposed changes:

* Fix an issue cache sticks under some circumstances

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
n/a

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

* Create a new JN site only site connected but not user connected
* Open /wp-admin/admin.php?page=stats
* Click Upgrade my Stats
* Click require a commercial license
* Ensure you are able to choose a tier and purchase
* Ensure you are redirected back to the Stats page after purchase
* Ensure you do NOT see upsell notices anymore

