### PR TITLE
External Media / AI Image Generator: update button style

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-external-media-button
+++ b/projects/plugins/jetpack/changelog/fix-external-media-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+External Media: ensure that the image block's external media picker button remains consistent with the other buttons in the image block.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -716,10 +716,10 @@ class Jetpack_Gutenberg {
 		}
 
 		$initial_state = array(
-			'available_blocks' => self::get_availability(),
-			'blocks_variation' => $blocks_variation,
-			'modules'          => $modules,
-			'jetpack'          => array(
+			'available_blocks'    => self::get_availability(),
+			'blocks_variation'    => $blocks_variation,
+			'modules'             => $modules,
+			'jetpack'             => array(
 				'is_active'                     => Jetpack::is_connection_ready(),
 				'is_current_user_connected'     => $is_current_user_connected,
 				/** This filter is documented in class.jetpack-gutenberg.php */
@@ -743,15 +743,16 @@ class Jetpack_Gutenberg {
 				 */
 				'republicize_enabled'           => apply_filters( 'jetpack_block_editor_republicize_feature', true ),
 			),
-			'siteFragment'     => $status->get_site_suffix(),
-			'adminUrl'         => esc_url( admin_url() ),
-			'tracksUserData'   => $user_data,
-			'wpcomBlogId'      => $blog_id,
-			'allowedMimeTypes' => wp_get_mime_types(),
-			'siteLocale'       => str_replace( '_', '-', get_locale() ),
-			'ai-assistant'     => $ai_assistant_state,
-			'screenBase'       => $screen_base,
-			'pluginBasePath'   => plugins_url( '', Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ),
+			'siteFragment'        => $status->get_site_suffix(),
+			'adminUrl'            => esc_url( admin_url() ),
+			'tracksUserData'      => $user_data,
+			'wpcomBlogId'         => $blog_id,
+			'allowedMimeTypes'    => wp_get_mime_types(),
+			'siteLocale'          => str_replace( '_', '-', get_locale() ),
+			'ai-assistant'        => $ai_assistant_state,
+			'screenBase'          => $screen_base,
+			'pluginBasePath'      => plugins_url( '', Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ),
+			'next40pxDefaultSize' => self::site_supports_next_default_size(),
 		);
 
 		if ( Jetpack::is_module_active( 'publicize' ) && function_exists( 'publicize_init' ) ) {
@@ -1291,6 +1292,44 @@ class Jetpack_Gutenberg {
 		}
 
 		return $block_content;
+	}
+
+	/**
+	 * Check whether the environment supports the newer default size of elements, gradually introduced starting with WP 6.4.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @see https://make.wordpress.org/core/2023/10/16/editor-components-updates-in-wordpress-6-4/#improving-size-consistency-for-ui-components
+	 *
+	 * @to-do: Deprecate this method and the logic around it when Jetpack requires WordPress 6.7.
+	 *
+	 * @return bool
+	 */
+	public static function site_supports_next_default_size() {
+		/*
+		 * If running a local dev build of gutenberg,
+		 * let's assume it supports the newest changes included in Gutenberg.
+		 */
+		if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE ) {
+			return true;
+		}
+
+		// Let's now check if the Gutenberg plugin is installed on the site.
+		if (
+			defined( 'GUTENBERG_VERSION' )
+			&& version_compare( GUTENBERG_VERSION, '19.4', '>=' )
+		) {
+			return true;
+		}
+
+		// Finally, let's check for the WordPress version.
+		global $wp_version;
+		if ( version_compare( $wp_version, '6.7', '>=' ) ) {
+			return true;
+		}
+
+		// Final fallback.
+		return false;
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
+++ b/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
@@ -144,7 +144,6 @@ $grid-size: 8px;
 	font-weight: 400;
 	line-height: 1.43;
 	color: var( --jp-gray-60 );
-	text-align: left;
 	margin: 0;
 }
 .jetpack-external-media-wrapper__jetpack_app_media-wrapper.has-no-image-uploaded {
@@ -543,33 +542,29 @@ $grid-size: 8px;
 }
 
 .jetpack-external-media-button-menu__dropdown {
-	width: 100%;
+	display: flex;
 
 	.jetpack-external-media-button-menu {
 		width: 100%;
 		flex-direction: row;
-		text-align: left;
 		padding-left: 12px;
 		padding-right: 12px;
-
-		.jetpack-external-media-button-menu__label {
-			flex-grow: 2;
-		}
 	}
 }
 
 // Set the wrapper as a flex container to allow displaying multiple buttons side by side.
 .jetpack-external-media-button-wrapper {
-	display: flex;
+	@media only screen and ( min-width: 783px ) {
+		display: flex;
+		gap: $grid-size * 2;
+	}
 }
 
 // Reset placeholder button margin.
 .components-placeholder__fieldset,
 .editor-post-featured-image {
 	.components-dropdown .jetpack-external-media-button-menu {
-		width: auto;
 		margin-bottom: 1em;
-
 		> svg {
 			display: none;
 		}

--- a/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
+++ b/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
@@ -552,24 +552,14 @@ $grid-size: 8px;
 	}
 }
 
-// Set the wrapper as a flex container to allow displaying multiple buttons side by side.
 .jetpack-external-media-button-wrapper {
-	@media only screen and ( min-width: 783px ) {
-		display: flex;
-		gap: $grid-size * 2;
-
-		:where(.is-medium, .is-small) & {
-			display: block;
-			gap: 0;
-		}
-	}
+	display: contents;
 }
 
 // Reset placeholder button margin.
 .components-placeholder__fieldset,
 .editor-post-featured-image {
 	.components-dropdown .jetpack-external-media-button-menu {
-		margin-bottom: 1em;
 		> svg {
 			display: none;
 		}

--- a/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
+++ b/projects/plugins/jetpack/extensions/shared/external-media/editor.scss
@@ -557,6 +557,11 @@ $grid-size: 8px;
 	@media only screen and ( min-width: 783px ) {
 		display: flex;
 		gap: $grid-size * 2;
+
+		:where(.is-medium, .is-small) & {
+			display: block;
+			gap: 0;
+		}
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/index.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/index.js
@@ -21,6 +21,9 @@ const isGeneralPurposeImageGeneratorBetaEnabled =
 		GENERAL_PURPOSE_IMAGE_GENERATOR_BETA_FLAG
 	]?.available === true;
 
+// to-do: remove when Jetpack requires WordPress 6.7.
+const hasLargeButtons = window?.Jetpack_Editor_Initial_State?.next40pxDefaultSize;
+
 function MediaButton( props ) {
 	const { name } = useBlockEditContext();
 	const { mediaProps } = props;
@@ -56,9 +59,13 @@ function MediaButton( props ) {
 				isReplace={ isReplaceMenu( mediaProps ) }
 				isFeatured={ isFeatured }
 				hasImage={ mediaProps.value > 0 }
+				hasLargeButtons={ hasLargeButtons }
 			/>
 			{ isGeneralPurposeImageGeneratorBetaEnabled && ! isFeatured && hasAiButtonSupport && (
-				<MediaAiButton setSelectedSource={ setSelectedSource } />
+				<MediaAiButton
+					setSelectedSource={ setSelectedSource }
+					hasLargeButtons={ hasLargeButtons }
+				/>
 			) }
 
 			{ ExternalLibrary && <ExternalLibrary { ...mediaProps } onClose={ closeLibrary } /> }

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-ai-button.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-ai-button.js
@@ -3,10 +3,11 @@ import { __ } from '@wordpress/i18n';
 import { SOURCE_JETPACK_AI_GENERAL_PURPOSE_IMAGE_FOR_BLOCK } from '../constants';
 
 function MediaAiButton( props ) {
-	const { setSelectedSource } = props;
+	const { setSelectedSource, hasLargeButtons } = props;
+
 	return (
 		<Button
-			__next40pxDefaultSize
+			__next40pxDefaultSize={ hasLargeButtons }
 			variant="secondary"
 			className="jetpack-external-media-button-menu"
 			aria-haspopup="false"

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-ai-button.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-ai-button.js
@@ -6,7 +6,8 @@ function MediaAiButton( props ) {
 	const { setSelectedSource } = props;
 	return (
 		<Button
-			variant="tertiary"
+			__next40pxDefaultSize
+			variant="secondary"
 			className="jetpack-external-media-button-menu"
 			aria-haspopup="false"
 			onClick={ () => {

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
@@ -4,7 +4,8 @@ import { Icon, media } from '@wordpress/icons';
 import MediaSources from './media-sources';
 
 function MediaButtonMenu( props ) {
-	const { mediaProps, open, setSelectedSource, isFeatured, isReplace, hasImage } = props;
+	const { mediaProps, open, setSelectedSource, isFeatured, isReplace, hasImage, hasLargeButtons } =
+		props;
 	const originalComponent = mediaProps.render;
 
 	if ( isReplace ) {
@@ -48,7 +49,7 @@ function MediaButtonMenu( props ) {
 					}
 					return (
 						<Button
-							__next40pxDefaultSize
+							__next40pxDefaultSize={ hasLargeButtons }
 							variant="secondary"
 							className="jetpack-external-media-button-menu"
 							aria-haspopup="true"

--- a/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
+++ b/projects/plugins/jetpack/extensions/shared/external-media/media-button/media-menu.js
@@ -6,7 +6,6 @@ import MediaSources from './media-sources';
 function MediaButtonMenu( props ) {
 	const { mediaProps, open, setSelectedSource, isFeatured, isReplace, hasImage } = props;
 	const originalComponent = mediaProps.render;
-	let variant = 'tertiary';
 
 	if ( isReplace ) {
 		return (
@@ -30,7 +29,6 @@ function MediaButtonMenu( props ) {
 
 	if ( isFeatured ) {
 		label = __( 'Replace Image', 'jetpack' );
-		variant = 'secondary';
 	}
 
 	return (
@@ -50,7 +48,8 @@ function MediaButtonMenu( props ) {
 					}
 					return (
 						<Button
-							variant={ variant }
+							__next40pxDefaultSize
+							variant="secondary"
 							className="jetpack-external-media-button-menu"
 							aria-haspopup="true"
 							aria-expanded={ isOpen }


### PR DESCRIPTION
See #39934

## Proposed changes:

Let's change the overall styles of the 2 buttons ("Select Image" and "Generate with AI"):

- the buttons should be 40px high, like in Core. See https://github.com/WordPress/gutenberg/issues/46741
- the buttons should use the secondary style variant by default, to match the "Insert from URL" button.
- the buttons should take the full width of the placeholder on mobile devices.

| Desktop | Mobile |
|--------|--------|
| <img width="778" alt="Screenshot 2024-10-31 at 13 14 41" src="https://github.com/user-attachments/assets/68fcf19b-1e3e-43ca-9696-f6052ce10b5e"> | <img width="474" alt="Screenshot 2024-10-31 at 13 13 30" src="https://github.com/user-attachments/assets/475bbcbe-532c-421c-8544-b59950693556"> |

> [!WARNING]
> This PR only addresses the design issues outlined in the comments of #39934. It does not remove or make any changes to the duplicate "Generate with AI" button or the "Select Image" button, as we discussed in #39934 and #39933. This is something we can do in a follow-up PR, after more discussion if necessary.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

See conversation in #39934

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:

> [!NOTE]
> This needs to be tested in different enviroments:
> - With the latest version of the Gutenberg plugin and the latest version of WordPress, like on WoA on WordPress.com Simple
> - On a site using the latest version of WordPress, but not the Gutenberg plugin.
> - On a site using WordPress 6.5.

1. Start by connecting your site to your WordPress.com account
2. Go to Posts > Add New
3. Add an Image block
4. View the different options, both on desktop and on mobile.

Once you've done this, you will also want to test the other blocks using the External Media option:

- Core Gallery block
- Tiled Gallery block
- Slideshow block

<img width="436" alt="image" src="https://github.com/user-attachments/assets/8a5f4070-25ee-491e-af25-4bdb169be518">

