### PR TITLE
Social | Fix whitespace in Bluesky and Mastodon connection forms

### DIFF
--- a/projects/js-packages/publicize-components/changelog/fix-social-whitespace-in-bluesky-and-mastodon-forms
+++ b/projects/js-packages/publicize-components/changelog/fix-social-whitespace-in-bluesky-and-mastodon-forms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fixed empty whitespace in Bluesky and Mastodon connection forms

--- a/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
+++ b/projects/js-packages/publicize-components/src/components/services/custom-inputs.tsx
@@ -28,9 +28,6 @@ export function CustomInputs( { service }: CustomInputsProps ) {
 				<label htmlFor={ `${ id }-handle` }>
 					{ _x( 'Handle', 'The handle of a social media account.', 'jetpack' ) }
 				</label>
-				<p className="description" id={ `${ id }-handle-description` }>
-					{ __( 'You can find the handle in your Mastodon profile.', 'jetpack' ) }
-				</p>
 				<input
 					id={ `${ id }-handle` }
 					required
@@ -44,6 +41,9 @@ export function CustomInputs( { service }: CustomInputsProps ) {
 					aria-describedby={ `${ id }-handle-description` }
 					placeholder={ '@mastodon@mastodon.social' }
 				/>
+				<p className="description" id={ `${ id }-handle-description` }>
+					{ __( 'You can find the handle in your Mastodon profile.', 'jetpack' ) }
+				</p>
 			</div>
 		);
 	}
@@ -55,9 +55,6 @@ export function CustomInputs( { service }: CustomInputsProps ) {
 					<label htmlFor={ `${ id }-handle` }>
 						{ _x( 'Handle', 'The handle of a social media account.', 'jetpack' ) }
 					</label>
-					<p className="description" id={ `${ id }-handle-description` }>
-						{ __( 'You can find the handle in your Bluesky profile.', 'jetpack' ) }
-					</p>
 					<input
 						id={ `${ id }-handle` }
 						required
@@ -76,20 +73,12 @@ export function CustomInputs( { service }: CustomInputsProps ) {
 						aria-describedby={ `${ id }-handle-description` }
 						placeholder={ 'username.bsky.social' }
 					/>
+					<p className="description" id={ `${ id }-handle-description` }>
+						{ __( 'You can find the handle in your Bluesky profile.', 'jetpack' ) }
+					</p>
 				</div>
 				<div className={ styles[ 'fields-item' ] }>
 					<label htmlFor={ `${ id }-password` }>{ __( 'App password', 'jetpack' ) }</label>
-					<p className="description" id={ `${ id }-password-description` }>
-						{ createInterpolateElement(
-							__(
-								'App password is needed to safely connect your account. App password is different from your account password. You can <link>generate it in Bluesky</link>.',
-								'jetpack'
-							),
-							{
-								link: <ExternalLink href="https://bsky.app/settings/app-passwords" />,
-							}
-						) }
-					</p>
 					<input
 						id={ `${ id }-password` }
 						required
@@ -103,6 +92,17 @@ export function CustomInputs( { service }: CustomInputsProps ) {
 						aria-describedby={ `${ id }-password-description` }
 						placeholder={ 'xxxx-xxxx-xxxx-xxxx' }
 					/>
+					<p className="description" id={ `${ id }-password-description` }>
+						{ createInterpolateElement(
+							__(
+								'App password is needed to safely connect your account. App password is different from your account password. You can <link>generate it in Bluesky</link>.',
+								'jetpack'
+							),
+							{
+								link: <ExternalLink href="https://bsky.app/settings/app-passwords" />,
+							}
+						) }
+					</p>
 					{ reconnectingAccount?.service_name === 'bluesky' && (
 						<Alert level="error" showIcon={ false }>
 							{ __( 'Please provide an app password to fix the connection.', 'jetpack' ) }

--- a/projects/js-packages/publicize-components/src/components/services/style.module.scss
+++ b/projects/js-packages/publicize-components/src/components/services/style.module.scss
@@ -188,10 +188,6 @@
 	justify-content: flex-end;
 	width: 100%;
 
-	@include break-medium {
-		max-width: 25rem;
-	}
-
 	.connect-button {
 		&:global(.components-button) {
 			padding: 6px 16px;
@@ -204,12 +200,11 @@
 	.fields-wrapper {
 		display: flex;
 		flex-direction: column;
-		align-items: flex-end;
-		flex-wrap: wrap;
+		justify-content: flex-end;
 		width: 100%;
 		gap: 1rem;
 
-		@include break-small {
+		@include break-medium {
 			flex-direction: row;
 		}
 	}
@@ -218,7 +213,16 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
-		width: 100%;
+		flex-basis: 100%;
+		@include break-medium {
+			flex-basis: 50%;
+		}
+
+		@include break-small {
+			button {
+				align-self: flex-end;
+			}
+		}
 	}
 
 	label {


### PR DESCRIPTION


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Move the field description below the inputs
* Fix layout to remove empty whitespace for Bluesky and Mastodon forms

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to connections management
* Expand Mastodon and Bluesky forms
* Confirm that there is no empty whitespace and the layout is fine on both desktop and mobile

- Large screens
    <img width="1052" alt="Screenshot 2024-10-31 at 5 32 56 PM" src="https://github.com/user-attachments/assets/597ada68-8301-4535-986b-cde3701c9cc7">
- Medium-sized screens
    <img width="734" alt="Screenshot 2024-10-31 at 5 33 21 PM" src="https://github.com/user-attachments/assets/5eb8ac82-51cc-4f49-bcc2-3f1136243fba">
- Small screens
    <img width="435" alt="Screenshot 2024-10-31 at 5 33 39 PM" src="https://github.com/user-attachments/assets/134dddeb-1fbb-4b5c-9aff-7e9908c757b7">



