### PR TITLE
Global Styles on Personal: Add feature check and sticker to eligible blogs

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-global-styles-on-personal-feature-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-global-styles-on-personal-feature-check
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Added feature check for the Global Styles on Personal plan changes.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -638,14 +638,11 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 	}
 
 	// If the GLOBAL_STYLES_ON_PERSONAL_PLAN feature is enabled, we need to check if the site has a Personal plan and add the sticker.
-	$is_blog_eligible = $blog_id >= 238540020;
-	if ( $is_blog_eligible && WPCOM_Feature_Flags::is_enabled( WPCOM_Feature_Flags::GLOBAL_STYLES_ON_PERSONAL_PLAN ) ) {
-		// If the site is on a Personal plan we add the sticker and allow access to the GS feature.
+	if ( class_exists( 'WPCOM_Feature_Flags' ) && WPCOM_Feature_Flags::is_enabled( 'GLOBAL_STYLES_ON_PERSONAL_PLAN' ) ) {
 		if ( wpcom_site_has_personal_plan( $blog_id ) ) {
 			$note = 'Automated sticker. See paYJgx-5w2-p2';
 			$user = 'a8c'; // A non-empty string avoids storing the current user as author of the sticker change.
 			add_blog_sticker( 'wpcom-global-styles-personal-plan', $note, $user, $blog_id );
-
 			return true;
 		}
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-global-styles/index.php
@@ -637,6 +637,19 @@ function wpcom_site_has_global_styles_feature( $blog_id = 0 ) {
 		}
 	}
 
+	// If the GLOBAL_STYLES_ON_PERSONAL_PLAN feature is enabled, we need to check if the site has a Personal plan and add the sticker.
+	$is_blog_eligible = $blog_id >= 238540020;
+	if ( $is_blog_eligible && WPCOM_Feature_Flags::is_enabled( WPCOM_Feature_Flags::GLOBAL_STYLES_ON_PERSONAL_PLAN ) ) {
+		// If the site is on a Personal plan we add the sticker and allow access to the GS feature.
+		if ( wpcom_site_has_personal_plan( $blog_id ) ) {
+			$note = 'Automated sticker. See paYJgx-5w2-p2';
+			$user = 'a8c'; // A non-empty string avoids storing the current user as author of the sticker change.
+			add_blog_sticker( 'wpcom-global-styles-personal-plan', $note, $user, $blog_id );
+
+			return true;
+		}
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes:
- https://github.com/Automattic/dotcom-forge/issues/9518

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Added a new check before granting access to GS
* This new check makes sure that the blog is eligible to access GS under the new circumstances (blog older than xxx and on a Personal plan)
* If access is granted, the `wpcom-global-styles-personal-plan` is added to the site.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In your `0-sandbox.php` file add: `const GLOBAL_STYLES_ON_PERSONAL_PLAN = true;`
* Now all new sites you create with the Personal plan should have access to the feature.
* Make sure there are no regressions on Atomic sites.
* Make sure that on old sites the Premium plan is required.
* The different upgrade strategies are excluded from this PR, the upgrade wording will still reference the Premium plan, but you should stop seeing them if you have a Personal plan.
* Remove the feature flag (set it to false) and you should still be able to use GS
* Remove the blog sticker and you should be prompted to upgrade to Premium


https://github.com/user-attachments/assets/a0017cad-35d0-4ea0-ad8b-2cc11deda57f


