### PR TITLE
Fix/jetpack connection initial state error

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-jetpack-connection-initial-state-error
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-jetpack-connection-initial-state-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+We now check if JP_CONNECTION_INITIAL_STATE is defined before accessing it when using Global Styles'

--- a/projects/packages/jetpack-mu-wpcom/src/common/tracks.js
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tracks.js
@@ -6,7 +6,7 @@ export const wpcomTrackEvent = (
 	eventUserId = null,
 	eventUsername = null
 ) => {
-	const currentUser = JP_CONNECTION_INITIAL_STATE?.userConnectionData?.currentUser ?? {};
+	const currentUser = window.JP_CONNECTION_INITIAL_STATE?.userConnectionData?.currentUser ?? {};
 
 	const userId = eventUserId ?? currentUser.id;
 	const username = eventUsername ?? currentUser.username;

--- a/projects/packages/jetpack-mu-wpcom/src/common/tracks.js
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tracks.js
@@ -1,5 +1,3 @@
-/* global JP_CONNECTION_INITIAL_STATE */
-
 export const wpcomTrackEvent = (
 	eventName,
 	eventProperties = {},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:
- https://github.com/Automattic/dotcom-forge/issues/9625

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* We now access the global through the window object so that we can access through optional chaining without triggering an error.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add the code to your site
* Trigger a wpcomTrackEvent, some events are:
    * calypso_global_styles_gating_modal_show
    * calypso_global_styles_gating_modal_dismiss 
* Check that there are no console errors.
* Delete JP_CONNECTION_INITIAL_STATE and try again, you should not see a `JP_CONNECTION_INITIAL_STATE is not defined` error.