### PR TITLE
ci: Skip `composer install` for JS-only coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,7 +161,7 @@ jobs:
               if [[ "${SLUG%%/*}" != "plugins" && ( "$TEST_SCRIPT" == "test-php" || "$TEST_SCRIPT" == "test-coverage" ) ]]; then
                 NEED_COMPOSER=true
                 if [[ "$TEST_SCRIPT" == "test-coverage" ]] &&
-                  ! jq -e '.scripts["test-php"]' "$DIR/composer.json"
+                  ! jq -e '.scripts["test-php"]' "$DIR/composer.json" &>/dev/null
                 then
                   echo "Skipping composer install, assuming test-coverage is only JS because the project has no test-php."
                   NEED_COMPOSER=false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,17 @@ jobs:
               echo "::group::Running tests for $SLUG"
 
               # Composer install, if appropriate. Note setup-wordpress-env.sh did it already for plugins.
+              NEED_COMPOSER=false
               if [[ "${SLUG%%/*}" != "plugins" && ( "$TEST_SCRIPT" == "test-php" || "$TEST_SCRIPT" == "test-coverage" ) ]]; then
+                NEED_COMPOSER=true
+                if [[ "$TEST_SCRIPT" == "test-coverage" ]] &&
+                  ! jq -e '.scripts["test-php"]' "$DIR/composer.json"
+                then
+                  echo "Skipping composer install, assuming test-coverage is only JS because the project has no test-php."
+                  NEED_COMPOSER=false
+                fi
+              fi
+              if $NEED_COMPOSER; then
                 if [[ ! -f "$DIR/composer.lock" ]]; then
                   echo 'No composer.lock, running `composer update`'
                   composer --working-dir="$DIR" update


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
We assume coverage is JS-only if there's no `test-php` script defined.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
none linkable

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Look at the CI run.
