### PR TITLE
Help Center: add new rest route

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/help-center-add-support-interactions-api
+++ b/projects/packages/jetpack-mu-wpcom/changelog/help-center-add-support-interactions-api
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Help Center: add new rest route for support interactions

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -285,6 +285,10 @@ class Help_Center {
 		$controller = new WP_REST_Help_Center_Support_Activity();
 		$controller->register_rest_route();
 
+		require_once __DIR__ . '/class-wp-rest-help-center-support-interactions.php';
+		$controller = new WP_REST_Help_Center_Support_Interactions();
+		$controller->register_rest_route();
+
 		require_once __DIR__ . '/class-wp-rest-help-center-user-fields.php';
 		$controller = new WP_REST_Help_Center_User_Fields();
 		$controller->register_rest_route();

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-support-interactions.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * WP_REST_Help_Center_Support_Interactions file.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_Help_Center_Support_Interactions.
+ */
+class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
+	/**
+	 * WP_REST_Help_Center_Support_Interactions constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'help-center';
+		$this->rest_base = '/support-status';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_support_interactions' ),
+				'permission_callback' => 'is_user_logged_in',
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<support_interaction_id>[a-zA-Z0-9-]+)',
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_support_interactions' ),
+				'permission_callback' => 'is_user_logged_in',
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_support_interaction' ),
+				'permission_callback' => 'is_user_logged_in',
+				'args'                => array(
+					'event_external_id' => array(
+						'type'     => 'int',
+						'required' => true,
+					),
+					'event_source'      => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'event_metadata'    => array(
+						'type'     => 'string',
+						'required' => false,
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<support_interaction_id>[a-zA-Z0-9-]+)/events',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'create_support_interaction_event' ),
+				'permission_callback' => 'is_user_logged_in',
+				'args'                => array(
+					'event_external_id' => array(
+						'type'     => 'int',
+						'required' => true,
+					),
+					'event_source'      => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'event_metadata'    => array(
+						'type'     => 'string',
+						'required' => false,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get support interactions.
+	 *
+	 * @param \WP_REST_Request $request    The request sent to the API.
+	 */
+	public function get_support_interactions( \WP_REST_Request $request ) {
+		$support_interaction_id = isset( $request['support_interaction_id'] ) ? (int) $request['support_interaction_id'] : null;
+		$body                   = Client::wpcom_json_api_request_as_user( "/support-interactions/$support_interaction_id" );
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Create support interaction.
+	 *
+	 * @param \WP_REST_Request $request    The request sent to the API.
+	 */
+	public function create_support_interaction( \WP_REST_Request $request ) {
+		$data = array(
+			'event_external_id' => $request['event_external_id'],
+			'event_source'      => $request['event_source'],
+			'event_metadata'    => $request['event_metadata'],
+		);
+
+		$body = Client::wpcom_json_api_request_as_user(
+			'/support-interactions',
+			'2',
+			array(
+				'method' => 'POST',
+				'body'   => $data,
+			)
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Create support interaction event.
+	 *
+	 * @param \WP_REST_Request $request    The request sent to the API.
+	 */
+	public function create_support_interaction_event( \WP_REST_Request $request ) {
+		$support_interaction_id = isset( $request['support_interaction_id'] ) ? (int) $request['support_interaction_id'] : null;
+
+		$data = array(
+			'event_external_id' => $request['event_external_id'],
+			'event_source'      => $request['event_source'],
+			'event_metadata'    => $request['event_metadata'],
+		);
+
+		$body = Client::wpcom_json_api_request_as_user(
+			"/support-interactions/$support_interaction_id/events",
+			'2',
+			array(
+				'method' => 'POST',
+				'body'   => $data,
+			)
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
+}


### PR DESCRIPTION
## Proposed changes:

We have recently added a new API endpoint to manage the support interactions across WordPress.com. This is going to be consumed in the Help Center. In order to make the endpoint accessible outside of Calypso we need to add a relay using the Jetpack Client. This is what that does.

This is the patch that added the API to WPCOM - D163455

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:

To be continued...

