### PR TITLE
Subscribe block: update notice margins

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-margin-subscribe-block-take-2
+++ b/projects/plugins/jetpack/changelog/fix-margin-subscribe-block-take-2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscribe block: adjust margin of the notice appearing in the block sidebar.

--- a/projects/plugins/jetpack/extensions/shared/components/inspector-notice/style.scss
+++ b/projects/plugins/jetpack/extensions/shared/components/inspector-notice/style.scss
@@ -2,7 +2,7 @@
 
 .jetpack-inspector-notice {
 	padding: 24px;
-	margin: 16px 24px;
+	margin: 24px 16px;
 	background: $gray-100;
 	border-radius: 4px;
 	display: flex;


### PR DESCRIPTION
Follow-up to #39929

## Proposed changes:

See https://github.com/Automattic/jetpack/pull/39929#pullrequestreview-2404226501

> I think you unintentionally swapped the horizontal and vertical margins:
> - `0 16px 24px` means top: 0px, left&right: 16px, bottom: 24px
> - `16px 24px` means top&bottom: 16px, left&right: 24px
>
> The correct style is `24px 16px`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

* N/A

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

1. Start with a site that's connected to WordPress.com, and where the Subscriptions feature is active. It's best if it's a site where you have a few subscribers.
2. Go to the Appearance > Themes menu and activate an old default theme such as Twenty Twenty.
3. Go to Posts > Add New
4. Insert a subscribe block.
5. In the sidebar, ensure the panel showing the number of subscribers is properly displayed, with the styles above.
6. Save this draft.
7. Go to Appearance > Themes, and switch to the Twenty Twenty Three theme
8. Go back to the post editor; the subscribe block settings should still look good, without the styles above.
