### PR TITLE
Repo Gardening: triage site migration and theme-related issues

### DIFF
--- a/projects/github-actions/repo-gardening/changelog/update-board-triage-dotcom
+++ b/projects/github-actions/repo-gardening/changelog/update-board-triage-dotcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Triage to Project boards: automatically triage Site Migrations and Theme-related issues.

--- a/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
+++ b/projects/github-actions/repo-gardening/src/tasks/update-board/automattic-label-team-assignments.js
@@ -27,6 +27,29 @@ export const automatticAssignments = {
 		slack_id: 'C03NLNTPZ2T',
 		board_id: 'https://github.com/orgs/Automattic/projects/448',
 	},
+	'Site Migrations': {
+		team: 'Serenity',
+		labels: [ '[Feature] Site Migration' ],
+		slack_id: 'C0Q664T29',
+		board_id: 'https://github.com/orgs/Automattic/projects/964/',
+	},
+	Themes: {
+		team: 'Marvel',
+		labels: [
+			'[Feature Group] Appearance & Themes',
+			'[Feature] Global Styles',
+			'[Feature] Premium Automattic Themes',
+			'[Feature] Free Automattic Themes',
+			'[Feature] Third-Party Themes',
+			'[Feature] .Org Themes',
+			'[Feature] Customizer',
+			'[Feature] Theme Showcase',
+			'[Feature] Headstart',
+			'[Feature] Google Fonts',
+		],
+		slack_id: 'C048CUFRGFQ',
+		board_id: 'https://github.com/orgs/Automattic/projects/1106/',
+	},
 	// Jetpack Division.
 	'AI Tools': {
 		team: 'Agora',


### PR DESCRIPTION
## Proposed changes:

This change is a trial run to start routing more issues to dotcom teams right away.

> Route all site migration-related issues to Serenity
> Route all theme-related issues to Marvel
-- pfVjQF-55-p2

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

Reference: pfVjQF-55-p2

## Does this pull request change what data or activity we track or use?

* N/A

## Testing instructions:

This cannot be tested before merge.

Once merged, all bugs labeled with the labels added in this PR will be automatically added to the team's project boards, and they will be pinged in Slack when high/blocker issues are detected.
