### PR TITLE
Google Fonts: Fix the module is not fully loaded due to the chagne of the late_initialization

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-google-fonts-not-loaded
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-google-fonts-not-loaded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Google Fonts: Fix the module is not fully loaded due to the chagne of the late_initialization

--- a/projects/plugins/jetpack/modules/google-fonts/load.php
+++ b/projects/plugins/jetpack/modules/google-fonts/load.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack
  */
 
+/**
+ * The modules is loaded during the late_initialization action and it also hooks to the `after_setup_theme`.
+ * See projects/plugins/jetpack/class.jetpack.php.
+ */
 add_action(
 	'after_setup_theme',
 	function () {
@@ -28,8 +32,5 @@ add_action(
 		}
 
 		require_once __DIR__ . '/current/load-google-fonts.php';
-	},
-	// Ensure the action is loaded after the late_initialization.
-	// See projects/plugins/jetpack/class.jetpack.php.
-	999
+	}
 );

--- a/projects/plugins/jetpack/modules/google-fonts/load.php
+++ b/projects/plugins/jetpack/modules/google-fonts/load.php
@@ -6,7 +6,7 @@
  */
 
 add_action(
-	'plugins_loaded',
+	'after_setup_theme',
 	function () {
 		if (
 			/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes https://github.com/Automattic/dotcom-forge/issues/9605, p1730298701137309-slack-C02FMH4G8, https://github.com/Automattic/jetpack/pull/39841

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* The https://github.com/Automattic/jetpack/pull/39841 made a change to hook the `load_modules` call into `after_setup_theme` instead of the `plugins_loaded` anymore so that the hook registered by the google-fonts module won't be called.
* As a result, this PR proposed the change to move the hook registered by the google-fonts module to the `after_setup_theme` as well

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new site with a Business Plan
* Use the site editor to set the default font to something provided by Google e.g. "Roboto". Note that on simple there isn't the ability to add a font using the fonts modal
* Confirm the frontend is rendering Roboto, hotlinked to fonts.wp.com
* Transfer the site to Atomic
* Apply changes to your atomic site via Jetpack Beta Tester
* Confirm the frontend is still rendering Roboto
* Confirm you can still see the list of fonts provided by Google when you configure the typography in the site editor