### PR TITLE
Disable launchpad for logged out users

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/try-disable-launchpad-for-logged-out-users
+++ b/projects/packages/jetpack-mu-wpcom/changelog/try-disable-launchpad-for-logged-out-users
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Launchpad: disable Launchpad functionality for logged-out users

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -390,6 +390,11 @@ function wpcom_launchpad_get_task_lists( $rebuild = false ) {
  * Register all tasks and task lists on init.
  */
 function wpcom_register_default_launchpad_checklists() {
+	// Only logged-in users should interact with the launchpad or trigger task completion.
+	if ( ! is_user_logged_in() ) {
+		return;
+	}
+
 	wpcom_launchpad_get_task_lists();
 	wpcom_add_active_task_listener_hooks_to_correct_action();
 }

--- a/projects/plugins/mu-wpcom-plugin/changelog/try-disable-launchpad-for-logged-out-users
+++ b/projects/plugins/mu-wpcom-plugin/changelog/try-disable-launchpad-for-logged-out-users
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Launchpad: disable Launchpad functionality for logged-out users

--- a/projects/plugins/wpcomsh/changelog/try-disable-launchpad-for-logged-out-users
+++ b/projects/plugins/wpcomsh/changelog/try-disable-launchpad-for-logged-out-users
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Launchpad: disable Launchpad functionality for logged-out users


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

This PR recreates @mreishus's original proposal in https://github.com/Automattic/jetpack/pull/38577, which prevents most of the Launchpad functionality from being initialised when WordPress is running in a logged-out user context

In general, this should provide a performance improvement for visitors of WordPress.com sites, because we're not loading the code or adding any actions/listeners.

The concerns on my side stem from us breaking an implicit assumption that the code is available when WordPress is loaded. In general, logged-out users shouldn't trigger any of the actions that we're listening for. However, I do have some concerns:
* I am not sure if we have contexts (like asynchronous background jobs) where we don't have a current user, and we're expecting to be able to call launchpad code/functions. Marking a task as complete definitely falls into this bucket.
* Do we always have a current user context when we're making Launchpad API calls? I am especially concerned about API calls that rely on the Jetpack blog token, which isn't connected to a specific user.

@Automattic/serenity, **please give this some thought -- are there additional things we might need to worry about?**

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
No direct impacts on Jetpack.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes to data tracking or usage.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


*

