### PR TITLE
Repo Gardening: automate board triage of Autoloader issues

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/add-autoloader-auto-triaging
+++ b/projects/github-actions/repo-gardening/changelog/add-autoloader-auto-triaging
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Triage to Project boards: automatically triage Autoloader-related issues to the Garage board.

--- a/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
@@ -85,7 +85,7 @@ export const automatticAssignments = {
 	},
 	'Monorepo tooling': {
 		team: 'Jetpack Garage',
-		labels: [ '[Tools] Development CLI', 'Actions' ],
+		labels: [ '[Tools] Development CLI', 'Actions', '[Package] Autoloader' ],
 		slack_id: 'CBG1CP4EN',
 		board_id: 'https://github.com/orgs/Automattic/projects/599',
 	},


### PR DESCRIPTION
## Proposed changes:

Since the Garage team has typically been the one handling changes to the Autoloader package, let's automatically triage issues labeled "Autoloader" to their GitHub Project board.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

We will not be able to test this until the PR is merged.

Once it is merged, when a bug is tagged with the "[Package] Autoloader" label, it will be automatically added to their Project board.

